### PR TITLE
[native] Fix RowExpressionTest.castToVarchar

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -602,7 +602,7 @@ TEST_F(RowExpressionTest, castToVarchar) {
     std::shared_ptr<protocol::CallExpression> p =
         json::parse(makeCastToVarchar(true, "varchar", "varchar(3)"));
 
-    ASSERT_THROW(converter_->toVeloxExpr(p), VeloxRuntimeError);
+    ASSERT_THROW(converter_->toVeloxExpr(p), VeloxUserError);
   }
   // CAST(nonvarchar_col AS varchar(3))
   {


### PR DESCRIPTION
## Description
Fix a test that was broken in https://github.com/prestodb/presto/pull/24776

## Motivation and Context
In https://github.com/prestodb/presto/pull/24776, we replaced VELOX_NYI with VELOX_UNSUPPORTED. A related unit test (RowExpressionTest.castToVarchar) broke, and showed in CI. However since it was not blocking, I mistakenly merged the PR. Fixing the test here.

## Impact
None

## Test Plan
Ran the test

```
== NO RELEASE NOTE ==
```

