### PR TITLE
Add test coverage for SqlFunctionProperties equals

### DIFF
--- a/presto-common/src/test/java/com/facebook/presto/common/function/TestSqlFunctionProperties.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/function/TestSqlFunctionProperties.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.function;
+
+import com.facebook.presto.common.type.TimeZoneKey;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class TestSqlFunctionProperties
+{
+    @Test
+    public void testEqualsSameProperties()
+    {
+        SqlFunctionProperties properties1 = SqlFunctionProperties.builder()
+                .setParseDecimalLiteralAsDouble(true)
+                .setLegacyRowFieldOrdinalAccessEnabled(false)
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .setLegacyTimestamp(false)
+                .setLegacyMapSubscript(false)
+                .setSessionStartTime(123456789L)
+                .setSessionLocale(Locale.US)
+                .setSessionUser("user1")
+                .setFieldNamesInJsonCastEnabled(true)
+                .setLegacyJsonCast(false)
+                .setExtraCredentials(Collections.singletonMap("key", "value"))
+                .setWarnOnCommonNanPatterns(false)
+                .setCanonicalizedJsonExtract(true)
+                .build();
+        SqlFunctionProperties properties2 = SqlFunctionProperties.builder()
+                .setParseDecimalLiteralAsDouble(true)
+                .setLegacyRowFieldOrdinalAccessEnabled(false)
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .setLegacyTimestamp(false)
+                .setLegacyMapSubscript(false)
+                .setSessionStartTime(123456789L)
+                .setSessionLocale(Locale.US)
+                .setSessionUser("user1")
+                .setFieldNamesInJsonCastEnabled(true)
+                .setLegacyJsonCast(false)
+                .setExtraCredentials(Collections.singletonMap("key", "value"))
+                .setWarnOnCommonNanPatterns(false)
+                .setCanonicalizedJsonExtract(true)
+                .build();
+        assertEquals(properties1, properties2);
+    }
+    @Test
+    public void testEqualsDifferentProperties()
+    {
+        SqlFunctionProperties properties1 = SqlFunctionProperties.builder()
+                .setParseDecimalLiteralAsDouble(true)
+                .setLegacyRowFieldOrdinalAccessEnabled(false)
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .setLegacyTimestamp(false)
+                .setLegacyMapSubscript(false)
+                .setSessionStartTime(123456789L)
+                .setSessionLocale(Locale.US)
+                .setSessionUser("user1")
+                .setFieldNamesInJsonCastEnabled(true)
+                .setLegacyJsonCast(false)
+                .setExtraCredentials(Collections.singletonMap("key", "value"))
+                .setWarnOnCommonNanPatterns(false)
+                .setCanonicalizedJsonExtract(true)
+                .build();
+        SqlFunctionProperties properties2 = SqlFunctionProperties.builder()
+                .setParseDecimalLiteralAsDouble(true)
+                .setLegacyRowFieldOrdinalAccessEnabled(false)
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .setLegacyTimestamp(false)
+                .setLegacyMapSubscript(false)
+                .setSessionStartTime(123456789L)
+                .setSessionLocale(Locale.US)
+                .setSessionUser("user1")
+                .setFieldNamesInJsonCastEnabled(true)
+                .setLegacyJsonCast(false)
+                .setExtraCredentials(Collections.singletonMap("key", "value"))
+                .setWarnOnCommonNanPatterns(false)
+                .setCanonicalizedJsonExtract(false) // Different value
+                .build();
+        assertNotEquals(properties1, properties2);
+    }
+}


### PR DESCRIPTION
## Description
Previously, in the PR https://github.com/prestodb/presto/pull/24614, we accidentally compared different fields in the SqlFunctionProperties, which caused an OOM error in the JVM metaspace and eventually led to a SEV. To prevent this issue from occurring again, we need to ensure that the SqlFunctionProperties equality function is implemented correctly. Additionally, we should create a unit test to reproduce the issue and prevent it from happening in the future.


## Motivation and Context
Prevent incorrect implementation of the equals method in SqlFunctionProperties

## Impact
low impact

## Test Plan
N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

