### PR TITLE
[native] Save 1 memcpy in parsing message body

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -133,3 +133,15 @@ TEST(UtilsTest, general) {
   EXPECT_EQ("2021-05-20T19:18:27.001Z", util::toISOTimestamp(1621538307001l));
   EXPECT_EQ("2021-05-20T19:18:27.000Z", util::toISOTimestamp(1621538307000l));
 }
+
+TEST(UtilsTest, extractMessageBody) {
+  std::vector<std::unique_ptr<folly::IOBuf>> body;
+  body.push_back(folly::IOBuf::copyBuffer("body1"));
+  body.push_back(folly::IOBuf::copyBuffer("body2"));
+  body.push_back(folly::IOBuf::copyBuffer("body3"));
+  auto iobuf = folly::IOBuf::copyBuffer("body4");
+  iobuf->appendToChain(folly::IOBuf::copyBuffer("body5"));
+  body.push_back(std::move(iobuf));
+  auto messageBody = util::extractMessageBody(body);
+  EXPECT_EQ(messageBody, "body1body2body3body4body5");
+}


### PR DESCRIPTION
## Description
In our HTTP callbacks, we parse the vector of iobufs into a string; however, we assume that each iobuf is singularly chained. This is not guaranteed to be the case.
This diff resolves two issues:

- Correctly consumes the vector of iobufs by taking each buffer chain into account

- Saves 1 memcopy. The previous code path would copy each iobuf into a stream, and then use.c_str(), which also is a copy ([https://en.cppreference.com/w/cpp/io/basic_ostringstream/str](https://l.facebook.com/l.php?u=https%3A%2F%2Fen.cppreference.com%2Fw%2Fcpp%2Fio%2Fbasic_ostringstream%2Fstr&h=AT2RH-TyloQE5MPfdcxYizn__by-8eZd_7-9saGWz05YOZfunpxrYWFq0lHU6WVhx1zpPwW_rnjI9dtanJo1HqBKf5SDv96S4UZBgEOE02Jzb2MevW9chO9bBLeyNU4g7pEs9yMea4EnPqVa9h_K4QrRx_c)). This diff will just copy once into the string buffer



## Test Plan
Added Unit test

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.




