### PR TITLE
Fix incorrect quote formatting on decimal functions documentation page

### DIFF
--- a/presto-docs/src/main/sphinx/functions/decimal.rst
+++ b/presto-docs/src/main/sphinx/functions/decimal.rst
@@ -5,11 +5,11 @@ Decimal Functions and Operators
 Decimal Literals
 ----------------
 
-    Use ``DECIMAL 'xxxxxxx.yyyyyyy'`` syntax to define literal of DECIMAL type.
+Use ``DECIMAL 'xxxxxxx.yyyyyyy'`` syntax to define literal of DECIMAL type.
 
-    The precision of DECIMAL type for literal will be equal to number of digits
-    in literal (including trailing and leading zeros).
-    The scale will be equal to number of digits in fractional part (including trailing zeros).
+The precision of DECIMAL type for literal will be equal to number of digits
+in literal (including trailing and leading zeros).
+The scale will be equal to number of digits in fractional part (including trailing zeros).
 
 =========================================== =============================
 Example literal                             Data type
@@ -22,9 +22,9 @@ Example literal                             Data type
 Binary Arithmetic Decimal Operators
 -----------------------------------
 
-    Standard mathematical operators are supported. The table below explains
-    precision and scale calculation rules for result.
-    Assuming ``x`` is of type ``DECIMAL(xp, xs)`` and ``y`` is of type ``DECIMAL(yp, ys)``.
+Standard mathematical operators are supported. The table below explains
+precision and scale calculation rules for result.
+Assuming ``x`` is of type ``DECIMAL(xp, xs)`` and ``y`` is of type ``DECIMAL(yp, ys)``.
 
 +---------------+-----------------------------------+-----------------------------------+
 | Operation     | Result type precision             | Result type scale                 |
@@ -52,23 +52,23 @@ Binary Arithmetic Decimal Operators
 |               |   max(xs, bs)                     |                                   |
 +---------------+-----------------------------------+-----------------------------------+
 
-    If the mathematical result of the operation is not exactly representable with
-    the precision and scale of the result data type,
-    then an exception condition is raised - ``Value is out of range``.
+If the mathematical result of the operation is not exactly representable with
+the precision and scale of the result data type,
+then an exception condition is raised - ``Value is out of range``.
 
-    When operating on decimal types with different scale and precision, the values are
-    first coerced to a common super type. For types near the largest representable precision (38),
-    this can result in Value is out of range errors when one of the operands doesn't fit
-    in the common super type. For example, the common super type of decimal(38, 0) and
-    decimal(38, 1) is decimal(38, 1), but certain values that fit in decimal(38, 0)
-    cannot be represented as a decimal(38, 1).
+When operating on decimal types with different scale and precision, the values are
+first coerced to a common super type. For types near the largest representable precision (38),
+this can result in Value is out of range errors when one of the operands doesn't fit
+in the common super type. For example, the common super type of decimal(38, 0) and
+decimal(38, 1) is decimal(38, 1), but certain values that fit in decimal(38, 0)
+cannot be represented as a decimal(38, 1).
 
 Comparison Operators
 --------------------
 
-    All standard comparison operators and ``BETWEEN`` operator work for ``DECIMAL`` type.
+All standard comparison operators and ``BETWEEN`` operator work for ``DECIMAL`` type.
 
 Unary Decimal Operators
 -----------------------
 
-    The ``-`` operator performs negation. The type of result is same as type of argument.
+The ``-`` operator performs negation. The type of result is same as type of argument.


### PR DESCRIPTION
## Description
This PR fixes [#19829](https://github.com/prestodb/presto/issues/19829), where the content on the [Decimal Functions documentation page](https://prestodb.io/docs/0.281/functions/decimal.html) appeared incorrectly formatted as a quote. 

- Corrected the markdown formatting in the decimal.rst file to remove unintended quotes.
- Verified that the rendered HTML no longer wraps the content in a quote.

## Motivation and Context
Address [#19829](https://github.com/prestodb/presto/issues/19829)

## Impact
Update Documents

## Test Plan
[Build the document](https://github.com/prestodb/presto/issues/19829) and test this path `/functions/decimal.html` and make sure document content is fixed.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== NO RELEASE NOTE ==
```

