### PR TITLE
[native] Add group name for writer tests and mvn profile for specific tests.

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -339,6 +339,20 @@
             </build>
         </profile>
         <profile>
+            <id>presto-native-execution-custom-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludedGroups combine.self="override">writer,parquet,remote-function,textfile_reader,no_textfile_reader,async_data_cache</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>docker-build</id>
             <dependencies>
                 <dependency>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeWriter.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeWriter.java
@@ -98,7 +98,7 @@ public class TestPrestoNativeWriter
         createPrestoBenchTables(queryRunner);
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testCreateTableWithUnsupportedFormats()
     {
         // Generate temporary table name.
@@ -109,7 +109,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testTableFormats()
     {
         Session session = Session.builder(getSession())
@@ -171,7 +171,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testCreateUnpartitionedTableAsSelect()
     {
         // Generate temporary table name.
@@ -200,7 +200,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testCreatePartitionedTableAsSelect()
     {
         {
@@ -223,7 +223,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testInsertIntoPartitionedTable()
     {
         // Generate temporary table name.
@@ -252,7 +252,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testInsertIntoSpecialPartitionName()
     {
         Session writeSession = buildSessionForTableWrite();
@@ -275,7 +275,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testCreateBucketTableAsSelect()
     {
         Session session = buildSessionForTableWrite();
@@ -300,7 +300,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testCreateBucketSortedTableAsSelect()
     {
         Session session = buildSessionForTableWrite();
@@ -324,7 +324,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testScaleWriterTasks()
     {
         Session session = buildSessionForTableWrite();
@@ -343,7 +343,7 @@ public class TestPrestoNativeWriter
         dropTableIfExists(tmpTableName);
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testScaleWriterThreads()
     {
         // no scaling for bucketed tables
@@ -605,7 +605,7 @@ public class TestPrestoNativeWriter
         }
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testCollectColumnStatisticsOnCreateTable()
     {
         Session session = buildSessionForTableWrite();
@@ -668,7 +668,7 @@ public class TestPrestoNativeWriter
         dropTableIfExists(tmpTableName);
     }
 
-    @Test
+    @Test(groups = {"writer"})
     public void testCollectColumnStatisticsOnInsert()
     {
         Session session = buildSessionForTableWrite();


### PR DESCRIPTION
## Description
Adding way to trigger specific e2e tests, also adding a group name for writer tests.

## Motivation and Context
We are observing several tests failing with java 17 upgrade changes. To debug this, we are providing group names and building a mvn profile to keep running good tests internally at Meta.

## Impact
None

## Test Plan
Running the tests

```
== NO RELEASE NOTE ==
```

