### PR TITLE
Reuse JoinType in IndexJoinNode

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
 import com.facebook.presto.spi.plan.MergeJoinNode;
 import com.facebook.presto.spi.plan.PartitioningScheme;
@@ -490,7 +491,7 @@ public class HashGenerationOptimizer
 
             // build map of all hash variables
             Map<HashComputation, VariableReferenceExpression> allHashVariables = new HashMap<>();
-            if (node.getType() == IndexJoinNode.Type.INNER) {
+            if (node.getType() == JoinType.INNER) {
                 allHashVariables.putAll(probe.getHashVariables());
             }
             allHashVariables.putAll(index.getHashVariables());

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/IndexJoinNode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/IndexJoinNode.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -33,7 +34,7 @@ import static java.util.Objects.requireNonNull;
 public class IndexJoinNode
         extends InternalPlanNode
 {
-    private final Type type;
+    private final JoinType type;
     private final PlanNode probeSource;
     private final PlanNode indexSource;
     private final List<EquiJoinClause> criteria;
@@ -44,7 +45,7 @@ public class IndexJoinNode
     public IndexJoinNode(
             Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
-            @JsonProperty("type") Type type,
+            @JsonProperty("type") JoinType type,
             @JsonProperty("probeSource") PlanNode probeSource,
             @JsonProperty("indexSource") PlanNode indexSource,
             @JsonProperty("criteria") List<EquiJoinClause> criteria,
@@ -58,7 +59,7 @@ public class IndexJoinNode
             Optional<SourceLocation> sourceLocation,
             PlanNodeId id,
             Optional<PlanNode> statsEquivalentPlanNode,
-            Type type,
+            JoinType type,
             PlanNode probeSource,
             PlanNode indexSource,
             List<EquiJoinClause> criteria,
@@ -74,26 +75,8 @@ public class IndexJoinNode
         this.indexHashVariable = requireNonNull(indexHashVariable, "indexHashVariable is null");
     }
 
-    public enum Type
-    {
-        INNER("Inner"),
-        SOURCE_OUTER("SourceOuter");
-
-        private final String joinLabel;
-
-        private Type(String joinLabel)
-        {
-            this.joinLabel = joinLabel;
-        }
-
-        public String getJoinLabel()
-        {
-            return joinLabel;
-        }
-    }
-
     @JsonProperty
-    public Type getType()
+    public JoinType getType()
     {
         return type;
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestSchedulingOrderVisitor.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestSchedulingOrderVisitor.java
@@ -23,7 +23,6 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
-import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
@@ -57,7 +56,7 @@ public class TestSchedulingOrderVisitor
         PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), METADATA);
         TableScanNode a = planBuilder.tableScan(emptyList(), emptyMap());
         TableScanNode b = planBuilder.tableScan(emptyList(), emptyMap());
-        List<PlanNodeId> order = scheduleOrder(planBuilder.indexJoin(IndexJoinNode.Type.INNER, a, b));
+        List<PlanNodeId> order = scheduleOrder(planBuilder.indexJoin(JoinType.INNER, a, b));
         assertEquals(order, ImmutableList.of(b.getId(), a.getId()));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -844,7 +844,7 @@ public class PlanBuilder
         return new JoinNode(Optional.empty(), idAllocator.getNextId(), type, left, right, criteria, outputVariables, filter, leftHashVariable, rightHashVariable, distributionType, dynamicFilters);
     }
 
-    public PlanNode indexJoin(IndexJoinNode.Type type, TableScanNode probe, TableScanNode index)
+    public PlanNode indexJoin(JoinType type, TableScanNode probe, TableScanNode index)
     {
         return new IndexJoinNode(
                 Optional.empty(),

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/optimizers/TestPickJoinSides.java
@@ -66,6 +66,7 @@ import static com.facebook.presto.spi.plan.JoinNode.flipType;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
 import static com.facebook.presto.spi.plan.JoinType.LEFT;
 import static com.facebook.presto.spi.plan.JoinType.RIGHT;
+import static com.facebook.presto.spi.plan.JoinType.SOURCE_OUTER;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
@@ -104,6 +105,7 @@ public class TestPickJoinSides
     public static Object[][] joinTypes()
     {
         return Arrays.stream(JoinType.values())
+                .filter(type -> type != SOURCE_OUTER)
                 .collect(toDataProvider());
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/JoinType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/JoinType.java
@@ -20,7 +20,8 @@ public enum JoinType
     INNER("InnerJoin"),
     LEFT("LeftJoin"),
     RIGHT("RightJoin"),
-    FULL("FullJoin");
+    FULL("FullJoin"),
+    SOURCE_OUTER("SourceOuter");
 
     private final String joinLabel;
 


### PR DESCRIPTION
Reuse JoinType instead of creating IndexJoinNode's own. JoinType is already part of Prestissimo protocol. Adding IndexJoinNode with another JoinType would cause naming conflict.

```
== NO RELEASE NOTE ==
```

