### PR TITLE
Fix duplicate class and dependency problem

### DIFF
--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -86,6 +86,17 @@
             <artifactId>okhttp-urlconnection</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-jvm</artifactId>
+        </dependency>
+
+        <!-- pull up to the version used in okio-jvm to avoid conlict with okhttp-* -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -127,6 +138,7 @@
                     <ignoredUnusedDeclaredDependencies>
                         <!-- This is needed to keep Okio in the build and prevent conflicts with OkHttp and Kotlin dependencies. -->
                         <ignoredUnusedDeclaredDependency>com.squareup.okio:okio-jvm</ignoredUnusedDeclaredDependency>
+                        <ignoredUnusedDeclaredDependency>org.jetbrains.kotlin:kotlin-stdlib-jdk8</ignoredUnusedDeclaredDependency>
                     </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -268,6 +268,10 @@
                                     <shadedPattern>${shadeBase}.commonMain.okio</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>okhttp.internal.tls</pattern>
+                                    <shadedPattern>${shadeBase}.okhttp.internal.tls</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>kotlin</pattern>
                                     <shadedPattern>${shadeBase}.kotlin</shadedPattern>
                                 </relocation>


### PR DESCRIPTION
## Description
Shade duplicate classes coming from presto-client & presto-jdbc
Explicitly add dependency to okio-jvm &  kotlin-stdlib-jdk8 which causes conflict with internal build

## Test Plan
Presto & internal build succeeds

```
== NO RELEASE NOTE ==
```

