### PR TITLE
Fix TDigest::scale() to update sum member.

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -768,6 +768,7 @@ public class TDigest
             weight[i] *= scaleFactor;
         }
         totalWeight *= scaleFactor;
+        sum *= scaleFactor;
     }
 
     public String toString()

--- a/presto-main-base/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -226,6 +226,25 @@ public class TestTDigest
     }
 
     @Test
+    public void testScale()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        NormalDistribution normal = new NormalDistribution(1000, 100);
+
+        for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
+            tDigest.add(normal.sample());
+        }
+
+        double oldMin = tDigest.getMin();
+        double oldMax = tDigest.getMax();
+        double oldSum = tDigest.getSum();
+        tDigest.scale(1.7);
+        assertEquals(tDigest.getSum(), oldSum * 1.7);
+        assertEquals(tDigest.getMin(), oldMin);
+        assertEquals(tDigest.getMax(), oldMax);
+    }
+
+    @Test
     public void testNormalDistributionHighVariance()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);


### PR DESCRIPTION
## Description
TDigest::sum member variable is not really used in any method that could affect result of TDigest functions.
However, for complete correctness we should update it.

```
== NO RELEASE NOTE ==
```

