### PR TITLE
Fix flaky test in TestMemoryRevokingScheduler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
@@ -151,6 +151,12 @@ public class MemoryRevokingScheduler
         memoryRevocationExecutor.invokeAll(singletonList((Callable<?>) () -> null));
     }
 
+    @VisibleForTesting
+    void submitAsynchronousCallable(Callable<?> callable)
+    {
+        memoryRevocationExecutor.submit(callable);
+    }
+
     private void onMemoryReserved(MemoryPool memoryPool, QueryId queryId, long queryMemoryReservation)
     {
         try {


### PR DESCRIPTION
## Description

This PR fix flaky test: TestMemoryRevokingScheduler.testTaskRevokingOrderForRevocableBytes.

The operation `LocalMemoryContext.setBytes(bytes)` will trigger `MemoryRevokingScheduler.onMemoryReserved(...)`, which will then try to request memory revoking asynchronously in thread pool `memoryRevocationExecutor`.

Considering this, the following code in this flaky test:

```
operatorContext1.localRevocableMemoryContext().setBytes(11);
operatorContext2.localRevocableMemoryContext().setBytes(12);
```

 May have different sequences of actions:

````
operator1 reserve 11 bytes
operator2 reserve 12 bytes
request memory revoking(asynchronously)
request memory revoking(asynchronously)
......
````

Or:

```
operator1 reserve 11 bytes
request memory revoking(asynchronously)
operator2 reserve 12 bytes
request memory revoking(asynchronously)
```

Although the first scenario may occur in most cases because asynchronous calls take much longer than sequential execution, but we cannot rely on it. When the second scenario occur, the test will fail. To make it more apparent, we can simply add a `Thread.sleep(10)` between the two lines.

This PR figure out a way to ensure that there will definitely no memory revoking between the two memory reserving actions.

## Motivation and Context

Fix: #24691

## Impact

N/A

## Test Plan

 - Add from `Thread.sleep(10)` to `Thread.sleep(10000)` between the two memory revoking lines in `testTaskRevokingOrderForRevocableBytes`, manually make sure that it works well.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

