### PR TITLE
[presto] Add state filter to the queryState resource

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfoResource.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfoResource.java
@@ -185,4 +185,37 @@ public class TestQueryStateInfoResource
                 prepareGet().setUri(server.resolve("/v1/queryState/123")).build(),
                 createJsonResponseHandler(jsonCodec(QueryStateInfo.class)));
     }
+
+    @Test
+    public void testGetQueryStateInfoStateFilter()
+    {
+        List<QueryStateInfo> infos = client.execute(
+                prepareGet()
+                        .setUri(server.resolve("/v1/queryState?state=DISPATCHING")) // Encoded user\d
+                        .build(),
+                createJsonResponseHandler(listJsonCodec(QueryStateInfo.class)));
+        assertEquals(infos.size(), 0);
+
+        infos = client.execute(
+                prepareGet()
+                        .setUri(server.resolve("/v1/queryState?state=QUEUED"))
+                        .build(),
+                createJsonResponseHandler(listJsonCodec(QueryStateInfo.class)));
+        assertEquals(infos.size(), 0);
+
+        infos = client.execute(
+                prepareGet()
+                        .setUri(server.resolve("/v1/queryState?includeAllQueries=true"))
+                        .build(),
+                createJsonResponseHandler(listJsonCodec(QueryStateInfo.class)));
+        assertEquals(infos.size(), 3);
+    }
+
+    @Test(expectedExceptions = {UnexpectedResponseException.class}, expectedExceptionsMessageRegExp = "Expected response code .*, but was 400")
+    public void testGetQueryStateInfoBadStateFilter()
+    {
+        client.execute(
+                prepareGet().setUri(server.resolve("/v1/queryState?state=INVALID_STATE")).build(),
+                createJsonResponseHandler(jsonCodec(QueryStateInfo.class)));
+    }
 }


### PR DESCRIPTION
Summary:
It looks during recent S506379, we were trying to preempt all QUEUED queries and it was erroring out.

python client first get all the queries using `/v1/queryState` and then filter via `state=QUEUED`. Added a param filter to pass state as well which can then be used in `query.py` client lib (pass `state=QUEUED`).

While it may not always help if queued queries are way too high, but it can roughly save ~10-20%  (to filter out RUNNING/DISPATCHING/PLANNING etc) of queries with relatively safe change and may alleviate coordinator n/w pressure.

Differential Revision: D72342392


