### PR TITLE
[sidecar] Prevent coordinator crashing in non-sidecar enabled clusters by making sidecar plugin functionalities config driven

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -418,13 +418,6 @@ public class FunctionAndTypeManager
         servingTypeManagerParametricTypesSupplier.set(this::getServingTypeManagerParametricTypes);
     }
 
-    public void loadTypeManagers()
-    {
-        for (String typeManagerName : typeManagerFactories.keySet()) {
-            loadTypeManager(typeManagerName);
-        }
-    }
-
     public void addTypeManagerFactory(TypeManagerFactory factory)
     {
         if (typeManagerFactories.putIfAbsent(factory.getName(), factory) != null) {

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/SessionPropertyProviderConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/SessionPropertyProviderConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+
+public class SessionPropertyProviderConfig
+{
+    private File sessionPropertyProvidersConfigurationDir = new File("etc/session-property-providers/");
+
+    @NotNull
+    public File getSessionPropertyProvidersConfigurationDir()
+    {
+        return sessionPropertyProvidersConfigurationDir;
+    }
+
+    @Config("session-property-provider.config-dir")
+    public SessionPropertyProviderConfig setSessionPropertyProvidersConfigurationDir(File dir)
+    {
+        this.sessionPropertyProvidersConfigurationDir = dir;
+        return this;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StaticTypeManagerStore.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StaticTypeManagerStore.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.log.Logger;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.io.Files.getNameWithoutExtension;
+
+public class StaticTypeManagerStore
+{
+    private static final Logger log = Logger.get(StaticTypeManagerStore.class);
+    private static final String TYPE_MANAGER_NAME = "type-manager.name";
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final File configDir;
+    private final AtomicBoolean typeManagersLoading = new AtomicBoolean();
+
+    @Inject
+    public StaticTypeManagerStore(FunctionAndTypeManager functionAndTypeManager, StaticTypeManagerStoreConfig config)
+    {
+        this.functionAndTypeManager = functionAndTypeManager;
+        this.configDir = config.getTypeManagerConfigurationDir();
+    }
+
+    public void loadTypeManagers()
+            throws Exception
+    {
+        if (!typeManagersLoading.compareAndSet(false, true)) {
+            return;
+        }
+
+        for (File file : listFiles(configDir)) {
+            if (file.isFile() && file.getName().endsWith(".properties")) {
+                String catalogName = getNameWithoutExtension(file.getName());
+                Map<String, String> properties = loadProperties(file);
+                checkState(!isNullOrEmpty(properties.get(TYPE_MANAGER_NAME)),
+                        "Type manager configuration %s does not contain %s",
+                        file.getAbsoluteFile(),
+                        TYPE_MANAGER_NAME);
+                loadTypeManager(catalogName, properties);
+            }
+        }
+    }
+
+    public void loadTypeManagers(Map<String, Map<String, String>> catalogProperties)
+    {
+        catalogProperties.entrySet().stream()
+                .forEach(entry -> loadTypeManager(entry.getKey(), entry.getValue()));
+    }
+
+    private void loadTypeManager(String catalogName, Map<String, String> properties)
+    {
+        log.info("-- Loading %s type manager --", catalogName);
+        properties = new HashMap<>(properties);
+        String typeManagerName = properties.remove(TYPE_MANAGER_NAME);
+        checkState(!isNullOrEmpty(typeManagerName), "%s property must be present", TYPE_MANAGER_NAME);
+        functionAndTypeManager.loadTypeManager(typeManagerName);
+        log.info("-- Added type manager [%s] --", catalogName);
+    }
+
+    private static List<File> listFiles(File dir)
+    {
+        if (dir != null && dir.isDirectory()) {
+            File[] files = dir.listFiles();
+            if (files != null) {
+                return ImmutableList.copyOf(files);
+            }
+        }
+        return ImmutableList.of();
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StaticTypeManagerStoreConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StaticTypeManagerStoreConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+
+public class StaticTypeManagerStoreConfig
+{
+    private File typeManagerConfigurationDir = new File("etc/type-managers/");
+
+    @NotNull
+    public File getTypeManagerConfigurationDir()
+    {
+        return typeManagerConfigurationDir;
+    }
+
+    @Config("type-manager.config-dir")
+    public StaticTypeManagerStoreConfig setTypeManagerConfigurationDir(File dir)
+    {
+        this.typeManagerConfigurationDir = dir;
+        return this;
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestSessionPropertyProviderConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestSessionPropertyProviderConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestSessionPropertyProviderConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(SessionPropertyProviderConfig.class)
+                .setSessionPropertyProvidersConfigurationDir(new File("etc/session-property-providers")));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("session-property-provider.config-dir", "/foo")
+                .build();
+
+        SessionPropertyProviderConfig expected = new SessionPropertyProviderConfig()
+                .setSessionPropertyProvidersConfigurationDir(new File("/foo"));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestStaticTypeManagerStoreConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestStaticTypeManagerStoreConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestStaticTypeManagerStoreConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(StaticTypeManagerStoreConfig.class)
+                .setTypeManagerConfigurationDir(new File("etc/type-managers")));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("type-manager.config-dir", "/foo")
+                .build();
+
+        StaticTypeManagerStoreConfig expected = new StaticTypeManagerStoreConfig()
+                .setTypeManagerConfigurationDir(new File("/foo"));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -43,11 +43,11 @@ import com.facebook.presto.execution.warnings.WarningCollectorModule;
 import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.DiscoveryNodeManager;
-import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
+import com.facebook.presto.metadata.StaticTypeManagerStore;
 import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AccessControlModule;
@@ -175,6 +175,7 @@ public class PrestoServer
                     injector.getInstance(DriftServer.class));
 
             injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
+            injector.getInstance(StaticTypeManagerStore.class).loadTypeManagers();
             injector.getInstance(SessionPropertyDefaults.class).loadConfigurationManager();
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
             if (!serverConfig.isResourceManager()) {
@@ -191,7 +192,6 @@ public class PrestoServer
             injector.getInstance(NodeStatusNotificationManager.class).loadNodeStatusNotificationProvider();
             injector.getInstance(GracefulShutdownHandler.class).loadNodeStatusNotification();
             injector.getInstance(SessionPropertyManager.class).loadSessionPropertyProviders();
-            injector.getInstance(FunctionAndTypeManager.class).loadTypeManagers();
             PlanCheckerProviderManager planCheckerProviderManager = injector.getInstance(PlanCheckerProviderManager.class);
             InternalNodeManager nodeManager = injector.getInstance(DiscoveryNodeManager.class);
             NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -100,11 +100,14 @@ import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.metadata.SchemaPropertyManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.metadata.SessionPropertyProviderConfig;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticCatalogStoreConfig;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStoreConfig;
+import com.facebook.presto.metadata.StaticTypeManagerStore;
+import com.facebook.presto.metadata.StaticTypeManagerStoreConfig;
 import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.operator.ExchangeClientConfig;
@@ -644,6 +647,9 @@ public class ServerMainModule
         configBinder(binder).bindConfig(StaticCatalogStoreConfig.class);
         binder.bind(StaticFunctionNamespaceStore.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(StaticFunctionNamespaceStoreConfig.class);
+        binder.bind(StaticTypeManagerStore.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(StaticTypeManagerStoreConfig.class);
+        configBinder(binder).bindConfig(SessionPropertyProviderConfig.class);
         binder.bind(FunctionAndTypeManager.class).in(Scopes.SINGLETON);
         binder.bind(MetadataManager.class).in(Scopes.SINGLETON);
 

--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -267,6 +267,18 @@
                     </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <systemPropertyVariables>
+                        <PRESTO_SERVER>/root/project/build/debug/presto_cpp/main/presto_server</PRESTO_SERVER>
+                        <DATA_DIR>/tmp/velox</DATA_DIR>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/sessionpropertyproviders/NativeSystemSessionPropertyProvider.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/sessionpropertyproviders/NativeSystemSessionPropertyProvider.java
@@ -77,7 +77,7 @@ public class NativeSystemSessionPropertyProvider
         this.nativeSessionPropertiesJsonCodec = requireNonNull(nativeSessionPropertiesJsonCodec, "nativeSessionPropertiesJsonCodec is null");
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
-        this.httpClient = requireNonNull(httpClient, "typeManager is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
         requireNonNull(config, "config is null");
         this.memoizedSessionPropertiesSupplier =
                 Suppliers.memoizeWithExpiration(this::fetchSessionProperties, config.getSessionPropertiesCacheExpiration().toMillis(), MILLISECONDS);

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -40,7 +40,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
 
-@Test(singleThreaded = true)
 public class TestNativeSidecarPlugin
         extends AbstractTestQueryFramework
 {

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPluginWithoutLoadingFunctionalities.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPluginWithoutLoadingFunctionalities.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
+
+public class TestNativeSidecarPluginWithoutLoadingFunctionalities
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createLineitem(queryRunner);
+        createNation(queryRunner);
+        createOrders(queryRunner);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(true, false, false, false);
+        // Installing the native sidecar plugin on a native cluster does not load the plugin functionalities because
+        // we aren't loading the individual functionalities.
+        queryRunner.installCoordinatorPlugin(new NativeSidecarPlugin());
+        return queryRunner;
+    }
+
+    @Override
+    protected QueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        // Installing the native sidecar plugin on a Java cluster, does not load the plugin functionalities because
+        // we aren't loading the individual functionalities.
+        queryRunner.installCoordinatorPlugin(new NativeSidecarPlugin());
+        return queryRunner;
+    }
+
+    @Test
+    public void testBasicQueries()
+    {
+        assertQuery("SELECT ARRAY['abc']");
+        assertQuery("SELECT ARRAY[1, 2, 3]");
+        assertQuery("SELECT substr(comment, 1, 10), length(comment), trim(comment) FROM orders");
+        assertQuery("SELECT substr(comment, 1, 10), length(comment), rtrim(comment) FROM orders");
+        assertQuery("select lower(comment) from nation");
+        assertQuery("SELECT mod(orderkey, linenumber) FROM lineitem");
+        assertQuery("select corr(nationkey, nationkey) from nation");
+        assertQuery("select count(comment) from orders");
+        assertQuery("select count(*) from nation");
+        assertQuery("select count(abs(orderkey) between 1 and 60000) from orders group by orderkey");
+        assertQuery("SELECT count(orderkey) FROM orders WHERE orderkey < 0 GROUP BY GROUPING SETS (())");
+        // This query will work when sidecar is enabled, should fail without it.
+        assertQueryFails(
+                "select array_sort(array[row('apples', 23), row('bananas', 12), row('grapes', 44)], x -> x[2])",
+                "line 1:84: Expected a lambda that takes 2 argument\\(s\\) but got 1");
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -76,10 +76,13 @@ import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.SchemaPropertyManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.metadata.SessionPropertyProviderConfig;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticCatalogStoreConfig;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStoreConfig;
+import com.facebook.presto.metadata.StaticTypeManagerStore;
+import com.facebook.presto.metadata.StaticTypeManagerStoreConfig;
 import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.operator.FileFragmentResultCacheConfig;
@@ -276,6 +279,8 @@ public class PrestoSparkModule
         configBinder(binder).bindConfig(CompilerConfig.class);
         configBinder(binder).bindConfig(SqlEnvironmentConfig.class);
         configBinder(binder).bindConfig(StaticFunctionNamespaceStoreConfig.class);
+        configBinder(binder).bindConfig(StaticTypeManagerStoreConfig.class);
+        configBinder(binder).bindConfig(SessionPropertyProviderConfig.class);
         configBinder(binder).bindConfig(PrestoSparkConfig.class);
         configBinder(binder).bindConfig(TracingConfig.class);
         configBinder(binder).bindConfig(NativeExecutionVeloxConfig.class);
@@ -370,6 +375,7 @@ public class PrestoSparkModule
         binder.bind(MetadataManager.class).in(Scopes.SINGLETON);
         binder.bind(Metadata.class).to(MetadataManager.class).in(Scopes.SINGLETON);
         binder.bind(StaticFunctionNamespaceStore.class).in(Scopes.SINGLETON);
+        binder.bind(StaticTypeManagerStore.class).in(Scopes.SINGLETON);
 
         // type
         newSetBinder(binder, Type.class);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -989,6 +989,7 @@ public class DistributedQueryRunner
         for (TestingPrestoServer server : servers) {
             server.getMetadata().getSessionPropertyManager().loadSessionPropertyProvider(
                     sessionPropertyProviderName,
+                    ImmutableMap.of(),
                     Optional.ofNullable(server.getMetadata().getFunctionAndTypeManager()),
                     Optional.ofNullable(server.getPluginNodeManager()));
         }


### PR DESCRIPTION
## Description
Prevent coordinator crashing in non-sidecar enabled clusters by making sidecar plugin functionalities config driven

## Motivation and Context
Solves part of #24964 

## Impact
Users would be able to include the ` presto-native-sidecar-plugin` plugin in the build even for non-sidecar enabled clusters.

## Test Plan
Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

