### PR TITLE
[native] Minor refactor in http filter registration.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1117,7 +1117,7 @@ PrestoServer::getExprSetListener() {
 }
 
 std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
-PrestoServer::getHttpServerFilters() {
+PrestoServer::getHttpServerFilters() const {
   std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>> filters;
   const auto* systemConfig = SystemConfig::instance();
   if (systemConfig->enableHttpAccessLog()) {
@@ -1126,10 +1126,7 @@ PrestoServer::getHttpServerFilters() {
   }
 
   if (systemConfig->enableHttpStatsFilter()) {
-    auto additionalFilters = getAdditionalHttpServerFilters();
-    for (auto& filter : additionalFilters) {
-      filters.push_back(std::move(filter));
-    }
+    filters.push_back(std::make_unique<http::filters::StatsFilterFactory>());
   }
 
   if (systemConfig->enableHttpEndpointLatencyFilter()) {
@@ -1143,13 +1140,6 @@ PrestoServer::getHttpServerFilters() {
   // without JWT enabled.
   filters.push_back(
       std::make_unique<http::filters::InternalAuthenticationFilterFactory>());
-  return filters;
-}
-
-std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
-PrestoServer::getAdditionalHttpServerFilters() {
-  std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>> filters;
-  filters.emplace_back(std::make_unique<http::filters::StatsFilterFactory>());
   return filters;
 }
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -131,10 +131,6 @@ class PrestoServer {
 
   virtual std::shared_ptr<velox::exec::ExprSetListener> getExprSetListener();
 
-  /// Returns any additional http filters.
-  virtual std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
-  getAdditionalHttpServerFilters();
-
   virtual std::vector<std::string> registerVeloxConnectors(
       const fs::path& configDirectoryPath);
 
@@ -189,8 +185,8 @@ class PrestoServer {
   VeloxPlanValidator* getVeloxPlanValidator();
 
   /// Invoked to get the list of filters passed to the http server.
-  std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
-  getHttpServerFilters();
+  virtual std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>>
+  getHttpServerFilters() const;
 
   void initializeVeloxMemory();
 


### PR DESCRIPTION
## Description
Removing getAdditionalHttpServerFilters and making getHttpServerFilters virtual.

## Motivation and Context
If any internal use case needs to add/remove filters, its more flexible to just make `getHttpServerFilters`virtual. Doing that here.

## Impact
None

## Test Plan
Existing tests

```
== NO RELEASE NOTE ==
```

