### PR TITLE
Reduce resource utilization in TestHiveIntegrationSmokeTest

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <air.test.jvmsize>5g</air.test.jvmsize>
     </properties>
 
     <dependencies>
@@ -630,9 +631,6 @@
         </profile>
         <profile>
             <id>test-hive-pushdown-filter-queries-basic</id>
-            <properties>
-                <air.test.jvmsize>5g</air.test.jvmsize>
-            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2382,23 +2382,23 @@ public class TestHiveIntegrationSmokeTest
                     session,
                     "CREATE TABLE create_partitioned_sorted_table (orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus)\n" +
                             "WITH (partitioned_by = ARRAY['orderstatus'], bucketed_by = ARRAY['custkey'], bucket_count = 11, sorted_by = ARRAY['orderkey']) AS\n" +
-                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.sf1.orders",
-                    (long) computeActual("SELECT count(*) FROM tpch.sf1.orders").getOnlyValue());
+                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
             assertQuery(
                     session,
                     "SELECT count(*) FROM create_partitioned_sorted_table",
-                    "SELECT count(*) * 100 FROM orders");
+                    "SELECT count(*) FROM orders");
 
             assertUpdate(
                     session,
                     "CREATE TABLE create_unpartitioned_sorted_table (orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus)\n" +
                             "WITH (bucketed_by = ARRAY['custkey'], bucket_count = 11, sorted_by = ARRAY['orderkey']) AS\n" +
-                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.sf1.orders",
-                    (long) computeActual("SELECT count(*) FROM tpch.sf1.orders").getOnlyValue());
+                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
             assertQuery(
                     session,
                     "SELECT count(*) FROM create_unpartitioned_sorted_table",
-                    "SELECT count(*) * 100 FROM orders");
+                    "SELECT count(*) FROM orders");
 
             // insert
             assertUpdate(
@@ -2409,12 +2409,12 @@ public class TestHiveIntegrationSmokeTest
             assertUpdate(
                     session,
                     "INSERT INTO insert_partitioned_sorted_table\n" +
-                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.sf1.orders",
-                    (long) computeActual("SELECT count(*) FROM tpch.sf1.orders").getOnlyValue());
+                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
             assertQuery(
                     session,
                     "SELECT count(*) FROM insert_partitioned_sorted_table",
-                    "SELECT count(*) * 100 FROM orders");
+                    "SELECT count(*) FROM orders");
         }
         finally {
             assertUpdate(session, "DROP TABLE IF EXISTS create_partitioned_sorted_table");
@@ -2441,23 +2441,23 @@ public class TestHiveIntegrationSmokeTest
                     session,
                     "CREATE TABLE create_partitioned_ordering_table (orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus)\n" +
                             "WITH (partitioned_by = ARRAY['orderstatus'], preferred_ordering_columns = ARRAY['orderkey']) AS\n" +
-                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.sf1.orders",
-                    (long) computeActual("SELECT count(*) FROM tpch.sf1.orders").getOnlyValue());
+                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
             assertQuery(
                     session,
                     "SELECT count(*) FROM create_partitioned_ordering_table",
-                    "SELECT count(*) * 100 FROM orders");
+                    "SELECT count(*) FROM orders");
 
             assertUpdate(
                     session,
                     "CREATE TABLE create_unpartitioned_ordering_table (orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus)\n" +
                             "WITH (preferred_ordering_columns = ARRAY['orderkey']) AS\n" +
-                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.sf1.orders",
-                    (long) computeActual("SELECT count(*) FROM tpch.sf1.orders").getOnlyValue());
+                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
             assertQuery(
                     session,
                     "SELECT count(*) FROM create_unpartitioned_ordering_table",
-                    "SELECT count(*) * 100 FROM orders");
+                    "SELECT count(*) FROM orders");
 
             // insert
             assertUpdate(
@@ -2468,12 +2468,12 @@ public class TestHiveIntegrationSmokeTest
             assertUpdate(
                     session,
                     "INSERT INTO insert_partitioned_ordering_table\n" +
-                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.sf1.orders",
-                    (long) computeActual("SELECT count(*) FROM tpch.sf1.orders").getOnlyValue());
+                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
             assertQuery(
                     session,
                     "SELECT count(*) FROM insert_partitioned_ordering_table",
-                    "SELECT count(*) * 100 FROM orders");
+                    "SELECT count(*) FROM orders");
 
             // invalid
             assertQueryFails(
@@ -2644,8 +2644,8 @@ public class TestHiveIntegrationSmokeTest
                             .build(),
                     "CREATE TABLE partitioned_ordering_table (orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus)\n" +
                             "WITH (partitioned_by = ARRAY['orderstatus'], preferred_ordering_columns = ARRAY['orderkey']) AS\n" +
-                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.sf1.orders",
-                    (long) computeActual("SELECT count(*) FROM tpch.sf1.orders").getOnlyValue());
+                            "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
 
             // Collect all file names
             Map<String, List<Integer>> partitionFileNamesMap = new HashMap<>();
@@ -2683,8 +2683,8 @@ public class TestHiveIntegrationSmokeTest
                             .setSystemProperty("writer_min_size", "1MB")
                             .setSystemProperty("task_writer_count", "1")
                             .build(),
-                    "CREATE TABLE unpartitioned_ordering_table AS SELECT * FROM tpch.sf1.orders",
-                    (long) computeActual("SELECT count(*) FROM tpch.sf1.orders").getOnlyValue());
+                    "CREATE TABLE unpartitioned_ordering_table AS SELECT * FROM tpch.tiny.orders",
+                    (long) computeActual("SELECT count(*) FROM tpch.tiny.orders").getOnlyValue());
 
             // Collect file names of the table
             List<Integer> fileNames = new ArrayList<>();


### PR DESCRIPTION
## Description

1. use tiny schema instead of SF1 except where necessary
2. Increase JVM size to 5g

Goal is to reduce test flakiness and speed up runtime. This cut the average runtime by about 2-3 minutes on my M1 mac and decreased the maximum observed memory usage from ~3.7g to ~3.0g. The maximum usage depends on the tests which are running, but generally it is when two of the following are executing:

- testGroupedExecution
- testMaterializedPartitioning
- testPartialMergePushdown
- testWriteSortedTable
- testWritePreferredOrderingTable

Related to https://github.com/prestodb/presto/issues/24775

## Motivation and Context

Reduce test flakiness in CI and speed up build time

## Impact

N/A

## Test Plan

Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

