### PR TITLE
[native] Add materialized view refresh to protocol

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -2418,6 +2418,10 @@ void to_json(json& j, const std::shared_ptr<ExecutionWriterTarget>& p) {
     j = *std::static_pointer_cast<DeleteHandle>(p);
     return;
   }
+  if (type == "RefreshMaterializedViewHandle") {
+    j = *std::static_pointer_cast<RefreshMaterializedViewHandle>(p);
+    return;
+  }
 
   throw TypeError(type + " no abstract type ExecutionWriterTarget ");
 }
@@ -2446,6 +2450,13 @@ void from_json(const json& j, std::shared_ptr<ExecutionWriterTarget>& p) {
   }
   if (type == "DeleteHandle") {
     std::shared_ptr<DeleteHandle> k = std::make_shared<DeleteHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
+    return;
+  }
+  if (type == "RefreshMaterializedViewHandle") {
+    std::shared_ptr<RefreshMaterializedViewHandle> k =
+        std::make_shared<RefreshMaterializedViewHandle>();
     j.get_to(*k);
     p = std::static_pointer_cast<ExecutionWriterTarget>(k);
     return;
@@ -8450,9 +8461,13 @@ void from_json(const json& j, Range& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+RefreshMaterializedViewHandle::RefreshMaterializedViewHandle() noexcept {
+  _type = "RefreshMaterializedViewHandle";
+}
 
 void to_json(json& j, const RefreshMaterializedViewHandle& p) {
   j = json::object();
+  j["@type"] = "RefreshMaterializedViewHandle";
   to_json_key(
       j,
       "handle",
@@ -8470,6 +8485,7 @@ void to_json(json& j, const RefreshMaterializedViewHandle& p) {
 }
 
 void from_json(const json& j, RefreshMaterializedViewHandle& p) {
+  p._type = j["@type"];
   from_json_key(
       j,
       "handle",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1948,9 +1948,11 @@ void to_json(json& j, const Range& p);
 void from_json(const json& j, Range& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct RefreshMaterializedViewHandle {
+struct RefreshMaterializedViewHandle : public ExecutionWriterTarget {
   InsertTableHandle handle = {};
   SchemaTableName schemaTableName = {};
+
+  RefreshMaterializedViewHandle() noexcept;
 };
 void to_json(json& j, const RefreshMaterializedViewHandle& p);
 void from_json(const json& j, RefreshMaterializedViewHandle& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -124,9 +124,10 @@ AbstractClasses:
   ExecutionWriterTarget:
     super: JsonEncodedSubclass
     subclasses:
-      - { name: CreateHandle,            key: CreateHandle }
-      - { name: InsertHandle,            key: InsertHandle }
-      - { name: DeleteHandle,            key: DeleteHandle }
+      - { name: CreateHandle,                   key: CreateHandle }
+      - { name: InsertHandle,                   key: InsertHandle }
+      - { name: DeleteHandle,                   key: DeleteHandle }
+      - { name: RefreshMaterializedViewHandle,  key: RefreshMaterializedViewHandle }
 
   InputDistribution:
     super: JsonEncodedSubclass


### PR DESCRIPTION
## Description
Materialized view refresh was not working due to the related plan handle is not mapped to CPP. It causes failure:
RefreshMaterializedViewHandle no abstract type ExecutionWriterTarget

This PR adds the mapping to the cpp protocol.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Run refresh materialized view succeeded in cpp.


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

