### PR TITLE
Add unified check logic for permissions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -32,13 +32,11 @@ import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.SessionSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
-import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.AnalyzerOptions;
 import com.facebook.presto.spi.analyzer.QueryPreparerProvider;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.facebook.presto.spi.resourceGroups.SelectionCriteria;
 import com.facebook.presto.spi.security.AccessControl;
-import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.AbstractFuture;
@@ -96,7 +94,7 @@ public class DispatchManager
 
     /**
      * Dispatch Manager is used for the pre-queuing part of queries prior to the query execution phase.
-     *
+     * <p>
      * Dispatch Manager object is instantiated when the presto server is launched by server bootstrap time. It is a critical component in resource management section of the query.
      *
      * @param queryIdGenerator query ID generator for generating a new query ID when a query is created
@@ -183,7 +181,7 @@ public class DispatchManager
 
     /**
      * Create a query id
-     *
+     * <p>
      * This method is called when a {@code Query} object is created
      *
      * @return {@link QueryId}
@@ -272,20 +270,8 @@ public class DispatchManager
             }
 
             // decode session
-            sessionBuilder = sessionSupplier.createSessionBuilder(queryId, sessionContext, warningCollectorFactory);
+            sessionBuilder = sessionSupplier.createSessionBuilder(queryId, sessionContext, warningCollectorFactory, query);
 
-            AccessControlContext accessControlContext = new AccessControlContext(
-                    queryId,
-                    Optional.ofNullable(sessionContext.getClientInfo()),
-                    sessionContext.getClientTags(),
-                    Optional.ofNullable(sessionContext.getSource()),
-                    WarningCollector.NOOP,
-                    sessionContext.getRuntimeStats(),
-                    Optional.empty(),
-                    Optional.ofNullable(sessionContext.getCatalog()),
-                    Optional.ofNullable(sessionContext.getSchema()));
-
-            accessControl.checkQueryIntegrity(sessionContext.getIdentity(), accessControlContext, query);
             session = sessionBuilder.build();
 
             // prepare query
@@ -392,7 +378,6 @@ public class DispatchManager
 
     /**
      * Return a list of {@link BasicQueryInfo}.
-     *
      */
     public List<BasicQueryInfo> getQueries()
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -799,12 +799,6 @@ public class AccessControlManager
     }
 
     @Override
-    public boolean isUnifiedPermissionsCheckEnabled(Identity identity)
-    {
-        return systemAccessControl.get().isUnifiedPermissionsCheckEnabled(identity);
-    }
-
-    @Override
     public boolean isSkipPermissionsCheckEnabled()
     {
         return systemAccessControl.get().isSkipPermissionsCheckEnabled();

--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -798,6 +798,18 @@ public class AccessControlManager
         }
     }
 
+    @Override
+    public boolean isUnifiedPermissionsCheckEnabled(Identity identity)
+    {
+        return systemAccessControl.get().isUnifiedPermissionsCheckEnabled(identity);
+    }
+
+    @Override
+    public boolean isSkipPermissionsCheckEnabled()
+    {
+        return systemAccessControl.get().isSkipPermissionsCheckEnabled();
+    }
+
     private CatalogAccessControlEntry getConnectorAccessControl(TransactionId transactionId, String catalogName)
     {
         return transactionManager.getOptionalCatalogMetadata(transactionId, catalogName)

--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlUtils.java
@@ -29,6 +29,36 @@ public class AccessControlUtils
 {
     private AccessControlUtils() {}
 
+    public static boolean isUnifiedPermissionsCheckEnabled(AccessControl accessControl, SessionContext sessionContext)
+    {
+        Identity identity = sessionContext.getIdentity();
+        return accessControl.isUnifiedPermissionsCheckEnabled(identity);
+    }
+
+    public static boolean isSkipPermissionsCheckEnabled(AccessControl accessControl)
+    {
+        return accessControl.isSkipPermissionsCheckEnabled();
+    }
+
+    public static void validateQueryToken(AccessControl accessControl, QueryId queryId, SessionContext sessionContext, String query)
+    {
+        Identity identity = sessionContext.getIdentity();
+        accessControl.checkQueryIntegrity(
+                identity,
+                new AccessControlContext(
+                        queryId,
+                        Optional.ofNullable(sessionContext.getClientInfo()),
+                        sessionContext.getClientTags(),
+                        Optional.ofNullable(sessionContext.getSource()),
+                        WarningCollector.NOOP,
+                        sessionContext.getRuntimeStats(),
+                        Optional.empty(),
+                        Optional.ofNullable(sessionContext.getCatalog()),
+                        Optional.ofNullable(sessionContext.getSchema())),
+                query
+        );
+    }
+
     /**
      * Uses checkCanSetUser API to check delegation permissions
      *

--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlUtils.java
@@ -29,12 +29,6 @@ public class AccessControlUtils
 {
     private AccessControlUtils() {}
 
-    public static boolean isUnifiedPermissionsCheckEnabled(AccessControl accessControl, SessionContext sessionContext)
-    {
-        Identity identity = sessionContext.getIdentity();
-        return accessControl.isUnifiedPermissionsCheckEnabled(identity);
-    }
-
     public static boolean isSkipPermissionsCheckEnabled(AccessControl accessControl)
     {
         return accessControl.isSkipPermissionsCheckEnabled();
@@ -55,8 +49,7 @@ public class AccessControlUtils
                         Optional.empty(),
                         Optional.ofNullable(sessionContext.getCatalog()),
                         Optional.ofNullable(sessionContext.getSchema())),
-                query
-        );
+                query);
     }
 
     /**

--- a/presto-main-base/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
@@ -231,4 +231,11 @@ public class AllowAllSystemAccessControl
     public void checkCanAddConstraint(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
     {
     }
+
+    @Override
+    public boolean isSkipPermissionsCheckEnabled()
+    {
+        // Need to override
+        return false;
+    }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -450,6 +450,13 @@ public class FileBasedSystemAccessControl
         }
     }
 
+    @Override
+    public boolean isSkipPermissionsCheckEnabled()
+    {
+        // Need to override
+        return false;
+    }
+
     private boolean isSchemaOwner(Identity identity, CatalogSchemaName schema)
     {
         if (!canAccessCatalog(identity, schema.getCatalogName(), ALL)) {

--- a/presto-main-base/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/NoOpSessionSupplier.java
@@ -26,13 +26,13 @@ public class NoOpSessionSupplier
         implements SessionSupplier
 {
     @Override
-    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
+    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, String query)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
+    public SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, String query)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -77,9 +77,9 @@ public class QuerySessionSupplier
     }
 
     @Override
-    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory)
+    public Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, String query)
     {
-        Session session = createSessionBuilder(queryId, context, warningCollectorFactory).build();
+        Session session = createSessionBuilder(queryId, context, warningCollectorFactory, query).build();
         if (context.getTransactionId().isPresent()) {
             session = session.beginTransactionId(context.getTransactionId().get(), transactionManager, accessControl);
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -43,7 +43,6 @@ import static com.facebook.presto.common.type.TimeZoneKey.getTimeZoneKey;
 import static com.facebook.presto.security.AccessControlUtils.checkPermissions;
 import static com.facebook.presto.security.AccessControlUtils.getAuthorizedIdentity;
 import static com.facebook.presto.security.AccessControlUtils.isSkipPermissionsCheckEnabled;
-import static com.facebook.presto.security.AccessControlUtils.isUnifiedPermissionsCheckEnabled;
 import static com.facebook.presto.security.AccessControlUtils.validateQueryToken;
 import static java.util.Map.Entry;
 import static java.util.Objects.requireNonNull;

--- a/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -146,18 +146,15 @@ public class QuerySessionSupplier
 
     private Identity authenticateIdentity(QueryId queryId, SessionContext context, String query)
     {
+        try {
+            validateQueryToken(accessControl, queryId, context, query);
 
-        if (isUnifiedPermissionsCheckEnabled(accessControl, context)) {
-            try {
-                validateQueryToken(accessControl, queryId, context, query);
-
-                if (isSkipPermissionsCheckEnabled(accessControl)) {
-                    return context.getIdentity();
-                }
+            if (isSkipPermissionsCheckEnabled(accessControl)) {
+                return context.getIdentity();
             }
-            catch (Exception e) {
-                logUnifiedPermissionsCheckFailure();
-            }
+        }
+        catch (Exception e) {
+            logUnifiedPermissionsCheckFailure();
         }
 
         checkPermissions(accessControl, securityConfig, queryId, context);

--- a/presto-main-base/src/main/java/com/facebook/presto/server/SessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/SessionSupplier.java
@@ -24,4 +24,6 @@ public interface SessionSupplier
     Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
 
     SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
+
+    SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, String query);
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/SessionSupplier.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/SessionSupplier.java
@@ -21,9 +21,7 @@ import static com.facebook.presto.Session.SessionBuilder;
 
 public interface SessionSupplier
 {
-    Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
-
-    SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory);
+    Session createSession(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, String query);
 
     SessionBuilder createSessionBuilder(QueryId queryId, SessionContext context, WarningCollectorFactory warningCollectorFactory, String query);
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQuerySessionSupplier.java
@@ -104,7 +104,7 @@ public class TestQuerySessionSupplier
                 return WarningCollector.NOOP;
             }
         };
-        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory);
+        Session session = sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory, "select * from test");
 
         assertEquals(session.getQueryId(), new QueryId("test_query_id"));
         assertEquals(session.getUser(), "testUser");
@@ -178,6 +178,6 @@ public class TestQuerySessionSupplier
                 return WarningCollector.NOOP;
             }
         };
-        sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory);
+        sessionSupplier.createSession(new QueryId("test_query_id"), context, warningCollectorFactory, "select * from test");
     }
 }

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
@@ -253,4 +253,11 @@ public abstract class ForwardingSystemAccessControl
     {
         delegate().checkCanAddConstraint(identity, context, table);
     }
+
+    @Override
+    public boolean isSkipPermissionsCheckEnabled()
+    {
+        // Need to override
+        return false;
+    }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -612,7 +612,7 @@ public class PrestoSparkQueryExecutionFactory
                 credentialsProviders,
                 authenticatorProviders);
 
-        SessionBuilder sessionBuilder = sessionSupplier.createSessionBuilder(queryId, sessionContext, warningCollectorFactory);
+        SessionBuilder sessionBuilder = sessionSupplier.createSessionBuilder(queryId, sessionContext, warningCollectorFactory, sql);
         sessionPropertyDefaults.applyDefaultProperties(sessionBuilder, Optional.empty(), Optional.empty());
 
         if (!executionStrategies.isEmpty()) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControl.java
@@ -326,7 +326,5 @@ public interface AccessControl
      */
     void checkCanAddConstraints(TransactionId transactionId, Identity identity, AccessControlContext context, QualifiedObjectName constraintName);
 
-    boolean isUnifiedPermissionsCheckEnabled(Identity identity);
-
     boolean isSkipPermissionsCheckEnabled();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControl.java
@@ -42,6 +42,7 @@ public interface AccessControl
 
     /**
      * Check if the query is unexpectedly modified using the credentials passed in the identity.
+     *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if query is modified.
      */
     void checkQueryIntegrity(Identity identity, AccessControlContext context, String query);
@@ -245,11 +246,12 @@ public interface AccessControl
     /**
      * Check if identity is allowed to select from the specified columns.
      * For columns with type row, subfields are provided. The column set can be empty.
-     *
+     * <p>
      * For example, "SELECT col1.field, col2 from table" will have:
      * columnOrSubfieldNames = [col1.field, col2]
-     *
+     * <p>
      * Implementations can choose which to use
+     *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
     void checkCanSelectFromColumns(TransactionId transactionId, Identity identity, AccessControlContext context, QualifiedObjectName tableName, Set<Subfield> columnOrSubfieldNames);
@@ -291,6 +293,7 @@ public interface AccessControl
 
     /**
      * Check if identity is allowed to show roles on the specified catalog.
+     *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
     void checkCanShowRoles(TransactionId transactionId, Identity identity, AccessControlContext context, String catalogName);
@@ -322,4 +325,8 @@ public interface AccessControl
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
     void checkCanAddConstraints(TransactionId transactionId, Identity identity, AccessControlContext context, QualifiedObjectName constraintName);
+
+    boolean isUnifiedPermissionsCheckEnabled(Identity identity);
+
+    boolean isSkipPermissionsCheckEnabled();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AllowAllAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AllowAllAccessControl.java
@@ -236,12 +236,6 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public boolean isUnifiedPermissionsCheckEnabled(Identity identity)
-    {
-        return false;
-    }
-
-    @Override
     public boolean isSkipPermissionsCheckEnabled()
     {
         return false;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AllowAllAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AllowAllAccessControl.java
@@ -234,4 +234,16 @@ public class AllowAllAccessControl
     public void checkCanAddConstraints(TransactionId transactionId, Identity identity, AccessControlContext context, QualifiedObjectName tableName)
     {
     }
+
+    @Override
+    public boolean isUnifiedPermissionsCheckEnabled(Identity identity)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isSkipPermissionsCheckEnabled()
+    {
+        return false;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/DenyAllAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/DenyAllAccessControl.java
@@ -317,12 +317,6 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public boolean isUnifiedPermissionsCheckEnabled(Identity identity)
-    {
-        return false;
-    }
-
-    @Override
     public boolean isSkipPermissionsCheckEnabled()
     {
         return false;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/DenyAllAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/DenyAllAccessControl.java
@@ -315,4 +315,16 @@ public class DenyAllAccessControl
     {
         denyAddConstraint(tableName.toString());
     }
+
+    @Override
+    public boolean isUnifiedPermissionsCheckEnabled(Identity identity)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isSkipPermissionsCheckEnabled()
+    {
+        return false;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -380,4 +380,8 @@ public interface SystemAccessControl
     {
         denyAddConstraint(table.toString());
     }
+
+    default boolean isUnifiedPermissionsCheckEnabled(Identity identity) {return false;}
+
+    default boolean isSkipPermissionsCheckEnabled() {return false;}
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -381,7 +381,13 @@ public interface SystemAccessControl
         denyAddConstraint(table.toString());
     }
 
-    default boolean isUnifiedPermissionsCheckEnabled(Identity identity) {return false;}
+    default boolean isUnifiedPermissionsCheckEnabled(Identity identity)
+    {
+        return false;
+    }
 
-    default boolean isSkipPermissionsCheckEnabled() {return false;}
+    default boolean isSkipPermissionsCheckEnabled()
+    {
+        return false;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -381,11 +381,6 @@ public interface SystemAccessControl
         denyAddConstraint(table.toString());
     }
 
-    default boolean isUnifiedPermissionsCheckEnabled(Identity identity)
-    {
-        return false;
-    }
-
     default boolean isSkipPermissionsCheckEnabled()
     {
         return false;


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This change will allow for the functionality of skipping accessControl calls if a checkQueryIntegrity is successful. checkQueryIntegrity is where a unified permissions check will occur, and if it is successful, it will skip all other authentication and authorization checks like checkPermissions under QuerySessionSupplier.java, and checks like checkCanSelectFromColumns, etc.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Currently, Presto authentication and authorization happens in different phases of the query execution. Authentication happens during dispatch in checkPermissions in QuerySessionSupplier.java, which is before the queuing phase. The authorization checks, like checkCanSelectFromColumns will happen after the queuing phase. By utilizing the result from the unified permissions check under checkQueryIntegrity, all the permission check can be done at once.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
- Gating this feature under isSkipPermissionsCheckEnabled configuration flag. If the flag is true, and the result of validateQueryToken is successful, then all other existing permissions checks get skipped

- Followup to this task is to determine the best place to have the validateQueryToken call. Currently, it will be in the same place as checkPermissions so that it can be skipped if the validateQueryToken call is successful. But it could be better for security purposes to move it after queuing phase in case a view definition changes during queuing phase, which can introduce a security loophole. This is because view definitions is retrieved after queuing. However, this can be addressed in a followup task. Currently, validateQueryToken will only be used for logging purposes, and its result will not be utilized.

## Test Plan
<!---Please fill in how you tested your change-->
Use HiveQueryRunner with debugger enabled. Set breakpoints in QuerySessionSupplier to see coverage on validateQueryToken usage
## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add synchronous shadow call to unified permission check, which can be used to skip existing permissions check if successful

