### PR TITLE
[docs] Fix formatting in /security/

### DIFF
--- a/presto-docs/src/main/sphinx/security/authorization.rst
+++ b/presto-docs/src/main/sphinx/security/authorization.rst
@@ -24,11 +24,11 @@ roles defined in Presto:
 Enabling Authorization
 ----------------------
 
-The following steps need to be taken in order to enable authorization:
+The following steps must be taken to enable authorization:
 
- 1. :ref:`enable_authentication`
- 2. :ref:`configure_authorizer`
- 3. :ref:`configure_authorization_settings`
+1. :ref:`enable_authentication`
+2. :ref:`configure_authorizer`
+3. :ref:`configure_authorization_settings`
 
 .. _enable_authentication:
 
@@ -38,20 +38,20 @@ Enable Authentication
 Presto authorization requires authentication to get the accessor's principal,
 so make sure you have authentication enabled.
 
-   - If TLS/SSL is configured properly, we can just use the certificate to
-     identify the accessor.
+- If TLS/SSL is configured properly, use the certificate to
+  identify the accessor.
 
-     .. code-block:: none
+  .. code-block:: none
 
-         http-server.authentication.type=CERTIFICATE
+     http-server.authentication.type=CERTIFICATE
 
-   - It is also possible to specify other authentication types such as
-     ``KERBEROS``, ``PASSWORD`` and ``JWT``. Additional configuration may be
-     needed.
+- It is also possible to specify other authentication types such as
+  ``KERBEROS``, ``PASSWORD`` and ``JWT``. Additional configuration may be
+  needed.
 
-     .. code-block:: none
+  .. code-block:: none
 
-         node.internal-address=<authentication type>
+     node.internal-address=<authentication type>
 
 .. _configure_authorizer:
 
@@ -75,17 +75,17 @@ Configuration-based authorizer:
 
 1. Create a role to identity regex mapping and store it in a file.
 
-    .. code-block:: none
+   .. code-block:: none
 
-        user=.*
-        internal=coordinator
-        admin=su.*
+       user=.*
+       internal=coordinator
+       admin=su.*
 
 2. Specify the path to the mapping file in ``config.properties`` file:
 
-    .. code-block:: none
+   .. code-block:: none
 
-        configuration-based-authorizer.role-regex-map.file-path=<path to mapping file>
+       configuration-based-authorizer.role-regex-map.file-path=<path to mapping file>
 
 3. Install the Guice module
    ``com.facebook.airlift.http.server.ConfigurationBasedAuthorizerModule``.
@@ -95,7 +95,7 @@ Configuration-based authorizer:
 Configure Authorization Settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Authorization settings is configured in the ``config.properties`` file. The
+Authorization settings are configured in the ``config.properties`` file. The
 authorization on the worker and coordinator nodes are configured using the same
 set of properties.
 

--- a/presto-docs/src/main/sphinx/security/internal-communication.rst
+++ b/presto-docs/src/main/sphinx/security/internal-communication.rst
@@ -18,16 +18,16 @@ To enable SSL/TLS for Presto internal communication, do the following:
 
 1. Disable HTTP endpoint.
 
-    .. code-block:: none
+   .. code-block:: none
 
-        http-server.http.enabled=false
+       http-server.http.enabled=false
 
-    .. warning::
+   .. warning::
 
-        You can enable HTTPS while leaving HTTP enabled. In most cases this is a
-        security hole. If you are certain you want to use this configuration, you
-        should consider using an firewall to limit access to the HTTP endpoint to
-        only those hosts that should be allowed to use it.
+       You can enable HTTPS while leaving HTTP enabled. In most cases this is a
+       security hole. If you are certain you want to use this configuration, you
+       should consider using an firewall to limit access to the HTTP endpoint to
+       only those hosts that should be allowed to use it.
 
 2. Configure the cluster to communicate using the fully qualified domain name (fqdn)
    of the cluster nodes. This can be done in either of the following ways:
@@ -57,62 +57,62 @@ To enable SSL/TLS for Presto internal communication, do the following:
    and specify it for the client (see step #8 below). In most cases it will be
    simpler to use a wildcard in the certificate as shown below.
 
-    .. code-block:: none
+   .. code-block:: none
 
-        keytool -genkeypair -alias example.com -keyalg RSA -keystore keystore.jks
-        Enter keystore password:
-        Re-enter new password:
-        What is your first and last name?
-          [Unknown]:  *.example.com
-        What is the name of your organizational unit?
-          [Unknown]:
-        What is the name of your organization?
-          [Unknown]:
-        What is the name of your City or Locality?
-          [Unknown]:
-        What is the name of your State or Province?
-          [Unknown]:
-        What is the two-letter country code for this unit?
-          [Unknown]:
-        Is CN=*.example.com, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
-          [no]:  yes
+       keytool -genkeypair -alias example.com -keyalg RSA -keystore keystore.jks
+       Enter keystore password:
+       Re-enter new password:
+       What is your first and last name?
+         [Unknown]:  *.example.com
+       What is the name of your organizational unit?
+         [Unknown]:
+       What is the name of your organization?
+         [Unknown]:
+       What is the name of your City or Locality?
+         [Unknown]:
+       What is the name of your State or Province?
+         [Unknown]:
+       What is the two-letter country code for this unit?
+         [Unknown]:
+       Is CN=*.example.com, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
+         [no]:  yes
 
-        Enter key password for <presto>
-                (RETURN if same as keystore password):
+       Enter key password for <presto>
+               (RETURN if same as keystore password):
 
-    .. Note: Replace `example.com` with the appropriate domain.
+   .. Note: Replace `example.com` with the appropriate domain.
 
 4. Distribute the Java Keystore File across the Presto cluster.
 
 5. Enable the HTTPS endpoint.
 
-    .. code-block:: none
+   .. code-block:: none
 
-        http-server.https.enabled=true
-        http-server.https.port=<https port>
-        http-server.https.keystore.path=<keystore path>
-        http-server.https.keystore.key=<keystore password>
+       http-server.https.enabled=true
+       http-server.https.port=<https port>
+       http-server.https.keystore.path=<keystore path>
+       http-server.https.keystore.key=<keystore password>
 
-Note: setting the ``http-server.https.port`` to ``0`` results in the use of an ephemeral port.
+   Note: setting the ``http-server.https.port`` to ``0`` results in the use of an ephemeral port.
 
 6. Change the discovery uri to HTTPS.
 
-    .. code-block:: none
+   .. code-block:: none
 
-        discovery.uri=https://<coordinator fqdn>:<https port>
+       discovery.uri=https://<coordinator fqdn>:<https port>
 
 7. Configure the internal communication to require HTTPS.
 
-    .. code-block:: none
+   .. code-block:: none
 
-        internal-communication.https.required=true
+       internal-communication.https.required=true
 
 8. Configure the internal communication to use the Java keystore file.
 
-    .. code-block:: none
+   .. code-block:: none
 
-        internal-communication.https.keystore.path=<keystore path>
-        internal-communication.https.keystore.key=<keystore password>
+       internal-communication.https.keystore.path=<keystore path>
+       internal-communication.https.keystore.key=<keystore password>
 
 Internal Authentication
 -----------------------
@@ -125,7 +125,7 @@ It is
   between clients and the coordinator
 * Mandatory when configuring both the above i.e internal TLS along with external authentication.
 
-There are multiple ways to enable internal authentication described in below sections
+There are multiple ways to enable internal authentication:
 
 1. JWT
 ~~~~~~
@@ -166,9 +166,9 @@ will be used for certificate authentication.
 If :doc:`Kerberos</security/server>` authentication is enabled, specify valid Kerberos
 credentials for the internal communication, in addition to the SSL/TLS properties.
 
-    .. code-block:: none
+.. code-block:: none
 
-        internal-communication.kerberos.enabled=true
+    internal-communication.kerberos.enabled=true
 
 .. note::
 
@@ -208,15 +208,15 @@ to switch the random number generator algorithm to ``SHA1PRNG``, by setting it v
 ``http-server.https.secure-random-algorithm`` property in ``config.properties`` on the coordinator
 and all of the workers:
 
-    .. code-block:: none
+.. code-block:: none
 
-        http-server.https.secure-random-algorithm=SHA1PRNG
+    http-server.https.secure-random-algorithm=SHA1PRNG
 
 Be aware that this algorithm takes the initial seed from
 the blocking ``/dev/random`` device. For environments that do not have enough entropy to seed
 the ``SHAPRNG`` algorithm, the source can be changed to ``/dev/urandom``
 by adding the ``java.security.egd`` property to ``jvm.config``:
 
-    .. code-block:: none
+.. code-block:: none
 
-        -Djava.security.egd=file:/dev/urandom
+    -Djava.security.egd=file:/dev/urandom

--- a/presto-docs/src/main/sphinx/security/jce-policy.fragment
+++ b/presto-docs/src/main/sphinx/security/jce-policy.fragment
@@ -6,8 +6,8 @@ strength of the cryptographic keys that can be used. Kerberos, by default, uses
 keys that are larger than those supported by the included policy files. There
 are two possible solutions to the problem:
 
-  * Update the :abbr:`JCE (Java Cryptography Extension)` policy files.
-  * Configure Kerberos to use reduced-strength keys.
+* Update the :abbr:`JCE (Java Cryptography Extension)` policy files.
+* Configure Kerberos to use reduced-strength keys.
 
 Of the two options, updating the JCE policy files is recommended. The JCE
 policy files can be downloaded from Oracle. Note that the JCE policy files vary

--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -51,8 +51,8 @@ Presto Coordinator Node Configuration
 You must make the following changes to the environment prior to configuring the
 Presto coordinator to use LDAP authentication and HTTPS.
 
- * :ref:`ldap_server`
- * :ref:`server_java_keystore`
+* :ref:`ldap_server`
+* :ref:`server_java_keystore`
 
 You also need to make changes to the Presto configuration files.
 LDAP authentication is configured on the coordinator in two parts.


### PR DESCRIPTION
## Description
Fix formatting in documentation files in /security/ to remove gray vertical lines from the built pages. 

## Motivation and Context
Readers may think the gray vertical lines have meaning and be confused or distracted. 

## Impact
Documentation. 

## Test Plan
Local doc builds before and after.

Some "before" examples:

I. 
<img width="901" alt="Screenshot 2025-05-09 at 12 55 23 PM" src="https://github.com/user-attachments/assets/5ba97954-583e-4257-a1c9-fb0277c6c774" />

II.
<img width="905" alt="Screenshot 2025-05-09 at 12 59 03 PM" src="https://github.com/user-attachments/assets/b483d15b-92fa-4d0a-85f3-c9a1e77e3cd4" />

III.
<img width="910" alt="Screenshot 2025-05-09 at 1 20 02 PM" src="https://github.com/user-attachments/assets/f511504a-4669-4883-887b-d6e3e85f14a7" />

Some "after" examples:

I.
<img width="895" alt="Screenshot 2025-05-09 at 12 55 51 PM" src="https://github.com/user-attachments/assets/04881cca-19fb-4901-a325-a0282ccf20bd" />

II.
<img width="895" alt="Screenshot 2025-05-09 at 1 00 24 PM" src="https://github.com/user-attachments/assets/5bd671ce-3b0a-4305-bc17-d12256427eea" />

III.
<img width="925" alt="Screenshot 2025-05-09 at 2 11 14 PM" src="https://github.com/user-attachments/assets/c8d89c6a-cbaf-42c5-a1ca-d737f774679c" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

