### PR TITLE
[refactor]Extract WindowNode.Specification as a separate class

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
 import com.facebook.presto.spi.plan.CteReferenceNode;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -480,7 +481,7 @@ public class CanonicalPlanGenerator
                 .sorted(comparing(this::writeValueAsString))
                 .collect(toImmutableSet());
 
-        WindowNode.Specification specification = new WindowNode.Specification(
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(
                 node.getSpecification().getPartitionBy().stream()
                         .map(variable -> inlineAndCanonicalize(context.getExpressions(), variable))
                         .sorted(comparing(this::writeValueAsString))
@@ -694,7 +695,7 @@ public class CanonicalPlanGenerator
                 Optional.empty(),
                 planNodeidAllocator.getNextId(),
                 source.get(),
-                new WindowNode.Specification(
+                new DataOrganizationSpecification(
                         partitionBy,
                         node.getSpecification().getOrderingScheme().map(scheme -> getCanonicalOrderingScheme(scheme, context.getExpressions()))),
                 rowNumberVariable,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.LimitNode;
@@ -1069,7 +1070,7 @@ class QueryPlanner
                             subPlan.getRoot().getSourceLocation(),
                             idAllocator.getNextId(),
                             subPlan.getRoot(),
-                            new WindowNode.Specification(
+                            new DataOrganizationSpecification(
                                     partitionByVariables.build(),
                                     orderingScheme),
                             ImmutableMap.of(newVariable, function),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -18,6 +18,7 @@ import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.Ordering;
@@ -27,7 +28,6 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TopNNode;
-import com.facebook.presto.spi.plan.WindowNode.Specification;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -307,7 +307,7 @@ public class PlanNodeDecorrelator
                                 decorrelatedChildNode.getSourceLocation(),
                                 node.getId(),
                                 decorrelatedChildNode,
-                                new Specification(
+                                new DataOrganizationSpecification(
                                         ImmutableList.copyOf(childDecorrelationResult.variablesToPropagate),
                                         Optional.of(orderingScheme)),
                                 variableAllocator.newVariable("row_number", BIGINT),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
 import com.facebook.presto.spi.plan.CteReferenceNode;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
@@ -799,9 +800,9 @@ public class UnaliasSymbolReferences
             return builder.build();
         }
 
-        private WindowNode.Specification canonicalizeAndDistinct(WindowNode.Specification specification)
+        private DataOrganizationSpecification canonicalizeAndDistinct(DataOrganizationSpecification specification)
         {
-            return new WindowNode.Specification(
+            return new DataOrganizationSpecification(
                     canonicalizeAndDistinct(specification.getPartitionBy()),
                     specification.getOrderingScheme().map(this::canonicalizeAndDistinct));
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/TopNRowNumberNode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/TopNRowNumberNode.java
@@ -14,10 +14,10 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
-import com.facebook.presto.spi.plan.WindowNode.Specification;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +37,7 @@ public final class TopNRowNumberNode
         extends InternalPlanNode
 {
     private final PlanNode source;
-    private final Specification specification;
+    private final DataOrganizationSpecification specification;
     private final VariableReferenceExpression rowNumberVariable;
     private final int maxRowCountPerPartition;
     private final boolean partial;
@@ -48,7 +48,7 @@ public final class TopNRowNumberNode
             Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("specification") Specification specification,
+            @JsonProperty("specification") DataOrganizationSpecification specification,
             @JsonProperty("rowNumberVariable") VariableReferenceExpression rowNumberVariable,
             @JsonProperty("maxRowCountPerPartition") int maxRowCountPerPartition,
             @JsonProperty("partial") boolean partial,
@@ -62,7 +62,7 @@ public final class TopNRowNumberNode
             PlanNodeId id,
             Optional<PlanNode> statsEquivalentPlanNode,
             PlanNode source,
-            Specification specification,
+            DataOrganizationSpecification specification,
             VariableReferenceExpression rowNumberVariable,
             int maxRowCountPerPartition,
             boolean partial,
@@ -109,7 +109,7 @@ public final class TopNRowNumberNode
     }
 
     @JsonProperty
-    public Specification getSpecification()
+    public DataOrganizationSpecification getSpecification()
     {
         return specification;
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestCanonicalize.java
@@ -15,7 +15,7 @@ package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.block.SortOrder;
-import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
 import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
@@ -81,7 +81,7 @@ public class TestCanonicalize
     @Test
     public void testDuplicatesInWindowOrderBy()
     {
-        ExpectedValueProvider<WindowNode.Specification> specification = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specification = specification(
                 ImmutableList.of(),
                 ImmutableList.of("A"),
                 ImmutableMap.of("A", SortOrder.ASC_NULLS_LAST));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.JoinNode;
@@ -342,7 +343,7 @@ public class TestEffectivePredicateExtractor
                                 equals(AV, BV),
                                 equals(BV, CV),
                                 lessThan(CV, bigintLiteral(10)))),
-                new WindowNode.Specification(
+                new DataOrganizationSpecification(
                         ImmutableList.of(AV),
                         Optional.of(new OrderingScheme(
                                 ImmutableList.of(new Ordering(AV, SortOrder.ASC_NULLS_LAST))))),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestTypeValidator.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.ProjectNode;
@@ -175,7 +176,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, DOUBLE, variableC), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 Optional.empty(),
@@ -437,7 +438,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, BIGINT, variableA), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 Optional.empty(),
@@ -471,7 +472,7 @@ public class TestTypeValidator
 
         WindowNode.Function function = new WindowNode.Function(call("sum", functionHandle, BIGINT, variableC), frame, false);
 
-        WindowNode.Specification specification = new WindowNode.Specification(ImmutableList.of(), Optional.empty());
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(ImmutableList.of(), Optional.empty());
 
         PlanNode node = new WindowNode(
                 Optional.empty(),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Step;
 import com.facebook.presto.spi.plan.CteConsumerNode;
 import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -927,7 +928,7 @@ public final class PlanMatchPattern
                 .collect(toImmutableList());
     }
 
-    public static ExpectedValueProvider<WindowNode.Specification> specification(
+    public static ExpectedValueProvider<DataOrganizationSpecification> specification(
             List<String> partitionBy,
             List<String> orderBy,
             Map<String, SortOrder> orderings)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/SpecificationProvider.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/SpecificationProvider.java
@@ -14,9 +14,9 @@
 package com.facebook.presto.sql.planner.assertions;
 
 import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
-import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -33,7 +33,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 public class SpecificationProvider
-        implements ExpectedValueProvider<WindowNode.Specification>
+        implements ExpectedValueProvider<DataOrganizationSpecification>
 {
     private final List<SymbolAlias> partitionBy;
     private final List<SymbolAlias> orderBy;
@@ -50,7 +50,7 @@ public class SpecificationProvider
     }
 
     @Override
-    public WindowNode.Specification getExpectedValue(SymbolAliases aliases)
+    public DataOrganizationSpecification getExpectedValue(SymbolAliases aliases)
     {
         Optional<OrderingScheme> orderingScheme = Optional.empty();
         if (!orderBy.isEmpty()) {
@@ -64,7 +64,7 @@ public class SpecificationProvider
                             .collect(toImmutableList())));
         }
 
-        return new WindowNode.Specification(
+        return new DataOrganizationSpecification(
                 partitionBy
                         .stream()
                         .map(alias -> new VariableReferenceExpression(Optional.empty(), alias.toSymbol(aliases).getName(), UNKNOWN))
@@ -87,7 +87,7 @@ public class SpecificationProvider
      * VariableReferenceExpression::equals to check whether two specification are equivalent once they include VariableReferenceExpression.
      * TODO Directly use equals once SymbolAlias is converted to something with type information.
      */
-    public static boolean matchSpecification(WindowNode.Specification actual, WindowNode.Specification expected)
+    public static boolean matchSpecification(DataOrganizationSpecification actual, DataOrganizationSpecification expected)
     {
         return actual.getPartitionBy().stream().map(VariableReferenceExpression::getName).collect(toImmutableList())
                 .equals(expected.getPartitionBy().stream().map(VariableReferenceExpression::getName).collect(toImmutableList())) &&
@@ -104,7 +104,7 @@ public class SpecificationProvider
                         .orElse(true);
     }
 
-    public static boolean matchSpecification(WindowNode.Specification actual, SpecificationProvider expected)
+    public static boolean matchSpecification(DataOrganizationSpecification actual, SpecificationProvider expected)
     {
         return actual.getPartitionBy().stream().map(VariableReferenceExpression::getName).collect(toImmutableList())
                 .equals(expected.partitionBy.stream().map(SymbolAlias::toString).collect(toImmutableList())) &&

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/TopNRowNumberMatcher.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/TopNRowNumberMatcher.java
@@ -17,8 +17,8 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.PlanNode;
-import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
@@ -38,14 +38,14 @@ import static java.util.Objects.requireNonNull;
 public class TopNRowNumberMatcher
         implements Matcher
 {
-    private final Optional<ExpectedValueProvider<WindowNode.Specification>> specification;
+    private final Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification;
     private final Optional<SymbolAlias> rowNumberSymbol;
     private final Optional<Integer> maxRowCountPerPartition;
     private final Optional<Boolean> partial;
     private final Optional<Optional<SymbolAlias>> hashSymbol;
 
     private TopNRowNumberMatcher(
-            Optional<ExpectedValueProvider<WindowNode.Specification>> specification,
+            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification,
             Optional<SymbolAlias> rowNumberSymbol,
             Optional<Integer> maxRowCountPerPartition,
             Optional<Boolean> partial,
@@ -125,7 +125,7 @@ public class TopNRowNumberMatcher
     public static class Builder
     {
         private final PlanMatchPattern source;
-        private Optional<ExpectedValueProvider<WindowNode.Specification>> specification = Optional.empty();
+        private Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification = Optional.empty();
         private Optional<SymbolAlias> rowNumberSymbol = Optional.empty();
         private Optional<Integer> maxRowCountPerPartition = Optional.empty();
         private Optional<Boolean> partial = Optional.empty();

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/WindowMatcher.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -46,13 +47,13 @@ public final class WindowMatcher
         implements Matcher
 {
     private final Optional<Set<SymbolAlias>> prePartitionedInputs;
-    private final Optional<ExpectedValueProvider<WindowNode.Specification>> specification;
+    private final Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification;
     private final Optional<Integer> preSortedOrderPrefix;
     private final Optional<Optional<SymbolAlias>> hashSymbol;
 
     private WindowMatcher(
             Optional<Set<SymbolAlias>> prePartitionedInputs,
-            Optional<ExpectedValueProvider<WindowNode.Specification>> specification,
+            Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification,
             Optional<Integer> preSortedOrderPrefix,
             Optional<Optional<SymbolAlias>> hashSymbol)
     {
@@ -136,7 +137,7 @@ public final class WindowMatcher
     {
         private final PlanMatchPattern source;
         private Optional<Set<SymbolAlias>> prePartitionedInputs = Optional.empty();
-        private Optional<ExpectedValueProvider<WindowNode.Specification>> specification = Optional.empty();
+        private Optional<ExpectedValueProvider<DataOrganizationSpecification>> specification = Optional.empty();
         private Optional<Integer> preSortedOrderPrefix = Optional.empty();
         private List<AliasMatcher> windowFunctionMatchers = new LinkedList<>();
         private Optional<Optional<SymbolAlias>> hashSymbol = Optional.empty();
@@ -164,7 +165,7 @@ public final class WindowMatcher
             return specification(PlanMatchPattern.specification(partitionBy, orderBy, orderings));
         }
 
-        public Builder specification(ExpectedValueProvider<WindowNode.Specification> specification)
+        public Builder specification(ExpectedValueProvider<DataOrganizationSpecification> specification)
         {
             requireNonNull(specification, "specification is null");
             this.specification = Optional.of(specification);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMergeAdjacentWindows.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -93,7 +94,7 @@ public class TestMergeAdjacentWindows
     private static final FunctionHandle LAG_FUNCTION_HANDLE = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("lag", fromTypes(DOUBLE));
     private static final FunctionHandle RANK_FUNCTION_HANDLE = createTestMetadataManager().getFunctionAndTypeManager().lookupFunction("rank", ImmutableList.of());
     private static final String columnAAlias = "ALIAS_A";
-    private static final ExpectedValueProvider<WindowNode.Specification> specificationA =
+    private static final ExpectedValueProvider<DataOrganizationSpecification> specificationA =
             specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
 
     @Test
@@ -275,14 +276,14 @@ public class TestMergeAdjacentWindows
                                                         values(columnAAlias, unusedAlias))))));
     }
 
-    private static WindowNode.Specification newWindowNodeSpecification(PlanBuilder planBuilder, String symbolName)
+    private static DataOrganizationSpecification newWindowNodeSpecification(PlanBuilder planBuilder, String symbolName)
     {
-        return new WindowNode.Specification(ImmutableList.of(planBuilder.variable(symbolName, BIGINT)), Optional.empty());
+        return new DataOrganizationSpecification(ImmutableList.of(planBuilder.variable(symbolName, BIGINT)), Optional.empty());
     }
 
-    private static WindowNode.Specification newWindowNodeSpecification(PlanBuilder planBuilder, String symbolName, String sortkey)
+    private static DataOrganizationSpecification newWindowNodeSpecification(PlanBuilder planBuilder, String symbolName, String sortkey)
     {
-        return new WindowNode.Specification(ImmutableList.of(planBuilder.variable(symbolName, BIGINT)),
+        return new DataOrganizationSpecification(ImmutableList.of(planBuilder.variable(symbolName, BIGINT)),
                 Optional.of(new OrderingScheme(
                         ImmutableList.of(new Ordering(planBuilder.variable(sortkey, BIGINT), SortOrder.ASC_NULLS_FIRST)))));
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPruneWindowColumns.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -280,7 +281,7 @@ public class TestPruneWindowColumns
                                 .filter(projectionFilter)
                                 .collect(toImmutableList())),
                 p.window(
-                        new WindowNode.Specification(
+                        new DataOrganizationSpecification(
                                 ImmutableList.of(partitionKey),
                                 Optional.of(new OrderingScheme(
                                         ImmutableList.of(new Ordering(orderKey, SortOrder.ASC_NULLS_FIRST))))),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSwapAdjacentWindowsBySpecifications.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -79,7 +80,7 @@ public class TestSwapAdjacentWindowsBySpecifications
     public void doesNotFireOnPlanWithSingleWindowNode()
     {
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
-                .on(p -> p.window(new WindowNode.Specification(
+                .on(p -> p.window(new DataOrganizationSpecification(
                                 ImmutableList.of(p.variable("a")),
                                 Optional.empty()),
                         ImmutableMap.of(p.variable("avg_1"),
@@ -94,16 +95,16 @@ public class TestSwapAdjacentWindowsBySpecifications
         String columnAAlias = "ALIAS_A";
         String columnBAlias = "ALIAS_B";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationA = specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
-        ExpectedValueProvider<WindowNode.Specification> specificationAB = specification(ImmutableList.of(columnAAlias, columnBAlias), ImmutableList.of(), ImmutableMap.of());
+        ExpectedValueProvider<DataOrganizationSpecification> specificationA = specification(ImmutableList.of(columnAAlias), ImmutableList.of(), ImmutableMap.of());
+        ExpectedValueProvider<DataOrganizationSpecification> specificationAB = specification(ImmutableList.of(columnAAlias, columnBAlias), ImmutableList.of(), ImmutableMap.of());
 
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
                 .on(p ->
-                        p.window(new WindowNode.Specification(
+                        p.window(new DataOrganizationSpecification(
                                         ImmutableList.of(p.variable("a")),
                                         Optional.empty()),
                                 ImmutableMap.of(p.variable("avg_1", DOUBLE), newWindowNodeFunction(ImmutableList.of(new Symbol("a")))),
-                                p.window(new WindowNode.Specification(
+                                p.window(new DataOrganizationSpecification(
                                                 ImmutableList.of(p.variable("a"), p.variable("b")),
                                                 Optional.empty()),
                                         ImmutableMap.of(p.variable("avg_2", DOUBLE), newWindowNodeFunction(ImmutableList.of(new Symbol("b")))),
@@ -123,11 +124,11 @@ public class TestSwapAdjacentWindowsBySpecifications
     {
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
                 .on(p ->
-                        p.window(new WindowNode.Specification(
+                        p.window(new DataOrganizationSpecification(
                                         ImmutableList.of(p.variable("a")),
                                         Optional.empty()),
                                 ImmutableMap.of(p.variable("avg_1"), newWindowNodeFunction(ImmutableList.of(new Symbol("avg_2")))),
-                                p.window(new WindowNode.Specification(
+                                p.window(new DataOrganizationSpecification(
                                                 ImmutableList.of(p.variable("a"), p.variable("b")),
                                                 Optional.empty()),
                                         ImmutableMap.of(p.variable("avg_2"), newWindowNodeFunction(ImmutableList.of(new Symbol("a")))),
@@ -168,11 +169,11 @@ public class TestSwapAdjacentWindowsBySpecifications
 
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
                 .on(p ->
-                        p.window(new WindowNode.Specification(
+                        p.window(new DataOrganizationSpecification(
                                         ImmutableList.of(p.variable("a")),
                                         Optional.of(new OrderingScheme(ImmutableList.of(new Ordering(p.variable("sortkey", BIGINT), SortOrder.ASC_NULLS_FIRST))))),
                                 ImmutableMap.of(p.variable("avg_1"), functionWithOffset),
-                                p.window(new WindowNode.Specification(
+                                p.window(new DataOrganizationSpecification(
                                                 ImmutableList.of(p.variable("a"), p.variable("b")),
                                                 Optional.of(new OrderingScheme(ImmutableList.of(new Ordering(p.variable("sortkey", BIGINT), SortOrder.ASC_NULLS_FIRST))))),
                                         ImmutableMap.of(p.variable("startValue"), windowFunction),
@@ -213,11 +214,11 @@ public class TestSwapAdjacentWindowsBySpecifications
 
         tester().assertThat(new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0))
                 .on(p ->
-                        p.window(new WindowNode.Specification(
+                        p.window(new DataOrganizationSpecification(
                                         ImmutableList.of(p.variable("a")),
                                         Optional.of(new OrderingScheme(ImmutableList.of(new Ordering(p.variable("sortkey", BIGINT), SortOrder.ASC_NULLS_FIRST))))),
                                 ImmutableMap.of(p.variable("avg_1"), functionWithOffset),
-                                p.window(new WindowNode.Specification(
+                                p.window(new DataOrganizationSpecification(
                                                 ImmutableList.of(p.variable("a"), p.variable("b")),
                                                 Optional.of(new OrderingScheme(ImmutableList.of(new Ordering(p.variable("sortkey", BIGINT), SortOrder.ASC_NULLS_FIRST))))),
                                         ImmutableMap.of(p.variable("startValue"), windowFunction),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.AggregationNode.Step;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.CteProducerNode;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.EquiJoinClause;
@@ -934,7 +935,7 @@ public class PlanBuilder
         return this;
     }
 
-    public WindowNode window(WindowNode.Specification specification, Map<VariableReferenceExpression, WindowNode.Function> functions, PlanNode source)
+    public WindowNode window(DataOrganizationSpecification specification, Map<VariableReferenceExpression, WindowNode.Function> functions, PlanNode source)
     {
         return new WindowNode(
                 Optional.empty(),
@@ -947,7 +948,7 @@ public class PlanBuilder
                 0);
     }
 
-    public WindowNode window(WindowNode.Specification specification, Map<VariableReferenceExpression, WindowNode.Function> functions, VariableReferenceExpression hashVariable, PlanNode source)
+    public WindowNode window(DataOrganizationSpecification specification, Map<VariableReferenceExpression, WindowNode.Function> functions, VariableReferenceExpression hashVariable, PlanNode source)
     {
         return new WindowNode(
                 Optional.empty(),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -15,7 +15,7 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.block.SortOrder;
-import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
@@ -53,7 +53,7 @@ public class TestEliminateSorts
     private static final String QUANTITY_ALIAS = "QUANTITY";
     private static final String TAX_ALIAS = "TAX";
 
-    private static final ExpectedValueProvider<WindowNode.Specification> windowSpec = specification(
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowSpec = specification(
             ImmutableList.of(),
             ImmutableList.of(QUANTITY_ALIAS),
             ImmutableMap.of(QUANTITY_ALIAS, SortOrder.ASC_NULLS_LAST));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
@@ -88,8 +89,8 @@ public class TestMergeWindows
 
     private static final Optional<WindowFrame> UNSPECIFIED_FRAME = Optional.empty();
 
-    private final ExpectedValueProvider<WindowNode.Specification> specificationA;
-    private final ExpectedValueProvider<WindowNode.Specification> specificationB;
+    private final ExpectedValueProvider<DataOrganizationSpecification> specificationA;
+    private final ExpectedValueProvider<DataOrganizationSpecification> specificationB;
 
     public TestMergeWindows()
     {
@@ -292,12 +293,12 @@ public class TestMergeWindows
     @Test
     public void testIdenticalWindowSpecificationsDefaultFrame()
     {
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
 
-        ExpectedValueProvider<WindowNode.Specification> specificationD = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationD = specification(
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableList.of(SHIPDATE_ALIAS),
                 ImmutableMap.of(SHIPDATE_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -328,7 +329,7 @@ public class TestMergeWindows
                 new FrameBound(FrameBound.Type.UNBOUNDED_PRECEDING),
                 Optional.of(new FrameBound(FrameBound.Type.CURRENT_ROW))));
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -362,7 +363,7 @@ public class TestMergeWindows
                 new FrameBound(FrameBound.Type.CURRENT_ROW),
                 Optional.of(new FrameBound(FrameBound.Type.UNBOUNDED_FOLLOWING))));
 
-        ExpectedValueProvider<WindowNode.Specification> specificationD = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationD = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -391,7 +392,7 @@ public class TestMergeWindows
                 new FrameBound(FrameBound.Type.CURRENT_ROW),
                 Optional.of(new FrameBound(FrameBound.Type.UNBOUNDED_FOLLOWING))));
 
-        ExpectedValueProvider<WindowNode.Specification> specificationD = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationD = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -433,12 +434,12 @@ public class TestMergeWindows
                 ")" +
                 "SELECT * FROM foo, bar WHERE foo.a = bar.b";
 
-        ExpectedValueProvider<WindowNode.Specification> leftSpecification = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> leftSpecification = specification(
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableList.of(SHIPDATE_ALIAS, QUANTITY_ALIAS),
                 ImmutableMap.of(SHIPDATE_ALIAS, SortOrder.ASC_NULLS_LAST, QUANTITY_ALIAS, SortOrder.DESC_NULLS_LAST));
 
-        ExpectedValueProvider<WindowNode.Specification> rightSpecification = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> rightSpecification = specification(
                 ImmutableList.of(rOrderkeyAlias),
                 ImmutableList.of(rShipdateAlias, rQuantityAlias),
                 ImmutableMap.of(rShipdateAlias, SortOrder.ASC_NULLS_LAST, rQuantityAlias, SortOrder.DESC_NULLS_LAST));
@@ -489,7 +490,7 @@ public class TestMergeWindows
                 "SUM(quantity) over (PARTITION BY quantity ORDER BY orderkey ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_quantity_C " +
                 "FROM lineitem";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(QUANTITY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -513,7 +514,7 @@ public class TestMergeWindows
                 "SUM(quantity) OVER (PARTITION BY suppkey ORDER BY quantity ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_quantity_C " +
                 "FROM lineitem";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(QUANTITY_ALIAS),
                 ImmutableMap.of(QUANTITY_ALIAS, SortOrder.ASC_NULLS_LAST));
@@ -538,7 +539,7 @@ public class TestMergeWindows
                 "SUM(discount) over (PARTITION BY suppkey ORDER BY orderkey ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_discount_A " +
                 "FROM lineitem";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.DESC_NULLS_LAST));
@@ -564,7 +565,7 @@ public class TestMergeWindows
                 "SUM(discount) OVER (PARTITION BY suppkey ORDER BY orderkey ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) sum_discount_A " +
                 "FROM lineitem";
 
-        ExpectedValueProvider<WindowNode.Specification> specificationC = specification(
+        ExpectedValueProvider<DataOrganizationSpecification> specificationC = specification(
                 ImmutableList.of(SUPPKEY_ALIAS),
                 ImmutableList.of(ORDERKEY_ALIAS),
                 ImmutableMap.of(ORDERKEY_ALIAS, SortOrder.ASC_NULLS_FIRST));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.optimizations;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -71,7 +72,7 @@ public class TestPruneUnreferencedOutputs
                         p.output(ImmutableList.of("user_uuid"), ImmutableList.of(p.variable("user_uuid", VARCHAR)),
                                 p.project(Assignments.of(p.variable("user_uuid", VARCHAR), p.variable("user_uuid", VARCHAR)),
                                         p.window(
-                                                new WindowNode.Specification(
+                                                new DataOrganizationSpecification(
                                                         ImmutableList.of(p.variable("user_uuid", VARCHAR)),
                                                         Optional.of(new OrderingScheme(
                                                                 ImmutableList.of(

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderWindows.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.common.block.SortOrder;
-import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.sql.InMemoryExpressionOptimizerProvider;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
@@ -59,13 +59,13 @@ public class TestReorderWindows
 
     private static final Optional<WindowFrame> commonFrame;
 
-    private static final ExpectedValueProvider<WindowNode.Specification> windowA;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowAp;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowApp;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowB;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowC;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowD;
-    private static final ExpectedValueProvider<WindowNode.Specification> windowE;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowA;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowAp;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowApp;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowB;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowC;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowD;
+    private static final ExpectedValueProvider<DataOrganizationSpecification> windowE;
 
     static {
         ImmutableMap.Builder<String, String> columns = ImmutableMap.builder();

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/plan/TestWindowNode.java
@@ -25,6 +25,7 @@ import com.facebook.presto.server.SliceDeserializer;
 import com.facebook.presto.server.SliceSerializer;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -116,7 +117,7 @@ public class TestWindowNode
                 Optional.empty());
 
         PlanNodeId id = newId();
-        WindowNode.Specification specification = new WindowNode.Specification(
+        DataOrganizationSpecification specification = new DataOrganizationSpecification(
                 ImmutableList.of(columnA),
                 Optional.of(new OrderingScheme(ImmutableList.of(new Ordering(columnB, SortOrder.ASC_NULLS_FIRST)))));
         CallExpression call = call("sum", functionHandle, BIGINT, new VariableReferenceExpression(Optional.empty(), columnC.getName(), BIGINT));

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -3146,6 +3146,43 @@ void from_json(const json& j, CreateHandle& p) {
       "schemaTableName");
 }
 } // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const DataOrganizationSpecification& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "partitionBy",
+      p.partitionBy,
+      "DataOrganizationSpecification",
+      "List<VariableReferenceExpression>",
+      "partitionBy");
+  to_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "DataOrganizationSpecification",
+      "OrderingScheme",
+      "orderingScheme");
+}
+
+void from_json(const json& j, DataOrganizationSpecification& p) {
+  from_json_key(
+      j,
+      "partitionBy",
+      p.partitionBy,
+      "DataOrganizationSpecification",
+      "List<VariableReferenceExpression>",
+      "partitionBy");
+  from_json_key(
+      j,
+      "orderingScheme",
+      p.orderingScheme,
+      "DataOrganizationSpecification",
+      "OrderingScheme",
+      "orderingScheme");
+}
+} // namespace facebook::presto::protocol
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -5634,6 +5671,19 @@ void from_json(const json& j, GroupIdNode& p) {
       "groupIdVariable");
 }
 } // namespace facebook::presto::protocol
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace facebook::presto::protocol {
 void to_json(json& j, const std::shared_ptr<ConnectorIndexHandle>& p) {
   if (p == nullptr) {
@@ -9532,43 +9582,6 @@ void from_json(const json& j, SpecialFormExpression& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-
-void to_json(json& j, const Specification& p) {
-  j = json::object();
-  to_json_key(
-      j,
-      "partitionBy",
-      p.partitionBy,
-      "Specification",
-      "List<VariableReferenceExpression>",
-      "partitionBy");
-  to_json_key(
-      j,
-      "orderingScheme",
-      p.orderingScheme,
-      "Specification",
-      "OrderingScheme",
-      "orderingScheme");
-}
-
-void from_json(const json& j, Specification& p) {
-  from_json_key(
-      j,
-      "partitionBy",
-      p.partitionBy,
-      "Specification",
-      "List<VariableReferenceExpression>",
-      "partitionBy");
-  from_json_key(
-      j,
-      "orderingScheme",
-      p.orderingScheme,
-      "Specification",
-      "OrderingScheme",
-      "orderingScheme");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 SqlFunctionHandle::SqlFunctionHandle() noexcept {
   _type = "json_file";
 }
@@ -11328,7 +11341,7 @@ void to_json(json& j, const TopNRowNumberNode& p) {
       "specification",
       p.specification,
       "TopNRowNumberNode",
-      "Specification",
+      "DataOrganizationSpecification",
       "specification");
   to_json_key(
       j,
@@ -11364,7 +11377,7 @@ void from_json(const json& j, TopNRowNumberNode& p) {
       "specification",
       p.specification,
       "TopNRowNumberNode",
-      "Specification",
+      "DataOrganizationSpecification",
       "specification");
   from_json_key(
       j,
@@ -11560,7 +11573,7 @@ void to_json(json& j, const WindowNode& p) {
       "specification",
       p.specification,
       "WindowNode",
-      "Specification",
+      "DataOrganizationSpecification",
       "specification");
   to_json_key(
       j,
@@ -11608,7 +11621,7 @@ void from_json(const json& j, WindowNode& p) {
       "specification",
       p.specification,
       "WindowNode",
-      "Specification",
+      "DataOrganizationSpecification",
       "specification");
   from_json_key(
       j,

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1018,6 +1018,14 @@ void to_json(json& j, const CreateHandle& p);
 void from_json(const json& j, CreateHandle& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+struct DataOrganizationSpecification {
+  List<VariableReferenceExpression> partitionBy = {};
+  std::shared_ptr<OrderingScheme> orderingScheme = {};
+};
+void to_json(json& j, const DataOrganizationSpecification& p);
+void from_json(const json& j, DataOrganizationSpecification& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct DeleteTableHandle {
   ConnectorId connectorId = {};
   std::shared_ptr<ConnectorTransactionHandle> transactionHandle = {};
@@ -2305,14 +2313,6 @@ void to_json(json& j, const SpecialFormExpression& p);
 void from_json(const json& j, SpecialFormExpression& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct Specification {
-  List<VariableReferenceExpression> partitionBy = {};
-  std::shared_ptr<OrderingScheme> orderingScheme = {};
-};
-void to_json(json& j, const Specification& p);
-void from_json(const json& j, Specification& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 struct SqlFunctionHandle : public FunctionHandle {
   SqlFunctionId functionId = {};
   String version = {};
@@ -2591,7 +2591,7 @@ void from_json(const json& j, TopNNode& p);
 namespace facebook::presto::protocol {
 struct TopNRowNumberNode : public PlanNode {
   std::shared_ptr<PlanNode> source = {};
-  Specification specification = {};
+  DataOrganizationSpecification specification = {};
   VariableReferenceExpression rowNumberVariable = {};
   int maxRowCountPerPartition = {};
   bool partial = {};
@@ -2641,7 +2641,7 @@ struct WindowNode : public PlanNode {
   std::shared_ptr<SourceLocation> sourceLocation = {};
 
   std::shared_ptr<PlanNode> source = {};
-  Specification specification = {};
+  DataOrganizationSpecification specification = {};
   Map<VariableReferenceExpression, Function> windowFunctions = {};
   std::shared_ptr<VariableReferenceExpression> hashVariable = {};
   List<VariableReferenceExpression> prePartitionedInputs = {};

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -208,6 +208,7 @@ JavaClasses:
   - presto-common/src/main/java/com/facebook/presto/common/RuntimeUnit.java
   - presto-main-base/src/main/java/com/facebook/presto/metadata/AnalyzeTableHandle.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/Assignments.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/plan/DataOrganizationSpecification.java
   - presto-common/src/main/java/com/facebook/presto/common/block/Block.java
   - presto-main-base/src/main/java/com/facebook/presto/operator/BlockedReason.java
   - presto-main-base/src/main/java/com/facebook/presto/execution/buffer/BufferInfo.java

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/DataOrganizationSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/DataOrganizationSpecification.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class DataOrganizationSpecification
+{
+    private final List<VariableReferenceExpression> partitionBy;
+    private final Optional<OrderingScheme> orderingScheme;
+
+    @JsonCreator
+    public DataOrganizationSpecification(
+            @JsonProperty("partitionBy") List<VariableReferenceExpression> partitionBy,
+            @JsonProperty("orderingScheme") Optional<OrderingScheme> orderingScheme)
+    {
+        requireNonNull(partitionBy, "partitionBy is null");
+        requireNonNull(orderingScheme, "orderingScheme is null");
+
+        this.partitionBy = unmodifiableList(new ArrayList<>(partitionBy));
+        this.orderingScheme = requireNonNull(orderingScheme, "orderingScheme is null");
+    }
+
+    @JsonProperty
+    public List<VariableReferenceExpression> getPartitionBy()
+    {
+        return partitionBy;
+    }
+
+    @JsonProperty
+    public Optional<OrderingScheme> getOrderingScheme()
+    {
+        return orderingScheme;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(partitionBy, orderingScheme);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        DataOrganizationSpecification other = (DataOrganizationSpecification) obj;
+
+        return Objects.equals(this.partitionBy, other.partitionBy) &&
+                Objects.equals(this.orderingScheme, other.orderingScheme);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/WindowNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/WindowNode.java
@@ -47,7 +47,7 @@ public class WindowNode
 {
     private final PlanNode source;
     private final Set<VariableReferenceExpression> prePartitionedInputs;
-    private final Specification specification;
+    private final DataOrganizationSpecification specification;
     private final int preSortedOrderPrefix;
     private final Map<VariableReferenceExpression, Function> windowFunctions;
     private final Optional<VariableReferenceExpression> hashVariable;
@@ -57,7 +57,7 @@ public class WindowNode
             @JsonProperty("sourceLocation") Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("specification") Specification specification,
+            @JsonProperty("specification") DataOrganizationSpecification specification,
             @JsonProperty("windowFunctions") Map<VariableReferenceExpression, Function> windowFunctions,
             @JsonProperty("hashVariable") Optional<VariableReferenceExpression> hashVariable,
             @JsonProperty("prePartitionedInputs") Set<VariableReferenceExpression> prePartitionedInputs,
@@ -71,7 +71,7 @@ public class WindowNode
             PlanNodeId id,
             Optional<PlanNode> statsEquivalentPlanNode,
             PlanNode source,
-            Specification specification,
+            DataOrganizationSpecification specification,
             Map<VariableReferenceExpression, Function> windowFunctions,
             Optional<VariableReferenceExpression> hashVariable,
             Set<VariableReferenceExpression> prePartitionedInputs,
@@ -122,7 +122,7 @@ public class WindowNode
     }
 
     @JsonProperty
-    public Specification getSpecification()
+    public DataOrganizationSpecification getSpecification()
     {
         return specification;
     }
@@ -134,7 +134,7 @@ public class WindowNode
 
     public Optional<OrderingScheme> getOrderingScheme()
     {
-        return specification.orderingScheme;
+        return specification.getOrderingScheme();
     }
 
     @JsonProperty
@@ -186,60 +186,6 @@ public class WindowNode
     public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
     {
         return new WindowNode(getSourceLocation(), getId(), statsEquivalentPlanNode, source, specification, windowFunctions, hashVariable, prePartitionedInputs, preSortedOrderPrefix);
-    }
-
-    @Immutable
-    public static class Specification
-    {
-        private final List<VariableReferenceExpression> partitionBy;
-        private final Optional<OrderingScheme> orderingScheme;
-
-        @JsonCreator
-        public Specification(
-                @JsonProperty("partitionBy") List<VariableReferenceExpression> partitionBy,
-                @JsonProperty("orderingScheme") Optional<OrderingScheme> orderingScheme)
-        {
-            requireNonNull(partitionBy, "partitionBy is null");
-            requireNonNull(orderingScheme, "orderingScheme is null");
-
-            this.partitionBy = unmodifiableList(new ArrayList<>(partitionBy));
-            this.orderingScheme = requireNonNull(orderingScheme, "orderingScheme is null");
-        }
-
-        @JsonProperty
-        public List<VariableReferenceExpression> getPartitionBy()
-        {
-            return partitionBy;
-        }
-
-        @JsonProperty
-        public Optional<OrderingScheme> getOrderingScheme()
-        {
-            return orderingScheme;
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(partitionBy, orderingScheme);
-        }
-
-        @Override
-        public boolean equals(Object obj)
-        {
-            if (this == obj) {
-                return true;
-            }
-
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-
-            Specification other = (Specification) obj;
-
-            return Objects.equals(this.partitionBy, other.partitionBy) &&
-                    Objects.equals(this.orderingScheme, other.orderingScheme);
-        }
     }
 
     @Immutable


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Extract WindowNode.Specification as a separate class to clean up TVF Porting PR which can be viewed here
https://github.com/prestodb/presto/pull/25032/

Changes adapted from trino/PR#14175

Had to regenerate Presto Protocol due to renaming of Specification -> DataOrganizationSpecification. 
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
WindowNode.Specification/DataOrganizationSpecification is utilized in table functions to store the order by and partition by properties for the table function. Therefore it is no longer WindowNode specific. 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
None.

## Test Plan
<!---Please fill in how you tested your change-->
No underlying changes.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== NO RELEASE NOTE ==
```

