### PR TITLE
update java class causing cpp protocol issues due to naming discrepancy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import static com.facebook.presto.execution.TaskStatus.initialTaskStatus;
 import static com.facebook.presto.execution.buffer.BufferState.OPEN;
 import static com.facebook.presto.metadata.MetadataUpdates.DEFAULT_METADATA_UPDATES;
-import static com.facebook.presto.util.DateTimeUtils.toTimeStampInMillis;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.System.currentTimeMillis;
@@ -56,15 +55,18 @@ public class TaskInfo
     private final MetadataUpdates metadataUpdates;
     private final String nodeId;
 
-    public TaskInfo(TaskId taskId,
-            TaskStatus taskStatus,
-            long lastHeartbeatInMillis,
-            OutputBufferInfo outputBuffers,
-            Set<PlanNodeId> noMoreSplits,
-            TaskStats stats,
-            boolean needsPlan,
-            MetadataUpdates metadataUpdates,
-            String nodeId)
+    @JsonCreator
+    @ThriftConstructor
+    public TaskInfo(
+            @JsonProperty("taskId") TaskId taskId,
+            @JsonProperty("taskStatus") TaskStatus taskStatus,
+            @JsonProperty("lastHeartbeatInMillis") long lastHeartbeatInMillis,
+            @JsonProperty("outputBuffers") OutputBufferInfo outputBuffers,
+            @JsonProperty("noMoreSplits") Set<PlanNodeId> noMoreSplits,
+            @JsonProperty("stats") TaskStats stats,
+            @JsonProperty("needsPlan") boolean needsPlan,
+            @JsonProperty("metadataUpdates") MetadataUpdates metadataUpdates,
+            @JsonProperty("nodeId") String nodeId)
     {
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.taskStatus = requireNonNull(taskStatus, "taskStatus is null");
@@ -77,30 +79,6 @@ public class TaskInfo
         this.needsPlan = needsPlan;
         this.metadataUpdates = metadataUpdates;
         this.nodeId = requireNonNull(nodeId, "nodeId is null");
-    }
-
-    @JsonCreator
-    @ThriftConstructor
-    public TaskInfo(
-            @JsonProperty("taskId") TaskId taskId,
-            @JsonProperty("taskStatus") TaskStatus taskStatus,
-            @JsonProperty("lastHeartbeat") DateTime lastHeartbeat,
-            @JsonProperty("outputBuffers") OutputBufferInfo outputBuffers,
-            @JsonProperty("noMoreSplits") Set<PlanNodeId> noMoreSplits,
-            @JsonProperty("stats") TaskStats stats,
-            @JsonProperty("needsPlan") boolean needsPlan,
-            @JsonProperty("metadataUpdates") MetadataUpdates metadataUpdates,
-            @JsonProperty("nodeId") String nodeId)
-    {
-        this(taskId,
-                taskStatus,
-                toTimeStampInMillis(lastHeartbeat),
-                outputBuffers,
-                noMoreSplits,
-                stats,
-                needsPlan,
-                metadataUpdates,
-                nodeId);
     }
 
     @JsonProperty
@@ -117,13 +95,13 @@ public class TaskInfo
         return taskStatus;
     }
 
-    @JsonProperty
-    @ThriftField(3)
     public DateTime getLastHeartbeat()
     {
         return new DateTime(lastHeartbeatInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(3)
     public long getLastHeartbeatInMillis()
     {
         return lastHeartbeatInMillis;

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -23,8 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 
-import javax.annotation.Nullable;
-
 import java.util.List;
 import java.util.Set;
 
@@ -138,11 +136,11 @@ public class TaskStats
 
     public TaskStats(DateTime createTime, DateTime endTime)
     {
-        this(createTime,
-                null,
-                null,
-                null,
-                endTime,
+        this(toTimeStampInMillis(createTime),
+                0L,
+                0L,
+                0L,
+                toTimeStampInMillis(endTime),
                 0L,
                 0L,
                 0,
@@ -181,59 +179,61 @@ public class TaskStats
                 new RuntimeStats());
     }
 
+    @JsonCreator
+    @ThriftConstructor
     public TaskStats(
-            long createTimeInMillis,
-            long firstStartTimeInMillis,
-            long lastStartTimeInMillis,
-            long lastEndTimeInMillis,
-            long endTimeInMillis,
-            long elapsedTimeInNanos,
-            long queuedTimeInNanos,
+            @JsonProperty("createTimeInMillis") long createTimeInMillis,
+            @JsonProperty("firstStartTimeInMillis") long firstStartTimeInMillis,
+            @JsonProperty("lastStartTimeInMillis") long lastStartTimeInMillis,
+            @JsonProperty("lastEndTimeInMillis") long lastEndTimeInMillis,
+            @JsonProperty("endTimeInMillis") long endTimeInMillis,
+            @JsonProperty("elapsedTimeInNanos") long elapsedTimeInNanos,
+            @JsonProperty("queuedTimeInNanos") long queuedTimeInNanos,
 
-            int totalDrivers,
-            int queuedDrivers,
-            int queuedPartitionedDrivers,
-            long queuedPartitionedSplitsWeight,
-            int runningDrivers,
-            int runningPartitionedDrivers,
-            long runningPartitionedSplitsWeight,
-            int blockedDrivers,
-            int completedDrivers,
+            @JsonProperty("totalDrivers") int totalDrivers,
+            @JsonProperty("queuedDrivers") int queuedDrivers,
+            @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
+            @JsonProperty("queuedPartitionedSplitsWeight") long queuedPartitionedSplitsWeight,
+            @JsonProperty("runningDrivers") int runningDrivers,
+            @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
+            @JsonProperty("runningPartitionedSplitsWeight") long runningPartitionedSplitsWeight,
+            @JsonProperty("blockedDrivers") int blockedDrivers,
+            @JsonProperty("completedDrivers") int completedDrivers,
 
-            double cumulativeUserMemory,
-            double cumulativeTotalMemory,
-            long userMemoryReservationInBytes,
-            long revocableMemoryReservationInBytes,
-            long systemMemoryReservationInBytes,
+            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
+            @JsonProperty("userMemoryReservationInBytes") long userMemoryReservationInBytes,
+            @JsonProperty("revocableMemoryReservationInBytes") long revocableMemoryReservationInBytes,
+            @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
 
-            long peakTotalMemoryInBytes,
-            long peakUserMemoryInBytes,
-            long peakNodeTotalMemoryInBytes,
+            @JsonProperty("peakTotalMemoryInBytes") long peakTotalMemoryInBytes,
+            @JsonProperty("peakUserMemoryInBytes") long peakUserMemoryInBytes,
+            @JsonProperty("peakNodeTotalMemoryInBytes") long peakNodeTotalMemoryInBytes,
 
-            long totalScheduledTimeInNanos,
-            long totalCpuTimeInNanos,
-            long totalBlockedTimeInNanos,
-            boolean fullyBlocked,
-            Set<BlockedReason> blockedReasons,
+            @JsonProperty("totalScheduledTimeInNanos") long totalScheduledTimeInNanos,
+            @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,
+            @JsonProperty("totalBlockedTimeInNanos") long totalBlockedTimeInNanos,
+            @JsonProperty("fullyBlocked") boolean fullyBlocked,
+            @JsonProperty("blockedReasons") Set<BlockedReason> blockedReasons,
 
-            long totalAllocationInBytes,
+            @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
 
-            long rawInputDataSizeInBytes,
-            long rawInputPositions,
+            @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
+            @JsonProperty("rawInputPositions") long rawInputPositions,
 
-            long processedInputDataSizeInBytes,
-            long processedInputPositions,
+            @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
+            @JsonProperty("processedInputPositions") long processedInputPositions,
 
-            long outputDataSizeInBytes,
-            long outputPositions,
+            @JsonProperty("outputDataSizeInBytes") long outputDataSizeInBytes,
+            @JsonProperty("outputPositions") long outputPositions,
 
-            long physicalWrittenDataSizeInBytes,
+            @JsonProperty("physicalWrittenDataSizeInBytes") long physicalWrittenDataSizeInBytes,
 
-            int fullGcCount,
-            long fullGcTimeInMillis,
+            @JsonProperty("fullGcCount") int fullGcCount,
+            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis,
 
-            List<PipelineStats> pipelines,
-            RuntimeStats runtimeStats)
+            @JsonProperty("pipelines") List<PipelineStats> pipelines,
+            @JsonProperty("runtimeStats") RuntimeStats runtimeStats)
     {
         checkArgument(createTimeInMillis >= 0, "createTimeInMillis is negative");
         this.createTimeInMillis = createTimeInMillis;
@@ -307,176 +307,61 @@ public class TaskStats
         this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
     }
 
-    @JsonCreator
-    @ThriftConstructor
-    public TaskStats(
-            @JsonProperty("createTime") DateTime createTime,
-            @JsonProperty("firstStartTime") DateTime firstStartTime,
-            @JsonProperty("lastStartTime") DateTime lastStartTime,
-            @JsonProperty("lastEndTime") DateTime lastEndTime,
-            @JsonProperty("endTime") DateTime endTime,
-            @JsonProperty("elapsedTimeInNanos") long elapsedTimeInNanos,
-            @JsonProperty("queuedTimeInNanos") long queuedTimeInNanos,
-
-            @JsonProperty("totalDrivers") int totalDrivers,
-            @JsonProperty("queuedDrivers") int queuedDrivers,
-            @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
-            @JsonProperty("queuedPartitionedSplitsWeight") long queuedPartitionedSplitsWeight,
-            @JsonProperty("runningDrivers") int runningDrivers,
-            @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
-            @JsonProperty("runningPartitionedSplitsWeight") long runningPartitionedSplitsWeight,
-            @JsonProperty("blockedDrivers") int blockedDrivers,
-            @JsonProperty("completedDrivers") int completedDrivers,
-
-            @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
-            @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
-            @JsonProperty("userMemoryReservationInBytes") long userMemoryReservationInBytes,
-            @JsonProperty("revocableMemoryReservationInBytes") long revocableMemoryReservationInBytes,
-            @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
-
-            @JsonProperty("peakTotalMemoryInBytes") long peakTotalMemoryInBytes,
-            @JsonProperty("peakUserMemoryInBytes") long peakUserMemoryInBytes,
-            @JsonProperty("peakNodeTotalMemoryInBytes") long peakNodeTotalMemoryInBytes,
-
-            @JsonProperty("totalScheduledTimeInNanos") long totalScheduledTimeInNanos,
-            @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,
-            @JsonProperty("totalBlockedTimeInNanos") long totalBlockedTimeInNanos,
-            @JsonProperty("fullyBlocked") boolean fullyBlocked,
-            @JsonProperty("blockedReasons") Set<BlockedReason> blockedReasons,
-
-            @JsonProperty("totalAllocationInBytes") long totalAllocationInBytes,
-
-            @JsonProperty("rawInputDataSizeInBytes") long rawInputDataSizeInBytes,
-            @JsonProperty("rawInputPositions") long rawInputPositions,
-
-            @JsonProperty("processedInputDataSizeInBytes") long processedInputDataSizeInBytes,
-            @JsonProperty("processedInputPositions") long processedInputPositions,
-
-            @JsonProperty("outputDataSizeInBytes") long outputDataSizeInBytes,
-            @JsonProperty("outputPositions") long outputPositions,
-
-            @JsonProperty("physicalWrittenDataSizeInBytes") long physicalWrittenDataSizeInBytes,
-
-            @JsonProperty("fullGcCount") int fullGcCount,
-            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis,
-
-            @JsonProperty("pipelines") List<PipelineStats> pipelines,
-            @JsonProperty("runtimeStats") RuntimeStats runtimeStats)
-    {
-        this(toTimeStampInMillis(createTime),
-                toTimeStampInMillis(firstStartTime),
-                toTimeStampInMillis(lastStartTime),
-                toTimeStampInMillis(lastEndTime),
-                toTimeStampInMillis(endTime),
-
-                elapsedTimeInNanos,
-                queuedTimeInNanos,
-
-                totalDrivers,
-                queuedDrivers,
-                queuedPartitionedDrivers,
-                queuedPartitionedSplitsWeight,
-                runningDrivers,
-                runningPartitionedDrivers,
-                runningPartitionedSplitsWeight,
-                blockedDrivers,
-                completedDrivers,
-
-                cumulativeUserMemory,
-                cumulativeTotalMemory,
-                userMemoryReservationInBytes,
-                revocableMemoryReservationInBytes,
-                systemMemoryReservationInBytes,
-
-                peakTotalMemoryInBytes,
-                peakUserMemoryInBytes,
-                peakNodeTotalMemoryInBytes,
-
-                totalScheduledTimeInNanos,
-                totalCpuTimeInNanos,
-                totalBlockedTimeInNanos,
-                fullyBlocked,
-                blockedReasons,
-
-                totalAllocationInBytes,
-
-                rawInputDataSizeInBytes,
-                rawInputPositions,
-
-                processedInputDataSizeInBytes,
-                processedInputPositions,
-
-                outputDataSizeInBytes,
-                outputPositions,
-
-                physicalWrittenDataSizeInBytes,
-
-                fullGcCount,
-                fullGcTimeInMillis,
-
-                pipelines,
-                runtimeStats);
-    }
-
-    @JsonProperty
-    @ThriftField(1)
     public DateTime getCreateTime()
     {
         return new DateTime(createTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(1)
     public long getCreateTimeInMillis()
     {
         return createTimeInMillis;
     }
 
-    @Nullable
-    @JsonProperty
-    @ThriftField(2)
     public DateTime getFirstStartTime()
     {
         return new DateTime(firstStartTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(2)
     public long getFirstStartTimeInMillis()
     {
         return firstStartTimeInMillis;
     }
 
-    @Nullable
-    @JsonProperty
-    @ThriftField(3)
     public DateTime getLastStartTime()
     {
         return new DateTime(lastStartTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(3)
     public long getLastStartTimeInMillis()
     {
         return lastStartTimeInMillis;
     }
 
-    @Nullable
-    @JsonProperty
-    @ThriftField(4)
     public DateTime getLastEndTime()
     {
         return new DateTime(lastEndTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(4)
     public long getLastEndTimeInMillis()
     {
         return lastEndTimeInMillis;
     }
 
-    @Nullable
-    @JsonProperty
-    @ThriftField(5)
     public DateTime getEndTime()
     {
         return new DateTime(endTimeInMillis);
     }
 
+    @JsonProperty
+    @ThriftField(5)
     public long getEndTimeInMillis()
     {
         return endTimeInMillis;
@@ -737,11 +622,11 @@ public class TaskStats
     public TaskStats summarize()
     {
         return new TaskStats(
-                new DateTime(createTimeInMillis),
-                new DateTime(firstStartTimeInMillis),
-                new DateTime(lastStartTimeInMillis),
-                new DateTime(lastEndTimeInMillis),
-                new DateTime(endTimeInMillis),
+                createTimeInMillis,
+                firstStartTimeInMillis,
+                lastStartTimeInMillis,
+                lastEndTimeInMillis,
+                endTimeInMillis,
                 elapsedTimeInNanos,
                 queuedTimeInNanos,
                 totalDrivers,
@@ -783,11 +668,11 @@ public class TaskStats
     public TaskStats summarizeFinal()
     {
         return new TaskStats(
-                new DateTime(createTimeInMillis),
-                new DateTime(firstStartTimeInMillis),
-                new DateTime(lastStartTimeInMillis),
-                new DateTime(lastEndTimeInMillis),
-                new DateTime(endTimeInMillis),
+                createTimeInMillis,
+                firstStartTimeInMillis,
+                lastStartTimeInMillis,
+                lastEndTimeInMillis,
+                endTimeInMillis,
                 elapsedTimeInNanos,
                 queuedTimeInNanos,
                 totalDrivers,

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/hive/presto_protocol_hive.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/hive/presto_protocol_hive.cpp
@@ -370,9 +370,10 @@ namespace facebook::presto::protocol::hive {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<BucketFunctionType, json>
-    BucketFunctionType_enum_table[] = { // NOLINT: cert-err58-cpp
-        {BucketFunctionType::HIVE_COMPATIBLE, "HIVE_COMPATIBLE"},
-        {BucketFunctionType::PRESTO_NATIVE, "PRESTO_NATIVE"}};
+    BucketFunctionType_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {BucketFunctionType::HIVE_COMPATIBLE, "HIVE_COMPATIBLE"},
+            {BucketFunctionType::PRESTO_NATIVE, "PRESTO_NATIVE"}};
 void to_json(json& j, const BucketFunctionType& e) {
   static_assert(
       std::is_enum<BucketFunctionType>::value,
@@ -598,12 +599,13 @@ namespace facebook::presto::protocol::hive {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<HiveCompressionCodec, json>
-    HiveCompressionCodec_enum_table[] = { // NOLINT: cert-err58-cpp
-        {HiveCompressionCodec::NONE, "NONE"},
-        {HiveCompressionCodec::SNAPPY, "SNAPPY"},
-        {HiveCompressionCodec::GZIP, "GZIP"},
-        {HiveCompressionCodec::LZ4, "LZ4"},
-        {HiveCompressionCodec::ZSTD, "ZSTD"}};
+    HiveCompressionCodec_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {HiveCompressionCodec::NONE, "NONE"},
+            {HiveCompressionCodec::SNAPPY, "SNAPPY"},
+            {HiveCompressionCodec::GZIP, "GZIP"},
+            {HiveCompressionCodec::LZ4, "LZ4"},
+            {HiveCompressionCodec::ZSTD, "ZSTD"}};
 void to_json(json& j, const HiveCompressionCodec& e) {
   static_assert(
       std::is_enum<HiveCompressionCodec>::value,

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -25,11 +25,12 @@ namespace facebook::presto::protocol::iceberg {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ChangelogOperation, json>
-    ChangelogOperation_enum_table[] = { // NOLINT: cert-err58-cpp
-        {ChangelogOperation::INSERT, "INSERT"},
-        {ChangelogOperation::DELETE, "DELETE"},
-        {ChangelogOperation::UPDATE_BEFORE, "UPDATE_BEFORE"},
-        {ChangelogOperation::UPDATE_AFTER, "UPDATE_AFTER"}};
+    ChangelogOperation_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {ChangelogOperation::INSERT, "INSERT"},
+            {ChangelogOperation::DELETE, "DELETE"},
+            {ChangelogOperation::UPDATE_BEFORE, "UPDATE_BEFORE"},
+            {ChangelogOperation::UPDATE_AFTER, "UPDATE_AFTER"}};
 void to_json(json& j, const ChangelogOperation& e) {
   static_assert(
       std::is_enum<ChangelogOperation>::value,
@@ -728,6 +729,13 @@ void to_json(json& j, const IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "Map<String, String>",
       "storageProperties");
+  to_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergInsertTableHandle",
+      "List<SortField>",
+      "sortOrder");
 }
 
 void from_json(const json& j, IcebergInsertTableHandle& p) {
@@ -795,6 +803,13 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "Map<String, String>",
       "storageProperties");
+  from_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergInsertTableHandle",
+      "List<SortField>",
+      "sortOrder");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -868,6 +883,13 @@ void to_json(json& j, const IcebergOutputTableHandle& p) {
       "IcebergOutputTableHandle",
       "Map<String, String>",
       "storageProperties");
+  to_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergOutputTableHandle",
+      "List<SortField>",
+      "sortOrder");
 }
 
 void from_json(const json& j, IcebergOutputTableHandle& p) {
@@ -935,6 +957,13 @@ void from_json(const json& j, IcebergOutputTableHandle& p) {
       "IcebergOutputTableHandle",
       "Map<String, String>",
       "storageProperties");
+  from_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergOutputTableHandle",
+      "List<SortField>",
+      "sortOrder");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -1013,6 +1042,13 @@ void to_json(json& j, const IcebergSplit& p) {
       "IcebergSplit",
       "int64_t",
       "dataSequenceNumber");
+  to_json_key(
+      j,
+      "affinitySchedulingSectionSize",
+      p.affinitySchedulingSectionSize,
+      "IcebergSplit",
+      "int64_t",
+      "affinitySchedulingSectionSize");
 }
 
 void from_json(const json& j, IcebergSplit& p) {
@@ -1085,6 +1121,13 @@ void from_json(const json& j, IcebergSplit& p) {
       "IcebergSplit",
       "int64_t",
       "dataSequenceNumber");
+  from_json_key(
+      j,
+      "affinitySchedulingSectionSize",
+      p.affinitySchedulingSectionSize,
+      "IcebergSplit",
+      "int64_t",
+      "affinitySchedulingSectionSize");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
@@ -1151,6 +1194,20 @@ void to_json(json& j, const IcebergTableHandle& p) {
       "IcebergTableHandle",
       "List<Integer>",
       "equalityFieldIds");
+  to_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergTableHandle",
+      "List<SortField>",
+      "sortOrder");
+  to_json_key(
+      j,
+      "updatedColumns",
+      p.updatedColumns,
+      "IcebergTableHandle",
+      "List<IcebergColumnHandle>",
+      "updatedColumns");
 }
 
 void from_json(const json& j, IcebergTableHandle& p) {
@@ -1211,6 +1268,20 @@ void from_json(const json& j, IcebergTableHandle& p) {
       "IcebergTableHandle",
       "List<Integer>",
       "equalityFieldIds");
+  from_json_key(
+      j,
+      "sortOrder",
+      p.sortOrder,
+      "IcebergTableHandle",
+      "List<SortField>",
+      "sortOrder");
+  from_json_key(
+      j,
+      "updatedColumns",
+      p.updatedColumns,
+      "IcebergTableHandle",
+      "List<IcebergColumnHandle>",
+      "updatedColumns");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -289,6 +289,8 @@ struct IcebergTableHandle : public ConnectorTableHandle {
   std::shared_ptr<String> tableSchemaJson = {};
   std::shared_ptr<List<Integer>> partitionFieldIds = {};
   std::shared_ptr<List<Integer>> equalityFieldIds = {};
+  List<SortField> sortOrder = {};
+  List<IcebergColumnHandle> updatedColumns = {};
 
   IcebergTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -36,10 +36,11 @@ namespace facebook::presto::protocol {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<NodeSelectionStrategy, json>
-    NodeSelectionStrategy_enum_table[] = { // NOLINT: cert-err58-cpp
-        {NodeSelectionStrategy::HARD_AFFINITY, "HARD_AFFINITY"},
-        {NodeSelectionStrategy::SOFT_AFFINITY, "SOFT_AFFINITY"},
-        {NodeSelectionStrategy::NO_PREFERENCE, "NO_PREFERENCE"}};
+    NodeSelectionStrategy_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {NodeSelectionStrategy::HARD_AFFINITY, "HARD_AFFINITY"},
+            {NodeSelectionStrategy::SOFT_AFFINITY, "SOFT_AFFINITY"},
+            {NodeSelectionStrategy::NO_PREFERENCE, "NO_PREFERENCE"}};
 void to_json(json& j, const NodeSelectionStrategy& e) {
   static_assert(
       std::is_enum<NodeSelectionStrategy>::value,
@@ -534,11 +535,12 @@ namespace facebook::presto::protocol {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<AggregationNodeStep, json>
-    AggregationNodeStep_enum_table[] = { // NOLINT: cert-err58-cpp
-        {AggregationNodeStep::PARTIAL, "PARTIAL"},
-        {AggregationNodeStep::FINAL, "FINAL"},
-        {AggregationNodeStep::INTERMEDIATE, "INTERMEDIATE"},
-        {AggregationNodeStep::SINGLE, "SINGLE"}};
+    AggregationNodeStep_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {AggregationNodeStep::PARTIAL, "PARTIAL"},
+            {AggregationNodeStep::FINAL, "FINAL"},
+            {AggregationNodeStep::INTERMEDIATE, "INTERMEDIATE"},
+            {AggregationNodeStep::SINGLE, "SINGLE"}};
 void to_json(json& j, const AggregationNodeStep& e) {
   static_assert(
       std::is_enum<AggregationNodeStep>::value,
@@ -3259,7 +3261,8 @@ DeleteHandle::DeleteHandle() noexcept {
 void to_json(json& j, const DeleteHandle& p) {
   j = json::object();
   j["@type"] = "DeleteHandle";
-  to_json_key(j, "handle", p.handle, "DeleteHandle", "TableHandle", "handle");
+  to_json_key(
+      j, "handle", p.handle, "DeleteHandle", "DeleteTableHandle", "handle");
   to_json_key(
       j,
       "schemaTableName",
@@ -3271,7 +3274,8 @@ void to_json(json& j, const DeleteHandle& p) {
 
 void from_json(const json& j, DeleteHandle& p) {
   p._type = j["@type"];
-  from_json_key(j, "handle", p.handle, "DeleteHandle", "TableHandle", "handle");
+  from_json_key(
+      j, "handle", p.handle, "DeleteHandle", "DeleteTableHandle", "handle");
   from_json_key(
       j,
       "schemaTableName",
@@ -4251,10 +4255,26 @@ void to_json(json& j, const DriverStats& p) {
   j = json::object();
   to_json_key(j, "lifespan", p.lifespan, "DriverStats", "Lifespan", "lifespan");
   to_json_key(
-      j, "createTimeInMillis", p.createTimeInMillis, "DriverStats", "int64_t", "createTimeInMillis");
+      j,
+      "createTimeInMillis",
+      p.createTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "createTimeInMillis");
   to_json_key(
-      j, "startTimeInMillis", p.startTimeInMillis, "DriverStats", "int64_t", "startTimeInMillis");
-  to_json_key(j, "endTimeInMillis", p.endTimeInMillis, "DriverStats", "int64_t", "endTimeInMillis");
+      j,
+      "startTimeInMillis",
+      p.startTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "startTimeInMillis");
+  to_json_key(
+      j,
+      "endTimeInMillis",
+      p.endTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "endTimeInMillis");
   to_json_key(
       j, "queuedTime", p.queuedTime, "DriverStats", "Duration", "queuedTime");
   to_json_key(
@@ -4391,10 +4411,26 @@ void from_json(const json& j, DriverStats& p) {
   from_json_key(
       j, "lifespan", p.lifespan, "DriverStats", "Lifespan", "lifespan");
   from_json_key(
-      j, "createTimeInMillis", p.createTimeInMillis, "DriverStats", "int64_t", "createTimeInMillis");
+      j,
+      "createTimeInMillis",
+      p.createTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "createTimeInMillis");
   from_json_key(
-      j, "startTimeInMillis", p.startTimeInMillis, "DriverStats", "int64_t", "startTimeInMillis");
-  from_json_key(j, "endTimeInMillis", p.endTimeInMillis, "DriverStats", "int64_t", "endTimeInMillis");
+      j,
+      "startTimeInMillis",
+      p.startTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "startTimeInMillis");
+  from_json_key(
+      j,
+      "endTimeInMillis",
+      p.endTimeInMillis,
+      "DriverStats",
+      "int64_t",
+      "endTimeInMillis");
   from_json_key(
       j, "queuedTime", p.queuedTime, "DriverStats", "Duration", "queuedTime");
   from_json_key(
@@ -5742,9 +5778,10 @@ namespace facebook::presto::protocol {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<JoinDistributionType, json>
-    JoinDistributionType_enum_table[] = { // NOLINT: cert-err58-cpp
-        {JoinDistributionType::PARTITIONED, "PARTITIONED"},
-        {JoinDistributionType::REPLICATED, "REPLICATED"}};
+    JoinDistributionType_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {JoinDistributionType::PARTITIONED, "PARTITIONED"},
+            {JoinDistributionType::REPLICATED, "REPLICATED"}};
 void to_json(json& j, const JoinDistributionType& e) {
   static_assert(
       std::is_enum<JoinDistributionType>::value,
@@ -7759,14 +7796,17 @@ namespace facebook::presto::protocol {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<StageExecutionStrategy, json>
-    StageExecutionStrategy_enum_table[] = { // NOLINT: cert-err58-cpp
-        {StageExecutionStrategy::UNGROUPED_EXECUTION, "UNGROUPED_EXECUTION"},
-        {StageExecutionStrategy::FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
-         "FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION"},
-        {StageExecutionStrategy::DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
-         "DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION"},
-        {StageExecutionStrategy::RECOVERABLE_GROUPED_EXECUTION,
-         "RECOVERABLE_GROUPED_EXECUTION"}};
+    StageExecutionStrategy_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {StageExecutionStrategy::UNGROUPED_EXECUTION,
+             "UNGROUPED_EXECUTION"},
+            {StageExecutionStrategy::FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
+             "FIXED_LIFESPAN_SCHEDULE_GROUPED_EXECUTION"},
+            {StageExecutionStrategy::
+                 DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION,
+             "DYNAMIC_LIFESPAN_SCHEDULE_GROUPED_EXECUTION"},
+            {StageExecutionStrategy::RECOVERABLE_GROUPED_EXECUTION,
+             "RECOVERABLE_GROUPED_EXECUTION"}};
 void to_json(json& j, const StageExecutionStrategy& e) {
   static_assert(
       std::is_enum<StageExecutionStrategy>::value,
@@ -9261,12 +9301,13 @@ namespace facebook::presto::protocol {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SystemPartitionFunction, json>
-    SystemPartitionFunction_enum_table[] = { // NOLINT: cert-err58-cpp
-        {SystemPartitionFunction::SINGLE, "SINGLE"},
-        {SystemPartitionFunction::HASH, "HASH"},
-        {SystemPartitionFunction::ROUND_ROBIN, "ROUND_ROBIN"},
-        {SystemPartitionFunction::BROADCAST, "BROADCAST"},
-        {SystemPartitionFunction::UNKNOWN, "UNKNOWN"}};
+    SystemPartitionFunction_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {SystemPartitionFunction::SINGLE, "SINGLE"},
+            {SystemPartitionFunction::HASH, "HASH"},
+            {SystemPartitionFunction::ROUND_ROBIN, "ROUND_ROBIN"},
+            {SystemPartitionFunction::BROADCAST, "BROADCAST"},
+            {SystemPartitionFunction::UNKNOWN, "UNKNOWN"}};
 void to_json(json& j, const SystemPartitionFunction& e) {
   static_assert(
       std::is_enum<SystemPartitionFunction>::value,
@@ -9303,13 +9344,14 @@ namespace facebook::presto::protocol {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SystemPartitioning, json>
-    SystemPartitioning_enum_table[] = { // NOLINT: cert-err58-cpp
-        {SystemPartitioning::SINGLE, "SINGLE"},
-        {SystemPartitioning::FIXED, "FIXED"},
-        {SystemPartitioning::SOURCE, "SOURCE"},
-        {SystemPartitioning::SCALED, "SCALED"},
-        {SystemPartitioning::COORDINATOR_ONLY, "COORDINATOR_ONLY"},
-        {SystemPartitioning::ARBITRARY, "ARBITRARY"}};
+    SystemPartitioning_enum_table[] =
+        { // NOLINT: cert-err58-cpp
+            {SystemPartitioning::SINGLE, "SINGLE"},
+            {SystemPartitioning::FIXED, "FIXED"},
+            {SystemPartitioning::SOURCE, "SOURCE"},
+            {SystemPartitioning::SCALED, "SCALED"},
+            {SystemPartitioning::COORDINATOR_ONLY, "COORDINATOR_ONLY"},
+            {SystemPartitioning::ARBITRARY, "ARBITRARY"}};
 void to_json(json& j, const SystemPartitioning& e) {
   static_assert(
       std::is_enum<SystemPartitioning>::value,
@@ -9927,7 +9969,12 @@ namespace facebook::presto::protocol {
 void to_json(json& j, const TaskStats& p) {
   j = json::object();
   to_json_key(
-      j, "createTimeInMillis", p.createTimeInMillis, "TaskStats", "int64_t", "createTimeInMillis");
+      j,
+      "createTimeInMillis",
+      p.createTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "createTimeInMillis");
   to_json_key(
       j,
       "firstStartTimeInMillis",
@@ -9943,8 +9990,19 @@ void to_json(json& j, const TaskStats& p) {
       "int64_t",
       "lastStartTimeInMillis");
   to_json_key(
-      j, "lastEndTimeInMillis", p.lastEndTimeInMillis, "TaskStats", "int64_t", "lastEndTimeInMillis");
-  to_json_key(j, "endTimeInMillis", p.endTimeInMillis, "TaskStats", "int64_t", "endTimeInMillis");
+      j,
+      "lastEndTimeInMillis",
+      p.lastEndTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "lastEndTimeInMillis");
+  to_json_key(
+      j,
+      "endTimeInMillis",
+      p.endTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "endTimeInMillis");
   to_json_key(
       j,
       "elapsedTimeInNanos",
@@ -10181,7 +10239,12 @@ void to_json(json& j, const TaskStats& p) {
 
 void from_json(const json& j, TaskStats& p) {
   from_json_key(
-      j, "createTimeInMillis", p.createTimeInMillis, "TaskStats", "int64_t", "createTimeInMillis");
+      j,
+      "createTimeInMillis",
+      p.createTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "createTimeInMillis");
   from_json_key(
       j,
       "firstStartTimeInMillis",
@@ -10197,8 +10260,19 @@ void from_json(const json& j, TaskStats& p) {
       "int64_t",
       "lastStartTimeInMillis");
   from_json_key(
-      j, "lastEndTimeInMillis", p.lastEndTimeInMillis, "TaskStats", "int64_t", "lastEndTimeInMillis");
-  from_json_key(j, "endTimeInMillis", p.endTimeInMillis, "TaskStats", "int64_t", "endTimeInMillis");
+      j,
+      "lastEndTimeInMillis",
+      p.lastEndTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "lastEndTimeInMillis");
+  from_json_key(
+      j,
+      "endTimeInMillis",
+      p.endTimeInMillis,
+      "TaskStats",
+      "int64_t",
+      "endTimeInMillis");
   from_json_key(
       j,
       "elapsedTimeInNanos",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -104,6 +104,7 @@ using Subfield = std::string;
 using HiveType = std::string;
 using Type = std::string;
 
+using DateTime = std::string;
 using Locale = std::string;
 using TimeZoneKey = long;
 using URI = std::string;
@@ -1027,7 +1028,7 @@ void from_json(const json& j, CreateHandle& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct DeleteHandle : public ExecutionWriterTarget {
-  TableHandle handle = {};
+  DeleteTableHandle handle = {};
   SchemaTableName schemaTableName = {};
 
   DeleteHandle() noexcept;
@@ -1177,9 +1178,9 @@ void from_json(const json& j, OperatorStats& p);
 namespace facebook::presto::protocol {
 struct DriverStats {
   Lifespan lifespan = {};
-  long createTimeInMillis = {};
-  long startTimeInMillis = {};
-  long endTimeInMillis = {};
+  int64_t createTimeInMillis = {};
+  int64_t startTimeInMillis = {};
+  int64_t endTimeInMillis = {};
   Duration queuedTime = {};
   Duration elapsedTime = {};
   int64_t userMemoryReservationInBytes = {};


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
Currently, cpp presto_protocol is breaking due to a change in naming in [this commit](https://github.com/prestodb/presto/pull/24673/commits/13e51f1f288a1be3baefb96332a584f1e3cbf109#diff-d86644e690e462e10b201908c9ffe20c201b264feefff04403471f546778e699), and the related java class not being updated to the new names. The breaking commit passed testing because the protocol was manually written, but when regenerated with make presto_protocol, it autogenerated the names and reverted the changes in the protocol file.

## Impact
Fix presto_cpp build

## Test Plan
Build presto_cpp server

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

