### PR TITLE
Release action fixes and improvements

### DIFF
--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -30,15 +30,10 @@ jobs:
       contents: write
 
     steps:
-      - name: Check for master branch
-        if: ${{ github.ref != 'refs/heads/master' }}
-        run: echo "Invalid branch. This action can only be run on the master branch." && exit 1
-
       - name: Checkout presto source
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PRESTODB_CI_TOKEN }}
-          ref: master
           show-progress: false
           fetch-depth: 5
 
@@ -77,7 +72,7 @@ jobs:
             -DdevelopmentVersion=${{ env.PRESTO_RELEASE_VERSION }} \
             -DreleaseVersion=${{ env.PRESTO_RELEASE_VERSION }}
           grep -m 2 "<version>" pom.xml
-          echo "commits on master branch"
+          echo "commits on branch ${{ github.ref_name }}"
           git ls -5
 
       - name: Push release tag, branch and commits
@@ -93,15 +88,15 @@ jobs:
           echo -e "\nPushed release tag to: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.PRESTO_RELEASE_VERSION }}"
           echo "Pushed release branch to: ${{ github.server_url }}/${{ github.repository }}/tree/release-${{ env.PRESTO_RELEASE_VERSION }}"
 
-          echo "Pushing master branch"
-          git checkout master
-          echo "commits on master branch"
+          echo "Pushing to branch ${{ github.ref_name }}"
+          git checkout ${{ github.ref_name }}
+          echo "commits on branch ${{ github.ref_name }}"
           git ls -5
-          git push origin master
+          git push origin ${{ github.ref_name }}
 
   prepare-release-notes:
     needs: prepare-release-branch
-    if: ${{ inputs.prepare_release_notes && always() && (needs.prepare-release-branch.result == 'success' || !inputs.prepare_release) }}
+    if: (!failure() && !cancelled()) && github.event.inputs.prepare_release_notes == 'true'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -111,7 +106,6 @@ jobs:
       - name: Checkout presto source
         uses: actions/checkout@v4
         with:
-          ref: master
           show-progress: false
 
       - name: Set up JDK $${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}

--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -15,7 +15,7 @@ on:
         required: false
 
 env:
-  JAVA_VERSION: '11'
+  JAVA_VERSION: '17'
   JAVA_DISTRIBUTION: 'temurin'
 
 jobs:

--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -15,8 +15,11 @@ on:
         required: false
 
 env:
-  JAVA_VERSION: '17'
-  JAVA_DISTRIBUTION: 'temurin'
+  JAVA_VERSION: ${{ vars.JAVA_VERSION || '11' }}
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
+  MAVEN_OPTS: ${{ vars.MAVEN_OPTS }}
+  GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
+  GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
 
 jobs:
   prepare-release-branch:
@@ -39,7 +42,7 @@ jobs:
           show-progress: false
           fetch-depth: 5
 
-      - name: Set up JDK
+      - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
@@ -48,8 +51,8 @@ jobs:
       - name: Configure git
         run: |
           git config --global --add safe.directory ${{github.workspace}}
-          git config --global user.email "ci@lists.prestodb.io"
-          git config --global user.name "prestodb-ci"
+          git config --global user.email "${{ env.GIT_CI_EMAIL }}"
+          git config --global user.name "${{ env.GIT_CI_USER }}"
           git config --global alias.ls 'log --pretty=format:"%cd %h %ce: %s" --date=short --no-merges'
           git config pull.rebase false
 
@@ -111,7 +114,7 @@ jobs:
           ref: master
           show-progress: false
 
-      - name: Set up JDK
+      - name: Set up JDK $${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
@@ -120,8 +123,8 @@ jobs:
       - name: Configure git
         run: |
           git config --global --add safe.directory ${{github.workspace}}
-          git config --global user.email "ci@lists.prestodb.io"
-          git config --global user.name "prestodb-ci"
+          git config --global user.email "${{ env.GIT_CI_EMAIL }}"
+          git config --global user.name "${{ env.GIT_CI_USER }}"
           git config pull.rebase false
 
       - name: Add git upstream

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -50,12 +50,16 @@ on:
         required: false
 
 env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRIBUTION: 'temurin'
   DOCKER_REPO: ${{ github.repository }}
   ORG_NAME: ${{ github.repository_owner }}
   IMAGE_NAME: presto-native
   RELEASE_BRANCH: release-${{ inputs.RELEASE_VERSION }}
   RELEASE_TAG: ${{ inputs.RELEASE_VERSION }}
   RELEASE_NOTES_COMMIT: ${{ inputs.release-notes-commit }}
+  GIT_USER_NAME: prestodb-ci
+  GIT_USER_EMAIL: ci@lists.prestodb.io
 
 jobs:
   publish-release-tag:
@@ -63,12 +67,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - name: Validate release notes commit
-        if: ${{ github.event.inputs.release-notes-commit == '' }}
-        run: |
-          echo "Error: release-notes-commit is required when publish_release_tag is true"
-          exit 1
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -80,11 +78,12 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --global user.email "ci@lists.prestodb.io"
-          git config --global user.name "prestodb-ci"
+          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+          git config --global user.name "${{ env.GIT_USER_NAME }}"
           git config pull.rebase false
 
       - name: Cherry-pick release notes
+        if: ${{ github.event.inputs.release-notes-commit != '' }}
         run: |
           git cherry-pick ${{ env.RELEASE_NOTES_COMMIT }}
 
@@ -112,11 +111,11 @@ jobs:
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
     steps:
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
           overwrite-settings: true
           gpg-private-key: ${{ secrets.GPG_SECRET }}
 
@@ -135,8 +134,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --global user.email "ci@lists.prestodb.io"
-          git config --global user.name "prestodb-ci"
+          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+          git config --global user.name "${{ env.GIT_USER_NAME }}"
           git config pull.rebase false
 
       - name: Create Maven Settings
@@ -385,8 +384,8 @@ jobs:
         run: |
           cd ${{ github.workspace }}/prestodb.github.io
           git config --global --add safe.directory ${{ github.workspace }}/prestodb.github.io
-          git config --global user.email "ci@lists.prestodb.io"
-          git config --global user.name "prestodb-ci"
+          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+          git config --global user.name "${{ env.GIT_USER_NAME }}"
           git config --global alias.ls 'log --pretty=format:"%cd %h %ce: %s" --date=short --no-merges'
           git ls -5
 

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -50,16 +50,17 @@ on:
         required: false
 
 env:
-  JAVA_VERSION: '17'
-  JAVA_DISTRIBUTION: 'temurin'
+  JAVA_VERSION: ${{ vars.JAVA_VERSION || '11' }}
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
+  MAVEN_OPTS: ${{ vars.MAVEN_OPTS || '' }}
   DOCKER_REPO: ${{ github.repository }}
   ORG_NAME: ${{ github.repository_owner }}
   IMAGE_NAME: presto-native
   RELEASE_BRANCH: release-${{ inputs.RELEASE_VERSION }}
   RELEASE_TAG: ${{ inputs.RELEASE_VERSION }}
   RELEASE_NOTES_COMMIT: ${{ inputs.release-notes-commit }}
-  GIT_USER_NAME: prestodb-ci
-  GIT_USER_EMAIL: ci@lists.prestodb.io
+  GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
+  GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
 
 jobs:
   publish-release-tag:
@@ -78,8 +79,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
-          git config --global user.name "${{ env.GIT_USER_NAME }}"
+          git config --global user.email "${{ env.GIT_CI_EMAIL }}"
+          git config --global user.name "${{ env.GIT_CI_USER }}"
           git config pull.rebase false
 
       - name: Cherry-pick release notes
@@ -111,7 +112,7 @@ jobs:
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
     steps:
-      - name: Setup JDK 17
+      - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
@@ -134,8 +135,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
-          git config --global user.name "${{ env.GIT_USER_NAME }}"
+          git config --global user.email "${{ env.GIT_CI_EMAIL }}"
+          git config --global user.name "${{ env.GIT_CI_USER }}"
           git config pull.rebase false
 
       - name: Create Maven Settings
@@ -384,8 +385,8 @@ jobs:
         run: |
           cd ${{ github.workspace }}/prestodb.github.io
           git config --global --add safe.directory ${{ github.workspace }}/prestodb.github.io
-          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
-          git config --global user.name "${{ env.GIT_USER_NAME }}"
+          git config --global user.email "${{ env.GIT_CI_EMAIL }}"
+          git config --global user.name "${{ env.GIT_CI_USER }}"
           git config --global alias.ls 'log --pretty=format:"%cd %h %ce: %s" --date=short --no-merges'
           git ls -5
 


### PR DESCRIPTION
## Description

By the release 0.292, I noticed there are some issues

### Prepare release action 

1. the action may failed when creating release PR(not really failed, the PR created, but the command exit with non-zero code because it failed to parse the warnings)
2. CLA issue for the `prestodb-ci` account - **fixed by signing the CLA for prestodb-ci account**

### publish release action
1. When there are issues, the release-tag need to be reset manually after patch commit pushed into the release branch, the publish release tag can not re-run without reset release tag - **by allowing the commit empty, recreate the tag based on the release branch**
2. ~~There are 5 jobs in the release action, each job requires approval by the github action environment~~ (seems not possible)
3. Variables like java version/distribution, ci user/email can be centrialized with org level variables

### Patch release
Need action to create patch release when there are issues after publishing

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact

Presto stable and patch release

## Test Plan

In the test repos and next release

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

