### PR TITLE
[native] Fix blank HTTP Host header in requests

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -522,9 +522,11 @@ void HttpClient::sendRequest(std::shared_ptr<ResponseHandler> responseHandler) {
 }
 
 folly::SemiFuture<std::unique_ptr<HttpResponse>> HttpClient::sendRequest(
-    const proxygen::HTTPMessage& request,
+    proxygen::HTTPMessage& request,
     const std::string& body,
     int64_t delayMs) {
+  request.setDstAddress(this->address_);
+  request.ensureHostHeader();
   auto responseHandler = std::make_shared<ResponseHandler>(
       request,
       maxResponseAllocBytes_,

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.h
@@ -172,7 +172,7 @@ class HttpClient : public std::enable_shared_from_this<HttpClient> {
 
   // TODO Avoid copy by using IOBuf for body
   folly::SemiFuture<std::unique_ptr<HttpResponse>> sendRequest(
-      const proxygen::HTTPMessage& request,
+      proxygen::HTTPMessage& request,
       const std::string& body = "",
       int64_t delayMs = 0);
 
@@ -244,7 +244,6 @@ class RequestBuilder {
   send(HttpClient* client, const std::string& body = "", int64_t delayMs = 0) {
     addJwtIfConfigured();
     header(proxygen::HTTP_HEADER_CONTENT_LENGTH, std::to_string(body.size()));
-    headers_.ensureHostHeader();
     return client->sendRequest(headers_, body, delayMs);
   }
 


### PR DESCRIPTION
## Description

This change properly sets the request destination address so that ensureHostHeader sets the correct value for the HTTP `Host` header.

## Motivation and Context

Because the request's destination address wasn't set inside of the RequestBuilder object, the Host was populated with a blank value. On older HTTP servers this is permissible, but on newer ones (such as the incoming Jetty 12 upgrade), this is a hard error and results in the request being rejected with a 400 error.

## Impact

N/A

## Test Plan

Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

