### PR TITLE
Remove negative check on 'outputDataSizeInBytes' stat.

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
@@ -203,8 +203,10 @@ public class StageExecutionStats
 
         checkArgument(bufferedDataSizeInBytes >= 0, "bufferedDataSizeInBytes is negative");
         this.bufferedDataSizeInBytes = bufferedDataSizeInBytes;
-        checkArgument(outputDataSizeInBytes >= 0, "outputDataSizeInBytes is negative");
-        this.outputDataSizeInBytes = outputDataSizeInBytes;
+
+        // An overflow could have occurred on this stat - handle this gracefully.
+        this.outputDataSizeInBytes = (outputDataSizeInBytes >= 0) ? outputDataSizeInBytes : Long.MAX_VALUE;
+
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/DriverStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/DriverStats.java
@@ -185,8 +185,8 @@ public class DriverStats
         checkArgument(processedInputPositions >= 0, "processedInputPositions is negative");
         this.processedInputPositions = processedInputPositions;
 
-        checkArgument(outputDataSizeInBytes >= 0, "outputDataSizeInBytes is negative");
-        this.outputDataSizeInBytes = outputDataSizeInBytes;
+        // An overflow could have occurred on this stat - handle this gracefully.
+        this.outputDataSizeInBytes = (outputDataSizeInBytes >= 0) ? outputDataSizeInBytes : Long.MAX_VALUE;
 
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -205,8 +205,10 @@ public class OperatorStats
         this.getOutputCpu = requireNonNull(getOutputCpu, "getOutputCpu is null");
         checkArgument(getOutputAllocationInBytes >= 0, "getOutputAllocationInBytes is negative");
         this.getOutputAllocationInBytes = getOutputAllocationInBytes;
-        checkArgument(outputDataSizeInBytes >= 0, "outputDataSizeInBytes is negative");
-        this.outputDataSizeInBytes = outputDataSizeInBytes;
+
+        // An overflow could have occurred on this stat - handle this gracefully.
+        this.outputDataSizeInBytes = (outputDataSizeInBytes >= 0) ? outputDataSizeInBytes : Long.MAX_VALUE;
+
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 


### PR DESCRIPTION
## Description
Native worker can report really large outputDataSizeInBytes from some operators (like CrossJoin).
Coordinator then can have overflow in this stat and it become negative.
This fails the query and leaves it in a permanent running state.

We plan to fix this in the native worker, however, it is also useful to remove this check for some valid high memory cases.

```
== NO RELEASE NOTE ==
```

