### PR TITLE
[Hive] Use S3 listObjectsV2 in PrestoS3FileSystem listPrefix

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/MockAmazonS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/MockAmazonS3.java
@@ -18,8 +18,8 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
@@ -34,8 +34,13 @@ import static java.net.HttpURLConnection.HTTP_OK;
 public class MockAmazonS3
         extends AbstractAmazonS3
 {
-    private static final String STANDARD_OBJECT_KEY = "test/standard";
+    private static final String STANDARD_ONE_OBJECT_KEY = "test/standardOne";
+    private static final String STANDARD_TWO_OBJECT_KEY = "test/standardTwo";
     private static final String GLACIER_OBJECT_KEY = "test/glacier";
+    private static final String HADOOP_FOLDER_MARKER_OBJECT_KEY = "test/test_$folder$";
+    private static final String CONTINUATION_TOKEN = "continue";
+    private static final String PAGINATION_PREFIX = "test-pagination/";
+    private static final String DEEP_ARCHIVE_OBJECT_KEY = "test/deepArchive";
 
     private int getObjectHttpCode = HTTP_OK;
     private int getObjectMetadataHttpCode = HTTP_OK;
@@ -111,24 +116,16 @@ public class MockAmazonS3
     }
 
     @Override
-    public ObjectListing listObjects(ListObjectsRequest listObjectsRequest)
+    public ListObjectsV2Result listObjectsV2(ListObjectsV2Request listObjectsV2Request)
     {
-        ObjectListing listing = new ObjectListing();
-
-        S3ObjectSummary standard = new S3ObjectSummary();
-        standard.setStorageClass(StorageClass.Standard.toString());
-        standard.setKey(STANDARD_OBJECT_KEY);
-        standard.setLastModified(new Date());
-        listing.getObjectSummaries().add(standard);
-
+        ListObjectsV2Result listing = new ListObjectsV2Result();
         if (hasHadoopFolderMarkerObjects) {
             S3ObjectSummary hadoopFolderMarker = new S3ObjectSummary();
             hadoopFolderMarker.setStorageClass(StorageClass.Standard.toString());
-            hadoopFolderMarker.setKey("test/test_$folder$");
+            hadoopFolderMarker.setKey(HADOOP_FOLDER_MARKER_OBJECT_KEY);
             hadoopFolderMarker.setLastModified(new Date());
             listing.getObjectSummaries().add(hadoopFolderMarker);
         }
-
         if (hasGlacierObjects) {
             S3ObjectSummary glacier = new S3ObjectSummary();
             glacier.setStorageClass(StorageClass.Glacier.toString());
@@ -138,11 +135,29 @@ public class MockAmazonS3
 
             S3ObjectSummary deepArchive = new S3ObjectSummary();
             deepArchive.setStorageClass(StorageClass.DeepArchive.toString());
-            deepArchive.setKey("test/deepArchive");
+            deepArchive.setKey(DEEP_ARCHIVE_OBJECT_KEY);
             deepArchive.setLastModified(new Date());
             listing.getObjectSummaries().add(deepArchive);
         }
-
+        if (CONTINUATION_TOKEN.equals(listObjectsV2Request.getContinuationToken())) {
+            S3ObjectSummary standardTwo = new S3ObjectSummary();
+            standardTwo.setStorageClass(StorageClass.Standard.toString());
+            standardTwo.setKey(STANDARD_TWO_OBJECT_KEY);
+            standardTwo.setLastModified(new Date());
+            listing.getObjectSummaries().add(standardTwo);
+            listing.setTruncated(false);
+        }
+        else {
+            S3ObjectSummary standardOne = new S3ObjectSummary();
+            standardOne.setStorageClass(StorageClass.Standard.toString());
+            standardOne.setKey(STANDARD_ONE_OBJECT_KEY);
+            standardOne.setLastModified(new Date());
+            listing.getObjectSummaries().add(standardOne);
+            if (listObjectsV2Request.getPrefix().equals(PAGINATION_PREFIX)) {
+                listing.setTruncated(true);
+                listing.setNextContinuationToken(CONTINUATION_TOKEN);
+            }
+        }
         return listing;
     }
 


### PR DESCRIPTION
## Description
The current implementation of PrestoS3FileSystem listPrefix uses listObjects, which retrieves all results at once and lacks efficient pagination, making it less suitable for large S3 buckets. 

This PR replaces listObjects with listObjectsV2, which supports token-based pagination, improving scalability and handling large object listings more effectively.

## Impact
Efficient handling of S3 object listing in Presto.

## Test Plan
tested using cli

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Replace listObjects with listObjectsV2 in PrestoS3FileSystem listPrefix.
```

