### PR TITLE
Fix linking issue in macOS when remote is enabled

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -121,6 +121,8 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   target_link_libraries(presto_server_remote_function velox_expression
                         velox_functions_remote ${FOLLY_WITH_DEPENDENCIES})
   target_link_libraries(presto_server_lib presto_server_remote_function)
+  target_link_libraries(presto_server presto_thrift-cpp2 presto_thrift_extra
+          ${THRIFT_LIBRARY})
 endif()
 
 set_property(TARGET presto_server PROPERTY JOB_POOL_LINK presto_link_job_pool)

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -48,6 +48,9 @@ target_link_libraries(
   velox_functions_prestosql
   velox_aggregates
   velox_hive_partition_function
+  presto_thrift-cpp2
+  presto_thrift_extra
+  ${THRIFT_LIBRARY}
   ${RE2}
   GTest::gmock
   GTest::gtest


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Fix linking issue in mac when `PRESTO_ENABLE_REMOTE_FUNCTIONS` is enabled.

```
[100%] Linking CXX executable presto_server
ld: warning: ignoring duplicate libraries: '../../velox/velox/buffer/libvelox_buffer.a', '../../velox/velox/common/base/libvelox_common_base.a', '../../velox/velox/common/base/libvelox_exception.a', '../../velox/velox/common/compression/libvelox_common_compression.a', '../../velox/velox/common/config/libvelox_common_config.a', '../../velox/velox/common/file/libvelox_file.a', '../../velox/velox/common/memory/libvelox_memory.a', '../../velox/velox/common/process/libvelox_process.a', '../../velox/velox/common/serialization/libvelox_serialization.a', '../../velox/velox/common/testutil/libvelox_test_util.a', '../../velox/velox/common/time/libvelox_time.a', '../../velox/velox/functions/prestosql/types/fuzzer_utils/libvelox_presto_types_fuzzer_utils.a', '../../velox/velox/functions/prestosql/types/libvelox_presto_types.a', '../../velox/velox/row/libvelox_row_fast.a', '../../velox/velox/type/libvelox_type.a', '../../velox/velox/type/tz/libvelox_type_tz.a', '../../velox/velox/vector/libvelox_vector.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libdouble-conversion.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libfizz.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libfmt.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libre2.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthrift-core.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftcpp2.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftmetadata.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftprotocol.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libtransport.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libwangle.a'
duplicate symbol 'apache::thrift::protocol::base64_encode(unsigned char const*, unsigned int, unsigned char*)' in:
    /Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthrift.a[10](TBase64Utils.cpp.o)
    /Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftprotocol.a[15](TBase64Utils.cpp.o)
duplicate symbol 'apache::thrift::protocol::base64_decode(unsigned char*, unsigned int)' in:
    /Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthrift.a[10](TBase64Utils.cpp.o)
    /Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftprotocol.a[15](TBase64Utils.cpp.o)
ld: 2 duplicate symbols
c++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [presto_cpp/main/presto_server] Error 1
make[1]: *** [presto_cpp/main/CMakeFiles/presto_server.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[100%] Linking CXX executable presto_server_test
ld: warning: ignoring duplicate libraries: '../../../velox/velox/buffer/libvelox_buffer.a', '../../../velox/velox/common/base/libvelox_common_base.a', '../../../velox/velox/common/base/libvelox_exception.a', '../../../velox/velox/common/caching/libvelox_caching.a', '../../../velox/velox/common/compression/libvelox_common_compression.a', '../../../velox/velox/common/config/libvelox_common_config.a', '../../../velox/velox/common/file/libvelox_file.a', '../../../velox/velox/common/memory/libvelox_memory.a', '../../../velox/velox/common/process/libvelox_process.a', '../../../velox/velox/common/serialization/libvelox_serialization.a', '../../../velox/velox/common/testutil/libvelox_test_util.a', '../../../velox/velox/common/time/libvelox_time.a', '../../../velox/velox/connectors/hive/libvelox_hive_partition_function.a', '../../../velox/velox/functions/prestosql/aggregates/libvelox_aggregates.a', '../../../velox/velox/functions/prestosql/registration/libvelox_functions_prestosql.a', '../../../velox/velox/functions/prestosql/types/fuzzer_utils/libvelox_presto_types_fuzzer_utils.a', '../../../velox/velox/functions/prestosql/types/libvelox_presto_types.a', '../../../velox/velox/row/libvelox_row_fast.a', '../../../velox/velox/serializers/libvelox_presto_serializer.a', '../../../velox/velox/type/libvelox_type.a', '../../../velox/velox/type/tz/libvelox_type_tz.a', '../../../velox/velox/vector/libvelox_vector.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libdouble-conversion.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libfizz.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libfmt.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libre2.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthrift-core.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftcpp2.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftmetadata.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftprotocol.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libtransport.a', '/Users/joe/Developer/utils/velox/scripts/deps-install/lib/libwangle.a', '/opt/homebrew/lib/libgtest.a', '/opt/homebrew/lib/libgtest_main.a'
duplicate symbol 'apache::thrift::protocol::base64_encode(unsigned char const*, unsigned int, unsigned char*)' in:
    /Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthrift.a[10](TBase64Utils.cpp.o)
    /Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftprotocol.a[15](TBase64Utils.cpp.o)
duplicate symbol 'apache::thrift::protocol::base64_decode(unsigned char*, unsigned int)' in:
    /Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthrift.a[10](TBase64Utils.cpp.o)
    /Users/joe/Developer/utils/velox/scripts/deps-install/lib/libthriftprotocol.a[15](TBase64Utils.cpp.o)
ld: 2 duplicate symbols
c++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [presto_cpp/main/tests/presto_server_test] Error 1
make[1]: *** [presto_cpp/main/tests/CMakeFiles/presto_server_test.dir/all] Error 2
make: *** [all] Error 2

```
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== NO RELEASE NOTE ==
```

