### PR TITLE
documentation: clarify that `ELEMENT_AT` returns `NULL` when out of bounds

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -281,7 +281,7 @@ Array Functions
 .. function:: element_at(array(E), index) -> E
 
     Returns element of ``array`` at given ``index``.
-    If ``index`` > 0, this function provides the same functionality as the SQL-standard subscript operator (``[]``), except that it returns ``NULL`` if ``index`` is out of bounds.
+    If ``index`` > 0, this function provides the same functionality as the SQL-standard subscript operator (``[]``), except that it returns ``NULL`` when ``index`` is out of bounds.
     If ``index`` < 0, ``element_at`` accesses elements from the last to the first.
 
 .. function:: filter(array(T), function(T,boolean)) -> array(T)

--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -281,7 +281,7 @@ Array Functions
 .. function:: element_at(array(E), index) -> E
 
     Returns element of ``array`` at given ``index``.
-    If ``index`` > 0, this function provides the same functionality as the SQL-standard subscript operator (``[]``).
+    If ``index`` > 0, this function provides the same functionality as the SQL-standard subscript operator (``[]``), except that it returns ``NULL`` if ``index`` is out of bounds.
     If ``index`` < 0, ``element_at`` accesses elements from the last to the first.
 
 .. function:: filter(array(T), function(T,boolean)) -> array(T)


### PR DESCRIPTION
## Description

Specify in the documentation that `ELEMENT_AT` returns `NULL` when `index` is out of bouds

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

The current statement can be missleading:

> If ``index`` > 0, this function provides the same functionality as the SQL-standard subscript operator (``[]``).

`ARRAY[][1]` throws an *"Array subscript out of bounds"* error, while `ELEMENT_AT(ARRAY[], 1)` returns `NULL`.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

Just clarify the documentation.

## Test Plan
<!---Please fill in how you tested your change-->
N/A

## Release Notes

```
== NO RELEASE NOTE ==
```

