### PR TITLE
Enable access control row filters and masks for views

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/QueryAssertions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/QueryAssertions.java
@@ -106,9 +106,19 @@ public class QueryAssertions
 
     public void assertQuery(@Language("SQL") String actual, @Language("SQL") String expected, boolean ensureOrdering)
     {
+        assertQuery(runner.getDefaultSession(), actual, expected, ensureOrdering);
+    }
+
+    public void assertQuery(Session session, @Language("SQL") String actual, @Language("SQL") String expected)
+    {
+        assertQuery(session, actual, expected, false);
+    }
+
+    public void assertQuery(Session session, @Language("SQL") String actual, @Language("SQL") String expected, boolean ensureOrdering)
+    {
         MaterializedResult actualResults = null;
         try {
-            actualResults = runner.execute(runner.getDefaultSession(), actual).toTestTypes();
+            actualResults = runner.execute(session, actual).toTestTypes();
         }
         catch (RuntimeException ex) {
             fail("Execution of 'actual' query failed: " + actual, ex);
@@ -116,7 +126,7 @@ public class QueryAssertions
 
         MaterializedResult expectedResults = null;
         try {
-            expectedResults = runner.execute(runner.getDefaultSession(), expected).toTestTypes();
+            expectedResults = runner.execute(session, expected).toTestTypes();
         }
         catch (RuntimeException ex) {
             fail("Execution of 'expected' query failed: " + expected, ex);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestColumnMask.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestColumnMask.java
@@ -464,5 +464,17 @@ public class TestColumnMask
 
             assertions.assertQuery(session, "SELECT name FROM mock.default.nation_view WHERE nationkey = 1", "VALUES CAST('ARGENTINA' AS VARCHAR(25))");
         });
+
+        // mask on the view
+        assertions.executeExclusively(() -> {
+            accessControl.reset();
+            accessControl.columnMask(
+                    new QualifiedObjectName(MOCK_CATALOG, "default", "nation_view"),
+                    "name",
+                    USER,
+                    new ViewExpression(USER, Optional.of(CATALOG), Optional.of("tiny"), "reverse(name)"));
+
+            assertions.assertQuery("SELECT name FROM mock.default.nation_view WHERE nationkey = 1", "VALUES CAST('ANITNEGRA' AS VARCHAR(25))");
+        });
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestColumnMask.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestColumnMask.java
@@ -13,13 +13,20 @@
  */
 package com.facebook.presto.sql.query;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.connector.MockConnectorFactory;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.ViewExpression;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.facebook.presto.testing.TestingAccessControlManager;
 import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -27,14 +34,23 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 
 public class TestColumnMask
 {
+    private static final JsonCodec<ViewDefinition> VIEW_DEFINITION_JSON_CODEC = JsonCodec.jsonCodec(ViewDefinition.class);
     private static final String CATALOG = "local";
+    private static final String MOCK_CATALOG = "mock";
     private static final String USER = "user";
     private static final String RUN_AS_USER = "run-as-user";
+    private static final String VIEW_OWNER = "view-owner";
+
+    private static final Session SESSION = testSessionBuilder()
+            .setCatalog(CATALOG)
+            .setSchema(TINY_SCHEMA_NAME)
+            .setIdentity(new Identity(USER, Optional.empty())).build();
 
     private QueryAssertions assertions;
     private TestingAccessControlManager accessControl;
@@ -42,14 +58,32 @@ public class TestColumnMask
     @BeforeClass
     public void init()
     {
-        Session session = testSessionBuilder()
-                .setCatalog(CATALOG)
-                .setSchema(TINY_SCHEMA_NAME)
-                .setIdentity(new Identity(USER, Optional.empty())).build();
-
-        LocalQueryRunner runner = new LocalQueryRunner(session);
+        LocalQueryRunner runner = new LocalQueryRunner(SESSION);
 
         runner.createCatalog(CATALOG, new TpchConnectorFactory(1), ImmutableMap.of());
+
+        SchemaTableName viewSchemaTableName = new SchemaTableName("default", "nation_view");
+        ViewDefinition viewDefinition = new ViewDefinition(
+                "SELECT nationkey, name FROM local.tiny.nation",
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of(new ViewDefinition.ViewColumn("nationkey", BIGINT), new ViewDefinition.ViewColumn("name", VarcharType.createVarcharType(25))),
+                Optional.of(VIEW_OWNER),
+                false);
+        String viewJson = VIEW_DEFINITION_JSON_CODEC.toJson(viewDefinition);
+
+        ConnectorViewDefinition view = new ConnectorViewDefinition(
+                viewSchemaTableName,
+                Optional.of(VIEW_OWNER),
+                viewJson);
+
+        MockConnectorFactory mock = MockConnectorFactory.builder()
+                .withGetViews((s, prefix) -> ImmutableMap.<SchemaTableName, ConnectorViewDefinition>builder()
+                        .put(viewSchemaTableName, view)
+                        .build())
+                .build();
+
+        runner.createCatalog(MOCK_CATALOG, mock, ImmutableMap.of());
 
         assertions = new QueryAssertions(runner);
         accessControl = assertions.getQueryRunner().getAccessControl();
@@ -377,6 +411,58 @@ public class TestColumnMask
                     new ViewExpression(USER, Optional.of(CATALOG), Optional.of("tiny"), "clerk"));
 
             assertions.assertFails("DELETE FROM orders", "\\Qline 1:1: Delete from table with column mask is not supported\\E");
+        });
+    }
+
+    @Test
+    public void testView()
+    {
+        // mask on the underlying table for view owner when running query as different user
+        assertions.executeExclusively(() -> {
+            accessControl.reset();
+            accessControl.columnMask(
+                    new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                    "name",
+                    VIEW_OWNER,
+                    new ViewExpression(VIEW_OWNER, Optional.empty(), Optional.empty(), "reverse(name)"));
+
+            Session session = Session.builder(SESSION)
+                    .setIdentity(new Identity(RUN_AS_USER, Optional.empty()))
+                    .build();
+
+            assertions.assertQuery(session, "SELECT name FROM mock.default.nation_view WHERE nationkey = 1", "VALUES CAST('ANITNEGRA' AS VARCHAR(25))");
+        });
+
+        // mask on the underlying table for view owner when running as themselves
+        assertions.executeExclusively(() -> {
+            accessControl.reset();
+            accessControl.columnMask(
+                    new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                    "name",
+                    VIEW_OWNER,
+                    new ViewExpression(VIEW_OWNER, Optional.of(CATALOG), Optional.of("tiny"), "reverse(name)"));
+
+            Session session = Session.builder(SESSION)
+                    .setIdentity(new Identity(VIEW_OWNER, Optional.empty()))
+                    .build();
+
+            assertions.assertQuery(session, "SELECT name FROM mock.default.nation_view WHERE nationkey = 1", "VALUES CAST('ANITNEGRA' AS VARCHAR(25))");
+        });
+
+        // mask on the underlying table for user running the query (different from view owner) should not be applied
+        assertions.executeExclusively(() -> {
+            accessControl.reset();
+            accessControl.columnMask(
+                    new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                    "name",
+                    RUN_AS_USER,
+                    new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "reverse(name)"));
+
+            Session session = Session.builder(SESSION)
+                    .setIdentity(new Identity(RUN_AS_USER, Optional.empty()))
+                    .build();
+
+            assertions.assertQuery(session, "SELECT name FROM mock.default.nation_view WHERE nationkey = 1", "VALUES CAST('ARGENTINA' AS VARCHAR(25))");
         });
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestRowFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/query/TestRowFilter.java
@@ -413,5 +413,15 @@ public class TestRowFilter
 
             assertions.assertQuery(session, "SELECT count(*) FROM mock.default.nation_view", "VALUES BIGINT '25'");
         });
+
+        // filter on the view
+        assertions.executeExclusively(() -> {
+            accessControl.reset();
+            accessControl.rowFilter(
+                    new QualifiedObjectName(MOCK_CATALOG, "default", "nation_view"),
+                    USER,
+                    new ViewExpression(USER, Optional.of(CATALOG), Optional.of("tiny"), "nationkey = 1"));
+            assertions.assertQuery("SELECT name FROM mock.default.nation_view", "VALUES CAST('ARGENTINA' AS VARCHAR(25))");
+        });
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/ViewAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/ViewAccessControl.java
@@ -16,8 +16,11 @@ package com.facebook.presto.spi.security;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.spi.ColumnMetadata;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -44,5 +47,17 @@ public class ViewAccessControl
     public void checkCanCreateViewWithSelectFromColumns(TransactionId transactionId, Identity identity, AccessControlContext context, QualifiedObjectName tableName, Set<String> columnNames)
     {
         delegate.checkCanCreateViewWithSelectFromColumns(transactionId, identity, context, tableName, columnNames);
+    }
+
+    @Override
+    public List<ViewExpression> getRowFilters(TransactionId transactionId, Identity identity, AccessControlContext context, QualifiedObjectName tableName)
+    {
+        return delegate.getRowFilters(transactionId, identity, context, tableName);
+    }
+
+    @Override
+    public Map<ColumnMetadata, ViewExpression> getColumnMasks(TransactionId transactionId, Identity identity, AccessControlContext context, QualifiedObjectName tableName, List<ColumnMetadata> columns)
+    {
+        return delegate.getColumnMasks(transactionId, identity, context, tableName, columns);
     }
 }


### PR DESCRIPTION
## Description
This enables adding row filters and column masks from an access control implementation to view.

Closes https://github.com/prestodb/presto/issues/25025

## Motivation and Context
The recent addition of access control row filters and column masks from https://github.com/prestodb/presto/issues/24278 worked for tables, but not for views. It is import for security that views and materialized views apply row filters and column masks from access control. 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No change in SPI.

## Test Plan
Unit tests added to verify filters and masks are correctly applied to views.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Add support for access control row filters and column masks on views.

```

