### PR TITLE
[native] Fix MV mapping

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -2410,16 +2410,16 @@ void to_json(json& j, const std::shared_ptr<ExecutionWriterTarget>& p) {
     j = *std::static_pointer_cast<CreateHandle>(p);
     return;
   }
+  if (type == "RefreshMaterializedViewHandle") {
+    j = *std::static_pointer_cast<InsertHandle>(p);
+    return;
+  }
   if (type == "InsertHandle") {
     j = *std::static_pointer_cast<InsertHandle>(p);
     return;
   }
   if (type == "DeleteHandle") {
     j = *std::static_pointer_cast<DeleteHandle>(p);
-    return;
-  }
-  if (type == "RefreshMaterializedViewHandle") {
-    j = *std::static_pointer_cast<RefreshMaterializedViewHandle>(p);
     return;
   }
 
@@ -2442,6 +2442,12 @@ void from_json(const json& j, std::shared_ptr<ExecutionWriterTarget>& p) {
     p = std::static_pointer_cast<ExecutionWriterTarget>(k);
     return;
   }
+  if (type == "RefreshMaterializedViewHandle") {
+    std::shared_ptr<InsertHandle> k = std::make_shared<InsertHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
+    return;
+  }
   if (type == "InsertHandle") {
     std::shared_ptr<InsertHandle> k = std::make_shared<InsertHandle>();
     j.get_to(*k);
@@ -2450,13 +2456,6 @@ void from_json(const json& j, std::shared_ptr<ExecutionWriterTarget>& p) {
   }
   if (type == "DeleteHandle") {
     std::shared_ptr<DeleteHandle> k = std::make_shared<DeleteHandle>();
-    j.get_to(*k);
-    p = std::static_pointer_cast<ExecutionWriterTarget>(k);
-    return;
-  }
-  if (type == "RefreshMaterializedViewHandle") {
-    std::shared_ptr<RefreshMaterializedViewHandle> k =
-        std::make_shared<RefreshMaterializedViewHandle>();
     j.get_to(*k);
     p = std::static_pointer_cast<ExecutionWriterTarget>(k);
     return;
@@ -8461,13 +8460,9 @@ void from_json(const json& j, Range& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-RefreshMaterializedViewHandle::RefreshMaterializedViewHandle() noexcept {
-  _type = "RefreshMaterializedViewHandle";
-}
 
 void to_json(json& j, const RefreshMaterializedViewHandle& p) {
   j = json::object();
-  j["@type"] = "RefreshMaterializedViewHandle";
   to_json_key(
       j,
       "handle",
@@ -8485,7 +8480,6 @@ void to_json(json& j, const RefreshMaterializedViewHandle& p) {
 }
 
 void from_json(const json& j, RefreshMaterializedViewHandle& p) {
-  p._type = j["@type"];
   from_json_key(
       j,
       "handle",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1948,11 +1948,9 @@ void to_json(json& j, const Range& p);
 void from_json(const json& j, Range& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct RefreshMaterializedViewHandle : public ExecutionWriterTarget {
+struct RefreshMaterializedViewHandle {
   InsertTableHandle handle = {};
   SchemaTableName schemaTableName = {};
-
-  RefreshMaterializedViewHandle() noexcept;
 };
 void to_json(json& j, const RefreshMaterializedViewHandle& p);
 void from_json(const json& j, RefreshMaterializedViewHandle& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -124,10 +124,11 @@ AbstractClasses:
   ExecutionWriterTarget:
     super: JsonEncodedSubclass
     subclasses:
-      - { name: CreateHandle,                   key: CreateHandle }
-      - { name: InsertHandle,                   key: InsertHandle }
-      - { name: DeleteHandle,                   key: DeleteHandle }
-      - { name: RefreshMaterializedViewHandle,  key: RefreshMaterializedViewHandle }
+      - { name: CreateHandle,  key: CreateHandle }
+      - { name: InsertHandle,  key: RefreshMaterializedViewHandle }
+      - { name: InsertHandle,  key: InsertHandle }
+      - { name: DeleteHandle,  key: DeleteHandle }
+
 
   InputDistribution:
     super: JsonEncodedSubclass


### PR DESCRIPTION
## Description
The original approach will cause a "Unsupported table writer handle" error. We should use InsertHandle with the MaterializedViewHandle key.
The order also needs to have MaterializedViewHandle key before InsertHandle key, otherwise the insertHandle type will be replaced with MaterializedViewHandle.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
refresh materialized view query

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

