### PR TITLE
Fix distributed sort parallelism for single node execution

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -107,6 +107,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -238,11 +239,18 @@ public class AddLocalExchanges
                 PlanWithProperties sortPlan = planAndEnforceChildren(node, fixedParallelism(), fixedParallelism());
 
                 if (!sortPlan.getProperties().isSingleStream()) {
+                    SortNode sortNode = (SortNode) sortPlan.getNode();
                     return deriveProperties(
                             mergingExchange(
                                     idAllocator.getNextId(),
                                     LOCAL,
-                                    sortPlan.getNode(),
+                                    new SortNode(
+                                            sortNode.getSourceLocation(),
+                                            sortNode.getId(),
+                                            getOnlyElement(sortNode.getSources()),
+                                            sortNode.getOrderingScheme(),
+                                            true,
+                                            sortNode.getPartitionBy()),
                                     node.getOrderingScheme()),
                             sortPlan.getProperties());
                 }


### PR DESCRIPTION
## Description

The AddExchanges optimizer rule is disabled for single node execution. The AddExchanges was responsible for marking the SortNode as partial. When the SortNode is not marked as partial, Velox only runs a single instance of a pipeline containing a SortNode.

## Motivation and Context

Improve parallelism for queries running in single node mode containing ORDER BY 

## Impact

Improved performance for ORDER BY queries running in single node mode

## Test Plan

Integration test

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve performance of ORDER BY queries on single node execution :pr:`25022`

```

