### PR TITLE
Support sorted shuffle write in Sapphire-Velox stack

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.cpp
@@ -104,6 +104,7 @@ void LocalPersistentShuffleWriter::storePartitionBlock(int32_t partition) {
 
 void LocalPersistentShuffleWriter::collect(
     int32_t partition,
+    std::string_view /* key */,
     std::string_view data) {
   using TRowSize = uint32_t;
 

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -79,7 +79,10 @@ class LocalPersistentShuffleWriter : public ShuffleWriter {
       uint64_t maxBytesPerPartition,
       velox::memory::MemoryPool* FOLLY_NONNULL pool);
 
-  void collect(int32_t partition, std::string_view data) override;
+  void collect(
+      int32_t partition,
+      std::string_view /* key */,
+      std::string_view data) override;
 
   void noMoreData(bool success) override;
 

--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -13,6 +13,7 @@
  */
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include <folly/lang/Bits.h>
+#include "presto_cpp/main/operators/BinarySortableSerializer.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/row/CompactRow.h"
 
@@ -21,13 +22,41 @@ using namespace facebook::velox;
 
 namespace facebook::presto::operators {
 namespace {
+folly::dynamic serializeSortingOrders(
+    const std::vector<velox::core::SortOrder>& sortingOrders) {
+  auto array = folly::dynamic::array();
+  for (const auto& order : sortingOrders) {
+    array.push_back(order.serialize());
+  }
+
+  return array;
+}
+
+std::vector<velox::core::SortOrder> deserializeSortingOrders(
+    const folly::dynamic& array) {
+  std::vector<velox::core::SortOrder> sortingOrders;
+  sortingOrders.reserve(array.size());
+  for (const auto& order : array) {
+    sortingOrders.push_back(velox::core::SortOrder::deserialize(order));
+  }
+  return sortingOrders;
+}
+
+std::vector<velox::core::FieldAccessTypedExprPtr> deserializeFields(
+    const folly::dynamic& array,
+    void* context) {
+  return ISerializable::deserialize<
+      std::vector<velox::core::FieldAccessTypedExpr>>(array, context);
+}
+
 velox::core::PlanNodeId deserializePlanNodeId(const folly::dynamic& obj) {
   return obj["id"].asString();
 }
 
-// The output of this operator has 2 columns:
+// The output of this operator has 3 columns:
 // (1) partition number (INTEGER);
-// (2) serialized row (VARBINARY)
+// (2) serialized key (VARBINARY)
+// (3) serialized row (VARBINARY)
 //
 // When replicateNullsAndAny is true, there is an extra boolean column that
 // indicated whether a row should be replicated to all partitions.
@@ -51,8 +80,14 @@ class PartitionAndSerializeOperator : public Operator {
             numPartitions_ == 1 ? nullptr
                                 : planNode->partitionFunctionFactory()->create(
                                       planNode->numPartitions())),
-        replicateNullsAndAny_(
-            numPartitions_ > 1 ? planNode->isReplicateNullsAndAny() : false) {
+        replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
+        sortingOrders_(planNode->sortingOrders()),
+        sortingKeys_(planNode->sortingKeys()),
+        sorted_(sortingOrders_ && sortingKeys_) {
+    // Ensure that sortingOrders and sortingKeys cannot be set without each
+    // other.
+    VELOX_CHECK(
+        (sortingOrders_ && sortingKeys_) || (!sortingOrders_ && !sortingKeys_));
     const auto& inputType = planNode->sources()[0]->outputType()->asRow();
     const auto& serializedRowTypeNames = serializedRowType_->names();
     bool identityMapping = (serializedRowType_->size() == inputType.size());
@@ -110,10 +145,17 @@ class PartitionAndSerializeOperator : public Operator {
         VARBINARY(), batchSize, pool());
     serializeRows(*dataVector, outputBufferSize, nextOutputRow_, endOutputRow);
 
+    // keyVector is initiallized to be an empty vector.
+    // If sorted_ is true, write serialized keys into keyVector.
+    auto keyVector = BaseVector::create<FlatVector<StringView>>(
+        VARBINARY(), batchSize, pool());
+    serializeKeys(nextOutputRow_, endOutputRow, *keyVector);
+
     // Extract slice from output_ and construct the output vector.
     std::vector<VectorPtr> childrenVectors;
     childrenVectors.push_back(
         output_->childAt(0)->slice(nextOutputRow_, batchSize));
+    childrenVectors.push_back(keyVector);
     childrenVectors.push_back(dataVector);
     RowVectorPtr outputBatch;
     // Handle replicateVector based on 'replicateNullsAndAny_' as it
@@ -130,7 +172,7 @@ class PartitionAndSerializeOperator : public Operator {
     } else {
       outputBatch = std::make_shared<RowVector>(
           pool(),
-          ROW({INTEGER(), VARBINARY()}),
+          outputType_,
           nullptr /*nulls*/,
           batchSize,
           std::move(childrenVectors));
@@ -173,10 +215,14 @@ class PartitionAndSerializeOperator : public Operator {
       vector_size_t& endOutputRow,
       uint32_t& outputBufferSize) {
     const auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
-    const auto preferredOutputBytes = queryConfig.preferredOutputBatchBytes();
+    auto preferredOutputBytes = queryConfig.preferredOutputBatchBytes();
     const auto preferredOutputRows = queryConfig.preferredOutputBatchRows();
     endOutputRow = nextOutputRow_;
 
+    if (sorted_) {
+      // substract key buffer size from preferredOutputBytes.
+      preferredOutputBytes -= kMaxSortKeyBufferSize_;
+    }
     VELOX_DCHECK(!rowSizes_.empty(), "rowSizes_ can not be empty");
     do {
       outputBufferSize += rowSizes_[endOutputRow++];
@@ -310,17 +356,54 @@ class PartitionAndSerializeOperator : public Operator {
     }
   }
 
+  void maybeInitializeSortKeySerializer() {
+    if (binarySortableSerializer_ != nullptr) {
+      return;
+    }
+    VELOX_CHECK(sortingOrders_.has_value() && sortingKeys_.has_value());
+    binarySortableSerializer_ = std::make_unique<BinarySortableSerializer>(
+        input_, sortingOrders_.value(), sortingKeys_.value());
+  }
+
+  void serializeKeys(
+      vector_size_t from,
+      vector_size_t to,
+      FlatVector<StringView>& keyVector) {
+    if (!sorted_) {
+      return;
+    }
+    maybeInitializeSortKeySerializer();
+    const vector_size_t batchSize = to - from;
+
+    // Serialize keys.
+    auto keyVectorBuffer = std::make_unique<velox::StringVectorBuffer>(
+        &keyVector, kInitialSortKeyBufferSize_, kMaxSortKeyBufferSize_);
+    for (size_t row = 0; row < batchSize; ++row) {
+      binarySortableSerializer_->serialize(from + row, keyVectorBuffer.get());
+      keyVectorBuffer->flushRow(row);
+    }
+  }
+
+  // TODO: Dynamically set the buffer size based on encoded key size estimation.
+  static constexpr size_t kInitialSortKeyBufferSize_ = 1 << 16; // 64 KB;
+  static constexpr size_t kMaxSortKeyBufferSize_ = 1 << 20; // 1 MB;
+
   const uint32_t numPartitions_;
   const RowTypePtr serializedRowType_;
   const std::vector<column_index_t> keyChannels_;
   const std::unique_ptr<core::PartitionFunction> partitionFunction_;
   const bool replicateNullsAndAny_;
+  const std::optional<std::vector<velox::core::SortOrder>> sortingOrders_;
+  const std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>>
+      sortingKeys_;
+  const bool sorted_;
   bool replicatedAny_{false};
   std::vector<column_index_t> serializedColumnIndices_;
   // Holder for partitionVector and replicateVector.
   RowVectorPtr output_;
 
   std::unique_ptr<velox::row::CompactRow> compactRow_;
+  std::unique_ptr<BinarySortableSerializer> binarySortableSerializer_;
   // Decoded 'keyChannels_' columns.
   std::vector<velox::DecodedVector> decodedVectors_;
   // Reusable vector for storing partition id for each input row.
@@ -373,12 +456,28 @@ folly::dynamic PartitionAndSerializeNode::serialize() const {
   obj["sources"] = ISerializable::serialize(sources_);
   obj["replicateNullsAndAny"] = replicateNullsAndAny_;
   obj["partitionFunctionSpec"] = partitionFunctionSpec_->serialize();
+  if (sortingOrders_) {
+    obj["sortingOrders"] = serializeSortingOrders(sortingOrders_.value());
+  }
+  if (sortingKeys_) {
+    obj["sortingKeys"] = ISerializable::serialize(sortingKeys_.value());
+  }
   return obj;
 }
 
 velox::core::PlanNodePtr PartitionAndSerializeNode::create(
     const folly::dynamic& obj,
     void* context) {
+  std::optional<std::vector<velox::core::SortOrder>> sortingOrders =
+      std::nullopt;
+  if (obj.count("sortingOrders")) {
+    sortingOrders = deserializeSortingOrders(obj["sortingOrders"]);
+  }
+  std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>> sortingKeys =
+      std::nullopt;
+  if (obj.count("sortingKeys")) {
+    sortingKeys = deserializeFields(obj["sortingKeys"], context);
+  }
   return std::make_shared<PartitionAndSerializeNode>(
       deserializePlanNodeId(obj),
       ISerializable::deserialize<std::vector<velox::core::ITypedExpr>>(
@@ -389,6 +488,8 @@ velox::core::PlanNodePtr PartitionAndSerializeNode::create(
           obj["sources"], context)[0],
       obj["replicateNullsAndAny"].asBool(),
       ISerializable::deserialize<velox::core::PartitionFunctionSpec>(
-          obj["partitionFunctionSpec"], context));
+          obj["partitionFunctionSpec"], context),
+      sortingOrders,
+      sortingKeys);
 }
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -23,7 +23,8 @@ class ShuffleWriter {
   virtual ~ShuffleWriter() = default;
 
   /// Write to the shuffle one row at a time.
-  virtual void collect(int32_t partition, std::string_view data) = 0;
+  virtual void
+  collect(int32_t partition, std::string_view key, std::string_view data) = 0;
 
   /// Tell the shuffle system the writer is done.
   /// @param success set to false to indicate aborted client.

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
@@ -27,8 +27,15 @@ std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)>
 addPartitionAndSerializeNode(
     uint32_t numPartitions,
     bool replicateNullsAndAny,
-    const std::vector<std::string>& serializedColumns) {
-  return [numPartitions, &serializedColumns, replicateNullsAndAny](
+    const std::vector<std::string>& serializedColumns,
+    const std::optional<std::vector<velox::core::SortOrder>>& sortOrders,
+    const std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>>&
+        fields) {
+  return [numPartitions,
+          &serializedColumns,
+          replicateNullsAndAny,
+          &sortOrders,
+          &fields](
              core::PlanNodeId nodeId,
              core::PlanNodePtr source) -> core::PlanNodePtr {
     std::vector<core::TypedExprPtr> keys{
@@ -53,7 +60,9 @@ addPartitionAndSerializeNode(
         std::move(source),
         replicateNullsAndAny,
         std::make_shared<exec::HashPartitionFunctionSpec>(
-            inputType, exec::toChannels(inputType, keys)));
+            inputType, exec::toChannels(inputType, keys)),
+        sortOrders,
+        fields);
   };
 }
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
@@ -25,7 +25,11 @@ std::function<
 addPartitionAndSerializeNode(
     uint32_t numPartitions,
     bool replicateNullsAndAny,
-    const std::vector<std::string>& serializedColumns = {});
+    const std::vector<std::string>& serializedColumns = {},
+    const std::optional<std::vector<velox::core::SortOrder>>& sortOrders =
+        std::nullopt,
+    const std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>>&
+        fields = std::nullopt);
 
 std::function<
     velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -57,20 +57,49 @@ struct TestShuffleInfo {
   }
 };
 
+int lexicographicalCompare(const BufferPtr& key1, const BufferPtr& key2) {
+  const char* data1 = static_cast<const char*>(key1->as<void>());
+  const char* data2 = static_cast<const char*>(key2->as<void>());
+  const size_t size1 = key1->size();
+  const size_t size2 = key2->size();
+  bool lessThan =
+      std::lexicographical_compare(data1, data1 + size1, data2, data2 + size2);
+
+  bool equal = std::equal(data1, data1 + size1, data2, data2 + size2);
+
+  return lessThan ? -1 : (equal ? 0 : 1);
+}
+
+std::vector<int> getSortOrder(const std::vector<BufferPtr>& keys) {
+  std::vector<int> order(keys.size());
+  std::iota(order.begin(), order.end(), 0); // Fill with 0, 1, 2, ..., n-1
+
+  std::sort(order.begin(), order.end(), [&keys](int a, int b) {
+    return lexicographicalCompare(keys[a], keys[b]) < 0;
+  });
+
+  return order;
+}
+
 class TestShuffleWriter : public ShuffleWriter {
  public:
   TestShuffleWriter(
       memory::MemoryPool* pool,
       uint32_t numPartitions,
-      uint32_t maxBytesPerPartition)
+      uint32_t maxBytesPerPartition,
+      uint32_t maxKeyBytes = 1024) // 1KB
       : pool_(pool),
         numPartitions_(numPartitions),
         maxBytesPerPartition_(maxBytesPerPartition),
+        maxKeyBytes_(maxKeyBytes),
         inProgressSizes_(numPartitions, 0),
         readyPartitions_(
+            std::make_shared<std::vector<std::vector<BufferPtr>>>()),
+        serializedSortKeys_(
             std::make_shared<std::vector<std::vector<BufferPtr>>>()) {
     inProgressPartitions_.resize(numPartitions_);
     readyPartitions_->resize(numPartitions_);
+    serializedSortKeys_->resize(numPartitions_);
   }
 
   void initialize(velox::memory::MemoryPool* pool) {
@@ -79,7 +108,8 @@ class TestShuffleWriter : public ShuffleWriter {
     }
   }
 
-  void collect(int32_t partition, std::string_view data) override {
+  void collect(int32_t partition, std::string_view key, std::string_view data)
+      override {
     using TRowSize = uint32_t;
 
     TestValue::adjust(
@@ -112,6 +142,13 @@ class TestShuffleWriter : public ShuffleWriter {
     ::memcpy(rawBuffer + sizeof(TRowSize), data.data(), rowSize);
 
     inProgressSizes_[partition] += size;
+
+    if (!key.empty()) {
+      auto keyBuffer = AlignedBuffer::allocate<char>(maxKeyBytes_, pool_);
+      auto* rawKeyBuffer = keyBuffer->asMutable<char>();
+      ::memcpy(rawKeyBuffer, key.data(), key.size());
+      serializedSortKeys_->at(partition).emplace_back(std::move(keyBuffer));
+    }
   }
 
   void noMoreData(bool success) override {
@@ -135,6 +172,10 @@ class TestShuffleWriter : public ShuffleWriter {
 
   std::shared_ptr<std::vector<std::vector<BufferPtr>>>& readyPartitions() {
     return readyPartitions_;
+  }
+
+  std::shared_ptr<std::vector<std::vector<BufferPtr>>>& serializedSortKeys() {
+    return serializedSortKeys_;
   }
 
   static void reset() {
@@ -166,6 +207,7 @@ class TestShuffleWriter : public ShuffleWriter {
   memory::MemoryPool* pool_{nullptr};
   const uint32_t numPartitions_;
   const uint32_t maxBytesPerPartition_;
+  const uint32_t maxKeyBytes_;
 
   /// Indexed by partition number. Each element represents currently being
   /// accumulated buffer by shuffler for a certain partition. Internal layout:
@@ -176,6 +218,7 @@ class TestShuffleWriter : public ShuffleWriter {
   /// inProgressPartitions_
   std::vector<size_t> inProgressSizes_;
   std::shared_ptr<std::vector<std::vector<BufferPtr>>> readyPartitions_;
+  std::shared_ptr<std::vector<std::vector<BufferPtr>>> serializedSortKeys_;
 };
 
 class TestShuffleReader : public ShuffleReader {
@@ -336,9 +379,10 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
   std::shared_ptr<exec::Task> makeTask(
       const std::string& taskId,
       core::PlanNodePtr planNode,
-      int destination) {
+      int destination,
+      core::QueryConfig&& queryConfig) {
     auto queryCtx =
-        core::QueryCtx::create(executor_.get(), core::QueryConfig({}));
+        core::QueryCtx::create(executor_.get(), std::move(queryConfig));
     core::PlanFragment planFragment{planNode};
     return exec::Task::create(
         taskId,
@@ -352,7 +396,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
       const RowVectorPtr& serializedResult,
       const RowTypePtr& rowType) {
     auto serializedData =
-        serializedResult->childAt(1)->as<FlatVector<StringView>>();
+        serializedResult->childAt(2)->as<FlatVector<StringView>>();
     auto* rawValues = serializedData->rawValues();
 
     std::vector<std::string_view> rows;
@@ -400,7 +444,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
 
     // Verify 'replicate' flags.
     if (replicateNullsAndAny) {
-      velox::test::assertEqualVectors(results->childAt(2), expectedReplicate);
+      velox::test::assertEqualVectors(results->childAt(3), expectedReplicate);
     }
   }
 
@@ -466,7 +510,13 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
       size_t numPartitions,
       size_t numMapDrivers,
       const std::vector<RowVectorPtr>& data,
-      uint64_t backgroundCpuTimeNanos = 0) {
+      uint64_t backgroundCpuTimeNanos = 0,
+      const std::optional<std::vector<velox::core::SortOrder>>& sortOrders =
+          std::nullopt,
+      const std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>>&
+          fields = std::nullopt,
+      const std::optional<std::vector<std::vector<int>>>& expectedOrdering = {},
+      core::QueryConfig&& queryConfig = core::QueryConfig({})) {
     // Register new shuffle related operators.
     exec::Operator::registerOperator(
         std::make_unique<PartitionAndSerializeTranslator>());
@@ -482,14 +532,15 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
         exec::test::PlanBuilder()
             .values(data, true)
             .addNode(addPartitionAndSerializeNode(
-                numPartitions, replicateNullsAndAny))
+                numPartitions, replicateNullsAndAny, {}, sortOrders, fields))
             .localPartition(std::vector<std::string>{})
             .addNode(addShuffleWriteNode(
                 numPartitions, shuffleName, serializedShuffleWriteInfo))
             .planNode();
 
     auto writerTaskId = makeTaskId("leaf", 0);
-    auto writerTask = makeTask(writerTaskId, writerPlan, 0);
+    auto writerTask =
+        makeTask(writerTaskId, writerPlan, 0, std::move(queryConfig));
     writerTask->start(numMapDrivers);
 
     ASSERT_TRUE(exec::test::waitForTaskCompletion(writerTask.get(), 5'000'000));
@@ -578,6 +629,25 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     } else {
       velox::exec::test::assertEqualResults(
           expectedOutputVectors, outputVectors);
+    }
+
+    auto shuffleWriter = TestShuffleWriter::getInstance();
+    if (shuffleWriter) {
+      const auto serializedSortKeys = shuffleWriter->serializedSortKeys();
+      if (sortOrders && fields) {
+        for (auto i = 0; i < numPartitions; ++i) {
+          const auto resultSortingOrder =
+              getSortOrder((*serializedSortKeys)[i]);
+          EXPECT_EQ(expectedOrdering.value()[i], resultSortingOrder);
+        }
+      } else {
+        for (auto i = 0; i < numPartitions; ++i) {
+          EXPECT_TRUE((*serializedSortKeys)[i].empty());
+        }
+      }
+    } else {
+      // Sorted shuffle is not supported with local shuffle.
+      EXPECT_FALSE(sortOrders && fields);
     }
   }
 
@@ -682,7 +752,8 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
       vector_size_t outputRowLimit,
       size_t outputSizeLimit,
       vector_size_t inputRows,
-      size_t expectedOutputCount) {
+      size_t expectedOutputCount,
+      bool sorted = false) {
     VectorFuzzer::Options opts;
     opts.vectorSize = 10;
     opts.nullRatio = 0;
@@ -695,14 +766,37 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     VectorFuzzer fuzzer(opts, pool_.get(), seed);
     // Create a deeply nested row, such that each row exceeds the output batch
     // limit.
-    auto data = makeRowVector({fuzzer.fuzzMap(
-        fuzzer.fuzzConstant(VARCHAR(), 100),
-        fuzzer.fuzzArray(fuzzer.fuzzArray(fuzzer.fuzzFlat(DOUBLE()), 100), 100),
-        inputRows)});
+    RowVectorPtr data;
+    std::optional<std::vector<velox::core::SortOrder>> ordering = std::nullopt;
+    std::optional<
+        std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>>>
+        fields = std::nullopt;
+
+    if (sorted) {
+      data = makeRowVector(
+          {fuzzer.fuzzConstant(INTEGER(), inputRows),
+           fuzzer.fuzzMap(
+               fuzzer.fuzzConstant(VARCHAR(), 100),
+               fuzzer.fuzzArray(
+                   fuzzer.fuzzArray(fuzzer.fuzzFlat(DOUBLE()), 100), 100),
+               inputRows)});
+      ordering = {velox::core::SortOrder(velox::core::kAscNullsFirst)};
+      fields =
+          std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>>{
+              std::make_shared<const velox::core::FieldAccessTypedExpr>(
+                  INTEGER(), "c0")};
+    } else {
+      data = makeRowVector({fuzzer.fuzzMap(
+          fuzzer.fuzzConstant(VARCHAR(), 100),
+          fuzzer.fuzzArray(
+              fuzzer.fuzzArray(fuzzer.fuzzFlat(DOUBLE()), 100), 100),
+          inputRows)});
+    }
 
     auto plan = exec::test::PlanBuilder()
                     .values({data}, false)
-                    .addNode(addPartitionAndSerializeNode(2, true))
+                    .addNode(addPartitionAndSerializeNode(
+                        2, true, {}, ordering, fields))
                     .planNode();
 
     auto properties = std::unordered_map<std::string, std::string>{
@@ -843,7 +937,7 @@ TEST_F(UnsafeRowShuffleTest, endToEnd) {
 
   // Make sure all previously registered exchange factory are gone.
   velox::exec::ExchangeSource::factories().clear();
-  const std::string shuffleInfo = testShuffleInfo(numPartitions, 1 << 20);
+  auto shuffleInfo = testShuffleInfo(numPartitions, 1 << 20);
   TestShuffleWriter::createWriter(shuffleInfo, pool());
   registerExchangeSource(std::string(TestShuffleFactory::kShuffleName));
   runShuffleTest(
@@ -855,6 +949,103 @@ TEST_F(UnsafeRowShuffleTest, endToEnd) {
       numMapDrivers,
       {data},
       kFakeBackgroundCpuTimeMs * Timestamp::kNanosecondsInMillisecond);
+  TestShuffleWriter::reset();
+}
+
+TEST_F(UnsafeRowShuffleTest, endToEndWithSortedShuffle) {
+  size_t numPartitions = 2;
+  size_t numMapDrivers = 1;
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({0, 0, 1, 1, 1, 1}), // partition key
+      makeFlatVector<int64_t>({30, 10, 20, 50, 40, 60}), // sorting column
+  });
+
+  auto expectedSortingOrder = {
+      std::vector<int>{1, 0}, // partition key 0
+      std::vector<int>{0, 2, 1, 3} // partition key 1
+  };
+
+  auto ordering = {velox::core::SortOrder(velox::core::kAscNullsFirst)};
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+      velox::BIGINT(), fmt::format("c{}", 1)));
+
+  // Make sure all previously registered exchange factory are gone.
+  velox::exec::ExchangeSource::factories().clear();
+  std::string shuffleInfo = testShuffleInfo(numPartitions, 1 << 20);
+  TestShuffleWriter::createWriter(shuffleInfo, pool());
+  registerExchangeSource(std::string(TestShuffleFactory::kShuffleName));
+  runShuffleTest(
+      std::string(TestShuffleFactory::kShuffleName),
+      shuffleInfo,
+      [&](auto /*partition*/) { return shuffleInfo; },
+      false,
+      numPartitions,
+      numMapDrivers,
+      {data},
+      kFakeBackgroundCpuTimeMs * Timestamp::kNanosecondsInMillisecond,
+      ordering,
+      fields,
+      expectedSortingOrder);
+  TestShuffleWriter::reset();
+}
+
+TEST_F(UnsafeRowShuffleTest, endToEndWithSortedShuffleRowLimit) {
+  size_t numPartitions = 3;
+  size_t numMapDrivers = 1;
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({0, 0, 1, 1, 1, 1, 2, 2, 2}), // partition key
+      makeFlatVector<StringView>(
+          {"key3",
+           "key1",
+           "key22",
+           "key55",
+           "key44",
+           "key66",
+           "key111",
+           "key222",
+           "key333"}) // sorting column
+  });
+
+  auto expectedSortingOrder = {
+      std::vector<int>{1, 0}, // partition key 0
+      std::vector<int>{0, 2, 1, 3}, // partition key 1
+      std::vector<int>{0, 1, 2} // partition key 2
+  };
+
+  auto ordering = {velox::core::SortOrder(velox::core::kAscNullsFirst)};
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields;
+  fields.push_back(std::make_shared<const velox::core::FieldAccessTypedExpr>(
+      velox::VARCHAR(), fmt::format("c{}", 1)));
+
+  // Make sure all previously registered exchange factory are gone.
+  velox::exec::ExchangeSource::factories().clear();
+  std::string shuffleInfo = testShuffleInfo(numPartitions, 1 << 20);
+  TestShuffleWriter::createWriter(shuffleInfo, pool());
+  registerExchangeSource(std::string(TestShuffleFactory::kShuffleName));
+
+  auto properties = std::unordered_map<std::string, std::string>{
+      {core::QueryConfig::kPreferredOutputBatchBytes,
+       std::to_string(1'000'000'000)},
+      {core::QueryConfig::kPreferredOutputBatchRows, std::to_string(3)}};
+
+  auto queryConfig = core::QueryConfig(properties);
+
+  runShuffleTest(
+      std::string(TestShuffleFactory::kShuffleName),
+      shuffleInfo,
+      [&](auto /*partition*/) { return shuffleInfo; },
+      false,
+      numPartitions,
+      numMapDrivers,
+      {data},
+      kFakeBackgroundCpuTimeMs * Timestamp::kNanosecondsInMillisecond,
+      ordering,
+      fields,
+      expectedSortingOrder,
+      std::move(queryConfig));
   TestShuffleWriter::reset();
 }
 
@@ -1029,6 +1220,10 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOutputRowLimit) {
   partitionAndSerializeWithThresholds(5, 1'000'000'000, 10, 2);
 }
 
+TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOutputRowLimitWithSort) {
+  partitionAndSerializeWithThresholds(5, 1'000'000'000, 10, 2, true);
+}
+
 TEST_F(UnsafeRowShuffleTest, partitionAndSerializeNoLimit) {
   partitionAndSerializeWithThresholds(1'000, 1'000'000'000, 5, 1);
 }
@@ -1132,7 +1327,7 @@ TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
   ASSERT_EQ(
       plan->toString(true, false),
       "-- ShuffleWrite[3][4, test-shuffle]"
-      " -> partition:INTEGER, data:VARBINARY\n");
+      " -> partition:INTEGER, key:VARBINARY, data:VARBINARY\n");
 }
 
 TEST_F(UnsafeRowShuffleTest, partitionAndSerializeToString) {
@@ -1150,7 +1345,7 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeToString) {
   ASSERT_EQ(
       plan->toString(true, false),
       "-- PartitionAndSerialize[1][(c0) 4 HASH(c0) ROW<c0:INTEGER,c1:BIGINT>]"
-      " -> partition:INTEGER, data:VARBINARY\n");
+      " -> partition:INTEGER, key:VARBINARY, data:VARBINARY\n");
 
   plan = exec::test::PlanBuilder()
              .values({data}, true)
@@ -1161,7 +1356,7 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeToString) {
   ASSERT_EQ(
       plan->toString(true, false),
       "-- PartitionAndSerialize[1][(c0) 4 HASH(c0) ROW<c0:INTEGER,c1:BIGINT>]"
-      " -> partition:INTEGER, data:VARBINARY, replicate:BOOLEAN\n");
+      " -> partition:INTEGER, key:VARBINARY, data:VARBINARY, replicate:BOOLEAN\n");
 }
 
 class DummyShuffleInterfaceFactory : public ShuffleInterfaceFactory {


### PR DESCRIPTION
Summary:
Add supported for sort key in PartitionAndSerialize operator. 
Use BinarySortableSerializer to serialize the sort key when `sortingOrders_` and `sortingKeys_` are both provided. 

Reviewed By: xiaoxmeng

Differential Revision: D72727156

### RELEASE NOTES
```

== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add supported for sort in PartitionAndSerialize operator

```

