### PR TITLE
Switch to integer based streaming aggregation output batch session

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -459,6 +459,6 @@ while a lower value limits the amount of memory used.
 * **Type:** ``integer``
 * **Default value:** ``0``
 
-In streaming aggregation, wait until we have enough number of output rows
+In streaming aggregation, wait until there are enough output rows 
 to produce a batch of size specified by this. If set to 0, then
 Operator::outputBatchRows will be used as the min output batch rows.

--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -460,5 +460,5 @@ while a lower value limits the amount of memory used.
 * **Default value:** ``0``
 
 In streaming aggregation, wait until there are enough output rows 
-to produce a batch of size specified by this. If set to 0, then
+to produce a batch of the size specified by this property. If set to ``0``, then 
 Operator::outputBatchRows will be used as the min output batch rows.

--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -453,13 +453,12 @@ Controls the ratio of available memory that can be used for scaling up table sca
 A higher value allows more memory to be allocated for scaling up table scans,
 while a lower value limits the amount of memory used.
 
-``native_streaming_aggregation_eager_flush``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``native_streaming_aggregation_min_output_batch_rows``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Type:** ``boolean``
-* **Default value:** ``false``
+* **Type:** ``integer``
+* **Default value:** ``0``
 
-Controls the way streaming aggregation flushes output. We put the rows in output
-batch, as soon as the corresponding groups are fully aggregated. This is useful
-for reducing memory consumption, if the downstream operators are not sensitive to
-small batch size.
+In streaming aggregation, wait until we have enough number of output rows
+to produce a batch of size specified by this. If set to 0, then
+Operator::outputBatchRows will be used as the min output batch rows.

--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -461,4 +461,4 @@ while a lower value limits the amount of memory used.
 
 In streaming aggregation, wait until there are enough output rows 
 to produce a batch of the size specified by this property. If set to ``0``, then 
-Operator::outputBatchRows will be used as the min output batch rows.
+``Operator::outputBatchRows`` is used as the minimum number of output batch rows.

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -76,7 +76,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_SCALED_WRITER_MIN_PROCESSED_BYTES_REBALANCE_THRESHOLD = "native_scaled_writer_min_processed_bytes_rebalance_threshold";
     public static final String NATIVE_TABLE_SCAN_SCALED_PROCESSING_ENABLED = "native_table_scan_scaled_processing_enabled";
     public static final String NATIVE_TABLE_SCAN_SCALE_UP_MEMORY_USAGE_RATIO = "native_table_scan_scale_up_memory_usage_ratio";
-    public static final String NATIVE_STREAMING_AGGREGATION_EAGER_FLUSH = "native_streaming_aggregation_eager_flush";
+    public static final String NATIVE_STREAMING_AGGREGATION_MIN_OUTPUT_BATCH_ROWS = "native_streaming_aggregation_min_output_batch_rows";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -338,13 +338,12 @@ public class NativeWorkerSessionPropertyProvider
                                 "range of [0, 1].",
                         0.7,
                         !nativeExecution),
-                booleanProperty(
-                        NATIVE_STREAMING_AGGREGATION_EAGER_FLUSH,
-                        "Controls the way streaming aggregation flushes output. We put the rows in output " +
-                                " batch, as soon as the corresponding groups are fully aggregated. This is useful " +
-                                "for reducing memory consumption, if the downstream operators are not sensitive to " +
-                                "small batch size.",
-                        false,
+                integerProperty(
+                        NATIVE_STREAMING_AGGREGATION_MIN_OUTPUT_BATCH_ROWS,
+                        "In streaming aggregation, wait until we have enough number of output rows " +
+                                "to produce a batch of size specified by this. If set to 0, then " +
+                                "Operator::outputBatchRows will be used as the min output batch rows.",
+                        0,
                         !nativeExecution));
     }
 

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -473,15 +473,14 @@ SessionProperties::SessionProperties() {
       std::to_string(c.tableScanScaleUpMemoryUsageRatio()));
 
   addSessionProperty(
-      kStreamingAggregationEagerFlush,
-      "Controls the way streaming aggregation flushes output. We put "
-      "the rows in output batch, as soon as the corresponding groups are fully "
-      "aggregated. This is useful for reducing memory consumption, if the "
-      "downstream operators are not sensitive to small batch size.",
-      BOOLEAN(),
+      kStreamingAggregationMinOutputBatchRows,
+      "In streaming aggregation, wait until we have enough number of output rows"
+      "to produce a batch of size specified by this. If set to 0, then"
+      "Operator::outputBatchRows will be used as the min output batch rows.",
+      INTEGER(),
       false,
-      QueryConfig::kStreamingAggregationEagerFlush,
-      std::to_string(c.streamingAggregationEagerFlush()));
+      QueryConfig::kStreamingAggregationMinOutputBatchRows,
+      std::to_string(c.streamingAggregationMinOutputBatchRows()));
 }
 
 const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -303,12 +303,11 @@ class SessionProperties {
   static constexpr const char* kTableScanScaleUpMemoryUsageRatio =
       "native_table_scan_scale_up_memory_usage_ratio";
 
-  /// Controls the way streaming aggregation flushes output. We put the rows in
-  /// output batch, as soon as the corresponding groups are fully aggregated.
-  /// This is useful for reducing memory consumption, if the downstream
-  /// operators are not sensitive to small batch size.
-  static constexpr const char* kStreamingAggregationEagerFlush =
-      "native_streaming_aggregation_eager_flush";
+  /// In streaming aggregation, wait until we have enough number of output rows
+  /// to produce a batch of size specified by this. If set to 0, then
+  /// Operator::outputBatchRows will be used as the min output batch rows.
+  static constexpr const char* kStreamingAggregationMinOutputBatchRows =
+      "native_streaming_aggregation_min_output_batch_rows";
 
   SessionProperties();
 

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -34,7 +34,7 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       SessionProperties::kScaleWriterMinProcessedBytesRebalanceThreshold,
       SessionProperties::kTableScanScaledProcessingEnabled,
       SessionProperties::kTableScanScaleUpMemoryUsageRatio,
-      SessionProperties::kStreamingAggregationEagerFlush};
+      SessionProperties::kStreamingAggregationMinOutputBatchRows};
   const std::vector<std::string> veloxConfigNames = {
       core::QueryConfig::kAdjustTimestampToTimezone,
       core::QueryConfig::kDriverCpuTimeSliceLimitMs,
@@ -46,7 +46,7 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       core::QueryConfig::kScaleWriterMinProcessedBytesRebalanceThreshold,
       core::QueryConfig::kTableScanScaledProcessingEnabled,
       core::QueryConfig::kTableScanScaleUpMemoryUsageRatio,
-      core::QueryConfig::kStreamingAggregationEagerFlush};
+      core::QueryConfig::kStreamingAggregationMinOutputBatchRows};
   auto sessionProperties = SessionProperties().getSessionProperties();
   const auto len = names.size();
   for (auto i = 0; i < len; i++) {


### PR DESCRIPTION
## Description
The old boolean based eager flush streaming aggregation session property only allows threshold to be 1. The new one allows a customized integer based configuration.

```
== NO RELEASE NOTE ==
```
* Added session property ``native_streaming_aggregation_min_output_batch_rows``
* Remove session property ``native_streaming_aggregation_eager_flush``
