### PR TITLE
static scan fix[do not review]

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/spiller/AesSpillCipher.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/spiller/AesSpillCipher.java
@@ -34,7 +34,7 @@ final class AesSpillCipher
         implements SpillCipher
 {
     //  256-bit AES CBC mode
-    private static final String CIPHER_NAME = "AES/CBC/PKCS5Padding";
+    private static final String CIPHER_NAME = "AES/CBC/PKCS7Padding";
     private static final int KEY_BITS = 256;
 
     private SecretKey key;


### PR DESCRIPTION
## Description
To identify test case failures related to the AES/CBC/PKCS7Padding encryption algorithm

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

