### PR TITLE
Upgrading mysql jar in presto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dep.j2objc.version>3.0.0</dep.j2objc.version>
         <dep.avro.version>1.11.4</dep.avro.version>
         <dep.commons.compress.version>1.26.2</dep.commons.compress.version>
-        <dep.protobuf-java.version>3.25.5</dep.protobuf-java.version>
+        <dep.protobuf-java.version>4.29.0</dep.protobuf-java.version>
         <dep.netty.version>4.1.118.Final</dep.netty.version>
         <dep.snakeyaml.version>2.0</dep.snakeyaml.version>
         <dep.jetty.version>9.4.56.v20240826</dep.jetty.version>
@@ -1406,9 +1406,9 @@
             </dependency>
 
             <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.48</version>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>9.2.0</version>
             </dependency>
 
             <dependency>
@@ -2001,8 +2001,14 @@
 
             <dependency>
                 <groupId>com.facebook.presto</groupId>
-                <artifactId>testing-mysql-server-5</artifactId>
+                <artifactId>testing-mysql-server-8</artifactId>
                 <version>${dep.testing-mysql-server-5.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>mysql</groupId>
+                        <artifactId>mysql-connector-java</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -180,7 +180,7 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
-            <artifactId>testing-mysql-server-5</artifactId>
+            <artifactId>testing-mysql-server-8</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -123,8 +123,8 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
 
@@ -179,7 +179,7 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
-            <artifactId>testing-mysql-server-5</artifactId>
+            <artifactId>testing-mysql-server-8</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -506,6 +506,10 @@
                             <groupId>org.apache.ratis</groupId>
                             <artifactId>ratis-server-api</artifactId>
                         </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-thirdparty-misc</artifactId>
+                        </dependency>
                     </ignoredDependencies>
                 </configuration>
             </plugin>

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -43,8 +43,8 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
 
         <dependency>
@@ -146,7 +146,7 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
-            <artifactId>testing-mysql-server-5</artifactId>
+            <artifactId>testing-mysql-server-8</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -29,8 +29,8 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableSet;
+import com.mysql.cj.jdbc.JdbcStatement;
 import com.mysql.jdbc.Driver;
-import com.mysql.jdbc.Statement;
 
 import javax.inject.Inject;
 
@@ -39,6 +39,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Properties;
@@ -53,14 +54,18 @@ import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static com.mysql.jdbc.SQLError.SQL_STATE_ER_TABLE_EXISTS_ERROR;
-import static com.mysql.jdbc.SQLError.SQL_STATE_SYNTAX_ERROR;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
 public class MySqlClient
         extends BaseJdbcClient
 {
+    /**
+     * Error code corresponding to code thrown when a table already exists.
+     * The code is derived from the MySQL documentation.
+     * @see <a href="https://dev.mysql.com/doc/connector-j/en/connector-j-reference-error-sqlstates.html">MySQL documentation</a>
+     */
+    private static final String SQL_STATE_ER_TABLE_EXISTS_ERROR = "42S01";
     @Inject
     public MySqlClient(JdbcConnectorId connectorId, BaseJdbcConfig config, MySqlConfig mySqlConfig)
             throws SQLException
@@ -127,8 +132,8 @@ public class MySqlClient
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);
-        if (statement.isWrapperFor(Statement.class)) {
-            statement.unwrap(Statement.class).enableStreamingResults();
+        if (statement.isWrapperFor(JdbcStatement.class)) {
+            statement.unwrap(JdbcStatement.class).enableStreamingResults();
         }
         return statement;
     }
@@ -220,11 +225,11 @@ public class MySqlClient
                     quoted(newColumnName));
             execute(connection, sql);
         }
-        catch (SQLException e) {
+        catch (SQLSyntaxErrorException e) {
             // MySQL versions earlier than 8 do not support the above RENAME COLUMN syntax
-            if (SQL_STATE_SYNTAX_ERROR.equals(e.getSQLState())) {
-                throw new PrestoException(NOT_SUPPORTED, format("Rename column not supported in catalog: '%s'", handle.getCatalogName()), e);
-            }
+            throw new PrestoException(NOT_SUPPORTED, format("Rename column not supported in catalog: '%s'", handle.getCatalogName()), e);
+        }
+        catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);
         }
     }

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
@@ -18,10 +18,9 @@ import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.JdbcClient;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
-import com.mysql.jdbc.Driver;
-
-import java.sql.SQLException;
-import java.util.Properties;
+import com.mysql.cj.conf.ConnectionUrl;
+import com.mysql.cj.conf.ConnectionUrlParser;
+import com.mysql.cj.util.StringUtils;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -39,14 +38,7 @@ public class MySqlClientModule
 
     private static void ensureCatalogIsEmpty(String connectionUrl)
     {
-        try {
-            Driver driver = new Driver();
-            Properties urlProperties = driver.parseURL(connectionUrl, null);
-            checkArgument(urlProperties != null, "Invalid JDBC URL for MySQL connector");
-            checkArgument(driver.database(urlProperties) == null, "Database (catalog) must not be specified in JDBC URL for MySQL connector");
-        }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
+        checkArgument(ConnectionUrlParser.isConnectionStringSupported(connectionUrl), "Invalid JDBC URL for MySQL connector");
+        checkArgument(StringUtils.isNullOrEmpty(ConnectionUrl.getConnectionUrlInstance(connectionUrl, null).getDatabase()), "Database (catalog) must not be specified in JDBC URL for MySQL connector");
     }
 }

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -167,8 +167,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -110,8 +110,8 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
 
         <!-- Presto SPI -->

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/MysqlDaoProvider.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/MysqlDaoProvider.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.resourceGroups.db;
 
-import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+import com.mysql.cj.jdbc.MysqlDataSource;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -193,8 +193,8 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
 
@@ -258,7 +258,7 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
-            <artifactId>testing-mysql-server-5</artifactId>
+            <artifactId>testing-mysql-server-8</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Description
This PR is for upgrading the mysql jar version to the latest version 9.2.0.
This fixes CVE-2023-22102.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes

* Upgrade the MySQL to version 9.2.0 in response to `CVE-2023-22102 <https://github.com/advisories/GHSA-m6vm-37g8-gqvh>`_. :pr:`24754`

```