### PR TITLE
Fix predicate pushdown for VariableReferenceExpression

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -356,7 +356,8 @@ public class PredicatePushDown
 
             return dependencies.entrySet().stream()
                     .allMatch(entry -> (entry.getValue() == 1 && !node.getAssignments().get(entry.getKey()).accept(new ExternalCallExpressionChecker(functionAndTypeManager), null)) ||
-                            node.getAssignments().get(entry.getKey()) instanceof ConstantExpression);
+                            node.getAssignments().get(entry.getKey()) instanceof ConstantExpression ||
+                            node.getAssignments().get(entry.getKey()) instanceof VariableReferenceExpression);
         }
 
         @Override


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This change will update the logic for determining if an expression is an inlining candidate or not. According to the current definition of inlining candidate, we can treat constant expressions as inlining candidate OR if a expression is only referenced exactly once. In this change, we would also treat a variable reference expression as a simple constant.

```
            // candidate symbols for inlining are
            //   1. references to simple constants
            //   2. references to complex expressions that appear only once
            // which come from the node, as opposed to an enclosing scope,
            // and the expression does not contain remote functions.

```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
[T218620281](https://www.internalfb.com/intern/tasks/?t=218620281)

This change addresses a very specific query shape that contains a CTE definition, has a filter that references a variable reference expression more than once, and uses a function call expression on a column. Here is an example to reproduce:

```
EXPLAIN 
SELECT 
  universe,
  ads_value_with_proxy_consolidated_exclude_app_aem_capped_3x
FROM 
  (
    WITH with_latest_attributed_ds AS (
      SELECT 
              universe, 
      attributed_ds ,
      ads_value_with_proxy_consolidated_exclude_app_aem_capped_3x
      FROM 
        "precomp_qrt_experiment_data_aggregated:ad_metrics" 
    ) 
    SELECT 
      universe, 
      attributed_ds ,
      ads_value_with_proxy_consolidated_exclude_app_aem_capped_3x + 1
       ads_value_with_proxy_consolidated_exclude_app_aem_capped_3x
    FROM 
      with_latest_attributed_ds 
  ) AS precomp_qrt_experiment_data_aggregated_view_presto 
  WHERE 
      (
      universe = 'aa_qrt_21' OR universe = 'qrt_feed'
      )
      AND 
            attributed_ds IN (
              '2025-03-21', 
              '2025-03-20'
              )
limit 100
```

This query will produce a query plan that is different from expected. It should produce a plan that uses a tablescan operator, but it does not.





## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Improves the query plan optimization for the specific query shape mentioned above.

## Test Plan
<!---Please fill in how you tested your change-->
Use prism query runner for 
Presto version 0.293-20250422.031333-102
and ran the example query above. Before the change, it produces a plan that does not have TableScan operator, but after the change, it does have table scan operator.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve PredicatePushDown optimization of filters by treating VariableReferenceExpression as simple constant expression
```

