### PR TITLE
Add view text hash info to accessControlReferences

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -32,13 +32,11 @@ import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.SessionSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
-import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.AnalyzerOptions;
 import com.facebook.presto.spi.analyzer.QueryPreparerProvider;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.facebook.presto.spi.resourceGroups.SelectionCriteria;
 import com.facebook.presto.spi.security.AccessControl;
-import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.sql.analyzer.QueryPreparerProviderManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.AbstractFuture;
@@ -273,18 +271,6 @@ public class DispatchManager
 
             // decode session
             sessionBuilder = sessionSupplier.createSessionBuilder(queryId, sessionContext, warningCollectorFactory);
-
-            AccessControlContext accessControlContext = new AccessControlContext(
-                    queryId,
-                    Optional.ofNullable(sessionContext.getClientInfo()),
-                    sessionContext.getClientTags(),
-                    Optional.ofNullable(sessionContext.getSource()),
-                    WarningCollector.NOOP,
-                    sessionContext.getRuntimeStats(),
-                    Optional.empty(),
-                    Optional.ofNullable(sessionContext.getCatalog()),
-                    Optional.ofNullable(sessionContext.getSchema()));
-
             session = sessionBuilder.build();
 
             // prepare query

--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -22,8 +22,10 @@ import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.AccessControl;
@@ -182,12 +184,12 @@ public class AccessControlManager
     }
 
     @Override
-    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
+    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(query, "query is null");
 
-        authenticationCheck(() -> systemAccessControl.get().checkQueryIntegrity(identity, context, query));
+        authenticationCheck(() -> systemAccessControl.get().checkQueryIntegrity(identity, context, query, viewDefinitions, materializedViewDefinitions));
     }
 
     @Override
@@ -945,7 +947,7 @@ public class AccessControlManager
             implements SystemAccessControl
     {
         @Override
-        public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
+        public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
         {
             throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.security;
 
 import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
@@ -64,7 +67,7 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
+    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
     {
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -15,13 +15,16 @@ package com.facebook.presto.security;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.plugin.base.security.ForwardingSystemAccessControl;
 import com.facebook.presto.plugin.base.security.SchemaAccessControlRule;
 import com.facebook.presto.security.CatalogAccessControlRule.AccessMode;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
@@ -198,7 +201,7 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
+    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
     {
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
@@ -14,8 +14,11 @@
 package com.facebook.presto.security;
 
 import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.spi.CatalogSchemaTableName;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.SystemAccessControl;
@@ -60,7 +63,7 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
-    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
+    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
     {
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1530,6 +1530,8 @@ class StatementAnalyzer
             }
             ViewDefinition view = optionalView.get();
 
+            analysis.getAccessControlReferences().addViewDefinitionReference(name, view);
+
             Query query = parseView(view.getOriginalSql(), name, table);
 
             analysis.registerNamedQuery(table, query, true);
@@ -1567,6 +1569,8 @@ class StatementAnalyzer
                 MaterializedViewDefinition materializedViewDefinition)
         {
             MaterializedViewPlanValidator.validate((Query) sqlParser.createStatement(materializedViewDefinition.getOriginalSql(), createParsingOptions(session, warningCollector)));
+
+            analysis.getAccessControlReferences().addMaterializedViewDefinitionReference(materializedViewName, materializedViewDefinition);
 
             analysis.registerMaterializedViewForAnalysis(materializedViewName, materializedView, materializedViewDefinition.getOriginalSql());
             String newSql = getMaterializedViewSQL(materializedView, materializedViewName, materializedViewDefinition, scope);

--- a/presto-main-base/src/main/java/com/facebook/presto/util/AnalyzerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/util/AnalyzerUtil.java
@@ -16,6 +16,7 @@ package com.facebook.presto.util;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
@@ -25,6 +26,7 @@ import com.facebook.presto.spi.analyzer.AnalyzerContext;
 import com.facebook.presto.spi.analyzer.AnalyzerOptions;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.QueryAnalyzer;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.security.AccessControlContext;
@@ -32,6 +34,7 @@ import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.sql.analyzer.BuiltInQueryAnalyzer;
 import com.facebook.presto.sql.parser.ParsingOptions;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.getWarningHandlingLevel;
@@ -114,7 +117,10 @@ public class AnalyzerUtil
             AccessControl queryAccessControl = queryAccessControlInfo.getAccessControl();
             Identity identity = queryAccessControlInfo.getIdentity();
             AccessControlContext queryAccessControlContext = queryAccessControlInfo.getAccessControlContext();
-            queryAccessControl.checkQueryIntegrity(identity, queryAccessControlContext, query);
+            Map<QualifiedObjectName, ViewDefinition> viewDefinitionMap = accessControlReferences.getViewDefinitions();
+            Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitionMap = accessControlReferences.getMaterializedViewDefinitions();
+
+            queryAccessControl.checkQueryIntegrity(identity, queryAccessControlContext, query, viewDefinitionMap, materializedViewDefinitionMap);
         }
     }
 

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.plugin.base.security;
 
 import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.AuthorizedIdentity;
 import com.facebook.presto.spi.security.Identity;
@@ -66,9 +69,9 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
-    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
+    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
     {
-        delegate().checkQueryIntegrity(identity, context, query);
+        delegate().checkQueryIntegrity(identity, context, query, viewDefinitions, materializedViewDefinitions);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlReferences.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/analyzer/AccessControlReferences.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.analyzer;
 
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.Subfield;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -29,11 +30,15 @@ public class AccessControlReferences
     private final Map<AccessControlRole, Set<AccessControlInfoForTable>> tableReferences;
     private final Map<AccessControlInfo, Map<QualifiedObjectName, Set<Subfield>>> tableColumnAndSubfieldReferencesForAccessControl;
     private AccessControlInfo queryAccessControlInfo;
+    private final Map<QualifiedObjectName, ViewDefinition> viewDefinitions;
+    private final Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions;
 
     public AccessControlReferences()
     {
         tableReferences = new LinkedHashMap<>();
         tableColumnAndSubfieldReferencesForAccessControl = new LinkedHashMap<>();
+        viewDefinitions = new LinkedHashMap<>();
+        materializedViewDefinitions = new LinkedHashMap<>();
     }
 
     public Map<AccessControlRole, Set<AccessControlInfoForTable>> getTableReferences()
@@ -66,5 +71,25 @@ public class AccessControlReferences
     public AccessControlInfo getQueryAccessControlInfo()
     {
         return queryAccessControlInfo;
+    }
+
+    public void addViewDefinitionReference(QualifiedObjectName viewDefinitionName, ViewDefinition viewDefinition)
+    {
+        viewDefinitions.put(viewDefinitionName, viewDefinition);
+    }
+
+    public void addMaterializedViewDefinitionReference(QualifiedObjectName viewDefinitionName, MaterializedViewDefinition materializedViewDefinition)
+    {
+        materializedViewDefinitions.put(viewDefinitionName, materializedViewDefinition);
+    }
+
+    public Map<QualifiedObjectName, ViewDefinition> getViewDefinitions()
+    {
+        return unmodifiableMap(new LinkedHashMap<>(viewDefinitions));
+    }
+
+    public Map<QualifiedObjectName, MaterializedViewDefinition> getMaterializedViewDefinitions()
+    {
+        return unmodifiableMap(new LinkedHashMap<>(materializedViewDefinitions));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControl.java
@@ -18,7 +18,9 @@ import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 
 import java.security.Principal;
 import java.security.cert.X509Certificate;
@@ -46,7 +48,7 @@ public interface AccessControl
      * Check if the query is unexpectedly modified using the credentials passed in the identity.
      * @throws com.facebook.presto.spi.security.AccessDeniedException if query is modified.
      */
-    void checkQueryIntegrity(Identity identity, AccessControlContext context, String query);
+    void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions);
 
     /**
      * Filter the list of catalogs to those visible to the identity.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AllowAllAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AllowAllAccessControl.java
@@ -17,7 +17,9 @@ import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 
 import java.security.Principal;
 import java.util.Map;
@@ -33,7 +35,7 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
+    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
     {
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/DenyAllAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/DenyAllAccessControl.java
@@ -17,7 +17,9 @@ import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 
 import java.security.Principal;
 import java.util.Collections;
@@ -77,7 +79,7 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query)
+    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
     {
         denyQueryIntegrityCheck();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.spi.security;
 
 import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.spi.CatalogSchemaTableName;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 
 import java.security.Principal;
 import java.security.cert.X509Certificate;
@@ -72,7 +75,7 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if query is modified.
      */
-    void checkQueryIntegrity(Identity identity, AccessControlContext context, String query);
+    void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions);
 
     /**
      * Check if identity is allowed to set the specified system property.


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
In addition to the raw SQL string that the user submitted, checkQueryIntegrity needs to have view definitions used inside the of the query to validate against the credentials passed in through the identity. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
This is to address the security vulnerability if a view definition gets changed in between when the approved credential was generated and when the query begins executing.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
- Add extra view text fields to AccessControlReferences
- change checkQueryintegrity API to take in view text
## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add view definitions from Analyzer phase to perform full integrity check on query credentials.
* Change checkQueryIntegrity function signature in AccessControl interface to pass in view definitions as params.

