### PR TITLE
Update deployment.rst

### DIFF
--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -562,7 +562,7 @@ The latest version of Presto is currently |version|.
     docker run --name presto prestodb:latest
 
 You'll see a series of logs as Presto starts, ending with ``SERVER STARTED`` signaling that it is ready to receive queries.
-We'll use the `Presto CLI <https://prestodb.io/docs/current/installation/cli.html>`_ to connect to Presto that we put inside the image
+We'll use the `Presto CLI <https://prestodb.io/docs/current/clients/presto-cli.html>`_ to connect to Presto that we put inside the image
 using a separate Terminal window.
 
 .. code-block:: none


### PR DESCRIPTION
Fix an invalid link to Presto CLI

## Description
This fixes a dead link in the documentation.

## Motivation and Context
The link takes you to the 404 error page.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

