### PR TITLE
Add link checker workflow

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,47 @@
+name: link checker
+
+on:
+  workflow_dispatch:
+  # Check links once a week on Monday
+  schedule:
+    - cron: "00 00 * * 1"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --verbose
+            --no-progress
+            --include-fragments
+            --accept 100..=103,200..=299,429
+            --exclude 408,504
+            --exclude-loopback
+            --exclude-path 'presto-docs/src/main/sphinx/_templates/partials/toc.html'
+            --exclude 'https://www.gnu.org/software/gperf'
+            --max-concurrency 32 
+            -- .
+          fail: false
+          jobSummary: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=now::$(date +'%d-%m-%Y')"
+
+      - name: Create Issue from File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Automated Links Checker Report for ${{ steps.date.outputs.now }}
+          content-filepath: ./lychee/out.md
+          labels: automated issue, docs


### PR DESCRIPTION
## Description

This PR introduces a GitHub Action workflow to automatically detect broken links in the codebase and optionally create issues to report them.

Although the [related issue](https://github.com/prestodb/presto/issues/21810) originally suggested using the Baler (Bad Link Reporter) GitHub Action, after evaluating several alternatives, I chose to implement the solution using **Lychee Broken Link Checker**. Lychee is more robust, better maintained, widely used, well-documented, and offers enhanced customization and error reporting.

I also reviewed [several repositories](https://github.com/lycheeverse/lychee?tab=readme-ov-file#users) that use Lychee. In most cases, they only run the link-checking step without automating issue creation—likely to avoid overwhelming the issue tracker, especially in projects with many existing problems. We can decide whether to enable the automated issue-reporting step based on how much noise we're willing to tolerate.

## Motivation and Context

Related Issue: [https://github.com/prestodb/presto/issues/21810](https://github.com/prestodb/presto/issues/21810)

## Test Plan

I tested the workflow by manually triggering it in my fork. It correctly identified several broken links and successfully created this issue: [https://github.com/mecit-san/presto/issues/11](https://github.com/mecit-san/presto/issues/11)

## Contributor Checklist

* [x] My submission complies with the [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), including [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
* [x] The PR description accurately and concisely addresses the issue and includes a link to the related GitHub issue.

## Release Notes

Please follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and complete the section below.

```
== NO RELEASE NOTE ==
```
