### PR TITLE
Support sorted shuffle write in Sapphire-Velox stack

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BinarySortableSerializer.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BinarySortableSerializer.cpp
@@ -1,0 +1,516 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/operators/BinarySortableSerializer.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::presto::operators {
+namespace {
+
+static constexpr int64_t DOUBLE_EXP_BIT_MASK = 0x7FF0000000000000L;
+static constexpr int64_t DOUBLE_SIGNIF_BIT_MASK = 0x000FFFFFFFFFFFFFL;
+
+static constexpr int64_t FLOAT_EXP_BIT_MASK = 0x7F800000;
+static constexpr int64_t FLOAT_SIGNIF_BIT_MASK = 0x007FFFFF;
+
+// This is to implement the java's Double.doubleToLongBits(double value)
+FOLLY_ALWAYS_INLINE int64_t doubleToLong(double value) {
+  const int64_t* result = reinterpret_cast<const int64_t*>(&value);
+
+  if (((*result & DOUBLE_EXP_BIT_MASK) == DOUBLE_EXP_BIT_MASK) &&
+      (*result & DOUBLE_SIGNIF_BIT_MASK) != 0L) {
+    return 0x7ff8000000000000L;
+  }
+  return *result;
+}
+
+// This is to implement the java's Float.floatToLongBits(float value)
+FOLLY_ALWAYS_INLINE int32_t floatToInt(float value) {
+  const int32_t* result = reinterpret_cast<const int32_t*>(&value);
+
+  if (((*result & FLOAT_EXP_BIT_MASK) == FLOAT_EXP_BIT_MASK) &&
+      (*result & FLOAT_SIGNIF_BIT_MASK) != 0L) {
+    return 0x7fc00000;
+  }
+  return *result;
+}
+
+template <typename T>
+FOLLY_ALWAYS_INLINE void writeByte(T* out, int8_t value, bool isDescending) {
+  if (isDescending) {
+    out->appendByte(0xff ^ value);
+  } else {
+    out->appendByte(value);
+  }
+}
+
+template <typename T>
+FOLLY_ALWAYS_INLINE void writeLong(T* out, int64_t value, bool isDescending) {
+  writeByte(out, static_cast<int8_t>((value >> 56) ^ 0x80), isDescending);
+  writeByte(out, static_cast<int8_t>(value >> 48), isDescending);
+  writeByte(out, static_cast<int8_t>(value >> 40), isDescending);
+  writeByte(out, static_cast<int8_t>(value >> 32), isDescending);
+  writeByte(out, static_cast<int8_t>(value >> 24), isDescending);
+  writeByte(out, static_cast<int8_t>(value >> 16), isDescending);
+  writeByte(out, static_cast<int8_t>(value >> 8), isDescending);
+  writeByte(out, static_cast<int8_t>(value), isDescending);
+}
+
+template <typename T>
+FOLLY_ALWAYS_INLINE void
+writeInteger(T* out, int32_t value, bool isDescending) {
+  writeByte(out, static_cast<int8_t>((value >> 24) ^ 0x80), isDescending);
+  writeByte(out, static_cast<int8_t>(value >> 16), isDescending);
+  writeByte(out, static_cast<int8_t>(value >> 8), isDescending);
+  writeByte(out, static_cast<int8_t>(value), isDescending);
+}
+
+template <typename T>
+FOLLY_ALWAYS_INLINE void writeBytes(
+    T* out,
+    const char* data,
+    size_t offset,
+    size_t size,
+    bool isDescending) {
+  for (auto i = 0; i < size; ++i) {
+    if (data[offset + i] == 0 || data[offset + i] == 1) {
+      writeByte(out, 1, isDescending);
+      writeByte(out, data[offset + i], isDescending);
+    } else {
+      writeByte(out, data[offset + i], isDescending);
+    }
+  }
+  writeByte(out, 0, isDescending);
+}
+
+template <typename T>
+FOLLY_ALWAYS_INLINE void writeBool(T* out, bool value) {
+  writeByte(out, value, /*isDescending=*/false);
+}
+
+template <typename T>
+void serializeSwitch(
+    const velox::BaseVector& source,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending);
+
+template <typename T>
+void serializeBigInt(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const auto value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::BIGINT>::NativeType>>()
+            ->valueAt(index);
+
+    writeLong(out, value, isDescending);
+  }
+}
+
+template <typename T>
+void serializeDouble(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const auto value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::DOUBLE>::NativeType>>()
+            ->valueAt(index);
+    int64_t longValue = doubleToLong(value);
+
+    if ((longValue & (1L << 63)) != 0) {
+      // negative number, flip all bits
+      longValue = ~longValue;
+    } else {
+      // positive number, flip the first bit
+      longValue = longValue ^ (1L << 63);
+    }
+    writeByte(out, static_cast<int8_t>(longValue >> 56), isDescending);
+    writeByte(out, static_cast<int8_t>(longValue >> 48), isDescending);
+    writeByte(out, static_cast<int8_t>(longValue >> 40), isDescending);
+    writeByte(out, static_cast<int8_t>(longValue >> 32), isDescending);
+    writeByte(out, static_cast<int8_t>(longValue >> 24), isDescending);
+    writeByte(out, static_cast<int8_t>(longValue >> 16), isDescending);
+    writeByte(out, static_cast<int8_t>(longValue >> 8), isDescending);
+    writeByte(out, static_cast<int8_t>(longValue), isDescending);
+  }
+}
+
+template <typename T>
+void serializeReal(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const auto value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::REAL>::NativeType>>()
+            ->valueAt(index);
+    int32_t intValue = floatToInt(value);
+
+    if ((intValue & (1L << 31)) != 0) {
+      // negative number, flip all bits
+      intValue = ~intValue;
+    } else {
+      // positive number, flip the first bit
+      intValue = intValue ^ (1L << 31);
+    }
+    writeByte(out, static_cast<int8_t>(intValue >> 24), isDescending);
+    writeByte(out, static_cast<int8_t>(intValue >> 16), isDescending);
+    writeByte(out, static_cast<int8_t>(intValue >> 8), isDescending);
+    writeByte(out, static_cast<int8_t>(intValue), isDescending);
+  }
+}
+
+template <typename T>
+void serializeTinyInt(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const int8_t value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::TINYINT>::NativeType>>()
+            ->valueAt(index);
+    writeByte(out, static_cast<int8_t>(value ^ 0x80), isDescending);
+  }
+}
+
+template <typename T>
+void serializeSmallInt(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const int16_t value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::SMALLINT>::NativeType>>()
+            ->valueAt(index);
+    writeByte(out, static_cast<int8_t>((value >> 8) ^ 0x80), isDescending);
+    writeByte(out, static_cast<int8_t>(value), isDescending);
+  }
+}
+
+template <typename T>
+void serializeInteger(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const int32_t value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::INTEGER>::NativeType>>()
+            ->valueAt(index);
+    writeInteger(out, value, isDescending);
+  }
+}
+
+template <typename T>
+void serializeDate(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const int32_t value = vector.loadedVector()
+                              ->asUnchecked<velox::SimpleVector<int32_t>>()
+                              ->valueAt(index);
+    writeInteger(out, value, isDescending);
+  }
+}
+
+template <typename T>
+void serializeTimestamp(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const int64_t value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::TIMESTAMP>::NativeType>>()
+            ->valueAt(index)
+            .toNanos();
+
+    writeLong(out, value, isDescending);
+  }
+}
+
+template <typename T>
+void serializeBoolean(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const auto value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::BOOLEAN>::NativeType>>()
+            ->valueAt(index);
+    writeByte(out, static_cast<int8_t>(value ? 2 : 1), isDescending);
+  }
+}
+
+template <typename T>
+void serializeVarchar(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const auto value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::VARCHAR>::NativeType>>()
+            ->valueAt(index);
+    writeBytes(out, value.data(), /*offset=*/0, value.size(), isDescending);
+  }
+}
+
+template <typename T>
+void serializeVarbinary(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const auto value =
+        vector.loadedVector()
+            ->asUnchecked<velox::SimpleVector<
+                velox::TypeTraits<velox::TypeKind::VARBINARY>::NativeType>>()
+            ->valueAt(index);
+
+    writeBytes(out, value.data(), /*offset=*/0, value.size(), isDescending);
+  }
+}
+
+template <typename T>
+void serializeRow(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    const auto* rowVector =
+        vector.wrappedVector()->template asUnchecked<velox::RowVector>();
+    const auto wrappedIndex = vector.wrappedIndex(index);
+    const auto& type = rowVector->type()->as<velox::TypeKind::ROW>();
+    const auto childrenSize = type.size();
+    const auto& children = rowVector->children();
+
+    for (int32_t i = 0; i < childrenSize; ++i) {
+      if (i >= children.size() || !children[i]) {
+        writeBool(out, isNullLast);
+      } else {
+        writeBool(out, !isNullLast);
+        serializeSwitch(
+            *children[i], wrappedIndex, out, isNullLast, isDescending);
+      }
+    }
+  }
+}
+
+template <typename T>
+void serializeArrayElements(
+    const velox::BaseVector& elements,
+    velox::vector_size_t offset,
+    velox::vector_size_t size,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  for (auto i = 0; i < size; ++i) {
+    writeByte(out, 1, isDescending);
+    serializeSwitch(elements, i + offset, out, isNullLast, isDescending);
+  }
+}
+
+template <typename T>
+void serializeArray(
+    const velox::BaseVector& vector,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (vector.isNullAt(index)) {
+    writeBool(out, isNullLast);
+  } else {
+    writeBool(out, !isNullLast);
+    const auto* arrayVector =
+        vector.wrappedVector()->asUnchecked<velox::ArrayVector>();
+    const auto wrappedIndex = vector.wrappedIndex(index);
+    serializeArrayElements(
+        *arrayVector->elements(),
+        arrayVector->offsetAt(wrappedIndex),
+        arrayVector->sizeAt(wrappedIndex),
+        out,
+        isNullLast,
+        isDescending);
+    writeByte(out, 0, isDescending);
+  }
+}
+
+template <typename T>
+void serializeSwitch(
+    const velox::BaseVector& source,
+    velox::vector_size_t index,
+    T* out,
+    bool isNullLast,
+    bool isDescending) {
+  if (source.type()->isDate()) {
+    return serializeDate(source, index, out, isNullLast, isDescending);
+  }
+
+  switch (source.typeKind()) {
+    case velox::TypeKind::BIGINT:
+      return serializeBigInt(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::BOOLEAN:
+      return serializeBoolean(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::DOUBLE:
+      return serializeDouble(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::REAL:
+      return serializeReal(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::TINYINT:
+      return serializeTinyInt(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::SMALLINT:
+      return serializeSmallInt(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::INTEGER:
+      return serializeInteger(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::VARCHAR:
+      return serializeVarchar(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::VARBINARY:
+      return serializeVarbinary(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::TIMESTAMP:
+      return serializeTimestamp(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::ROW:
+      return serializeRow(source, index, out, isNullLast, isDescending);
+    case velox::TypeKind::ARRAY:
+      return serializeArray(source, index, out, isNullLast, isDescending);
+    default:
+      VELOX_NYI("Unsupported type: {}", source.typeKind());
+  }
+};
+
+std::vector<std::pair<int32_t, velox::column_index_t>> computeSortChannels(
+    const std::vector<velox::core::FieldAccessTypedExprPtr>& sortFields,
+    const velox::RowTypePtr& inputRowType) {
+  std::vector<std::pair<int32_t, velox::column_index_t>> sortChannels;
+  sortChannels.reserve(sortFields.size());
+  for (int32_t i = 0; i < sortFields.size(); ++i) {
+    sortChannels.emplace_back(
+        i, velox::exec::exprToChannel(sortFields[i].get(), inputRowType));
+  }
+  return sortChannels;
+}
+} // namespace
+
+BinarySortableSerializer::BinarySortableSerializer(
+    const velox::RowVectorPtr& source,
+    const std::vector<velox::core::SortOrder>& sortOrders,
+    const std::vector<velox::core::FieldAccessTypedExprPtr>& sortFields)
+    : input_(source),
+      sortOrders_(sortOrders),
+      sortChannels_(
+          computeSortChannels(sortFields, velox::asRowType(source->type()))) {
+  VELOX_CHECK_EQ(sortFields.size(), sortOrders_.size());
+}
+
+void BinarySortableSerializer::serialize(
+    velox::vector_size_t rowId,
+    velox::StringVectorBuffer* out) {
+  const auto* rowVector =
+      input_->wrappedVector()->template asUnchecked<velox::RowVector>();
+  const auto wrappedIndex = input_->wrappedIndex(rowId);
+  const auto& children = rowVector->children();
+
+  for (const auto& pair : sortChannels_) {
+    const int32_t idx = pair.first;
+    const auto channel = pair.second;
+    const bool isNullLast = !sortOrders_[idx].isNullsFirst();
+    const bool isDescending = !sortOrders_[idx].isAscending();
+    if (channel >= children.size() || !children[channel]) {
+      writeBool(out, isNullLast);
+    } else {
+      writeBool(out, !isNullLast);
+      serializeSwitch(
+          *children[channel], wrappedIndex, out, isNullLast, isDescending);
+    }
+  }
+}
+
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/BinarySortableSerializer.h
+++ b/presto-native-execution/presto_cpp/main/operators/BinarySortableSerializer.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/StringVectorBuffer.h"
+
+namespace facebook::presto::operators {
+/// BinarySortableSerializer is responsible for serializing sort keys from a
+/// RowVector source. The key is generated so that a
+/// lexicographical sort of the key will produce the ordering.
+///
+/// Based on Hive's BinarySortableSerDe:
+///
+/// BinarySortableSerDe can be used to write data in a way that the data can be
+/// compared byte-by-byte with the same order.
+///
+class BinarySortableSerializer {
+ public:
+  BinarySortableSerializer(
+      const velox::RowVectorPtr& source,
+      const std::vector<velox::core::SortOrder>& sortOrders,
+      const std::vector<velox::core::FieldAccessTypedExprPtr>& sortFields);
+
+  /// Serialize the data into an raw buffer, the caller needs to ensure there
+  /// serialized data won't overflow the buffer.
+  void serialize(velox::vector_size_t rowId, velox::StringVectorBuffer* out);
+
+ private:
+  const velox::RowVectorPtr input_;
+  const std::vector<velox::core::SortOrder> sortOrders_;
+  const std::vector<std::pair<int32_t, velox::column_index_t>> sortChannels_;
+};
+} // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/benchmarks/BinarySortableSerializerBenchmark.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/benchmarks/BinarySortableSerializerBenchmark.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+#include "presto_cpp/main/operators/BinarySortableSerializer.h"
+
+using namespace facebook::velox;
+namespace facebook::presto::operators {
+namespace {
+class BinarySortableSerializerBenchmark {
+ public:
+  void serializeWithStringVectorBuffer(
+      const RowTypePtr& rowType,
+      const std::vector<velox::core::SortOrder>& ordering) {
+    folly::BenchmarkSuspender suspender;
+    auto data = makeData(rowType);
+    auto fields = getFields(rowType);
+    suspender.dismiss();
+
+    BinarySortableSerializer binarySortableSerializer(data, ordering, fields);
+
+    auto vector =
+        velox::BaseVector::create<velox::FlatVector<velox::StringView>>(
+            velox::VARBINARY(), data->size(), pool());
+    // Create a ResizableVectorBuffer with initial and max capacity.
+    velox::StringVectorBuffer buffer(vector.get(), 1024, 1 << 20);
+    serialize(binarySortableSerializer, data->size(), &buffer);
+    VELOX_CHECK_EQ(vector->size(), data->size());
+  }
+
+ private:
+  RowVectorPtr makeData(const RowTypePtr& rowType) {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+
+    const auto seed = 1; // For reproducibility.
+    VectorFuzzer fuzzer(options, pool_.get(), seed);
+
+    return fuzzer.fuzzInputRow(rowType);
+  }
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>>
+  getFields(const RowTypePtr& rowType) {
+    std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>>
+        fieldAccessExprs;
+    for (const auto& fieldName : rowType->names()) {
+      auto fieldExpr = std::make_shared<velox::core::FieldAccessTypedExpr>(
+          rowType->findChild(fieldName), fieldName);
+      fieldAccessExprs.push_back(fieldExpr);
+    }
+    return fieldAccessExprs;
+  }
+
+  void serialize(
+      BinarySortableSerializer binarySortableSerializer,
+      vector_size_t numRows,
+      velox::StringVectorBuffer* out) {
+    for (auto i = 0; i < numRows; ++i) {
+      binarySortableSerializer.serialize(i, out);
+      out->flushRow(i);
+    }
+  }
+
+  memory::MemoryPool* pool() {
+    return pool_.get();
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+};
+
+BENCHMARK(decimalsSerialize) {
+  BinarySortableSerializerBenchmark benchmark;
+
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+
+  benchmark.serializeWithStringVectorBuffer(
+      ROW({BIGINT(), DECIMAL(12, 2), DECIMAL(38, 18)}), ordering);
+}
+
+BENCHMARK(string1Serialize) {
+  BinarySortableSerializerBenchmark benchmark;
+
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kDescNullsFirst)};
+
+  benchmark.serializeWithStringVectorBuffer(
+      ROW({BIGINT(), VARCHAR()}), ordering);
+}
+
+BENCHMARK(strings5Serialize) {
+  BinarySortableSerializerBenchmark benchmark;
+
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast)};
+
+  benchmark.serializeWithStringVectorBuffer(
+      ROW({BIGINT(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR()}),
+      ordering);
+}
+
+BENCHMARK(arraysSerialize) {
+  BinarySortableSerializerBenchmark benchmark;
+
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+
+  benchmark.serializeWithStringVectorBuffer(
+      ROW({BIGINT(), ARRAY(BIGINT())}), ordering);
+}
+
+BENCHMARK(nestedArraysSerialize) {
+  BinarySortableSerializerBenchmark benchmark;
+
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast)};
+
+  benchmark.serializeWithStringVectorBuffer(
+      ROW({BIGINT(), ARRAY(ARRAY(BIGINT()))}), ordering);
+}
+
+BENCHMARK(structsSerialize) {
+  BinarySortableSerializerBenchmark benchmark;
+
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kDescNullsFirst),
+      velox::core::SortOrder(velox::core::kDescNullsFirst)};
+
+  benchmark.serializeWithStringVectorBuffer(
+      ROW({BIGINT(), ROW({BIGINT(), DOUBLE(), BOOLEAN(), TINYINT(), REAL()})}),
+      ordering);
+}
+
+} // namespace
+} // namespace facebook::presto::operators
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/presto-native-execution/presto_cpp/main/operators/benchmarks/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/benchmarks/CMakeLists.txt
@@ -11,27 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(
-  presto_operators
-  PartitionAndSerialize.cpp
-  ShuffleRead.cpp
-  ShuffleWrite.cpp
-  UnsafeRowExchangeSource.cpp
-  LocalPersistentShuffle.cpp
-  BroadcastWrite.cpp
-  BroadcastFactory.cpp
-  BroadcastExchangeSource.cpp
-  BinarySortableSerializer.cpp)
 
+add_executable(binary_sortable_serializer_benchmark
+               BinarySortableSerializerBenchmark.cpp)
 target_link_libraries(
-  presto_operators
-  presto_common
-  velox_core
-  velox_exec
-  velox_presto_serializer
-  velox_vector
-  velox_row_fast)
-
-if(PRESTO_ENABLE_TESTING)
-  add_subdirectory(tests)
-endif()
+  binary_sortable_serializer_benchmark
+  PRIVATE
+    presto_operators
+    velox_vector_fuzzer
+    Folly::folly
+    Folly::follybenchmark)

--- a/presto-native-execution/presto_cpp/main/operators/tests/BinarySortableSerializerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BinarySortableSerializerTest.cpp
@@ -1,0 +1,762 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+
+#include "velox/core/PlanNode.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include "presto_cpp/main/operators/BinarySortableSerializer.h"
+
+namespace facebook::presto::operators::test {
+namespace {
+
+class BinarySortableSerializerTest : public ::testing::Test,
+                                     public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  // return -1 if key1 < key2, 0 if key1 == key2, 1 if key1 > key 2
+  int lexicographicalCompare(std::string key1, std::string key2) {
+    // doing unsinged byte comparison following the Cosco test suite's semantic.
+    auto begin1 = reinterpret_cast<unsigned char*>(key1.data());
+    auto end1 = begin1 + key1.size();
+    auto begin2 = reinterpret_cast<unsigned char*>(key2.data());
+    auto end2 = begin2 + key2.size();
+    bool lessThan = std::lexicographical_compare(begin1, end1, begin2, end2);
+
+    bool equal = std::equal(begin1, end1, begin2, end2);
+
+    return lessThan ? -1 : (equal ? 0 : 1);
+  }
+
+  void serializeRow(
+      BinarySortableSerializer binarySortableSerializer,
+      size_t index,
+      velox::StringVectorBuffer* out) {
+    binarySortableSerializer.serialize(/*rowId=*/index, out);
+    out->flushRow(index);
+  }
+
+  int compareRowVector(
+      const velox::RowVectorPtr& rowVector,
+      const std::vector<
+          std::shared_ptr<const velox::core::FieldAccessTypedExpr>>& fields,
+      const std::vector<velox::core::SortOrder>& ordering) {
+    VELOX_CHECK_EQ(rowVector->size(), 2);
+    BinarySortableSerializer binarySortableSerializer(
+        rowVector, ordering, fields);
+
+    auto vector =
+        velox::BaseVector::create<velox::FlatVector<velox::StringView>>(
+            velox::VARBINARY(), 2, pool_.get());
+    // Create a ResizableVectorBuffer with initial and max capacity.
+    velox::StringVectorBuffer buffer(vector.get(), 10, 1000);
+    serializeRow(binarySortableSerializer, /*index=*/0, &buffer);
+    serializeRow(binarySortableSerializer, /*index=*/1, &buffer);
+
+    return lexicographicalCompare(vector->valueAt(0), vector->valueAt(1));
+  }
+
+  template <typename T>
+  int singlePrimitiveFieldCompare(
+      const std::vector<std::optional<T>>& values,
+      const velox::core::SortOrder& ordering) {
+    VELOX_CHECK_EQ(values.size(), 2);
+    auto c0 = vectorMaker_.flatVectorNullable<T>(values);
+    auto rowVector = vectorMaker_.rowVector({c0});
+
+    std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>>
+        fields;
+    fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+        velox::CppToType<T>::create(), /*name=*/"c0"));
+    return compareRowVector(rowVector, fields, {ordering});
+  }
+
+  template <typename T>
+  int singleArrayFieldCompare(
+      const std::vector<std::optional<std::vector<std::optional<T>>>>& values,
+      const velox::core::SortOrder& ordering) {
+    VELOX_CHECK_EQ(values.size(), 2);
+    auto c0 = makeNullableArrayVector<T>(values);
+    // auto c0 = makeNullableArrayVector<T>(values);
+    auto rowVector = vectorMaker_.rowVector({c0});
+
+    std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>>
+        fields;
+    fields.push_back(std::make_shared<velox::core::FieldAccessTypedExpr>(
+        velox::CppToType<T>::create(), /*name=*/"c0"));
+    return compareRowVector(rowVector, fields, {ordering});
+  }
+
+  template <typename T0, typename T1>
+  int singleRowFieldCompare(
+      const std::vector<std::optional<T0>>& col0,
+      const std::vector<std::optional<T1>>& col1,
+      const velox::core::SortOrder& ordering,
+      const std::function<bool(velox::vector_size_t /* row */)>& isNullAt =
+          nullptr) {
+    VELOX_CHECK_EQ(col0.size(), 2);
+    VELOX_CHECK_EQ(col1.size(), 2);
+    auto c0 = vectorMaker_.flatVectorNullable<T0>(col0);
+    auto c1 = vectorMaker_.flatVectorNullable<T1>(col1);
+    auto rowField = vectorMaker_.rowVector({c0, c1});
+    auto rowVector = vectorMaker_.rowVector({rowField});
+
+    if (isNullAt) {
+      rowVector->childAt(0)->setNull(0, isNullAt(0));
+      rowVector->childAt(0)->setNull(1, isNullAt(1));
+    }
+    std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>>
+        fields;
+    fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+        rowField->type(), /*name=*/"c0"));
+    return compareRowVector(rowVector, fields, {ordering});
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_ =
+      velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  velox::test::VectorMaker vectorMaker_{pool_.get()};
+  std::unique_ptr<velox::StreamArena> streamArena_ =
+      std::make_unique<velox::StreamArena>(pool_.get());
+};
+} // namespace
+
+TEST_F(BinarySortableSerializerTest, LongTypeAllFields) {
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+  auto c0 = vectorMaker_.flatVectorNullable<int64_t>({0, 2});
+  auto c1 = vectorMaker_.flatVectorNullable<int64_t>({1, 1});
+  auto c2 = vectorMaker_.flatVectorNullable<int64_t>({2, 0});
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.reserve(3);
+  for (int32_t i = 0; i < 3; ++i) {
+    fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+        velox::BIGINT(), fmt::format("c{}", i)));
+  }
+  auto rowVector = vectorMaker_.rowVector({c0, c1, c2});
+
+  auto result = compareRowVector(rowVector, fields, ordering);
+
+  // (0,1,2) < (2,1,0)
+  EXPECT_TRUE(result < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, LongTypeAllFieldsDescending) {
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kDescNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+  auto c0 = vectorMaker_.flatVectorNullable<int64_t>({0, 2});
+  auto c1 = vectorMaker_.flatVectorNullable<int64_t>({1, 1});
+  auto c2 = vectorMaker_.flatVectorNullable<int64_t>({2, 0});
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.reserve(3);
+  for (int32_t i = 0; i < 3; ++i) {
+    fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+        velox::BIGINT(), fmt::format("c{}", i)));
+  }
+  auto rowVector = vectorMaker_.rowVector({c0, c1, c2});
+
+  auto result = compareRowVector(rowVector, fields, ordering);
+
+  // (0d,1,2) > (2d,1,0)
+  EXPECT_TRUE(result > 0);
+}
+
+TEST_F(BinarySortableSerializerTest, LongTypeAllFieldsWithNulls) {
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+  auto c0 =
+      vectorMaker_.flatVectorNullable<int64_t>({std::nullopt, std::nullopt});
+  auto c1 =
+      vectorMaker_.flatVectorNullable<int64_t>({std::nullopt, std::nullopt});
+  auto c2 = vectorMaker_.flatVectorNullable<int64_t>({2, 0});
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.reserve(3);
+  for (int32_t i = 0; i < 3; ++i) {
+    fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+        velox::BIGINT(), fmt::format("c{}", i)));
+  }
+  auto rowVector = vectorMaker_.rowVector({c0, c1, c2});
+
+  auto result = compareRowVector(rowVector, fields, ordering);
+
+  // (null,null,2) > (null,null,0)
+  EXPECT_TRUE(result > 0);
+}
+
+TEST_F(BinarySortableSerializerTest, DefaultNullsOrdering) {
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+  auto c0 =
+      vectorMaker_.flatVectorNullable<int64_t>({std::nullopt, std::nullopt});
+  auto c1 =
+      vectorMaker_.flatVectorNullable<int64_t>({std::nullopt, std::nullopt});
+  auto c2 = vectorMaker_.flatVectorNullable<int64_t>({0, std::nullopt});
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.reserve(3);
+  for (int32_t i = 0; i < 3; ++i) {
+    fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+        velox::BIGINT(), fmt::format("c{}", i)));
+  }
+  auto rowVector = vectorMaker_.rowVector({c0, c1, c2});
+
+  auto result = compareRowVector(rowVector, fields, ordering);
+
+  // (null,null,0) > (null,null,null)
+  EXPECT_TRUE(result > 0);
+}
+
+TEST_F(
+    BinarySortableSerializerTest,
+    ExplicitNullsOrdering_ascending_nulls_last) {
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsLast)};
+  auto c0 =
+      vectorMaker_.flatVectorNullable<int64_t>({std::nullopt, std::nullopt});
+  auto c1 =
+      vectorMaker_.flatVectorNullable<int64_t>({std::nullopt, std::nullopt});
+  auto c2 = vectorMaker_.flatVectorNullable<int64_t>({0, std::nullopt});
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.reserve(3);
+  for (int32_t i = 0; i < 3; ++i) {
+    fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+        velox::BIGINT(), fmt::format("c{}", i)));
+  }
+  auto rowVector = vectorMaker_.rowVector({c0, c1, c2});
+
+  auto result = compareRowVector(rowVector, fields, ordering);
+
+  // (null,null,0) < (null,null,null)
+  EXPECT_TRUE(result < 0);
+}
+
+TEST_F(
+    BinarySortableSerializerTest,
+    ExplicitNullsOrdering_descending_nulls_last) {
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kDescNullsLast),
+      velox::core::SortOrder(velox::core::kDescNullsLast),
+      velox::core::SortOrder(velox::core::kDescNullsLast)};
+  auto c0 =
+      vectorMaker_.flatVectorNullable<int64_t>({std::nullopt, std::nullopt});
+  auto c1 =
+      vectorMaker_.flatVectorNullable<int64_t>({std::nullopt, std::nullopt});
+  auto c2 = vectorMaker_.flatVectorNullable<int64_t>({0, std::nullopt});
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.reserve(3);
+  for (int32_t i = 0; i < 3; ++i) {
+    fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+        velox::BIGINT(), fmt::format("c{}", i)));
+  }
+  auto rowVector = vectorMaker_.rowVector({c0, c1, c2});
+
+  auto result = compareRowVector(rowVector, fields, ordering);
+
+  // (null,null,0) < (null,null,null)
+  EXPECT_TRUE(result < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, LongTypeSubsetOfFields) {
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+
+  auto c0 = vectorMaker_.flatVectorNullable<int64_t>({0, 2});
+  auto c1 = vectorMaker_.flatVectorNullable<int64_t>({1, 1});
+  auto c2 = vectorMaker_.flatVectorNullable<int64_t>({2, 0});
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+      velox::BIGINT(), /*name=*/"c2"));
+  fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+      velox::BIGINT(), /*name=*/"c0"));
+
+  auto rowVector = vectorMaker_.rowVector({c0, c1, c2});
+
+  auto result = compareRowVector(rowVector, fields, ordering);
+
+  // (2, 0) > (0, 2)
+  EXPECT_TRUE(result > 0);
+}
+
+TEST_F(BinarySortableSerializerTest, ComplexTypeDictionaryEncoded) {
+  auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields =
+      {
+          std::make_shared<const velox::core::FieldAccessTypedExpr>(
+              velox::ROW(
+                  {"f0", "f1", "f2"},
+                  {velox::BIGINT(), velox::BIGINT(), velox::BIGINT()}),
+              "c0"),
+          std::make_shared<const velox::core::FieldAccessTypedExpr>(
+              velox::ARRAY(velox::INTEGER()), "c1"),
+      };
+
+  auto c0 = vectorMaker_.flatVectorNullable<int64_t>({0, 2});
+  auto c1 = vectorMaker_.flatVectorNullable<int64_t>({1, 1});
+  auto c2 = vectorMaker_.flatVectorNullable<int64_t>({2, 0});
+
+  auto baseRow = vectorMaker_.rowVector({"f0", "f1", "f2"}, {c0, c1, c2});
+  auto baseArray = makeArrayVector<int32_t>({{1, 2, 3}, {4, 5, 6}});
+  auto rowVector = vectorMaker_.rowVector(
+      {"c0", "c1"},
+      {
+          velox::BaseVector::wrapInDictionary(
+              nullptr, makeIndicesInReverse(2), 2, baseRow),
+          velox::BaseVector::wrapInDictionary(
+              nullptr, makeIndicesInReverse(2), 2, baseArray),
+      });
+
+  auto result = compareRowVector(rowVector, fields, ordering);
+
+  // 0: {{0, 1, 2}, [1, 2, 3]} < 1: {{2, 1, 0}, [4, 5,6]}
+  // the dictionary indices are reversed, so result is > 0.
+  EXPECT_TRUE(result > 0);
+}
+
+TEST_F(BinarySortableSerializerTest, BooleanTypeSingleFieldTests) {
+  // true == true
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<bool>(
+          {true, true}, velox::core::kAscNullsFirst) == 0);
+
+  // false < true
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<bool>(
+          {false, true}, velox::core::kAscNullsFirst) < 0);
+
+  // true < false (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<bool>(
+          {true, false}, velox::core::kDescNullsLast) < 0);
+
+  // null < false
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<bool>(
+          {std::nullopt, false}, velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, DoubleTypeSingleFieldTests) {
+  // 0.1 == 0.1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<double>(
+          {0.1, 0.1}, velox::core::kAscNullsFirst) == 0);
+
+  // 0.01 < 0.1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<double>(
+          {0.01, 0.1}, velox::core::kAscNullsFirst) < 0);
+
+  // 0.1 < 0.01 (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<double>(
+          {0.1, 0.01}, velox::core::kDescNullsLast) < 0);
+
+  // Double.NaN == Double.NaN
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<double>(
+          {std::numeric_limits<double>::quiet_NaN(),
+           std::numeric_limits<double>::quiet_NaN()},
+          velox::core::kAscNullsFirst) == 0);
+
+  // null < Double.NaN
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<double>(
+          {std::nullopt, std::numeric_limits<double>::quiet_NaN()},
+          velox::core::kAscNullsFirst) < 0);
+
+  // null < Double.MinValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<double>(
+          {std::nullopt, std::numeric_limits<double>::min()},
+          velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, FloatTypeSingleFieldTests) {
+  // 0.1 == 0.1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<float>(
+          {0.1f, 0.1f}, velox::core::kAscNullsFirst) == 0);
+
+  // 0.01 < 0.1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<float>(
+          {0.01f, 0.1f}, velox::core::kAscNullsFirst) < 0);
+
+  // 0.1 < 0.01 (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<float>(
+          {0.1f, 0.01f}, velox::core::kDescNullsLast) < 0);
+
+  // Float.NaN == Float.NaN
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<float>(
+          {std::numeric_limits<float>::quiet_NaN(),
+           std::numeric_limits<float>::quiet_NaN()},
+          velox::core::kAscNullsFirst) == 0);
+
+  // null < Float.NaN
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<float>(
+          {std::nullopt, std::numeric_limits<float>::quiet_NaN()},
+          velox::core::kAscNullsFirst) < 0);
+
+  // null < Float.MinValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<float>(
+          {std::nullopt, std::numeric_limits<float>::min()},
+          velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, ByteTypeSingleFieldTests) {
+  // 1 == 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int8_t>(
+          {1, 1}, velox::core::kAscNullsFirst) == 0);
+
+  // 1 < 2
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int8_t>({1, 2}, velox::core::kAscNullsFirst) <
+      0);
+
+  // 2 < 1 (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int8_t>({2, 1}, velox::core::kDescNullsLast) <
+      0);
+
+  // Byte.MinValue < Byte.MaxValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int8_t>(
+          {std::numeric_limits<int8_t>::min(),
+           std::numeric_limits<int8_t>::max()},
+          velox::core::kAscNullsFirst) < 0);
+
+  // Byte.MaxValue < Byte.MinValue (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int8_t>(
+          {std::numeric_limits<int8_t>::min(),
+           std::numeric_limits<int8_t>::max()},
+          velox::core::kDescNullsLast) > 0);
+
+  // null < 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int8_t>(
+          {std::nullopt, 1}, velox::core::kAscNullsFirst) < 0);
+
+  // null < Byte.MinValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int8_t>(
+          {std::nullopt, std::numeric_limits<int8_t>::min()},
+          velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, ShortTypeSingleFieldTests) {
+  // 1 == 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int16_t>(
+          {1, 1}, velox::core::kAscNullsFirst) == 0);
+
+  // 1 < 2
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int16_t>(
+          {1, 2}, velox::core::kAscNullsFirst) < 0);
+
+  // 2 < 1 (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int16_t>(
+          {2, 1}, velox::core::kDescNullsLast) < 0);
+
+  // Short.MinValue < Short.MaxValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int16_t>(
+          {std::numeric_limits<int16_t>::min(),
+           std::numeric_limits<int16_t>::max()},
+          velox::core::kAscNullsFirst) < 0);
+
+  // Short.MaxValue < Short.MinValue (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int16_t>(
+          {std::numeric_limits<int16_t>::min(),
+           std::numeric_limits<int16_t>::max()},
+          velox::core::kDescNullsLast) > 0);
+
+  // null < 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int16_t>(
+          {std::nullopt, 1}, velox::core::kAscNullsFirst) < 0);
+
+  // null < Short.MinValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int16_t>(
+          {std::nullopt, std::numeric_limits<int16_t>::min()},
+          velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, IntegerTypeSingleFieldTests) {
+  // 1 == 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {1, 1}, velox::core::kAscNullsFirst) == 0);
+
+  // 1 < 2
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {1, 2}, velox::core::kAscNullsFirst) < 0);
+
+  // 2 < 1 (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {2, 1}, velox::core::kDescNullsLast) < 0);
+
+  // Int.MinValue < Int.MaxValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {std::numeric_limits<int32_t>::min(),
+           std::numeric_limits<int32_t>::max()},
+          velox::core::kAscNullsFirst) < 0);
+
+  // Int.MaxValue < Int.MinValue (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {std::numeric_limits<int32_t>::min(),
+           std::numeric_limits<int32_t>::max()},
+          velox::core::kDescNullsLast) > 0);
+
+  // null < 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {std::nullopt, 1}, velox::core::kAscNullsFirst) < 0);
+
+  // null < Int.MinValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {std::nullopt, std::numeric_limits<int32_t>::min()},
+          velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, DateTypeSingleFieldTests) {
+  // 1 == 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {1, 1}, velox::core::kAscNullsFirst) == 0);
+
+  // 1 < 2
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {1, 2}, velox::core::kAscNullsFirst) < 0);
+
+  // 2 < 1 (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {2, 1}, velox::core::kDescNullsLast) < 0);
+
+  // null < 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int32_t>(
+          {std::nullopt, 1}, velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, LongTypeSingleFieldTests) {
+  // 1 == 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int64_t>(
+          {1, 1}, velox::core::kAscNullsFirst) == 0);
+
+  // 1 < 2
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int64_t>(
+          {1, 2}, velox::core::kAscNullsFirst) < 0);
+
+  // 2 < 1 (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int64_t>(
+          {2, 1}, velox::core::kDescNullsLast) < 0);
+
+  // Long.MinValue < Long.MaxValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int64_t>(
+          {std::numeric_limits<int64_t>::min(),
+           std::numeric_limits<int64_t>::max()},
+          velox::core::kAscNullsFirst) < 0);
+
+  // Long.MaxValue < Long.MinValue (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int64_t>(
+          {std::numeric_limits<int64_t>::min(),
+           std::numeric_limits<int64_t>::max()},
+          velox::core::kDescNullsLast) > 0);
+
+  // null < 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int64_t>(
+          {std::nullopt, 1}, velox::core::kAscNullsFirst) < 0);
+
+  // null < Long.MinValue
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<int64_t>(
+          {std::nullopt, std::numeric_limits<int64_t>::min()},
+          velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, TimestampTypeSingleFieldTests) {
+  // 1 == 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<velox::Timestamp>(
+          {velox::Timestamp::fromMicros(1), velox::Timestamp::fromMicros(1)},
+          velox::core::kAscNullsFirst) == 0);
+
+  // 1 < 2
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<velox::Timestamp>(
+          {velox::Timestamp::fromMicros(1), velox::Timestamp::fromMicros(2)},
+          velox::core::kAscNullsFirst) < 0);
+
+  // 2 < 1 (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<velox::Timestamp>(
+          {velox::Timestamp::fromMicros(2), velox::Timestamp::fromMicros(1)},
+          velox::core::kDescNullsLast) < 0);
+
+  // null < 1
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<velox::Timestamp>(
+          {std::nullopt, velox::Timestamp::fromMicros(1)},
+          velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, StringTypeSingleFieldTests) {
+  // "abc" == "abc"
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<std::string>(
+          {"abc", "abc"}, velox::core::kAscNullsFirst) == 0);
+
+  // "aaa" < "abc"
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<std::string>(
+          {"aaa", "abc"}, velox::core::kAscNullsFirst) < 0);
+
+  // "aaa" < "aaaa"
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<std::string>(
+          {"aaa", "aaaa"}, velox::core::kAscNullsFirst) < 0);
+
+  // "abc" < "aaa" (descending)
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<std::string>(
+          {"abc", "aaa"}, velox::core::kDescNullsLast) < 0);
+
+  // null < ""
+  EXPECT_TRUE(
+      singlePrimitiveFieldCompare<std::string>(
+          {std::nullopt, ""}, velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, ArrayTypeSingleFieldTests) {
+  // [1, 1] == [1, 1]
+  EXPECT_TRUE(
+      singleArrayFieldCompare<int64_t>(
+          {{{1L, 1L}}, {{1L, 1L}}}, velox::core::kAscNullsFirst) == 0);
+
+  // [1, 1] < [1, 1, 1]
+  EXPECT_TRUE(
+      singleArrayFieldCompare<int64_t>(
+          {{{1L, 1L}}, {{1L, 1L, 1L}}}, velox::core::kAscNullsFirst) < 0);
+
+  // [1, 1, 1] < [1, 1] (descending)
+  EXPECT_TRUE(
+      singleArrayFieldCompare<int64_t>(
+          {{{1L, 1L, 1L}}, {{1L, 1L}}}, velox::core::kDescNullsLast) < 0);
+
+  // [1, 1, 1] < [1, 2]
+  EXPECT_TRUE(
+      singleArrayFieldCompare<int64_t>(
+          {{{1L, 1L, 1L}}, {{1L, 2L}}}, velox::core::kAscNullsFirst) < 0);
+
+  //[ 1, null, 1 ] < [ 1, 0, 1 ]
+  EXPECT_TRUE(
+      singleArrayFieldCompare<int64_t>(
+          {{{1L, std::nullopt, 1L}}, {{1L, 0L, 1L}}},
+          velox::core::kAscNullsFirst) < 0);
+
+  // null < [1]
+  EXPECT_TRUE(
+      singleArrayFieldCompare<int64_t>(
+          {std::nullopt, {{1L}}}, velox::core::kAscNullsFirst) < 0);
+
+  // null < [null]
+  std::vector<std::optional<int64_t>> arrayWithNull{std::nullopt};
+  EXPECT_TRUE(
+      singleArrayFieldCompare<int64_t>(
+          {std::nullopt, arrayWithNull}, velox::core::kAscNullsFirst) < 0);
+
+  // null < []
+  EXPECT_TRUE(
+      singleArrayFieldCompare<int64_t>(
+          {std::nullopt, {{}}}, velox::core::kAscNullsFirst) < 0);
+}
+
+TEST_F(BinarySortableSerializerTest, RowTypeSingleFieldTests) {
+  // (1, "aaa") == (1, "aaa")
+  int cmp = singleRowFieldCompare<int64_t, std::string>(
+      {1L, 1L}, {"aaa", "aaa"}, velox::core::kAscNullsFirst);
+  EXPECT_TRUE(cmp == 0);
+
+  // (1, "aaa") < (1, "abc")
+  cmp = singleRowFieldCompare<int64_t, std::string>(
+      {1L, 1L}, {"aaa", "abc"}, velox::core::kAscNullsFirst);
+  EXPECT_TRUE(cmp < 0);
+
+  // (1, "abc") < (1, "aaa") (descending)
+  cmp = singleRowFieldCompare<int64_t, std::string>(
+      {1L, 1L}, {"aaa", "abc"}, velox::core::kDescNullsLast);
+  EXPECT_TRUE(cmp > 0);
+
+  // (1, null) < (1, "abc")
+  cmp = singleRowFieldCompare<int64_t, std::string>(
+      {1L, 1L}, {std::nullopt, "abc"}, velox::core::kAscNullsFirst);
+  EXPECT_TRUE(cmp < 0);
+
+  // null < (null, null)
+  cmp = singleRowFieldCompare<int64_t, std::string>(
+      {std::nullopt, std::nullopt},
+      {std::nullopt, std::nullopt},
+      velox::core::kAscNullsFirst,
+      [](velox::vector_size_t row) { return row == 0 ? true : false; });
+  EXPECT_TRUE(cmp < 0);
+}
+} // namespace facebook::presto::operators::test

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -14,7 +14,9 @@ add_library(presto_operators_plan_builder PlanBuilder.cpp)
 target_link_libraries(presto_operators_plan_builder velox_core)
 
 add_executable(presto_operators_test PlanNodeSerdeTest.cpp
-                                     UnsafeRowShuffleTest.cpp BroadcastTest.cpp)
+                                     UnsafeRowShuffleTest.cpp
+                                     BroadcastTest.cpp
+                                     BinarySortableSerializerTest.cpp)
 
 add_test(presto_operators_test presto_operators_test)
 


### PR DESCRIPTION
Summary:
Support sorted shuffle write in Sapphire-Velox stack: 
- Copy the key value serializer: `fbcode/spark_cpp/src/main/serializer/CoscoKeyValueSerializer.h` from Spruce to `github/presto-trunk/presto-native-execution/presto_cpp/main/operators/KeyValueSerializer.h` 
This is so that we don't have dependency on the internal implementation. 

- Allow PartitionAndSerialize Node to take `sortingOrder and `sortingKeys` as optional parameters. 

- If both `sortingOrder and `sortingKeys` are provided, serialize the Keys and invoke Cosco sorted shuffle by providing an non-empty key.

Differential Revision: D71236519


