### PR TITLE
Overload util function addPartitionAndSerializeNode

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
@@ -25,11 +25,21 @@ std::function<
 addPartitionAndSerializeNode(
     uint32_t numPartitions,
     bool replicateNullsAndAny,
+    const std::vector<velox::core::TypedExprPtr>& partitionKeys,
     const std::vector<std::string>& serializedColumns = {},
     const std::optional<std::vector<velox::core::SortOrder>>& sortOrders =
         std::nullopt,
     const std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>>&
-        fields = std::nullopt);
+        sortKeys = std::nullopt);
+
+std::function<
+    velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>
+
+addPartitionAndSerializeNode(
+    uint32_t numPartitions,
+    const std::vector<std::string>& partitionKeys,
+    const std::optional<std::vector<std::string>>& sortExpr,
+    velox::memory::MemoryPool* pool);
 
 std::function<
     velox::core::PlanNodePtr(std::string nodeId, velox::core::PlanNodePtr)>

--- a/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/UnsafeRowShuffleTest.cpp
@@ -423,11 +423,13 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
       const RowVectorPtr& data,
       const VectorPtr& expectedReplicate = nullptr) {
     const bool replicateNullsAndAny = expectedReplicate != nullptr;
-    auto plan =
-        exec::test::PlanBuilder()
-            .values({data})
-            .addNode(addPartitionAndSerializeNode(7, replicateNullsAndAny))
-            .planNode();
+    const auto partitionKey =
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
+    auto plan = exec::test::PlanBuilder()
+                    .values({data})
+                    .addNode(addPartitionAndSerializeNode(
+                        7, replicateNullsAndAny, {partitionKey}))
+                    .planNode();
 
     auto results = exec::test::AssertQueryBuilder(plan).copyResults(pool());
 
@@ -527,12 +529,19 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     // Flatten the inputs to avoid issues assertEqualResults referred here:
     // https://github.com/facebookincubator/velox/issues/2859
     auto dataType = asRowType(data[0]->type());
+    const auto partitionKey =
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
     auto writerPlan =
         exec::test::PlanBuilder()
             .values(data, true)
             .addNode(addPartitionAndSerializeNode(
-                numPartitions, replicateNullsAndAny, {}, sortOrders, fields))
+                numPartitions,
+                replicateNullsAndAny,
+                {partitionKey},
+                {},
+                sortOrders,
+                fields))
             .localPartition(std::vector<std::string>{})
             .addNode(addShuffleWriteNode(
                 numPartitions, shuffleName, serializedShuffleWriteInfo))
@@ -771,6 +780,8 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     std::optional<
         std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>>>
         fields = std::nullopt;
+    const auto partitionKey =
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
     if (sorted) {
       data = makeRowVector(
@@ -796,7 +807,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
     auto plan = exec::test::PlanBuilder()
                     .values({data}, false)
                     .addNode(addPartitionAndSerializeNode(
-                        2, true, {}, ordering, fields))
+                        2, true, {partitionKey}, {}, ordering, fields))
                     .planNode();
 
     auto properties = std::unordered_map<std::string, std::string>{
@@ -828,14 +839,17 @@ TEST_F(UnsafeRowShuffleTest, operators) {
       makeFlatVector<int32_t>({1, 2, 3, 4}),
       makeFlatVector<int64_t>({10, 20, 30, 40}),
   });
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
   auto info = testShuffleInfo(4, 1 << 20 /* 1MB */);
-  auto plan = exec::test::PlanBuilder()
-                  .values({data}, true)
-                  .addNode(addPartitionAndSerializeNode(4, false))
-                  .localPartition(std::vector<std::string>{})
-                  .addNode(addShuffleWriteNode(
-                      4, std::string(TestShuffleFactory::kShuffleName), info))
-                  .planNode();
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({data}, true)
+          .addNode(addPartitionAndSerializeNode(4, false, {partitionKey}))
+          .localPartition(std::vector<std::string>{})
+          .addNode(addShuffleWriteNode(
+              4, std::string(TestShuffleFactory::kShuffleName), info))
+          .planNode();
 
   exec::CursorParameters params;
   params.planNode = plan;
@@ -852,6 +866,8 @@ DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleWriterExceptions) {
       makeFlatVector<int32_t>({1, 2, 3, 4}),
       makeFlatVector<int64_t>({10, 20, 30, 40}),
   });
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
   auto info = testShuffleInfo(4, 1 << 20 /* 1MB */);
 
   SCOPED_TESTVALUE_SET(
@@ -867,7 +883,7 @@ DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleWriterExceptions) {
   params.planNode =
       exec::test::PlanBuilder()
           .values({data})
-          .addNode(addPartitionAndSerializeNode(4, false))
+          .addNode(addPartitionAndSerializeNode(4, false, {partitionKey}))
           .addNode(addShuffleWriteNode(
               4, std::string(TestShuffleFactory::kShuffleName), info))
           .planNode();
@@ -885,6 +901,8 @@ DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleReaderExceptions) {
       makeFlatVector<int32_t>({1, 2, 3, 4}),
       makeFlatVector<int64_t>({10, 20, 30, 40}),
   });
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
   auto info = testShuffleInfo(4, 1 << 20 /* 1MB */);
   TestShuffleWriter::createWriter(info, pool());
@@ -893,7 +911,7 @@ DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleReaderExceptions) {
   params.planNode =
       exec::test::PlanBuilder()
           .values({data})
-          .addNode(addPartitionAndSerializeNode(2, false))
+          .addNode(addPartitionAndSerializeNode(2, false, {partitionKey}))
           .addNode(addShuffleWriteNode(
               2, std::string(TestShuffleFactory::kShuffleName), info))
           .planNode();
@@ -1237,11 +1255,14 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperator) {
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
   });
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
-  auto plan = exec::test::PlanBuilder()
-                  .values({data}, false)
-                  .addNode(addPartitionAndSerializeNode(4, false))
-                  .planNode();
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({data}, false)
+          .addNode(addPartitionAndSerializeNode(4, false, {partitionKey}))
+          .planNode();
 
   testPartitionAndSerialize(plan, data);
 }
@@ -1249,11 +1270,14 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperator) {
 TEST_F(UnsafeRowShuffleTest, partitionAndSerializeWithLargeInput) {
   auto data = makeRowVector(
       {makeFlatVector<int32_t>(20'000, [](auto row) { return row; })});
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
-  auto plan = exec::test::PlanBuilder()
-                  .values({data}, false)
-                  .addNode(addPartitionAndSerializeNode(1, true))
-                  .planNode();
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({data}, false)
+          .addNode(addPartitionAndSerializeNode(1, true, {partitionKey}))
+          .planNode();
 
   testPartitionAndSerialize(plan, data);
 }
@@ -1263,21 +1287,24 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeWithDifferentColumnOrder) {
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
   });
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
   auto plan = exec::test::PlanBuilder()
                   .values({data}, false)
-                  .addNode(addPartitionAndSerializeNode(4, false, {"c1", "c0"}))
+                  .addNode(addPartitionAndSerializeNode(
+                      4, false, {partitionKey}, {"c1", "c0"}))
                   .planNode();
 
   auto expected = makeRowVector({data->childAt(1), data->childAt(0)});
   testPartitionAndSerialize(plan, expected);
 
   // Duplicate some columns.
-  plan =
-      exec::test::PlanBuilder()
-          .values({data}, false)
-          .addNode(addPartitionAndSerializeNode(4, false, {"c1", "c0", "c1"}))
-          .planNode();
+  plan = exec::test::PlanBuilder()
+             .values({data}, false)
+             .addNode(addPartitionAndSerializeNode(
+                 4, false, {partitionKey}, {"c1", "c0", "c1"}))
+             .planNode();
 
   expected =
       makeRowVector({data->childAt(1), data->childAt(0), data->childAt(1)});
@@ -1286,7 +1313,8 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeWithDifferentColumnOrder) {
   // Remove one column.
   plan = exec::test::PlanBuilder()
              .values({data}, false)
-             .addNode(addPartitionAndSerializeNode(4, false, {"c1"}))
+             .addNode(
+                 addPartitionAndSerializeNode(4, false, {partitionKey}, {"c1"}))
              .planNode();
 
   expected = makeRowVector({data->childAt(1)});
@@ -1298,11 +1326,14 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperatorWhenSinglePartition) {
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
   });
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
-  auto plan = exec::test::PlanBuilder()
-                  .values({data}, false)
-                  .addNode(addPartitionAndSerializeNode(1, false))
-                  .planNode();
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({data}, false)
+          .addNode(addPartitionAndSerializeNode(1, false, {partitionKey}))
+          .planNode();
 
   testPartitionAndSerialize(plan, data);
 }
@@ -1312,16 +1343,19 @@ TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
   });
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
-  auto plan = exec::test::PlanBuilder()
-                  .values({data}, true)
-                  .addNode(addPartitionAndSerializeNode(4, false))
-                  .localPartition(std::vector<std::string>{})
-                  .addNode(addShuffleWriteNode(
-                      4,
-                      std::string(TestShuffleFactory::kShuffleName),
-                      testShuffleInfo(10, 10)))
-                  .planNode();
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({data}, true)
+          .addNode(addPartitionAndSerializeNode(4, false, {partitionKey}))
+          .localPartition(std::vector<std::string>{})
+          .addNode(addShuffleWriteNode(
+              4,
+              std::string(TestShuffleFactory::kShuffleName),
+              testShuffleInfo(10, 10)))
+          .planNode();
 
   ASSERT_EQ(plan->toString(false, false), "-- ShuffleWrite[3]\n");
   ASSERT_EQ(
@@ -1335,11 +1369,14 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeToString) {
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
   });
+  const auto partitionKey =
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
 
-  auto plan = exec::test::PlanBuilder()
-                  .values({data}, true)
-                  .addNode(addPartitionAndSerializeNode(4, false))
-                  .planNode();
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({data}, true)
+          .addNode(addPartitionAndSerializeNode(4, false, {partitionKey}))
+          .planNode();
 
   ASSERT_EQ(plan->toString(false, false), "-- PartitionAndSerialize[1]\n");
   ASSERT_EQ(
@@ -1349,7 +1386,7 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeToString) {
 
   plan = exec::test::PlanBuilder()
              .values({data}, true)
-             .addNode(addPartitionAndSerializeNode(4, true))
+             .addNode(addPartitionAndSerializeNode(4, true, {partitionKey}))
              .planNode();
 
   ASSERT_EQ(plan->toString(false, false), "-- PartitionAndSerialize[1]\n");


### PR DESCRIPTION
Summary:
Provide function overloading for the util function addPartitionAndSerializeNode

The new function signature: 
addPartitionAndSerializeNode(
    uint32_t numPartitions,
    const std::vector<std::string>& partitionKeys,
    const std::optional<std::vector<std::string>>& sortExpr,
    memory::MemoryPool* pool)

This takes a input of partition key names, and sort params as an expression. 
Contains the logic of translating partitionKeys -> TypedExprPtr,
 sortExpr -> sortKeys and sortOrders
The new interface will be used by PySpark-Velox shuffle.

Differential Revision:
D73696009

Privacy Context Container: L1170431


