### PR TITLE
Restore exception handling for IllegalArgumentException during type resolution

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -89,7 +89,7 @@ public class AddColumnTask
         try {
             type = metadata.getType(parseTypeSignature(element.getType()));
         }
-        catch (UnknownTypeException e) {
+        catch (IllegalArgumentException | UnknownTypeException e) {
             throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", element.getType(), element.getName());
         }
         if (type.equals(UNKNOWN)) {

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -126,7 +126,7 @@ public class CreateTableTask
                 try {
                     type = metadata.getType(parseTypeSignature(column.getType()));
                 }
-                catch (UnknownTypeException e) {
+                catch (IllegalArgumentException | UnknownTypeException e) {
                     throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", column.getType(), column.getName());
                 }
                 if (type.equals(UNKNOWN)) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -890,7 +890,7 @@ public class ExpressionAnalyzer
             try {
                 type = functionAndTypeResolver.getType(parseTypeSignature(node.getType()));
             }
-            catch (UnknownTypeException e) {
+            catch (IllegalArgumentException | UnknownTypeException e) {
                 throw new SemanticException(TYPE_MISMATCH, node, "Unknown type: " + node.getType());
             }
 
@@ -913,7 +913,7 @@ public class ExpressionAnalyzer
             try {
                 type = functionAndTypeResolver.getType(parseTypeSignature(node.getType()));
             }
-            catch (UnknownTypeException e) {
+            catch (IllegalArgumentException | UnknownTypeException e) {
                 throw new SemanticException(TYPE_MISMATCH, node, "Unknown type: " + node.getType());
             }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -153,7 +153,7 @@ public final class ExpressionTreeUtils
                 return Optional.of((TypeWithName) baseType);
             }
         }
-        catch (UnknownTypeException e) {
+        catch (IllegalArgumentException | UnknownTypeException e) {
             return Optional.empty();
         }
         return Optional.empty();


### PR DESCRIPTION
## Description
In #24179, the exception thrown when a parsing an unknown type was replaced from `IllegalArgumentException` to a new Exception `UnknownTypeException`. As a result of this, exception handling for `IllegalArgumentException` was removed. But `IllegalArgumentException` can be thrown at multiple places down that execution path, so this change adds exception handling for `IllegalArgumentException` back.

## Motivation and Context
Solves the issue described in this PR: #24963 

## Impact
No Impact

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

