### PR TITLE
Enrich Update information in QueryInfo 

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.analyzer.AccessControlInfo;
 import com.facebook.presto.spi.analyzer.AccessControlInfoForTable;
 import com.facebook.presto.spi.analyzer.AccessControlReferences;
 import com.facebook.presto.spi.analyzer.AccessControlRole;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.security.AccessControl;
@@ -100,7 +101,7 @@ public class Analysis
     @Nullable
     private final Statement root;
     private final Map<NodeRef<Parameter>, Expression> parameters;
-    private String updateType;
+    private UpdateInfo updateInfo;
 
     private final Map<NodeRef<Table>, NamedQuery> namedQueries = new LinkedHashMap<>();
 
@@ -212,14 +213,14 @@ public class Analysis
         return root;
     }
 
-    public String getUpdateType()
+    public UpdateInfo getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
-    public void setUpdateType(String updateType)
+    public void setUpdateInfo(UpdateInfo updateInfo)
     {
-        this.updateType = updateType;
+        this.updateInfo = updateInfo;
     }
 
     public boolean isCreateTableAsSelectWithData()

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.analyzer.AccessControlReferences;
 import com.facebook.presto.spi.analyzer.QueryAnalysis;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.sql.tree.Explain;
 import com.google.common.collect.ImmutableSet;
@@ -41,9 +42,9 @@ public class BuiltInQueryAnalysis
     }
 
     @Override
-    public String getUpdateType()
+    public UpdateInfo getUpdateInfo()
     {
-        return analysis.getUpdateType();
+        return analysis.getUpdateInfo();
     }
 
     @Override

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -160,7 +160,7 @@ public class Query
         // if running or finished
         if (client.isRunning() || (client.isFinished() && client.finalStatusInfo().getError() == null)) {
             QueryStatusInfo results = client.isRunning() ? client.currentStatusInfo() : client.finalStatusInfo();
-            if (results.getUpdateType() != null) {
+            if (results.getUpdateInfo() != null) {
                 renderUpdate(errorChannel, results);
             }
             else if (results.getColumns() == null) {
@@ -220,7 +220,8 @@ public class Query
 
     private void renderUpdate(PrintStream out, QueryStatusInfo results)
     {
-        String status = results.getUpdateType();
+        checkState(results.getUpdateInfo() != null, "Update info is null");
+        String status = results.getUpdateInfo().getUpdateType();
         if (results.getUpdateCount() != null) {
             long count = results.getUpdateCount();
             status += format(": %s row%s", count, (count != 1) ? "s" : "");

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.client;
 
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -45,7 +46,7 @@ public class QueryResults
     private final StatementStats stats;
     private final QueryError error;
     private final List<PrestoWarning> warnings;
-    private final String updateType;
+    private final UpdateInfo updateInfo;
     private final Long updateCount;
 
     @JsonCreator
@@ -60,7 +61,7 @@ public class QueryResults
             @JsonProperty("stats") StatementStats stats,
             @JsonProperty("error") QueryError error,
             @JsonProperty("warnings") List<PrestoWarning> warnings,
-            @JsonProperty("updateType") String updateType,
+            @JsonProperty("updateInfo") UpdateInfo updateInfo,
             @JsonProperty("updateCount") Long updateCount)
     {
         this(
@@ -74,7 +75,7 @@ public class QueryResults
                 stats,
                 error,
                 firstNonNull(warnings, ImmutableList.of()),
-                updateType,
+                updateInfo,
                 updateCount);
     }
 
@@ -89,7 +90,7 @@ public class QueryResults
             StatementStats stats,
             QueryError error,
             List<PrestoWarning> warnings,
-            String updateType,
+            UpdateInfo updateInfo,
             Long updateCount)
     {
         this.id = requireNonNull(id, "id is null");
@@ -103,7 +104,7 @@ public class QueryResults
         this.stats = requireNonNull(stats, "stats is null");
         this.error = error;
         this.warnings = ImmutableList.copyOf(requireNonNull(warnings, "warnings is null"));
-        this.updateType = updateType;
+        this.updateInfo = updateInfo;
         this.updateCount = updateCount;
     }
 
@@ -226,9 +227,9 @@ public class QueryResults
     @Nullable
     @JsonProperty
     @Override
-    public String getUpdateType()
+    public UpdateInfo getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
     /**
@@ -255,7 +256,7 @@ public class QueryResults
                 .add("hasBinaryData", binaryData != null)
                 .add("stats", stats)
                 .add("error", error)
-                .add("updateType", updateType)
+                .add("updateInfo", updateInfo)
                 .add("updateCount", updateCount)
                 .toString();
     }

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryStatusInfo.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryStatusInfo.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.client;
 
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 
 import java.net.URI;
 import java.util.List;
@@ -36,7 +37,7 @@ public interface QueryStatusInfo
 
     List<PrestoWarning> getWarnings();
 
-    String getUpdateType();
+    UpdateInfo getUpdateInfo();
 
     Long getUpdateCount();
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -5847,7 +5847,7 @@ public class TestHiveIntegrationSmokeTest
         assertQueryFails(
                 "CREATE MATERIALIZED VIEW test_customer_view AS SELECT name FROM test_customer_base",
                 format(
-                        ".* Materialized view '%s.%s.test_customer_view' already exists",
+                        ".* Destination materialized view '%s.%s.test_customer_view' already exists",
                         getSession().getCatalog().get(),
                         getSession().getSchema().get()));
         assertQuerySucceeds("CREATE MATERIALIZED VIEW IF NOT EXISTS test_customer_view AS SELECT name FROM test_customer_base");

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -20,6 +20,7 @@ import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.jdbc.ColumnInfo.Nullable;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -1775,14 +1776,14 @@ public class PrestoResultSet
 
         private static boolean isQuery(StatementClient client)
         {
-            String updateType;
+            UpdateInfo updateInfo;
             if (client.isRunning()) {
-                updateType = client.currentStatusInfo().getUpdateType();
+                updateInfo = client.currentStatusInfo().getUpdateInfo();
             }
             else {
-                updateType = client.finalStatusInfo().getUpdateType();
+                updateInfo = client.finalStatusInfo().getUpdateInfo();
             }
-            return updateType == null;
+            return updateInfo == null;
         }
 
         @Override

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -35,6 +35,7 @@ import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.plugin.blackhole.BlackHolePlugin;
 import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.security.SelectedRole;
 import com.facebook.presto.tpch.TpchMetadata;
 import com.facebook.presto.tpch.TpchPlugin;
@@ -1257,7 +1258,7 @@ public class TestPrestoDriver
             try (PrestoStatement statement = connection.createStatement().unwrap(PrestoStatement.class)) {
                 assertFalse(statement.execute("CREATE TABLE test_more_results_clears_update_count (id bigint)"));
                 assertEquals(statement.getUpdateCount(), 0);
-                assertEquals(statement.getUpdateType(), "CREATE TABLE");
+                assertEquals(statement.getUpdateType(), new UpdateInfo("CREATE TABLE", "test_more_results_clears_update_count"));
                 assertFalse(statement.getMoreResults());
                 assertEquals(statement.getUpdateCount(), -1);
                 assertNull(statement.getUpdateType());

--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -48,6 +48,7 @@ import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.BasicQueryStats;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.eventlistener.Column;
 import com.facebook.presto.spi.eventlistener.OperatorStatistics;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
@@ -277,6 +278,7 @@ public class QueryMonitor
                 ImmutableSet.of(),
                 Optional.empty(),
                 ImmutableMap.of(),
+                Optional.empty(),
                 Optional.empty()));
 
         logQueryTimeline(queryInfo);
@@ -320,7 +322,8 @@ public class QueryMonitor
                         queryInfo.getWindowFunctions(),
                         queryInfo.getPrestoSparkExecutionContext(),
                         getPlanHash(queryInfo.getPlanCanonicalInfo(), historyBasedPlanStatisticsTracker.getStatsEquivalentPlanRootNode(queryInfo.getQueryId())),
-                        Optional.of(queryInfo.getPlanIdNodeMap())));
+                        Optional.of(queryInfo.getPlanIdNodeMap()),
+                        Optional.ofNullable(queryInfo.getUpdateInfo()).map(UpdateInfo::getUpdateObject)));
 
         logQueryTimeline(queryInfo);
     }
@@ -363,7 +366,7 @@ public class QueryMonitor
                         .map(stageId -> String.valueOf(stageId.getId()))
                         .collect(toImmutableList()),
                 queryInfo.getSession().getTraceToken(),
-                Optional.ofNullable(queryInfo.getUpdateType()));
+                Optional.ofNullable(queryInfo.getUpdateInfo()).map(UpdateInfo::getUpdateType));
     }
 
     private List<OperatorStatistics> createOperatorStatistics(QueryInfo queryInfo)

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.eventlistener.CTEInformation;
 import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.function.SqlFunctionId;
@@ -77,7 +78,7 @@ public class QueryInfo
     private final Set<String> deallocatedPreparedStatements;
     private final Optional<TransactionId> startedTransactionId;
     private final boolean clearTransactionId;
-    private final String updateType;
+    private final UpdateInfo updateInfo;
     private final Optional<StageInfo> outputStage;
     private final ExecutionFailureInfo failureInfo;
     private final ErrorType errorType;
@@ -127,7 +128,7 @@ public class QueryInfo
             @JsonProperty("deallocatedPreparedStatements") Set<String> deallocatedPreparedStatements,
             @JsonProperty("startedTransactionId") Optional<TransactionId> startedTransactionId,
             @JsonProperty("clearTransactionId") boolean clearTransactionId,
-            @JsonProperty("updateType") String updateType,
+            @JsonProperty("updateInfo") UpdateInfo updateInfo,
             @JsonProperty("outputStage") Optional<StageInfo> outputStage,
             @JsonProperty("failureInfo") ExecutionFailureInfo failureInfo,
             @JsonProperty("errorCode") ErrorCode errorCode,
@@ -206,7 +207,7 @@ public class QueryInfo
         this.deallocatedPreparedStatements = ImmutableSet.copyOf(deallocatedPreparedStatements);
         this.startedTransactionId = startedTransactionId;
         this.clearTransactionId = clearTransactionId;
-        this.updateType = updateType;
+        this.updateInfo = updateInfo;
         this.outputStage = outputStage;
         this.failureInfo = failureInfo;
         this.errorType = errorCode == null ? null : errorCode.getType();
@@ -363,9 +364,9 @@ public class QueryInfo
 
     @Nullable
     @JsonProperty
-    public String getUpdateType()
+    public UpdateInfo getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
     @JsonProperty

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -155,7 +156,7 @@ public class QueryStateMachine
     private final AtomicReference<TransactionId> startedTransactionId = new AtomicReference<>();
     private final AtomicBoolean clearTransactionId = new AtomicBoolean();
 
-    private final AtomicReference<String> updateType = new AtomicReference<>();
+    private final AtomicReference<UpdateInfo> updateInfo = new AtomicReference<>();
 
     private final AtomicReference<ExecutionFailureInfo> failureCause = new AtomicReference<>();
 
@@ -482,7 +483,7 @@ public class QueryStateMachine
                 deallocatedPreparedStatements,
                 Optional.ofNullable(startedTransactionId.get()),
                 clearTransactionId.get(),
-                updateType.get(),
+                updateInfo.get(),
                 rootStage,
                 failureCause,
                 errorCode,
@@ -753,9 +754,9 @@ public class QueryStateMachine
         clearTransactionId.set(true);
     }
 
-    public void setUpdateType(String updateType)
+    public void setUpdateInfo(UpdateInfo updateInfo)
     {
-        this.updateType.set(updateType);
+        this.updateInfo.set(updateInfo);
     }
 
     public void setExpandedQuery(Optional<String> expandedQuery)
@@ -1122,7 +1123,7 @@ public class QueryStateMachine
                 queryInfo.getDeallocatedPreparedStatements(),
                 queryInfo.getStartedTransactionId(),
                 queryInfo.isClearTransactionId(),
-                queryInfo.getUpdateType(),
+                queryInfo.getUpdateInfo(),
                 queryInfo.getOutputStage().map(QueryStateMachine::pruneStatsFromStageInfo),
                 queryInfo.getFailureInfo(),
                 queryInfo.getErrorCode(),
@@ -1240,7 +1241,7 @@ public class QueryStateMachine
                 queryInfo.getDeallocatedPreparedStatements(),
                 queryInfo.getStartedTransactionId(),
                 queryInfo.isClearTransactionId(),
-                queryInfo.getUpdateType(),
+                queryInfo.getUpdateInfo(),
                 prunedOutputStage,
                 queryInfo.getFailureInfo(),
                 queryInfo.getErrorCode(),

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SessionDefinitionExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SessionDefinitionExecution.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
 import com.facebook.presto.sql.tree.Expression;
@@ -116,7 +117,7 @@ public class SessionDefinitionExecution<T extends Statement>
             SessionTransactionControlTask<T> task = (SessionTransactionControlTask<T>) tasks.get(statement.getClass());
             checkArgument(task != null, "no task for statement: %s", statement.getClass().getSimpleName());
 
-            stateMachine.setUpdateType(task.getName());
+            stateMachine.setUpdateInfo(new UpdateInfo(task.getName(), ""));
             return new SessionDefinitionExecution<>(task, statement, slug, retryCount, transactionManager, metadata, accessControl, stateMachine, parameters, query);
         }
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -220,7 +220,7 @@ public class SqlQueryExecution
                         .recordWallAndCpuTime(ANALYZE_TIME_NANOS, () -> queryAnalyzer.analyze(analyzerContext, preparedQuery));
             }
 
-            stateMachine.setUpdateType(queryAnalysis.getUpdateType());
+            stateMachine.setUpdateInfo(queryAnalysis.getUpdateInfo());
             stateMachine.setExpandedQuery(queryAnalysis.getExpandedQuery());
 
             stateMachine.beginColumnAccessPermissionChecking();

--- a/presto-main-base/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -441,7 +441,7 @@ class Query
                         .build(),
                 null,
                 ImmutableList.of(),
-                queryResults.getUpdateType(),
+                queryResults.getUpdateInfo(),
                 queryResults.getUpdateCount());
     }
 
@@ -526,7 +526,7 @@ class Query
 
         // TODO: figure out a better way to do this
         // grab the update count for non-queries
-        if ((data != null) && (queryInfo.getUpdateType() != null) && (updateCount == null) &&
+        if ((data != null) && (queryInfo.getUpdateInfo() != null) && (updateCount == null) &&
                 (columns.size() == 1) && (columns.get(0).getType().equals(StandardTypes.BIGINT))) {
             Iterator<List<Object>> iterator = data.iterator();
             if (iterator.hasNext()) {
@@ -597,7 +597,7 @@ class Query
                 toStatementStats(queryInfo),
                 toQueryError(queryInfo),
                 queryInfo.getWarnings(),
-                queryInfo.getUpdateType(),
+                queryInfo.getUpdateInfo(),
                 updateCount);
 
         // cache the new result

--- a/presto-main-base/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -178,7 +178,7 @@ public final class QueryResourceUtil
                 queryResults.getStats(),
                 queryResults.getError(),
                 queryResults.getWarnings(),
-                queryResults.getUpdateType(),
+                queryResults.getUpdateInfo(),
                 queryResults.getUpdateCount());
 
         return toResponse(query, resultsClone, compressionEnabled);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -78,9 +78,11 @@ import com.facebook.presto.sql.tree.Call;
 import com.facebook.presto.sql.tree.Commit;
 import com.facebook.presto.sql.tree.CreateFunction;
 import com.facebook.presto.sql.tree.CreateMaterializedView;
+import com.facebook.presto.sql.tree.CreateRole;
 import com.facebook.presto.sql.tree.CreateSchema;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
+import com.facebook.presto.sql.tree.CreateType;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.Deallocate;
@@ -91,6 +93,7 @@ import com.facebook.presto.sql.tree.DropColumn;
 import com.facebook.presto.sql.tree.DropConstraint;
 import com.facebook.presto.sql.tree.DropFunction;
 import com.facebook.presto.sql.tree.DropMaterializedView;
+import com.facebook.presto.sql.tree.DropRole;
 import com.facebook.presto.sql.tree.DropSchema;
 import com.facebook.presto.sql.tree.DropTable;
 import com.facebook.presto.sql.tree.DropView;
@@ -106,6 +109,7 @@ import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.FrameBound;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.Grant;
+import com.facebook.presto.sql.tree.GrantRoles;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.GroupingOperation;
@@ -142,6 +146,7 @@ import com.facebook.presto.sql.tree.RenameView;
 import com.facebook.presto.sql.tree.ResetSession;
 import com.facebook.presto.sql.tree.Return;
 import com.facebook.presto.sql.tree.Revoke;
+import com.facebook.presto.sql.tree.RevokeRoles;
 import com.facebook.presto.sql.tree.Rollback;
 import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.Row;
@@ -150,6 +155,7 @@ import com.facebook.presto.sql.tree.Select;
 import com.facebook.presto.sql.tree.SelectItem;
 import com.facebook.presto.sql.tree.SetOperation;
 import com.facebook.presto.sql.tree.SetProperties;
+import com.facebook.presto.sql.tree.SetRole;
 import com.facebook.presto.sql.tree.SetSession;
 import com.facebook.presto.sql.tree.SimpleGroupBy;
 import com.facebook.presto.sql.tree.SingleColumn;
@@ -412,7 +418,7 @@ class StatementAnalyzer
             // analyze the query that creates the data
             Scope queryScope = process(insert.getQuery(), scope);
 
-            analysis.setUpdateType("INSERT");
+            analysis.setUpdateInfo(insert.getUpdateInfo());
 
             TableColumnMetadata tableColumnsMetadata = getTableColumnsMetadata(session, metadataResolver, metadataHandle, targetTable);
             // verify the insert destination columns match the query
@@ -612,7 +618,7 @@ class StatementAnalyzer
             Scope tableScope = analyzer.analyze(table, scope);
             node.getWhere().ifPresent(where -> analyzeWhere(node, tableScope, where));
 
-            analysis.setUpdateType("DELETE");
+            analysis.setUpdateInfo(node.getUpdateInfo());
 
             analysis.addAccessControlCheckForTable(TABLE_DELETE, new AccessControlInfoForTable(accessControl, session.getIdentity(), session.getTransactionId(), session.getAccessControlContext(), tableName));
 
@@ -632,8 +638,8 @@ class StatementAnalyzer
         @Override
         protected Scope visitAnalyze(Analyze node, Optional<Scope> scope)
         {
-            analysis.setUpdateType("ANALYZE");
             QualifiedObjectName tableName = createQualifiedObjectName(session, node, node.getTableName(), metadata);
+            analysis.setUpdateInfo(node.getUpdateInfo());
             MetadataHandle metadataHandle = analysis.getMetadataHandle();
 
             // verify the target table exists, and it's not a view
@@ -667,7 +673,7 @@ class StatementAnalyzer
         @Override
         protected Scope visitCreateTableAsSelect(CreateTableAsSelect node, Optional<Scope> scope)
         {
-            analysis.setUpdateType("CREATE TABLE");
+            analysis.setUpdateInfo(node.getUpdateInfo());
 
             // turn this into a query that has a new table writer node on top.
             QualifiedObjectName targetTable = createQualifiedObjectName(session, node, node.getName(), metadata);
@@ -714,9 +720,8 @@ class StatementAnalyzer
         @Override
         protected Scope visitCreateView(CreateView node, Optional<Scope> scope)
         {
-            analysis.setUpdateType("CREATE VIEW");
-
             QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName(), metadata);
+            analysis.setUpdateInfo(node.getUpdateInfo());
 
             // analyze the query that creates the view
             StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session, warningCollector);
@@ -734,9 +739,8 @@ class StatementAnalyzer
         @Override
         protected Scope visitCreateMaterializedView(CreateMaterializedView node, Optional<Scope> scope)
         {
-            analysis.setUpdateType("CREATE MATERIALIZED VIEW");
-
             QualifiedObjectName viewName = createQualifiedObjectName(session, node, node.getName(), metadata);
+            analysis.setUpdateInfo(node.getUpdateInfo());
             analysis.setCreateTableDestination(viewName);
 
             if (metadataResolver.tableExists(viewName)) {
@@ -766,9 +770,8 @@ class StatementAnalyzer
         @Override
         protected Scope visitRefreshMaterializedView(RefreshMaterializedView node, Optional<Scope> scope)
         {
-            analysis.setUpdateType("INSERT");
-
             QualifiedObjectName viewName = createQualifiedObjectName(session, node.getTarget(), node.getTarget().getName(), metadata);
+            analysis.setUpdateInfo(node.getUpdateInfo());
 
             MaterializedViewDefinition view = getMaterializedViewDefinition(session, metadataResolver, analysis.getMetadataHandle(), viewName)
                     .orElseThrow(() -> new SemanticException(MISSING_MATERIALIZED_VIEW, node, "Materialized view '%s' does not exist", viewName));
@@ -864,7 +867,7 @@ class StatementAnalyzer
         @Override
         protected Scope visitCreateFunction(CreateFunction node, Optional<Scope> scope)
         {
-            analysis.setUpdateType("CREATE FUNCTION");
+            analysis.setUpdateInfo(node.getUpdateInfo());
 
             // Check function name
             checkFunctionName(node, node.getFunctionName(), node.isTemporary());
@@ -941,12 +944,14 @@ class StatementAnalyzer
         @Override
         protected Scope visitAddColumn(AddColumn node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitCreateSchema(CreateSchema node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             validateProperties(node.getProperties(), scope);
             return createAndAssignScope(node, scope);
         }
@@ -954,19 +959,64 @@ class StatementAnalyzer
         @Override
         protected Scope visitDropSchema(DropSchema node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitRenameSchema(RenameSchema node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitCreateTable(CreateTable node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             validateProperties(node.getProperties(), scope);
+            return createAndAssignScope(node, scope);
+        }
+
+        @Override
+        protected Scope visitCreateRole(CreateRole node, Optional<Scope> scope)
+        {
+            analysis.setUpdateInfo(node.getUpdateInfo());
+            return createAndAssignScope(node, scope);
+        }
+
+        @Override
+        protected Scope visitDropRole(DropRole node, Optional<Scope> scope)
+        {
+            analysis.setUpdateInfo(node.getUpdateInfo());
+            return createAndAssignScope(node, scope);
+        }
+
+        @Override
+        protected Scope visitSetRole(SetRole node, Optional<Scope> scope)
+        {
+            analysis.setUpdateInfo(node.getUpdateInfo());
+            return createAndAssignScope(node, scope);
+        }
+
+        @Override
+        protected Scope visitGrantRoles(GrantRoles node, Optional<Scope> scope)
+        {
+            analysis.setUpdateInfo(node.getUpdateInfo());
+            return createAndAssignScope(node, scope);
+        }
+
+        @Override
+        protected Scope visitRevokeRoles(RevokeRoles node, Optional<Scope> scope)
+        {
+            analysis.setUpdateInfo(node.getUpdateInfo());
+            return createAndAssignScope(node, scope);
+        }
+
+        @Override
+        protected Scope visitCreateType(CreateType node, Optional<Scope> scope)
+        {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
@@ -982,72 +1032,84 @@ class StatementAnalyzer
         @Override
         protected Scope visitTruncateTable(TruncateTable node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitDropTable(DropTable node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitRenameTable(RenameTable node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitSetProperties(SetProperties node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitRenameColumn(RenameColumn node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitDropColumn(DropColumn node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitDropConstraint(DropConstraint node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitAddConstraint(AddConstraint node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitAlterColumnNotNull(AlterColumnNotNull node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitRenameView(RenameView node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitDropView(DropView node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitDropMaterializedView(DropMaterializedView node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
@@ -1090,18 +1152,21 @@ class StatementAnalyzer
         @Override
         protected Scope visitGrant(Grant node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitRevoke(Revoke node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
         @Override
         protected Scope visitCall(Call node, Optional<Scope> scope)
         {
+            analysis.setUpdateInfo(node.getUpdateInfo());
             return createAndAssignScope(node, scope);
         }
 
@@ -1192,7 +1257,7 @@ class StatementAnalyzer
                     .map(ExplainType::getType)
                     .orElse(DISTRIBUTED).equals(DISTRIBUTED), "only DISTRIBUTED type is supported in EXPLAIN ANALYZE");
             process(node.getStatement(), scope);
-            analysis.setUpdateType(null);
+            analysis.setUpdateInfo(null);
             return createAndAssignScope(node, scope, Field.newUnqualified(node.getLocation(), "Query Plan", VARCHAR));
         }
 
@@ -2126,7 +2191,7 @@ class StatementAnalyzer
             List<ColumnMetadata> updatedColumns = allColumns.stream()
                     .filter(column -> assignmentTargets.contains(column.getName()))
                     .collect(toImmutableList());
-            analysis.setUpdateType("UPDATE");
+            analysis.setUpdateInfo(update.getUpdateInfo());
             analysis.setUpdatedColumns(updatedColumns);
 
             // Analyzer checks for select permissions but UPDATE has a separate permission, so disable access checks

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -35,6 +35,7 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -97,7 +98,7 @@ public class MaterializedResult
     private final List<Type> types;
     private final Map<String, String> setSessionProperties;
     private final Set<String> resetSessionProperties;
-    private final Optional<String> updateType;
+    private final Optional<UpdateInfo> updateInfo;
     private final OptionalLong updateCount;
     private final List<PrestoWarning> warnings;
 
@@ -111,7 +112,7 @@ public class MaterializedResult
             List<? extends Type> types,
             Map<String, String> setSessionProperties,
             Set<String> resetSessionProperties,
-            Optional<String> updateType,
+            Optional<UpdateInfo> updateInfo,
             OptionalLong updateCount,
             List<PrestoWarning> warnings)
     {
@@ -119,7 +120,7 @@ public class MaterializedResult
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.setSessionProperties = ImmutableMap.copyOf(requireNonNull(setSessionProperties, "setSessionProperties is null"));
         this.resetSessionProperties = ImmutableSet.copyOf(requireNonNull(resetSessionProperties, "resetSessionProperties is null"));
-        this.updateType = requireNonNull(updateType, "updateType is null");
+        this.updateInfo = requireNonNull(updateInfo, "updateInfo is null");
         this.updateCount = requireNonNull(updateCount, "updateCount is null");
         this.warnings = requireNonNull(warnings, "warnings is null");
     }
@@ -155,9 +156,9 @@ public class MaterializedResult
         return resetSessionProperties;
     }
 
-    public Optional<String> getUpdateType()
+    public Optional<UpdateInfo> getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
     public OptionalLong getUpdateCount()
@@ -184,14 +185,14 @@ public class MaterializedResult
                 Objects.equals(rows, o.rows) &&
                 Objects.equals(setSessionProperties, o.setSessionProperties) &&
                 Objects.equals(resetSessionProperties, o.resetSessionProperties) &&
-                Objects.equals(updateType, o.updateType) &&
+                Objects.equals(updateInfo, o.updateInfo) &&
                 Objects.equals(updateCount, o.updateCount);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(rows, types, setSessionProperties, resetSessionProperties, updateType, updateCount);
+        return Objects.hash(rows, types, setSessionProperties, resetSessionProperties, updateInfo, updateCount);
     }
 
     @Override
@@ -202,7 +203,7 @@ public class MaterializedResult
                 .add("types", types)
                 .add("setSessionProperties", setSessionProperties)
                 .add("resetSessionProperties", resetSessionProperties)
-                .add("updateType", updateType.orElse(null))
+                .add("updateInfo", updateInfo.orElse(null))
                 .add("updateCount", updateCount.isPresent() ? updateCount.getAsLong() : null)
                 .omitNullValues()
                 .toString();
@@ -358,7 +359,7 @@ public class MaterializedResult
                 types,
                 setSessionProperties,
                 resetSessionProperties,
-                updateType,
+                updateInfo,
                 updateCount,
                 warnings);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCode;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.ValuesNode;
@@ -101,7 +102,7 @@ public class TestQueryInfo
         assertEquals(actual.getStartedTransactionId(), expected.getStartedTransactionId());
         assertEquals(actual.isClearTransactionId(), expected.isClearTransactionId());
 
-        assertEquals(actual.getUpdateType(), expected.getUpdateType());
+        assertEquals(actual.getUpdateInfo(), expected.getUpdateInfo());
         assertEquals(actual.getOutputStage(), expected.getOutputStage());
 
         assertEquals(actual.getFailureInfo(), expected.getFailureInfo());
@@ -178,7 +179,7 @@ public class TestQueryInfo
                 ImmutableSet.of("deallocated_prepared_statement", "statement"),
                 Optional.of(TransactionId.create()),
                 true,
-                "update_type",
+                new UpdateInfo("UPDATE TYPE", ""),
                 Optional.empty(),
                 null,
                 null,

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -26,6 +26,7 @@ import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.AccessControl;
@@ -86,7 +87,6 @@ public class TestQueryStateMachine
     private static final Optional<Output> OUTPUT = Optional.empty();
     private static final List<String> OUTPUT_FIELD_NAMES = ImmutableList.of("a", "b", "c");
     private static final List<Type> OUTPUT_FIELD_TYPES = ImmutableList.of(BIGINT, BIGINT, BIGINT);
-    private static final String UPDATE_TYPE = "update type";
     private static final VersionedMemoryPoolId MEMORY_POOL = new VersionedMemoryPoolId(new MemoryPoolId("pool"), 42);
     private static final Map<String, String> SET_SESSION_PROPERTIES = ImmutableMap.<String, String>builder()
             .put("fruit", "apple")
@@ -558,7 +558,7 @@ public class TestQueryStateMachine
         assertEquals(queryInfo.getInputs(), INPUTS);
         assertEquals(queryInfo.getOutput(), OUTPUT);
         assertEquals(queryInfo.getFieldNames(), OUTPUT_FIELD_NAMES);
-        assertEquals(queryInfo.getUpdateType(), UPDATE_TYPE);
+        assertEquals(queryInfo.getUpdateInfo(), new UpdateInfo("UPDATE TYPE", ""));
         assertEquals(queryInfo.getMemoryPool(), MEMORY_POOL.getId());
         assertEquals(queryInfo.getQueryType(), QUERY_TYPE);
 
@@ -644,7 +644,7 @@ public class TestQueryStateMachine
         stateMachine.setInputs(INPUTS);
         stateMachine.setOutput(OUTPUT);
         stateMachine.setColumns(OUTPUT_FIELD_NAMES, OUTPUT_FIELD_TYPES);
-        stateMachine.setUpdateType(UPDATE_TYPE);
+        stateMachine.setUpdateInfo(new UpdateInfo("UPDATE TYPE", ""));
         stateMachine.setMemoryPool(MEMORY_POOL);
         for (Entry<String, String> entry : SET_SESSION_PROPERTIES.entrySet()) {
             stateMachine.addSetSessionProperties(entry.getKey(), entry.getValue());

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.QueryStats;
 import com.facebook.presto.operator.BlockedReason;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.StandardErrorCode;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.eventlistener.StageGcStatistics;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.google.common.collect.ImmutableList;
@@ -130,7 +131,7 @@ public class TestBasicQueryInfo
                         ImmutableSet.of(),
                         Optional.empty(),
                         false,
-                        "33",
+                        new UpdateInfo("UPDATE TYPE", ""),
                         Optional.empty(),
                         null,
                         StandardErrorCode.ABANDONED_QUERY.toErrorCode(),

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -23,6 +23,7 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCode;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.google.common.collect.ImmutableList;
@@ -282,7 +283,7 @@ public class TestQueryStateInfo
                 ImmutableSet.of(),
                 Optional.empty(),
                 false,
-                "33",
+                new UpdateInfo("UPDATE TYPE", ""),
                 Optional.empty(),
                 null,
                 EXCEEDED_GLOBAL_MEMORY_LIMIT.toErrorCode(),

--- a/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.eventlistener.CTEInformation;
 import com.facebook.presto.spi.eventlistener.Column;
 import com.facebook.presto.spi.eventlistener.EventListener;
@@ -185,7 +186,7 @@ public class TestEventListenerManager
         Optional<PrestoSparkExecutionContext> prestoSparkExecutionContext = Optional.empty();
         Map<PlanCanonicalizationStrategy, String> hboPlanHash = new HashMap<>();
         Optional<Map<PlanNodeId, PlanNode>> planIdNodeMap = Optional.ofNullable(new HashMap<>());
-
+        UpdateInfo updateInfo = new UpdateInfo("CREATE TABLE", "ctlog.schema.tbl");
         return new QueryCompletedEvent(
                 metadata,
                 statistics,
@@ -213,7 +214,8 @@ public class TestEventListenerManager
                 windowFunctions,
                 prestoSparkExecutionContext,
                 hboPlanHash,
-                planIdNodeMap);
+                planIdNodeMap,
+                Optional.of(updateInfo.getUpdateObject()));
     }
 
     public static QueryStatistics createDummyQueryStatistics()
@@ -303,7 +305,7 @@ public class TestEventListenerManager
         Optional<String> payload = Optional.of("dummy-payload");
         List<String> runtimeOptimizedStages = new ArrayList<>(Arrays.asList("stage1", "stage2"));
         Optional<String> tracingId = Optional.of("dummy-tracing-id");
-        Optional<String> updateType = Optional.of("dummy-type");
+        Optional<String> updateType = Optional.of("CREATE TABLE");
 
         return new QueryMetadata(
                 queryId,

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1210,7 +1210,7 @@ public abstract class AbstractTestNativeGeneralQueries
                 "MaterializedResult{rows=[[true]], " +
                         "types=[boolean], " +
                         "setSessionProperties={distinct_aggregation_spill_enabled=false}, " +
-                        "resetSessionProperties=[], updateType=SET SESSION}");
+                        "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}}");
     }
 
     @Test

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -104,7 +104,7 @@ public class TestNativeSidecarPlugin
                 "MaterializedResult{rows=[[true]], " +
                         "types=[boolean], " +
                         "setSessionProperties={driver_cpu_time_slice_limit_ms=500}, " +
-                        "resetSessionProperties=[], updateType=SET SESSION}");
+                        "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}}");
     }
 
     @Test

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -80,6 +81,12 @@ public class AddColumn
     public List<Node> getChildren()
     {
         return ImmutableList.of(column);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("ADD COLUMN", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddConstraint.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddConstraint.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -72,6 +73,12 @@ public final class AddConstraint
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("ADD CONSTRAINT", tableName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AlterColumnNotNull.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AlterColumnNotNull.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -79,6 +80,12 @@ public class AlterColumnNotNull
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("ALTER COLUMN NOT NULL", table.getSuffix());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AlterFunction.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AlterFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -78,6 +79,12 @@ public class AlterFunction
     public int hashCode()
     {
         return Objects.hash(functionName, parameterTypes, characteristics);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("ALTER FUNCTION", functionName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Analyze.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Analyze.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -71,6 +72,12 @@ public class Analyze
     public int hashCode()
     {
         return Objects.hash(tableName, properties);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("ANALYZE", tableName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Call.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Call.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public final class Call
     public List<? extends Node> getChildren()
     {
         return arguments;
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CALL", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Commit.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Commit.java
@@ -15,6 +15,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -48,6 +49,12 @@ public final class Commit
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("COMMIT", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateFunction.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -109,6 +110,12 @@ public class CreateFunction
         return ImmutableList.<Node>builder()
                 .add(body)
                 .build();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CREATE FUNCTION", functionName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateMaterializedView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateMaterializedView.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -81,6 +82,12 @@ public class CreateMaterializedView
     public List<Node> getChildren()
     {
         return ImmutableList.<Node>builder().add(query).addAll(properties).build();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CREATE MATERIALIZED VIEW", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateRole.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateRole.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -53,6 +54,12 @@ public class CreateRole
     public Optional<GrantorSpecification> getGrantor()
     {
         return grantor;
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CREATE ROLE", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateSchema.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateSchema.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -72,6 +73,12 @@ public class CreateSchema
     public List<Property> getChildren()
     {
         return properties;
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CREATE SCHEMA", schemaName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTable.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -89,6 +90,12 @@ public class CreateTable
                 .addAll(elements)
                 .addAll(properties)
                 .build();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CREATE TABLE", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateTableAsSelect.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -103,6 +104,12 @@ public class CreateTableAsSelect
                 .add(query)
                 .addAll(properties)
                 .build();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CREATE TABLE", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateType.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateType.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.HashSet;
@@ -92,6 +93,12 @@ public class CreateType
     public List<? extends Node> getChildren()
     {
         return null;
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CREATE TYPE", typeName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/CreateView.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -83,6 +84,12 @@ public class CreateView
     public List<Node> getChildren()
     {
         return ImmutableList.of(query);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("CREATE VIEW", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Deallocate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Deallocate.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -58,6 +59,12 @@ public class Deallocate
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DEALLOCATE", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -594,4 +594,17 @@ public abstract class DefaultTraversalVisitor<R, C>
 
         return super.visitLateral(node, context);
     }
+
+    @Override
+    protected R visitRevokeRoles(RevokeRoles node, C context)
+    {
+        node.getRoles().forEach(property -> process(property, context));
+        return null;
+    }
+
+    @Override
+    protected R visitCreateType(CreateType node, C context)
+    {
+        return null;
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Delete.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Delete.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -68,6 +69,12 @@ public class Delete
         nodes.add(table);
         where.ifPresent(nodes::add);
         return nodes.build();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DELETE", table.getName().toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeInput.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeInput.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -57,6 +58,12 @@ public class DescribeInput
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DESCRIBE INPUT", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeOutput.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DescribeOutput.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -57,6 +58,12 @@ public class DescribeOutput
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DESCRIBE OUTPUT", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropColumn.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -79,6 +80,12 @@ public class DropColumn
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DROP COLUMN", table.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropConstraint.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropConstraint.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -79,6 +80,12 @@ public class DropConstraint
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DROP CONSTRAINT", tableName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropFunction.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -79,6 +80,12 @@ public class DropFunction
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DROP FUNCTION", functionName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropMaterializedView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropMaterializedView.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -55,6 +56,12 @@ public class DropMaterializedView
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DROP MATERIALIZED VIEW", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropRole.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropRole.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -46,6 +47,12 @@ public class DropRole
     public Identifier getName()
     {
         return name;
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DROP ROLE", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropSchema.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropSchema.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -72,6 +73,12 @@ public final class DropSchema
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DROP SCHEMA", schemaName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropTable.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -64,6 +65,12 @@ public class DropTable
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DROP TABLE", tableName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropView.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -64,6 +65,12 @@ public class DropView
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("DROP VIEW", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Execute.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Execute.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public class Execute
     public List<? extends Node> getChildren()
     {
         return parameters;
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("EXECUTE", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Explain.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Explain.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -87,6 +88,12 @@ public class Explain
                 .add(statement)
                 .addAll(options)
                 .build();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("EXPlAIN", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Grant.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -87,6 +88,12 @@ public class Grant
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("GRANT", tableName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GrantRoles.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GrantRoles.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -89,6 +90,12 @@ public class GrantRoles
     public List<? extends Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("GRANT ROLE", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Insert.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -67,6 +68,12 @@ public final class Insert
     public List<Node> getChildren()
     {
         return ImmutableList.of(query);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("INSERT", target.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Prepare.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Prepare.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public class Prepare
     public List<Node> getChildren()
     {
         return ImmutableList.of(statement);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("PREPARE", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -114,6 +115,12 @@ public class Query
         orderBy.ifPresent(nodes::add);
         offset.ifPresent(nodes::add);
         return nodes.build();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("QUERY", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RefreshMaterializedView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RefreshMaterializedView.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public class RefreshMaterializedView
     public List<Node> getChildren()
     {
         return ImmutableList.of(where);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("REFRESH MATERIALIZED VIEW", target.getName().toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -86,6 +87,12 @@ public class RenameColumn
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("RENAME COLUMN", table.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameSchema.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameSchema.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public final class RenameSchema
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("RENAME SCHEMA", source.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameTable.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -72,6 +73,12 @@ public final class RenameTable
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("RENAME TABLE", target.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameView.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -73,6 +74,12 @@ public final class RenameView
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("RENAME VIEW", source.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ResetSession.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ResetSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -57,6 +58,12 @@ public class ResetSession
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("RESET SESSION", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Revoke.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Revoke.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -87,6 +88,12 @@ public class Revoke
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("REVOKE", tableName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RevokeRoles.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RevokeRoles.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -95,6 +96,12 @@ public class RevokeRoles
     public <R, C> R accept(AstVisitor<R, C> visitor, C context)
     {
         return visitor.visitRevokeRoles(this, context);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("REVOKE ROLES", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollback.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollback.java
@@ -14,6 +14,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -47,6 +48,12 @@ public final class Rollback
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("ROLLBACK", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetProperties.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetProperties.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -83,6 +84,12 @@ public class SetProperties
     public List<? extends Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SET PROPERTIES", tableName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetRole.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetRole.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -64,6 +65,12 @@ public class SetRole
     public List<? extends Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SET ROLE", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetSession.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SetSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -64,6 +65,12 @@ public class SetSession
     public List<Node> getChildren()
     {
         return ImmutableList.of(value);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SET SESSION", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCatalogs.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCatalogs.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public final class ShowCatalogs
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW CATALOGS", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowColumns.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowColumns.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -58,6 +59,12 @@ public class ShowColumns
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW COLUMNS", table.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreate.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreate.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -73,6 +74,12 @@ public class ShowCreate
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW CREATE", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreateFunction.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowCreateFunction.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public class ShowCreateFunction
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW CREATE FUNCTION", name.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowFunctions.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowFunctions.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public class ShowFunctions
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW FUNCTIONS", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowGrants.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowGrants.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -67,6 +68,12 @@ public class ShowGrants
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW GRANTS", tableName.map(QualifiedName::toString).orElse(""));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowRoleGrants.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowRoleGrants.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -58,6 +59,12 @@ public class ShowRoleGrants
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW ROLE GRANTS", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowRoles.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowRoles.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public class ShowRoles
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW ROLES", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSchemas.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -72,6 +73,12 @@ public class ShowSchemas
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW SCHEMAS", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSession.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -65,6 +66,12 @@ public class ShowSession
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW SESSION", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowStats.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowStats.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -49,6 +50,12 @@ public class ShowStats
     public List<? extends Node> getChildren()
     {
         return ImmutableList.of(relation);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW STATS", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowTables.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/ShowTables.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -76,6 +77,12 @@ public class ShowTables
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("SHOW TABLES", schema.map(QualifiedName::toString).orElse(""));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/StartTransaction.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/StartTransaction.java
@@ -14,6 +14,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -59,6 +60,12 @@ public final class StartTransaction
     public List<? extends Node> getChildren()
     {
         return transactionModes;
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("START TRANSACTION", "");
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Statement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Statement.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
+
 import java.util.Optional;
 
 public abstract class Statement
@@ -28,4 +30,6 @@ public abstract class Statement
     {
         return visitor.visitStatement(this, context);
     }
+
+    public abstract UpdateInfo getUpdateInfo();
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/TruncateTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/TruncateTable.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -57,6 +58,12 @@ public class TruncateTable
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("TRUNCATE TABLE", tableName.toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Update.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Update.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -90,6 +91,12 @@ public class Update
         return table.equals(update.table) &&
                 assignments.equals(update.assignments) &&
                 where.equals(update.where);
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("UPDATE", table.getName().toString());
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Use.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Use.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -67,6 +68,12 @@ public final class Use
     public List<Node> getChildren()
     {
         return ImmutableList.of();
+    }
+
+    @Override
+    public UpdateInfo getUpdateInfo()
+    {
+        return new UpdateInfo("USE", "");
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -369,7 +369,7 @@ public class PrestoSparkQueryExecutionFactory
                 ImmutableSet.of(),
                 Optional.empty(),
                 false,
-                planAndMore.flatMap(PlanAndMore::getUpdateType).orElse(null),
+                planAndMore.flatMap(PlanAndMore::getUpdateInfo).orElse(null),
                 rootStage,
                 failureInfo.orElse(null),
                 failureInfo.map(ExecutionFailureInfo::getErrorCode).orElse(null),
@@ -480,7 +480,7 @@ public class PrestoSparkQueryExecutionFactory
                 stats,
                 Optional.ofNullable(queryInfo.getFailureInfo()).map(PrestoSparkQueryExecutionFactory::toQueryError),
                 warningCollector.getWarnings(),
-                planAndMore.flatMap(PlanAndMore::getUpdateType),
+                planAndMore.flatMap(PlanAndMore::getUpdateInfo),
                 updateCount);
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -70,6 +70,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.page.PagesSerde;
@@ -415,7 +416,7 @@ public abstract class AbstractPrestoSparkQueryExecution
 
         // Based on com.facebook.presto.server.protocol.Query#getNextResult
         OptionalLong updateCount = OptionalLong.empty();
-        if (planAndMore.getUpdateType().isPresent() &&
+        if (planAndMore.getUpdateInfo().isPresent() &&
                 types.size() == 1 &&
                 types.get(0).equals(BIGINT) &&
                 results.size() == 1 &&
@@ -448,9 +449,9 @@ public abstract class AbstractPrestoSparkQueryExecution
         return subPlanOptional.get().getFragment().getTypes();
     }
 
-    public Optional<String> getUpdateType()
+    public Optional<UpdateInfo> getUpdateType()
     {
-        return planAndMore.getUpdateType();
+        return planAndMore.getUpdateInfo();
     }
 
     protected abstract List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>> doExecute()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spark.PrestoSparkPhysicalResourceCalculator;
 import com.facebook.presto.spark.PrestoSparkSourceStatsCollector;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -167,7 +168,7 @@ public class PrestoSparkQueryPlanner
 
         return new PlanAndMore(
                 plan,
-                Optional.ofNullable(analysis.getUpdateType()),
+                Optional.ofNullable(analysis.getUpdateInfo()),
                 columnNames,
                 ImmutableSet.copyOf(inputs),
                 output,
@@ -182,7 +183,7 @@ public class PrestoSparkQueryPlanner
     public static class PlanAndMore
     {
         private final Plan plan;
-        private final Optional<String> updateType;
+        private final Optional<UpdateInfo> updateInfo;
         private final List<String> fieldNames;
         private final Set<Input> inputs;
         private final Optional<Output> output;
@@ -195,7 +196,7 @@ public class PrestoSparkQueryPlanner
 
         public PlanAndMore(
                 Plan plan,
-                Optional<String> updateType,
+                Optional<UpdateInfo> updateInfo,
                 List<String> fieldNames,
                 Set<Input> inputs,
                 Optional<Output> output,
@@ -207,7 +208,7 @@ public class PrestoSparkQueryPlanner
                 Set<String> invokedWindowFunctions)
         {
             this.plan = requireNonNull(plan, "plan is null");
-            this.updateType = requireNonNull(updateType, "updateType is null");
+            this.updateInfo = requireNonNull(updateInfo, "updateType is null");
             this.fieldNames = ImmutableList.copyOf(requireNonNull(fieldNames, "fieldNames is null"));
             this.inputs = ImmutableSet.copyOf(requireNonNull(inputs, "inputs is null"));
             this.output = requireNonNull(output, "output is null");
@@ -224,9 +225,9 @@ public class PrestoSparkQueryPlanner
             return plan;
         }
 
-        public Optional<String> getUpdateType()
+        public Optional<UpdateInfo> getUpdateInfo()
         {
-            return updateType;
+            return updateInfo;
         }
 
         public List<String> getFieldNames()

--- a/presto-spark-common/src/main/java/com/facebook/presto/spark/PrestoSparkQueryStatusInfo.java
+++ b/presto-spark-common/src/main/java/com/facebook/presto/spark/PrestoSparkQueryStatusInfo.java
@@ -17,6 +17,7 @@ import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.StatementStats;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +44,7 @@ public class PrestoSparkQueryStatusInfo
     private final StatementStats stats;
     private final Optional<QueryError> error;
     private final List<PrestoWarning> warnings;
-    private final Optional<String> updateType;
+    private final Optional<UpdateInfo> updateInfo;
     private final OptionalLong updateCount;
 
     @JsonCreator
@@ -53,7 +54,7 @@ public class PrestoSparkQueryStatusInfo
             @JsonProperty("stats") StatementStats stats,
             @JsonProperty("error") Optional<QueryError> error,
             @JsonProperty("warnings") List<PrestoWarning> warnings,
-            @JsonProperty("updateType") Optional<String> updateType,
+            @JsonProperty("updateType") Optional<UpdateInfo> updateInfo,
             @JsonProperty("updateCount") OptionalLong updateCount)
     {
         this.id = requireNonNull(id, "id is null");
@@ -61,7 +62,7 @@ public class PrestoSparkQueryStatusInfo
         this.stats = requireNonNull(stats, "stats is null");
         this.error = requireNonNull(error, "error is null");
         this.warnings = ImmutableList.copyOf(requireNonNull(warnings, "warnings is null"));
-        this.updateType = requireNonNull(updateType, "updateType is null");
+        this.updateInfo = requireNonNull(updateInfo, "updateType is null");
         this.updateCount = requireNonNull(updateCount, "updateCount is null");
     }
 
@@ -96,9 +97,9 @@ public class PrestoSparkQueryStatusInfo
     }
 
     @JsonProperty
-    public Optional<String> getUpdateType()
+    public Optional<UpdateInfo> getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
     @JsonProperty

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalysis.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalysis.java
@@ -27,11 +27,11 @@ import java.util.Set;
 public interface QueryAnalysis
 {
     /**
-     * Returns the update type of the query.
+     * Returns information about the type of Update
      *
      * @return a String representing the type of update (e.g., "INSERT", "CREATE TABLE", "DELETE", etc)
      */
-    String getUpdateType();
+    UpdateInfo getUpdateInfo();
 
     /**
      * Returns the expanded query, which might have been enhanced after analyzing materialized view.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/UpdateInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/UpdateInfo.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.analyzer;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+@ThriftStruct
+public class UpdateInfo
+{
+    /**
+     * The type of update being performed (e.g., INSERT, DELETE, UPDATE).
+     */
+    private final String updateType;
+
+    /**
+     * The object being updated (e.g., table name, view name).
+     */
+    private final String updateObject;
+
+    @JsonCreator
+    @ThriftConstructor
+    public UpdateInfo(
+            @JsonProperty("updateType") String updateType,
+            @JsonProperty("updateObject") String updateObject)
+    {
+        this.updateType = requireNonNull(updateType, "updateType is null");
+        this.updateObject = updateObject;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public String getUpdateType()
+    {
+        return updateType;
+    }
+
+    @JsonProperty
+    @ThriftField(2)
+    public String getUpdateObject()
+    {
+        return updateObject;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UpdateInfo that = (UpdateInfo) o;
+        return Objects.equals(updateType, that.updateType) && Objects.equals(updateObject, that.updateObject);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(updateType, updateObject);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "UpdateInfo{" +
+                "updateType='" + updateType + '\'' +
+                ", updateObject='" + updateObject + '\'' +
+                '}';
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
@@ -59,6 +59,7 @@ public class QueryCompletedEvent
     private final Optional<PrestoSparkExecutionContext> prestoSparkExecutionContext;
     private final Map<PlanCanonicalizationStrategy, String> hboPlanHash;
     private final Optional<Map<PlanNodeId, PlanNode>> planIdNodeMap;
+    private final Optional<String> qualifiedName;
 
     public QueryCompletedEvent(
             QueryMetadata metadata,
@@ -87,7 +88,8 @@ public class QueryCompletedEvent
             Set<String> windowFunctions,
             Optional<PrestoSparkExecutionContext> prestoSparkExecutionContext,
             Map<PlanCanonicalizationStrategy, String> hboPlanHash,
-            Optional<Map<PlanNodeId, PlanNode>> planNodeIdMap)
+            Optional<Map<PlanNodeId, PlanNode>> planNodeIdMap,
+            Optional<String> qualifiedName)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.statistics = requireNonNull(statistics, "statistics is null");
@@ -116,6 +118,7 @@ public class QueryCompletedEvent
         this.prestoSparkExecutionContext = requireNonNull(prestoSparkExecutionContext, "prestoSparkExecutionContext is null");
         this.hboPlanHash = requireNonNull(hboPlanHash, "planHash is null");
         this.planIdNodeMap = requireNonNull(planNodeIdMap, "planNodeIdMap is null");
+        this.qualifiedName = qualifiedName;
     }
 
     public QueryMetadata getMetadata()
@@ -251,5 +254,10 @@ public class QueryCompletedEvent
     public Optional<Map<PlanNodeId, PlanNode>> getPlanNodeIdMap()
     {
         return planIdNodeMap;
+    }
+
+    public Optional<String> getQualifiedName()
+    {
+        return qualifiedName;
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -3177,7 +3177,7 @@ public abstract class AbstractTestQueries
                 "MaterializedResult{rows=[[true]], " +
                         "types=[boolean], " +
                         "setSessionProperties={native_expression_max_array_size_in_reduce=50000}, " +
-                        "resetSessionProperties=[], updateType=SET SESSION}");
+                        "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}}");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -108,8 +108,8 @@ public abstract class AbstractTestingPrestoClient<T>
 
             if (error == null) {
                 QueryStatusInfo results = client.finalStatusInfo();
-                if (results.getUpdateType() != null) {
-                    resultsSession.setUpdateType(results.getUpdateType());
+                if (results.getUpdateInfo() != null) {
+                    resultsSession.setUpdateInfo(results.getUpdateInfo());
                 }
                 if (results.getUpdateCount() != null) {
                     resultsSession.setUpdateCount(results.getUpdateCount());

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -80,7 +80,7 @@ public final class QueryAssertions
             planAssertion.get().accept(queryPlan);
         }
 
-        if (!results.getUpdateType().isPresent()) {
+        if (!results.getUpdateInfo().isPresent()) {
             fail("update type is not set");
         }
 
@@ -197,8 +197,8 @@ public final class QueryAssertions
             log.info("FINISHED in presto: %s, expected: %s, total: %s", actualTime, nanosSince(expectedStart), totalTime);
         }
 
-        if (actualResults.getUpdateType().isPresent() || actualResults.getUpdateCount().isPresent()) {
-            if (!actualResults.getUpdateType().isPresent()) {
+        if (actualResults.getUpdateInfo().isPresent() || actualResults.getUpdateCount().isPresent()) {
+            if (!actualResults.getUpdateInfo().isPresent()) {
                 fail("update count present without update type for query: \n" + actual);
             }
             if (!compareUpdate) {
@@ -210,7 +210,7 @@ public final class QueryAssertions
         List<MaterializedRow> expectedRows = expectedResults.getMaterializedRows();
 
         if (compareUpdate) {
-            if (!actualResults.getUpdateType().isPresent()) {
+            if (!actualResults.getUpdateInfo().isPresent()) {
                 fail("update type not present for query: \n" + actual);
             }
             if (!actualResults.getUpdateCount().isPresent()) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/ResultsSession.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/ResultsSession.java
@@ -16,6 +16,7 @@ package com.facebook.presto.tests;
 import com.facebook.presto.client.QueryData;
 import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ import java.util.Set;
 
 public interface ResultsSession<T>
 {
-    default void setUpdateType(String type)
+    default void setUpdateInfo(UpdateInfo type)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -34,6 +34,7 @@ import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.type.SqlIntervalDayTime;
@@ -110,14 +111,14 @@ public class TestingPrestoClient
 
         private final AtomicReference<List<Type>> types = new AtomicReference<>();
 
-        private final AtomicReference<Optional<String>> updateType = new AtomicReference<>(Optional.empty());
+        private final AtomicReference<Optional<UpdateInfo>> updateInfo = new AtomicReference<>(Optional.empty());
         private final AtomicReference<OptionalLong> updateCount = new AtomicReference<>(OptionalLong.empty());
         private final AtomicReference<List<PrestoWarning>> warnings = new AtomicReference<>(ImmutableList.of());
 
         @Override
-        public void setUpdateType(String type)
+        public void setUpdateInfo(UpdateInfo type)
         {
-            updateType.set(Optional.of(type));
+            updateInfo.set(Optional.of(type));
         }
 
         @Override
@@ -154,7 +155,7 @@ public class TestingPrestoClient
                     types.get(),
                     setSessionProperties,
                     resetSessionProperties,
-                    updateType.get(),
+                    updateInfo.get(),
                     updateCount.get(),
                     warnings.get());
         }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestQueryManager.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCode;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.google.common.base.Stopwatch;
@@ -511,7 +512,7 @@ public class TestQueryManager
                 ImmutableSet.of(),
                 Optional.empty(),
                 false,
-                "33",
+                new UpdateInfo("UPDATE TYPE", ""),
                 Optional.empty(),
                 null,
                 EXCEEDED_GLOBAL_MEMORY_LIMIT.toErrorCode(),

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSetWorkerSessionPropertiesExcludingInvalidProperties.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSetWorkerSessionPropertiesExcludingInvalidProperties.java
@@ -51,6 +51,6 @@ public class TestSetWorkerSessionPropertiesExcludingInvalidProperties
                 "MaterializedResult{rows=[[true]], " +
                         "types=[boolean], " +
                         "setSessionProperties={distinct_aggregation_spill_enabled=false}, " +
-                        "resetSessionProperties=[], updateType=SET SESSION}");
+                        "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}}");
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSetWorkerSessionPropertiesIncludingInvalidProperties.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSetWorkerSessionPropertiesIncludingInvalidProperties.java
@@ -42,7 +42,7 @@ public class TestSetWorkerSessionPropertiesIncludingInvalidProperties
                 "MaterializedResult{rows=[[true]], " +
                         "types=[boolean], " +
                         "setSessionProperties={native_expression_max_array_size_in_reduce=50000}, " +
-                        "resetSessionProperties=[], updateType=SET SESSION}");
+                        "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}}");
     }
 
     @Test
@@ -56,6 +56,6 @@ public class TestSetWorkerSessionPropertiesIncludingInvalidProperties
                 "MaterializedResult{rows=[[true]], " +
                         "types=[boolean], " +
                         "setSessionProperties={distinct_aggregation_spill_enabled=false}, " +
-                        "resetSessionProperties=[], updateType=SET SESSION}");
+                        "resetSessionProperties=[], updateInfo=UpdateInfo{updateType='SET SESSION', updateObject=''}}");
     }
 }


### PR DESCRIPTION
## Description
Add additional information to about DDL operations to QueryInfo

## Motivation and Context
Issue: https://github.com/prestodb/presto/issues/24894

updateType tracking in QueryInfo was added in https://github.com/prestodb/presto/commit/3715be85ef5f5886efceddcbc3fb89131d6f72fc

For lineage tracing, we would like to enhance this with additional information about the object(s) we are updating

## Impact
User's can track what tables/columns/schemas were operated on in query info and event listener data

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

