### PR TITLE
[native] Add session property for eager streaming aggregation flush

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -439,3 +439,14 @@ If set to ``true``, enables scaling the table scan concurrency on each worker.
 Controls the ratio of available memory that can be used for scaling up table scans.
 A higher value allows more memory to be allocated for scaling up table scans,
 while a lower value limits the amount of memory used.
+
+``native_streaming_aggregation_eager_flush``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Controls the way streaming aggregation flushes output. We put the rows in output
+batch, as soon as the corresponding groups are fully aggregated. This is useful
+for reducing memory consumption, if the downstream operators are not sensitive to
+small batch size.

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -76,6 +76,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_SCALED_WRITER_MIN_PROCESSED_BYTES_REBALANCE_THRESHOLD = "native_scaled_writer_min_processed_bytes_rebalance_threshold";
     public static final String NATIVE_TABLE_SCAN_SCALED_PROCESSING_ENABLED = "native_table_scan_scaled_processing_enabled";
     public static final String NATIVE_TABLE_SCAN_SCALE_UP_MEMORY_USAGE_RATIO = "native_table_scan_scale_up_memory_usage_ratio";
+    public static final String NATIVE_STREAMING_AGGREGATION_EAGER_FLUSH = "native_streaming_aggregation_eager_flush";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -336,6 +337,14 @@ public class NativeWorkerSessionPropertyProvider
                                 "thread for scale up, and stop once exceeds this ratio. The value is in the " +
                                 "range of [0, 1].",
                         0.7,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_STREAMING_AGGREGATION_EAGER_FLUSH,
+                        "Controls the way streaming aggregation flushes output. We put the rows in output " +
+                                " batch, as soon as the corresponding groups are fully aggregated. This is useful " +
+                                "for reducing memory consumption, if the downstream operators are not sensitive to " +
+                                "small batch size.",
+                        false,
                         !nativeExecution));
     }
 

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -471,6 +471,17 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kTableScanScaleUpMemoryUsageRatio,
       std::to_string(c.tableScanScaleUpMemoryUsageRatio()));
+
+  addSessionProperty(
+      kStreamingAggregationEagerFlush,
+      "Controls the way streaming aggregation flushes output. We put "
+      "the rows in output batch, as soon as the corresponding groups are fully "
+      "aggregated. This is useful for reducing memory consumption, if the "
+      "downstream operators are not sensitive to small batch size.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kStreamingAggregationEagerFlush,
+      std::to_string(c.streamingAggregationEagerFlush()));
 }
 
 const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -303,6 +303,13 @@ class SessionProperties {
   static constexpr const char* kTableScanScaleUpMemoryUsageRatio =
       "native_table_scan_scale_up_memory_usage_ratio";
 
+  /// Controls the way streaming aggregation flushes output. We put the rows in
+  /// output batch, as soon as the corresponding groups are fully aggregated.
+  /// This is useful for reducing memory consumption, if the downstream
+  /// operators are not sensitive to small batch size.
+  static constexpr const char* kStreamingAggregationEagerFlush =
+      "native_streaming_aggregation_eager_flush";
+
   SessionProperties();
 
   const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -33,7 +33,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
           kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
       SessionProperties::kScaleWriterMinProcessedBytesRebalanceThreshold,
       SessionProperties::kTableScanScaledProcessingEnabled,
-      SessionProperties::kTableScanScaleUpMemoryUsageRatio};
+      SessionProperties::kTableScanScaleUpMemoryUsageRatio,
+      SessionProperties::kStreamingAggregationEagerFlush};
   const std::vector<std::string> veloxConfigNames = {
       core::QueryConfig::kAdjustTimestampToTimezone,
       core::QueryConfig::kDriverCpuTimeSliceLimitMs,
@@ -44,7 +45,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
           kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
       core::QueryConfig::kScaleWriterMinProcessedBytesRebalanceThreshold,
       core::QueryConfig::kTableScanScaledProcessingEnabled,
-      core::QueryConfig::kTableScanScaleUpMemoryUsageRatio};
+      core::QueryConfig::kTableScanScaleUpMemoryUsageRatio,
+      core::QueryConfig::kStreamingAggregationEagerFlush};
   auto sessionProperties = SessionProperties().getSessionProperties();
   const auto len = names.size();
   for (auto i = 0; i < len; i++) {


### PR DESCRIPTION
## Description
This session property makes use of Velox's same name query config. This allows streaming aggregation's memory usage to reduce significantly.

```
== RELEASE NOTES ==

Session property changes:
* Added `native_streaming_aggregation_eager_flush` session property

