### PR TITLE
Add team-velox as code owners for presto-native-(sidecar-plugin|tests) modules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -112,6 +112,8 @@ CODEOWNERS @prestodb/team-tsc
 #####################################################################
 # Prestissimo module
 /presto-native-execution @prestodb/team-velox
+/presto-native-sidecar-plugin @prestodb/team-velox
+/presto-native-tests @prestodb/team-velox
 /.github/workflows/prestocpp-* @prestodb/team-velox @prestodb/committers
 
 #####################################################################


### PR DESCRIPTION
## Motivation and Context
presto-native-execution owners should be able to approve changes to these 2 new dependent modules.

