### PR TITLE
Pass full session to avoid Unknown connector errors

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
@@ -83,4 +83,12 @@ public class TestIcebergDistributedNessie
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageMatching("Cannot expire snapshots: GC is disabled .*");
     }
+
+    @Test
+    public void testUnknownConnectorNotThrown()
+    {
+        // Checks an Unknown connector exception is not thrown when trying to explore through JDBC an Iceberg catalog of type Nessie
+        assertQuerySucceeds("select * from system.jdbc.schemas where TABLE_CATALOG = 'iceberg'");
+        assertQuerySucceeds("select * from system.jdbc.tables where TABLE_CAT = 'iceberg' and TABLE_SCHEM = 'tpch'");
+    }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/connector/system/jdbc/SchemaJdbcTable.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/system/jdbc/SchemaJdbcTable.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.connector.system.jdbc;
 
+import com.facebook.presto.FullConnectorSession;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.metadata.Metadata;
@@ -30,7 +31,6 @@ import javax.inject.Inject;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
-import static com.facebook.presto.connector.system.SystemConnectorSessionUtil.toSession;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.filter;
 import static com.facebook.presto.metadata.MetadataListing.listCatalogs;
 import static com.facebook.presto.metadata.MetadataListing.listSchemas;
@@ -66,7 +66,7 @@ public class SchemaJdbcTable
     @Override
     public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession connectorSession, TupleDomain<Integer> constraint)
     {
-        Session session = toSession(transactionHandle, connectorSession);
+        Session session = ((FullConnectorSession) connectorSession).getSession();
         Optional<String> catalogFilter = FilterUtil.stringFilter(constraint, 1);
 
         Builder table = InMemoryRecordSet.builder(METADATA);

--- a/presto-main-base/src/main/java/com/facebook/presto/connector/system/jdbc/TableJdbcTable.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/system/jdbc/TableJdbcTable.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.connector.system.jdbc;
 
+import com.facebook.presto.FullConnectorSession;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.metadata.Metadata;
@@ -33,7 +34,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
-import static com.facebook.presto.connector.system.SystemConnectorSessionUtil.toSession;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.filter;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.stringFilter;
 import static com.facebook.presto.connector.system.jdbc.FilterUtil.tablePrefix;
@@ -80,7 +80,7 @@ public class TableJdbcTable
     @Override
     public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession connectorSession, TupleDomain<Integer> constraint)
     {
-        Session session = toSession(transactionHandle, connectorSession);
+        Session session = ((FullConnectorSession) connectorSession).getSession();
         Optional<String> catalogFilter = stringFilter(constraint, 0);
         Optional<String> schemaFilter = stringFilter(constraint, 1);
         Optional<String> tableFilter = stringFilter(constraint, 2);


### PR DESCRIPTION
## Description
The session passed to the system connector did not retain any connector properties, so an `Unknown connector` exception is thrown when trying to browse an Iceberg catalog connected to Nessie with a JDBC client.

## Motivation and Context

Same issue as addressed here #22936, but when connecting to the Nessie catalog.

Iceberg catalog properties:
```
connector.name=iceberg
iceberg.catalog.type=nessie
iceberg.catalog.warehouse=/tmp
iceberg.nessie.uri=http://localhost:19120/api/v1
```

`SchemaJdbcTable.cursor` related trace:
```
com.facebook.presto.spi.PrestoException: Unknown connector iceberg_nessie
    at com.facebook.presto.metadata.SessionPropertyManager.getConnectorSessionPropertyMetadata(SessionPropertyManager.java:207)
    at com.facebook.presto.metadata.SessionPropertyManager.decodeCatalogPropertyValue(SessionPropertyManager.java:295)
    at com.facebook.presto.FullConnectorSession.getProperty(FullConnectorSession.java:160)
    at com.facebook.presto.iceberg.IcebergSessionProperties.getNessieReferenceName(IcebergSessionProperties.java:321)
    at com.facebook.presto.iceberg.nessie.IcebergNessieCatalogFactory.getCatalogCacheKey(IcebergNessieCatalogFactory.java:88)
    at com.facebook.presto.iceberg.IcebergNativeCatalogFactory.getCacheKey(IcebergNativeCatalogFactory.java:118)
    at com.facebook.presto.iceberg.IcebergNativeCatalogFactory.getCatalog(IcebergNativeCatalogFactory.java:85)
    at com.facebook.presto.iceberg.IcebergNativeCatalogFactory.getNamespaces(IcebergNativeCatalogFactory.java:102)
    at com.facebook.presto.iceberg.IcebergNativeMetadata.listSchemaNames(IcebergNativeMetadata.java:150)
    at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.listSchemaNames(ClassLoaderSafeConnectorMetadata.java:211)
    at com.facebook.presto.metadata.MetadataManager.listSchemaNames(MetadataManager.java:314)
    at com.facebook.presto.metadata.MetadataListing.listSchemas(MetadataListing.java:58)
    at com.facebook.presto.connector.system.jdbc.**SchemaJdbcTable.cursor(SchemaJdbcTable.java:74)**
```

`TableJdbcTable.cursor` related trace:
```
com.facebook.presto.spi.PrestoException: Unknown connector iceberg_nessie
    at com.facebook.presto.metadata.SessionPropertyManager.getConnectorSessionPropertyMetadata(SessionPropertyManager.java:207)
    at com.facebook.presto.metadata.SessionPropertyManager.decodeCatalogPropertyValue(SessionPropertyManager.java:295)
    at com.facebook.presto.FullConnectorSession.getProperty(FullConnectorSession.java:160)
    at com.facebook.presto.iceberg.IcebergSessionProperties.getNessieReferenceName(IcebergSessionProperties.java:321)
    at com.facebook.presto.iceberg.nessie.IcebergNessieCatalogFactory.getCatalogCacheKey(IcebergNessieCatalogFactory.java:88)
    at com.facebook.presto.iceberg.IcebergNativeCatalogFactory.getCacheKey(IcebergNativeCatalogFactory.java:118)
    at com.facebook.presto.iceberg.IcebergNativeCatalogFactory.getCatalog(IcebergNativeCatalogFactory.java:85)
    at com.facebook.presto.iceberg.IcebergNativeMetadata.listViews(IcebergNativeMetadata.java:241)
    at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.listViews(ClassLoaderSafeConnectorMetadata.java:506)
    at com.facebook.presto.metadata.MetadataManager.listViews(MetadataManager.java:964)
    at com.facebook.presto.metadata.MetadataListing.listViews(MetadataListing.java:72)
    at com.facebook.presto.connector.system.jdbc.**TableJdbcTable.cursor(TableJdbcTable.java:95)**
```

## Impact
Cannot connect Presto to a Nessie catalog.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix to pass full session to avoid ``Unknown connector`` errors using the Nessie catalog.

