### PR TITLE
[native] Remove `register-test-functions` worker config

### DIFF
--- a/presto-native-execution/etc/config.properties
+++ b/presto-native-execution/etc/config.properties
@@ -2,5 +2,4 @@ discovery.uri=http://127.0.0.1:58215
 presto.version=testversion
 http-server.http.port=7777
 shutdown-onset-sec=1
-register-test-functions=true
 runtime-metrics-collection-enabled=true

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1286,12 +1286,6 @@ void PrestoServer::registerFunctions() {
       prestoBuiltinFunctionPrefix_);
   velox::window::prestosql::registerAllWindowFunctions(
       prestoBuiltinFunctionPrefix_);
-  if (SystemConfig::instance()->registerTestFunctions()) {
-    velox::functions::prestosql::registerAllScalarFunctions(
-        "json.test_schema.");
-    velox::aggregate::prestosql::registerAllAggregateFunctions(
-        "json.test_schema.");
-  }
 }
 
 void PrestoServer::registerRemoteFunctions() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -217,7 +217,6 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kHttpEnableAccessLog, false),
           BOOL_PROP(kHttpEnableStatsFilter, false),
           BOOL_PROP(kHttpEnableEndpointLatencyFilter, false),
-          BOOL_PROP(kRegisterTestFunctions, false),
           NUM_PROP(kHttpMaxAllocateBytes, 65536),
           STR_PROP(kQueryMaxMemoryPerNode, "4GB"),
           BOOL_PROP(kEnableMemoryLeakCheck, true),
@@ -735,10 +734,6 @@ bool SystemConfig::enableHttpStatsFilter() const {
 
 bool SystemConfig::enableHttpEndpointLatencyFilter() const {
   return optionalProperty<bool>(kHttpEnableEndpointLatencyFilter).value();
-}
-
-bool SystemConfig::registerTestFunctions() const {
-  return optionalProperty<bool>(kRegisterTestFunctions).value();
 }
 
 uint64_t SystemConfig::httpMaxAllocateBytes() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -558,8 +558,6 @@ class SystemConfig : public ConfigBase {
       "http-server.enable-stats-filter"};
   static constexpr std::string_view kHttpEnableEndpointLatencyFilter{
       "http-server.enable-endpoint-latency-filter"};
-  static constexpr std::string_view kRegisterTestFunctions{
-      "register-test-functions"};
 
   /// The options to configure the max quantized memory allocation size to store
   /// the received http response data.


### PR DESCRIPTION
## Description
Removes worker config `register-test-functions`.

## Motivation and Context
This config was added to test loading of Cpp UDFs from Json file. Test functions can now be registered with prefix `json.test_schema` using the config `presto.default-namespace=json.test_schema`. 

## Impact
When `register-test-functions=true` in the sidecar, scalar functions registered with default namespace prefix are overwritten by the ones registered with the test prefix `json.test_schema` in Velox's function registry. This can cause issues in function resolution when using the sidecar.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Removes worker config `register-test-functions`.
```

