### PR TITLE
Fix failing CI: pin JVM 8 to 8.0.442

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
         modules:
           - ":presto-base-arrow-flight"  # Only run tests for the `presto-base-arrow-flight` module
 
@@ -183,7 +183,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 8.0.442
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 8.0.442
           cache: 'maven'
       - name: Maven Install
         run: |

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 20

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 8.0.442
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs
@@ -204,7 +204,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '8.0.442'
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs
@@ -275,7 +275,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '8.0.442'
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 30

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 17.0.13 ]
+        java: [ 8.0.442, 17.0.13 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 17.0.13]
+        java: [8.0.442, 17.0.13]
         modules:
           - ":presto-tests -P presto-tests-execution-memory"
           - ":presto-tests -P presto-tests-general"


### PR DESCRIPTION
## Description

Pin CI to 8u442

## Motivation and Context

Fix failing CI while we handle the JVM tzdata upgrade. See #24635 

8u452 was recently released which contains new tzdata that causes some of our tests to fail. Until we're ready to fix tests with the new tzdata, pin to the last version

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

