### PR TITLE
Fix the partial aggregation pushdown for system table for native execution

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/Lookup.java
@@ -35,7 +35,7 @@ public interface Lookup
     default PlanNode resolve(PlanNode node)
     {
         if (node instanceof GroupReference) {
-            return resolveGroup(node).collect(toOptional()).get();
+            return resolveGroup(node).collect(toOptional()).orElse(node);
         }
         return node;
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeSystemQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeSystemQueries.java
@@ -21,7 +21,8 @@ import java.util.Collections;
 
 import static com.facebook.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.getNativeQueryRunnerParameters;
-import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
@@ -67,10 +68,13 @@ public abstract class AbstractTestNativeSystemQueries
                 anyTree(
                         aggregation(
                                 Collections.emptyMap(),
-                                SINGLE,
+                                FINAL,
                                 exchange(LOCAL, GATHER,
-                                        exchange(REMOTE_STREAMING, GATHER,
-                                                tableScan("tasks"))))));
+                                        aggregation(
+                                                Collections.emptyMap(),
+                                                PARTIAL,
+                                                exchange(REMOTE_STREAMING, GATHER,
+                                                        tableScan("tasks")))))));
     }
 
     @Test


### PR DESCRIPTION
Follow up on https://github.com/prestodb/presto/pull/21725

`containsSystemTableScan` will limit all the partial aggregation generation and pushdown 
whenever we have a system table for native execution as leaf node.

When we have an aggregation on mix of empty grouping set and non-empty grouping set,
It would be forced to split into a partial aggregation and final aggregation on repartitioned 
exchange. The partial aggregation could have been pushed down under the repartitioned 
exchange but is not pushed down, due to the above constraint, leading to an invalid plan.

Fix the behavior by more precise check `directlyOnSystemTableScan` for partial aggregatio
pushdown.


```
== NO RELEASE NOTE ==
```

