### PR TITLE
[Iceberg]Prefer `AppendFiles` over `RowDelta` in insert-only statement

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -72,7 +72,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.airlift.slice.Slice;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.FileFormat;
@@ -113,6 +115,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
@@ -174,7 +177,6 @@ import static com.facebook.presto.iceberg.SortFieldUtils.toSortFields;
 import static com.facebook.presto.iceberg.TableStatisticsMaker.getSupportedColumnStatistics;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
-import static com.facebook.presto.iceberg.changelog.ChangelogOperation.INSERT;
 import static com.facebook.presto.iceberg.changelog.ChangelogOperation.UPDATE_AFTER;
 import static com.facebook.presto.iceberg.changelog.ChangelogOperation.UPDATE_BEFORE;
 import static com.facebook.presto.iceberg.changelog.ChangelogUtil.getRowTypeFromColumnMeta;
@@ -491,7 +493,7 @@ public abstract class IcebergAbstractMetadata
     @Override
     public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
-        return finishWrite(session, (IcebergOutputTableHandle) tableHandle, fragments, INSERT);
+        return finishInsert(session, (IcebergOutputTableHandle) tableHandle, fragments);
     }
 
     protected ConnectorInsertTableHandle beginIcebergTableInsert(ConnectorSession session, IcebergTableHandle table, Table icebergTable)
@@ -538,7 +540,39 @@ public abstract class IcebergAbstractMetadata
     @Override
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
-        return finishWrite(session, (IcebergInsertTableHandle) insertHandle, fragments, INSERT);
+        return finishInsert(session, (IcebergInsertTableHandle) insertHandle, fragments);
+    }
+
+    private Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, IcebergWritableTableHandle writableTableHandle, Collection<Slice> fragments)
+    {
+        if (fragments.isEmpty()) {
+            transaction.commitTransaction();
+            return Optional.empty();
+        }
+
+        List<CommitTaskData> commitTasks = fragments.stream()
+                .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
+                .collect(toImmutableList());
+
+        Table icebergTable = transaction.table();
+        AppendFiles appendFiles = transaction.newAppend();
+
+        ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
+        commitTasks.forEach(task -> handleInsertTask(task, icebergTable, appendFiles, writtenFiles));
+
+        try {
+            appendFiles.set(PRESTO_QUERY_ID, session.getQueryId());
+            appendFiles.commit();
+            transaction.commitTransaction();
+        }
+        catch (ValidationException e) {
+            log.error(e, "ValidationException in finishWrite");
+            throw new PrestoException(ICEBERG_COMMIT_ERROR, "Failed to commit Iceberg update to table: " + writableTableHandle.getTableName(), e);
+        }
+
+        return Optional.of(new HiveWrittenPartitions(commitTasks.stream()
+                .map(CommitTaskData::getPath)
+                .collect(toImmutableList())));
     }
 
     private Optional<ConnectorOutputMetadata> finishWrite(ConnectorSession session, IcebergWritableTableHandle writableTableHandle, Collection<Slice> fragments, ChangelogOperation operationType)
@@ -588,6 +622,15 @@ public abstract class IcebergAbstractMetadata
                 .collect(toImmutableList())));
     }
 
+    private void handleInsertTask(CommitTaskData task, Table icebergTable, AppendFiles appendFiles, ImmutableSet.Builder<String> writtenFiles)
+    {
+        PartitionSpec partitionSpec = icebergTable.specs().get(task.getPartitionSpecId());
+        Type[] partitionColumnTypes = partitionSpec.fields().stream()
+                .map(field -> field.transform().getResultType(icebergTable.schema().findType(field.sourceId())))
+                .toArray(Type[]::new);
+        handleFinishData(task, icebergTable, partitionSpec, partitionColumnTypes, appendFiles::appendFile, writtenFiles);
+    }
+
     private void handleTask(CommitTaskData task, Table icebergTable, RowDelta rowDelta, ImmutableSet.Builder<String> writtenFiles, ImmutableSet.Builder<String> referencedDataFiles)
     {
         PartitionSpec partitionSpec = icebergTable.specs().get(task.getPartitionSpecId());
@@ -599,7 +642,7 @@ public abstract class IcebergAbstractMetadata
                 handleFinishPositionDeletes(task, partitionSpec, partitionColumnTypes, rowDelta, writtenFiles, referencedDataFiles);
                 break;
             case DATA:
-                handleFinishData(task, icebergTable, partitionSpec, partitionColumnTypes, rowDelta, writtenFiles, referencedDataFiles);
+                handleFinishData(task, icebergTable, partitionSpec, partitionColumnTypes, rowDelta::addRows, writtenFiles);
                 break;
             default:
                 throw new UnsupportedOperationException("Unsupported task content: " + task.getContent());
@@ -626,7 +669,7 @@ public abstract class IcebergAbstractMetadata
         task.getReferencedDataFile().ifPresent(referencedDataFiles::add);
     }
 
-    private void handleFinishData(CommitTaskData task, Table icebergTable, PartitionSpec partitionSpec, Type[] partitionColumnTypes, RowDelta rowDelta, ImmutableSet.Builder<String> writtenFiles, ImmutableSet.Builder<String> referencedDataFiles)
+    private void handleFinishData(CommitTaskData task, Table icebergTable, PartitionSpec partitionSpec, Type[] partitionColumnTypes, Consumer<DataFile> dataFileConsumer, ImmutableSet.Builder<String> writtenFiles)
     {
         DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                 .withPath(task.getPath())
@@ -639,7 +682,7 @@ public abstract class IcebergAbstractMetadata
                     .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
             builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
         }
-        rowDelta.addRows(builder.build());
+        dataFileConsumer.accept(builder.build());
         writtenFiles.add(task.getPath());
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -165,7 +165,7 @@ public class TestIcebergSystemTables
                         "('manifest_list', 'varchar', '', '')," +
                         "('summary', 'map(varchar, varchar)', '', '')");
 
-        assertQuery("SELECT operation FROM test_schema.\"test_table$snapshots\"", "VALUES 'overwrite', 'overwrite'");
+        assertQuery("SELECT operation FROM test_schema.\"test_table$snapshots\"", "VALUES 'append', 'append'");
         assertQuery("SELECT summary['total-records'] FROM test_schema.\"test_table$snapshots\"", "VALUES '3', '6'");
     }
 


### PR DESCRIPTION
## Description

This PR use `AppendFiles` rather than `RowDelta` for insert-only statement like `INSERT` and `CTAS`. For insert-only actions, the benefit of selecting `AppendFiles` is:

 - `AppendFiles` is inherently idempotent, whereas `RowDelta` needs conflict validation.
 - `AppendFiles` allows for potential optimizations later, for example, merging multiple sequential inserts within a single transaction into:

```
Transaction txn = table.newTransaction();
table.newAppend()
	.appendFile(DATA_FILE_1)
	.appendFile(DATA_FILE_1)
	.appendFile(DATA_FILE_1)
	......
	.commit();
txn.commitTransaction();
```

This will significantly improve performance for frequent small-batch writes while reducing the amount of metadata files needing maintenance.

## Motivation and Context

Remove unnecessary conflict validations for insert-only operations, and keep the potential for future optimizations.

## Impact

The operation type for insertion changes from `overwrite` to `append` in `snapshots` table.

## Test Plan

 - Make sure all CI tests pass.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

