### PR TITLE
Add distinct to the right side when LOJ + IS NULL is rewritten to Semijoin

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLeftJoinNullFilterToSemiJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLeftJoinNullFilterToSemiJoin.java
@@ -13,15 +13,22 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 
 public class TestLeftJoinNullFilterToSemiJoin
@@ -52,7 +59,7 @@ public class TestLeftJoinNullFilterToSemiJoin
                                                 "right_k1",
                                                 "semijoinoutput",
                                                 values("left_k1", "left_k2"),
-                                                values("right_k1")))));
+                                                aggregation(singleGroupingSet(ImmutableList.of("right_k1")), ImmutableMap.of(), ImmutableMap.of(), Optional.empty(), AggregationNode.Step.SINGLE, values("right_k1"))))));
     }
 
     @Test
@@ -192,6 +199,6 @@ public class TestLeftJoinNullFilterToSemiJoin
                                                         "right_k1",
                                                         "semijoinoutput",
                                                         values("left_k1", "left_k2"),
-                                                        values("right_k1"))))));
+                                                        aggregation(singleGroupingSet(ImmutableList.of("right_k1")), ImmutableMap.of(), ImmutableMap.of(), Optional.empty(), AggregationNode.Step.SINGLE, values("right_k1")))))));
     }
 }


### PR DESCRIPTION
## Description

issue https://github.com/prestodb/presto/issues/24510

The join might have a huge right side in cases of following optimization:
When left join has the 'is null' key filter on the right side, it is effectively making the query return rows from the left side where there is a no match on the right side. This currently is optimized by converting the section into a left semi join. But the current issue is the right side (key only) might have large amount of duplication that is completely unnecessary for evaluation of the join. This PR addresses it by adding a distinct aggregation operator before to optimize the performance

Selective Meta internal production queries showed 100x performance gain and 3x memory reduction
```
== RELEASE NOTE ==
General Changes
Add distinct on the right side optimization on optimizer rule ``LeftJoinNullFilterToSemiJoin``.
```

