### PR TITLE
[native] Export proper Task create time

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -108,6 +108,7 @@ struct PrestoTask {
 
   uint64_t lastMemoryReservation{0};
   uint64_t createTimeMs{0};
+  uint64_t startTimeMs{0};
   uint64_t firstSplitStartTimeMs{0};
   uint64_t lastEndTimeMs{0};
   mutable std::mutex mutex;


### PR DESCRIPTION
## Description
We used to put execution start time into Task creation time. Fix it.
Also remove unnecessary Task state string from a method.

```
== NO RELEASE NOTE ==
```

