### PR TITLE
Fix: Re-initialize sort key serializer for every new input added

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp
@@ -119,6 +119,7 @@ class PartitionAndSerializeOperator : public Operator {
     compactRow_ =
         std::make_unique<velox::row::CompactRow>(reorderInputsIfNeeded());
     calculateRowSize();
+    maybeInitializeSortKeySerializer();
 
     // Process partitionVector and replicateVector once, and reuse on subsequent
     // batch.
@@ -357,7 +358,7 @@ class PartitionAndSerializeOperator : public Operator {
   }
 
   void maybeInitializeSortKeySerializer() {
-    if (binarySortableSerializer_ != nullptr) {
+    if (!sorted_) {
       return;
     }
     VELOX_CHECK(sortingOrders_.has_value() && sortingKeys_.has_value());
@@ -372,7 +373,7 @@ class PartitionAndSerializeOperator : public Operator {
     if (!sorted_) {
       return;
     }
-    maybeInitializeSortKeySerializer();
+    VELOX_CHECK_NOT_NULL(binarySortableSerializer_);
     const vector_size_t batchSize = to - from;
 
     // Serialize keys.


### PR DESCRIPTION
Summary:
The sort key serializer `binarySortableSerializer_` needs to be initialized for every input batch. Otherwise, we end up re-using only keys from the first batch of data.
This diffs move the initialization of `binarySortableSerializer_` to `addInput()` so that the above condition is satisfied.

Reviewed By: xiaoxmeng

Differential Revision: D73903883

```
== RELEASE NOTES ==
Prestissimo (Native Execution) Changes
* Fix issue with PartitionAndSerialize re-using only keys from the first batch of data.
```
