### PR TITLE
Update error classification for group by with lambdas

### DIFF
--- a/presto-parser/pom.xml
+++ b/presto-parser/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
@@ -13,8 +13,12 @@
  */
 package com.facebook.presto.sql.tree;
 
+import com.facebook.presto.spi.PrestoException;
+
 import java.util.List;
 import java.util.Optional;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 
 public abstract class GroupingElement
         extends Node
@@ -39,7 +43,7 @@ public abstract class GroupingElement
             @Override
             public Expression rewriteLambdaExpression(LambdaExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
-                throw new UnsupportedOperationException("GROUP BY does not support lambda expressions, please use GROUP BY # instead");
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "GROUP BY does not support lambda expressions, please use GROUP BY # instead");
             }
         }, expression, null));
     }


### PR DESCRIPTION
## Description
Presto does not support Group by lambda functions. Therefore, queries attempting to use this functionality should be classified as User Errors rather than generic Internal Errors.

## Motivation and Context
Last week, we received 33 hits from queries using  Group by lambda, but unfortunately, the incorrect classification resulted in inaccuracies and UER monitoring.

## Impact
no impact

## Test Plan
N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

