### PR TITLE
[sidecar] Fix sidecar-coordinator HTTPS communication and handle IPv6 in URL generation

### DIFF
--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionDefinitionProvider.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionDefinitionProvider.java
@@ -73,10 +73,8 @@ public class NativeFunctionDefinitionProvider
     private URI getSidecarLocation()
     {
         Node sidecarNode = nodeManager.getSidecarNode();
-        return HttpUriBuilder.uriBuilder()
-                .scheme("http")
-                .host(sidecarNode.getHost())
-                .port(sidecarNode.getHostAndPort().getPort())
+        return HttpUriBuilder
+                .uriBuilderFrom(sidecarNode.getHttpUri())
                 .appendPath(FUNCTION_SIGNATURES_ENDPOINT)
                 .build();
     }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/sessionpropertyproviders/NativeSystemSessionPropertyProvider.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/sessionpropertyproviders/NativeSystemSessionPropertyProvider.java
@@ -139,10 +139,8 @@ public class NativeSystemSessionPropertyProvider
     private URI getSidecarLocation()
     {
         Node sidecarNode = nodeManager.getSidecarNode();
-        return HttpUriBuilder.uriBuilder()
-                .scheme("http")
-                .host(sidecarNode.getHost())
-                .port(sidecarNode.getHostAndPort().getPort())
+        return HttpUriBuilder
+                .uriBuilderFrom(sidecarNode.getHttpUri())
                 .appendPath(SESSION_PROPERTIES_ENDPOINT)
                 .build();
     }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestURIGenerationForSidecarEndpoints.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestURIGenerationForSidecarEndpoints.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar;
+
+import com.facebook.airlift.http.client.HttpUriBuilder;
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.nodeManager.PluginNodeManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.PrestoException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+
+import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestURIGenerationForSidecarEndpoints
+{
+    private InMemoryNodeManager inMemoryNodeManager;
+    private PluginNodeManager pluginNodeManager;
+
+    @BeforeClass
+    public void setUp()
+    {
+        // Initialize the InMemoryNodeManager and PluginNodeManager before each test.
+        inMemoryNodeManager = new InMemoryNodeManager();
+        pluginNodeManager = new PluginNodeManager(inMemoryNodeManager, "test-env");
+    }
+
+    @Test(dataProvider = "testDifferentIPs")
+    public void testURIGenerationForSidecarEndpoints(String nodeIdentifier, String url)
+    {
+        String testEndpoint = "/v1/test";
+        ConnectorId connectorId = new ConnectorId("test");
+        InternalNode node = new InternalNode(nodeIdentifier, URI.create(url), new NodeVersion("1"), false, false, false, true);
+        inMemoryNodeManager.addNode(connectorId, node);
+        Node sidecarNode = pluginNodeManager.getAllNodes()
+                .stream()
+                .filter((node1 -> node1.getNodeIdentifier().equals(nodeIdentifier))).findFirst()
+                .orElseThrow(() ->
+                        new PrestoException(
+                                NO_NODES_AVAILABLE, format("Failed to find node with nodeIdentifier %s", nodeIdentifier)));
+        URI expectedURI = URI.create(url + testEndpoint);
+        URI actualURI = HttpUriBuilder
+                .uriBuilderFrom(sidecarNode.getHttpUri())
+                .appendPath(testEndpoint)
+                .build();
+        assertEquals(actualURI, expectedURI);
+        assertEquals(actualURI.getScheme(), expectedURI.getScheme());
+    }
+
+    @DataProvider(name = "testDifferentIPs")
+    public static Object[][] testDifferentIPs()
+    {
+        return new Object[][] {
+                {"activeNode1", "https://[::1]:8080"},
+                {"activeNode2", "http://[::1]:8080"},
+                {"activeNode3", "http://example1.com:8081"},
+                {"activeNode4", "https://example1.com:8081"}};
+    }
+}


### PR DESCRIPTION
Fix queries when the sidecar-worker and coordinator are talking in HTTPS mode.
Additionally, fixes the URL generation bug found when dealing with IPv6 address.

## Motivation and Context
Solves part of #24964.

## Impact
No impact

## Test Plan
Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

