### PR TITLE
Use feature toggle for event loop logging

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SafeEventLoopGroup.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SafeEventLoopGroup.java
@@ -86,8 +86,10 @@ public class SafeEventLoopGroup
         public void execute(Runnable task, Consumer<Throwable> failureHandler, SchedulerStatsTracker statsTracker, String methodSignature)
         {
             requireNonNull(task, "task is null");
+
             long initialGCTime = getTotalGCTime();
             long start = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+
             this.execute(() -> {
                 try {
                     task.run();
@@ -103,7 +105,7 @@ public class SafeEventLoopGroup
                     long cpuTimeInNanos = THREAD_MX_BEAN.getCurrentThreadCpuTime() - start - (currentGCTime - initialGCTime);
 
                     statsTracker.recordEventLoopMethodExecutionCpuTime(cpuTimeInNanos);
-                    if (cpuTimeInNanos > slowMethodThresholdOnEventLoopInNanos) {
+                    if (slowMethodThresholdOnEventLoopInNanos > 0 && cpuTimeInNanos > slowMethodThresholdOnEventLoopInNanos) {
                         log.warn("Slow method execution on event loop: %s took %s milliseconds", methodSignature, NANOSECONDS.toMillis(cpuTimeInNanos));
                     }
                 }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -102,9 +102,8 @@ public class TaskManagerConfig
     private Duration highMemoryTaskKillerFrequentFullGCDurationThreshold = new Duration(1, SECONDS);
     private double highMemoryTaskKillerHeapMemoryThreshold = 0.9;
     private boolean enableEventLoop;
-    private Duration slowMethodThresholdOnEventLoop = new Duration(10, SECONDS);
+    private Duration slowMethodThresholdOnEventLoop = new Duration(0, SECONDS);
 
-    @Min(50_000_000L)
     public long getSlowMethodThresholdOnEventLoop()
     {
         return slowMethodThresholdOnEventLoop.roundTo(NANOSECONDS);

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -29,6 +29,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.record
 import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.QUERY_FAIR;
 import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.TASK_FAIR;
 import static io.airlift.units.DataSize.Unit;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestTaskManagerConfig
@@ -79,7 +80,7 @@ public class TestTaskManagerConfig
                 .setHighMemoryTaskKillerFrequentFullGCDurationThreshold(new Duration(1, SECONDS))
                 .setHighMemoryTaskKillerHeapMemoryThreshold(0.9)
                 .setTaskUpdateSizeTrackingEnabled(true)
-                .setSlowMethodThresholdOnEventLoop(new Duration(10, SECONDS))
+                .setSlowMethodThresholdOnEventLoop(new Duration(0, SECONDS))
                 .setEventLoopEnabled(false));
     }
 
@@ -130,7 +131,7 @@ public class TestTaskManagerConfig
                 .put("experimental.task.high-memory-task-killer-heap-memory-threshold", "0.8")
                 .put("task.update-size-tracking-enabled", "false")
                 .put("task.enable-event-loop", "true")
-                .put("task.event-loop-slow-method-threshold", "1s")
+                .put("task.event-loop-slow-method-threshold", "10m")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
@@ -177,7 +178,7 @@ public class TestTaskManagerConfig
                 .setHighMemoryTaskKillerHeapMemoryThreshold(0.8)
                 .setTaskUpdateSizeTrackingEnabled(false)
                 .setEventLoopEnabled(true)
-                .setSlowMethodThresholdOnEventLoop(new Duration(1, SECONDS));
+                .setSlowMethodThresholdOnEventLoop(new Duration(10, MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -109,7 +109,6 @@ public class HttpRemoteTaskFactory
     private final DecayCounter taskUpdateRequestSize;
     private final boolean taskUpdateSizeTrackingEnabled;
     private final Optional<SafeEventLoopGroup> eventLoopGroup;
-    private final long slowMethodThresholdOnEventLoopInNanos;
 
     @Inject
     public HttpRemoteTaskFactory(
@@ -195,9 +194,8 @@ public class HttpRemoteTaskFactory
         this.taskUpdateRequestSize = new DecayCounter(ExponentialDecay.oneMinute());
         this.taskUpdateSizeTrackingEnabled = taskConfig.isTaskUpdateSizeTrackingEnabled();
 
-        this.slowMethodThresholdOnEventLoopInNanos = taskConfig.getSlowMethodThresholdOnEventLoop();
         this.eventLoopGroup = taskConfig.isEventLoopEnabled() ? Optional.of(new SafeEventLoopGroup(config.getRemoteTaskMaxCallbackThreads(),
-                new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build(), this.slowMethodThresholdOnEventLoopInNanos)
+                new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build(), taskConfig.getSlowMethodThresholdOnEventLoop())
         {
             @Override
             protected EventLoop newChild(Executor executor, Object... args)


### PR DESCRIPTION
## Description
1. add a feature toggle for slow method logging on event loop
2. bump the default logging threshold to 5 minutes based on recent benchmarking and after all, we want to use this logging to catch corner case where methods running on event loop is taking too long or get stuck causing head-of-line blocking.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. running verifier

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.



```
== NO RELEASE NOTE ==
```

