### PR TITLE
Add integer type to visitGenericLiteral in SqlToRowExpressionTranslator

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -417,6 +417,9 @@ public final class SqlToRowExpressionTranslator
                 else if (SMALLINT.equals(type)) {
                     return constant((long) Short.parseShort(node.getValue()), SMALLINT);
                 }
+                else if (INTEGER.equals(type)) {
+                    return constant((long) Integer.parseInt(node.getValue()), INTEGER);
+                }
                 else if (BIGINT.equals(type)) {
                     return constant(Long.parseLong(node.getValue()), BIGINT);
                 }

--- a/presto-main-base/src/test/java/com/facebook/presto/type/TestIntegerOperators.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/TestIntegerOperators.java
@@ -26,7 +26,7 @@ import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.StandardErrorCode.DIVISION_BY_ZERO;
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL;
 import static java.lang.String.format;
 
 public class TestIntegerOperators
@@ -37,7 +37,7 @@ public class TestIntegerOperators
     {
         assertFunction("INTEGER'37'", INTEGER, 37);
         assertFunction("INTEGER'17'", INTEGER, 17);
-        assertInvalidCast("INTEGER'" + ((long) Integer.MAX_VALUE + 1L) + "'");
+        assertInvalidFunction("INTEGER'" + ((long) Integer.MAX_VALUE + 1L) + "'", INVALID_LITERAL);
     }
 
     @Test
@@ -52,7 +52,7 @@ public class TestIntegerOperators
     {
         assertFunction("INTEGER'-37'", INTEGER, -37);
         assertFunction("INTEGER'-17'", INTEGER, -17);
-        assertInvalidFunction("INTEGER'-" + Integer.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
+        assertInvalidFunction("INTEGER'-" + Integer.MIN_VALUE + "'", INVALID_LITERAL);
     }
 
     @Test


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Modify visitGenericLiteral in SqlToRowExpressionTranslator to support Integer types.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
I'm not sure of the context of why INTEGER is not being turned into a constant expression here but, TINYINT, SMALLINT, and BIGINT are all translated to constant expression when utilized in a context like `BIGINT '123'` for a values node.

However INTEGER type is translated to a call expression on cast VARCHAR -> INTEGER when utilized in a context like `INTEGER '123'` on the values node.

As a result, when checking the expression of a Values node in our case for table functions, we were unable to compare against Integer type in the values matcher. 

To be able to check for integer constant expressions in the values matcher.

SQL QUERY
```
SELECT * FROM TABLE(mock.system.two_table_arguments_function(
                           INPUT1 => TABLE(VALUES SMALLINT '1') t1(c1) PARTITION BY c1,
                           INPUT2 => TABLE(VALUES INTEGER '2') t2(c2) PARTITION BY c2
                           COPARTITION (t1, t2))) t
```

Values Matcher
```
 if (!expectedRows.map(rows -> rows.equals(valuesNode.getRows()
                .stream()
                .map(rowExpressions -> rowExpressions.stream()
                        .map(rowExpression -> {
                            ConstantExpression expression = (ConstantExpression) rowExpression;
                            if (expression.getType().getJavaType() == boolean.class) {
                                return new BooleanLiteral(String.valueOf(expression.getValue()));
                            }
                            if (expression.getType() instanceof ShortDecimalType) {
                                return new DecimalLiteral(String.valueOf(expression.getValue()));
                            }
                            if (expression.getType().getJavaType() == long.class) {
                                return new LongLiteral(String.valueOf(expression.getValue()));
                            }
                            if (expression.getType().getJavaType() == double.class) {
                                return new DoubleLiteral(String.valueOf(expression.getValue()));
                            }
                            if (expression.getType().getJavaType() == Slice.class) {
                                return new StringLiteral(((Slice) expression.getValue()).toStringUtf8());
                            }
                            return new GenericLiteral(expression.getType().toString(), String.valueOf(expression.getValue()));
                        })
                        .collect(toImmutableList()))
                .collect(toImmutableSet())))
                .orElse(true)) {
            return NO_MATCH;
        }
```

Error
```
java.lang.ClassCastException: com.facebook.presto.spi.relation.CallExpression cannot be cast to com.facebook.presto.spi.relation.ConstantExpression

	at com.facebook.presto.sql.planner.assertions.ValuesMatcher.lambda$null$0(ValuesMatcher.java:83)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at com.facebook.presto.sql.planner.assertions.ValuesMatcher.lambda$null$1(ValuesMatcher.java:101)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at com.facebook.presto.sql.planner.assertions.ValuesMatcher.lambda$detailMatches$2(ValuesMatcher.java:102)
	at java.util.Optional.map(Optional.java:215)
	at com.facebook.presto.sql.planner.assertions.ValuesMatcher.detailMatches(ValuesMatcher.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchPattern.detailMatches(PlanMatchPattern.java:742)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchLeaf(PlanMatchingVisitor.java:149)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:110)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitValues(PlanVisitor.java:70)
	at com.facebook.presto.spi.plan.ValuesNode.accept(ValuesNode.java:109)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitProject(PlanVisitor.java:35)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:108)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitProject(PlanVisitor.java:35)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:108)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitProject(PlanVisitor.java:35)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:108)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitProject(PlanVisitor.java:35)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:108)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.sql.planner.plan.InternalPlanVisitor.visitTableFunction(InternalPlanVisitor.java:142)
	at com.facebook.presto.sql.planner.plan.TableFunctionNode.accept(TableFunctionNode.java:151)
	at com.facebook.presto.sql.planner.plan.InternalPlanNode.accept(InternalPlanNode.java:34)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitProject(PlanVisitor.java:35)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:108)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitProject(PlanVisitor.java:35)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:108)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitProject(PlanVisitor.java:35)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:108)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitProject(PlanVisitor.java:35)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:79)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitProject(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:108)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.matchSources(PlanMatchingVisitor.java:185)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:116)
	at com.facebook.presto.sql.planner.assertions.PlanMatchingVisitor.visitPlan(PlanMatchingVisitor.java:36)
	at com.facebook.presto.spi.plan.PlanVisitor.visitOutput(PlanVisitor.java:25)
	at com.facebook.presto.spi.plan.OutputNode.accept(OutputNode.java:98)
	at com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlan(PlanAssert.java:52)
	at com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlan(PlanAssert.java:41)
	at com.facebook.presto.sql.planner.assertions.BasePlanTest.lambda$assertPlan$3(BasePlanTest.java:205)
	at com.facebook.presto.transaction.TransactionBuilder.execute(TransactionBuilder.java:151)
	at com.facebook.presto.testing.LocalQueryRunner.inTransaction(LocalQueryRunner.java:860)
	at com.facebook.presto.sql.planner.assertions.BasePlanTest.assertPlan(BasePlanTest.java:198)
	at com.facebook.presto.sql.planner.assertions.BasePlanTest.assertPlan(BasePlanTest.java:179)
	at com.facebook.presto.sql.planner.TestTableFunctionInvocation.testTableFunctionInitialPlanWithCoercionForCopartitioning(TestTableFunctionInvocation.java:133)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:135)
	at org.testng.internal.invokers.TestInvoker.invokeMethod(TestInvoker.java:673)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethod(TestInvoker.java:220)
	at org.testng.internal.invokers.MethodRunner.runInSequence(MethodRunner.java:50)
	at org.testng.internal.invokers.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:945)
	at org.testng.internal.invokers.TestInvoker.invokeTestMethods(TestInvoker.java:193)
	at org.testng.internal.invokers.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.invokers.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at org.testng.TestRunner.privateRun(TestRunner.java:808)
	at org.testng.TestRunner.run(TestRunner.java:603)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:429)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:423)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:383)
	at org.testng.SuiteRunner.run(SuiteRunner.java:326)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:95)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1249)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1169)
	at org.testng.TestNG.runSuites(TestNG.java:1092)
	at org.testng.TestNG.run(TestNG.java:1060)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:65)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
```

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Integer literals will now be translated to constant expression instead of using varchar cast to integer. 

## Test Plan
<!---Please fill in how you tested your change-->
Current tests fixed to adjust for error coming from visitGenericLiteral rather than from cast operator.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== NO RELEASE NOTE ==
```

