### PR TITLE
Fix second UDF not respecting sub-minute time zone offsets

### DIFF
--- a/presto-function-server/src/test/java/com/facebook/presto/tests/TestRestRemoteFunctions.java
+++ b/presto-function-server/src/test/java/com/facebook/presto/tests/TestRestRemoteFunctions.java
@@ -75,9 +75,9 @@ public class TestRestRemoteFunctions
                         .getMaterializedRows().get(0).getField(0).toString(),
                 "1230");
         assertEquals(
-                computeActual(session, "select rest.default.second(CAST('2001-01-02 03:04:05' as timestamp))")
+                computeActual(session, "select rest.default.day(interval '2' day)")
                         .getMaterializedRows().get(0).getField(0).toString(),
-                "5");
+                "2");
         assertEquals(
                 computeActual(session, "select rest.default.length(CAST('AB' AS VARBINARY))")
                         .getMaterializedRows().get(0).getField(0).toString(),

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -851,12 +851,14 @@ public final class DateTimeFunctions
     @Description("second of the minute of the given timestamp")
     @ScalarFunction("second")
     @SqlType(StandardTypes.BIGINT)
-    public static long secondFromTimestamp(@SqlType(StandardTypes.TIMESTAMP) long timestamp)
+    public static long secondFromTimestamp(SqlFunctionProperties properties, @SqlType(StandardTypes.TIMESTAMP) long timestamp)
     {
-        // No need to check isLegacyTimestamp:
-        // * Under legacy semantics, the session zone matters. But a zone always has offset of whole minutes.
-        // * Under new semantics, timestamp is agnostic to the session zone.
-        return SECOND_OF_MINUTE.get(timestamp);
+        if (properties.isLegacyTimestamp()) {
+            return getChronology(properties.getTimeZoneKey()).secondOfMinute().get(timestamp);
+        }
+        else {
+            return SECOND_OF_MINUTE.get(timestamp);
+        }
     }
 
     @Description("second of the minute of the given timestamp")
@@ -864,28 +866,28 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long secondFromTimestampWithTimeZone(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long timestampWithTimeZone)
     {
-        // No need to check the associated zone here. A zone always has offset of whole minutes.
-        return SECOND_OF_MINUTE.get(unpackMillisUtc(timestampWithTimeZone));
+        return unpackChronology(timestampWithTimeZone).secondOfMinute().get(unpackMillisUtc(timestampWithTimeZone));
     }
 
     @Description("second of the minute of the given time")
     @ScalarFunction("second")
     @SqlType(StandardTypes.BIGINT)
-    public static long secondFromTime(@SqlType(StandardTypes.TIME) long time)
+    public static long secondFromTime(SqlFunctionProperties properties, @SqlType(StandardTypes.TIME) long time)
     {
-        // No need to check isLegacyTimestamp:
-        // * Under legacy semantics, the session zone matters. But a zone always has offset of whole minutes.
-        // * Under new semantics, time is agnostic to the session zone.
-        return SECOND_OF_MINUTE.get(time);
+        if (properties.isLegacyTimestamp()) {
+            return getChronology(properties.getTimeZoneKey()).secondOfMinute().get(time);
+        }
+        else {
+            return SECOND_OF_MINUTE.get(time);
+        }
     }
 
     @Description("second of the minute of the given time")
     @ScalarFunction("second")
     @SqlType(StandardTypes.BIGINT)
-    public static long secondFromTimeWithTimeZone(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long time)
+    public static long secondFromTimeWithTimeZone(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long timeWithTimeZone)
     {
-        // No need to check the associated zone here. A zone always has offset of whole minutes.
-        return SECOND_OF_MINUTE.get(unpackMillisUtc(time));
+        return unpackChronology(timeWithTimeZone).secondOfMinute().get(unpackMillisUtc(timeWithTimeZone));
     }
 
     @Description("second of the minute of the given interval")

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -383,6 +383,19 @@ public abstract class TestDateTimeFunctionsBase
     }
 
     @Test
+    public void testPartFunctionsWithSecondsOffset()
+    {
+        // Prior to 1920 Asia/Kathmandu's offset was 5:41:16
+        DateTime dateTime = new DateTime(1910, 1, 22, 3, 4, 5, 678, KATHMANDU_ZONE);
+        String dateTimeLiteral = "TIMESTAMP '1910-01-22 03:04:05.678 Asia/Kathmandu'";
+
+        assertFunction("millisecond(" + dateTimeLiteral + ")", BIGINT, (long) dateTime.getMillisOfSecond());
+        assertFunction("second(" + dateTimeLiteral + ")", BIGINT, (long) dateTime.getSecondOfMinute());
+        assertFunction("minute(" + dateTimeLiteral + ")", BIGINT, (long) dateTime.getMinuteOfHour());
+        assertFunction("hour(" + dateTimeLiteral + ")", BIGINT, (long) dateTime.getHourOfDay());
+    }
+
+    @Test
     public void testYearOfWeek()
     {
         assertFunction("year_of_week(DATE '2001-08-22')", BIGINT, 2001L);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/gen/TestExpressionCompiler.java
@@ -1536,7 +1536,7 @@ public class TestExpressionCompiler
             case MINUTE:
                 return DateTimeFunctions.minuteFromTimestamp(session.getSqlFunctionProperties(), value);
             case SECOND:
-                return DateTimeFunctions.secondFromTimestamp(value);
+                return DateTimeFunctions.secondFromTimestamp(session.getSqlFunctionProperties(), value);
             case TIMEZONE_MINUTE:
                 return DateTimeFunctions.timeZoneMinuteFromTimestampWithTimeZone(packDateTimeWithZone(value, session.getSqlFunctionProperties().getTimeZoneKey()));
             case TIMEZONE_HOUR:


### PR DESCRIPTION
## Description
This change updates the "second" UDF to account for the time zone when calculating its return value.

## Motivation and Context
There are certain time zones that, especially historically, had time zone offsets that were not just hours and minutes, but seconds different from present day UTC. The "second" UDF assumes that time zone offsets are always whole minute offsets from UTC.  Therefore it produces incorrect results.

For example, prior to 1920 Asia/Kathmandu	had an offset of 5:41:16. Also America/Los_Angeles had an offset of -7:52:58 prior to November 18, 1883.

## Impact
This will change the result of the "second" UDF when called on timestamps with a time zone with an offset that is seconds different from UTC.

## Test Plan
Added a unit test that covers one of these historical timestamps in Asia/Kathmandu and verifies that the result "second" is now correct.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix returning incorrect results from the "second" UDF when a timestamp is in a time zone with an offset that is at the granularity of seconds.

```

