### PR TITLE
[native] Remove unused file from protocol generation

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -271,7 +271,6 @@ JavaClasses:
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/StatisticAggregations.java
   - presto-main/src/main/java/com/facebook/presto/cost/PartialAggregationStatsEstimate.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/ProjectNode.java
-  - presto-matching/src/test/java/com/facebook/presto/matching/example/rel/ProjectNode.java
   - presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
   - presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RemoteSourceNode.java
   - presto-spi/src/main/java/com/facebook/presto/spi/session/ResourceEstimates.java

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -313,7 +313,6 @@ JavaClasses:
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/StatisticAggregations.java
   - presto-main/src/main/java/com/facebook/presto/cost/PartialAggregationStatsEstimate.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/ProjectNode.java
-  - presto-matching/src/test/java/com/facebook/presto/matching/example/rel/ProjectNode.java
   - presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
   - presto-main/src/main/java/com/facebook/presto/sql/planner/plan/RemoteSourceNode.java
   - presto-spi/src/main/java/com/facebook/presto/spi/session/ResourceEstimates.java


### PR DESCRIPTION
A ProjectNode file from a test directory was included to be used during the protocol generation but the object it generated “ProjectNode” was already generated from the SPI. As a result the generated protocol files are unchanged.

The file does not and should not be included.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

