### PR TITLE
Fix return type for fnv1_32 and fnv1a_32 functions

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
@@ -395,7 +395,7 @@ public final class VarbinaryFunctions
 
     @Description("compute fnv-1 32 bit")
     @ScalarFunction("fnv1_32")
-    @SqlType(StandardTypes.BIGINT)
+    @SqlType(StandardTypes.INTEGER)
     public static long fnv1Hash32(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
         return FnvHash.fnv1Hash32(slice);
@@ -411,7 +411,7 @@ public final class VarbinaryFunctions
 
     @Description("compute fnv-1a 32 bit")
     @ScalarFunction("fnv1a_32")
-    @SqlType(StandardTypes.BIGINT)
+    @SqlType(StandardTypes.INTEGER)
     public static long fnv1aHash32(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
         return FnvHash.fnv1aHash32(slice);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
@@ -413,21 +413,21 @@ public class TestVarbinaryFunctions
     public void testFnv()
     {
         // ground truth result is generated via https://nqv.github.io/fnv/
-        assertFunction("fnv1_32(from_hex(''))", BIGINT, 0x811c9dc5L + Integer.MIN_VALUE * 2L);
-        assertFunction("fnv1_32(from_hex('19'))", BIGINT, 0x050c5d06L);
-        assertFunction("fnv1_32(from_hex('F5'))", BIGINT, 0x050c5deaL); // Check for sign extension bug
-        assertFunction("fnv1_32(from_hex('0919'))", BIGINT, 0x087689bbL); // Check for byte ordering
-        assertFunction("fnv1_32(from_hex('F50919'))", BIGINT, 0x67a7fdecL);
-        assertFunction("fnv1_32(from_hex('232706FC6BF50919'))", BIGINT, 0x9f2263f3L + Integer.MIN_VALUE * 2L);
+        assertFunction("fnv1_32(from_hex(''))", INTEGER, 0x811c9dc5);
+        assertFunction("fnv1_32(from_hex('19'))", INTEGER, 0x050c5d06);
+        assertFunction("fnv1_32(from_hex('F5'))", INTEGER, 0x050c5dea); // Check for sign extension bug
+        assertFunction("fnv1_32(from_hex('0919'))", INTEGER, 0x087689bb); // Check for byte ordering
+        assertFunction("fnv1_32(from_hex('F50919'))", INTEGER, 0x67a7fdec);
+        assertFunction("fnv1_32(from_hex('232706FC6BF50919'))", INTEGER, 0x9f2263f3);
         assertFunction("fnv1_64(from_hex(''))", BIGINT, 0xcbf29ce484222325L);
         assertFunction("fnv1_64(from_hex('232706FC6BF50919'))", BIGINT, 0x4a65ff96675a9f33L);
 
-        assertFunction("fnv1a_32(from_hex(''))", BIGINT, 0x811c9dc5L + Integer.MIN_VALUE * 2L);
-        assertFunction("fnv1a_32(from_hex('19'))", BIGINT, 0x1c0c8154L);
-        assertFunction("fnv1a_32(from_hex('F5'))", BIGINT, 0x700b7290L); // Check for sign extension bug
-        assertFunction("fnv1a_32(from_hex('0919'))", BIGINT, 0x34881807L); // Check for byte ordering
-        assertFunction("fnv1a_32(from_hex('F50919'))", BIGINT, 0xeb80c366L + Integer.MIN_VALUE * 2L);
-        assertFunction("fnv1a_32(from_hex('232706FC6BF50919'))", BIGINT, 0x0951d55fL);
+        assertFunction("fnv1a_32(from_hex(''))", INTEGER, 0x811c9dc5);
+        assertFunction("fnv1a_32(from_hex('19'))", INTEGER, 0x1c0c8154);
+        assertFunction("fnv1a_32(from_hex('F5'))", INTEGER, 0x700b7290); // Check for sign extension bug
+        assertFunction("fnv1a_32(from_hex('0919'))", INTEGER, 0x34881807); // Check for byte ordering
+        assertFunction("fnv1a_32(from_hex('F50919'))", INTEGER, 0xeb80c366);
+        assertFunction("fnv1a_32(from_hex('232706FC6BF50919'))", INTEGER, 0x0951d55f);
         assertFunction("fnv1a_64(from_hex(''))", BIGINT, 0xcbf29ce484222325L);
         assertFunction("fnv1a_64(from_hex('232706FC6BF50919'))", BIGINT, 0x68addc0b0febac5fL);
     }


### PR DESCRIPTION
## Description
fnv1_32 fnv1_32a return 4-bytes hash of varbinary. The correct return type is INTEGER.

## Test Plan
1. Unittests
2. Tested with verifier
```
// 1. Correct type

$ presto di --smc pnb2_verifier_t1_ec2
select typeof(fnv1a_32(from_hex('')));
  _col0               
---------
 integer
(1 row)

// 2. Coordinator results:
presto:di> SELECT fnv1_32(from_hex('')),
        -> fnv1_32(from_hex('19')),
        -> fnv1_32(from_hex('F5')),
        -> fnv1_32(from_hex('0919')),
        -> fnv1_32(from_hex('F50919')),
        -> fnv1_32(from_hex('232706FC6BF50919')),
        -> fnv1a_32(from_hex('')),
        -> fnv1a_32(from_hex('19')),
        -> fnv1a_32(from_hex('F5')),
        -> fnv1a_32(from_hex('0919')),
        -> fnv1a_32(from_hex('F50919')),
        -> fnv1a_32(from_hex('232706FC6BF50919')) \G
-[ RECORD 1 ]-------  
_col0  | -2128831035
_col1  | 84696326
_col2  | 84696554
_col3  | 141986235
_col4  | 1739062764
_col5  | -1625136141
_col6  | -2128831035
_col7  | 470581588
_col8  | 1879798416
_col9  | 881334279
_col10 | -343882906
_col11 | 156357983

Query 20250320_232624_00032_etmsr, FINISHED, 1 node

// 3. Worker results:
presto:di> SELECT fnv1_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', ''))),
        -> fnv1_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', '19'))),
        -> fnv1_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', 'F5'))),
        -> fnv1_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', '0919'))),
        -> fnv1_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', 'F50919'))),
        -> fnv1_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', '232706FC6BF50919'))),
        -> fnv1a_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', ''))),
        -> fnv1a_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', '19'))),
        -> fnv1a_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', 'F5'))),
        -> fnv1a_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', '0919'))),
        -> fnv1a_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', 'F50919'))),
        -> fnv1a_32(from_hex(IF(o_orderpriority = 'IMPOSSIBLE', '', '232706FC6BF50919'))) from tpch.sf1.orders limit 1 \G
-[ RECORD 1 ]-------  
_col0  | -2128831035
_col1  | 84696326
_col2  | 84696554
_col3  | 141986235
_col4  | 1739062764
_col5  | -1625136141
_col6  | -2128831035
_col7  | 470581588
_col8  | 1879798416
_col9  | 881334279
_col10 | -343882906
_col11 | 156357983

Query 20250320_232953_00036_etmsr, FINISHED, 850 nodes

// 4. Prod results for comparison:
$ presto di 
presto:di> SELECT fnv1_32(from_hex('')),
        -> fnv1_32(from_hex('19')),
        -> fnv1_32(from_hex('F5')),
        -> fnv1_32(from_hex('0919')),
        -> fnv1_32(from_hex('F50919')),
        -> fnv1_32(from_hex('232706FC6BF50919')),
        -> fnv1a_32(from_hex('')),
        -> fnv1a_32(from_hex('19')),
        -> fnv1a_32(from_hex('F5')),
        -> fnv1a_32(from_hex('0919')),
        -> fnv1a_32(from_hex('F50919')),
        -> fnv1a_32(from_hex('232706FC6BF50919')) \G
-[ RECORD 1 ]-------  
_col0  | -2128831035
_col1  | 84696326
_col2  | 84696554
_col3  | 141986235
_col4  | 1739062764
_col5  | -1625136141
_col6  | -2128831035
_col7  | 470581588
_col8  | 1879798416
_col9  | 881334279
_col10 | -343882906
_col11 | 156357983

Query 20250320_233241_58398_ws4y7, FINISHED, 1 node
```
All responses are identical. The test data is taken from:
`presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java`

== NO RELEASE NOTE ==


