### PR TITLE
Add longest_common_prefix implementation, documentation and tests

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -66,6 +66,10 @@ String Functions
     i.e. the minimum number of single-character edits (insertions,
     deletions or substitutions) needed to change ``string1`` into ``string2``.
 
+.. function:: longest_common_prefix(string1, string2) -> varchar
+
+    Returns the longest common prefix between ``string1`` and ``string2``
+
 .. function:: lower(string) -> varchar
 
     Converts ``string`` to lowercase.

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -756,6 +756,27 @@ public final class StringFunctions
         return pad(text, targetLength, padString, text.length());
     }
 
+    @Description("returns the longest common prefix shared by two strings")
+    @ScalarFunction("longest_common_prefix")
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice longestCommonPrefix(@SqlType("varchar(x)") Slice left, @SqlType("varchar(y)") Slice right)
+    {
+        int i = 0;
+        int byteIndex = 0;
+        int[] leftCodePoints = castToCodePoints(left);
+        int[] rightCodePoints = castToCodePoints(right);
+        int leftLength = leftCodePoints.length;
+        int rightLength = rightCodePoints.length;
+
+        while (i < leftLength && i < rightLength && leftCodePoints[i] == rightCodePoints[i]) {
+            i++;
+            byteIndex += SliceUtf8.lengthOfCodePointSafe(left, byteIndex);
+        }
+
+        return Slices.wrappedBuffer(left.getBytes(0, byteIndex));
+    }
+
     @Description("computes Levenshtein distance between two strings")
     @ScalarFunction
     @LiteralParameters({"x", "y"})

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -165,6 +165,30 @@ public class TestStringFunctions
     }
 
     @Test
+    public void testLongestCommonPrefix()
+    {
+        assertFunction("LONGEST_COMMON_PREFIX('', '')", VARCHAR, "");
+        assertFunction("LONGEST_COMMON_PREFIX('', 'hello')", VARCHAR, "");
+        assertFunction("LONGEST_COMMON_PREFIX('hello', '')", VARCHAR, "");
+        assertFunction("LONGEST_COMMON_PREFIX('hello', 'hello')", VARCHAR, "hello");
+        assertFunction("LONGEST_COMMON_PREFIX('hello world', 'hello')", VARCHAR, "hello");
+        assertFunction("LONGEST_COMMON_PREFIX('hello', 'hello world')", VARCHAR, "hello");
+        assertFunction("LONGEST_COMMON_PREFIX('hello world', 'hel wold')", VARCHAR, "hel");
+        assertFunction("LONGEST_COMMON_PREFIX('hel wold', 'hello world')", VARCHAR, "hel");
+
+        // Test for non-ASCII
+        assertFunction("LONGEST_COMMON_PREFIX('\u4FE1\u5FF5,\u7231,\u5E0C\u671B', '')", VARCHAR, "");
+        assertFunction("LONGEST_COMMON_PREFIX('', '\u4FE1\u5FF5,\u7231,\u5E0C\u671B')", VARCHAR, "");
+        assertFunction("LONGEST_COMMON_PREFIX('\u4FE1\u5FF5,\u7231,\u5E0C\u671B', '\u4FE1\u5FF5,\u7231,\u5E0C\u671B')", VARCHAR, "\u4FE1\u5FF5,\u7231,\u5E0C\u671B");
+        assertFunction("LONGEST_COMMON_PREFIX('\u4FE1\u5FF5,\u7221,\u5E0C\u671B', '\u4FE1\u5FF5,\u7231,\u5E0C\u671B')", VARCHAR, "\u4FE1\u5FF5,");
+        assertFunction("LONGEST_COMMON_PREFIX('hello na\u00EFve world', 'hello na\u00EFve')", VARCHAR, "hello na\u00EFve");
+
+        // Test for invalid-utf8 characters
+        assertInvalidFunction("LONGEST_COMMON_PREFIX('hello world', utf8(from_hex('81')))", "Invalid UTF-8 encoding in characters: �");
+        assertInvalidFunction("LONGEST_COMMON_PREFIX('hello world', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
+    }
+
+    @Test
     public void testLevenshteinDistance()
     {
         assertFunction("LEVENSHTEIN_DISTANCE('', '')", BIGINT, 0L);


### PR DESCRIPTION
## Description

Add longest_common_prefix function

## Motivation and Context

Feature requested by myself (😃) - I'm currently doing some data analysis at Meta which involves numerous string comparisons (i.e. string similarity). I found the levenshtein_distance built-in function really useful for this, and found that there was also a hamming_distance function. For the purposes of my data analysis, I need functions for finding out the longest common prefix, substring, suffix and ideally also the Jaro-Winkler distance. For posterity, I thought it would be really handy to have this implemented just like Levenshtein distance or the Hamming distance. So I went for it - this diff specifically contains the longest common prefix function, plus tests.

## Impact

Added a longest_common_prefix function

![image](https://github.com/user-attachments/assets/7083c087-0010-4989-8ffa-c359cfa54dc7)

## Test Plan

Tested manually on TCPH catalog via presto-cli, then wrote tests which include non-ASCII characters (took direction from the Levenshtein distance function tests on this)

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

