### PR TITLE
Add factorial implementation, documentation and tests

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -175,6 +175,10 @@ Mathematical Functions
     element in ``bins``, but due to the binary search algorithm some such elements
     might go unnoticed and the function will return a result.
 
+.. function:: factorial(x) -> bigint
+
+    Returns the factorial of ``x``.
+
 Probability Functions: cdf
 --------------------------
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -1655,4 +1655,27 @@ public final class MathFunctions
 
         return Math.sqrt(norm);
     }
+
+    @Description("factorial of a given integer in the range of 0 to 20")
+    @ScalarFunction
+    @SqlType(StandardTypes.BIGINT)
+    public static long factorial(@SqlType(StandardTypes.INTEGER) long x)
+    {
+        checkCondition(
+                x >= 0,
+                INVALID_FUNCTION_ARGUMENT,
+                "The factorial function is only defined for non-negative integers");
+
+        checkCondition(
+                x <= 20,
+                INVALID_FUNCTION_ARGUMENT,
+                "The output of the factorial function would overflow for any input over 20");
+
+        long result = 1;
+        for (int i = 2; i <= x; i++) {
+            result *= i;
+        }
+
+        return result;
+    }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1641,4 +1641,20 @@ public class TestMathFunctions
 
         assertFunction("wilson_interval_upper(1250, 1310, 1.96e0)", DOUBLE, 0.9642524717143908);
     }
+
+    @Test
+    public void testFactorial()
+    {
+        assertFunction("factorial(1)", BIGINT, 1L);
+        assertFunction("factorial(2)", BIGINT, 2L);
+        assertFunction("factorial(3)", BIGINT, 6L);
+        assertFunction("factorial(4)", BIGINT, 24L);
+        assertFunction("factorial(5)", BIGINT, 120L);
+
+        assertFunction("factorial(0)", BIGINT, 1L);
+        assertFunction("factorial(20)", BIGINT, 2432902008176640000L);
+
+        assertInvalidFunction("factorial(-1)", "The factorial function is only defined for non-negative integers");
+        assertInvalidFunction("factorial(21)", "The output of the factorial function would overflow for any input over 20");
+    }
 }


### PR DESCRIPTION
## Description

I noticed that Snowflake has a factorial function and presto doesn't, and thought it wouldn't hurt to add one since I already had the necessary know-how.

## Motivation and Context

Provides a standardized way to calculate a factorial of an integer.

## Impact

Added factorial function

## Test Plan

I wrote tests for basic cases, as well as for the smallest and largest eligible numbers. I also made sure to cover the overflow case and the negative number case.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

