### PR TITLE
[native] Fix container based native functional test

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -127,6 +127,7 @@ public class ContainerQueryRunner
             throws IOException
     {
         ContainerQueryRunnerUtils.createCoordinatorTpchProperties();
+        ContainerQueryRunnerUtils.createCoordinatorTpcdsProperties();
         ContainerQueryRunnerUtils.createCoordinatorConfigProperties(coordinatorPort);
         ContainerQueryRunnerUtils.createCoordinatorJvmConfig();
         ContainerQueryRunnerUtils.createCoordinatorLogProperties();

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunnerUtils.java
@@ -64,6 +64,15 @@ public class ContainerQueryRunnerUtils
         createPropertiesFile("testcontainers/coordinator/etc/catalog/tpch.properties", properties);
     }
 
+    public static void createCoordinatorTpcdsProperties()
+            throws IOException
+    {
+        Properties properties = new Properties();
+        properties.setProperty("connector.name", "tpcds");
+        properties.setProperty("tpcds.use-varchar-type", "true");
+        createPropertiesFile("testcontainers/coordinator/etc/catalog/tpcds.properties", properties);
+    }
+
     public static void createNativeWorkerTpchProperties(String nodeId)
             throws IOException
     {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Error while running the testcase `TestPrestoContainerBasicQueries`

Attached the docker log
```
2025-04-22T08:46:50.446Z	INFO	main	com.facebook.presto.server.PluginManager	-- Finished loading plugin /var/lib/presto/data/plugin/ttl-fetchers --
2025-04-22T08:46:50.451Z	INFO	main	com.facebook.presto.metadata.StaticCatalogStore	-- Loading catalog properties etc/catalog/tpch.properties --
2025-04-22T08:46:50.452Z	INFO	main	com.facebook.presto.metadata.StaticCatalogStore	-- Loading catalog tpch --
2025-04-22T08:46:50.454Z	INFO	main	com.facebook.presto.metadata.StaticCatalogStore	-- Added catalog tpch using connector tpch --
2025-04-22T08:46:50.454Z	INFO	main	com.facebook.presto.metadata.StaticCatalogStore	-- Loading catalog properties etc/catalog/tpcds.properties --
2025-04-22T08:46:50.455Z	INFO	main	com.facebook.presto.metadata.StaticCatalogStore	-- Loading catalog tpcds --
2025-04-22T08:46:50.455Z	ERROR	main	com.facebook.presto.server.PrestoServer	`tpcds.use-varchar-type` config property is not true for a native cluster
java.lang.IllegalArgumentException: `tpcds.use-varchar-type` config property is not true for a native cluster
	at com.facebook.presto.tpcds.TpcdsConnectorFactory.create(TpcdsConnectorFactory.java:71)
	at com.facebook.presto.connector.ConnectorManager.createConnector(ConnectorManager.java:397)
	at com.facebook.presto.connector.ConnectorManager.addCatalogConnector(ConnectorManager.java:243)
	at com.facebook.presto.connector.ConnectorManager.createConnection(ConnectorManager.java:235)
	at com.facebook.presto.connector.ConnectorManager.createConnection(ConnectorManager.java:221)
	at com.facebook.presto.metadata.StaticCatalogStore.loadCatalog(StaticCatalogStore.java:123)
	at com.facebook.presto.metadata.StaticCatalogStore.loadCatalog(StaticCatalogStore.java:98)
	at com.facebook.presto.metadata.StaticCatalogStore.loadCatalogs(StaticCatalogStore.java:80)
	at com.facebook.presto.metadata.StaticCatalogStore.loadCatalogs(StaticCatalogStore.java:68)
	at com.facebook.presto.server.PrestoServer.run(PrestoServer.java:162)
	at com.facebook.presto.server.PrestoServer.main(PrestoServer.java:96)
```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

