### PR TITLE
Unit Test for Query Planner Regression

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -1906,4 +1906,11 @@ public class TestLogicalPlanner
                                                         anyTree(
                                                                 tableScan("supplier", ImmutableMap.of("suppkey_4", "suppkey")))))))));
     }
+
+    @Test
+    public void testSubselectQualifiedObjectNameContainsDot()
+    {
+        String query = "SELECT min((SELECT totalprice FROM orders WHERE orderstatus = \"Outer.Table\".\"orderstatus\")) as min FROM orders AS \"Outer.Table\"";
+        assertPlanSucceeded(query, this.getQueryRunner().getDefaultSession());
+    }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
We noticed a regression in the query planner between versions 0.288 and 0.292 and this is a test to demonstrate that. The query passes the parser but throws an exception in the planner

```
QualifiedObjectName should have exactly 3 parts
```

Here's a truncated stacktrace
```
Caused by: com.facebook.presto.jdbc.internal.client.FailureInfo$FailureException: QualifiedObjectName should have exactly 3 parts
 at com.facebook.presto.common.QualifiedObjectName.valueOf(QualifiedObjectName.java:45)
 at com.facebook.presto.common.type.TypeSignatureBase.of(TypeSignatureBase.java:43)
 at com.facebook.presto.common.type.TypeSignature.<init>(TypeSignature.java:101)
 at com.facebook.presto.common.type.TypeSignature.parseTypeSignature(TypeSignature.java:209)
 at com.facebook.presto.common.type.TypeSignature.parseTypeSignature(TypeSignature.java:195)
 at com.facebook.presto.sql.analyzer.ExpressionTreeUtils.tryResolveEnumLiteralType(ExpressionTreeUtils.java:149)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitDereferenceExpression(ExpressionAnalyzer.java:536)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitDereferenceExpression(ExpressionAnalyzer.java:389)
 at com.facebook.presto.sql.tree.DereferenceExpression.accept(DereferenceExpression.java:54)
 at com.facebook.presto.sql.tree.StackableAstVisitor.process(StackableAstVisitor.java:26)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.process(ExpressionAnalyzer.java:412)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.getOperator(ExpressionAnalyzer.java:1603)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitComparisonExpression(ExpressionAnalyzer.java:608)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.visitComparisonExpression(ExpressionAnalyzer.java:389)
 at com.facebook.presto.sql.tree.ComparisonExpression.accept(ComparisonExpression.java:71)
 at com.facebook.presto.sql.tree.StackableAstVisitor.process(StackableAstVisitor.java:26)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer$Visitor.process(ExpressionAnalyzer.java:412)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:350)
 at com.facebook.presto.sql.analyzer.ExpressionAnalyzer.analyzeExpression(ExpressionAnalyzer.java:1941)
 at com.facebook.presto.sql.planner.TranslateExpressionsUtil.toRowExpression(TranslateExpressionsUtil.java:57)
 at com.facebook.presto.sql.planner.QueryPlanner.rowExpression(QueryPlanner.java:1327)
 at com.facebook.presto.sql.planner.QueryPlanner.filter(QueryPlanner.java:478)
 at com.facebook.presto.sql.planner.QueryPlanner.plan(QueryPlanner.java:208)
 at com.facebook.presto.sql.planner.RelationPlanner.visitQuerySpecification(RelationPlanner.java:776)
 at com.facebook.presto.sql.planner.RelationPlanner.visitQuerySpecification(RelationPlanner.java:137)
 at com.facebook.presto.sql.tree.QuerySpecification.accept(QuerySpecification.java:138)
 at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
 at com.facebook.presto.sql.planner.RelationPlanner.process(RelationPlanner.java:173)
 at com.facebook.presto.sql.planner.QueryPlanner.planQueryBody(QueryPlanner.java:411)
 at com.facebook.presto.sql.planner.QueryPlanner.plan(QueryPlanner.java:188)
 at com.facebook.presto.sql.planner.RelationPlanner.visitQuery(RelationPlanner.java:769)
 at com.facebook.presto.sql.planner.RelationPlanner.visitQuery(RelationPlanner.java:137)
 at com.facebook.presto.sql.tree.Query.accept(Query.java:105)
 at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
 at com.facebook.presto.sql.planner.RelationPlanner.process(RelationPlanner.java:173)
 at com.facebook.presto.sql.planner.RelationPlanner.process(RelationPlanner.java:137)
 at com.facebook.presto.sql.tree.DefaultTraversalVisitor.visitSubqueryExpression(DefaultTraversalVisitor.java:320)
 at com.facebook.presto.sql.tree.SubqueryExpression.accept(SubqueryExpression.java:51)
 at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
 at com.facebook.presto.sql.planner.RelationPlanner.process(RelationPlanner.java:173)
 at com.facebook.presto.sql.planner.SubqueryPlanner.createPlanBuilder(SubqueryPlanner.java:506)
 at com.facebook.presto.sql.planner.SubqueryPlanner.appendInPredicateApplyNode(SubqueryPlanner.java:209)
 at com.facebook.presto.sql.planner.SubqueryPlanner.appendInPredicateApplyNodes(SubqueryPlanner.java:190)
 at com.facebook.presto.sql.planner.SubqueryPlanner.handleSubqueries(SubqueryPlanner.java:148)
 at com.facebook.presto.sql.planner.SubqueryPlanner.handleSubqueries(SubqueryPlanner.java:142)
```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

