### PR TITLE
[Iceberg]Explicitly close the transactions opened manually in tests

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSplitManager.java
@@ -271,6 +271,9 @@ public class TestIcebergSplitManager
         catch (ExecutionException | InterruptedException e) {
             throw new RuntimeException(e);
         }
+        finally {
+            transactionManager.asyncAbort(transactionId);
+        }
     }
 
     private void validateSplitsPlannedForSql(SplitManager splitManager,
@@ -302,12 +305,7 @@ public class TestIcebergSplitManager
             fail("Should not throw exception when getting split source: " + e.getMessage());
         }
         finally {
-            try {
-                transactionManager.asyncAbort(transactionId).get();
-            }
-            catch (Exception e) {
-                // do nothing
-            }
+            transactionManager.asyncAbort(transactionId);
         }
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -249,6 +249,7 @@ public class TestIcebergSystemTables
 
             // Query should fail because of the conflicts between session property and table property in table mode validation
             assertQueryFails(txnSession, "select * from test_schema.test_session_properties_table", "merge-on-read table mode not supported yet");
+            transactionManager.asyncAbort(txnId);
         }
         finally {
             assertUpdate("drop table if exists test_schema.test_session_properties_table");


### PR DESCRIPTION
## Description

The transaction manager in QueryRunner is a long lived instance through the whole test class scope. This PR explicitly abort the manually opened transactions in test methods, otherwise, the transaction manager will accumulate many stale un-closed transactions. For example, before this change, we will observe 47 un-closed transactions when running `TestIcebergDistributedHive`; after this change, the number is 0.

## Motivation and Context

Prevent the shared transaction manager of the whole test class from containing stale transactions that are not properly closed.

## Impact

N/A

## Test Plan

 - Make sure the change do not affect any existing CI test

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

