### PR TITLE
Reduce memory usage in reader by reset all underlying readers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -31,6 +31,7 @@ public class OrcReaderOptions
     private final boolean appendRowNumber;
     // slice reader will throw if the slice size is larger than this value
     private final DataSize maxSliceSize;
+    private final boolean resetAllReaders;
 
     /**
      * Read column statistics for flat map columns. Usually there are quite a
@@ -46,7 +47,8 @@ public class OrcReaderOptions
             boolean mapNullKeysEnabled,
             boolean appendRowNumber,
             boolean readMapStatistics,
-            DataSize maxSliceSize)
+            DataSize maxSliceSize,
+            boolean resetAllReaders)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
@@ -56,6 +58,7 @@ public class OrcReaderOptions
         this.appendRowNumber = appendRowNumber;
         this.readMapStatistics = readMapStatistics;
         this.maxSliceSize = maxSliceSize;
+        this.resetAllReaders = resetAllReaders;
     }
 
     public DataSize getMaxMergeDistance()
@@ -98,6 +101,11 @@ public class OrcReaderOptions
         return maxSliceSize;
     }
 
+    public boolean isResetAllReaders()
+    {
+        return resetAllReaders;
+    }
+
     @Override
     public String toString()
     {
@@ -110,6 +118,7 @@ public class OrcReaderOptions
                 .add("appendRowNumber", appendRowNumber)
                 .add("readMapStatistics", readMapStatistics)
                 .add("maxSliceSize", maxSliceSize)
+                .add("resetAllReaders", resetAllReaders)
                 .toString();
     }
 
@@ -128,6 +137,7 @@ public class OrcReaderOptions
         private boolean appendRowNumber;
         private boolean readMapStatistics;
         private DataSize maxSliceSize = DEFAULT_MAX_SLICE_SIZE;
+        private boolean resetAllReaders;
 
         private Builder() {}
 
@@ -179,6 +189,12 @@ public class OrcReaderOptions
             return this;
         }
 
+        public Builder withResetAllReaders(boolean resetAllReaders)
+        {
+            this.resetAllReaders = resetAllReaders;
+            return this;
+        }
+
         public OrcReaderOptions build()
         {
             return new OrcReaderOptions(
@@ -189,7 +205,8 @@ public class OrcReaderOptions
                     mapNullKeysEnabled,
                     appendRowNumber,
                     readMapStatistics,
-                    maxSliceSize);
+                    maxSliceSize,
+                    resetAllReaders);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
@@ -26,6 +26,7 @@ public class OrcRecordReaderOptions
     private final boolean mapNullKeysEnabled;
     private final boolean appendRowNumber;
     private final long maxSliceSize;
+    private final boolean resetAllReaders;
 
     public OrcRecordReaderOptions(OrcReaderOptions options)
     {
@@ -34,7 +35,8 @@ public class OrcRecordReaderOptions
                 options.getMaxBlockSize(),
                 options.mapNullKeysEnabled(),
                 options.appendRowNumber(),
-                options.getMaxSliceSize());
+                options.getMaxSliceSize(),
+                options.isResetAllReaders());
     }
 
     public OrcRecordReaderOptions(
@@ -43,7 +45,8 @@ public class OrcRecordReaderOptions
             DataSize maxBlockSize,
             boolean mapNullKeysEnabled,
             boolean appendRowNumber,
-            DataSize maxSliceSize)
+            DataSize maxSliceSize,
+            boolean resetAllReaders)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
@@ -53,6 +56,7 @@ public class OrcRecordReaderOptions
         checkArgument(maxSliceSize.toBytes() < Integer.MAX_VALUE, "maxSliceSize cannot be larger than Integer.MAX_VALUE");
         checkArgument(maxSliceSize.toBytes() > 0, "maxSliceSize must be positive");
         this.maxSliceSize = maxSliceSize.toBytes();
+        this.resetAllReaders = resetAllReaders;
     }
 
     public DataSize getMaxMergeDistance()
@@ -83,5 +87,10 @@ public class OrcRecordReaderOptions
     public long getMaxSliceSize()
     {
         return maxSliceSize;
+    }
+
+    public boolean isResetAllReaders()
+    {
+        return resetAllReaders;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -40,7 +40,7 @@ public final class BatchStreamReaders
             case INT:
             case LONG:
             case DATE:
-                return new LongBatchStreamReader(type, streamDescriptor, systemMemoryContext);
+                return new LongBatchStreamReader(type, streamDescriptor, systemMemoryContext, options.isResetAllReaders());
             case FLOAT:
                 return new FloatBatchStreamReader(type, streamDescriptor);
             case DOUBLE:
@@ -49,7 +49,7 @@ public final class BatchStreamReaders
             case STRING:
             case VARCHAR:
             case CHAR:
-                return new SliceBatchStreamReader(type, streamDescriptor, systemMemoryContext, options.getMaxSliceSize());
+                return new SliceBatchStreamReader(type, streamDescriptor, systemMemoryContext, options.getMaxSliceSize(), options.isResetAllReaders());
             case TIMESTAMP:
             case TIMESTAMP_MICROSECONDS:
                 boolean enableMicroPrecision = type == TIMESTAMP_MICROSECONDS;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongBatchStreamReader.java
@@ -43,13 +43,15 @@ public class LongBatchStreamReader
     private final LongDirectBatchStreamReader directReader;
     private final LongDictionaryBatchStreamReader dictionaryReader;
     private BatchStreamReader currentReader;
+    private final boolean resetAllReaders;
 
-    public LongBatchStreamReader(Type type, StreamDescriptor streamDescriptor, OrcAggregatedMemoryContext systemMemoryContext)
+    public LongBatchStreamReader(Type type, StreamDescriptor streamDescriptor, OrcAggregatedMemoryContext systemMemoryContext, boolean resetAllReaders)
             throws OrcCorruptionException
     {
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         directReader = new LongDirectBatchStreamReader(type, streamDescriptor, systemMemoryContext.newOrcLocalMemoryContext(LongBatchStreamReader.class.getSimpleName()));
         dictionaryReader = new LongDictionaryBatchStreamReader(type, streamDescriptor, systemMemoryContext.newOrcLocalMemoryContext(LongBatchStreamReader.class.getSimpleName()));
+        this.resetAllReaders = resetAllReaders;
     }
 
     @Override
@@ -74,9 +76,17 @@ public class LongBatchStreamReader
                 .getColumnEncodingKind();
         if (kind == DIRECT || kind == DIRECT_V2 || kind == DWRF_DIRECT) {
             currentReader = directReader;
+            if (dictionaryReader != null && resetAllReaders) {
+                dictionaryReader.startStripe(stripe);
+                System.setProperty("RESET_LONG_BATCH_READER", "RESET_LONG_BATCH_READER");
+            }
         }
         else if (kind == DICTIONARY) {
             currentReader = dictionaryReader;
+            if (directReader != null && resetAllReaders) {
+                directReader.startStripe(stripe);
+                System.setProperty("RESET_LONG_BATCH_READER", "RESET_LONG_BATCH_READER");
+            }
         }
         else {
             throw new IllegalArgumentException("Unsupported encoding " + kind);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveReaderContext.java
@@ -41,6 +41,7 @@ public class SelectiveReaderContext
     private final OrcAggregatedMemoryContext systemMemoryContext;
     private final boolean isLowMemory;
     private final long maxSliceSize;
+    private final boolean resetAllReaders;
 
     public SelectiveReaderContext(
             StreamDescriptor streamDescriptor,
@@ -48,7 +49,8 @@ public class SelectiveReaderContext
             Optional<TupleDomainFilter> filter,
             OrcAggregatedMemoryContext systemMemoryContext,
             boolean isLowMemory,
-            long maxSliceSize)
+            long maxSliceSize,
+            boolean resetAllReaders)
     {
         this.filter = requireNonNull(filter, "filter is null").orElse(null);
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
@@ -62,6 +64,7 @@ public class SelectiveReaderContext
         checkArgument(maxSliceSize < Integer.MAX_VALUE, "maxSliceSize cannot be larger than Integer.MAX_VALUE");
         checkArgument(maxSliceSize > 0, "maxSliceSize must be positive");
         this.maxSliceSize = maxSliceSize;
+        this.resetAllReaders = resetAllReaders;
     }
 
     public StreamDescriptor getStreamDescriptor()
@@ -115,5 +118,10 @@ public class SelectiveReaderContext
     public long getMaxSliceSize()
     {
         return maxSliceSize;
+    }
+
+    public boolean isResetAllReaders()
+    {
+        return resetAllReaders;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
@@ -83,7 +83,7 @@ public final class SelectiveStreamReaders
             case DATE: {
                 checkArgument(requiredSubfields.isEmpty(), "Primitive type stream reader doesn't support subfields");
                 verifyStreamType(streamDescriptor, outputType, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType);
-                return new LongSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext, isLowMemory, options.getMaxSliceSize());
+                return new LongSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext, isLowMemory, options.getMaxSliceSize(), options.isResetAllReaders());
             }
             case FLOAT: {
                 checkArgument(requiredSubfields.isEmpty(), "Float type stream reader doesn't support subfields");
@@ -100,7 +100,7 @@ public final class SelectiveStreamReaders
             case CHAR:
                 checkArgument(requiredSubfields.isEmpty(), "Primitive stream reader doesn't support subfields");
                 verifyStreamType(streamDescriptor, outputType, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType);
-                return new SliceSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext, isLowMemory, options.getMaxSliceSize());
+                return new SliceSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext, isLowMemory, options.getMaxSliceSize(), options.isResetAllReaders());
             case TIMESTAMP:
             case TIMESTAMP_MICROSECONDS: {
                 boolean enableMicroPrecision = outputType.isPresent() && outputType.get() == TIMESTAMP_MICROSECONDS;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
@@ -54,8 +54,9 @@ public class SliceBatchStreamReader
     private final SliceDirectBatchStreamReader directReader;
     private final SliceDictionaryBatchStreamReader dictionaryReader;
     private BatchStreamReader currentReader;
+    private final boolean resetAllReaders;
 
-    public SliceBatchStreamReader(Type type, StreamDescriptor streamDescriptor, OrcAggregatedMemoryContext systemMemoryContext, long maxSliceSize)
+    public SliceBatchStreamReader(Type type, StreamDescriptor streamDescriptor, OrcAggregatedMemoryContext systemMemoryContext, long maxSliceSize, boolean resetAllReaders)
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
@@ -63,6 +64,7 @@ public class SliceBatchStreamReader
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         this.directReader = new SliceDirectBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type), maxSliceSize);
         this.dictionaryReader = new SliceDictionaryBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type), systemMemoryContext.newOrcLocalMemoryContext(SliceBatchStreamReader.class.getSimpleName()));
+        this.resetAllReaders = resetAllReaders;
     }
 
     @Override
@@ -87,9 +89,17 @@ public class SliceBatchStreamReader
                 .getColumnEncodingKind();
         if (columnEncodingKind == DIRECT || columnEncodingKind == DIRECT_V2 || columnEncodingKind == DWRF_DIRECT) {
             currentReader = directReader;
+            if (dictionaryReader != null && resetAllReaders) {
+                dictionaryReader.startStripe(stripe);
+                System.setProperty("RESET_SLICE_BATCH_READER", "RESET_SLICE_BATCH_READER");
+            }
         }
         else if (columnEncodingKind == DICTIONARY || columnEncodingKind == DICTIONARY_V2) {
             currentReader = dictionaryReader;
+            if (directReader != null && resetAllReaders) {
+                directReader.startStripe(stripe);
+                System.setProperty("RESET_SLICE_BATCH_READER", "RESET_SLICE_BATCH_READER");
+            }
         }
         else {
             throw new IllegalArgumentException("Unsupported encoding " + columnEncodingKind);


### PR DESCRIPTION
## Description
Currently for reader with multiple underlying readers (e.g. dictionaryReader and directReader in LongSelectiveStreamReader), only the current reader get reset in startStripe(), the other reader won't get reset, leads to extra memory usage and OOM.

This PR avoid those extra memory usage by reset all underlying readers in startStripe(). This behavior is controlled by resetAllReaders in OrcReaderOptions, and it's disabled by default

## Impact
Reduce memory usage in reader.

## Test Plan
Tested with Spark workload.
Around 10% workload triggered the code path which reset all underlying readers, leading to less memory usage and OOM.

```
== RELEASE NOTES ==
General change
* Improve memory usage in reader with nested readers by resetting all nested readers.
```
