### PR TITLE
[docs] Fix formatting in /functions/

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -135,17 +135,17 @@ General Aggregate Functions
     ``combineFunction`` is `commutative <https://en.wikipedia.org/wiki/Commutative_property>`_
     and `associative <https://en.wikipedia.org/wiki/Associative_property>`_
     operation with ``initialState`` as the
-    `identity <https://en.wikipedia.org/wiki/Identity_element>`_ value.
+    `identity <https://en.wikipedia.org/wiki/Identity_element>`_ value.::
 
-     combineFunction(s, initialState) = s for any s
+        combineFunction(s, initialState) = s for any s
 
-     combineFunction(s1, s2) = combineFunction(s2, s1) for any s1 and s2
+        combineFunction(s1, s2) = combineFunction(s2, s1) for any s1 and s2
 
-     combineFunction(s1, combineFunction(s2, s3)) = combineFunction(combineFunction(s1, s2), s3) for any s1, s2, s3
+        combineFunction(s1, combineFunction(s2, s3)) = combineFunction(combineFunction(s1, s2), s3) for any s1, s2, s3
 
-    In addition, make sure that the following holds for the inputFunction:
+    In addition, make sure that the following holds for the inputFunction::
 
-     inputFunction(inputFunction(initialState, x), y) = combineFunction(inputFunction(initialState, x), inputFunction(initialState, y)) for any x and y
+        inputFunction(inputFunction(initialState, x), y) = combineFunction(inputFunction(initialState, x), inputFunction(initialState, y)) for any x and y
 
     ::
 
@@ -511,62 +511,62 @@ classification thresholds. They are meant to be used in conjunction.
 
 For example, to find the `precision-recall curve <https://en.wikipedia.org/wiki/Precision_and_recall>`_, use
 
-    .. code-block:: none
+.. code-block:: none
 
-         WITH
-             recall_precision AS (
-                 SELECT
-                     CLASSIFICATION_RECALL(10000, correct, pred) AS recalls,
-                     CLASSIFICATION_PRECISION(10000, correct, pred) AS precisions
-                 FROM
-                    classification_dataset
-             )
-         SELECT
-             recall,
-             precision
-         FROM
-             recall_precision
-         CROSS JOIN UNNEST(recalls, precisions) AS t(recall, precision)
+    WITH
+        recall_precision AS (
+            SELECT
+                CLASSIFICATION_RECALL(10000, correct, pred) AS recalls,
+                CLASSIFICATION_PRECISION(10000, correct, pred) AS precisions
+            FROM
+                classification_dataset
+        )
+    SELECT
+        recall,
+        precision
+    FROM
+        recall_precision
+    CROSS JOIN UNNEST(recalls, precisions) AS t(recall, precision)
 
 To get the corresponding thresholds for these values, use
 
-    .. code-block:: none
+.. code-block:: none
 
-         WITH
-             recall_precision AS (
-                 SELECT
-                     CLASSIFICATION_THRESHOLDS(10000, correct, pred) AS thresholds,
-                     CLASSIFICATION_RECALL(10000, correct, pred) AS recalls,
-                     CLASSIFICATION_PRECISION(10000, correct, pred) AS precisions
-                 FROM
-                    classification_dataset
-             )
-         SELECT
-             threshold,
-             recall,
-             precision
-         FROM
-             recall_precision
-         CROSS JOIN UNNEST(thresholds, recalls, precisions) AS t(threshold, recall, precision)
+    WITH
+        recall_precision AS (
+            SELECT
+                CLASSIFICATION_THRESHOLDS(10000, correct, pred) AS thresholds,
+                CLASSIFICATION_RECALL(10000, correct, pred) AS recalls,
+                CLASSIFICATION_PRECISION(10000, correct, pred) AS precisions
+            FROM
+                classification_dataset
+        )
+    SELECT
+        threshold,
+        recall,
+        precision
+    FROM
+        recall_precision
+    CROSS JOIN UNNEST(thresholds, recalls, precisions) AS t(threshold, recall, precision)
 
 To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_characteristic>`_, use
 
-    .. code-block:: none
+.. code-block:: none
 
-         WITH
-             fallout_recall AS (
-                 SELECT
-                     CLASSIFICATION_FALLOUT(10000, correct, pred) AS fallouts,
-                     CLASSIFICATION_RECALL(10000, correct, pred) AS recalls
-                 FROM
-                    classification_dataset
-             )
-         SELECT
-             fallout
-             recall,
-         FROM
-             recall_fallout
-         CROSS JOIN UNNEST(fallouts, recalls) AS t(fallout, recall)
+    WITH
+        fallout_recall AS (
+            SELECT
+                CLASSIFICATION_FALLOUT(10000, correct, pred) AS fallouts,
+                CLASSIFICATION_RECALL(10000, correct, pred) AS recalls
+            FROM
+                classification_dataset
+        )
+    SELECT
+        fallout
+        recall,
+    FROM
+        recall_fallout
+    CROSS JOIN UNNEST(fallouts, recalls) AS t(fallout, recall)
 
 
 .. function:: classification_miss_rate(buckets, y, x, weight) -> array<double>
@@ -725,10 +725,10 @@ where :math:`f(x)` is the partial density function of :math:`x`.
 
     .. code-block:: none
 
-         SELECT
-             differential_entropy(1000000, x)
-         FROM
-             data
+        SELECT
+            differential_entropy(1000000, x)
+        FROM
+            data
 
     .. note::
 
@@ -807,12 +807,12 @@ where :math:`f(x)` is the partial density function of :math:`x`.
     To find the differential entropy of ``x``, each between ``-2.0`` and ``2.0``,
     with weights ``weight`` of ``data`` using 1000000 buckets and maximum-likelihood estimates, use
 
-        .. code-block:: none
+    .. code-block:: none
 
-             SELECT
-                 differential_entropy(1000000, x, weight, 'fixed_histogram_mle', -2.0, 2.0)
-             FROM
-                 data
+        SELECT
+            differential_entropy(1000000, x, weight, 'fixed_histogram_mle', -2.0, 2.0)
+        FROM
+            data
 
     .. note::
 

--- a/presto-docs/src/main/sphinx/functions/comparison.rst
+++ b/presto-docs/src/main/sphinx/functions/comparison.rst
@@ -160,7 +160,7 @@ The LIKE operator is used to match a specified character pattern in a string. Pa
 regular characters as well as wildcards. Wildcard characters can be escaped using the single character
 specified for the ESCAPE parameter. Matching is case sensitive, and the pattern must match the whole string.
 
-Syntax:
+Syntax::
 
     expression LIKE pattern [ ESCAPE 'escape_character' ]
 

--- a/presto-docs/src/main/sphinx/functions/conditional.rst
+++ b/presto-docs/src/main/sphinx/functions/conditional.rst
@@ -55,12 +55,12 @@ IF
 The ``IF`` function is actually a language construct
 that is equivalent to the following ``CASE`` expression:
 
-    .. code-block:: none
+.. code-block:: none
 
-        CASE
-            WHEN condition THEN true_value
-            [ ELSE false_value ]
-        END
+    CASE
+        WHEN condition THEN true_value
+        [ ELSE false_value ]
+    END
 
 .. function:: if(condition, true_value)
 

--- a/presto-docs/src/main/sphinx/functions/setdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/setdigest.rst
@@ -65,37 +65,37 @@ Functions
 
 Composes all input values of ``x`` into a ``setdigest``.
 
-    Examples::
+Examples:
 
-        Create a ``setdigest`` corresponding to a ``bigint`` array::
+Create a ``setdigest`` corresponding to a ``bigint`` array::
 
-        SELECT make_set_digest(value)
-        FROM (VALUES 1, 2, 3) T(value);
+    SELECT make_set_digest(value)
+    FROM (VALUES 1, 2, 3) T(value);
 
-        Create a ``setdigest`` corresponding to a ``varchar`` array::
+Create a ``setdigest`` corresponding to a ``varchar`` array::
 
-        SELECT make_set_digest(value)
-        FROM (VALUES 'Presto', 'SQL', 'on', 'everything') T(value);
+    SELECT make_set_digest(value)
+    FROM (VALUES 'Presto', 'SQL', 'on', 'everything') T(value);
 
 
 .. function:: merge_set_digest(setdigest) -> setdigest
 
 Returns the ``setdigest`` of the aggregate union of the individual ``setdigest`` structures.
 
-     Examples::
+Example::
 
-        SELECT merge_set_digest(a) from (SELECT make_set_digest(value) as a FROM (VALUES 4,3,2,1) T(value));
+    SELECT merge_set_digest(a) from (SELECT make_set_digest(value) as a FROM (VALUES 4,3,2,1) T(value));
 
 .. function:: cardinality(setdigest) -> bigint
 
 Returns the cardinality of the set digest from its internal
 ``HyperLogLog`` component.
 
-    Examples::
+Example::
 
-        SELECT cardinality(make_set_digest(value))
-        FROM (VALUES 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5) T(value);
-        -- 5
+    SELECT cardinality(make_set_digest(value))
+    FROM (VALUES 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5) T(value);
+    -- 5
 
 .. function:: intersection_cardinality(x,y) -> bigint
 
@@ -103,11 +103,11 @@ Returns the estimation for the cardinality of the intersection of the two set di
 
 ``x`` and ``y``  be of type  ``setdigest``
 
-    Examples::
+Example::
 
-        SELECT intersection_cardinality(make_set_digest(v1), make_set_digest(v2))
-        FROM (VALUES (1, 1), (NULL, 2), (2, 3), (3, 4)) T(v1, v2);
-        -- 3
+    SELECT intersection_cardinality(make_set_digest(v1), make_set_digest(v2))
+    FROM (VALUES (1, 1), (NULL, 2), (2, 3), (3, 4)) T(v1, v2);
+    -- 3
 
 .. function:: jaccard_index(x, y) -> double
 
@@ -116,11 +116,11 @@ the two set digests.
 
 ``x`` and ``y`` be of type  ``setdigest``.
 
-    Examples::
+Example::
 
-        SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2))
-        FROM (VALUES (1, 1), (NULL,2), (2, 3), (NULL, 4)) T(v1, v2);
-        -- 0.5
+    SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2))
+    FROM (VALUES (1, 1), (NULL,2), (2, 3), (NULL, 4)) T(v1, v2);
+    -- 0.5
 
 .. function:: hash_counts(x) -> map(bigint, smallint)
 
@@ -130,8 +130,8 @@ the internal ``MinHash`` structure belonging to ``x`` or varchar
 
 ``x`` must be of type  ``setdigest``.
 
-    Examples::
+Example::
 
-        SELECT hash_counts(make_set_digest(value))
-        FROM (VALUES 1, 1, 1, 2, 2) T(value);
-        -- {19144387141682250=3, -2447670524089286488=2}
+    SELECT hash_counts(make_set_digest(value))
+    FROM (VALUES 1, 1, 1, 2, 2) T(value);
+    -- {19144387141682250=3, -2447670524089286488=2}


### PR DESCRIPTION
## Description
Fix formatting in documentation files in /functions/ to remove gray vertical lines from the built pages.

## Motivation and Context
Readers may think the gray vertical lines have meaning and be confused or distracted.

Builds on the work in #25081. 

## Impact
Documentation.

## Test Plan
Local doc builds. 

Before, 1: 
<img width="751" alt="Screenshot 2025-05-12 at 2 24 07 PM" src="https://github.com/user-attachments/assets/cb46eec9-5059-4c05-a0ab-af4f8eec8a80" />

After, 1: 
<img width="758" alt="Screenshot 2025-05-12 at 2 28 13 PM" src="https://github.com/user-attachments/assets/aac0a699-294c-4151-b439-ec993d5299f8" />


Before, 2:
<img width="799" alt="Screenshot 2025-05-12 at 2 32 29 PM" src="https://github.com/user-attachments/assets/2289c52f-5af2-4048-832b-a0b98bf0ad61" />

After, 2: 
<img width="785" alt="Screenshot 2025-05-12 at 2 33 37 PM" src="https://github.com/user-attachments/assets/8dd5f5ce-951e-47d9-ae19-45cbf3c55059" />

Before, 3:
<img width="794" alt="Screenshot 2025-05-12 at 2 46 20 PM" src="https://github.com/user-attachments/assets/d03cc5a3-6894-4e8d-bd33-e9ac7279d52e" />

After, 3:
<img width="789" alt="Screenshot 2025-05-12 at 2 46 34 PM" src="https://github.com/user-attachments/assets/f965a484-a1df-472a-bfc1-debd91baa723" />


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

