### PR TITLE
[Iceberg]Support bucket transform for TimeType

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1224,7 +1224,8 @@ Transform Name        Source Types
 ``Identity``          ``boolean``, ``int``, ``bigint``, ``real``, ``double``, ``decimal``,
                       ``varchar``, ``varbinary``, ``date``, ``time``, ``timestamp``
 
-``Bucket``            ``int``, ``bigint``, ``decimal``, ``varchar``, ``varbinary``, ``date``
+``Bucket``            ``int``, ``bigint``, ``decimal``, ``varchar``, ``varbinary``, ``date``,
+                      ``time``
 
 ``Truncate``          ``int``, ``bigint``, ``decimal``, ``varchar``, ``varbinary``
 


### PR DESCRIPTION
## Description

In the Iceberg specification, columns of type TimeType support being specified bucket transforms. This PR support bucket transform for columns of type TimeType in presto.

## Motivation and Context

Support as many types as possible for partition transforms according to Iceberg specification.

## Impact

We can now use bucket transform on TimeType columns in Iceberg table.

## Test Plan

 - Newly added test case for testing the bucket transform set and used on TimeType columns of the Iceberg table.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Support bucket transform for columns of type `TimeType` in Iceberg table 
```

