### PR TITLE
Prevent extra license checks on presto-root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2769,6 +2769,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <!-- This execution re-binds the default check to child projects -->
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+                <!-- this configuration skips license check on presto-root -->
+                <!-- without propagating it to child projects -->
+                <inherited>false</inherited>
+                <configuration>
+                    <excludes>
+                        <exclude>**/presto-*/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/assembly/tests-with-dependencies.xml
+++ b/src/assembly/tests-with-dependencies.xml
@@ -1,3 +1,18 @@
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">

--- a/src/modernizer/violations.xml
+++ b/src/modernizer/violations.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <modernizer>
     <violation>
         <name>java/lang/Class.newInstance:()Ljava/lang/Object;</name>

--- a/src/release/release-notes.sh
+++ b/src/release/release-notes.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 if [[ "$#" -ne 2 ]]; then
     echo "Usage: $0 <github_user> <github_access_token>"


### PR DESCRIPTION
## Description

This adds a configuration for the license-maven-plugin to skip checks against unnecessary files in presto-root, but still enables it for all child modules.

The main issue is that when enabled for presto-root, the plugin will check *all* child directories, even if it is already covered by the plugin execution at a later stage. When running `./mvnw validate` the build spends a significant chunk of time checking all files under presto-root, then continues on to do  the validations for all other modules.

On my MacBook Pro M1 processor I found the following performance improvements after experimenting with 5-6 builds:

Before:
- ./mvnw validate: 44-48 seconds (average ~45 seconds) After:
- ./mvnw validate 30-33 seconds (average ~31 seconds)


## Motivation and Context

Annoyed by longer build times when not specifying a specific module to build.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

