### PR TITLE
[native] Fix v1/operation/task/getDetail

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
@@ -68,6 +68,14 @@ std::string getConnectorCacheStats(proxygen::HTTPMessage* message) {
   VELOX_USER_FAIL("connector '{}' operation is not supported", name);
 }
 
+std::string prettyJson(folly::dynamic const& dyn) {
+  folly::json::serialization_opts opts;
+  opts.pretty_formatting = true;
+  opts.sort_keys = true;
+  opts.convert_int_keys = true;
+  return folly::json::serialize(dyn, opts);
+}
+
 } // namespace
 
 void PrestoServerOperations::runOperation(
@@ -205,7 +213,7 @@ std::string PrestoServerOperations::taskOperation(
       if (task == taskMap.end()) {
         return fmt::format("No task found with id {}", id);
       }
-      return folly::toPrettyJson(task->second->toJson());
+      return prettyJson(task->second->toJson());
     }
     case ServerOperation::Action::kListAll: {
       uint32_t limit;
@@ -233,7 +241,7 @@ std::string PrestoServerOperations::taskOperation(
           break;
         }
       }
-      oss << folly::toPrettyJson(arrayObj);
+      oss << prettyJson(arrayObj);
       return oss.str();
     }
     default:


### PR DESCRIPTION
## Description

folly::toPrettyJson does not handle integer keys. 
Implement prettyJson which supports integer keys.

Resolves https://github.com/prestodb/presto/issues/24836


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution)
* Fix REST API call ``v1/operator/task/getDetails?id=`` crash.

```
