### PR TITLE
Fix test-other-modules running tests for presto-main-base

### DIFF
--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -76,6 +76,7 @@ jobs:
             !presto-docs,
             !presto-server,
             !presto-main,
+            !presto-main-base,
             !presto-mongodb,
             !presto-spark-package,
             !presto-spark-launcher,


### PR DESCRIPTION
## Description

Prevents running tests for presto-main-base in the test-other-modules github action

## Motivation and Context

We are using extra CPU time running these tests twice

## Impact

N/A

## Test Plan

Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

