### PR TITLE
Use built-in functions for constant folding in ValuesStatsRule

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
@@ -106,7 +106,7 @@ public class JdbcComputePushdown
             TableHandle oldTableHandle = oldTableScanNode.getTable();
             JdbcTableHandle oldConnectorTable = (JdbcTableHandle) oldTableHandle.getConnectorHandle();
 
-            RowExpression predicate = expressionOptimizerProvider.getExpressionOptimizer(session).optimize(node.getPredicate(), OPTIMIZED, session);
+            RowExpression predicate = expressionOptimizerProvider.getExpressionOptimizer(session).optimize(node.getPredicate(), OPTIMIZED, session, false);
             predicate = logicalRowExpressions.convertToConjunctiveNormalForm(predicate);
             TranslatedExpression<JdbcExpression> jdbcExpression = translateWith(
                     predicate,

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/optimization/ClickHouseComputePushdown.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/optimization/ClickHouseComputePushdown.java
@@ -257,7 +257,7 @@ public class ClickHouseComputePushdown
             TableHandle oldTableHandle = oldTableScanNode.getTable();
             ClickHouseTableHandle oldConnectorTable = (ClickHouseTableHandle) oldTableHandle.getConnectorHandle();
 
-            RowExpression predicate = rowExpressionService.getExpressionOptimizer(session).optimize(node.getPredicate(), OPTIMIZED, session);
+            RowExpression predicate = rowExpressionService.getExpressionOptimizer(session).optimize(node.getPredicate(), OPTIMIZED, session, false);
             predicate = logicalRowExpressions.convertToConjunctiveNormalForm(predicate);
             TranslatedExpression<ClickHouseExpression> clickHouseExpression = translateWith(
                     predicate,

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
@@ -122,7 +122,7 @@ public final class SubfieldExtractor
                 RowExpression indexExpression = expressionOptimizer.optimize(
                         dereferenceExpression.getArguments().get(1),
                         ExpressionOptimizer.Level.OPTIMIZED,
-                        connectorSession);
+                        connectorSession, false);
 
                 if (indexExpression instanceof ConstantExpression) {
                     Object index = ((ConstantExpression) indexExpression).getValue();
@@ -143,7 +143,7 @@ public final class SubfieldExtractor
                 RowExpression indexExpression = expressionOptimizer.optimize(
                         arguments.get(1),
                         ExpressionOptimizer.Level.OPTIMIZED,
-                        connectorSession);
+                        connectorSession, false);
 
                 if (indexExpression instanceof ConstantExpression) {
                     Object index = ((ConstantExpression) indexExpression).getValue();

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/rule/BaseSubfieldExtractionRewriter.java
@@ -233,7 +233,7 @@ public abstract class BaseSubfieldExtractionRewriter
         }
 
         RowExpression optimizedRemainingExpression = rowExpressionService.getExpressionOptimizer(session)
-                .optimize(decomposedFilter.getRemainingExpression(), OPTIMIZED, session);
+                .optimize(decomposedFilter.getRemainingExpression(), OPTIMIZED, session, false);
         if (optimizedRemainingExpression instanceof ConstantExpression) {
             ConstantExpression constantExpression = (ConstantExpression) optimizedRemainingExpression;
             if (FALSE_CONSTANT.equals(constantExpression) || constantExpression.getValue() == null) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/FilteringPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/FilteringPageSource.java
@@ -118,7 +118,7 @@ public class FilteringPageSource
                         columnHandle -> new VariableReferenceExpression(Optional.empty(), columnHandle.getName(), columnHandle.getHiveType().getType(typeManager)),
                         columnHandle -> new InputReferenceExpression(Optional.empty(), columnHandle.getHiveColumnIndex(), columnHandle.getHiveType().getType(typeManager))));
 
-        RowExpression optimizedRemainingPredicate = rowExpressionService.getExpressionOptimizer(session).optimize(remainingPredicate, OPTIMIZED, session);
+        RowExpression optimizedRemainingPredicate = rowExpressionService.getExpressionOptimizer(session).optimize(remainingPredicate, OPTIMIZED, session, false);
         if (TRUE_CONSTANT.equals(optimizedRemainingPredicate)) {
             this.filterFunction = null;
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -129,7 +129,7 @@ public class HivePageSourceProvider
         this.optimizedRowExpressionCache = CacheBuilder.newBuilder()
                 .recordStats()
                 .maximumSize(10_000)
-                .build(CacheLoader.from(cacheKey -> rowExpressionService.getExpressionOptimizer(cacheKey.session).optimize(cacheKey.rowExpression, OPTIMIZED, cacheKey.session)));
+                .build(CacheLoader.from(cacheKey -> rowExpressionService.getExpressionOptimizer(cacheKey.session).optimize(cacheKey.rowExpression, OPTIMIZED, cacheKey.session, false)));
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
@@ -89,7 +89,7 @@ public class TestDomainTranslator
     private static final ExpressionOptimizer TEST_EXPRESSION_OPTIMIZER = new ExpressionOptimizer()
     {
         @Override
-        public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
+        public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session, boolean useBuiltInFunctions)
         {
             return rowExpression;
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
@@ -74,7 +74,7 @@ public class TestSubfieldExtractor
     private static final ExpressionOptimizer TEST_EXPRESSION_OPTIMIZER = new ExpressionOptimizer()
     {
         @Override
-        public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
+        public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session, boolean useBuiltInFunctions)
         {
             return rowExpression;
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/ScalarStatsCalculator.java
@@ -134,7 +134,7 @@ public class ScalarStatsCalculator
                 return computeArithmeticBinaryStatistics(call, context);
             }
 
-            RowExpression value = expressionOptimizerProvider.getExpressionOptimizer(session).optimize(call, OPTIMIZED, session);
+            RowExpression value = expressionOptimizerProvider.getExpressionOptimizer(session).optimize(call, OPTIMIZED, session, false);
 
             if (isNull(value)) {
                 return nullStatsEstimate();

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cost;
 
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -36,6 +37,7 @@ public class StatsCalculatorModule
         configBinder(binder).bindConfig(HistoryBasedOptimizationConfig.class);
         binder.bind(HistoryBasedPlanStatisticsManager.class).in(Scopes.SINGLETON);
         binder.bind(FragmentStatsProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ExpressionOptimizerManager.class).in(Scopes.SINGLETON);
     }
 
     @Provides
@@ -46,9 +48,10 @@ public class StatsCalculatorModule
             StatsNormalizer normalizer,
             FilterStatsCalculator filterStatsCalculator,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
-            FragmentStatsProvider fragmentStatsProvider)
+            FragmentStatsProvider fragmentStatsProvider,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
-        StatsCalculator delegate = createComposableStatsCalculator(metadata, scalarStatsCalculator, normalizer, filterStatsCalculator, fragmentStatsProvider);
+        StatsCalculator delegate = createComposableStatsCalculator(metadata, scalarStatsCalculator, normalizer, filterStatsCalculator, fragmentStatsProvider, expressionOptimizerManager);
         return historyBasedPlanStatisticsManager.getHistoryBasedPlanStatisticsCalculator(delegate);
     }
 
@@ -57,14 +60,15 @@ public class StatsCalculatorModule
             ScalarStatsCalculator scalarStatsCalculator,
             StatsNormalizer normalizer,
             FilterStatsCalculator filterStatsCalculator,
-            FragmentStatsProvider fragmentStatsProvider)
+            FragmentStatsProvider fragmentStatsProvider,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
         ImmutableList.Builder<ComposableStatsCalculator.Rule<?>> rules = ImmutableList.builder();
         rules.add(new OutputStatsRule());
         rules.add(new TableScanStatsRule(metadata, normalizer));
         rules.add(new SimpleFilterProjectSemiJoinStatsRule(normalizer, filterStatsCalculator, metadata.getFunctionAndTypeManager())); // this must be before FilterStatsRule
         rules.add(new FilterStatsRule(normalizer, filterStatsCalculator));
-        rules.add(new ValuesStatsRule(metadata));
+        rules.add(new ValuesStatsRule(metadata, expressionOptimizerManager));
         rules.add(new LimitStatsRule(normalizer));
         rules.add(new EnforceSingleRowStatsRule(normalizer));
         rules.add(new ProjectStatsRule(scalarStatsCalculator, normalizer));

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
@@ -69,7 +69,7 @@ public class SimplifyRowExpressions
             // Rewrite RowExpression first to reduce depth of RowExpression tree by balancing AND/OR predicates.
             // It doesn't matter whether we rewrite/optimize first because this will be called by IterativeOptimizer.
             RowExpression rewritten = RowExpressionTreeRewriter.rewriteWith(logicalExpressionRewriter, expression, true);
-            return expressionOptimizerManager.getExpressionOptimizer(session.toConnectorSession()).optimize(rewritten, SERIALIZABLE, session.toConnectorSession());
+            return expressionOptimizerManager.getExpressionOptimizer(session.toConnectorSession()).optimize(rewritten, SERIALIZABLE, session.toConnectorSession(), false);
         }
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -1439,7 +1439,7 @@ public class PredicatePushDown
         // Temporary implementation for joins because the SimplifyExpressions optimizers can not run properly on join clauses
         private RowExpression simplifyExpression(RowExpression expression)
         {
-            return expressionOptimizerProvider.getExpressionOptimizer(session.toConnectorSession()).optimize(expression, ExpressionOptimizer.Level.SERIALIZABLE, session.toConnectorSession());
+            return expressionOptimizerProvider.getExpressionOptimizer(session.toConnectorSession()).optimize(expression, ExpressionOptimizer.Level.SERIALIZABLE, session.toConnectorSession(), false);
         }
 
         private boolean areExpressionsEquivalent(RowExpression leftExpression, RowExpression rightExpression)
@@ -1454,7 +1454,7 @@ public class PredicatePushDown
         {
             expression = RowExpressionNodeInliner.replaceExpression(expression, nullSymbols.stream()
                     .collect(Collectors.toMap(identity(), variable -> constantNull(variable.getSourceLocation(), variable.getType()))));
-            return expressionOptimizerProvider.getExpressionOptimizer(session.toConnectorSession()).optimize(expression, ExpressionOptimizer.Level.OPTIMIZED, session.toConnectorSession());
+            return expressionOptimizerProvider.getExpressionOptimizer(session.toConnectorSession()).optimize(expression, ExpressionOptimizer.Level.OPTIMIZED, session.toConnectorSession(), false);
         }
 
         private Predicate<RowExpression> joinEqualityExpression(final Collection<VariableReferenceExpression> leftVariables)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -591,7 +591,7 @@ public class PushdownSubfields
                     RowExpression indexExpression = expressionOptimizer.optimize(
                             dereference.getArguments().get(1),
                             ExpressionOptimizer.Level.OPTIMIZED,
-                            connectorSession);
+                            connectorSession, false);
 
                     if (indexExpression instanceof ConstantExpression) {
                         Object index = ((ConstantExpression) indexExpression).getValue();
@@ -613,7 +613,7 @@ public class PushdownSubfields
                     RowExpression indexExpression = expressionOptimizer.optimize(
                             arguments.get(1),
                             ExpressionOptimizer.Level.OPTIMIZED,
-                            connectorSession);
+                            connectorSession, false);
 
                     if (indexExpression instanceof ConstantExpression) {
                         Object index = ((ConstantExpression) indexExpression).getValue();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
@@ -43,12 +43,12 @@ public final class RowExpressionOptimizer
     }
 
     @Override
-    public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
+    public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session, boolean useBuiltInFunctions)
     {
         if (level.ordinal() <= OPTIMIZED.ordinal()) {
             return toRowExpression(rowExpression.getSourceLocation(), new RowExpressionInterpreter(rowExpression, functionAndTypeManager, session, level).optimize(), rowExpression.getType());
         }
-        throw new IllegalArgumentException("Not supported optimization level: " + level);
+        return toRowExpression(rowExpression.getSourceLocation(), new RowExpressionInterpreter(rowExpression, functionAndTypeManager, session, level, useBuiltInFunctions).evaluate(), rowExpression.getType());
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -478,7 +478,7 @@ public class LocalQueryRunner
         this.filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer);
         this.historyBasedPlanStatisticsManager = new HistoryBasedPlanStatisticsManager(objectMapper, createTestingSessionPropertyManager(), metadata, new HistoryBasedOptimizationConfig(), featuresConfig, new NodeVersion("1"));
         this.fragmentStatsProvider = new FragmentStatsProvider();
-        this.statsCalculator = createNewStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, filterStatsCalculator, historyBasedPlanStatisticsManager, fragmentStatsProvider);
+        this.statsCalculator = createNewStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, filterStatsCalculator, historyBasedPlanStatisticsManager, fragmentStatsProvider, expressionOptimizerManager);
         this.taskCountEstimator = new TaskCountEstimator(() -> nodeCountForStats);
         this.costCalculator = new CostCalculatorUsingExchanges(taskCountEstimator);
         this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, taskCountEstimator);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonExtract.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonExtract.java
@@ -137,7 +137,7 @@ public class BenchmarkJsonExtract
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyMap(), WarningCollector.NOOP);
         RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionAndTypeManager(), TEST_SESSION);
         RowExpressionOptimizer optimizer = new RowExpressionOptimizer(METADATA);
-        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession(), false);
     }
 
     private static Block createChannel()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestRowExpressionSerde.java
@@ -271,7 +271,7 @@ public class TestRowExpressionSerde
         RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, getExpressionTypes(expression), ImmutableMap.of(), metadata.getFunctionAndTypeManager(), TEST_SESSION);
         if (optimize) {
             RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
-            return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+            return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession(), false);
         }
         return rowExpression;
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestingRowExpressionTranslator.java
@@ -82,7 +82,7 @@ public class TestingRowExpressionTranslator
     {
         RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionAndTypeManager(), TEST_SESSION);
         RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
-        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession(), false);
     }
 
     Expression simplifyExpression(Expression expression)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/expressions/TestExpressionOptimizerManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/expressions/TestExpressionOptimizerManager.java
@@ -127,7 +127,7 @@ public class TestExpressionOptimizerManager
         Session.SessionBuilder sessionBuilder = testSessionBuilder();
         systemProperties.forEach(sessionBuilder::setSystemProperty);
         Session session = sessionBuilder.build();
-        assertEquals(manager.getExpressionOptimizer(session.toConnectorSession()).optimize(expression(originalExpression), OPTIMIZED, session.toConnectorSession()),
+        assertEquals(manager.getExpressionOptimizer(session.toConnectorSession()).optimize(expression(originalExpression), OPTIMIZED, session.toConnectorSession(), false),
                 expression(optimizedExpression));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/gen/CommonSubExpressionBenchmark.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/gen/CommonSubExpressionBenchmark.java
@@ -186,7 +186,7 @@ public class CommonSubExpressionBenchmark
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyMap(), WarningCollector.NOOP);
         RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionAndTypeManager(), TEST_SESSION);
         RowExpressionOptimizer optimizer = new RowExpressionOptimizer(METADATA);
-        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession(), false);
     }
 
     private static Page createPage(String functionType, boolean dictionary)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/gen/PageProcessorBenchmark.java
@@ -184,7 +184,7 @@ public class PageProcessorBenchmark
         Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, METADATA, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyMap(), WarningCollector.NOOP);
         RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, METADATA.getFunctionAndTypeManager(), TEST_SESSION);
         RowExpressionOptimizer optimizer = new RowExpressionOptimizer(METADATA);
-        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+        return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession(), false);
     }
 
     private static Page createPage(List<? extends Type> types, boolean dictionary)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
@@ -263,7 +263,7 @@ public class TestRowExpressionFormatter
                         constant(utf8Slice("prefix%"), VARCHAR)));
         assertEquals(format(callExpression), "c_varchar LIKE VARCHAR'prefix%'");
 
-        callExpression = OPTIMIZER.optimize(callExpression, OPTIMIZED, SESSION);
+        callExpression = OPTIMIZER.optimize(callExpression, OPTIMIZED, SESSION, false);
         assertTrue(format(callExpression).startsWith("c_varchar LIKE LIKEPATTERN'io.airlift.joni.Regex@"));
 
         // like escape
@@ -280,7 +280,7 @@ public class TestRowExpressionFormatter
                         constant(utf8Slice("$"), VARCHAR)));
         assertEquals(format(callExpression), "c_varchar LIKE VARCHAR'%escaped$_' ESCAPE VARCHAR'$'");
 
-        callExpression = OPTIMIZER.optimize(callExpression, OPTIMIZED, SESSION);
+        callExpression = OPTIMIZER.optimize(callExpression, OPTIMIZED, SESSION, false);
         assertTrue(format(callExpression).startsWith("c_varchar LIKE LIKEPATTERN'io.airlift.joni.Regex@"));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestRowExpressionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestRowExpressionOptimizer.java
@@ -141,6 +141,6 @@ public class TestRowExpressionOptimizer
 
     private RowExpression optimize(RowExpression expression)
     {
-        return optimizer.optimize(expression, OPTIMIZED, SESSION);
+        return optimizer.optimize(expression, OPTIMIZED, SESSION, false);
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/BenchmarkDecimalOperators.java
@@ -611,7 +611,7 @@ public class BenchmarkDecimalOperators
             Map<NodeRef<Expression>, Type> expressionTypes = getExpressionTypes(TEST_SESSION, metadata, SQL_PARSER, TypeProvider.copyOf(symbolTypes), expression, emptyMap(), WarningCollector.NOOP);
             RowExpression rowExpression = SqlToRowExpressionTranslator.translate(expression, expressionTypes, sourceLayout, metadata.getFunctionAndTypeManager(), TEST_SESSION);
             RowExpressionOptimizer optimizer = new RowExpressionOptimizer(metadata);
-            return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession());
+            return optimizer.optimize(rowExpression, OPTIMIZED, TEST_SESSION.toConnectorSession(), false);
         }
 
         private Object generateRandomValue(Type type)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/rule/ParquetDereferencePushDown.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/rule/ParquetDereferencePushDown.java
@@ -182,7 +182,7 @@ public abstract class ParquetDereferencePushDown
                 RowExpression indexExpression = expressionOptimizer.optimize(
                         dereferenceExpression.getArguments().get(1),
                         ExpressionOptimizer.Level.OPTIMIZED,
-                        session);
+                        session, false);
 
                 if (indexExpression instanceof ConstantExpression) {
                     Object index = ((ConstantExpression) indexExpression).getValue();
@@ -245,7 +245,7 @@ public abstract class ParquetDereferencePushDown
                     RowExpression indexExpression = expressionOptimizer.optimize(
                             dereferenceExpression.getArguments().get(1),
                             ExpressionOptimizer.Level.OPTIMIZED,
-                            connectorSession);
+                            connectorSession, false);
 
                     if (indexExpression instanceof ConstantExpression) {
                         Object index = ((ConstantExpression) indexExpression).getValue();

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkStatsCalculatorModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkStatsCalculatorModule.java
@@ -22,6 +22,7 @@ import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsNormalizer;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -44,6 +45,7 @@ public class PrestoSparkStatsCalculatorModule
         configBinder(binder).bindConfig(HistoryBasedOptimizationConfig.class);
         binder.bind(HistoryBasedPlanStatisticsManager.class).in(Scopes.SINGLETON);
         binder.bind(FragmentStatsProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ExpressionOptimizerManager.class).in(Scopes.SINGLETON);
     }
 
     @Provides
@@ -55,9 +57,10 @@ public class PrestoSparkStatsCalculatorModule
             FilterStatsCalculator filterStatsCalculator,
             FragmentStatsProvider fragmentStatsProvider,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
-            HistoryBasedOptimizationConfig historyBasedOptimizationConfig)
+            HistoryBasedOptimizationConfig historyBasedOptimizationConfig,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
-        StatsCalculator delegate = createComposableStatsCalculator(metadata, scalarStatsCalculator, normalizer, filterStatsCalculator, fragmentStatsProvider);
+        StatsCalculator delegate = createComposableStatsCalculator(metadata, scalarStatsCalculator, normalizer, filterStatsCalculator, fragmentStatsProvider, expressionOptimizerManager);
         return new PrestoSparkStatsCalculator(historyBasedPlanStatisticsManager.getHistoryBasedPlanStatisticsCalculator(delegate), delegate, historyBasedOptimizationConfig);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ExpressionOptimizer.java
@@ -22,7 +22,7 @@ public interface ExpressionOptimizer
     /**
      * Optimize a RowExpression to its simplest equivalent form.
      */
-    default RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
+    default RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session, boolean useBuiltInFunctions)
     {
         return optimize(rowExpression, level, session, variable -> variable);
     }


### PR DESCRIPTION
## Description
When the optimizer computes plan stats for the rewritten plan, the rule `ValuesStatsRule` attempts to evaluate variables to constants in function [getVariableValues](https://github.com/prestodb/presto/blob/38f9ae6698d6cba4f513b8f1bb686e77043c074c/presto-main-base/src/main/java/com/facebook/presto/cost/ValuesStatsRule.java#L75). C++ functions should not be used to constant fold in `ValuesStatsRule` when native function namespace manager is used in sidecar until constant folding is supported by sidecar. Enable use of built-in functions for constant folding in default `RowExpressionOptimizer` and use built-in functions to evaluate constants in `ValuesStatsRule`.

## Motivation and Context
When the native CTE tests are run with the sidecar enabled, the testcase [`testPersistentCteForVarbinaryType`](https://github.com/prestodb/presto/blob/38f9ae6698d6cba4f513b8f1bb686e77043c074c/presto-hive/src/test/java/com/facebook/presto/hive/TestCteExecution.java#L277) fails with the following error:
```
java.lang.RuntimeException: RowExpression interpreter returned an unresolved expression
```
This is because the plan optimizer attempts to [evaluate CallExpressions](https://github.com/prestodb/presto/blob/38f9ae6698d6cba4f513b8f1bb686e77043c074c/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java#L134C26-L134C55) in the query plan, such as `from_base64('Qm9iIEpvaG5zb24=')`, to ConstantExpressions when calculating plan stats in [`ValuesStatsRule`](https://github.com/prestodb/presto/blob/38f9ae6698d6cba4f513b8f1bb686e77043c074c/presto-main-base/src/main/java/com/facebook/presto/cost/ValuesStatsRule.java#L85). This evaluation will fail when native function implementations are used by the sidecar, since the function implementation type will be `CPP` and these functions will [not be evaluated](https://github.com/prestodb/presto/blob/38f9ae6698d6cba4f513b8f1bb686e77043c074c/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java#L280) in the coordinator. `ValuesStatsRule` should use built-in functions for evaluating constant expressions until the sidecar supports expression evaluation with native engine (WIP: https://github.com/prestodb/presto/pull/24126).

## Test Plan
Please refer to [commit](https://github.com/prestodb/presto/pull/24717/commits/dc547bde61da9c0a7a452c13f9f6c0d6bc924a85), comprehensive e2e tests for function analysis with native sidecar will be added in https://github.com/prestodb/presto/pull/24717.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

