### PR TITLE
fix: TDigest Functions Null Input Behavior

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -70,6 +70,7 @@ public final class TDigestFunctions
         TDigest tDigest = createTDigest(input);
         BlockBuilder output = DOUBLE.createBlockBuilder(null, percentilesArrayBlock.getPositionCount());
         for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+            checkCondition(!percentilesArrayBlock.isNull(i), INVALID_FUNCTION_ARGUMENT, "All quantiles should be non-null.");
             DOUBLE.writeDouble(output, tDigest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)));
         }
         return output.build();
@@ -91,6 +92,7 @@ public final class TDigestFunctions
         TDigest tDigest = createTDigest(input);
         BlockBuilder output = DOUBLE.createBlockBuilder(null, valuesArrayBlock.getPositionCount());
         for (int i = 0; i < valuesArrayBlock.getPositionCount(); i++) {
+            checkCondition(!valuesArrayBlock.isNull(i), INVALID_FUNCTION_ARGUMENT, "All values should be non-null.");
             DOUBLE.writeDouble(output, tDigest.getCdf(DOUBLE.getDouble(valuesArrayBlock, i)));
         }
         return output.build();

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
@@ -87,6 +87,36 @@ public class TestTDigestFunctions
                 null);
     }
 
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "All quantiles should be non-null.")
+    public void testValuesAtQuantilesWithNullsThrowsError()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        for (int i = 0; i < 100; i++) {
+            tDigest.add(i);
+        }
+
+        functionAssertions.assertFunction(
+                format("values_at_quantiles(%s, ARRAY[0.25, NULL, 0.75])",
+                        toSqlString(tDigest)),
+                new ArrayType(DOUBLE),
+                null);
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "All values should be non-null.")
+    public void testQuantilesAtValuesWithNullsThrowsError()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        for (int i = 0; i < 100; i++) {
+            tDigest.add(i);
+        }
+
+        functionAssertions.assertFunction(
+                format("quantiles_at_values(%s, ARRAY[25.0, NULL, 75.0])",
+                        toSqlString(tDigest)),
+                new ArrayType(DOUBLE),
+                null);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testGetValueAtQuantileBelowZero()
     {


### PR DESCRIPTION
## Description
Two TDigest functions are not behaving as expected in Java
values_at_quantiles - This takes an array of quantiles and returns value at that position. Quantile is valid between 0 - 1. Null quantile should be treated as an error
quantiles_at_values - This takes an array of values and returns quantile associated with that value. TDigest only contains non-null values.

This issue was hidden as null was implicitly converted to 0 and treated as such.

Note - value_at_quantile/quantile_at_value throws generic internal error if null quantile/value is provided as input.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
Impacts TDigest values_at_quantiles and quantiles_at_values apis

## Test Plan
- [x] Unit tests for both

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

