### PR TITLE
[native] Allow options for wget and tar commands during setup Part:2

### DIFF
--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -19,7 +19,6 @@ export CC=/opt/rh/gcc-toolset-12/root/bin/gcc
 export CXX=/opt/rh/gcc-toolset-12/root/bin/g++
 
 WGET_OPTIONS=${WGET_OPTIONS:-""}
-TAR_OPTIONS=${TAR_OPTIONS:-"-v"}
 
 CPU_TARGET="${CPU_TARGET:-avx}"
 SCRIPT_DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
@@ -38,7 +37,7 @@ function install_presto_deps_from_package_managers {
 
 function install_gperf {
   wget ${WGET_OPTIONS} http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz &&
-  tar ${TAR_OPTIONS} -xzf gperf-3.1.tar.gz &&
+  tar -xzf gperf-3.1.tar.gz &&
   cd gperf-3.1 &&
   ./configure --prefix=/usr/local/gperf/3_1 &&
   make "-j$(nproc)" &&


### PR DESCRIPTION
## Description
issue: 
The current setup scripts generate excessive output, the goal is to reduce the log output by implementing the following changes:

Avoid printing the files extracted by tar.
Silence the download progress from curl by using an appropriate curl option.
Suppress unnecessary CMake messages, logging only warnings instead of info or status messages.
Introduce a new environment variable to enable the extensive logging when needed.
These changes will help minimize log size while maintaining flexibility for detailed logging when required.

## Motivation and Context

The current setup scripts generate excessive log output, which can overwhelm users and make it difficult to identify important information. This excessive logging increases log file sizes unnecessarily, which can be problematic for storage and debugging. By implementing changes to reduce log output, we aim to streamline the logging process, improve readability, and maintain flexibility for detailed logging when required.

This part addresses since part 1 is already merged : [this](https://github.com/prestodb/presto/pull/24455#issuecomment-2768519161) comment from the reviewer.


