### PR TITLE
[Iceberg] Cache invalidation procedure for Iceberg coordinator cache

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1073,6 +1073,13 @@ Examples:
 
     CALL iceberg.system.fast_forward('schema_name', 'table_name', 'branch1', 'main');
 
+Statistics file cache invalidation procedure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Invalidate Statistics file cache ::
+
+    CALL <catalog-name>.system.invalidate_statistics_file_cache();
+
 Set Table Property
 ^^^^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1080,6 +1080,13 @@ Statistics file cache invalidation procedure
 
     CALL <catalog-name>.system.invalidate_statistics_file_cache();
 
+Manifest file cache invalidation procedure
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Invalidate Manifest file cache ::
+
+    CALL <catalog-name>.system.invalidate_manifest_file_cache();
+
 Set Table Property
 ^^^^^^^^^^^^^^^^^^
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -46,6 +46,7 @@ import com.facebook.presto.iceberg.nessie.IcebergNessieConfig;
 import com.facebook.presto.iceberg.optimizer.IcebergPlanOptimizerProvider;
 import com.facebook.presto.iceberg.procedure.ExpireSnapshotsProcedure;
 import com.facebook.presto.iceberg.procedure.FastForwardBranchProcedure;
+import com.facebook.presto.iceberg.procedure.ManifestFileCacheInvalidationProcedure;
 import com.facebook.presto.iceberg.procedure.RegisterTableProcedure;
 import com.facebook.presto.iceberg.procedure.RemoveOrphanFiles;
 import com.facebook.presto.iceberg.procedure.RollbackToSnapshotProcedure;
@@ -185,6 +186,7 @@ public class IcebergCommonModule
         procedures.addBinding().toProvider(SetCurrentSnapshotProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(SetTablePropertyProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(StatisticsFileCacheInvalidationProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(ManifestFileCacheInvalidationProcedure.class).in(Scopes.SINGLETON);
 
         if (buildConfigObject(MetastoreClientConfig.class).isInvalidateMetastoreCacheProcedureEnabled()) {
             procedures.addBinding().toProvider(InvalidateMetastoreCacheProcedure.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -52,6 +52,7 @@ import com.facebook.presto.iceberg.procedure.RollbackToSnapshotProcedure;
 import com.facebook.presto.iceberg.procedure.RollbackToTimestampProcedure;
 import com.facebook.presto.iceberg.procedure.SetCurrentSnapshotProcedure;
 import com.facebook.presto.iceberg.procedure.SetTablePropertyProcedure;
+import com.facebook.presto.iceberg.procedure.StatisticsFileCacheInvalidationProcedure;
 import com.facebook.presto.iceberg.procedure.UnregisterTableProcedure;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCacheKey;
@@ -183,6 +184,7 @@ public class IcebergCommonModule
         procedures.addBinding().toProvider(FastForwardBranchProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(SetCurrentSnapshotProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(SetTablePropertyProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(StatisticsFileCacheInvalidationProcedure.class).in(Scopes.SINGLETON);
 
         if (buildConfigObject(MetastoreClientConfig.class).isInvalidateMetastoreCacheProcedureEnabled()) {
             procedures.addBinding().toProvider(InvalidateMetastoreCacheProcedure.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/ManifestFileCacheInvalidationProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/ManifestFileCacheInvalidationProcedure.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.procedure;
+
+import com.facebook.presto.iceberg.ManifestFileCache;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static java.util.Objects.requireNonNull;
+
+public class ManifestFileCacheInvalidationProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle CACHE_DATA_INVALIDATION = methodHandle(
+            ManifestFileCacheInvalidationProcedure.class,
+            "manifestFileCacheInvalidation");
+
+    private final ManifestFileCache manifestFileCache;
+
+    @Inject
+    public ManifestFileCacheInvalidationProcedure(ManifestFileCache manifestFileCache)
+    {
+        this.manifestFileCache = requireNonNull(manifestFileCache, "manifestFileCache is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "invalidate_manifest_file_cache",
+                ImmutableList.of(),
+                CACHE_DATA_INVALIDATION.bindTo(this));
+    }
+
+    public void manifestFileCacheInvalidation()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            manifestFileCache.invalidateAll();
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/StatisticsFileCacheInvalidationProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/StatisticsFileCacheInvalidationProcedure.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.procedure;
+
+import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static java.util.Objects.requireNonNull;
+
+public class StatisticsFileCacheInvalidationProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle CACHE_DATA_INVALIDATION = methodHandle(
+            StatisticsFileCacheInvalidationProcedure.class,
+            "statisticsFileCacheInvalidation");
+
+    private final StatisticsFileCache statisticsFileCache;
+
+    @Inject
+    public StatisticsFileCacheInvalidationProcedure(StatisticsFileCache statisticsFileCache)
+    {
+        this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "invalidate_statistics_file_cache",
+                ImmutableList.of(),
+                CACHE_DATA_INVALIDATION.bindTo(this));
+    }
+
+    public void statisticsFileCacheInvalidation()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            statisticsFileCache.invalidateAll();
+        }
+    }
+}


### PR DESCRIPTION
## Description
Cache invalidation procedure for Iceberg coordinator cache

## Motivation and Context
Cache invalidation procedure for Iceberg coordinator cache.

The rationale for enabling this procedure is:

- To provide a mechanism for on-demand cache invalidation, allowing memory to be freed up on the coordinator.

- To facilitate detailed query execution analysis when there are no plan changes. This is particularly useful for single-query cold/warm analysis, where:
Cold: The state where caches are not populated.
Warm: The state where caches are already populated, and the query primarily runs in memory.

- To accurately measure query performance, we need a way to clear all caches before executing the next query. Since there is currently no built-in method to invalidate the coordinator cache, this PR introduces a procedure to enable cache cleanup.

## Impact

Enable new procedure -

```
presto> CALL <catalog-name>.system.invalidate_statistics_file_cache();

presto> CALL <catalog-name>.system.invalidate_manifest_file_cache();
```

## Test Plan
Test added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support for the procedure <catalog-name>.system.invalidate_statistics_file_cache() for StatisticsFile cache invalidation in Iceberg.
* Add support for the procedure <catalog-name>.system.invalidate_manifest_file_cache() for ManifestFile cache invalidation in Iceberg.
```

