### PR TITLE
OperatorStats overflow fix

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -757,21 +757,21 @@ public class OperatorStats
         long addInputCalls = this.addInputCalls;
         long addInputWall = this.addInputWall.roundTo(NANOSECONDS);
         long addInputCpu = this.addInputCpu.roundTo(NANOSECONDS);
-        long addInputAllocation = this.addInputAllocationInBytes;
-        long rawInputDataSize = this.rawInputDataSizeInBytes;
+        double addInputAllocation = this.addInputAllocationInBytes;
+        double rawInputDataSize = this.rawInputDataSizeInBytes;
         long rawInputPositions = this.rawInputPositions;
-        long inputDataSize = this.inputDataSizeInBytes;
+        double inputDataSize = this.inputDataSizeInBytes;
         long inputPositions = this.inputPositions;
         double sumSquaredInputPositions = this.sumSquaredInputPositions;
 
         long getOutputCalls = this.getOutputCalls;
         long getOutputWall = this.getOutputWall.roundTo(NANOSECONDS);
         long getOutputCpu = this.getOutputCpu.roundTo(NANOSECONDS);
-        long getOutputAllocation = this.getOutputAllocationInBytes;
-        long outputDataSize = this.outputDataSizeInBytes;
+        double getOutputAllocation = this.getOutputAllocationInBytes;
+        double outputDataSize = this.outputDataSizeInBytes;
         long outputPositions = this.outputPositions;
 
-        long physicalWrittenDataSize = this.physicalWrittenDataSizeInBytes;
+        double physicalWrittenDataSize = this.physicalWrittenDataSizeInBytes;
 
         long additionalCpu = this.additionalCpu.roundTo(NANOSECONDS);
         long blockedWall = this.blockedWall.roundTo(NANOSECONDS);
@@ -781,14 +781,14 @@ public class OperatorStats
         long finishCpu = this.finishCpu.roundTo(NANOSECONDS);
         long finishAllocation = this.finishAllocationInBytes;
 
-        long memoryReservation = this.userMemoryReservationInBytes;
-        long revocableMemoryReservation = this.revocableMemoryReservationInBytes;
-        long systemMemoryReservation = this.systemMemoryReservationInBytes;
-        long peakUserMemory = this.peakUserMemoryReservationInBytes;
-        long peakSystemMemory = this.peakSystemMemoryReservationInBytes;
-        long peakTotalMemory = this.peakTotalMemoryReservationInBytes;
+        double memoryReservation = this.userMemoryReservationInBytes;
+        double revocableMemoryReservation = this.revocableMemoryReservationInBytes;
+        double systemMemoryReservation = this.systemMemoryReservationInBytes;
+        double peakUserMemory = this.peakUserMemoryReservationInBytes;
+        double peakSystemMemory = this.peakSystemMemoryReservationInBytes;
+        double peakTotalMemory = this.peakTotalMemoryReservationInBytes;
 
-        long spilledDataSize = this.spilledDataSizeInBytes;
+        double spilledDataSize = this.spilledDataSizeInBytes;
 
         Optional<BlockedReason> blockedReason = this.blockedReason;
 
@@ -884,21 +884,21 @@ public class OperatorStats
                 addInputCalls,
                 succinctNanos(addInputWall),
                 succinctNanos(addInputCpu),
-                addInputAllocation,
-                rawInputDataSize,
+                (long) addInputAllocation,
+                (long) rawInputDataSize,
                 rawInputPositions,
-                inputDataSize,
+                (long) inputDataSize,
                 inputPositions,
                 sumSquaredInputPositions,
 
                 getOutputCalls,
                 succinctNanos(getOutputWall),
                 succinctNanos(getOutputCpu),
-                getOutputAllocation,
-                outputDataSize,
+                (long) getOutputAllocation,
+                (long) outputDataSize,
                 outputPositions,
 
-                physicalWrittenDataSize,
+                (long) physicalWrittenDataSize,
 
                 succinctNanos(additionalCpu),
                 succinctNanos(blockedWall),
@@ -908,14 +908,14 @@ public class OperatorStats
                 succinctNanos(finishCpu),
                 finishAllocation,
 
-                memoryReservation,
-                revocableMemoryReservation,
-                systemMemoryReservation,
-                peakUserMemory,
-                peakSystemMemory,
-                peakTotalMemory,
+                (long) memoryReservation,
+                (long) revocableMemoryReservation,
+                (long) systemMemoryReservation,
+                (long) peakUserMemory,
+                (long) peakSystemMemory,
+                (long) peakTotalMemory,
 
-                spilledDataSize,
+                (long) spilledDataSize,
 
                 blockedReason,
 

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -85,7 +85,7 @@ public class TestOperatorStats
             new Duration(18, NANOSECONDS),
             345L,
 
-            1_000_000_000L,
+            Long.MAX_VALUE,
             20L,
             21L,
             22L,
@@ -213,7 +213,7 @@ public class TestOperatorStats
         assertEquals(actual.getFinishCpu(), new Duration(18, NANOSECONDS));
         assertEquals(actual.getFinishAllocationInBytes(), 345);
 
-        assertEquals(actual.getUserMemoryReservationInBytes(), 1_000_000_000L);
+        assertEquals(actual.getUserMemoryReservationInBytes(), Long.MAX_VALUE);
         assertEquals(actual.getRevocableMemoryReservationInBytes(), 20);
         assertEquals(actual.getSystemMemoryReservationInBytes(), 21);
         assertEquals(actual.getPeakUserMemoryReservationInBytes(), 22);
@@ -262,7 +262,7 @@ public class TestOperatorStats
         assertEquals(actual.getFinishCpu(), new Duration(3 * 18, NANOSECONDS));
         assertEquals(actual.getFinishAllocationInBytes(), 3 * 345);
 
-        assertEquals(actual.getUserMemoryReservationInBytes(), 3 * 1_000_000_000L);
+        assertEquals(actual.getUserMemoryReservationInBytes(), Long.MAX_VALUE);
         assertEquals(actual.getRevocableMemoryReservationInBytes(), 3 * 20);
         assertEquals(actual.getSystemMemoryReservationInBytes(), 3 * 21);
         assertEquals(actual.getPeakUserMemoryReservationInBytes(), 22);


### PR DESCRIPTION
## Description
In OperatorStats, summing long types leads to overflow. Use double type to do calculation.
If final result is larger than Long.MAX_VALUE, return Long.MAX_VALUE.

## Motivation and Context
This fix was originally made in March 2024 and accidentally reverted on March 2025 
Fix: https://github.com/prestodb/presto/pull/22230
Revert of fix: 
https://github.com/prestodb/presto/pull/24414
https://github.com/prestodb/presto/pull/24750/

## Impact

## Test Plan
- [x] Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```


