### PR TITLE
Fix RedisProviderPlugin cannot be instantiated using reflection in Pl…

### DIFF
--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderPlugin.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderPlugin.java
@@ -41,6 +41,11 @@ public class RedisProviderPlugin
         this(initializeConfigs(configPath));
     }
 
+    public RedisProviderPlugin()
+    {
+        this(RedisProviderConfig.REDIS_PROPERTIES_PATH);
+    }
+
     @VisibleForTesting
     public RedisProviderPlugin(Map<String, String> configs)
     {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add back no-arg constructor in `RedisProviderPlugin`
Related issue: https://github.com/prestodb/presto/issues/24828
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
When PrestoServer is bootstraping, it tries to load the RedisProviderPlugin using Reflection, which requires no-arg constructor, but the no-arg constructor in RedisProviderPlugin is somehow missing.
In `com.facebook.presto.server.PluginManager` the plugins will be instantiated by ImmutableList.copyOf using no-arg constructor reflection. The code for this is as follows: 
```
// com.facebook.presto.server.PluginManager#loadPlugin
private void loadPlugin(URLClassLoader pluginClassLoader, Class<?> clazz)
{
     ServiceLoader<?> serviceLoader = ServiceLoader.load(clazz, pluginClassLoader);
     List<?> plugins = ImmutableList.copyOf(serviceLoader);
     // ............
}
```

## Test Plan
I've tried to come up with a test, I think this is not necessary to test, and it would be a little hacky to test this. 
