### PR TITLE
[native] ArrowFlight connector missing ColumnHandle operator<()

### DIFF
--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightNativeQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightNativeQueries.java
@@ -317,6 +317,12 @@ public class TestArrowFlightNativeQueries
         assertQuery("SELECT sign(shippriority) from orders");
     }
 
+    @Test
+    public void testQueryWithColumnHandleOrdering()
+    {
+        assertQuery("SELECT * FROM nation WHERE (name <= 'B' OR 'G' <= name) AND (nationkey BETWEEN 1 AND 10)");
+    }
+
     public static Map<String, String> getNativeWorkerSystemProperties()
     {
         return ImmutableMap.<String, String>builder()

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_flight/presto_protocol_arrow_flight.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_flight/presto_protocol_arrow_flight.h
@@ -38,15 +38,38 @@ void to_json(json& j, const ArrowTransactionHandle& p);
 void from_json(const json& j, ArrowTransactionHandle& p);
 
 } // namespace facebook::presto::protocol::arrow_flight
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ArrowColumnHandle is special since it needs an implementation of
+// operator<().
+
 namespace facebook::presto::protocol::arrow_flight {
 struct ArrowColumnHandle : public ColumnHandle {
   String columnName = {};
   Type columnType = {};
 
   ArrowColumnHandle() noexcept;
+
+  bool operator<(const ColumnHandle& o) const override {
+    return columnName < dynamic_cast<const ArrowColumnHandle&>(o).columnName;
+  }
 };
+
 void to_json(json& j, const ArrowColumnHandle& p);
 void from_json(const json& j, ArrowColumnHandle& p);
+
 } // namespace facebook::presto::protocol::arrow_flight
 namespace facebook::presto::protocol::arrow_flight {
 struct ArrowSplit : public ConnectorSplit {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_flight/special/ArrowColumnHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_flight/special/ArrowColumnHandle.hpp.inc
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ArrowColumnHandle is special since it needs an implementation of
+// operator<().
+
+namespace facebook::presto::protocol::arrow_flight {
+struct ArrowColumnHandle : public ColumnHandle {
+  String columnName = {};
+  Type columnType = {};
+
+  ArrowColumnHandle() noexcept;
+
+  bool operator<(const ColumnHandle& o) const override {
+    return columnName < dynamic_cast<const ArrowColumnHandle&>(o).columnName;
+  }
+};
+
+void to_json(json& j, const ArrowColumnHandle& p);
+void from_json(const json& j, ArrowColumnHandle& p);
+
+} // namespace facebook::presto::protocol::arrow_flight

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol-json-hpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol-json-hpp.mustache
@@ -246,7 +246,7 @@ namespace facebook::presto::protocol {
         {{/fields}}
         {{#comparable}}
             virtual bool operator<(const {{&class_name}}& /* o */) const {
-                throw std::runtime_error("missing operator<() in {class_name} subclass");
+                throw std::runtime_error("missing operator<() in {{class_name}} subclass");
             }
         {{/comparable}}
     };

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -335,7 +335,7 @@ void from_json(const json& j, std::shared_ptr<ConnectorIndexHandle>& p);
 namespace facebook::presto::protocol {
 struct ColumnHandle : public JsonEncodedSubclass {
   virtual bool operator<(const ColumnHandle& /* o */) const {
-    throw std::runtime_error("missing operator<() in {class_name} subclass");
+    throw std::runtime_error("missing operator<() in ColumnHandle subclass");
   }
 };
 void to_json(json& j, const std::shared_ptr<ColumnHandle>& p);


### PR DESCRIPTION
## Description
ArrowColumnHandle was missing the operator<() in the protocol definition. This was causing queries that require ordering of columns to fail. A special definition of ArrowColumnHandle is required in the protocol to define the operator to order columns by the columnName.

Add a Java unit test to test the native ArrowFlight connector will support queries that require ordering of column names.

Fixed the error message to correctly insert the mustache template for the `ColumnHandle` class.

## Motivation and Context
Queries using the ArrowFlight connector that require ordering of column names will fail with the error:
```
Query 20250414_191718_00006_9pc45 failed: Expected response code from http://127.0.0.1:7778/v1/task/20250414_191718_00006_9pc45.1.0.0.0?summarize to be 200, but was 500: 
missing operator<() in {class_name} subclass
```

## Impact
NA

## Test Plan
Added a Java e2e with a query that reproduces the error.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

