### PR TITLE
Add task splits counter

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -619,6 +619,7 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTaskImpl(
             std::max(maxSplitSequenceId, protocolSplit.sequenceId);
         execTask->addSplitWithSequence(
             source.planNodeId, std::move(split), protocolSplit.sequenceId);
+        RECORD_METRIC_VALUE(kCounterNumTaskSplits, 1);
       }
     }
     // Update task's max split sequence id after all splits have been added.

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -58,6 +58,7 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(
       kCounterNumCancelledTasksByStuckDriver, facebook::velox::StatType::COUNT);
   DEFINE_METRIC(kCounterNumTasksDeadlock, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterNumTaskSplits, facebook::velox::StatType::COUNT);
   DEFINE_METRIC(
       kCounterNumTaskManagerLockTimeOut, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumQueuedDrivers, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -80,6 +80,9 @@ constexpr folly::StringPiece kCounterNumTasksDeadlock{
     "presto_cpp.num_tasks_deadlock"};
 constexpr folly::StringPiece kCounterNumTaskManagerLockTimeOut{
     "presto_cpp.num_tasks_manager_lock_timeout"};
+constexpr folly::StringPiece kCounterNumTaskSplits{
+    "presto_cpp.num_task_splits"
+};
 
 constexpr folly::StringPiece kCounterNumQueuedDrivers{
     "presto_cpp.num_queued_drivers"};


### PR DESCRIPTION
Summary: Add total task splits counter to Presto native worker.

Differential Revision: D72575836


