### PR TITLE
Remove negative check on more byte-related stats.

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.OptionalDouble;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.Duration.succinctDuration;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -104,21 +103,17 @@ public class BasicStageExecutionStats
         this.queuedDrivers = queuedDrivers;
         this.runningDrivers = runningDrivers;
         this.completedDrivers = completedDrivers;
-        checkArgument(rawInputDataSizeInBytes >= 0, "rawInputDataSizeInBytes is negative");
-        this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        this.rawInputDataSizeInBytes = (rawInputDataSizeInBytes >= 0) ? rawInputDataSizeInBytes : Long.MAX_VALUE;
         this.rawInputPositions = rawInputPositions;
         this.cumulativeUserMemory = cumulativeUserMemory;
         this.cumulativeTotalMemory = cumulativeTotalMemory;
-        checkArgument(userMemoryReservationInBytes >= 0, "userMemoryReservationInBytes is negative");
-        this.userMemoryReservationInBytes = userMemoryReservationInBytes;
-        checkArgument(totalMemoryReservationInBytes >= 0, "totalMemoryReservationInBytes is negative");
-        this.totalMemoryReservationInBytes = totalMemoryReservationInBytes;
+        this.userMemoryReservationInBytes = (userMemoryReservationInBytes >= 0) ? userMemoryReservationInBytes : Long.MAX_VALUE;
+        this.totalMemoryReservationInBytes = (totalMemoryReservationInBytes >= 0) ? totalMemoryReservationInBytes : Long.MAX_VALUE;
         this.totalCpuTime = requireNonNull(totalCpuTime, "totalCpuTime is null");
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
         this.fullyBlocked = fullyBlocked;
         this.blockedReasons = ImmutableSet.copyOf(requireNonNull(blockedReasons, "blockedReasons is null"));
-        checkArgument(totalAllocationInBytes >= 0, "totalAllocationInBytes is negative");
-        this.totalAllocationInBytes = totalAllocationInBytes;
+        this.totalAllocationInBytes = (totalAllocationInBytes >= 0) ? totalAllocationInBytes : Long.MAX_VALUE;
         this.progressPercentage = requireNonNull(progressPercentage, "progressPercentage is null");
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
@@ -173,14 +173,10 @@ public class StageExecutionStats
         this.cumulativeUserMemory = cumulativeUserMemory;
         checkArgument(cumulativeTotalMemory >= 0, "cumulativeTotalMemory is negative");
         this.cumulativeTotalMemory = cumulativeTotalMemory;
-        checkArgument(userMemoryReservationInBytes >= 0, "userMemoryReservationInBytes is negative");
-        this.userMemoryReservationInBytes = userMemoryReservationInBytes;
-        checkArgument(totalMemoryReservationInBytes >= 0, "totalMemoryReservationInBytes is negative");
-        this.totalMemoryReservationInBytes = totalMemoryReservationInBytes;
-        checkArgument(peakUserMemoryReservationInBytes >= 0, "peakUserMemoryReservationInBytes is negative");
-        this.peakUserMemoryReservationInBytes = peakUserMemoryReservationInBytes;
-        checkArgument(peakNodeTotalMemoryReservationInBytes >= 0, "peakNodeTotalMemoryReservationInBytes is negative");
-        this.peakNodeTotalMemoryReservationInBytes = peakNodeTotalMemoryReservationInBytes;
+        this.userMemoryReservationInBytes = (userMemoryReservationInBytes >= 0) ? userMemoryReservationInBytes : Long.MAX_VALUE;
+        this.totalMemoryReservationInBytes = (totalMemoryReservationInBytes >= 0) ? totalMemoryReservationInBytes : Long.MAX_VALUE;
+        this.peakUserMemoryReservationInBytes = (peakUserMemoryReservationInBytes >= 0) ? peakUserMemoryReservationInBytes : Long.MAX_VALUE;
+        this.peakNodeTotalMemoryReservationInBytes = (peakNodeTotalMemoryReservationInBytes >= 0) ? peakNodeTotalMemoryReservationInBytes : Long.MAX_VALUE;
 
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
         this.totalCpuTime = requireNonNull(totalCpuTime, "totalCpuTime is null");
@@ -189,20 +185,17 @@ public class StageExecutionStats
         this.fullyBlocked = fullyBlocked;
         this.blockedReasons = ImmutableSet.copyOf(requireNonNull(blockedReasons, "blockedReasons is null"));
 
-        checkArgument(totalAllocationInBytes >= 0, "totalAllocationInBytes is negative");
-        this.totalAllocationInBytes = totalAllocationInBytes;
-        checkArgument(rawInputDataSizeInBytes >= 0, "rawInputDataSizeInBytes is negative");
-        this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        this.totalAllocationInBytes = (totalAllocationInBytes >= 0) ? totalAllocationInBytes : Long.MAX_VALUE;
+        this.rawInputDataSizeInBytes = (rawInputDataSizeInBytes >= 0) ? rawInputDataSizeInBytes : Long.MAX_VALUE;
         checkArgument(rawInputPositions >= 0, "rawInputPositions is negative");
         this.rawInputPositions = rawInputPositions;
 
-        checkArgument(processedInputDataSizeInBytes >= 0, "processedInputDataSizeInBytes is negative");
-        this.processedInputDataSizeInBytes = processedInputDataSizeInBytes;
+        // An overflow could have occurred on this stat - handle this gracefully.
+        this.processedInputDataSizeInBytes = (processedInputDataSizeInBytes >= 0) ? processedInputDataSizeInBytes : Long.MAX_VALUE;
         checkArgument(processedInputPositions >= 0, "processedInputPositions is negative");
         this.processedInputPositions = processedInputPositions;
 
-        checkArgument(bufferedDataSizeInBytes >= 0, "bufferedDataSizeInBytes is negative");
-        this.bufferedDataSizeInBytes = bufferedDataSizeInBytes;
+        this.bufferedDataSizeInBytes = (bufferedDataSizeInBytes >= 0) ? bufferedDataSizeInBytes : Long.MAX_VALUE;
 
         // An overflow could have occurred on this stat - handle this gracefully.
         this.outputDataSizeInBytes = (outputDataSizeInBytes >= 0) ? outputDataSizeInBytes : Long.MAX_VALUE;
@@ -210,8 +203,7 @@ public class StageExecutionStats
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 
-        checkArgument(physicalWrittenDataSizeInBytes >= 0, "writtenDataSizeInBytes is negative");
-        this.physicalWrittenDataSizeInBytes = physicalWrittenDataSizeInBytes;
+        this.physicalWrittenDataSizeInBytes = (physicalWrittenDataSizeInBytes >= 0) ? physicalWrittenDataSizeInBytes : Long.MAX_VALUE;
 
         this.gcInfo = requireNonNull(gcInfo, "gcInfo is null");
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/DriverStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/DriverStats.java
@@ -156,12 +156,9 @@ public class DriverStats
         this.queuedTime = requireNonNull(queuedTime, "queuedTime is null");
         this.elapsedTime = requireNonNull(elapsedTime, "elapsedTime is null");
 
-        checkArgument(userMemoryReservationInBytes >= 0, "userMemoryReservationInBytes is negative");
-        this.userMemoryReservationInBytes = userMemoryReservationInBytes;
-        checkArgument(revocableMemoryReservationInBytes >= 0, "revocableMemoryReservationInBytes is negative");
-        this.revocableMemoryReservationInBytes = revocableMemoryReservationInBytes;
-        checkArgument(systemMemoryReservationInBytes >= 0, "systemMemoryReservationInBytes is negative");
-        this.systemMemoryReservationInBytes = systemMemoryReservationInBytes;
+        this.userMemoryReservationInBytes = (userMemoryReservationInBytes >= 0) ? userMemoryReservationInBytes : Long.MAX_VALUE;
+        this.revocableMemoryReservationInBytes = (revocableMemoryReservationInBytes >= 0) ? revocableMemoryReservationInBytes : Long.MAX_VALUE;
+        this.systemMemoryReservationInBytes = (systemMemoryReservationInBytes >= 0) ? systemMemoryReservationInBytes : Long.MAX_VALUE;
 
         this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
         this.totalCpuTime = requireNonNull(totalCpuTime, "totalCpuTime is null");
@@ -169,30 +166,25 @@ public class DriverStats
         this.fullyBlocked = fullyBlocked;
         this.blockedReasons = ImmutableSet.copyOf(requireNonNull(blockedReasons, "blockedReasons is null"));
 
-        checkArgument(totalAllocationInBytes >= 0, "totalAllocationInBytes is negative");
-        this.totalAllocationInBytes = totalAllocationInBytes;
+        this.totalAllocationInBytes = (totalAllocationInBytes >= 0) ? totalAllocationInBytes : Long.MAX_VALUE;
 
-        checkArgument(rawInputDataSizeInBytes >= 0, "rawInputDataSizeInBytes is negative");
-        this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        this.rawInputDataSizeInBytes = (rawInputDataSizeInBytes >= 0) ? rawInputDataSizeInBytes : Long.MAX_VALUE;
 
         checkArgument(rawInputPositions >= 0, "rawInputPositions is negative");
         this.rawInputPositions = rawInputPositions;
         this.rawInputReadTime = requireNonNull(rawInputReadTime, "rawInputReadTime is null");
 
-        checkArgument(processedInputDataSizeInBytes >= 0, "processedInputDataSizeInBytes is negative");
-        this.processedInputDataSizeInBytes = processedInputDataSizeInBytes;
+        this.processedInputDataSizeInBytes = (processedInputDataSizeInBytes >= 0) ? processedInputDataSizeInBytes : Long.MAX_VALUE;
 
         checkArgument(processedInputPositions >= 0, "processedInputPositions is negative");
         this.processedInputPositions = processedInputPositions;
 
-        // An overflow could have occurred on this stat - handle this gracefully.
         this.outputDataSizeInBytes = (outputDataSizeInBytes >= 0) ? outputDataSizeInBytes : Long.MAX_VALUE;
 
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 
-        checkArgument(physicalWrittenDataSizeInBytes >= 0, "writtenDataSizeInBytes is negative");
-        this.physicalWrittenDataSizeInBytes = physicalWrittenDataSizeInBytes;
+        this.physicalWrittenDataSizeInBytes = (physicalWrittenDataSizeInBytes >= 0) ? physicalWrittenDataSizeInBytes : Long.MAX_VALUE;
 
         this.operatorStats = ImmutableList.copyOf(requireNonNull(operatorStats, "operatorStats is null"));
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -182,20 +182,16 @@ public class OperatorStats
         this.isBlockedCalls = isBlockedCalls;
         this.isBlockedWall = requireNonNull(isBlockedWall, "isBlockedWall is null");
         this.isBlockedCpu = requireNonNull(isBlockedCpu, "isBlockedCpu is null");
-        checkArgument(isBlockedAllocationInBytes >= 0, "isBlockedAllocationInBytes is negative");
-        this.isBlockedAllocationInBytes = isBlockedAllocationInBytes;
+        this.isBlockedAllocationInBytes = (isBlockedAllocationInBytes >= 0) ? isBlockedAllocationInBytes : Long.MAX_VALUE;
 
         this.addInputCalls = addInputCalls;
         this.addInputWall = requireNonNull(addInputWall, "addInputWall is null");
         this.addInputCpu = requireNonNull(addInputCpu, "addInputCpu is null");
-        checkArgument(addInputAllocationInBytes >= 0, "addInputAllocationInBytes is negative");
-        this.addInputAllocationInBytes = addInputAllocationInBytes;
-        checkArgument(rawInputDataSizeInBytes >= 0, "rawInputDataSizeInBytes is negative");
-        this.rawInputDataSizeInBytes = rawInputDataSizeInBytes;
+        this.addInputAllocationInBytes = (addInputAllocationInBytes >= 0) ? addInputAllocationInBytes : Long.MAX_VALUE;
+        this.rawInputDataSizeInBytes = (rawInputDataSizeInBytes >= 0) ? rawInputDataSizeInBytes : Long.MAX_VALUE;
         checkArgument(rawInputPositions >= 0, "rawInputPositions is negative");
         this.rawInputPositions = rawInputPositions;
-        checkArgument(inputDataSizeInBytes >= 0, "inputDataSizeInBytes is negative");
-        this.inputDataSizeInBytes = inputDataSizeInBytes;
+        this.inputDataSizeInBytes = (inputDataSizeInBytes >= 0) ? inputDataSizeInBytes : Long.MAX_VALUE;
         checkArgument(inputPositions >= 0, "inputPositions is negative");
         this.inputPositions = inputPositions;
         this.sumSquaredInputPositions = sumSquaredInputPositions;
@@ -203,39 +199,28 @@ public class OperatorStats
         this.getOutputCalls = getOutputCalls;
         this.getOutputWall = requireNonNull(getOutputWall, "getOutputWall is null");
         this.getOutputCpu = requireNonNull(getOutputCpu, "getOutputCpu is null");
-        checkArgument(getOutputAllocationInBytes >= 0, "getOutputAllocationInBytes is negative");
-        this.getOutputAllocationInBytes = getOutputAllocationInBytes;
+        this.getOutputAllocationInBytes = (getOutputAllocationInBytes >= 0) ? getOutputAllocationInBytes : Long.MAX_VALUE;
 
-        // An overflow could have occurred on this stat - handle this gracefully.
         this.outputDataSizeInBytes = (outputDataSizeInBytes >= 0) ? outputDataSizeInBytes : Long.MAX_VALUE;
 
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 
-        checkArgument(physicalWrittenDataSizeInBytes >= 0, "writtenDataSizeInBytes is negative");
-        this.physicalWrittenDataSizeInBytes = physicalWrittenDataSizeInBytes;
+        this.physicalWrittenDataSizeInBytes = (physicalWrittenDataSizeInBytes >= 0) ? physicalWrittenDataSizeInBytes : Long.MAX_VALUE;
         this.additionalCpu = requireNonNull(additionalCpu, "additionalCpu is negative");
         this.blockedWall = requireNonNull(blockedWall, "blockedWall is null");
 
         this.finishCalls = finishCalls;
         this.finishWall = requireNonNull(finishWall, "finishWall is null");
         this.finishCpu = requireNonNull(finishCpu, "finishCpu is null");
-        checkArgument(finishAllocationInBytes >= 0, "finishAllocationInBytes is negative");
-        this.finishAllocationInBytes = finishAllocationInBytes;
-        checkArgument(userMemoryReservationInBytes >= 0, "userMemoryReservationInBytes is negative");
-        this.userMemoryReservationInBytes = userMemoryReservationInBytes;
-        checkArgument(revocableMemoryReservationInBytes >= 0, "revocableMemoryReservationInBytes is negative");
-        this.revocableMemoryReservationInBytes = revocableMemoryReservationInBytes;
-        checkArgument(systemMemoryReservationInBytes >= 0, "systemMemoryReservationInBytes is negative");
-        this.systemMemoryReservationInBytes = systemMemoryReservationInBytes;
-        checkArgument(peakUserMemoryReservationInBytes >= 0, "peakUserMemoryReservationInBytes is negative");
-        this.peakUserMemoryReservationInBytes = peakUserMemoryReservationInBytes;
-        checkArgument(peakSystemMemoryReservationInBytes >= 0, "peakSystemMemoryReservationInBytes is negative");
-        this.peakSystemMemoryReservationInBytes = peakSystemMemoryReservationInBytes;
-        checkArgument(peakTotalMemoryReservationInBytes >= 0, "peakTotalMemoryReservationInBytes is negative");
-        this.peakTotalMemoryReservationInBytes = peakTotalMemoryReservationInBytes;
-        checkArgument(spilledDataSizeInBytes >= 0, "spilledDataSizeInBytes is negative");
-        this.spilledDataSizeInBytes = spilledDataSizeInBytes;
+        this.finishAllocationInBytes = (finishAllocationInBytes >= 0) ? finishAllocationInBytes : Long.MAX_VALUE;
+        this.userMemoryReservationInBytes = (userMemoryReservationInBytes >= 0) ? userMemoryReservationInBytes : Long.MAX_VALUE;
+        this.revocableMemoryReservationInBytes = (revocableMemoryReservationInBytes >= 0) ? revocableMemoryReservationInBytes : Long.MAX_VALUE;
+        this.systemMemoryReservationInBytes = (systemMemoryReservationInBytes >= 0) ? systemMemoryReservationInBytes : Long.MAX_VALUE;
+        this.peakUserMemoryReservationInBytes = (peakUserMemoryReservationInBytes >= 0) ? peakUserMemoryReservationInBytes : Long.MAX_VALUE;
+        this.peakSystemMemoryReservationInBytes = (peakSystemMemoryReservationInBytes >= 0) ? peakSystemMemoryReservationInBytes : Long.MAX_VALUE;
+        this.peakTotalMemoryReservationInBytes = (peakTotalMemoryReservationInBytes >= 0) ? peakTotalMemoryReservationInBytes : Long.MAX_VALUE;
+        this.spilledDataSizeInBytes = (spilledDataSizeInBytes >= 0) ? spilledDataSizeInBytes : Long.MAX_VALUE;
         this.runtimeStats = runtimeStats;
 
         this.dynamicFilterStats = dynamicFilterStats;


### PR DESCRIPTION
## Description
Native worker can report really large stats from some operators (like CrossJoin).
Coordinator then can have overflow in this stat and it become negative.
This fails the query and leaves it in a permanent running state.

It is useful to remove this check for some valid high memory cases.

```
== NO RELEASE NOTE ==
```

