### PR TITLE
[native] Add longVariableConstraints to function metadata

### DIFF
--- a/presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/JsonBasedUdfFunctionMetadata.java
+++ b/presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/JsonBasedUdfFunctionMetadata.java
@@ -16,6 +16,7 @@ package com.facebook.presto.functionNamespace;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.function.AggregationFunctionMetadata;
 import com.facebook.presto.spi.function.FunctionKind;
+import com.facebook.presto.spi.function.LongVariableConstraint;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.TypeVariableConstraint;
@@ -73,6 +74,7 @@ public class JsonBasedUdfFunctionMetadata
      * Optional list of the typeVariableConstraints.
      */
     private final Optional<List<TypeVariableConstraint>> typeVariableConstraints;
+    private final Optional<List<LongVariableConstraint>> longVariableConstraints;
     private final Optional<SqlFunctionId> functionId;
     private final Optional<String> version;
 
@@ -88,7 +90,8 @@ public class JsonBasedUdfFunctionMetadata
             @JsonProperty("aggregateMetadata") Optional<AggregationFunctionMetadata> aggregateMetadata,
             @JsonProperty("functionId") Optional<SqlFunctionId> functionId,
             @JsonProperty("version") Optional<String> version,
-            @JsonProperty("typeVariableConstraints") Optional<List<TypeVariableConstraint>> typeVariableConstraints)
+            @JsonProperty("typeVariableConstraints") Optional<List<TypeVariableConstraint>> typeVariableConstraints,
+            @JsonProperty("longVariableConstraints") Optional<List<LongVariableConstraint>> longVariableConstraints)
     {
         this.docString = requireNonNull(docString, "docString is null");
         this.functionKind = requireNonNull(functionKind, "functionKind is null");
@@ -104,6 +107,7 @@ public class JsonBasedUdfFunctionMetadata
         this.functionId = requireNonNull(functionId, "functionId is null");
         this.version = requireNonNull(version, "version is null");
         this.typeVariableConstraints = requireNonNull(typeVariableConstraints, "typeVariableConstraints is null");
+        this.longVariableConstraints = requireNonNull(longVariableConstraints, "longVariableConstraints is null");
     }
 
     @JsonProperty
@@ -176,5 +180,11 @@ public class JsonBasedUdfFunctionMetadata
     public Optional<List<TypeVariableConstraint>> getTypeVariableConstraints()
     {
         return typeVariableConstraints;
+    }
+
+    @JsonProperty
+    public Optional<List<LongVariableConstraint>> getLongVariableConstraints()
+    {
+        return longVariableConstraints;
     }
 }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/rest/RestBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/rest/RestBasedFunctionNamespaceManager.java
@@ -139,6 +139,7 @@ public class RestBasedFunctionNamespaceManager
                 qualifiedFunctionName,
                 parameterBuilder.build(),
                 emptyList(),
+                emptyList(),
                 jsonBasedUdfFunctionMetaData.getOutputType(),
                 jsonBasedUdfFunctionMetaData.getDocString(),
                 jsonBasedUdfFunctionMetaData.getRoutineCharacteristics(),

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestRestBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/TestRestBasedFunctionNamespaceManager.java
@@ -146,6 +146,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.default.square"), ImmutableList.of(parseTypeSignature("integer")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         squareFunctions.add(new JsonBasedUdfFunctionMetadata(
                 "square a double",
@@ -158,6 +159,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.test_schema.square"), ImmutableList.of(parseTypeSignature("double")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         udfSignatureMap.put("square", squareFunctions);
 
@@ -174,6 +176,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.default.array_function_1"), ImmutableList.of(parseTypeSignature("ARRAY<ARRAY<BOOLEAN>>"), parseTypeSignature("ARRAY<ARRAY<BOOLEAN>>")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         arrayFunction1.add(new JsonBasedUdfFunctionMetadata(
                 "combines two float arrays into one",
@@ -186,6 +189,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.test_schema.array_function_1"), ImmutableList.of(parseTypeSignature("ARRAY<ARRAY<BIGINT>>"), parseTypeSignature("ARRAY<ARRAY<BIGINT>>")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         arrayFunction1.add(new JsonBasedUdfFunctionMetadata(
                 "combines two double arrays into one",
@@ -198,6 +202,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.test_schema.array_function_1"), ImmutableList.of(parseTypeSignature("ARRAY<DOUBLE>"), parseTypeSignature("ARRAY<DOUBLE>")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         udfSignatureMap.put("array_function_1", arrayFunction1);
 
@@ -214,6 +219,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.default.array_function_2"), ImmutableList.of(parseTypeSignature("ARRAY<map<BIGINT, DOUBLE>>"), parseTypeSignature("ARRAY<varchar>")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         arrayFunction2.add(new JsonBasedUdfFunctionMetadata(
                 "transforms inputs into the output",
@@ -226,6 +232,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.test_schema.array_function_2"), ImmutableList.of(parseTypeSignature("ARRAY<map<BIGINT, DOUBLE>>"), parseTypeSignature("ARRAY<ARRAY<BOOLEAN>>"), parseTypeSignature("ARRAY<varchar>")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         udfSignatureMap.put("array_function_2", arrayFunction2);
 
@@ -249,6 +256,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.default.square"), ImmutableList.of(parseTypeSignature("integer")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         squareFunctions.add(new JsonBasedUdfFunctionMetadata(
                 "square a double",
@@ -261,6 +269,7 @@ public class TestRestBasedFunctionNamespaceManager
                 Optional.empty(),
                 Optional.of(new SqlFunctionId(QualifiedObjectName.valueOf("unittest.test_schema.square"), ImmutableList.of(parseTypeSignature("double")))),
                 Optional.of("1"),
+                Optional.of(emptyList()),
                 Optional.of(emptyList())));
         udfSignatureMap.put("square", squareFunctions);
 

--- a/presto-function-server/src/main/java/com/facebook/presto/server/FunctionResource.java
+++ b/presto-function-server/src/main/java/com/facebook/presto/server/FunctionResource.java
@@ -140,7 +140,8 @@ public class FunctionResource
                                 function.getSignature().getName(),
                                 function.getSignature().getArgumentTypes())),
                 Optional.of("1"),
-                Optional.of(function.getSignature().getTypeVariableConstraints()));
+                Optional.of(function.getSignature().getTypeVariableConstraints()),
+                Optional.ofNullable(function.getSignature().getLongVariableConstraints()));
     }
 
     @GET

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
@@ -54,6 +54,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
+import static java.util.Collections.emptyList;
 
 public final class SqlInvokedScalarFromAnnotationsParser
 {
@@ -169,6 +170,7 @@ public final class SqlInvokedScalarFromAnnotationsParser
                         QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, name),
                         parameters,
                         typeVariableConstraints,
+                        emptyList(),
                         returnType,
                         functionDescription,
                         routineCharacteristics,

--- a/presto-native-execution/presto_cpp/main/types/FunctionMetadata.cpp
+++ b/presto-native-execution/presto_cpp/main/types/FunctionMetadata.cpp
@@ -134,6 +134,23 @@ const std::vector<protocol::TypeVariableConstraint> getTypeVariableConstraints(
   return typeVariableConstraints;
 }
 
+const std::vector<protocol::LongVariableConstraint> getLongVariableConstraints(
+    const FunctionSignature& functionSignature) {
+  std::vector<protocol::LongVariableConstraint> longVariableConstraints;
+  const auto functionVariables = functionSignature.variables();
+  for (const auto& [name, signature] : functionVariables) {
+    if (signature.isIntegerParameter() && !signature.constraint().empty()) {
+      protocol::LongVariableConstraint longVariableConstraint;
+      longVariableConstraint.name =
+          boost::algorithm::to_lower_copy(signature.name());
+      longVariableConstraint.expression =
+          boost::algorithm::to_lower_copy(signature.constraint());
+      longVariableConstraints.emplace_back(longVariableConstraint);
+    }
+  }
+  return longVariableConstraints;
+}
+
 std::optional<protocol::JsonBasedUdfFunctionMetadata> buildFunctionMetadata(
     const std::string& name,
     const std::string& schema,
@@ -165,6 +182,9 @@ std::optional<protocol::JsonBasedUdfFunctionMetadata> buildFunctionMetadata(
   metadata.typeVariableConstraints =
       std::make_shared<std::vector<protocol::TypeVariableConstraint>>(
           getTypeVariableConstraints(signature));
+  metadata.longVariableConstraints =
+      std::make_shared<std::vector<protocol::LongVariableConstraint>>(
+          getLongVariableConstraints(signature));
 
   if (aggregateSignature) {
     metadata.aggregateMetadata =

--- a/presto-native-execution/presto_cpp/main/types/tests/FunctionMetadataTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/FunctionMetadataTest.cpp
@@ -88,6 +88,10 @@ TEST_F(FunctionMetadataTest, lead) {
   testFunction("lead", "Lead.json", 3);
 }
 
+TEST_F(FunctionMetadataTest, mod) {
+  testFunction("mod", "Mod.json", 7);
+}
+
 TEST_F(FunctionMetadataTest, ntile) {
   testFunction("ntile", "Ntile.json", 1);
 }

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ApproxMostFrequent.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ApproxMostFrequent.json
@@ -7,6 +7,7 @@
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "map(boolean,bigint)",
       "paramTypes": [
         "bigint",
@@ -29,6 +30,7 @@
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "map(tinyint,bigint)",
       "paramTypes": [
         "bigint",
@@ -51,6 +53,7 @@
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "map(smallint,bigint)",
       "paramTypes": [
         "bigint",
@@ -73,6 +76,7 @@
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "map(integer,bigint)",
       "paramTypes": [
         "bigint",
@@ -95,6 +99,7 @@
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "map(bigint,bigint)",
       "paramTypes": [
         "bigint",
@@ -117,6 +122,7 @@
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "map(varchar,bigint)",
       "paramTypes": [
         "bigint",
@@ -139,6 +145,7 @@
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "map(json,bigint)",
       "paramTypes": [
         "bigint",

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ArrayFrequency.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ArrayFrequency.json
@@ -3,6 +3,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(double,integer)",
       "paramTypes": [
         "array(double)"
@@ -19,6 +20,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(real,integer)",
       "paramTypes": [
         "array(real)"
@@ -35,6 +37,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(integer,integer)",
       "paramTypes": [
         "array(integer)"
@@ -51,6 +54,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(varchar,integer)",
       "paramTypes": [
         "array(varchar)"
@@ -67,6 +71,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(bigint,integer)",
       "paramTypes": [
         "array(bigint)"
@@ -83,6 +88,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(smallint,integer)",
       "paramTypes": [
         "array(smallint)"
@@ -99,6 +105,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(timestamp,integer)",
       "paramTypes": [
         "array(timestamp)"
@@ -115,6 +122,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(tinyint,integer)",
       "paramTypes": [
         "array(tinyint)"
@@ -131,6 +139,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(date,integer)",
       "paramTypes": [
         "array(date)"
@@ -147,6 +156,7 @@
     {
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(boolean,integer)",
       "paramTypes": [
         "array(boolean)"

--- a/presto-native-execution/presto_cpp/main/types/tests/data/Combinations.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/Combinations.json
@@ -3,6 +3,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(__user_t1))",
       "paramTypes": [
         "array(__user_t1)",
@@ -28,6 +29,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(date))",
       "paramTypes": [
         "array(date)",
@@ -45,6 +47,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(timestamp))",
       "paramTypes": [
         "array(timestamp)",
@@ -62,6 +65,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(varchar))",
       "paramTypes": [
         "array(varchar)",
@@ -79,6 +83,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(boolean))",
       "paramTypes": [
         "array(boolean)",
@@ -96,6 +101,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(double))",
       "paramTypes": [
         "array(double)",
@@ -113,6 +119,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(real))",
       "paramTypes": [
         "array(real)",
@@ -130,6 +137,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(tinyint))",
       "paramTypes": [
         "array(tinyint)",
@@ -147,6 +155,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(bigint))",
       "paramTypes": [
         "array(bigint)",
@@ -164,6 +173,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(integer))",
       "paramTypes": [
         "array(integer)",
@@ -181,6 +191,7 @@
     {
       "docString": "presto.default.combinations",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "array(array(smallint))",
       "paramTypes": [
         "array(smallint)",

--- a/presto-native-execution/presto_cpp/main/types/tests/data/CovarSamp.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/CovarSamp.json
@@ -7,6 +7,7 @@
       },
       "docString": "presto.default.covar_samp",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "double",
@@ -28,6 +29,7 @@
       },
       "docString": "presto.default.covar_samp",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "real",
       "paramTypes": [
         "real",

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ElementAt.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ElementAt.json
@@ -3,6 +3,7 @@
     {
       "docString": "presto.default.element_at",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "t",
       "paramTypes": [
         "array(t)",
@@ -28,6 +29,7 @@
     {
       "docString": "presto.default.element_at",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "t",
       "paramTypes": [
         "array(t)",
@@ -53,6 +55,7 @@
     {
       "docString": "presto.default.element_at",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "v",
       "paramTypes": [
         "map(k,v)",

--- a/presto-native-execution/presto_cpp/main/types/tests/data/Greatest.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/Greatest.json
@@ -3,6 +3,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"timestamp with time zone",
             "paramTypes":["timestamp with time zone","timestamp with time zone"],
             "routineCharacteristics": {
@@ -16,6 +17,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"double",
             "paramTypes":["double","double"],
             "routineCharacteristics": {
@@ -30,6 +32,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"varchar",
             "paramTypes":["varchar","varchar"],
             "routineCharacteristics": {
@@ -44,6 +47,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"real",
             "paramTypes":["real","real"],
             "routineCharacteristics": {
@@ -58,6 +62,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"timestamp",
             "paramTypes":["timestamp","timestamp"],
             "routineCharacteristics": {
@@ -72,6 +77,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"bigint",
             "paramTypes":["bigint","bigint"],
             "routineCharacteristics": {
@@ -86,6 +92,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"decimal(i1,i5)",
             "paramTypes":["decimal(i1,i5)","decimal(i1,i5)"],
             "routineCharacteristics": {
@@ -100,6 +107,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"boolean",
             "paramTypes":["boolean","boolean"],
             "routineCharacteristics": {
@@ -114,6 +122,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"smallint",
             "paramTypes":["smallint","smallint"],
             "routineCharacteristics": {
@@ -128,6 +137,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"date",
             "paramTypes":["date","date"],
             "routineCharacteristics": {
@@ -142,6 +152,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"tinyint",
             "paramTypes":["tinyint","tinyint"],
             "routineCharacteristics": {
@@ -156,6 +167,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"integer",
             "paramTypes":["integer","integer"],
             "routineCharacteristics": {
@@ -170,6 +182,7 @@
         {
             "docString":"presto.default.greatest",
             "functionKind":"SCALAR",
+            "longVariableConstraints":[],
             "outputType":"ipaddress",
             "paramTypes":["ipaddress","ipaddress"],
             "routineCharacteristics": {

--- a/presto-native-execution/presto_cpp/main/types/tests/data/Lead.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/Lead.json
@@ -3,6 +3,7 @@
     {
       "docString": "presto.default.lead",
       "functionKind": "WINDOW",
+      "longVariableConstraints":[],
       "outputType": "t",
       "paramTypes": [
         "t"
@@ -27,6 +28,7 @@
     {
       "docString": "presto.default.lead",
       "functionKind": "WINDOW",
+      "longVariableConstraints":[],
       "outputType": "t",
       "paramTypes": [
         "t",
@@ -52,6 +54,7 @@
     {
       "docString": "presto.default.lead",
       "functionKind": "WINDOW",
+      "longVariableConstraints":[],
       "outputType": "t",
       "paramTypes": [
         "t",

--- a/presto-native-execution/presto_cpp/main/types/tests/data/Mod.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/Mod.json
@@ -1,0 +1,118 @@
+{
+    "mod": [
+      {
+        "docString": "presto.default.mod",
+        "functionKind": "SCALAR",
+        "longVariableConstraints":[],
+        "outputType": "integer",
+        "paramTypes": ["integer", "integer"],
+        "routineCharacteristics": {
+          "determinism": "DETERMINISTIC",
+          "language": "CPP",
+          "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+        },
+        "schema": "default",
+        "typeVariableConstraints":[],
+        "variableArity":false
+      },
+      {
+        "docString": "presto.default.mod",
+        "functionKind": "SCALAR",
+        "longVariableConstraints":[],
+        "outputType": "smallint",
+        "paramTypes": ["smallint", "smallint"],
+        "routineCharacteristics": {
+          "determinism": "DETERMINISTIC",
+          "language": "CPP",
+          "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+        },
+        "schema": "default",
+        "typeVariableConstraints":[],
+        "variableArity":false
+      },
+      {
+        "docString": "presto.default.mod",
+        "functionKind": "SCALAR",
+        "longVariableConstraints":[],
+        "outputType": "bigint",
+        "paramTypes": ["bigint", "bigint"],
+        "routineCharacteristics": {
+          "determinism": "DETERMINISTIC",
+          "language": "CPP",
+          "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+        },
+        "schema": "default",
+        "typeVariableConstraints":[],
+        "variableArity":false
+      },
+      {
+        "docString": "presto.default.mod",
+        "functionKind": "SCALAR",
+        "longVariableConstraints":[],
+        "outputType": "tinyint",
+        "paramTypes": ["tinyint", "tinyint"],
+        "routineCharacteristics": {
+          "determinism": "DETERMINISTIC",
+          "language": "CPP",
+          "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+        },
+        "schema": "default",
+        "typeVariableConstraints":[],
+        "variableArity":false
+      },
+      {
+        "docString": "presto.default.mod",
+        "functionKind": "SCALAR",
+        "longVariableConstraints":[],
+        "outputType": "double",
+        "paramTypes": ["double", "double"],
+        "routineCharacteristics": {
+          "determinism": "DETERMINISTIC",
+          "language": "CPP",
+          "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+        },
+        "schema": "default",
+        "typeVariableConstraints":[],
+        "variableArity":false
+      },
+      {
+        "docString": "presto.default.mod",
+        "functionKind": "SCALAR",
+        "longVariableConstraints":[],
+        "outputType": "real",
+        "paramTypes": ["real", "real"],
+        "routineCharacteristics": {
+          "determinism": "DETERMINISTIC",
+          "language": "CPP",
+          "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+        },
+        "schema": "default",
+        "typeVariableConstraints":[],
+        "variableArity":false
+      },
+      {
+        "docString": "presto.default.mod",
+        "functionKind": "SCALAR",
+        "longVariableConstraints":[
+            {
+                "expression":"max(i5, i6)",
+                "name":"i7"
+            },
+            {
+                "expression":"min(i2 - i6, i1 - i5) + max(i5, i6)",
+                "name":"i3"
+            }
+        ],
+        "outputType":"decimal(i3,i7)",
+        "paramTypes":["decimal(i1,i5)","decimal(i2,i6)"],
+        "routineCharacteristics": {
+          "determinism": "DETERMINISTIC",
+          "language": "CPP",
+          "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+        },
+        "schema": "default",
+        "typeVariableConstraints":[],
+        "variableArity":false
+      }
+    ]
+}

--- a/presto-native-execution/presto_cpp/main/types/tests/data/Ntile.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/Ntile.json
@@ -3,6 +3,7 @@
     {
       "docString": "presto.default.ntile",
       "functionKind": "WINDOW",
+      "longVariableConstraints":[],
       "outputType": "bigint",
       "paramTypes": [
         "bigint"

--- a/presto-native-execution/presto_cpp/main/types/tests/data/SetAgg.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/SetAgg.json
@@ -7,6 +7,7 @@
       },
       "docString": "presto.default.set_agg",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "array(t)",
       "paramTypes": [
         "t"

--- a/presto-native-execution/presto_cpp/main/types/tests/data/StddevSamp.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/StddevSamp.json
@@ -7,6 +7,7 @@
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "smallint"
@@ -27,6 +28,7 @@
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "integer"
@@ -47,6 +49,7 @@
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "bigint"
@@ -67,6 +70,7 @@
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "real"
@@ -87,6 +91,7 @@
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "double"

--- a/presto-native-execution/presto_cpp/main/types/tests/data/TransformKeys.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/TransformKeys.json
@@ -3,6 +3,7 @@
     {
       "docString": "presto.default.transform_keys",
       "functionKind": "SCALAR",
+      "longVariableConstraints":[],
       "outputType": "map(k2,v)",
       "paramTypes": [
         "map(k1,v)",

--- a/presto-native-execution/presto_cpp/main/types/tests/data/Variance.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/Variance.json
@@ -7,6 +7,7 @@
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "smallint"
@@ -27,6 +28,7 @@
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "integer"
@@ -47,6 +49,7 @@
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "bigint"
@@ -67,6 +70,7 @@
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "real"
@@ -87,6 +91,7 @@
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "double"
@@ -107,6 +112,7 @@
       },
       "docString": "presto.default.variance",
       "functionKind": "WINDOW",
+      "longVariableConstraints":[],
       "outputType": "double",
       "paramTypes": [
         "smallint"

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -6207,6 +6207,13 @@ void to_json(json& j, const JsonBasedUdfFunctionMetadata& p) {
       "JsonBasedUdfFunctionMetadata",
       "List<TypeVariableConstraint>",
       "typeVariableConstraints");
+  to_json_key(
+      j,
+      "longVariableConstraints",
+      p.longVariableConstraints,
+      "JsonBasedUdfFunctionMetadata",
+      "List<LongVariableConstraint>",
+      "longVariableConstraints");
 }
 
 void from_json(const json& j, JsonBasedUdfFunctionMetadata& p) {
@@ -6287,6 +6294,13 @@ void from_json(const json& j, JsonBasedUdfFunctionMetadata& p) {
       "JsonBasedUdfFunctionMetadata",
       "List<TypeVariableConstraint>",
       "typeVariableConstraints");
+  from_json_key(
+      j,
+      "longVariableConstraints",
+      p.longVariableConstraints,
+      "JsonBasedUdfFunctionMetadata",
+      "List<LongVariableConstraint>",
+      "longVariableConstraints");
 }
 } // namespace facebook::presto::protocol
 /*

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -67,21 +67,21 @@ extern const char* const PRESTO_ABORT_TASK_URL_PARAM;
 class Exception : public std::runtime_error {
  public:
   explicit Exception(const std::string& message)
-      : std::runtime_error(message) {};
+      : std::runtime_error(message){};
 };
 
 class TypeError : public Exception {
  public:
-  explicit TypeError(const std::string& message) : Exception(message) {};
+  explicit TypeError(const std::string& message) : Exception(message){};
 };
 
 class OutOfRange : public Exception {
  public:
-  explicit OutOfRange(const std::string& message) : Exception(message) {};
+  explicit OutOfRange(const std::string& message) : Exception(message){};
 };
 class ParseError : public Exception {
  public:
-  explicit ParseError(const std::string& message) : Exception(message) {};
+  explicit ParseError(const std::string& message) : Exception(message){};
 };
 
 using String = std::string;
@@ -1556,6 +1556,7 @@ struct JsonBasedUdfFunctionMetadata {
   std::shared_ptr<SqlFunctionId> functionId = {};
   std::shared_ptr<String> version = {};
   std::shared_ptr<List<TypeVariableConstraint>> typeVariableConstraints = {};
+  std::shared_ptr<List<LongVariableConstraint>> longVariableConstraints = {};
 };
 void to_json(json& j, const JsonBasedUdfFunctionMetadata& p);
 void from_json(const json& j, JsonBasedUdfFunctionMetadata& p);

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionNamespaceManager.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionNamespaceManager.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.spi.function.LongVariableConstraint;
 import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.ScalarFunctionImplementation;
 import com.facebook.presto.spi.function.Signature;
@@ -210,6 +211,8 @@ public class NativeFunctionNamespaceManager
         List<TypeSignature> parameterTypeList = convertApplicableTypeToVariable(jsonBasedUdfFunctionMetaData.getParamTypes());
         List<TypeVariableConstraint> typeVariableConstraintsList = jsonBasedUdfFunctionMetaData.getTypeVariableConstraints().isPresent() ?
                 jsonBasedUdfFunctionMetaData.getTypeVariableConstraints().get() : Collections.emptyList();
+        List<LongVariableConstraint> longVariableConstraintList = jsonBasedUdfFunctionMetaData.getLongVariableConstraints().isPresent() ?
+                jsonBasedUdfFunctionMetaData.getLongVariableConstraints().get() : Collections.emptyList();
 
         TypeSignature outputType = convertApplicableTypeToVariable(jsonBasedUdfFunctionMetaData.getOutputType());
         ImmutableList.Builder<Parameter> parameterBuilder = ImmutableList.builder();
@@ -227,6 +230,7 @@ public class NativeFunctionNamespaceManager
                 qualifiedFunctionName,
                 parameterBuilder.build(),
                 typeVariableConstraintsList,
+                longVariableConstraintList,
                 outputType,
                 jsonBasedUdfFunctionMetaData.getDocString(),
                 jsonBasedUdfFunctionMetaData.getRoutineCharacteristics(),

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -142,6 +142,7 @@ public class TestNativeSidecarPlugin
                 "date_trunc('month', from_unixtime(orderkey, '+03:00')), date_trunc('day', from_unixtime(orderkey, '-07:00')), " +
                 "date_trunc('hour', from_unixtime(orderkey, '-09:30')), date_trunc('minute', from_unixtime(orderkey, '+05:30')), " +
                 "date_trunc('second', from_unixtime(orderkey, '+00:00')) FROM orders");
+        assertQuery("SELECT mod(orderkey, linenumber) FROM lineitem");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedFunction.java
@@ -91,7 +91,7 @@ public class SqlInvokedFunction
             String body,
             FunctionVersion version)
     {
-        this(functionName, parameters, emptyList(), returnType, description, routineCharacteristics, body, false, version, SCALAR, Optional.empty());
+        this(functionName, parameters, emptyList(), emptyList(), returnType, description, routineCharacteristics, body, false, version, SCALAR, Optional.empty());
     }
 
     public SqlInvokedFunction(
@@ -105,13 +105,14 @@ public class SqlInvokedFunction
             FunctionKind kind,
             Optional<AggregationFunctionMetadata> aggregationMetadata)
     {
-        this(functionName, parameters, emptyList(), returnType, description, routineCharacteristics, body, false, version, kind, aggregationMetadata);
+        this(functionName, parameters, emptyList(), emptyList(), returnType, description, routineCharacteristics, body, false, version, kind, aggregationMetadata);
     }
 
     public SqlInvokedFunction(
             QualifiedObjectName functionName,
             List<Parameter> parameters,
             List<TypeVariableConstraint> typeVariableConstraints,
+            List<LongVariableConstraint> longVariableConstraints,
             TypeSignature returnType,
             String description,
             RoutineCharacteristics routineCharacteristics,
@@ -125,6 +126,7 @@ public class SqlInvokedFunction
                 functionName,
                 parameters,
                 typeVariableConstraints,
+                longVariableConstraints,
                 returnType,
                 description,
                 routineCharacteristics,
@@ -145,6 +147,7 @@ public class SqlInvokedFunction
             QualifiedObjectName functionName,
             List<Parameter> parameters,
             List<TypeVariableConstraint> typeVariableConstraints,
+            List<LongVariableConstraint> longVariableConstraints,
             TypeSignature returnType,
             String description,
             RoutineCharacteristics routineCharacteristics,
@@ -160,7 +163,7 @@ public class SqlInvokedFunction
         this.description = requireNonNull(description, "description is null");
         this.routineCharacteristics = requireNonNull(routineCharacteristics, "routineCharacteristics is null");
         this.body = requireNonNull(body, "body is null");
-        this.signature = new Signature(functionName, kind, typeVariableConstraints, emptyList(), returnType, getArgumentTypes(parameters), variableArity);
+        this.signature = new Signature(functionName, kind, typeVariableConstraints, longVariableConstraints, returnType, getArgumentTypes(parameters), variableArity);
         this.functionId = requireNonNull(functionId, "functionId is null");
         this.variableArity = variableArity;
         this.functionVersion = requireNonNull(version, "version is null");
@@ -193,6 +196,7 @@ public class SqlInvokedFunction
                 signature.getName(),
                 parameters,
                 signature.getTypeVariableConstraints(),
+                signature.getLongVariableConstraints(),
                 signature.getReturnType(),
                 description,
                 routineCharacteristics,


### PR DESCRIPTION
## Description
Add `longVariableConstraints` to function metadata.
`longVariableConstraints` are optional constraints present in the signature which are used to identify the applicable functions in the coordinator. 

For eg:
Consider a query like `SELECT mod(orderkey, linenumber) FROM lineitem`.
While identifying the applicable functions for `mod`, there is a function signature with decimal args and a decimal return type.

```
{
        "docString": "presto.default.mod",
        "functionKind": "SCALAR",
        "longVariableConstraints":[
            {
                "expression":"max(i5, i6)",
                "name":"i7"
            },
            {
                "expression":"min(i2 - i6, i1 - i5) + max(i5, i6)",
                "name":"i3"
            }
        ],
        "outputType":"decimal(i3,i7)",
        "paramTypes":["decimal(i1,i5)","decimal(i2,i6)"],
        "routineCharacteristics": {
          "determinism": "DETERMINISTIC",
          "language": "CPP",
          "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
        },
        "schema": "default",
        "typeVariableConstraints":[],
        "variableArity":false
      }
```
      
     To resolve the variables `i3` and `i7` to valid integers, you use the underlying formula specified in the longVariableConstraints.
     
     To clarify more, 
     For this eg: select mod(decimal(`<i1>` 18,`<i5>` 2), decimal(`<i2>` 38,`<i6>` 2));
     i7 will be resolved to max(i5, i6) = max(2,2) = 2
     i3 will be resolved to min(i2 - i6, i1 - i5) + max(i5, i6) = min(38 - 2, 18 - 2) + max(2,2) = 15 + 2 = 17
     
     The final output type = decimal(i3, i7) = (17,2)
     
## Motivation and Context  
When sidecar is enabled,  this query fails
`"SELECT mod(orderkey, linenumber) FROM lineitem");  with the error: Variable is not bound: i3`
The issue arose when identifying applicable functions for the mod operation, as the lack of `longVariableConstraints` prevented the coordinator from binding variables properly. Without this metadata, the coordinator could not determine how to bind variables to the functions.

This change addresses the issue by adding the necessary `longVariableConstraints` metadata to the functions, enabling the coordinator to bind the variables correctly using the formulae defined in `longVariableConstraints`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.


```
== RELEASE NOTES ==

General Changes

*  (Functions with long constraints) fail in sidecar

