### PR TITLE
Expose QueryType & Catalog in Session API

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -15,6 +15,7 @@ package com.facebook.presto;
 
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.ConnectorId;
@@ -167,6 +168,12 @@ public class FullConnectorSession
     }
 
     @Override
+    public Optional<String> getCatalog()
+    {
+        return Optional.of(catalog);
+    }
+
+    @Override
     public boolean isReadConstraints()
     {
         return isExploitConstraints(session);
@@ -204,5 +211,11 @@ public class FullConnectorSession
     public ConnectorSession forConnectorId(ConnectorId connectorId)
     {
         return new FullConnectorSession(session, identity);
+    }
+
+    @Override
+    public Optional<QueryType> getQueryType()
+    {
+        return session.getQueryType();
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi;
 
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -58,6 +59,11 @@ public interface ConnectorSession
 
     Optional<String> getSchema();
 
+    default Optional<String> getCatalog()
+    {
+        return Optional.empty();
+    };
+
     default boolean isReadConstraints()
     {
         return false;
@@ -72,4 +78,9 @@ public interface ConnectorSession
      * @return
      */
     ConnectorSession forConnectorId(ConnectorId connectorId);
+
+    default Optional<QueryType> getQueryType()
+    {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
## Description
Exposes catalog & queryType in the Session API

## Motivation and Context
Additional modules eg Phoenix, netezza & db2 need this change to implement the Presto JDBC API 
Exposing these variables will make it possible to use the modules & possibly bring them in here.

## Impact
Catalog & QueryType can be retrieved from session

## Test Plan
UTs

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

SPI Changes
* Add query type & catalog in Session API.
```
