### PR TITLE
Add ConnectorMetadata.commitPageSinkAsync hook for ConnectorDeleteTableHandle

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -572,6 +572,12 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
+    public ListenableFuture<Void> commitPageSinkAsync(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+    }
+
+    @Override
     public MetadataUpdates getMetadataUpdateResults(Session session, QueryManager queryManager, MetadataUpdates metadataUpdates, QueryId queryId)
     {
         return delegate.getMetadataUpdateResults(session, queryManager, metadataUpdates, queryId);

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -481,6 +481,12 @@ public interface Metadata
     @Experimental
     ListenableFuture<Void> commitPageSinkAsync(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments);
 
+    /**
+     * Commits page sink for table deletion.
+     */
+    @Experimental
+    ListenableFuture<Void> commitPageSinkAsync(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments);
+
     MetadataUpdates getMetadataUpdateResults(Session session, QueryManager queryManager, MetadataUpdates metadataUpdates, QueryId queryId);
 
     // TODO: metadata should not provide FunctionAndTypeManager

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -1264,6 +1264,17 @@ public class MetadataManager
     }
 
     @Override
+    public ListenableFuture<Void> commitPageSinkAsync(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        ConnectorId connectorId = tableHandle.getConnectorId();
+        CatalogMetadata catalogMetadata = getCatalogMetadata(session, connectorId);
+        ConnectorMetadata metadata = catalogMetadata.getMetadata();
+        ConnectorSession connectorSession = session.toConnectorSession(connectorId);
+
+        return toListenableFuture(metadata.commitPageSinkAsync(connectorSession, tableHandle.getConnectorHandle(), fragments));
+    }
+
+    @Override
     public MetadataUpdates getMetadataUpdateResults(Session session, QueryManager queryManager, MetadataUpdates metadataUpdateRequests, QueryId queryId)
     {
         ConnectorId connectorId = metadataUpdateRequests.getConnectorId();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -3519,6 +3519,9 @@ public class LocalExecutionPlanner
             else if (target instanceof InsertHandle) {
                 return metadata.commitPageSinkAsync(session, ((InsertHandle) target).getHandle(), fragments);
             }
+            else if (target instanceof DeleteHandle) {
+                return metadata.commitPageSinkAsync(session, ((DeleteHandle) target).getHandle(), fragments);
+            }
             else if (target instanceof RefreshMaterializedViewHandle) {
                 return metadata.commitPageSinkAsync(session, ((RefreshMaterializedViewHandle) target).getHandle(), fragments);
             }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -591,6 +591,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public ListenableFuture<Void> commitPageSinkAsync(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public MetadataUpdates getMetadataUpdateResults(Session session, QueryManager queryManager, MetadataUpdates metadataUpdateRequests, QueryId queryId)
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -808,6 +808,17 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Commits page sink for table insertion.
+     * To enable recoverable grouped execution, it is required that output connector supports page sink commit.
+     * This method is unstable and subject to change in the future.
+     */
+    @Experimental
+    default CompletableFuture<Void> commitPageSinkAsync(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support page sink commit");
+    }
+
+    /**
      * Handles metadata update requests and sends the results back to worker
      */
     default List<ConnectorMetadataUpdateHandle> getMetadataUpdateResults(List<ConnectorMetadataUpdateHandle> metadataUpdateRequests, QueryId queryId)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -746,6 +746,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public CompletableFuture<Void> commitPageSinkAsync(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+        }
+    }
+
+    @Override
     public List<ConnectorMetadataUpdateHandle> getMetadataUpdateResults(List<ConnectorMetadataUpdateHandle> metadataUpdateRequests, QueryId queryId)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
Summary: When ConnectorDeleteTableHandle and DeleteTableHandle were added to the ConnectorMetadata interface for beginDelete() / finishDelete(), we missed adding a commitPageSinkAsync() for implementations which use a PageSink to write out deletes.  This corrects the oversight and puts a hook in place for implementors that need it.

Differential Revision: D71692192


