### PR TITLE
Improve failure message for QualifiedObjectName not 3 parts

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/QualifiedObjectName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/QualifiedObjectName.java
@@ -42,7 +42,7 @@ public class QualifiedObjectName
 
         String[] parts = name.split("\\.");
         if (parts.length != 3) {
-            throw new IllegalArgumentException("QualifiedObjectName should have exactly 3 parts");
+            throw new IllegalArgumentException(format("QualifiedObjectName should have exactly 3 parts, found %s: %s", parts.length, name));
         }
 
         return new QualifiedObjectName(parts[0], parts[1], parts[2]);


### PR DESCRIPTION
## Description
Add more context to the failure message when QualifiedObjectName doesn't have 3 parts so you can see how many parts it had and what the name was.


## Motivation and Context
easier debugging

## Impact
more detailed error message.

## Test Plan
ci

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes


```
== NO RELEASE NOTE ==
```

