### PR TITLE
Enrich Update information in QueryInfo

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.analyzer.AccessControlInfo;
 import com.facebook.presto.spi.analyzer.AccessControlInfoForTable;
 import com.facebook.presto.spi.analyzer.AccessControlReferences;
 import com.facebook.presto.spi.analyzer.AccessControlRole;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.security.AccessControl;
@@ -96,7 +97,7 @@ public class Analysis
     @Nullable
     private final Statement root;
     private final Map<NodeRef<Parameter>, Expression> parameters;
-    private String updateType;
+    private UpdateInfo updateInfo;
 
     private final Map<NodeRef<Table>, NamedQuery> namedQueries = new LinkedHashMap<>();
 
@@ -202,14 +203,14 @@ public class Analysis
         return root;
     }
 
-    public String getUpdateType()
+    public UpdateInfo getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
-    public void setUpdateType(String updateType)
+    public void setUpdateInfo(UpdateInfo updateInfo)
     {
-        this.updateType = updateType;
+        this.updateInfo = updateInfo;
     }
 
     public boolean isCreateTableAsSelectWithData()

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/BuiltInQueryAnalysis.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.analyzer.AccessControlReferences;
 import com.facebook.presto.spi.analyzer.QueryAnalysis;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.sql.tree.Explain;
 import com.google.common.collect.ImmutableSet;
@@ -41,9 +42,9 @@ public class BuiltInQueryAnalysis
     }
 
     @Override
-    public String getUpdateType()
+    public UpdateInfo getUpdateInfo()
     {
-        return analysis.getUpdateType();
+        return analysis.getUpdateInfo();
     }
 
     @Override

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -160,7 +160,7 @@ public class Query
         // if running or finished
         if (client.isRunning() || (client.isFinished() && client.finalStatusInfo().getError() == null)) {
             QueryStatusInfo results = client.isRunning() ? client.currentStatusInfo() : client.finalStatusInfo();
-            if (results.getUpdateType() != null) {
+            if (results.getUpdateInfo() != null) {
                 renderUpdate(errorChannel, results);
             }
             else if (results.getColumns() == null) {
@@ -220,7 +220,7 @@ public class Query
 
     private void renderUpdate(PrintStream out, QueryStatusInfo results)
     {
-        String status = results.getUpdateType();
+        String status = results.getUpdateInfo().getUpdateType();
         if (results.getUpdateCount() != null) {
             long count = results.getUpdateCount();
             status += format(": %s row%s", count, (count != 1) ? "s" : "");

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryResults.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.client;
 
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -45,7 +46,7 @@ public class QueryResults
     private final StatementStats stats;
     private final QueryError error;
     private final List<PrestoWarning> warnings;
-    private final String updateType;
+    private final UpdateInfo updateInfo;
     private final Long updateCount;
 
     @JsonCreator
@@ -60,7 +61,7 @@ public class QueryResults
             @JsonProperty("stats") StatementStats stats,
             @JsonProperty("error") QueryError error,
             @JsonProperty("warnings") List<PrestoWarning> warnings,
-            @JsonProperty("updateType") String updateType,
+            @JsonProperty("updateType") UpdateInfo updateInfo,
             @JsonProperty("updateCount") Long updateCount)
     {
         this(
@@ -74,7 +75,7 @@ public class QueryResults
                 stats,
                 error,
                 firstNonNull(warnings, ImmutableList.of()),
-                updateType,
+                updateInfo,
                 updateCount);
     }
 
@@ -89,7 +90,7 @@ public class QueryResults
             StatementStats stats,
             QueryError error,
             List<PrestoWarning> warnings,
-            String updateType,
+            UpdateInfo updateInfo,
             Long updateCount)
     {
         this.id = requireNonNull(id, "id is null");
@@ -103,7 +104,7 @@ public class QueryResults
         this.stats = requireNonNull(stats, "stats is null");
         this.error = error;
         this.warnings = ImmutableList.copyOf(requireNonNull(warnings, "warnings is null"));
-        this.updateType = updateType;
+        this.updateInfo = updateInfo;
         this.updateCount = updateCount;
     }
 
@@ -226,9 +227,9 @@ public class QueryResults
     @Nullable
     @JsonProperty
     @Override
-    public String getUpdateType()
+    public UpdateInfo getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
     /**
@@ -255,7 +256,7 @@ public class QueryResults
                 .add("hasBinaryData", binaryData != null)
                 .add("stats", stats)
                 .add("error", error)
-                .add("updateType", updateType)
+                .add("updateType", updateInfo)
                 .add("updateCount", updateCount)
                 .toString();
     }

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryStatusInfo.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryStatusInfo.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.client;
 
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 
 import java.net.URI;
 import java.util.List;
@@ -36,7 +37,7 @@ public interface QueryStatusInfo
 
     List<PrestoWarning> getWarnings();
 
-    String getUpdateType();
+    UpdateInfo getUpdateInfo();
 
     Long getUpdateCount();
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoResultSet.java
@@ -20,6 +20,7 @@ import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.jdbc.ColumnInfo.Nullable;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -1775,12 +1776,12 @@ public class PrestoResultSet
 
         private static boolean isQuery(StatementClient client)
         {
-            String updateType;
+            UpdateInfo updateType;
             if (client.isRunning()) {
-                updateType = client.currentStatusInfo().getUpdateType();
+                updateType = client.currentStatusInfo().getUpdateInfo();
             }
             else {
-                updateType = client.finalStatusInfo().getUpdateType();
+                updateType = client.finalStatusInfo().getUpdateInfo();
             }
             return updateType == null;
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/DDLDefinitionExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/DDLDefinitionExecution.java
@@ -17,8 +17,14 @@ import com.facebook.presto.common.analyzer.PreparedQuery;
 import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.AnalyzerContext;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
+import com.facebook.presto.spi.analyzer.QueryAnalysis;
+import com.facebook.presto.spi.analyzer.QueryAnalyzer;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
 import com.facebook.presto.sql.tree.Expression;
@@ -32,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.util.AnalyzerUtil.getAnalyzerContext;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -97,6 +104,13 @@ public class DDLDefinitionExecution<T extends Statement>
             checkState(preparedQuery instanceof BuiltInQueryPreparer.BuiltInPreparedQuery, "Unsupported prepared query type: %s", preparedQuery.getClass().getSimpleName());
             BuiltInQueryPreparer.BuiltInPreparedQuery builtInQueryPreparer = (BuiltInQueryPreparer.BuiltInPreparedQuery) preparedQuery;
 
+            // Run thru analyzer to get info about the update
+            QueryAnalyzer queryAnalyzer = analyzerProvider.getQueryAnalyzer();
+            AnalyzerContext analyzerContext = getAnalyzerContext(queryAnalyzer,
+                    metadata.getMetadataResolver(stateMachine.getSession()), new PlanNodeIdAllocator(), new VariableAllocator(), stateMachine.getSession());
+            QueryAnalysis analysis = queryAnalyzer.analyze(analyzerContext, preparedQuery);
+            stateMachine.setUpdateInfo(analysis.getUpdateInfo());
+
             return createDDLDefinitionExecution(builtInQueryPreparer.getStatement(), builtInQueryPreparer.getParameters(), stateMachine, slug, retryCount);
         }
 
@@ -111,7 +125,6 @@ public class DDLDefinitionExecution<T extends Statement>
             DDLDefinitionTask<T> task = (DDLDefinitionTask<T>) tasks.get(statement.getClass());
             checkArgument(task != null, "no task for statement: %s", statement.getClass().getSimpleName());
 
-            stateMachine.setUpdateType(task.getName());
             return new DDLDefinitionExecution<>(task, statement, slug, retryCount, transactionManager, metadata, accessControl, stateMachine, parameters);
         }
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.eventlistener.CTEInformation;
 import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.function.SqlFunctionId;
@@ -77,7 +78,7 @@ public class QueryInfo
     private final Set<String> deallocatedPreparedStatements;
     private final Optional<TransactionId> startedTransactionId;
     private final boolean clearTransactionId;
-    private final String updateType;
+    private final UpdateInfo updateInfo;
     private final Optional<StageInfo> outputStage;
     private final ExecutionFailureInfo failureInfo;
     private final ErrorType errorType;
@@ -127,7 +128,7 @@ public class QueryInfo
             @JsonProperty("deallocatedPreparedStatements") Set<String> deallocatedPreparedStatements,
             @JsonProperty("startedTransactionId") Optional<TransactionId> startedTransactionId,
             @JsonProperty("clearTransactionId") boolean clearTransactionId,
-            @JsonProperty("updateType") String updateType,
+            @JsonProperty("updateInfo") UpdateInfo updateInfo,
             @JsonProperty("outputStage") Optional<StageInfo> outputStage,
             @JsonProperty("failureInfo") ExecutionFailureInfo failureInfo,
             @JsonProperty("errorCode") ErrorCode errorCode,
@@ -206,7 +207,7 @@ public class QueryInfo
         this.deallocatedPreparedStatements = ImmutableSet.copyOf(deallocatedPreparedStatements);
         this.startedTransactionId = startedTransactionId;
         this.clearTransactionId = clearTransactionId;
-        this.updateType = updateType;
+        this.updateInfo = updateInfo;
         this.outputStage = outputStage;
         this.failureInfo = failureInfo;
         this.errorType = errorCode == null ? null : errorCode.getType();
@@ -363,9 +364,9 @@ public class QueryInfo
 
     @Nullable
     @JsonProperty
-    public String getUpdateType()
+    public UpdateInfo getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
     @JsonProperty

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -155,7 +156,7 @@ public class QueryStateMachine
     private final AtomicReference<TransactionId> startedTransactionId = new AtomicReference<>();
     private final AtomicBoolean clearTransactionId = new AtomicBoolean();
 
-    private final AtomicReference<String> updateType = new AtomicReference<>();
+    private final AtomicReference<UpdateInfo> updateInfo = new AtomicReference<>();
 
     private final AtomicReference<ExecutionFailureInfo> failureCause = new AtomicReference<>();
 
@@ -482,7 +483,7 @@ public class QueryStateMachine
                 deallocatedPreparedStatements,
                 Optional.ofNullable(startedTransactionId.get()),
                 clearTransactionId.get(),
-                updateType.get(),
+                updateInfo.get(),
                 rootStage,
                 failureCause,
                 errorCode,
@@ -752,9 +753,9 @@ public class QueryStateMachine
         clearTransactionId.set(true);
     }
 
-    public void setUpdateType(String updateType)
+    public void setUpdateInfo(UpdateInfo updateInfo)
     {
-        this.updateType.set(updateType);
+        this.updateInfo.set(updateInfo);
     }
 
     public void setExpandedQuery(Optional<String> expandedQuery)
@@ -1121,7 +1122,7 @@ public class QueryStateMachine
                 queryInfo.getDeallocatedPreparedStatements(),
                 queryInfo.getStartedTransactionId(),
                 queryInfo.isClearTransactionId(),
-                queryInfo.getUpdateType(),
+                queryInfo.getUpdateInfo(),
                 queryInfo.getOutputStage().map(QueryStateMachine::pruneStatsFromStageInfo),
                 queryInfo.getFailureInfo(),
                 queryInfo.getErrorCode(),
@@ -1239,7 +1240,7 @@ public class QueryStateMachine
                 queryInfo.getDeallocatedPreparedStatements(),
                 queryInfo.getStartedTransactionId(),
                 queryInfo.isClearTransactionId(),
-                queryInfo.getUpdateType(),
+                queryInfo.getUpdateInfo(),
                 prunedOutputStage,
                 queryInfo.getFailureInfo(),
                 queryInfo.getErrorCode(),

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SessionDefinitionExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SessionDefinitionExecution.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.AnalyzerProvider;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.BuiltInQueryPreparer;
 import com.facebook.presto.sql.tree.Expression;
@@ -110,7 +111,7 @@ public class SessionDefinitionExecution<T extends Statement>
             SessionTransactionControlTask<T> task = (SessionTransactionControlTask<T>) tasks.get(statement.getClass());
             checkArgument(task != null, "no task for statement: %s", statement.getClass().getSimpleName());
 
-            stateMachine.setUpdateType(task.getName());
+            stateMachine.setUpdateInfo(new UpdateInfo(task.getName(), ""));
             return new SessionDefinitionExecution<>(task, statement, slug, retryCount, transactionManager, metadata, accessControl, stateMachine, parameters);
         }
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -211,7 +211,7 @@ public class SqlQueryExecution
                         .recordWallAndCpuTime(ANALYZE_TIME_NANOS, () -> queryAnalyzer.analyze(analyzerContext, preparedQuery));
             }
 
-            stateMachine.setUpdateType(queryAnalysis.getUpdateType());
+            stateMachine.setUpdateInfo(queryAnalysis.getUpdateInfo());
             stateMachine.setExpandedQuery(queryAnalysis.getExpandedQuery());
 
             stateMachine.beginColumnAccessPermissionChecking();

--- a/presto-main-base/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -441,7 +441,7 @@ class Query
                         .build(),
                 null,
                 ImmutableList.of(),
-                queryResults.getUpdateType(),
+                queryResults.getUpdateInfo(),
                 queryResults.getUpdateCount());
     }
 
@@ -526,7 +526,7 @@ class Query
 
         // TODO: figure out a better way to do this
         // grab the update count for non-queries
-        if ((data != null) && (queryInfo.getUpdateType() != null) && (updateCount == null) &&
+        if ((data != null) && (queryInfo.getUpdateInfo() != null) && (updateCount == null) &&
                 (columns.size() == 1) && (columns.get(0).getType().equals(StandardTypes.BIGINT))) {
             Iterator<List<Object>> iterator = data.iterator();
             if (iterator.hasNext()) {
@@ -597,7 +597,7 @@ class Query
                 toStatementStats(queryInfo),
                 toQueryError(queryInfo),
                 queryInfo.getWarnings(),
-                queryInfo.getUpdateType(),
+                queryInfo.getUpdateInfo(),
                 updateCount);
 
         // cache the new result

--- a/presto-main-base/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -178,7 +178,7 @@ public final class QueryResourceUtil
                 queryResults.getStats(),
                 queryResults.getError(),
                 queryResults.getWarnings(),
-                queryResults.getUpdateType(),
+                queryResults.getUpdateInfo(),
                 queryResults.getUpdateCount());
 
         return toResponse(query, resultsClone, compressionEnabled);

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -35,6 +35,7 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -97,7 +98,7 @@ public class MaterializedResult
     private final List<Type> types;
     private final Map<String, String> setSessionProperties;
     private final Set<String> resetSessionProperties;
-    private final Optional<String> updateType;
+    private final Optional<UpdateInfo> updateType;
     private final OptionalLong updateCount;
     private final List<PrestoWarning> warnings;
 
@@ -111,7 +112,7 @@ public class MaterializedResult
             List<? extends Type> types,
             Map<String, String> setSessionProperties,
             Set<String> resetSessionProperties,
-            Optional<String> updateType,
+            Optional<UpdateInfo> updateType,
             OptionalLong updateCount,
             List<PrestoWarning> warnings)
     {
@@ -155,7 +156,7 @@ public class MaterializedResult
         return resetSessionProperties;
     }
 
-    public Optional<String> getUpdateType()
+    public Optional<UpdateInfo> getUpdateType()
     {
         return updateType;
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
@@ -101,7 +101,7 @@ public class TestQueryInfo
         assertEquals(actual.getStartedTransactionId(), expected.getStartedTransactionId());
         assertEquals(actual.isClearTransactionId(), expected.isClearTransactionId());
 
-        assertEquals(actual.getUpdateType(), expected.getUpdateType());
+        assertEquals(actual.getUpdateInfo(), expected.getUpdateInfo());
         assertEquals(actual.getOutputStage(), expected.getOutputStage());
 
         assertEquals(actual.getFailureInfo(), expected.getFailureInfo());

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -26,6 +26,7 @@ import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.AccessControl;
@@ -558,7 +559,7 @@ public class TestQueryStateMachine
         assertEquals(queryInfo.getInputs(), INPUTS);
         assertEquals(queryInfo.getOutput(), OUTPUT);
         assertEquals(queryInfo.getFieldNames(), OUTPUT_FIELD_NAMES);
-        assertEquals(queryInfo.getUpdateType(), UPDATE_TYPE);
+        assertEquals(queryInfo.getUpdateInfo(), UPDATE_TYPE);
         assertEquals(queryInfo.getMemoryPool(), MEMORY_POOL.getId());
         assertEquals(queryInfo.getQueryType(), QUERY_TYPE);
 
@@ -644,7 +645,7 @@ public class TestQueryStateMachine
         stateMachine.setInputs(INPUTS);
         stateMachine.setOutput(OUTPUT);
         stateMachine.setColumns(OUTPUT_FIELD_NAMES, OUTPUT_FIELD_TYPES);
-        stateMachine.setUpdateType(UPDATE_TYPE);
+        stateMachine.setUpdateInfo(new UpdateInfo(UPDATE_TYPE, ""));
         stateMachine.setMemoryPool(MEMORY_POOL);
         for (Entry<String, String> entry : SET_SESSION_PROPERTIES.entrySet()) {
             stateMachine.addSetSessionProperties(entry.getKey(), entry.getValue());

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -369,7 +369,7 @@ public class PrestoSparkQueryExecutionFactory
                 ImmutableSet.of(),
                 Optional.empty(),
                 false,
-                planAndMore.flatMap(PlanAndMore::getUpdateType).orElse(null),
+                planAndMore.flatMap(PlanAndMore::getUpdateInfo).orElse(null),
                 rootStage,
                 failureInfo.orElse(null),
                 failureInfo.map(ExecutionFailureInfo::getErrorCode).orElse(null),
@@ -480,7 +480,7 @@ public class PrestoSparkQueryExecutionFactory
                 stats,
                 Optional.ofNullable(queryInfo.getFailureInfo()).map(PrestoSparkQueryExecutionFactory::toQueryError),
                 warningCollector.getWarnings(),
-                planAndMore.flatMap(PlanAndMore::getUpdateType),
+                planAndMore.flatMap(PlanAndMore::getUpdateInfo),
                 updateCount);
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -70,6 +70,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.page.PagesSerde;
@@ -415,7 +416,7 @@ public abstract class AbstractPrestoSparkQueryExecution
 
         // Based on com.facebook.presto.server.protocol.Query#getNextResult
         OptionalLong updateCount = OptionalLong.empty();
-        if (planAndMore.getUpdateType().isPresent() &&
+        if (planAndMore.getUpdateInfo().isPresent() &&
                 types.size() == 1 &&
                 types.get(0).equals(BIGINT) &&
                 results.size() == 1 &&
@@ -448,9 +449,9 @@ public abstract class AbstractPrestoSparkQueryExecution
         return subPlanOptional.get().getFragment().getTypes();
     }
 
-    public Optional<String> getUpdateType()
+    public Optional<UpdateInfo> getUpdateType()
     {
-        return planAndMore.getUpdateType();
+        return planAndMore.getUpdateInfo();
     }
 
     protected abstract List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>> doExecute()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spark.PrestoSparkPhysicalResourceCalculator;
 import com.facebook.presto.spark.PrestoSparkSourceStatsCollector;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -166,7 +167,7 @@ public class PrestoSparkQueryPlanner
 
         return new PlanAndMore(
                 plan,
-                Optional.ofNullable(analysis.getUpdateType()),
+                Optional.ofNullable(analysis.getUpdateInfo()),
                 columnNames,
                 ImmutableSet.copyOf(inputs),
                 output,
@@ -181,7 +182,7 @@ public class PrestoSparkQueryPlanner
     public static class PlanAndMore
     {
         private final Plan plan;
-        private final Optional<String> updateType;
+        private final Optional<UpdateInfo> updateInfo;
         private final List<String> fieldNames;
         private final Set<Input> inputs;
         private final Optional<Output> output;
@@ -194,7 +195,7 @@ public class PrestoSparkQueryPlanner
 
         public PlanAndMore(
                 Plan plan,
-                Optional<String> updateType,
+                Optional<UpdateInfo> updateInfo,
                 List<String> fieldNames,
                 Set<Input> inputs,
                 Optional<Output> output,
@@ -206,7 +207,7 @@ public class PrestoSparkQueryPlanner
                 Set<String> invokedWindowFunctions)
         {
             this.plan = requireNonNull(plan, "plan is null");
-            this.updateType = requireNonNull(updateType, "updateType is null");
+            this.updateInfo = requireNonNull(updateInfo, "updateType is null");
             this.fieldNames = ImmutableList.copyOf(requireNonNull(fieldNames, "fieldNames is null"));
             this.inputs = ImmutableSet.copyOf(requireNonNull(inputs, "inputs is null"));
             this.output = requireNonNull(output, "output is null");
@@ -223,9 +224,9 @@ public class PrestoSparkQueryPlanner
             return plan;
         }
 
-        public Optional<String> getUpdateType()
+        public Optional<UpdateInfo> getUpdateInfo()
         {
-            return updateType;
+            return updateInfo;
         }
 
         public List<String> getFieldNames()

--- a/presto-spark-common/src/main/java/com/facebook/presto/spark/PrestoSparkQueryStatusInfo.java
+++ b/presto-spark-common/src/main/java/com/facebook/presto/spark/PrestoSparkQueryStatusInfo.java
@@ -17,6 +17,7 @@ import com.facebook.presto.client.Column;
 import com.facebook.presto.client.QueryError;
 import com.facebook.presto.client.StatementStats;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +44,7 @@ public class PrestoSparkQueryStatusInfo
     private final StatementStats stats;
     private final Optional<QueryError> error;
     private final List<PrestoWarning> warnings;
-    private final Optional<String> updateType;
+    private final Optional<UpdateInfo> updateInfo;
     private final OptionalLong updateCount;
 
     @JsonCreator
@@ -53,7 +54,7 @@ public class PrestoSparkQueryStatusInfo
             @JsonProperty("stats") StatementStats stats,
             @JsonProperty("error") Optional<QueryError> error,
             @JsonProperty("warnings") List<PrestoWarning> warnings,
-            @JsonProperty("updateType") Optional<String> updateType,
+            @JsonProperty("updateType") Optional<UpdateInfo> updateInfo,
             @JsonProperty("updateCount") OptionalLong updateCount)
     {
         this.id = requireNonNull(id, "id is null");
@@ -61,7 +62,7 @@ public class PrestoSparkQueryStatusInfo
         this.stats = requireNonNull(stats, "stats is null");
         this.error = requireNonNull(error, "error is null");
         this.warnings = ImmutableList.copyOf(requireNonNull(warnings, "warnings is null"));
-        this.updateType = requireNonNull(updateType, "updateType is null");
+        this.updateInfo = requireNonNull(updateInfo, "updateType is null");
         this.updateCount = requireNonNull(updateCount, "updateCount is null");
     }
 
@@ -96,9 +97,9 @@ public class PrestoSparkQueryStatusInfo
     }
 
     @JsonProperty
-    public Optional<String> getUpdateType()
+    public Optional<UpdateInfo> getUpdateInfo()
     {
-        return updateType;
+        return updateInfo;
     }
 
     @JsonProperty

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalysis.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/QueryAnalysis.java
@@ -27,11 +27,11 @@ import java.util.Set;
 public interface QueryAnalysis
 {
     /**
-     * Returns the update type of the query.
+     * Returns information about the type of Update
      *
      * @return a String representing the type of update (e.g., "INSERT", "CREATE TABLE", "DELETE", etc)
      */
-    String getUpdateType();
+    UpdateInfo getUpdateInfo();
 
     /**
      * Returns the expanded query, which might have been enhanced after analyzing materialized view.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/UpdateInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/UpdateInfo.java
@@ -1,0 +1,38 @@
+package com.facebook.presto.spi.analyzer;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@ThriftStruct
+public class UpdateInfo
+{
+    private final String updateType;
+    private final String updateObject;
+
+    @JsonCreator
+    @ThriftConstructor
+    public UpdateInfo(
+            @JsonProperty("updateType") String updateType,
+            @JsonProperty("updateObject") String updateObject)
+    {
+        this.updateType = updateType;
+        this.updateObject = updateObject;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public String getUpdateType()
+    {
+        return updateType;
+    }
+
+    @JsonProperty
+    @ThriftField(2)
+    public String getUpdateObject()
+    {
+        return updateObject;
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -108,8 +108,8 @@ public abstract class AbstractTestingPrestoClient<T>
 
             if (error == null) {
                 QueryStatusInfo results = client.finalStatusInfo();
-                if (results.getUpdateType() != null) {
-                    resultsSession.setUpdateType(results.getUpdateType());
+                if (results.getUpdateInfo() != null) {
+                    resultsSession.setUpdateType(results.getUpdateInfo());
                 }
                 if (results.getUpdateCount() != null) {
                     resultsSession.setUpdateCount(results.getUpdateCount());

--- a/presto-tests/src/main/java/com/facebook/presto/tests/ResultsSession.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/ResultsSession.java
@@ -16,6 +16,7 @@ package com.facebook.presto.tests;
 import com.facebook.presto.client.QueryData;
 import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ import java.util.Set;
 
 public interface ResultsSession<T>
 {
-    default void setUpdateType(String type)
+    default void setUpdateType(UpdateInfo type)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -34,6 +34,7 @@ import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.analyzer.UpdateInfo;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.type.SqlIntervalDayTime;
@@ -110,12 +111,12 @@ public class TestingPrestoClient
 
         private final AtomicReference<List<Type>> types = new AtomicReference<>();
 
-        private final AtomicReference<Optional<String>> updateType = new AtomicReference<>(Optional.empty());
+        private final AtomicReference<Optional<UpdateInfo>> updateType = new AtomicReference<Optional<com.facebook.presto.spi.analyzer.UpdateInfo>>(Optional.empty());
         private final AtomicReference<OptionalLong> updateCount = new AtomicReference<>(OptionalLong.empty());
         private final AtomicReference<List<PrestoWarning>> warnings = new AtomicReference<>(ImmutableList.of());
 
         @Override
-        public void setUpdateType(String type)
+        public void setUpdateType(UpdateInfo type)
         {
             updateType.set(Optional.of(type));
         }


### PR DESCRIPTION
## Description
Alternate implementation for https://github.com/prestodb/presto/pull/24899
Fixes https://github.com/prestodb/presto/issues/24894

## Motivation and Context
`updateType` tracking in QueryInfo was added in https://github.com/prestodb/presto/commit/3715be85ef5f5886efceddcbc3fb89131d6f72fc

For lineage tracing, we would like to enhance this with additional information about the object(s) we are updating

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

