### PR TITLE
Arrow Flight tests should use open port for server

### DIFF
--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/ArrowFlightQueryRunner.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/ArrowFlightQueryRunner.java
@@ -26,6 +26,8 @@ import org.apache.arrow.flight.Location;
 import org.apache.arrow.memory.RootAllocator;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +42,14 @@ public class ArrowFlightQueryRunner
     private ArrowFlightQueryRunner()
     {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    public static int findUnusedPort()
+            throws IOException
+    {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
     }
 
     public static DistributedQueryRunner createQueryRunner(int flightServerPort) throws Exception

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightNativeQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightNativeQueries.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,10 +49,16 @@ public class TestArrowFlightNativeQueries
         extends AbstractTestQueryFramework
 {
     private static final Logger log = Logger.get(TestArrowFlightNativeQueries.class);
+    private final int serverPort;
     private RootAllocator allocator;
-    private int serverPort;
     private FlightServer server;
     private DistributedQueryRunner arrowFlightQueryRunner;
+
+    public TestArrowFlightNativeQueries()
+            throws IOException
+    {
+        this.serverPort = ArrowFlightQueryRunner.findUnusedPort();
+    }
 
     @BeforeClass
     public void setup()
@@ -87,9 +92,6 @@ public class TestArrowFlightNativeQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        // Base class initializes query runner first, need to assign server port here
-        serverPort = findUnusedPort();
-
         Path prestoServerPath = Paths.get(getProperty("PRESTO_SERVER")
                         .orElse("_build/debug/presto_cpp/main/presto_server"))
                 .toAbsolutePath();
@@ -313,14 +315,6 @@ public class TestArrowFlightNativeQueries
         assertQuery("SELECT sign(custkey) from orders");
         assertQuery("SELECT sign(-custkey) from orders");
         assertQuery("SELECT sign(shippriority) from orders");
-    }
-
-    private static int findUnusedPort()
-            throws IOException
-    {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        }
     }
 
     public static Map<String, String> getNativeWorkerSystemProperties()

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightQueries.java
@@ -29,6 +29,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -52,10 +53,16 @@ public class TestArrowFlightQueries
         extends AbstractTestQueries
 {
     private static final Logger logger = Logger.get(TestArrowFlightQueries.class);
+    private final int serverPort;
     private RootAllocator allocator;
     private FlightServer server;
-    private Location serverLocation;
     private DistributedQueryRunner arrowFlightQueryRunner;
+
+    public TestArrowFlightQueries()
+            throws IOException
+    {
+        this.serverPort = ArrowFlightQueryRunner.findUnusedPort();
+    }
 
     @BeforeClass
     public void setup()
@@ -66,8 +73,8 @@ public class TestArrowFlightQueries
         File privateKeyFile = new File("src/test/resources/server.key");
 
         allocator = new RootAllocator(Long.MAX_VALUE);
-        serverLocation = Location.forGrpcTls("localhost", 9443);
-        server = FlightServer.builder(allocator, serverLocation, new TestingArrowProducer(allocator))
+        Location location = Location.forGrpcTls("localhost", serverPort);
+        server = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator))
                 .useTls(certChainFile, privateKeyFile)
                 .build();
 
@@ -88,7 +95,7 @@ public class TestArrowFlightQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return ArrowFlightQueryRunner.createQueryRunner(9443);
+        return ArrowFlightQueryRunner.createQueryRunner(serverPort);
     }
 
     @Test


### PR DESCRIPTION
## Description
Arrow Flight tests should use a random free port instead of a fixed value to prevent test failure if the port is not available.

## Motivation and Context
Arrow Flight tests can fail if using a fixed port value that is not available.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Updated Arrow Flight tests to first find an open port for the Flight server.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

