### PR TITLE
[native] Make PeriodicMemoryChecker member of PrestoServer

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
@@ -223,8 +223,8 @@ void PeriodicMemoryChecker::pushbackMemory() {
 #ifndef PRESTO_MEMORY_CHECKER_TYPE
 // Initialize singleton for the checker to be nullptr if
 // PRESTO_MEMORY_CHECKER_TYPE is not defined.
-folly::Singleton<facebook::presto::PeriodicMemoryChecker> checker([]() {
+std::unique_ptr<PeriodicMemoryChecker> createMemoryChecker() {
   return nullptr;
-});
+}
 #endif
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
@@ -76,9 +76,14 @@ class PeriodicMemoryChecker {
   /// Stops the 'PeriodicMemoryChecker'.
   void stop();
 
+  /// Returns the last known cached 'current' system memory usage in bytes.
+  int64_t cachedSystemUsedMemoryBytes() const {
+    return cachedSystemUsedMemoryBytes_;
+  }
+
  protected:
-  /// Returns current system memory usage. The returned value is used to compare
-  /// with 'Config::systemMemLimitBytes'.
+  /// Fetches and returns current system memory usage in bytes.
+  /// The returned value is used to compare with 'Config::systemMemLimitBytes'.
   virtual int64_t systemUsedMemoryBytes() = 0;
 
   /// Returns current bytes allocated by malloc. The returned value is used to
@@ -102,6 +107,7 @@ class PeriodicMemoryChecker {
   virtual void pushbackMemory();
 
   const Config config_;
+  std::atomic<int64_t> cachedSystemUsedMemoryBytes_{0};
 
  private:
   // Struct that stores the file names of the heap profiles dumped and the
@@ -137,4 +143,6 @@ class PeriodicMemoryChecker {
       std::greater<DumpFileInfo>>
       dumpFilesByHeapMemUsageMinPq_;
 };
+
+std::unique_ptr<PeriodicMemoryChecker> createMemoryChecker();
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -67,6 +67,7 @@ class Announcer;
 class SignalHandler;
 class TaskManager;
 class TaskResource;
+class PeriodicMemoryChecker;
 class PeriodicTaskManager;
 class SystemConfig;
 
@@ -115,15 +116,13 @@ class PrestoServer {
   void enableAnnouncer(bool enable);
 
  protected:
+  virtual void createPeriodicMemoryChecker();
+
   /// Hook for derived PrestoServer implementations to add/stop additional
   /// periodic tasks.
   virtual void addAdditionalPeriodicTasks(){};
 
   virtual void stopAdditionalPeriodicTasks(){};
-
-  virtual void addMemoryCheckerPeriodicTask();
-
-  virtual void stopMemoryCheckerPeriodicTask();
 
   virtual void initializeCoordinatorDiscoverer();
 
@@ -277,6 +276,7 @@ class PrestoServer {
   std::chrono::steady_clock::time_point start_;
   std::unique_ptr<PeriodicTaskManager> periodicTaskManager_;
   std::unique_ptr<PrestoServerOperations> prestoServerOperations_;
+  std::unique_ptr<PeriodicMemoryChecker> memoryChecker_;
 
   // We update these members asynchronously and return in http requests w/o
   // delay.


### PR DESCRIPTION
## Description
We well need this in the upcoming changes to be able to fetch the current memory use from PeriodicMemoryChecker to determine if the worker is overloaded in terms of memory.

```
== NO RELEASE NOTE ==
```

