### PR TITLE
Remove Nimble file format references from Java OSS

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStorageFormat.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveStorageFormat.java
@@ -58,11 +58,6 @@ public enum HiveStorageFormat
             com.facebook.hive.orc.OrcInputFormat.class.getName(),
             com.facebook.hive.orc.OrcOutputFormat.class.getName(),
             new DataSize(256, Unit.MEGABYTE)),
-    ALPHA(
-            "com.facebook.alpha.AlphaSerde",
-            "com.facebook.alpha.AlphaInputFormat",
-            "com.facebook.alpha.AlphaOutputFormat",
-            new DataSize(256, Unit.MEGABYTE)),
     PARQUET(
             ParquetHiveSerDe.class.getName(),
             MapredParquetInputFormat.class.getName(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -233,7 +233,6 @@ import static com.facebook.presto.hive.HiveMetadata.convertToPredicate;
 import static com.facebook.presto.hive.HiveQueryRunner.METASTORE_CONTEXT;
 import static com.facebook.presto.hive.HiveSessionProperties.OFFLINE_DATA_DEBUG_MODE_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.SORTED_WRITE_TO_TEMP_PATH_ENABLED;
-import static com.facebook.presto.hive.HiveStorageFormat.ALPHA;
 import static com.facebook.presto.hive.HiveStorageFormat.AVRO;
 import static com.facebook.presto.hive.HiveStorageFormat.CSV;
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
@@ -5859,8 +5858,7 @@ public abstract class AbstractTestHiveClient
         return difference(
                 ImmutableSet.copyOf(HiveStorageFormat.values()),
                 // exclude formats that change table schema with serde
-                // exclude ALPHA because it does not support DML yet
-                ImmutableSet.of(AVRO, CSV, ALPHA));
+                ImmutableSet.of(AVRO, CSV));
     }
 
     private List<TableConstraint<String>> getTableConstraints(SchemaTableName tableName)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -409,9 +409,9 @@ public abstract class AbstractTestHiveFileSystem
 
     protected List<HiveStorageFormat> getSupportedHiveStorageFormats()
     {
-        // CSV supports only unbounded VARCHAR type, and Alpha does not support DML yet
+        // CSV supports only unbounded VARCHAR type
         return Arrays.stream(HiveStorageFormat.values())
-                .filter(format -> format != HiveStorageFormat.CSV && format != HiveStorageFormat.ALPHA)
+                .filter(format -> format != HiveStorageFormat.CSV)
                 .collect(toImmutableList());
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -6113,29 +6113,6 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
-    public void testAlphaFormatDdl()
-    {
-        assertUpdate("CREATE TABLE test_alpha_ddl_table (col1 bigint) WITH (format = 'ALPHA')");
-        assertUpdate("ALTER TABLE test_alpha_ddl_table ADD COLUMN col2 bigint");
-        assertUpdate("ALTER TABLE test_alpha_ddl_table DROP COLUMN col2");
-        assertUpdate("DROP TABLE test_alpha_ddl_table");
-
-        assertUpdate("CREATE TABLE test_alpha_ddl_partitioned_table (col1 bigint, ds VARCHAR) WITH (format = 'ALPHA', partitioned_by = ARRAY['ds'])");
-        assertUpdate("ALTER TABLE test_alpha_ddl_partitioned_table ADD COLUMN col2 bigint");
-        assertUpdate("ALTER TABLE test_alpha_ddl_partitioned_table DROP COLUMN col2");
-        assertUpdate("DROP TABLE test_alpha_ddl_partitioned_table");
-    }
-
-    @Test
-    public void testAlphaFormatDml()
-    {
-        assertUpdate("CREATE TABLE test_alpha_dml_partitioned_table (col1 bigint, ds VARCHAR) WITH (format = 'ALPHA', partitioned_by = ARRAY['ds'])");
-        // Alpha does not support DML yet
-        assertQueryFails("INSERT INTO test_alpha_dml_partitioned_table VALUES (1, '2022-01-01')", "Serializer does not exist: com.facebook.alpha.AlphaSerde");
-        assertUpdate("DROP TABLE test_alpha_dml_partitioned_table");
-    }
-
-    @Test
     public void testInvokedFunctionNamesLog()
     {
         QueryRunner queryRunner = getQueryRunner();
@@ -6966,9 +6943,9 @@ public class TestHiveIntegrationSmokeTest
 
     protected List<HiveStorageFormat> getSupportedHiveStorageFormats()
     {
-        // CSV supports only unbounded VARCHAR type, and Alpha does not support DML yet
+        // CSV supports only unbounded VARCHAR type
         return Arrays.stream(HiveStorageFormat.values())
-                .filter(format -> format != HiveStorageFormat.CSV && format != HiveStorageFormat.ALPHA)
+                .filter(format -> format != HiveStorageFormat.CSV)
                 .collect(toImmutableList());
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -142,9 +142,9 @@ public class TestHivePageSink
 
     protected List<HiveStorageFormat> getSupportedHiveStorageFormats()
     {
-        // CSV supports only unbounded VARCHAR type, and Alpha does not support DML yet
+        // CSV supports only unbounded VARCHAR type
         return Arrays.stream(HiveStorageFormat.values())
-                .filter(format -> format != HiveStorageFormat.CSV && format != HiveStorageFormat.ALPHA)
+                .filter(format -> format != HiveStorageFormat.CSV)
                 .collect(toImmutableList());
     }
 


### PR DESCRIPTION
## Description
Remove Nimble file format references from Java OSS.

Differential Revision: D72808755

## Motivation and Context
Not needed in Java OSS.

## Impact
No impact.

## Test Plan
It builds.

## Contributor checklist
- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```






