### PR TITLE
Add QueryType to QueryContext in event listener API

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -22,6 +22,7 @@ import com.facebook.presto.SessionRepresentation;
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
+import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsManager;
 import com.facebook.presto.cost.HistoryBasedPlanStatisticsTracker;
@@ -153,7 +154,7 @@ public class QueryMonitor
         eventListenerManager.queryCreated(
                 new QueryCreatedEvent(
                         queryInfo.getQueryStats().getCreateTime().toDate().toInstant(),
-                        createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
+                        createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId(), queryInfo.getQueryType()),
                         new QueryMetadata(
                                 queryInfo.getQueryId().toString(),
                                 queryInfo.getSession().getTransactionId().map(TransactionId::toString),
@@ -194,7 +195,7 @@ public class QueryMonitor
                         ImmutableList.of(),
                         queryInfo.getSession().getTraceToken()),
                 createQueryStatistics(queryInfo),
-                createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
+                createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId(), queryInfo.getQueryType()),
                 queryInfo.getQueryType(),
                 ofEpochMilli(queryInfo.getQueryStats().getCreateTime().getMillis())));
     }
@@ -250,7 +251,7 @@ public class QueryMonitor
                         0,
                         true,
                         new RuntimeStats()),
-                createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
+                createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId(), queryInfo.getQueryType()),
                 new QueryIOMetadata(ImmutableList.of(), Optional.empty()),
                 createQueryFailureInfo(failure, Optional.empty()),
                 ImmutableList.of(),
@@ -291,7 +292,7 @@ public class QueryMonitor
                 new QueryCompletedEvent(
                         createQueryMetadata(queryInfo),
                         createQueryStatistics(queryInfo),
-                        createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
+                        createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId(), queryInfo.getQueryType()),
                         getQueryIOMetadata(queryInfo),
                         createQueryFailureInfo(queryInfo.getFailureInfo(), queryInfo.getOutputStage()),
                         queryInfo.getWarnings(),
@@ -499,7 +500,7 @@ public class QueryMonitor
                 new RuntimeStats());
     }
 
-    private QueryContext createQueryContext(SessionRepresentation session, Optional<ResourceGroupId> resourceGroup)
+    private QueryContext createQueryContext(SessionRepresentation session, Optional<ResourceGroupId> resourceGroup, Optional<QueryType> queryType)
     {
         return new QueryContext(
                 session.getUser(),
@@ -517,7 +518,8 @@ public class QueryMonitor
                 serverAddress,
                 serverVersion,
                 environment,
-                workerType);
+                workerType,
+                queryType);
     }
 
     private Optional<String> createTextQueryPlan(QueryInfo queryInfo)

--- a/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
@@ -66,6 +66,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.common.resourceGroups.QueryType.CONTROL;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.expectThrows;
@@ -335,7 +336,7 @@ public class TestEventListenerManager
         Optional<String> catalog = Optional.of("dummyCatalog");
         Optional<String> schema = Optional.of("dummySchema");
         Optional<ResourceGroupId> resourceGroupId = Optional.of(new ResourceGroupId("dummyGroupId"));
-
+        Optional<QueryType> queryType = Optional.of(CONTROL);
         Set<String> clientTags = new HashSet<>(Arrays.asList("tag1", "tag2", "tag3"));
 
         Map<String, String> sessionProperties = new HashMap<>();
@@ -363,7 +364,8 @@ public class TestEventListenerManager
                 serverAddress,
                 serverVersion,
                 environment,
-                workerType);
+                workerType,
+                queryType);
     }
 
     private static QueryIOMetadata createDummyQueryIoMetadata()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryContext.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.eventlistener;
 
+import com.facebook.presto.common.resourceGroups.QueryType;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.session.ResourceEstimates;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,6 +36,7 @@ public class QueryContext
 
     private final Optional<String> catalog;
     private final Optional<String> schema;
+    private final Optional<QueryType> queryType;
 
     private final Optional<ResourceGroupId> resourceGroupId;
 
@@ -62,7 +64,8 @@ public class QueryContext
             String serverAddress,
             String serverVersion,
             String environment,
-            String workerType)
+            String workerType,
+            Optional<QueryType> queryType)
     {
         this.user = requireNonNull(user, "user is null");
         this.principal = requireNonNull(principal, "principal is null");
@@ -80,6 +83,7 @@ public class QueryContext
         this.serverVersion = requireNonNull(serverVersion, "serverVersion is null");
         this.environment = requireNonNull(environment, "environment is null");
         this.workerType = requireNonNull(workerType, "workerType is null");
+        this.queryType = requireNonNull(queryType, "queryType is null");
     }
 
     @JsonProperty
@@ -176,5 +180,11 @@ public class QueryContext
     public String getWorkerType()
     {
         return workerType;
+    }
+
+    @JsonProperty
+    public Optional<QueryType> getQueryType()
+    {
+        return queryType;
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestEventListener.java
@@ -220,6 +220,7 @@ public class TestEventListener
         assertEquals(queryCreatedEvent.getContext().getServerAddress(), "127.0.0.1");
         assertEquals(queryCreatedEvent.getContext().getEnvironment(), "testing");
         assertEquals(queryCreatedEvent.getContext().getClientInfo().get(), "{\"clientVersion\":\"testVersion\"}");
+        assertEquals(queryCreatedEvent.getContext().getQueryType().get().toString(), "CONTROL");
         assertEquals(queryCreatedEvent.getMetadata().getQuery(), prepareQuery);
         assertFalse(queryCreatedEvent.getMetadata().getPreparedQuery().isPresent());
 


### PR DESCRIPTION
## Description
Enhance event listener API by adding QueryType to QueryContext

## Motivation and Context
Resolvers prestodb/presto#25004

## Impact
Adds QueryType to QueryContext

## Test Plan
UTs
## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

SPI Changes
* Add query type to QueryContext in event listener API
```

