### PR TITLE
refactor: Move MemoryManagerOptions inside MemoryManager step0, explicitly specify object type

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
@@ -34,7 +34,7 @@ class HttpJwtTestSuite : public ::testing::TestWithParam<bool> {
 
  protected:
   static void SetUpTestCase() {
-    memory::MemoryManager::testingSetInstance({});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
   }
 
   std::unique_ptr<config::ConfigBase> jwtSystemConfig(

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
 class HttpsBasicTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    memory::MemoryManager::testingSetInstance({});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
   }
 };
 
@@ -64,7 +64,7 @@ class HttpTestSuite : public ::testing::TestWithParam<bool> {
 
  protected:
   static void SetUpTestCase() {
-    memory::MemoryManager::testingSetInstance({});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
   }
 
   std::unique_ptr<http::HttpServer> getServer(

--- a/presto-native-execution/presto_cpp/main/operators/benchmarks/BinarySortableSerializerBenchmark.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/benchmarks/BinarySortableSerializerBenchmark.cpp
@@ -163,7 +163,7 @@ BENCHMARK(structsSerialize) {
 
 int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
-  facebook::velox::memory::MemoryManager::initialize({});
+  facebook::velox::memory::MemoryManager::initialize(facebook::velox::memory::MemoryManagerOptions{});
   folly::runBenchmarks();
   return 0;
 }

--- a/presto-native-execution/presto_cpp/main/operators/benchmarks/BinarySortableSerializerBenchmark.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/benchmarks/BinarySortableSerializerBenchmark.cpp
@@ -163,7 +163,8 @@ BENCHMARK(structsSerialize) {
 
 int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
-  facebook::velox::memory::MemoryManager::initialize(facebook::velox::memory::MemoryManagerOptions{});
+  facebook::velox::memory::MemoryManager::initialize(
+      facebook::velox::memory::MemoryManagerOptions{});
   folly::runBenchmarks();
   return 0;
 }

--- a/presto-native-execution/presto_cpp/main/operators/tests/BinarySortableSerializerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BinarySortableSerializerTest.cpp
@@ -52,7 +52,7 @@ class BinarySortableSerializerTest : public ::testing::Test,
                                      public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
-    velox::memory::MemoryManager::testingSetInstance({});
+    velox::memory::MemoryManager::testingSetInstance(velox::memory::MemoryManagerOptions{});
   }
 
   int compareRowVector(
@@ -142,7 +142,7 @@ class BinarySortableSerializerFuzzerTest : public ::testing::Test,
                                            public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
-    velox::memory::MemoryManager::testingSetInstance({});
+    velox::memory::MemoryManager::testingSetInstance(velox::memory::MemoryManagerOptions{});
   }
 
   void runFuzzerTest(const velox::RowTypePtr& rowType) {

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeSerdeTest.cpp
@@ -30,7 +30,7 @@ class PlanNodeSerdeTest : public testing::Test,
                           public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
-    memory::MemoryManager::testingSetInstance({});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
   }
 
   PlanNodeSerdeTest() {

--- a/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
@@ -222,6 +222,6 @@ TEST_F(PeriodicMemoryCheckerTest, pushbackMemory) {
   // Shutdown global memory setups
   asyncDataCache->shutdown();
   cache::AsyncDataCache::setInstance(nullptr);
-  memory::MemoryManager::testingSetInstance({});
+  memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
 }
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
@@ -37,7 +37,7 @@ void verifyQueryCtxCache(
 class QueryContextCacheTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
-    memory::MemoryManager::testingSetInstance({});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
   }
 
   void SetUp() override {

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -22,7 +22,7 @@ namespace facebook::presto {
 class QueryContextManagerTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
-    velox::memory::MemoryManager::testingSetInstance({});
+    velox::memory::MemoryManager::testingSetInstance(velox::memory::MemoryManagerOptions{});
   }
 
   void SetUp() override {

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<const core::PlanNode> assertToBatchVeloxQueryPlan(
 class PlanConverterTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    memory::MemoryManager::testingSetInstance({});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
   }
 
   void SetUp() override {

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -27,7 +27,7 @@ using namespace facebook::velox::core;
 class RowExpressionTest : public ::testing::Test {
  public:
   static void SetUpTestCase() {
-    memory::MemoryManager::testingSetInstance({});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManagerOptions{});
   }
 
   void SetUp() override {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

