### PR TITLE
Add support for optional kafka SASL

### DIFF
--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -28,11 +28,18 @@ To configure the Kafka connector, create a catalog properties file
 ``etc/catalog/kafka.properties`` with the following contents,
 replacing the properties as appropriate:
 
+In some cases, such as when using specialized authentication methods, it is necessary to specify
+additional Kafka client properties to access your Kafka cluster. To do so,
+add the ``kafka.config.resources`` property to reference your Kafka configuration files.
+Configuration settings in the files in ``kafka.config.resources`` can be overridden if
+specified explicitly in ``kafka.properties`` (for example, ``security.protocol=SSL``):
+
 .. code-block:: none
 
     connector.name=kafka
     kafka.table-names=table1,table2
     kafka.nodes=host1:port,host2:port
+    kafka.config.resources=/etc/kafka-configuration.properties
 
 Multiple Kafka Clusters
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -59,6 +66,13 @@ Property Name                       Description
 ``kafka.max-partition-fetch-bytes`` Maximum number of bytes from one partition per poll
 ``kafka.table-description-dir``     Directory containing topic description files
 ``kafka.hide-internal-columns``     Controls whether internal columns are part of the table schema or not
+``kafka.security-protocol``         Security protocol for connection to Kafka cluster, defaults to ``SASL_PLAINTEXT``
+``kafka.sasl.mechanism``            Authentication mechanism of the SASL
+``kafka.sasl.jaas.config``          JAAS config of the SASL authentication
+``kafka.truststore.path``           Path of the truststore file
+``kafka.truststore.password``       Password for the truststore file
+``kafka.truststore.type``           File format of the truststore file, defaults to ``JKS``
+``kafka.config.resources``          A comma-separated list of Kafka client configuration files. If a specialized authentication method is required, it can be specified in these additional Kafka client properties files. Example: `/etc/kafka-configuration.properties`
 =================================== ==============================================================
 
 ``kafka.table-names``
@@ -136,6 +150,50 @@ these columns are hidden, they can still be used in queries but do not
 show up in ``DESCRIBE <table-name>`` or ``SELECT *``.
 
 This property is optional; the default is ``true``.
+
+``kafka.security-protocol``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Protocol used to communicate with brokers.
+Valid values are: ``SASL_PLAINTEXT``, ``SASL_SSL``.
+
+This property is optional; default is ``SASL_PLAINTEXT``.
+
+``kafka.sasl.mechanism``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The authentication mechanism used by SASL.
+Valid values are: ``PLAIN``, ``SCRAM-SHA-256``, ``SCRAM-SHA-512``.
+
+This property is optional.
+
+``kafka.sasl.jaas.config``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The configuration used for SASL authentication, which is a method for securing communication with brokers.
+
+This property is optional, but is required when ``kafka.sasl.mechanism`` is given.
+
+``kafka.truststore.path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Path of the truststore file used for connecting to the Kafka cluster.
+
+This property is optional.
+
+``kafka.truststore.password``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Password for the truststore file used for connecting to the Kafka cluster.
+
+This property is optional, but is required when ``kafka.truststore.path`` is given.
+
+``kafka.truststore.type``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+File format of the truststore file.
+Valid values are: ``JKS``, ``PKCS12``.
+
+This property is optional; default is ``JKS``.
 
 Internal Columns
 ----------------

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -288,6 +288,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>test</scope>

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
@@ -14,12 +14,20 @@
 package com.facebook.presto.kafka;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.presto.kafka.schema.file.FileTableDescriptionSupplier;
 import com.facebook.presto.kafka.server.file.FileKafkaClusterMetadataSupplier;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.NotNull;
+
+import java.io.File;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class KafkaConnectorConfig
 {
@@ -57,6 +65,11 @@ public class KafkaConnectorConfig
      * The kafka cluster metadata supplier to use, default is FILE
      */
     private String clusterMetadataSupplier = FileKafkaClusterMetadataSupplier.NAME;
+
+    /**
+     * The resourceConfigFiles to use for additional properties, default is empty
+     */
+    private List<File> resourceConfigFiles = ImmutableList.of();
 
     @NotNull
     public String getDefaultSchema()
@@ -143,6 +156,22 @@ public class KafkaConnectorConfig
     public KafkaConnectorConfig setHideInternalColumns(boolean hideInternalColumns)
     {
         this.hideInternalColumns = hideInternalColumns;
+        return this;
+    }
+
+    @NotNull
+    public List<File> getResourceConfigFiles()
+    {
+        return resourceConfigFiles;
+    }
+
+    @Config("kafka.config.resources")
+    @ConfigDescription("Optional config files")
+    public KafkaConnectorConfig setResourceConfigFiles(String files)
+    {
+        this.resourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files).stream()
+                .map(File::new)
+                .collect(toImmutableList());
         return this;
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPageSink.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPageSink.java
@@ -54,7 +54,7 @@ public class KafkaPageSink
             List<KafkaColumnHandle> columns,
             RowEncoder keyEncoder,
             RowEncoder messageEncoder,
-            PlainTextKafkaProducerFactory producerFactory,
+            KafkaProducerFactory producerFactory,
             KafkaClusterMetadataSupplier supplier)
     {
         this.topicName = requireNonNull(topicName, "topicName is null");

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPageSinkProvider.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPageSinkProvider.java
@@ -42,11 +42,11 @@ public class KafkaPageSinkProvider
         implements ConnectorPageSinkProvider
 {
     private final DispatchingRowEncoderFactory encoderFactory;
-    private final PlainTextKafkaProducerFactory producerFactory;
+    private final KafkaProducerFactory producerFactory;
     private final KafkaClusterMetadataSupplier kafkaClusterMetadataSupplier;
 
     @Inject
-    public KafkaPageSinkProvider(DispatchingRowEncoderFactory encoderFactory, PlainTextKafkaProducerFactory producerFactory, KafkaClusterMetadataSupplier kafkaClusterMetadataSupplier)
+    public KafkaPageSinkProvider(DispatchingRowEncoderFactory encoderFactory, KafkaProducerFactory producerFactory, KafkaClusterMetadataSupplier kafkaClusterMetadataSupplier)
     {
         this.encoderFactory = requireNonNull(encoderFactory, "encoderFactory is null");
         this.producerFactory = requireNonNull(producerFactory, "producerFactory is null");

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPlainTextModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPlainTextModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class KafkaPlainTextModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(KafkaProducerFactory.class).to(PlainTextKafkaProducerFactory.class).in(Scopes.SINGLETON);
+        binder.bind(KafkaConsumerManager.class).to(PlainTextKafkaConsumerManager.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaProducerFactory.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaProducerFactory.java
@@ -14,20 +14,17 @@
 package com.facebook.presto.kafka;
 
 import com.facebook.presto.spi.HostAddress;
-import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
 
-import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Properties;
 
-public interface KafkaConsumerManager
+public interface KafkaProducerFactory
 {
-    default KafkaConsumer<ByteBuffer, ByteBuffer> createConsumer(String threadName, HostAddress hostAddress)
+    default KafkaProducer<byte[], byte[]> create(List<HostAddress> bootstrapServers)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(KafkaPlugin.class.getClassLoader())) {
-            return new KafkaConsumer<>(configure(threadName, hostAddress));
-        }
+        return new KafkaProducer<>(configure(bootstrapServers));
     }
 
-    Properties configure(String threadName, HostAddress hostAddress);
+    Properties configure(List<HostAddress> bootstrapServers);
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSaslModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSaslModule.java
@@ -13,16 +13,24 @@
  */
 package com.facebook.presto.kafka;
 
+import com.facebook.presto.kafka.security.ForKafkaSasl;
+import com.facebook.presto.kafka.security.KafkaSaslConfig;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
-public class KafkaProducerModule
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class KafkaSaslModule
         implements Module
 {
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(PlainTextKafkaProducerFactory.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(KafkaSaslConfig.class);
+        binder.bind(KafkaProducerFactory.class).annotatedWith(ForKafkaSasl.class).to(PlainTextKafkaProducerFactory.class).in(Scopes.SINGLETON);
+        binder.bind(KafkaProducerFactory.class).to(SaslKafkaProducerFactory.class).in(Scopes.SINGLETON);
+        binder.bind(KafkaConsumerManager.class).annotatedWith(ForKafkaSasl.class).to(PlainTextKafkaConsumerManager.class).in(Scopes.SINGLETON);
+        binder.bind(KafkaConsumerManager.class).to(SaslKafkaConsumerManager.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSecurityConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSecurityConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+
+import javax.validation.constraints.AssertTrue;
+
+import java.util.Optional;
+
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SASL_PLAINTEXT;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SASL_SSL;
+
+public class KafkaSecurityConfig
+{
+    private SecurityProtocol securityProtocol;
+
+    public Optional<SecurityProtocol> getSecurityProtocol()
+    {
+        return Optional.ofNullable(securityProtocol);
+    }
+
+    @Config("kafka.security-protocol")
+    @ConfigDescription("Kafka communication security protocol")
+    public KafkaSecurityConfig setSecurityProtocol(SecurityProtocol securityProtocol)
+    {
+        this.securityProtocol = securityProtocol;
+        return this;
+    }
+
+    @AssertTrue(message = "Only SASL_PLAINTEXT and SASL_SSL security protocols are supported. See 'kafka.config.resources' if other security protocols are needed")
+    public boolean isValidSecurityProtocol()
+    {
+        return securityProtocol == null || securityProtocol.equals(SASL_PLAINTEXT) || securityProtocol.equals(SASL_SSL);
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/PlainTextKafkaConsumerManager.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/PlainTextKafkaConsumerManager.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.spi.HostAddress;
+import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+
+import javax.inject.Inject;
+
+import java.util.Properties;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+
+/**
+ * Manages connections to the Kafka nodes. A worker may connect to multiple Kafka nodes depending on partitions
+ * it needs to process.
+ */
+public class PlainTextKafkaConsumerManager
+        implements KafkaConsumerManager
+{
+    private final int maxPartitionFetchBytes;
+    private final int maxPollRecords;
+
+    @Inject
+    public PlainTextKafkaConsumerManager(KafkaConnectorConfig kafkaConnectorConfig)
+    {
+        requireNonNull(kafkaConnectorConfig, "kafkaConnectorConfig is null");
+        this.maxPartitionFetchBytes = kafkaConnectorConfig.getMaxPartitionFetchBytes();
+        this.maxPollRecords = kafkaConnectorConfig.getMaxPollRecords();
+    }
+
+    @Override
+    public Properties configure(String threadName, HostAddress hostAddress)
+    {
+        final Properties properties = new Properties();
+        properties.put(BOOTSTRAP_SERVERS_CONFIG, hostAddress.toString());
+        properties.put(GROUP_ID_CONFIG, threadName);
+        properties.put(MAX_POLL_RECORDS_CONFIG, Integer.toString(maxPollRecords));
+        properties.put(MAX_PARTITION_FETCH_BYTES_CONFIG, maxPartitionFetchBytes);
+        properties.put(CLIENT_ID_CONFIG, String.format("%s-%s", threadName, hostAddress));
+        properties.put(ENABLE_AUTO_COMMIT_CONFIG, false);
+        properties.setProperty(KEY_DESERIALIZER_CLASS_CONFIG, ByteBufferDeserializer.class.getName());
+        properties.setProperty(VALUE_DESERIALIZER_CLASS_CONFIG, ByteBufferDeserializer.class.getName());
+        return properties;
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/SaslKafkaConsumerManager.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/SaslKafkaConsumerManager.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.kafka.security.ForKafkaSasl;
+import com.facebook.presto.kafka.security.KafkaSaslConfig;
+import com.facebook.presto.spi.HostAddress;
+
+import javax.inject.Inject;
+
+import java.util.Properties;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Manages connections to the Kafka nodes. A worker may connect to multiple Kafka nodes depending on partitions
+ * it needs to process.
+ */
+public class SaslKafkaConsumerManager
+        implements KafkaConsumerManager
+{
+    private final KafkaSaslConfig saslConfig;
+    private final KafkaConsumerManager delegate;
+
+    @Inject
+    public SaslKafkaConsumerManager(@ForKafkaSasl KafkaConsumerManager delegate, KafkaSaslConfig saslConfig)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.saslConfig = requireNonNull(saslConfig, "saslConfig is null");
+    }
+
+    @Override
+    public Properties configure(String threadName, HostAddress hostAddress)
+    {
+        Properties properties = new Properties();
+        properties.putAll(delegate.configure(threadName, hostAddress));
+        properties.putAll(saslConfig.getKafkaSaslProperties());
+        return properties;
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/SaslKafkaProducerFactory.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/SaslKafkaProducerFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.kafka.security.ForKafkaSasl;
+import com.facebook.presto.kafka.security.KafkaSaslConfig;
+import com.facebook.presto.spi.HostAddress;
+import com.google.inject.Inject;
+
+import java.util.List;
+import java.util.Properties;
+
+import static java.util.Objects.requireNonNull;
+
+public class SaslKafkaProducerFactory
+        implements KafkaProducerFactory
+{
+    private final KafkaSaslConfig saslConfig;
+    private final KafkaProducerFactory delegate;
+
+    @Inject
+    public SaslKafkaProducerFactory(@ForKafkaSasl KafkaProducerFactory delegate, KafkaSaslConfig saslConfig)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.saslConfig = requireNonNull(saslConfig, "saslConfig is null");
+    }
+
+    @Override
+    public Properties configure(List<HostAddress> bootstrapServers)
+    {
+        Properties properties = new Properties();
+        properties.putAll(delegate.configure(bootstrapServers));
+        properties.putAll(saslConfig.getKafkaSaslProperties());
+        return properties;
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/security/ForKafkaSasl.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/security/ForKafkaSasl.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.security;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForKafkaSasl
+{
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/security/KafkaKeystoreTruststoreType.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/security/KafkaKeystoreTruststoreType.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.security;
+
+public enum KafkaKeystoreTruststoreType {
+    JKS,
+    PKCS12;
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/security/KafkaSaslConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/security/KafkaSaslConfig.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.security;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
+import com.google.common.collect.ImmutableMap;
+
+import javax.validation.constraints.AssertTrue;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.kafka.security.KafkaKeystoreTruststoreType.JKS;
+import static org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_MECHANISM;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SASL_SSL;
+
+/**
+ *  Manages Kafka SASL authentication and encryption between clients and brokers.
+ */
+public class KafkaSaslConfig
+{
+    private String saslJaasConfig;
+    private String saslMechanism;
+    private String truststorePath;
+    private String truststorePassword;
+    private KafkaKeystoreTruststoreType truststoreType = JKS;
+
+    public Optional<String> getSaslJaasConfig()
+    {
+        return Optional.ofNullable(saslJaasConfig);
+    }
+
+    @Config("kafka.sasl.jaas.config")
+    @ConfigDescription("The JAAS config of the SASL authentication")
+    public KafkaSaslConfig setSaslJaasConfig(String saslJaasConfig)
+    {
+        this.saslJaasConfig = saslJaasConfig;
+        return this;
+    }
+
+    public Optional<String> getSaslMechanism()
+    {
+        return Optional.ofNullable(saslMechanism);
+    }
+
+    @Config("kafka.sasl.mechanism")
+    @ConfigDescription("The authentication mechanism of the SASL")
+    @ConfigSecuritySensitive
+    public KafkaSaslConfig setSaslMechanism(String saslMechanism)
+    {
+        this.saslMechanism = saslMechanism;
+        return this;
+    }
+
+    public Optional<String> getTruststorePath()
+    {
+        return Optional.ofNullable(truststorePath);
+    }
+
+    @Config("kafka.truststore.path")
+    @ConfigDescription("The path of the trust store file")
+    public KafkaSaslConfig setTruststorePath(String truststorePath)
+    {
+        this.truststorePath = truststorePath;
+        return this;
+    }
+
+    public Optional<String> getTruststorePassword()
+    {
+        return Optional.ofNullable(truststorePassword);
+    }
+
+    @Config("kafka.truststore.password")
+    @ConfigSecuritySensitive
+    @ConfigDescription("The password for the trust store file")
+    public KafkaSaslConfig setTruststorePassword(String truststorePassword)
+    {
+        this.truststorePassword = truststorePassword;
+        return this;
+    }
+
+    public Optional<KafkaKeystoreTruststoreType> getTruststoreType()
+    {
+        return Optional.ofNullable(truststoreType);
+    }
+
+    @Config("kafka.truststore.type")
+    @ConfigDescription("The file format of the trust store file")
+    public KafkaSaslConfig setTruststoreType(KafkaKeystoreTruststoreType truststoreType)
+    {
+        this.truststoreType = truststoreType;
+        return this;
+    }
+
+    public Map<String, Object> getKafkaSaslProperties()
+    {
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        getSaslMechanism().ifPresent(v -> properties.put(SASL_MECHANISM, v));
+        getSaslJaasConfig().ifPresent(v -> properties.put(SASL_JAAS_CONFIG, v));
+        getTruststorePath().ifPresent(v -> properties.put(SSL_TRUSTSTORE_LOCATION_CONFIG, v));
+        getTruststorePassword().ifPresent(v -> properties.put(SSL_TRUSTSTORE_PASSWORD_CONFIG, v));
+        getTruststoreType().ifPresent(v -> properties.put(SSL_TRUSTSTORE_TYPE_CONFIG, v.name()));
+        properties.put(SECURITY_PROTOCOL_CONFIG, SASL_SSL.name());
+        return properties.buildOrThrow();
+    }
+
+    @AssertTrue(message = "kafka.sasl.jaas.config must be set when kafka.sasl.mechanism is given")
+    public boolean isSaslJaasConfigValid()
+    {
+        return !getSaslMechanism().isPresent() || getSaslJaasConfig().isPresent();
+    }
+
+    @AssertTrue(message = "kafka.ssl.truststore.password must be set when kafka.ssl.truststore.location is given")
+    public boolean isTruststorePasswordValid()
+    {
+        return !getTruststorePath().isPresent() || getTruststorePassword().isPresent();
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/utils/PropertiesUtils.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/utils/PropertiesUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.kafka.utils;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class PropertiesUtils
+{
+    private PropertiesUtils() {}
+
+    public static Map<String, String> readProperties(List<File> resourcePaths)
+            throws IOException
+    {
+        Properties connectionProperties = new Properties();
+        for (File resourcePath : resourcePaths) {
+            checkArgument(resourcePath.exists(), "File does not exist: %s", resourcePath);
+
+            try (InputStream in = new FileInputStream(resourcePath)) {
+                connectionProperties.load(in);
+            }
+        }
+        return ImmutableMap.copyOf(Maps.fromProperties(connectionProperties));
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
@@ -32,12 +32,16 @@ public class TestKafkaConnectorConfig
                 .setTableDescriptionSupplier(FileTableDescriptionSupplier.NAME)
                 .setHideInternalColumns(true)
                 .setMaxPartitionFetchBytes(1048576)
-                .setMaxPollRecords(500));
+                .setMaxPollRecords(500)
+                .setResourceConfigFiles(""));
     }
 
     @Test
     public void testExplicitPropertyMappings()
     {
+        String tempFile1 = "/temp/path/file1";
+        String tempFile2 = "/temp/path/file2";
+
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("kafka.table-description-supplier", "test")
                 .put("kafka.cluster-metadata-supplier", "test")
@@ -46,6 +50,7 @@ public class TestKafkaConnectorConfig
                 .put("kafka.hide-internal-columns", "false")
                 .put("kafka.max-partition-fetch-bytes", "1024")
                 .put("kafka.max-poll-records", "1000")
+                .put("kafka.config.resources", tempFile1 + "," + tempFile2)
                 .build();
 
         KafkaConnectorConfig expected = new KafkaConnectorConfig()
@@ -55,7 +60,8 @@ public class TestKafkaConnectorConfig
                 .setKafkaConnectTimeout("1h")
                 .setHideInternalColumns(false)
                 .setMaxPartitionFetchBytes(1024)
-                .setMaxPollRecords(1000);
+                .setMaxPollRecords(1000)
+                .setResourceConfigFiles(tempFile1 + "," + tempFile2);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaPlugin.java
@@ -19,8 +19,15 @@ import com.facebook.presto.testing.TestingConnectorContext;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.testng.Assert.assertNotNull;
 
 @Test
@@ -42,5 +49,89 @@ public class TestKafkaPlugin
                         .build(),
                 new TestingConnectorContext());
         assertNotNull(c);
+    }
+
+    @Test
+    public void testSslSpinup()
+            throws IOException
+    {
+        KafkaPlugin plugin = new KafkaPlugin();
+
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        assertThat(factory).isInstanceOf(KafkaConnectorFactory.class);
+
+        String secret = "confluent";
+        Path truststorePath = Files.createTempFile("truststore", ".jks");
+
+        writeToFile(truststorePath, secret);
+
+        Connector connector = factory.create(
+                "test-connector",
+                ImmutableMap.<String, String>builder()
+                        .put("kafka.table-names", "test")
+                        .put("kafka.nodes", "localhost:9092")
+                        .put("kafka.security-protocol", "SASL_SSL")
+                        .put("kafka.sasl.jaas.config", "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"testuser\" password=\"testpassword\"")
+                        .put("kafka.sasl.mechanism", "SCRAM-SHA-512")
+                        .put("kafka.truststore.type", "JKS")
+                        .put("kafka.truststore.path", truststorePath.toString())
+                        .put("kafka.truststore.password", "truststore-password")
+                        .buildOrThrow(),
+                new TestingConnectorContext());
+        assertThat(connector).isNotNull();
+        connector.shutdown();
+    }
+
+    @Test
+    public void testConfigResourceSpinup()
+            throws IOException
+    {
+        KafkaPlugin plugin = new KafkaPlugin();
+
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        assertThat(factory).isInstanceOf(KafkaConnectorFactory.class);
+
+        String nativeContent = "security.protocol=SSL";
+        Path nativeKafkaResourcePath = Files.createTempFile("native_kafka", ".properties");
+        writeToFile(nativeKafkaResourcePath, nativeContent);
+
+        Connector connector = factory.create(
+                "test-connector",
+                ImmutableMap.<String, String>builder()
+                        .put("kafka.table-names", "test")
+                        .put("kafka.nodes", "localhost:9092")
+                        .put("kafka.config.resources", nativeKafkaResourcePath.toString())
+                        .buildOrThrow(),
+                new TestingConnectorContext());
+        assertThat(connector).isNotNull();
+        connector.shutdown();
+    }
+
+    @Test
+    public void testResourceConfigMissingFileSpindown()
+    {
+        KafkaPlugin plugin = new KafkaPlugin();
+
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        assertThat(factory).isInstanceOf(KafkaConnectorFactory.class);
+
+        assertThatThrownBy(() -> factory.create(
+                "test-connector",
+                ImmutableMap.<String, String>builder()
+                        .put("kafka.table-names", "test")
+                        .put("kafka.nodes", "localhost:9092")
+                        .put("kafka.security-protocol", "SASL_PLAINTEXT")
+                        .put("kafka.config.resources", "/not/a/real/path")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("IllegalArgumentException: File does not exist: /not/a/real/path");
+    }
+
+    private void writeToFile(Path filepath, String content)
+            throws IOException
+    {
+        try (FileWriter writer = new FileWriter(filepath.toFile())) {
+            writer.write(content);
+        }
     }
 }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaSecurityConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaSecurityConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import javax.validation.constraints.AssertTrue;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static com.facebook.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static com.facebook.airlift.testing.ValidationAssertions.assertValidates;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.PLAINTEXT;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SASL_PLAINTEXT;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SASL_SSL;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SSL;
+
+public class TestKafkaSecurityConfig
+{
+    private static final String INVALID_ERROR_MESSAGE = "Only SASL_PLAINTEXT and SASL_SSL security protocols are supported. See 'kafka.config.resources' if other security protocols are needed";
+    private static final String IS_VALID_SECURITY_PROTOCOL = "validSecurityProtocol";
+
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(KafkaSecurityConfig.class)
+                .setSecurityProtocol(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("kafka.security-protocol", SASL_SSL.name())
+                .build();
+
+        KafkaSecurityConfig expected = new KafkaSecurityConfig().setSecurityProtocol(SASL_SSL);
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testValidSecurityProtocols()
+    {
+        assertValidates(new KafkaSecurityConfig()
+                .setSecurityProtocol(SASL_PLAINTEXT));
+
+        assertValidates(new KafkaSecurityConfig()
+                .setSecurityProtocol(SASL_SSL));
+    }
+
+    @Test
+    public void testInvalidSecurityProtocol()
+    {
+        assertFailsValidation(new KafkaSecurityConfig().setSecurityProtocol(PLAINTEXT),
+                IS_VALID_SECURITY_PROTOCOL,
+                INVALID_ERROR_MESSAGE,
+                AssertTrue.class);
+
+        assertFailsValidation(new KafkaSecurityConfig().setSecurityProtocol(SSL),
+                IS_VALID_SECURITY_PROTOCOL,
+                INVALID_ERROR_MESSAGE,
+                AssertTrue.class);
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/security/TestKafkaSaslConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/security/TestKafkaSaslConfig.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.security;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.testng.annotations.Test;
+
+import javax.validation.constraints.AssertTrue;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static com.facebook.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static com.facebook.presto.kafka.security.KafkaKeystoreTruststoreType.JKS;
+import static com.facebook.presto.kafka.security.KafkaKeystoreTruststoreType.PKCS12;
+import static org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_JAAS_CONFIG;
+import static org.apache.kafka.common.config.SaslConfigs.SASL_MECHANISM;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG;
+import static org.apache.kafka.common.security.auth.SecurityProtocol.SASL_SSL;
+import static org.testng.Assert.assertTrue;
+
+public class TestKafkaSaslConfig
+{
+    private static final String KAFKA_SASL_JAAS_CONFIG = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"testuser\" password=\"testpassword\"";
+    private static final String KAFKA_SASL_MECHANISM = "SCRAM-SHA-512";
+    private static final String KAFKA_TRUSTSTORE_PATH = "/some/path/to/truststore";
+    private static final String KAFKA_TRUSTSTORE_PASSWORD = "my-password";
+    private static final String KAFKA_TRUSTSTORE_TYPE = "PKCS12";
+
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(KafkaSaslConfig.class)
+                .setSaslJaasConfig(null)
+                .setSaslMechanism(null)
+                .setTruststorePath(null)
+                .setTruststorePassword(null)
+                .setTruststoreType(JKS));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+            throws Exception
+    {
+        String secret = "confluent";
+        Path truststorePath = Files.createTempFile("truststore", ".p12");
+        writeToFile(truststorePath, secret);
+
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("kafka.sasl.jaas.config", KAFKA_SASL_JAAS_CONFIG)
+                .put("kafka.sasl.mechanism", KAFKA_SASL_MECHANISM)
+                .put("kafka.truststore.path", truststorePath.toString())
+                .put("kafka.truststore.password", KAFKA_TRUSTSTORE_PASSWORD)
+                .put("kafka.truststore.type", KAFKA_TRUSTSTORE_TYPE)
+                .build();
+
+        KafkaSaslConfig expected = new KafkaSaslConfig()
+                .setSaslJaasConfig(KAFKA_SASL_JAAS_CONFIG)
+                .setSaslMechanism(KAFKA_SASL_MECHANISM)
+                .setTruststorePath(truststorePath.toString())
+                .setTruststorePassword(KAFKA_TRUSTSTORE_PASSWORD)
+                .setTruststoreType(PKCS12);
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testAllConfigPropertiesAreContained()
+    {
+        KafkaSaslConfig config = new KafkaSaslConfig()
+                .setSaslJaasConfig(KAFKA_SASL_JAAS_CONFIG)
+                .setSaslMechanism(KAFKA_SASL_MECHANISM)
+                .setTruststorePath(KAFKA_TRUSTSTORE_PATH)
+                .setTruststorePassword(KAFKA_TRUSTSTORE_PASSWORD)
+                .setTruststoreType(JKS);
+
+        Map<String, Object> securityProperties = config.getKafkaSaslProperties();
+        // Since security related properties are all passed to the underlying kafka-clients library,
+        // the property names must match those expected by kafka-clients
+        Map<String, String> map = Stream.of(
+                        new AbstractMap.SimpleImmutableEntry<>(SASL_JAAS_CONFIG, KAFKA_SASL_JAAS_CONFIG),
+                        new AbstractMap.SimpleImmutableEntry<>(SASL_MECHANISM, KAFKA_SASL_MECHANISM),
+                        new AbstractMap.SimpleImmutableEntry<>(SSL_TRUSTSTORE_LOCATION_CONFIG, KAFKA_TRUSTSTORE_PATH),
+                        new AbstractMap.SimpleImmutableEntry<>(SSL_TRUSTSTORE_PASSWORD_CONFIG, KAFKA_TRUSTSTORE_PASSWORD),
+                        new AbstractMap.SimpleImmutableEntry<>(SSL_TRUSTSTORE_TYPE_CONFIG, JKS.name()),
+                        new AbstractMap.SimpleImmutableEntry<>(SECURITY_PROTOCOL_CONFIG, SASL_SSL.name()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        assertTrue(Maps.difference(map, securityProperties).areEqual());
+    }
+
+    @Test
+    public void testFailOnMissingSaslJaasConfigWithSaslMechanism()
+    {
+        KafkaSaslConfig config = new KafkaSaslConfig();
+        config.setSaslMechanism(KAFKA_SASL_MECHANISM);
+
+        assertFailsValidation(
+                config,
+                "saslJaasConfigValid",
+                "kafka.sasl.jaas.config must be set when kafka.sasl.mechanism is given",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testFailOnMissingTruststorePasswordWithTruststoreLocationSet()
+            throws Exception
+    {
+        String secret = "confluent";
+        Path truststorePath = Files.createTempFile("truststore", ".p12");
+
+        writeToFile(truststorePath, secret);
+
+        KafkaSaslConfig config = new KafkaSaslConfig();
+        config.setTruststorePath(truststorePath.toString());
+
+        assertFailsValidation(
+                config,
+                "truststorePasswordValid",
+                "kafka.ssl.truststore.password must be set when kafka.ssl.truststore.location is given",
+                AssertTrue.class);
+    }
+
+    private void writeToFile(Path filepath, String content)
+            throws IOException
+    {
+        try (FileWriter writer = new FileWriter(filepath.toFile())) {
+            writer.write(content);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Currently the presto-kafka connector can be configured to use SASL authentication (https://docs.confluent.io/platform/current/security/authentication/sasl/plain/overview.html#kafka-sasl-auth-plain) those config properties were made known to the KafkaConfig and are used in the producer as well as consumer factory if being set (all optional).

As of now, we have configured the following parameters for the above requirement:

1. security.protocol
2. sasl.mechanism
3. sasl.jaas.config
4. ssl.truststore.location
5. ssl.truststore.password
6. ssl.truststore.type

As part of the code-level configuration, represent the parameter naming as below and map them to the corresponding Kafka config parameters:

1. kafka.security-protocol=SASL_SSL
2. kafka.sasl.mechanism=PLAIN
3. kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=<USERNAME> password=<API KEY/PASSWORD>;
4. kafka.truststore.path=XXX
5. kafka.truststore.password=XXX
6. kafka.truststore.type=XXX


Taking reference from Trinodb Kafka SSL implementation: https://github.com/trinodb/trino/pull/6929

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Kafka Connector Changes 
* Add support for optional Apache Kafka SASL. 
```