### PR TITLE
[native] Throw velox_unsupported error when try_cast of varchar is not supported.

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -202,7 +202,7 @@ std::optional<TypedExprPtr> convertCastToVarcharWithMaxLength(
   static const std::string prestoDefaultNamespacePrefix =
       SystemConfig::instance()->prestoDefaultNamespacePrefix();
   if (nullOnFailure) {
-    VELOX_NYI("TRY_CAST of varchar to {} is not supported.", returnType);
+    VELOX_UNSUPPORTED("TRY_CAST of varchar to {} is not supported.", returnType);
   }
 
   // Parse the max length from the return type string in the format of


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

