### PR TITLE
Updated MySql version to support arm64 architecture

### DIFF
--- a/presto-product-tests/conf/docker/singlenode-mysql/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-mysql/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   mysql:
     hostname: mysql
-    image: 'mysql:5.7'
+    image: 'mysql:8.0'
     ports:
       - '13306:13306'
     command:


### PR DESCRIPTION
## Description
Updated MySql version used in product-tests to 8.0 to support arm64 architecture

## Motivation and Context
To address the issue https://github.com/prestodb/presto/issues/24801

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==

```

