### PR TITLE
[native] Map kUnsupportedInputUncatchable to not supported error code.

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Exception.h
+++ b/presto-native-execution/presto_cpp/main/common/Exception.h
@@ -106,10 +106,10 @@ class VeloxToPrestoExceptionTranslator {
                {0x00000000,
                 "GENERIC_USER_ERROR",
                 protocol::ErrorType::USER_ERROR}},
-
               {velox::error_code::kUnsupported,
                {0x0000000D, "NOT_SUPPORTED", protocol::ErrorType::USER_ERROR}},
-
+              {velox::error_code::kUnsupportedInputUncatchable,
+               {0x0000000D, "NOT_SUPPORTED", protocol::ErrorType::USER_ERROR}},
               {velox::error_code::kArithmeticError,
                {0x00000000,
                 "GENERIC_USER_ERROR",


### PR DESCRIPTION
## Description
Mapping kUnsupportedInputUncatchable with NOT_SUPPORTED

## Motivation and Context
Better error reporting from presto side.

```
== NO RELEASE NOTE ==
```

