### PR TITLE
Fix sensitive data disclosure in logs

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore.thrift;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 
 import java.io.File;
 
@@ -54,6 +55,7 @@ public class ThriftHiveMetastoreConfig
 
     @Config("hive.metastore.thrift.client.tls.keystore-password")
     @ConfigDescription("Password to key store")
+    @ConfigSecuritySensitive
     public ThriftHiveMetastoreConfig setKeystorePassword(String keystorePassword)
     {
         this.keystorePassword = keystorePassword;
@@ -80,6 +82,7 @@ public class ThriftHiveMetastoreConfig
 
     @Config("hive.metastore.thrift.client.tls.truststore-password")
     @ConfigDescription("Path to trust store")
+    @ConfigSecuritySensitive
     public ThriftHiveMetastoreConfig setTrustStorePassword(String truststorePassword)
     {
         this.trustStorePassword = truststorePassword;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Config.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/HiveS3Config.java
@@ -68,6 +68,7 @@ public class HiveS3Config
     }
 
     @Config("hive.s3.aws-access-key")
+    @ConfigSecuritySensitive
     public HiveS3Config setS3AwsAccessKey(String s3AwsAccessKey)
     {
         this.s3AwsAccessKey = s3AwsAccessKey;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/ranger/RangerBasedAccessControlConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/ranger/RangerBasedAccessControlConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.security.ranger;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
@@ -98,6 +99,7 @@ public class RangerBasedAccessControlConfig
     }
 
     @Config(RANGER_REST_USER_GROUPS_AUTH_PASSWORD)
+    @ConfigSecuritySensitive
     public RangerBasedAccessControlConfig setBasicAuthPassword(String basicAuthPassword)
     {
         this.basicAuthPassword = basicAuthPassword;

--- a/presto-main-base/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
@@ -106,6 +106,7 @@ public class InternalCommunicationConfig
     }
 
     @Config("internal-communication.https.trust-store-password")
+    @ConfigSecuritySensitive
     public InternalCommunicationConfig setTrustStorePassword(String trustStorePassword)
     {
         this.trustStorePassword = trustStorePassword;

--- a/presto-password-authenticators/src/main/java/com/facebook/presto/password/file/FileConfig.java
+++ b/presto-password-authenticators/src/main/java/com/facebook/presto/password/file/FileConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.password.file;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
@@ -38,6 +39,7 @@ public class FileConfig
 
     @Config("file.password-file")
     @ConfigDescription("Location of the file that provides user names and passwords")
+    @ConfigSecuritySensitive
     public FileConfig setPasswordFile(File passwordFile)
     {
         this.passwordFile = passwordFile;

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -510,6 +510,7 @@ public class PinotConfig
     }
 
     @Config("pinot.grpc-tls-key-store-password")
+    @ConfigSecuritySensitive
     public PinotConfig setGrpcTlsKeyStorePassword(String grpcTlsKeyStorePassword)
     {
         this.grpcTlsKeyStorePassword = grpcTlsKeyStorePassword;
@@ -546,6 +547,7 @@ public class PinotConfig
     }
 
     @Config("pinot.grpc-tls-trust-store-password")
+    @ConfigSecuritySensitive
     public PinotConfig setGrpcTlsTrustStorePassword(String grpcTlsTrustStorePassword)
     {
         this.grpcTlsTrustStorePassword = grpcTlsTrustStorePassword;

--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusConnectorConfig.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusConnectorConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.prometheus;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
@@ -149,6 +150,7 @@ public class PrometheusConnectorConfig
     }
 
     @Config("prometheus.tls.truststore-password")
+    @ConfigSecuritySensitive
     public PrometheusConnectorConfig setTruststorePassword(String password)
     {
         this.truststorePassword = password;

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderConfig.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.statistic;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 
 public class RedisProviderConfig
 {
@@ -92,6 +93,7 @@ public class RedisProviderConfig
     }
 
     @Config("hbo.redis-provider.cluster-password")
+    @ConfigSecuritySensitive
     public RedisProviderConfig setClusterPassword(String value)
     {
         this.clusterPassword = value;


### PR DESCRIPTION
## Description
Resolved the issue of sensitive data being exposed in logs by adding the @ConfigSecuritySensitive annotation to methods exposing such information, ensuring that sensitive field values are properly redacted.

## Motivation and Context
Close the git issue https://github.com/prestodb/presto/issues/24885

## Impact
Logs before fix
![image](https://github.com/user-attachments/assets/0c3059fb-3ebc-4136-afbe-7741068e8491)

Logs after fix
![image](https://github.com/user-attachments/assets/c89aec39-fce4-4b7e-9cd7-79469b54b7b8)
![image](https://github.com/user-attachments/assets/4647b90a-1a4d-43c4-88eb-260aef51263b)


## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix the issue of sensitive data such as passwords and access keys being exposed in logs by redacting sensitive field values.
```

