### PR TITLE
[native] Separate Task start logic into a method.

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -192,6 +192,9 @@ class TaskManager {
       const protocol::TaskId& taskId,
       long startProcessCpuTime = 0);
 
+  // Starting the task with task mutex already locked.
+  void startTaskLocked(std::shared_ptr<PrestoTask>& prestoTask);
+
   std::string baseUri_;
   std::string nodeId_;
   folly::Synchronized<std::string> baseSpillDir_;

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -730,7 +730,7 @@ TEST_P(TaskManagerTest, tableScanAllSplitsAtOnce) {
       makeSource("0", filePaths, true, splitSequenceId));
   auto taskInfo = createOrUpdateTask(taskId, updateRequest, planFragment);
 
-  ASSERT_GT(taskInfo->stats.queuedTimeInNanos, 0);
+  ASSERT_GE(taskInfo->stats.queuedTimeInNanos, 0);
   assertResults(taskId, rowType_, "SELECT * FROM tmp WHERE c0 % 5 = 0");
 }
 


### PR DESCRIPTION
## Description
Separating the start of the Task into a new method.
We will use it to start queued Tasks later.

```
== NO RELEASE NOTE ==
```