### PR TITLE
Use Java built-in functions to create failure function

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.RowBlockBuilder;
 import com.facebook.presto.common.function.OperatorType;
@@ -71,6 +72,7 @@ import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.expressions.DynamicFilters.isDynamicFilter;
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
 import static com.facebook.presto.metadata.CastType.CAST;
 import static com.facebook.presto.metadata.CastType.JSON_TO_ARRAY_CAST;
 import static com.facebook.presto.metadata.CastType.JSON_TO_MAP_CAST;
@@ -721,7 +723,7 @@ public class RowExpressionInterpreter
             requireNonNull(exception, "Exception is null");
 
             String failureInfo = JsonCodec.jsonCodec(FailureInfo.class).toJson(Failures.toFailure(exception).toFailureInfo());
-            FunctionHandle jsonParse = functionAndTypeManager.lookupFunction("json_parse", fromTypes(VARCHAR));
+            FunctionHandle jsonParse = functionAndTypeManager.lookupFunction(QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "json_parse"), fromTypes(VARCHAR));
             Object json = functionInvoker.invoke(jsonParse, session.getSqlFunctionProperties(), utf8Slice(failureInfo));
             FunctionHandle cast = functionAndTypeManager.lookupCast(CAST, UNKNOWN, type);
             if (exception instanceof PrestoException) {

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -145,6 +145,7 @@ public class TestNativeSidecarPlugin
                 "date_trunc('hour', from_unixtime(orderkey, '-09:30')), date_trunc('minute', from_unixtime(orderkey, '+05:30')), " +
                 "date_trunc('second', from_unixtime(orderkey, '+00:00')) FROM orders");
         assertQuery("SELECT mod(orderkey, linenumber) FROM lineitem");
+        assertQueryFails("SELECT IF(true, 0/0, 1)", "[\\s\\S]*/ by zero native.default.fail[\\s\\S]*");
     }
 
     @Test
@@ -187,6 +188,8 @@ public class TestNativeSidecarPlugin
         assertQuery("SELECT min(orderkey) OVER (PARTITION BY orderdate ORDER BY orderdate, totalprice) FROM orders");
         assertQuery("SELECT sum(rn) FROM (SELECT row_number() over() rn, * from orders) WHERE rn = 10");
         assertQuery("SELECT * FROM (SELECT row_number() over(partition by orderstatus order by orderkey) rn, * from orders) WHERE rn = 1");
+        assertQuery("SELECT first_value(orderdate) OVER (PARTITION BY orderkey ORDER BY totalprice RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) FROM orders");
+        assertQuery("SELECT lead(orderkey, 5) OVER (PARTITION BY custkey, orderdate ORDER BY totalprice desc ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) FROM orders");
     }
 
     @Test


### PR DESCRIPTION
## Description
When sidecar is enabled, the coordinator is unable to create a failure function. Use Java functions to create a failure function.

## Motivation and Context
When the sidecar is used for query analysis, the default namespace is switched to reflect the different set of functions used in Velox. While eventually we wish to use Velox for both expression evaluation and also as a registry of functions, the former is taking a long time due to refactoring in Velox. In the meantime, we need function evaluation over C++ namespaces to work properly, which means we need to use the Java functions for now. This is a stopgap solution until function evaluation in Velox works end to end. (copied from https://github.com/prestodb/presto/pull/25135)

Eg: 
`java.lang.AssertionError: Execution of 'actual' query failed: SELECT IF(true, 0/0, 1)`

```
Caused by: java.lang.RuntimeException: Error getting ScalarFunctionImplementation for handle: native.default.json_parse(varchar):1
	at com.facebook.presto.tests.AbstractTestingPrestoClient.execute(AbstractTestingPrestoClient.java:126)
	at com.facebook.presto.tests.DistributedQueryRunner.execute(DistributedQueryRunner.java:852)
	at com.facebook.presto.tests.DistributedQueryRunner.execute(DistributedQueryRunner.java:820)
	at com.facebook.presto.tests.QueryAssertions.assertQuery(QueryAssertions.java:176)
	... 31 more
Caused by: com.facebook.presto.spi.PrestoException: Error getting ScalarFunctionImplementation for handle: native.default.json_parse(varchar):1
	at com.facebook.presto.functionNamespace.AbstractSqlInvokedFunctionNamespaceManager.convertToPrestoException(AbstractSqlInvokedFunctionNamespaceManager.java:255)
	at com.facebook.presto.functionNamespace.AbstractSqlInvokedFunctionNamespaceManager.getScalarFunctionImplementation(AbstractSqlInvokedFunctionNamespaceManager.java:231)
	at com.facebook.presto.metadata.FunctionAndTypeManager.getScalarFunctionImplementation(FunctionAndTypeManager.java:607)
	at com.facebook.presto.metadata.FunctionAndTypeManager.getJavaScalarFunctionImplementation(FunctionAndTypeManager.java:640)
	at com.facebook.presto.sql.InterpretedFunctionInvoker.invoke(InterpretedFunctionInvoker.java:60)
	at com.facebook.presto.sql.InterpretedFunctionInvoker.invoke(InterpretedFunctionInvoker.java:55)
	at com.facebook.presto.sql.planner.RowExpressionInterpreter$Visitor.createFailureFunction(RowExpressionInterpreter.java:727)
	at com.facebook.presto.sql.planner.RowExpressionInterpreter$Visitor.processWithExceptionHandling(RowExpressionInterpreter.java:717)
	at com.facebook.presto.sql.planner.RowExpressionInterpreter$Visitor.visitSpecialForm(RowExpressionInterpreter.java:367)
	at com.facebook.presto.spi.relation.SpecialFormExpression.accept(SpecialFormExpression.java:127)
	at com.facebook.presto.sql.planner.RowExpressionInterpreter.optimize(RowExpressionInterpreter.java:191)
	at com.facebook.presto.sql.planner.RowExpressionInterpreter.optimize(RowExpressionInterpreter.java:182)
	at com.facebook.presto.sql.relational.RowExpressionOptimizer.optimize(RowExpressionOptimizer.java:49)
	at com.facebook.presto.sql.planner.iterative.rule.SimplifyRowExpressions$Rewriter.rewrite(SimplifyRowExpressions.java:72)
	at com.facebook.presto.sql.planner.iterative.rule.SimplifyRowExpressions$Rewriter.rewrite(SimplifyRowExpressions.java:64)
	at com.facebook.presto.sql.planner.iterative.rule.RowExpressionRewriteRuleSet$ProjectRowExpressionRewrite.apply(RowExpressionRewriteRuleSet.java:176)
	at com.facebook.presto.sql.planner.iterative.rule.RowExpressionRewriteRuleSet$ProjectRowExpressionRewrite.apply(RowExpressionRewriteRuleSet.java:155)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:237)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:189)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:151)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:281)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:153)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:281)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:153)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:281)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:153)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:281)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:153)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.optimize(IterativeOptimizer.java:138)
	at com.facebook.presto.sql.Optimizer.validateAndOptimizePlan(Optimizer.java:112)
	at com.facebook.presto.execution.SqlQueryExecution.lambda$doCreateLogicalPlanAndOptimize$5(SqlQueryExecution.java:589)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
	at com.facebook.presto.execution.SqlQueryExecution.doCreateLogicalPlanAndOptimize(SqlQueryExecution.java:587)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
	at com.facebook.presto.execution.SqlQueryExecution.createLogicalPlanAndOptimize(SqlQueryExecution.java:558)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:486)
	at com.facebook.presto.$gen.Presto_null__testversion____20250521_201034_5.run(Unknown Source)
	at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:320)
	at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:210)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalStateException: Presto coordinator can not resolve implementation of CPP UDF functions

```

Another example would be whenever window queries encounter invalid frames, we create a failure function, which is failing too. 

## Impact
No impact

## Test Plan
Test cases included

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

== RELEASE NOTES ==

```
Prestissimo (Native Execution)
* Replace using native functions with Java functions for creating failure functions when native execution is enabled.
```

