### PR TITLE
Add cosine_similarity function for two arrays

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -1602,11 +1602,11 @@ public final class MathFunctions
         return lower;
     }
 
-    @Description("cosine similarity between the given sparse vectors")
-    @ScalarFunction
+    @Description("cosine similarity between the given sparse vectors represented as maps")
+    @ScalarFunction("cosine_similarity")
     @SqlNullable
     @SqlType(StandardTypes.DOUBLE)
-    public static Double cosineSimilarity(@SqlType("map(varchar,double)") Block leftMap, @SqlType("map(varchar,double)") Block rightMap)
+    public static Double mapCosineSimilarity(@SqlType("map(varchar,double)") Block leftMap, @SqlType("map(varchar,double)") Block rightMap)
     {
         Double normLeftMap = mapL2Norm(leftMap);
         Double normRightMap = mapL2Norm(rightMap);
@@ -1618,6 +1618,29 @@ public final class MathFunctions
         double dotProduct = mapDotProduct(leftMap, rightMap);
 
         return dotProduct / (normLeftMap * normRightMap);
+    }
+
+    @Description("cosine similarity between the given identical sized vectors represented as arrays")
+    @ScalarFunction("cosine_similarity")
+    @SqlNullable
+    @SqlType(StandardTypes.DOUBLE)
+    public static Double arrayCosineSimilarity(@SqlType("array(double)") Block leftArray, @SqlType("array(double)") Block rightArray)
+    {
+        checkCondition(
+                leftArray.getPositionCount() == rightArray.getPositionCount(),
+                INVALID_FUNCTION_ARGUMENT,
+                "Both array arguments need to have identical size");
+
+        Double normLeftArray = array2Norm(leftArray);
+        Double normRightArray = array2Norm(rightArray);
+
+        if (normLeftArray == null || normRightArray == null) {
+            return null;
+        }
+
+        double dotProduct = arrayDotProduct(leftArray, rightArray);
+
+        return dotProduct / (normLeftArray * normRightArray);
     }
 
     private static double mapDotProduct(Block leftMap, Block rightMap)
@@ -1642,6 +1665,17 @@ public final class MathFunctions
         return result;
     }
 
+    private static double arrayDotProduct(Block leftArray, Block rightArray)
+    {
+        double result = 0.0;
+
+        for (int i = 0; i < leftArray.getPositionCount(); i++) {
+            result += DOUBLE.getDouble(leftArray, i) * DOUBLE.getDouble(rightArray, i);
+        }
+
+        return result;
+    }
+
     private static Double mapL2Norm(Block map)
     {
         double norm = 0.0;
@@ -1651,6 +1685,19 @@ public final class MathFunctions
                 return null;
             }
             norm += DOUBLE.getDouble(map, i) * DOUBLE.getDouble(map, i);
+        }
+
+        return Math.sqrt(norm);
+    }
+
+    private static Double array2Norm(Block array)
+    {
+        double norm = 0.0;
+        for (int i = 0; i < array.getPositionCount(); i++) {
+            if (array.isNull(i)) {
+                return null;
+            }
+            norm += DOUBLE.getDouble(array, i) * DOUBLE.getDouble(array, i);
         }
 
         return Math.sqrt(norm);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1338,7 +1338,7 @@ public class TestMathFunctions
     }
 
     @Test
-    public void testCosineSimilarity()
+    public void testMapCosineSimilarity()
     {
         assertFunction("cosine_similarity(map(array ['a', 'b'], array [1.0E0, 2.0E0]), map(array ['c', 'b'], array [1.0E0, 3.0E0]))",
                 DOUBLE,
@@ -1357,6 +1357,52 @@ public class TestMathFunctions
                 null);
 
         assertFunction("cosine_similarity(map(array ['a', 'b'], array [1.0E0, null]), map(array ['c', 'b'], array [1.0E0, 3.0E0]))",
+                DOUBLE,
+                null);
+
+        assertFunction("cosine_similarity(map(), map(array ['c', 'b'], array [1.0E0, 3.0E0]))",
+                DOUBLE,
+                Double.NaN);
+
+        assertFunction("cosine_similarity(map(), map())",
+                DOUBLE,
+                Double.NaN);
+
+        assertFunction("cosine_similarity(map(), null)",
+                DOUBLE,
+                null);
+    }
+
+    @Test
+    public void testArrayCosineSimilarity()
+    {
+        assertFunction("cosine_similarity(array [1.0E0, 2.0E0], array [1.0E0, 3.0E0])",
+                DOUBLE,
+                (1 * 1 + 2 * 3) / (Math.sqrt(5) * Math.sqrt(10)));
+
+        assertFunction("cosine_similarity(array [1.0E0, 2.0E0, -1.0E0], array [1.0E0, 3.0E0, 5.0E0])",
+                DOUBLE,
+                (1 * 1 + 2 * 3 + (-1) * 5) / (Math.sqrt(1 + 4 + 1) * Math.sqrt(1 + 9 + 25)));
+
+        assertFunction("cosine_similarity(null, array [1.0E0, 3.0E0])",
+                DOUBLE,
+                null);
+
+        assertFunction("cosine_similarity(null, null)",
+                DOUBLE,
+                null);
+
+        assertFunction("cosine_similarity(array [1.0E0, null], array [1.0E0, 3.0E0])",
+                DOUBLE,
+                null);
+
+        assertInvalidFunction("cosine_similarity(array [], array [1.0E0, 3.0E0])", "Both array arguments need to have identical size");
+
+        assertFunction("cosine_similarity(array [], array [])",
+                DOUBLE,
+                Double.NaN);
+
+        assertFunction("cosine_similarity(array [], null)",
                 DOUBLE,
                 null);
     }


### PR DESCRIPTION
## Description
Adding cosine_similarity function for two identical sized arrays.

## Motivation and Context
cosine_similarity is a mesaure to perform basic similarity search between vectors. In warehouse storage, often vectors are stored as array of doubles. Presto already supports this function. Current implementation takes two maps as argument. This way one can specificy sparse vectors easily. However for non-sparse vectors, where storage tables have arrays of doubles, it's useful have same computation function with array parameters.

## Impact
None

## Test Plan
Unit tests

== RELEASE NOTES ==

General Changes
*  Add ``cosine_similarity`` function for two arrays.