### PR TITLE
Fix error when describing a nonexistent table

### DIFF
--- a/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowMetadata.java
+++ b/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowMetadata.java
@@ -175,7 +175,9 @@ public class ArrowMetadata
         for (SchemaTableName tableName : tables) {
             try {
                 ConnectorTableHandle tableHandle = getTableHandle(session, tableName);
-                columns.put(tableName, getTableMetadata(session, tableHandle).getColumns());
+                if (tableHandle != null) {
+                    columns.put(tableName, getTableMetadata(session, tableHandle).getColumns());
+                }
             }
             catch (ClassCastException | NotFoundException e) {
                 throw new ArrowException(ARROW_FLIGHT_METADATA_ERROR, "Table columns could not be listed for table: " + tableName, e);

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightQueries.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
 import static org.testng.Assert.assertTrue;
 
@@ -135,6 +136,16 @@ public class TestArrowFlightQueries
                         getDateTimeAtZone("2005-12-31 23:59:59", session.getTimeZoneKey()))
                 .build();
         assertTrue(actualRow.equals(expectedRow));
+    }
+
+    @Test
+    public void testDescribeUnknownTable()
+    {
+        MaterializedResult actualRows = computeActual("DESCRIBE information_schema.enabled_roles");
+        MaterializedResult expectedRows = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("role_name", "varchar", "", "")
+                .build();
+        assertEquals(actualRows, expectedRows);
     }
 
     private LocalDate getDate(String dateString)


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This change fixes a null pointer exception when table columns were attempted to be listed for a nonexistent table

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
If a statement like `DESCRIBE arrowdb2.information_schema.enabled_roles` was executed, where `enabled_roles` table does not exist in `information_schema` in the remote database, this would result in a null pointer exception. 

This error occurs in special scenarios where a table like `enabled_roles` exist in the Presto `information_schema` schema, so statement analyzer does not throw "table not found" error. In normal scenario, statement analyzer would throw "table not found" error and execution does not reach the point where table handle is retrieved from remote datasource.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
New unit test added to test this special scenario.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

