### PR TITLE
[Refactor] `parquet_writer_version` -> `parquet_writer_datapage_version`

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -918,12 +918,16 @@ The following operations are not supported when ``avro_schema_url`` is set:
 * Using partitioning(``partitioned_by``) or bucketing(``bucketed_by``) columns are not supported in ``CREATE TABLE``.
 * ``ALTER TABLE`` commands modifying columns are not supported.
 
-Parquet Writer Version
+Parquet Data Page Version (formerly referred to as "Parquet Writer Version")
 ----------------------
 
-Presto now supports Parquet writer versions V1 and V2 for the Hive catalog.
-It can be toggled using the session property ``parquet_writer_version`` and the config property ``hive.parquet.writer.version``.
-Valid values for these properties are ``PARQUET_1_0`` and ``PARQUET_2_0``. Default is ``PARQUET_1_0``.
+Presto supports Parquet Data Page versions V1 and V2 for the Hive catalog.
+It can be toggled using the session property ``parquet_writer_datapage_version`` and the config property ``hive.parquet.writer.datapage.version``.
+Valid values for these properties are ``V1`` and ``V2``. Default is ``V1``.
+
+The former session property that handled this toggle, ``parquet_writer_version``, is now deprecated.
+Use ``parquet_writer_datapage_version`` instead.
+It should be noted that this setting controls the data page encoding (V1/V2), not the file‑format version often referred to as the "Parquet format version" (2.4, 2.6, etc.).
 
 Procedures
 ----------

--- a/presto-hive/src/main/java/com/facebook/presto/hive/DataPageVersion.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DataPageVersion.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.PrestoException;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static java.lang.String.format;
+
+public enum DataPageVersion {
+    V1(WriterVersion.PARQUET_1_0),
+    V2(WriterVersion.PARQUET_2_0);
+
+    private final WriterVersion writerVersion;
+
+    DataPageVersion(WriterVersion writerVersion)
+    {
+        this.writerVersion = writerVersion;
+    }
+
+    /** Convert back to the Apache‑Parquet WriterVersion enum. */
+    WriterVersion toWriterVersion()
+    {
+        return writerVersion;
+    }
+
+    /** Accept short-form datapage string (V1/V2).  */
+    static DataPageVersion fromString(String value)
+    {
+        switch (value.toUpperCase()) {
+            case "V1":
+                return V1;
+            case "V2":
+                return V2;
+            default:
+                throw new PrestoException(
+                        INVALID_SESSION_PROPERTY,
+                        format("Unsupported value '%s' for session property (allowed: V1, V2)", value));
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -67,7 +67,9 @@ public final class HiveSessionProperties
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "parquet_optimized_writer_enabled";
+    @Deprecated
     private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
+    private static final String PARQUET_WRITER_DATAPAGE_VERSION = "parquet_writer_datapage_version";
     private static final String MAX_SPLIT_SIZE = "max_split_size";
     private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
     public static final String RCFILE_OPTIMIZED_WRITER_ENABLED = "rcfile_optimized_writer_enabled";
@@ -441,13 +443,22 @@ public final class HiveSessionProperties
                         false),
                 new PropertyMetadata<>(
                         PARQUET_WRITER_VERSION,
-                        "Parquet: Writer version",
+                        "Parquet: Writer version (deprecated)",
                         VARCHAR,
                         ParquetProperties.WriterVersion.class,
                         parquetFileWriterConfig.getWriterVersion(),
                         false,
                         value -> ParquetProperties.WriterVersion.valueOf(((String) value).toUpperCase()),
                         ParquetProperties.WriterVersion::name),
+                new PropertyMetadata<>(
+                        PARQUET_WRITER_DATAPAGE_VERSION,
+                        "Parquet: Datapage version (V1 or V2)",
+                        VARCHAR,
+                        DataPageVersion.class,
+                        DataPageVersion.V1,
+                        false,
+                        value -> DataPageVersion.fromString(((String) value).toUpperCase()),
+                        DataPageVersion::name),
                 booleanProperty(
                         IGNORE_UNREADABLE_PARTITION,
                         "Ignore unreadable partitions and report as warnings instead of failing the query",
@@ -980,7 +991,7 @@ public final class HiveSessionProperties
 
     public static ParquetProperties.WriterVersion getParquetWriterVersion(ConnectorSession session)
     {
-        return session.getProperty(PARQUET_WRITER_VERSION, ParquetProperties.WriterVersion.class);
+        return session.getProperty(PARQUET_WRITER_DATAPAGE_VERSION, DataPageVersion.class).toWriterVersion();
     }
 
     public static BucketFunctionType getBucketFunctionTypeForExchange(ConnectorSession session)

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -70,6 +70,11 @@ toConnectorConfigs(const protocol::SessionRepresentation& session) {
       auto veloxConfig = (sessionProperty.first.rfind("native_", 0) == 0)
           ? sessionProperty.first.substr(7)
           : sessionProperty.first;
+
+      if (veloxConfig == "parquet_writer_datapage_version") {
+        veloxConfig = "hive.parquet.writer.datapage_version";
+      }
+
       connectorConfig.emplace(veloxConfig, sessionProperty.second);
     }
     connectorConfigs.insert(
@@ -90,6 +95,7 @@ void updateVeloxConfigs(
     configStrings.emplace(
         core::QueryConfig::kAdjustTimestampToTimezone, "true");
   }
+
   // TODO: remove this once cpu driver slicing config is turned on by default in
   // Velox.
   it = configStrings.find(core::QueryConfig::kDriverCpuTimeSliceLimitMs);


### PR DESCRIPTION
## Description
Refactoring the `parquet_writer_version` session property to `parquet_writer_datapage_version`. 

TODO - check Hive config property

## Motivation and Context
Resolves https://github.com/prestodb/presto/issues/24818. 

The ambiguous naming with 'writer_version'  has been a source of confusion for many, due to the fact that there are two major "version" concepts when it comes to Parquet - the file format version, and the data page version. This property always toggled the latter, but the ambiguity in its naming and documentation did not necessarily make this fact clear. 

The old property name , `parquet_writer_version`,  often caused confusion as to what it actually modifies because Parquet has two distinct "version" concepts - the file‑format version (2.4, 2.6, etc) and the data page version.

Although this property always toggled the data page version, its name and documentation didn’t make that clear. Refactoring it to `parquet_writer_datapage_version` removes this ambiguity and makes its purpose immediately obvious.

## Impact
The former `parquet_writer_version` property will be deprecated - users will have to transition to using `parquet_writer_datapage_version` instead.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

