### PR TITLE
Remove DeleteScanInfo

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -40,7 +40,6 @@ import com.facebook.presto.execution.scheduler.ExecutionWriterTarget.InsertHandl
 import com.facebook.presto.execution.scheduler.ExecutionWriterTarget.RefreshMaterializedViewHandle;
 import com.facebook.presto.execution.scheduler.ExecutionWriterTarget.UpdateHandle;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
-import com.facebook.presto.execution.scheduler.TableWriteInfo.DeleteScanInfo;
 import com.facebook.presto.expressions.DynamicFilters;
 import com.facebook.presto.expressions.DynamicFilters.DynamicFilterExtractResult;
 import com.facebook.presto.expressions.DynamicFilters.DynamicFilterPlaceholder;
@@ -1453,13 +1452,7 @@ public class LocalExecutionPlanner
             PhysicalOperation source = null;
             if (sourceNode instanceof TableScanNode && locality.equals(LOCAL)) {
                 TableScanNode tableScanNode = (TableScanNode) sourceNode;
-                Optional<DeleteScanInfo> deleteScanInfo = context.getTableWriteInfo().getDeleteScanInfo();
-                if (deleteScanInfo.isPresent() && deleteScanInfo.get().getId() == tableScanNode.getId()) {
-                    table = deleteScanInfo.get().getTableHandle();
-                }
-                else {
-                    table = tableScanNode.getTable();
-                }
+                table = tableScanNode.getTable();
 
                 // extract the column handles and channel to type mapping
                 sourceLayout = new LinkedHashMap<>();
@@ -1613,14 +1606,7 @@ public class LocalExecutionPlanner
                 columns.add(node.getAssignments().get(variable));
             }
 
-            TableHandle tableHandle;
-            Optional<DeleteScanInfo> deleteScanInfo = context.getTableWriteInfo().getDeleteScanInfo();
-            if (deleteScanInfo.isPresent() && deleteScanInfo.get().getId() == node.getId()) {
-                tableHandle = deleteScanInfo.get().getTableHandle();
-            }
-            else {
-                tableHandle = node.getTable();
-            }
+            TableHandle tableHandle = node.getTable();
             OperatorFactory operatorFactory = new TableScanOperatorFactory(context.getNextOperatorId(), node.getId(), pageSourceProvider, tableHandle, columns);
             return new PhysicalOperation(operatorFactory, makeLayout(node), context, stageExecutionDescriptor.isScanGroupedExecution(node.getId()) ? GROUPED_EXECUTION : UNGROUPED_EXECUTION);
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
@@ -16,7 +16,6 @@ package com.facebook.presto.sql.planner;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
-import com.facebook.presto.execution.scheduler.TableWriteInfo.DeleteScanInfo;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
@@ -67,7 +66,6 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
@@ -146,14 +144,7 @@ public class SplitSourceFactory
         public Map<PlanNodeId, SplitSource> visitTableScan(TableScanNode node, Context context)
         {
             // get dataSource for table
-            TableHandle table;
-            Optional<DeleteScanInfo> deleteScanInfo = context.getTableWriteInfo().getDeleteScanInfo();
-            if (deleteScanInfo.isPresent() && deleteScanInfo.get().getId() == node.getId()) {
-                table = deleteScanInfo.get().getTableHandle();
-            }
-            else {
-                table = node.getTable();
-            }
+            TableHandle table = node.getTable();
             Supplier<SplitSource> splitSourceSupplier = () -> splitSourceProvider.getSplits(
                     session,
                     table,

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -146,7 +146,7 @@ public class MockRemoteTaskFactory
                 createInitialEmptyOutputBuffers(BROADCAST),
                 nodeStatsTracker,
                 true,
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                new TableWriteInfo(Optional.empty(), Optional.empty()),
                 SchedulerStatsTracker.NOOP);
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -196,7 +196,7 @@ public final class TaskTestUtils
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)
     {
-        return sqlTask.updateTask(TEST_SESSION, Optional.of(PLAN_FRAGMENT), taskSources, outputBuffers, Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+        return sqlTask.updateTask(TEST_SESSION, Optional.of(PLAN_FRAGMENT), taskSources, outputBuffers, Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
     }
 
     public static SplitMonitor createTestSplitMonitor()

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -109,7 +109,7 @@ public class TestSqlStageExecution
                 executor,
                 new NoOpFailureDetector(),
                 new SplitSchedulerStats(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty()));
         stage.setOutputBuffers(createInitialEmptyOutputBuffers(ARBITRARY));
 
         // add listener that fetches stage info when the final status is available

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -349,7 +349,7 @@ public class TestSqlTaskManager
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, splits, true)),
                 outputBuffers,
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
     }
 
     private TaskInfo createTask(SqlTaskManager sqlTaskManager, TaskId taskId, OutputBuffers outputBuffers)
@@ -370,7 +370,7 @@ public class TestSqlTaskManager
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(),
                 outputBuffers,
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
     }
 
     public static class MockExchangeClientSupplier

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
@@ -143,7 +143,7 @@ public class TestAdaptivePhasedExecutionPolicy
                 newDirectExecutorService(),
                 new NoOpFailureDetector(),
                 new SplitSchedulerStats(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty()));
         StageLinkage stageLinkage = new StageLinkage(fragmentId, (id, tasks, noMoreExchangeLocations) -> {}, ImmutableSet.of());
         StageScheduler stageScheduler = new FixedCountScheduler(stageExecution, ImmutableList.of());
         StageExecutionAndScheduler scheduler = new StageExecutionAndScheduler(stageExecution, stageLinkage, stageScheduler);

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -546,7 +546,7 @@ public class TestSourcePartitionedScheduler
                 queryExecutor,
                 new NoOpFailureDetector(),
                 new SplitSchedulerStats(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty()));
 
         stage.setOutputBuffers(createInitialEmptyOutputBuffers(PARTITIONED)
                 .withBuffer(OUT, 0)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
@@ -199,7 +199,7 @@ public class TestLocalExecutionPlanner
                 testFragment,
                 new TestingOutputBuffer(),
                 new TestingRemoteSourceFactory(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                new TableWriteInfo(Optional.empty(), Optional.empty()),
                 customPlanTranslators);
     }
 
@@ -218,7 +218,7 @@ public class TestLocalExecutionPlanner
                 leafFragment,
                 new TestingOutputBuffer(),
                 new TestingRemoteSourceFactory(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty()));
     }
 
     private static class CustomNodeA

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -123,7 +123,7 @@ public class TestSqlTask
                 ImmutableList.of(),
                 createInitialEmptyOutputBuffers(PARTITIONED)
                         .withNoMoreBufferIds(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
         assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
 
         taskInfo = sqlTask.getTaskInfo();
@@ -134,7 +134,7 @@ public class TestSqlTask
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(), true)),
                 createInitialEmptyOutputBuffers(PARTITIONED)
                         .withNoMoreBufferIds(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
         assertEquals(taskInfo.getTaskStatus().getState(), TaskState.FINISHED);
 
         taskInfo = sqlTask.getTaskInfo();
@@ -151,7 +151,7 @@ public class TestSqlTask
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
                 createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
         assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
 
         taskInfo = sqlTask.getTaskInfo();
@@ -201,7 +201,7 @@ public class TestSqlTask
                 createInitialEmptyOutputBuffers(PARTITIONED)
                         .withBuffer(OUT, 0)
                         .withNoMoreBufferIds(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
         assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
         assertEquals(taskInfo.getStats().getEndTimeInMillis(), 0);
 
@@ -228,7 +228,7 @@ public class TestSqlTask
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), true)),
                 createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
         assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
 
         taskInfo = sqlTask.getTaskInfo();

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestHighMemoryTaskKiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestHighMemoryTaskKiller.java
@@ -128,7 +128,7 @@ public class TestHighMemoryTaskKiller
                 ImmutableList.of(),
                 createInitialEmptyOutputBuffers(PARTITIONED)
                         .withNoMoreBufferIds(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
         assertEquals(taskInfo.getTaskStatus().getState(), TaskState.RUNNING);
 
         TaskContext taskContext = sqlTask.getTaskContext().get();

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -330,7 +330,7 @@ public class TestHttpRemoteTask
                 createInitialEmptyOutputBuffers(OutputBuffers.BufferType.BROADCAST),
                 new NodeTaskMap.NodeStatsTracker(i -> {}, i -> {}, (age, i) -> {}),
                 true,
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                new TableWriteInfo(Optional.empty(), Optional.empty()),
                 SchedulerStatsTracker.NOOP);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskWithEventLoop.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskWithEventLoop.java
@@ -338,7 +338,7 @@ public class TestHttpRemoteTaskWithEventLoop
                 createInitialEmptyOutputBuffers(OutputBuffers.BufferType.BROADCAST),
                 new NodeTaskMap.NodeStatsTracker(i -> {}, i -> {}, (age, i) -> {}),
                 true,
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                new TableWriteInfo(Optional.empty(), Optional.empty()),
                 SchedulerStatsTracker.NOOP);
     }
 

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -2298,130 +2298,6 @@ void from_json(const json& j, SessionRepresentation& p) {
       "sessionFunctions");
 }
 } // namespace facebook::presto::protocol
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-namespace facebook::presto::protocol {
-void to_json(json& j, const std::shared_ptr<ConnectorTableLayoutHandle>& p) {
-  if (p == nullptr) {
-    return;
-  }
-  String type = p->_type;
-  getConnectorProtocol(type).to_json(j, p);
-}
-
-void from_json(const json& j, std::shared_ptr<ConnectorTableLayoutHandle>& p) {
-  String type;
-  try {
-    type = p->getSubclassKey(j);
-  } catch (json::parse_error& e) {
-    throw ParseError(
-        std::string(e.what()) +
-        " ConnectorTableLayoutHandle  ConnectorTableLayoutHandle");
-  }
-  getConnectorProtocol(type).from_json(j, p);
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const TableHandle& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "TableHandle",
-      "ConnectorId",
-      "connectorId");
-  to_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "TableHandle",
-      "ConnectorTableHandle",
-      "connectorHandle");
-  to_json_key(
-      j,
-      "transaction",
-      p.transaction,
-      "TableHandle",
-      "ConnectorTransactionHandle",
-      "transaction");
-  to_json_key(
-      j,
-      "connectorTableLayout",
-      p.connectorTableLayout,
-      "TableHandle",
-      "ConnectorTableLayoutHandle",
-      "connectorTableLayout");
-}
-
-void from_json(const json& j, TableHandle& p) {
-  from_json_key(
-      j,
-      "connectorId",
-      p.connectorId,
-      "TableHandle",
-      "ConnectorId",
-      "connectorId");
-  from_json_key(
-      j,
-      "connectorHandle",
-      p.connectorHandle,
-      "TableHandle",
-      "ConnectorTableHandle",
-      "connectorHandle");
-  from_json_key(
-      j,
-      "transaction",
-      p.transaction,
-      "TableHandle",
-      "ConnectorTransactionHandle",
-      "transaction");
-  from_json_key(
-      j,
-      "connectorTableLayout",
-      p.connectorTableLayout,
-      "TableHandle",
-      "ConnectorTableLayoutHandle",
-      "connectorTableLayout");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
-void to_json(json& j, const DeleteScanInfo& p) {
-  j = json::object();
-  to_json_key(j, "id", p.id, "DeleteScanInfo", "PlanNodeId", "id");
-  to_json_key(
-      j,
-      "tableHandle",
-      p.tableHandle,
-      "DeleteScanInfo",
-      "TableHandle",
-      "tableHandle");
-}
-
-void from_json(const json& j, DeleteScanInfo& p) {
-  from_json_key(j, "id", p.id, "DeleteScanInfo", "PlanNodeId", "id");
-  from_json_key(
-      j,
-      "tableHandle",
-      p.tableHandle,
-      "DeleteScanInfo",
-      "TableHandle",
-      "tableHandle");
-}
-} // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 void to_json(json& j, const std::shared_ptr<ExecutionWriterTarget>& p) {
   if (p == nullptr) {
@@ -2505,13 +2381,6 @@ void to_json(json& j, const TableWriteInfo& p) {
       "TableWriteInfo",
       "AnalyzeTableHandle",
       "analyzeTableHandle");
-  to_json_key(
-      j,
-      "deleteScanInfo",
-      p.deleteScanInfo,
-      "TableWriteInfo",
-      "DeleteScanInfo",
-      "deleteScanInfo");
 }
 
 void from_json(const json& j, TableWriteInfo& p) {
@@ -2529,13 +2398,6 @@ void from_json(const json& j, TableWriteInfo& p) {
       "TableWriteInfo",
       "AnalyzeTableHandle",
       "analyzeTableHandle");
-  from_json_key(
-      j,
-      "deleteScanInfo",
-      p.deleteScanInfo,
-      "TableWriteInfo",
-      "DeleteScanInfo",
-      "deleteScanInfo");
 }
 } // namespace facebook::presto::protocol
 /*
@@ -5999,6 +5861,105 @@ void from_json(const json& j, std::shared_ptr<ColumnHandle>& p) {
     throw ParseError(std::string(e.what()) + " ColumnHandle  ColumnHandle");
   }
   getConnectorProtocol(type).from_json(j, p);
+}
+} // namespace facebook::presto::protocol
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace facebook::presto::protocol {
+void to_json(json& j, const std::shared_ptr<ConnectorTableLayoutHandle>& p) {
+  if (p == nullptr) {
+    return;
+  }
+  String type = p->_type;
+  getConnectorProtocol(type).to_json(j, p);
+}
+
+void from_json(const json& j, std::shared_ptr<ConnectorTableLayoutHandle>& p) {
+  String type;
+  try {
+    type = p->getSubclassKey(j);
+  } catch (json::parse_error& e) {
+    throw ParseError(
+        std::string(e.what()) +
+        " ConnectorTableLayoutHandle  ConnectorTableLayoutHandle");
+  }
+  getConnectorProtocol(type).from_json(j, p);
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const TableHandle& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "TableHandle",
+      "ConnectorId",
+      "connectorId");
+  to_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "TableHandle",
+      "ConnectorTableHandle",
+      "connectorHandle");
+  to_json_key(
+      j,
+      "transaction",
+      p.transaction,
+      "TableHandle",
+      "ConnectorTransactionHandle",
+      "transaction");
+  to_json_key(
+      j,
+      "connectorTableLayout",
+      p.connectorTableLayout,
+      "TableHandle",
+      "ConnectorTableLayoutHandle",
+      "connectorTableLayout");
+}
+
+void from_json(const json& j, TableHandle& p) {
+  from_json_key(
+      j,
+      "connectorId",
+      p.connectorId,
+      "TableHandle",
+      "ConnectorId",
+      "connectorId");
+  from_json_key(
+      j,
+      "connectorHandle",
+      p.connectorHandle,
+      "TableHandle",
+      "ConnectorTableHandle",
+      "connectorHandle");
+  from_json_key(
+      j,
+      "transaction",
+      p.transaction,
+      "TableHandle",
+      "ConnectorTransactionHandle",
+      "transaction");
+  from_json_key(
+      j,
+      "connectorTableLayout",
+      p.connectorTableLayout,
+      "TableHandle",
+      "ConnectorTableLayoutHandle",
+      "connectorTableLayout");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -293,11 +293,6 @@ void to_json(json& j, const std::shared_ptr<ConnectorTransactionHandle>& p);
 void from_json(const json& j, std::shared_ptr<ConnectorTransactionHandle>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct ConnectorTableLayoutHandle : public JsonEncodedSubclass {};
-void to_json(json& j, const std::shared_ptr<ConnectorTableLayoutHandle>& p);
-void from_json(const json& j, std::shared_ptr<ConnectorTableLayoutHandle>& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 struct ExecutionWriterTarget : public JsonEncodedSubclass {};
 void to_json(json& j, const std::shared_ptr<ExecutionWriterTarget>& p);
 void from_json(const json& j, std::shared_ptr<ExecutionWriterTarget>& p);
@@ -345,6 +340,11 @@ struct ColumnHandle : public JsonEncodedSubclass {
 };
 void to_json(json& j, const std::shared_ptr<ColumnHandle>& p);
 void from_json(const json& j, std::shared_ptr<ColumnHandle>& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct ConnectorTableLayoutHandle : public JsonEncodedSubclass {};
+void to_json(json& j, const std::shared_ptr<ConnectorTableLayoutHandle>& p);
+void from_json(const json& j, std::shared_ptr<ConnectorTableLayoutHandle>& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct ConnectorInsertTableHandle : public JsonEncodedSubclass {};
@@ -769,28 +769,9 @@ void to_json(json& j, const SessionRepresentation& p);
 void from_json(const json& j, SessionRepresentation& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct TableHandle {
-  ConnectorId connectorId = {};
-  std::shared_ptr<ConnectorTableHandle> connectorHandle = {};
-  std::shared_ptr<ConnectorTransactionHandle> transaction = {};
-  std::shared_ptr<ConnectorTableLayoutHandle> connectorTableLayout = {};
-};
-void to_json(json& j, const TableHandle& p);
-void from_json(const json& j, TableHandle& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-struct DeleteScanInfo {
-  PlanNodeId id = {};
-  TableHandle tableHandle = {};
-};
-void to_json(json& j, const DeleteScanInfo& p);
-void from_json(const json& j, DeleteScanInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 struct TableWriteInfo {
   std::shared_ptr<ExecutionWriterTarget> writerTarget = {};
   std::shared_ptr<AnalyzeTableHandle> analyzeTableHandle = {};
-  std::shared_ptr<DeleteScanInfo> deleteScanInfo = {};
 };
 void to_json(json& j, const TableWriteInfo& p);
 void from_json(const json& j, TableWriteInfo& p);
@@ -1518,6 +1499,16 @@ struct IndexJoinNode : public PlanNode {
 };
 void to_json(json& j, const IndexJoinNode& p);
 void from_json(const json& j, IndexJoinNode& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct TableHandle {
+  ConnectorId connectorId = {};
+  std::shared_ptr<ConnectorTableHandle> connectorHandle = {};
+  std::shared_ptr<ConnectorTransactionHandle> transaction = {};
+  std::shared_ptr<ConnectorTableLayoutHandle> connectorTableLayout = {};
+};
+void to_json(json& j, const TableHandle& p);
+void from_json(const json& j, TableHandle& p);
 } // namespace facebook::presto::protocol
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestBatchTaskUpdateRequest.java
@@ -99,7 +99,7 @@ public class TestBatchTaskUpdateRequest
                 Optional.of(createPlanFragment().bytesForTaskSerialization(PLAN_FRAGMENT_JSON_CODEC)),
                 sources,
                 createInitialEmptyOutputBuffers(PARTITIONED),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
         String shuffleWriteInfo = "dummy-shuffle-write-info";
         BatchTaskUpdateRequest batchUpdateRequest = new BatchTaskUpdateRequest(updateRequest, Optional.of(shuffleWriteInfo), Optional.empty());
         JsonCodec<BatchTaskUpdateRequest> batchTaskUpdateRequestJsonCodec = getJsonCodec();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/task/TestPrestoSparkTaskExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/task/TestPrestoSparkTaskExecution.java
@@ -98,7 +98,7 @@ public class TestPrestoSparkTaskExecution
                 planFragment,
                 new TestingOutputBuffer(),
                 new TestingRemoteSourceFactory(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                new TableWriteInfo(Optional.empty(), Optional.empty()),
                 new ArrayList<>());
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -712,7 +712,7 @@ public class TestMemoryRevokingScheduler
                 Optional.of(PLAN_FRAGMENT),
                 ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), false)),
                 createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds(),
-                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty())));
 
         // use implicitly created task context from updateTask. It should be the only task in this QueryContext's tasks
         TaskContext taskContext = sqlTask.getQueryContext().getTaskContextByTaskId(sqlTask.getTaskId());


### PR DESCRIPTION
## Description
More details in #24807.
Remove DeleteScanInfo because after the beginDelete update, this returns the same information as the tableScanNode tablehandle. Instead, we just pull the tablehandle directly from the tableScanNode. This diff removes the usage of TableWriteInfo.DeleteScanInfo, the supporting code, and the protocol. Protocol has also been remade. One concern I have is that I didn't see any usages of DeleteScanInfo in the native workers. If there's no usages, the protocol change won't have any impact, but I'm unsure if there might be something I missed on that end.

For Reviewer: 
Only significant changes are in TableWriteInfo, SplitSourceFactory, and LocalExecutionPlanner.
Everthing else is either adjusting test code for parameter changes, or protocol generation
## Motivation and Context
Details in #24807 

## Impact
If there is a user that used DeleteScanInfo to return specific tablescan information they required, that functionality will no longer be available. In open source connectors and meta internal code, there doesn't seem to be any impact.

## Test Plan
Test on IcebergHiveIntegrationSmokeTest for deletes.
TODO: test with meta internal DELETE build

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
