### PR TITLE
[native] Add optional Task queuing framework.

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -617,6 +617,25 @@ memory use. Ignored if zero.
 CPU threshold in % above which the worker is considered overloaded in terms of
 CPU use. Ignored if zero.
 
+``worker-overloaded-cooldown-period-sec``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``5``
+
+Specifies how many seconds worker has to be not overloaded (in terms of
+memory and CPU) before its status changes to not overloaded.
+This is to prevent spiky fluctuation of the overloaded status.
+
+``worker-overloaded-task-queuing-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+If true, the worker starts queuing new tasks when overloaded, and
+starts them gradually when it stops being overloaded.
+
 Environment Variables As Values For Worker Properties
 -----------------------------------------------------
 

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -334,19 +334,23 @@ void PeriodicTaskManager::updateTaskStats() {
       kCounterNumTasksBytesProcessed, taskManager_->getBytesProcessed());
   RECORD_METRIC_VALUE(
       kCounterNumTasksRunning,
-      taskNumbers[static_cast<int>(velox::exec::TaskState::kRunning)]);
+      taskNumbers[static_cast<int>(PrestoTaskState::kRunning)]);
   RECORD_METRIC_VALUE(
       kCounterNumTasksFinished,
-      taskNumbers[static_cast<int>(velox::exec::TaskState::kFinished)]);
+      taskNumbers[static_cast<int>(PrestoTaskState::kFinished)]);
   RECORD_METRIC_VALUE(
       kCounterNumTasksCancelled,
-      taskNumbers[static_cast<int>(velox::exec::TaskState::kCanceled)]);
+      taskNumbers[static_cast<int>(PrestoTaskState::kCanceled)]);
   RECORD_METRIC_VALUE(
       kCounterNumTasksAborted,
-      taskNumbers[static_cast<int>(velox::exec::TaskState::kAborted)]);
+      taskNumbers[static_cast<int>(PrestoTaskState::kAborted)]);
   RECORD_METRIC_VALUE(
       kCounterNumTasksFailed,
-      taskNumbers[static_cast<int>(velox::exec::TaskState::kFailed)]);
+      taskNumbers[static_cast<int>(PrestoTaskState::kFailed)]);
+  RECORD_METRIC_VALUE(
+      kCounterNumTasksPlanned,
+      taskNumbers[static_cast<int>(PrestoTaskState::kPlanned)]);
+  RECORD_METRIC_VALUE(kCounterNumTasksQueued, taskManager_->numQueuedTasks());
 
   const auto driverCounts = taskManager_->getDriverCounts();
   RECORD_METRIC_VALUE(kCounterNumQueuedDrivers, driverCounts.numQueuedDrivers);

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1425,6 +1425,9 @@ void PrestoServer::populateMemAndCPUInfo() {
     poolInfo.reservedBytes += bytes;
   });
   RECORD_METRIC_VALUE(kCounterNumQueryContexts, numContexts);
+  RECORD_METRIC_VALUE(
+      kCounterMemoryManagerTotalBytes,
+      velox::memory::memoryManager()->getTotalBytes());
   cpuMon_.update();
   checkOverload();
   **memoryInfo_.wlock() = std::move(memoryInfo);
@@ -1439,41 +1442,74 @@ void PrestoServer::checkOverload() {
     const auto currentUsedMemoryBytes = (memoryChecker_ != nullptr)
         ? memoryChecker_->cachedSystemUsedMemoryBytes()
         : 0;
-    const bool isMemOverloaded =
+    const bool memOverloaded =
         (currentUsedMemoryBytes > overloadedThresholdMemBytes);
-    if (isMemOverloaded) {
-      LOG(WARNING) << "Server memory is overloaded. Currently used: "
+    if (memOverloaded && !memOverloaded_) {
+      LOG(WARNING) << "OVERLOAD: Server memory is overloaded. Currently used: "
                    << velox::succinctBytes(currentUsedMemoryBytes)
+                   << ", including tracked: "
+                   << velox::succinctBytes(
+                          velox::memory::memoryManager()->getTotalBytes())
                    << ", threshold: "
                    << velox::succinctBytes(overloadedThresholdMemBytes);
-    } else if (isMemOverloaded_) {
-      LOG(INFO) << "Server memory is no longer overloaded. Currently used: "
-                << velox::succinctBytes(currentUsedMemoryBytes)
-                << ", threshold: "
-                << velox::succinctBytes(overloadedThresholdMemBytes);
+    } else if (!memOverloaded && memOverloaded_) {
+      LOG(INFO)
+          << "OVERLOAD: Server memory is no longer overloaded. Currently used: "
+          << velox::succinctBytes(currentUsedMemoryBytes)
+          << ", including tracked: "
+          << velox::succinctBytes(
+                 velox::memory::memoryManager()->getTotalBytes())
+          << ", threshold: "
+          << velox::succinctBytes(overloadedThresholdMemBytes);
     }
-    RECORD_METRIC_VALUE(kCounterOverloadedMem, isMemOverloaded ? 100 : 0);
-    isMemOverloaded_ = isMemOverloaded;
+    RECORD_METRIC_VALUE(kCounterOverloadedMem, memOverloaded ? 100 : 0);
+    memOverloaded_ = memOverloaded;
   }
 
   const auto overloadedThresholdCpuPct =
       systemConfig->workerOverloadedThresholdCpuPct();
   if (overloadedThresholdCpuPct > 0) {
     const auto currentUsedCpuPct = cpuMon_.getCPULoadPct();
-    const bool isCpuOverloaded =
-        (currentUsedCpuPct > overloadedThresholdCpuPct);
-    if (isCpuOverloaded) {
-      LOG(WARNING) << "Server CPU is overloaded. Currently used: "
+    const bool cpuOverloaded = (currentUsedCpuPct > overloadedThresholdCpuPct);
+    if (cpuOverloaded && !cpuOverloaded_) {
+      LOG(WARNING) << "OVERLOAD: Server CPU is overloaded. Currently used: "
                    << currentUsedCpuPct
                    << "%, threshold: " << overloadedThresholdCpuPct << "%";
-    } else if (isCpuOverloaded_) {
-      LOG(INFO) << "Server CPU is no longer overloaded. Currently used: "
-                << currentUsedCpuPct
-                << "%, threshold: " << overloadedThresholdCpuPct << "%";
+    } else if (!cpuOverloaded && cpuOverloaded_) {
+      LOG(INFO)
+          << "OVERLOAD: Server CPU is no longer overloaded. Currently used: "
+          << currentUsedCpuPct << "%, threshold: " << overloadedThresholdCpuPct
+          << "%";
     }
-    RECORD_METRIC_VALUE(kCounterOverloadedCpu, isCpuOverloaded ? 100 : 0);
-    isCpuOverloaded_ = isCpuOverloaded;
+    RECORD_METRIC_VALUE(kCounterOverloadedCpu, cpuOverloaded ? 100 : 0);
+    cpuOverloaded_ = cpuOverloaded;
   }
+
+  // Determine if the server is overloaded. We require both memory and CPU to be
+  // not overloaded for some time (continuous period) to consider the server as
+  // not overloaded.
+  const uint64_t currentTimeSecs = velox::getCurrentTimeSec();
+  if (memOverloaded_ || cpuOverloaded_) {
+    lastOverloadedTimeInSecs_ = currentTimeSecs;
+  }
+  VELOX_CHECK_GE(currentTimeSecs, lastOverloadedTimeInSecs_);
+  const bool serverOverloaded =
+      ((cpuOverloaded_ || memOverloaded_) ||
+       ((currentTimeSecs - lastOverloadedTimeInSecs_) <
+        systemConfig->workerOverloadedCooldownPeriodSec()));
+
+  if (serverOverloaded && !serverOverloaded_) {
+    LOG(WARNING) << "OVERLOAD: Server is overloaded.";
+  } else if (!serverOverloaded && serverOverloaded_) {
+    LOG(INFO) << "OVERLOAD: Server is no longer overloaded.";
+  }
+  RECORD_METRIC_VALUE(kCounterOverloaded, serverOverloaded ? 100 : 0);
+  serverOverloaded_ = serverOverloaded;
+
+  if (systemConfig->workerOverloadedTaskQueuingEnabled()) {
+    taskManager_->setServerOverloaded(serverOverloaded_);
+  }
+  taskManager_->maybeStartNextQueuedTask();
 }
 
 static protocol::Duration getUptime(

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -275,8 +275,16 @@ class PrestoServer {
   std::unique_ptr<PeriodicTaskManager> periodicTaskManager_;
   std::unique_ptr<PrestoServerOperations> prestoServerOperations_;
   std::unique_ptr<PeriodicMemoryChecker> memoryChecker_;
-  bool isMemOverloaded_{false};
-  bool isCpuOverloaded_{false};
+
+  // Last known memory overloaded status.
+  bool memOverloaded_{false};
+  // Last known CPU overloaded status.
+  bool cpuOverloaded_{false};
+  // Current worker overloaded status. It can still be true when memory and CPU
+  // overloaded flags are not due to cooldown period.
+  bool serverOverloaded_{false};
+  // Last time point (in seconds) when the worker was overloaded.
+  uint64_t lastOverloadedTimeInSecs_{0};
 
   // We update these members asynchronously and return in http requests w/o
   // delay.

--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -25,6 +25,19 @@ struct RuntimeMetric;
 
 namespace facebook::presto {
 
+/// Velox Task does not have Planned state, so we add this enum to have this
+/// state.
+enum class PrestoTaskState : int {
+  kRunning = 0,
+  kFinished = 1,
+  kCanceled = 2,
+  kAborted = 3,
+  kFailed = 4,
+  kPlanned = 5
+};
+
+std::string prestoTaskStateString(PrestoTaskState state);
+
 template <typename T>
 struct PromiseHolder {
   explicit PromiseHolder(folly::Promise<T> p) : promise(std::move(p)) {}
@@ -139,6 +152,10 @@ struct PrestoTask {
       const std::string& nodeId,
       long startProcessCpuTime = 0);
 
+  /// Returns current task state, including 'planning'.
+  /// If Velox task is null, it returns 'aborted'.
+  PrestoTaskState taskState() const;
+
   /// Updates when this task was touched last time.
   void updateHeartbeatLocked();
 
@@ -169,7 +186,7 @@ struct PrestoTask {
 
   /// Turns the task numbers (per state) into a string.
   static std::string taskStatesToString(
-      const std::array<size_t, 5>& taskStates);
+      const std::array<size_t, 6>& taskStates);
 
   /// Invoked to update presto task status from the updated velox task stats.
   protocol::TaskStatus updateStatusLocked();

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -185,6 +185,8 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kSystemMemPushbackAbortEnabled, false),
           NUM_PROP(kWorkerOverloadedThresholdMemGb, 0),
           NUM_PROP(kWorkerOverloadedThresholdCpuPct, 0),
+          NUM_PROP(kWorkerOverloadedCooldownPeriodSec, 5),
+          BOOL_PROP(kWorkerOverloadedTaskQueuingEnabled, false),
           NUM_PROP(kMallocHeapDumpThresholdGb, 20),
           NUM_PROP(kMallocMemMinHeapDumpInterval, 10),
           NUM_PROP(kMallocMemMaxHeapDumpFiles, 5),
@@ -507,6 +509,14 @@ uint64_t SystemConfig::workerOverloadedThresholdMemGb() const {
 
 uint32_t SystemConfig::workerOverloadedThresholdCpuPct() const {
   return optionalProperty<uint32_t>(kWorkerOverloadedThresholdCpuPct).value();
+}
+
+uint32_t SystemConfig::workerOverloadedCooldownPeriodSec() const {
+  return optionalProperty<uint32_t>(kWorkerOverloadedCooldownPeriodSec).value();
+}
+
+bool SystemConfig::workerOverloadedTaskQueuingEnabled() const {
+  return optionalProperty<bool>(kWorkerOverloadedTaskQueuingEnabled).value();
 }
 
 bool SystemConfig::mallocMemHeapDumpEnabled() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -313,6 +313,15 @@ class SystemConfig : public ConfigBase {
   /// Ignored if zero. Default is zero.
   static constexpr std::string_view kWorkerOverloadedThresholdCpuPct{
       "worker-overloaded-threshold-cpu-pct"};
+  /// Specifies how many seconds worker has to be not overloaded (in terms of
+  /// memory and CPU) before its status changes to not overloaded.
+  /// This is to prevent spiky fluctuation of the overloaded status.
+  static constexpr std::string_view kWorkerOverloadedCooldownPeriodSec{
+      "worker-overloaded-cooldown-period-sec"};
+  /// If true, the worker starts queuing new tasks when overloaded, and
+  /// starts them gradually when it stops being overloaded.
+  static constexpr std::string_view kWorkerOverloadedTaskQueuingEnabled{
+      "worker-overloaded-task-queuing-enabled"};
 
   /// If true, memory allocated via malloc is periodically checked and a heap
   /// profile is dumped if usage exceeds 'malloc-heap-dump-gb-threshold'.
@@ -719,7 +728,7 @@ class SystemConfig : public ConfigBase {
 
   // Specifies the type of worker pool
   static constexpr std::string_view kPoolType{"pool-type"};
-  
+
   // Spill related configs
   static constexpr std::string_view kSpillEnabled{"spill-enabled"};
   static constexpr std::string_view kJoinSpillEnabled{"join-spill-enabled"};
@@ -840,6 +849,10 @@ class SystemConfig : public ConfigBase {
   uint64_t workerOverloadedThresholdMemGb() const;
 
   uint32_t workerOverloadedThresholdCpuPct() const;
+
+  uint32_t workerOverloadedCooldownPeriodSec() const;
+
+  bool workerOverloadedTaskQueuingEnabled() const;
 
   bool mallocMemHeapDumpEnabled() const;
 
@@ -986,12 +999,12 @@ class SystemConfig : public ConfigBase {
   bool enableRuntimeMetricsCollection() const;
 
   bool prestoNativeSidecar() const;
-  
+
   std::string prestoDefaultNamespacePrefix() const;
 
   std::string poolType() const;
 
-  bool spillEnabled() const; 
+  bool spillEnabled() const;
 
   bool joinSpillEnabled() const;
 

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -44,6 +44,8 @@ void registerPrestoMetrics() {
       99,
       100);
   DEFINE_METRIC(kCounterNumQueryContexts, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(
+      kCounterMemoryManagerTotalBytes, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasks, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasksBytesProcessed, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasksRunning, facebook::velox::StatType::AVG);
@@ -51,6 +53,8 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(kCounterNumTasksCancelled, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasksAborted, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumTasksFailed, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterNumTasksPlanned, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterNumTasksQueued, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumZombieVeloxTasks, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumZombiePrestoTasks, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
@@ -86,7 +90,9 @@ void registerPrestoMetrics() {
   DEFINE_METRIC(kCounterNumBlockedYieldDrivers, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterOverloadedMem, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterOverloadedCpu, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterOverloaded, facebook::velox::StatType::AVG);
   DEFINE_METRIC(kCounterNumStuckDrivers, facebook::velox::StatType::AVG);
+  DEFINE_METRIC(kCounterTaskPlannedTimeMs, facebook::velox::StatType::AVG);
   DEFINE_METRIC(
       kCounterTotalPartitionedOutputBuffer, facebook::velox::StatType::AVG);
   DEFINE_METRIC(

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -54,6 +54,9 @@ constexpr folly::StringPiece kCounterExchangeRequestNumTries{
 
 constexpr folly::StringPiece kCounterNumQueryContexts{
     "presto_cpp.num_query_contexts"};
+/// Export total bytes used by memory manager (in queries' memory pools).
+constexpr folly::StringPiece kCounterMemoryManagerTotalBytes{
+    "presto_cpp.memory_manager_total_bytes"};
 
 constexpr folly::StringPiece kCounterNumTasks{"presto_cpp.num_tasks"};
 constexpr folly::StringPiece kCounterNumTasksBytesProcessed{
@@ -68,6 +71,13 @@ constexpr folly::StringPiece kCounterNumTasksAborted{
     "presto_cpp.num_tasks_aborted"};
 constexpr folly::StringPiece kCounterNumTasksFailed{
     "presto_cpp.num_tasks_failed"};
+/// Number of the created but not yet started tasks, including queued tasks.
+constexpr folly::StringPiece kCounterNumTasksPlanned{
+    "presto_cpp.num_tasks_planned"};
+/// Number of the created tasks in the task queue.
+constexpr folly::StringPiece kCounterNumTasksQueued{
+    "presto_cpp.num_tasks_queued"};
+
 constexpr folly::StringPiece kCounterNumZombieVeloxTasks{
     "presto_cpp.num_zombie_velox_tasks"};
 constexpr folly::StringPiece kCounterNumZombiePrestoTasks{
@@ -108,12 +118,16 @@ constexpr folly::StringPiece kCounterNumBlockedYieldDrivers{
 constexpr folly::StringPiece kCounterNumStuckDrivers{
     "presto_cpp.num_stuck_drivers"};
 
-/// Worker exports 0 or 100 for this counter. 0 meaning not memory overloaded
-/// and 100 meaning memory overloaded.
+/// Export 100 if worker is overloaded in terms of memory, 0 otherwise.
 constexpr folly::StringPiece kCounterOverloadedMem{"presto_cpp.overloaded_mem"};
-/// Worker exports 0 or 100 for this counter. 0 meaning not CPU overloaded
-/// and 100 meaning CPU overloaded.
+/// Export 100 if worker is overloaded in terms of CPU, 0 otherwise.
 constexpr folly::StringPiece kCounterOverloadedCpu{"presto_cpp.overloaded_cpu"};
+/// Export 100 if worker is overloaded in terms of memory or CPU, 0 otherwise.
+constexpr folly::StringPiece kCounterOverloaded{"presto_cpp.overloaded"};
+/// Worker exports the average time tasks spend in the queue (considered
+/// planned) in milliseconds.
+constexpr folly::StringPiece kCounterTaskPlannedTimeMs{
+    "presto_cpp.task_planned_time_ms"};
 
 /// Number of total OutputBuffer managed by all
 /// OutputBufferManager


### PR DESCRIPTION
## Description
Adding ability to queue new Tasks on the native worker, when the worker is overloaded. The functionality is controlled by the config parameter.

When the Task queuing is enabled and the worker is overloaded all oncoming Tasks will be queued.
Task queue depletion happens as the new Tasks arriving, assuming we are no longer overloaded (we queue the new Tasks and start the queued ones) and periodically (using the memory check thread).

The functionality is added to alleviate the problem of workers being overloaded in terms of CPU or memory, which leads to underperformance (queries run longer and hotter) and query failures (due to comms errors and queries getting killed by memory pushback mechanism).

The functionality is a pilot one and intended to be run on the shadow clusters for now.

The multiple 12+ hour shadow tests showed the algorithm is working properly and no noticeable side effects were detected.
However, to assess the efficiency and benefit we need to run it longer and even have an A/B test set up.

A parallel work is being done to pick up overloaded signals on the Coordinator and change query scheduling. This can coexist with the worker Task queuing for cases when Coordinator for any reasons still lets workers to run overloaded.

```
== NO RELEASE NOTE ==
```