### PR TITLE
[native] Track CPU & Memory overload in native worker.

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -578,6 +578,33 @@ The default value of 60 gb is calculated based on available machine memory of 64
 Specifies the amount of memory to shrink when the memory pushback is
 triggered. This only applies if ``system-mem-pushback-enabled`` is ``true``.
 
+``system-mem-pushback-abort-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+If true, memory pushback will abort queries with the largest memory usage under
+low memory condition. This only applies if ``system-mem-pushback-enabled`` is ``true``.
+
+``worker-overloaded-threshold-mem-gb``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Memory threshold in GB above which the worker is considered overloaded in terms of
+memory use. Ignored if zero.
+
+``worker-overloaded-threshold-cpu-pct``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+CPU threshold in % above which the worker is considered overloaded in terms of
+CPU use. Ignored if zero.
+
 Environment Variables As Values For Worker Properties
 -----------------------------------------------------
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -221,6 +221,8 @@ class PrestoServer {
 
   std::unique_ptr<velox::cache::SsdCache> setupSsdCache();
 
+  void checkOverload();
+
   const std::string configDirectoryPath_;
 
   std::shared_ptr<CoordinatorDiscoverer> coordinatorDiscoverer_;
@@ -273,6 +275,8 @@ class PrestoServer {
   std::unique_ptr<PeriodicTaskManager> periodicTaskManager_;
   std::unique_ptr<PrestoServerOperations> prestoServerOperations_;
   std::unique_ptr<PeriodicMemoryChecker> memoryChecker_;
+  bool isMemOverloaded_{false};
+  bool isCpuOverloaded_{false};
 
   // We update these members asynchronously and return in http requests w/o
   // delay.

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -183,6 +183,8 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kSystemMemShrinkGb, 8),
           BOOL_PROP(kMallocMemHeapDumpEnabled, false),
           BOOL_PROP(kSystemMemPushbackAbortEnabled, false),
+          NUM_PROP(kWorkerOverloadedThresholdMemGb, 0),
+          NUM_PROP(kWorkerOverloadedThresholdCpuPct, 0),
           NUM_PROP(kMallocHeapDumpThresholdGb, 20),
           NUM_PROP(kMallocMemMinHeapDumpInterval, 10),
           NUM_PROP(kMallocMemMaxHeapDumpFiles, 5),
@@ -497,6 +499,14 @@ bool SystemConfig::systemMemPushbackEnabled() const {
 
 bool SystemConfig::systemMemPushBackAbortEnabled() const {
   return optionalProperty<bool>(kSystemMemPushbackAbortEnabled).value();
+}
+
+uint64_t SystemConfig::workerOverloadedThresholdMemGb() const {
+  return optionalProperty<uint64_t>(kWorkerOverloadedThresholdMemGb).value();
+}
+
+uint32_t SystemConfig::workerOverloadedThresholdCpuPct() const {
+  return optionalProperty<uint32_t>(kWorkerOverloadedThresholdCpuPct).value();
 }
 
 bool SystemConfig::mallocMemHeapDumpEnabled() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -299,11 +299,20 @@ class SystemConfig : public ConfigBase {
   /// get the server out of low memory condition. This only applies if
   /// 'system-mem-pushback-enabled' is true.
   static constexpr std::string_view kSystemMemShrinkGb{"system-mem-shrink-gb"};
-  /// If true, memory pushback will quickly abort queries with the most memory
+  /// If true, memory pushback will abort queries with the largest memory
   /// usage under low memory condition. This only applies if
   /// 'system-mem-pushback-enabled' is set.
   static constexpr std::string_view kSystemMemPushbackAbortEnabled{
       "system-mem-pushback-abort-enabled"};
+
+  /// Memory threshold in GB above which the worker is considered overloaded.
+  /// Ignored if zero. Default is zero.
+  static constexpr std::string_view kWorkerOverloadedThresholdMemGb{
+      "worker-overloaded-threshold-mem-gb"};
+  /// CPU threshold in % above which the worker is considered overloaded.
+  /// Ignored if zero. Default is zero.
+  static constexpr std::string_view kWorkerOverloadedThresholdCpuPct{
+      "worker-overloaded-threshold-cpu-pct"};
 
   /// If true, memory allocated via malloc is periodically checked and a heap
   /// profile is dumped if usage exceeds 'malloc-heap-dump-gb-threshold'.
@@ -827,6 +836,10 @@ class SystemConfig : public ConfigBase {
   uint32_t systemMemShrinkGb() const;
 
   bool systemMemPushBackAbortEnabled() const;
+
+  uint64_t workerOverloadedThresholdMemGb() const;
+
+  uint32_t workerOverloadedThresholdCpuPct() const;
 
   bool mallocMemHeapDumpEnabled() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -84,6 +84,8 @@ void registerPrestoMetrics() {
       kCounterNumBlockedWaitForConnectorDrivers,
       facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumBlockedYieldDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterOverloadedMem, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterOverloadedCpu, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumStuckDrivers, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterTotalPartitionedOutputBuffer, facebook::velox::StatType::AVG);

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -108,6 +108,13 @@ constexpr folly::StringPiece kCounterNumBlockedYieldDrivers{
 constexpr folly::StringPiece kCounterNumStuckDrivers{
     "presto_cpp.num_stuck_drivers"};
 
+/// Worker exports 0 or 100 for this counter. 0 meaning not memory overloaded
+/// and 100 meaning memory overloaded.
+constexpr folly::StringPiece kCounterOverloadedMem{"presto_cpp.overloaded_mem"};
+/// Worker exports 0 or 100 for this counter. 0 meaning not CPU overloaded
+/// and 100 meaning CPU overloaded.
+constexpr folly::StringPiece kCounterOverloadedCpu{"presto_cpp.overloaded_cpu"};
+
 /// Number of total OutputBuffer managed by all
 /// OutputBufferManager
 constexpr folly::StringPiece kCounterTotalPartitionedOutputBuffer{


### PR DESCRIPTION
## Description
We introduce new set of config properties to setup cpu and memory use thresholds above which we will consider worker overloaded.
Default values are zero, meaning we are not tracking it.

## Motivation and Context
We want to spin up a system where Presto is aware of the workers' load and acts accordingly.

## Impact
The change is harmless - only tracking the overload (optionally).

```
== NO RELEASE NOTE ==
```

