### PR TITLE
[native] Add Builder classes for custom PlanNodes

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.h
@@ -35,6 +35,61 @@ class BroadcastWriteNode : public velox::core::PlanNode {
         serdeRowType_{serdeRowType},
         sources_{std::move(source)} {}
 
+  class Builder {
+   public:
+    Builder() = default;
+
+    explicit Builder(const BroadcastWriteNode& other) {
+      id_ = other.id();
+      basePath_ = other.basePath();
+      serdeRowType_ = other.serdeRowType();
+      source_ = other.sources()[0];
+    }
+
+    Builder& id(velox::core::PlanNodeId id) {
+      id_ = std::move(id);
+      return *this;
+    }
+
+    Builder& basePath(std::string basePath) {
+      basePath_ = std::move(basePath);
+      return *this;
+    }
+
+    Builder& serdeRowType(velox::RowTypePtr serdeRowType) {
+      serdeRowType_ = std::move(serdeRowType);
+      return *this;
+    }
+
+    Builder& source(velox::core::PlanNodePtr source) {
+      source_ = std::move(source);
+      return *this;
+    }
+
+    std::shared_ptr<BroadcastWriteNode> build() const {
+      VELOX_USER_CHECK(id_.has_value(), "BroadcastWriteNode id is not set");
+      VELOX_USER_CHECK(
+          basePath_.has_value(), "BroadcastWriteNode basePath is not set");
+      VELOX_USER_CHECK(
+          serdeRowType_.has_value(),
+          "BroadcastWriteNode serdeRowType is not set");
+      VELOX_USER_CHECK(
+          source_.has_value(), "BroadcastWriteNode source is not set");
+
+      return std::make_shared<BroadcastWriteNode>(
+          id_.value(),
+          basePath_.value(),
+          serdeRowType_.value(),
+          source_.value());
+    }
+
+   private:
+    std::optional<velox::core::PlanNodeId> id_;
+    std::optional<std::string> basePath_;
+    std::optional<velox::RowTypePtr> serdeRowType_;
+    std::optional<velox::core::PlanNodePtr> source_;
+  };
+
   folly::dynamic serialize() const override;
 
   static velox::core::PlanNodePtr create(

--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
@@ -51,6 +51,117 @@ class PartitionAndSerializeNode : public velox::core::PlanNode {
         partitionFunctionSpec_, "Partition function factory cannot be null.");
   }
 
+  class Builder {
+   public:
+    Builder() = default;
+
+    explicit Builder(const PartitionAndSerializeNode& other) {
+      id_ = other.id();
+      keys_ = other.keys();
+      numPartitions_ = other.numPartitions();
+      serializedRowType_ = other.serializedRowType();
+      source_ = other.sources()[0];
+      replicateNullsAndAny_ = other.isReplicateNullsAndAny();
+      partitionFunctionFactory_ = other.partitionFunctionFactory();
+      sortingOrders_ = other.sortingOrders();
+      sortingKeys_ = other.sortingKeys();
+    }
+
+    Builder& id(velox::core::PlanNodeId id) {
+      id_ = std::move(id);
+      return *this;
+    }
+
+    Builder& keys(std::vector<velox::core::TypedExprPtr> keys) {
+      keys_ = std::move(keys);
+      return *this;
+    }
+
+    Builder& numPartitions(uint32_t numPartitions) {
+      numPartitions_ = numPartitions;
+      return *this;
+    }
+
+    Builder& serializedRowType(velox::RowTypePtr serializedRowType) {
+      serializedRowType_ = std::move(serializedRowType);
+      return *this;
+    }
+
+    Builder& source(velox::core::PlanNodePtr source) {
+      source_ = std::move(source);
+      return *this;
+    }
+
+    Builder& replicateNullsAndAny(bool replicateNullsAndAny) {
+      replicateNullsAndAny_ = replicateNullsAndAny;
+      return *this;
+    }
+
+    Builder& partitionFunctionFactory(
+        velox::core::PartitionFunctionSpecPtr partitionFunctionFactory) {
+      partitionFunctionFactory_ = std::move(partitionFunctionFactory);
+      return *this;
+    }
+
+    Builder& sortingOrders(
+        std::optional<std::vector<velox::core::SortOrder>> sortingOrders) {
+      sortingOrders_ = std::move(sortingOrders);
+      return *this;
+    }
+
+    Builder& sortingKeys(
+        std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>>
+            sortingKeys) {
+      sortingKeys_ = sortingKeys;
+      return *this;
+    }
+
+    std::shared_ptr<PartitionAndSerializeNode> build() const {
+      VELOX_USER_CHECK(
+          id_.has_value(), "PartitionAndSerializeNode id is not set");
+      VELOX_USER_CHECK(
+          keys_.has_value(), "PartitionAndSerializeNode keys is not set");
+      VELOX_USER_CHECK(
+          numPartitions_.has_value(),
+          "PartitionAndSerializeNode numPartitions is not set");
+      VELOX_USER_CHECK(
+          serializedRowType_.has_value(),
+          "PartitionAndSerializeNode serializedRowType is not set");
+      VELOX_USER_CHECK(
+          source_.has_value(), "PartitionAndSerializeNode source is not set");
+      VELOX_USER_CHECK(
+          replicateNullsAndAny_.has_value(),
+          "PartitionAndSerializeNode replicateNullsAndAny is not set");
+      VELOX_USER_CHECK(
+          partitionFunctionFactory_.has_value(),
+          "PartitionAndSerializeNode partitionFunctionFactory is not set");
+
+      return std::make_shared<PartitionAndSerializeNode>(
+          id_.value(),
+          keys_.value(),
+          numPartitions_.value(),
+          serializedRowType_.value(),
+          source_.value(),
+          replicateNullsAndAny_.value(),
+          partitionFunctionFactory_.value(),
+          sortingOrders_,
+          sortingKeys_);
+    }
+
+   private:
+    std::optional<velox::core::PlanNodeId> id_;
+    std::optional<std::vector<velox::core::TypedExprPtr>> keys_;
+    std::optional<uint32_t> numPartitions_;
+    std::optional<velox::RowTypePtr> serializedRowType_;
+    std::optional<velox::core::PlanNodePtr> source_;
+    std::optional<bool> replicateNullsAndAny_;
+    std::optional<velox::core::PartitionFunctionSpecPtr>
+        partitionFunctionFactory_;
+    std::optional<std::vector<velox::core::SortOrder>> sortingOrders_;
+    std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>>
+        sortingKeys_;
+  };
+
   folly::dynamic serialize() const override;
 
   static velox::core::PlanNodePtr create(

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
@@ -22,6 +22,39 @@ class ShuffleReadNode : public velox::core::PlanNode {
   ShuffleReadNode(const velox::core::PlanNodeId& id, velox::RowTypePtr type)
       : PlanNode(id), outputType_(type) {}
 
+  class Builder {
+   public:
+    Builder() = default;
+
+    explicit Builder(const ShuffleReadNode& other) {
+      id_ = other.id();
+      outputType_ = other.outputType();
+    }
+
+    Builder& id(velox::core::PlanNodeId id) {
+      id_ = std::move(id);
+      return *this;
+    }
+
+    Builder& outputType(velox::RowTypePtr outputType) {
+      outputType_ = std::move(outputType);
+      return *this;
+    }
+
+    std::shared_ptr<ShuffleReadNode> build() const {
+      VELOX_USER_CHECK(id_.has_value(), "ShuffleReadNode id is not set");
+      VELOX_USER_CHECK(
+          outputType_.has_value(), "ShuffleReadNode outputType is not set");
+
+      return std::make_shared<ShuffleReadNode>(
+          id_.value(), outputType_.value());
+    }
+
+   private:
+    std::optional<velox::core::PlanNodeId> id_;
+    std::optional<velox::RowTypePtr> outputType_;
+  };
+
   folly::dynamic serialize() const override;
 
   static velox::core::PlanNodePtr create(

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.h
@@ -33,6 +33,73 @@ class ShuffleWriteNode : public velox::core::PlanNode {
         serializedShuffleWriteInfo_(serializedShuffleWriteInfo),
         sources_{std::move(source)} {}
 
+  class Builder {
+   public:
+    Builder() = default;
+
+    explicit Builder(const ShuffleWriteNode& other) {
+      id_ = other.id();
+      numPartitions_ = other.numPartitions();
+      shuffleName_ = other.shuffleName();
+      serializedShuffleWriteInfo_ = other.serializedShuffleWriteInfo();
+      source_ = other.sources()[0];
+    }
+
+    Builder& id(velox::core::PlanNodeId id) {
+      id_ = std::move(id);
+      return *this;
+    }
+
+    Builder& numPartitions(uint32_t numPartitions) {
+      numPartitions_ = numPartitions;
+      return *this;
+    }
+
+    Builder& shuffleName(std::string shuffleName) {
+      shuffleName_ = std::move(shuffleName);
+      return *this;
+    }
+
+    Builder& serializedShuffleWriteInfo(
+        std::string serializedShuffleWriteInfo) {
+      serializedShuffleWriteInfo_ = std::move(serializedShuffleWriteInfo);
+      return *this;
+    }
+
+    Builder& source(velox::core::PlanNodePtr source) {
+      source_ = std::move(source);
+      return *this;
+    }
+
+    std::shared_ptr<ShuffleWriteNode> build() const {
+      VELOX_USER_CHECK(id_.has_value(), "ShuffleWriteNode id is not set");
+      VELOX_USER_CHECK(
+          numPartitions_.has_value(),
+          "ShuffleWriteNode numPartitions_ is not set");
+      VELOX_USER_CHECK(
+          shuffleName_.has_value(), "ShuffleWriteNode shuffleName is not set");
+      VELOX_USER_CHECK(
+          serializedShuffleWriteInfo_.has_value(),
+          "ShuffleWriteNode serializedShuffleWriteInfo is not set");
+      VELOX_USER_CHECK(
+          source_.has_value(), "ShuffleWriteNode source is not set");
+
+      return std::make_shared<ShuffleWriteNode>(
+          id_.value(),
+          numPartitions_.value(),
+          shuffleName_.value(),
+          serializedShuffleWriteInfo_.value(),
+          source_.value());
+    }
+
+   private:
+    std::optional<velox::core::PlanNodeId> id_;
+    std::optional<uint32_t> numPartitions_;
+    std::optional<std::string> shuffleName_;
+    std::optional<std::string> serializedShuffleWriteInfo_;
+    std::optional<velox::core::PlanNodePtr> source_;
+  };
+
   folly::dynamic serialize() const override;
 
   static velox::core::PlanNodePtr create(

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -13,10 +13,10 @@ add_library(presto_operators_plan_builder PlanBuilder.cpp)
 
 target_link_libraries(presto_operators_plan_builder velox_core)
 
-add_executable(presto_operators_test PlanNodeSerdeTest.cpp
-                                     UnsafeRowShuffleTest.cpp
-                                     BroadcastTest.cpp
-                                     BinarySortableSerializerTest.cpp)
+add_executable(
+  presto_operators_test
+  PlanNodeSerdeTest.cpp UnsafeRowShuffleTest.cpp BroadcastTest.cpp
+  BinarySortableSerializerTest.cpp PlanNodeBuilderTest.cpp)
 
 add_test(presto_operators_test presto_operators_test)
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeBuilderTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeBuilderTest.cpp
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "presto_cpp/main/operators/BroadcastWrite.h"
+#include "presto_cpp/main/operators/PartitionAndSerialize.h"
+#include "presto_cpp/main/operators/ShuffleRead.h"
+#include "presto_cpp/main/operators/ShuffleWrite.h"
+
+using namespace facebook::velox;
+
+namespace facebook::presto::operators::test {
+namespace {
+// Most nodes need a source, and shuffle read is a good example of one.
+// Providing a default instance here that can be reused by tests.
+const std::shared_ptr<const ShuffleReadNode> kShuffleRead =
+    ShuffleReadNode::Builder()
+        .id("shuffle_read_id")
+        .outputType(ROW({"c0", "c1"}, {INTEGER(), VARCHAR()}))
+        .build();
+} // namespace
+
+TEST(PlanNodeBuilderTest, testBroadcastWrite) {
+  const core::PlanNodeId id = "broadcast_write_id";
+  const std::string basePath = "base_path";
+  const RowTypePtr serdeRowType =
+      ROW({"write_c0", "write_c1"}, {BIGINT(), DOUBLE()});
+
+  const auto verify =
+      [&](const std::shared_ptr<const BroadcastWriteNode>& node) {
+        EXPECT_EQ(node->id(), id);
+        EXPECT_EQ(node->basePath(), basePath);
+        EXPECT_EQ(node->serdeRowType(), serdeRowType);
+        EXPECT_EQ(
+            node->sources(), std::vector<core::PlanNodePtr>{kShuffleRead});
+      };
+
+  const auto node = BroadcastWriteNode::Builder()
+                        .id(id)
+                        .basePath(basePath)
+                        .serdeRowType(serdeRowType)
+                        .source(kShuffleRead)
+                        .build();
+  verify(node);
+
+  const auto node2 = BroadcastWriteNode::Builder(*node).build();
+  verify(node2);
+}
+
+TEST(PlanNodeBuilderTest, testPartitionAndSerialize) {
+  const core::PlanNodeId id = "partition_and_serialize_id";
+  const std::vector<core::TypedExprPtr> keys{
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "col0")};
+  const uint32_t numPartitions = 10;
+  const velox::RowTypePtr serializedRowType =
+      ROW({"partition_c0", "partition_c1"}, {BIGINT(), DOUBLE()});
+  const bool replicateNullsAndAny = true;
+  const core::PartitionFunctionSpecPtr partitionFunctionFactory =
+      std::make_shared<core::GatherPartitionFunctionSpec>();
+  const std::vector<core::SortOrder> sortingOrders{core::kAscNullsFirst};
+  const std::vector<core::FieldAccessTypedExprPtr> sortingKeys{
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "col1")};
+
+  const auto verify =
+      [&](const std::shared_ptr<const PartitionAndSerializeNode>& node) {
+        EXPECT_EQ(node->id(), id);
+        EXPECT_EQ(node->keys(), keys);
+        EXPECT_EQ(node->numPartitions(), numPartitions);
+        EXPECT_EQ(node->serializedRowType(), serializedRowType);
+        EXPECT_EQ(node->isReplicateNullsAndAny(), replicateNullsAndAny);
+        EXPECT_EQ(node->partitionFunctionFactory(), partitionFunctionFactory);
+        EXPECT_EQ(node->sortingOrders(), sortingOrders);
+        EXPECT_EQ(node->sortingKeys(), sortingKeys);
+        EXPECT_EQ(
+            node->sources(), std::vector<core::PlanNodePtr>{kShuffleRead});
+      };
+
+  const auto node = PartitionAndSerializeNode::Builder()
+                        .id(id)
+                        .keys(keys)
+                        .numPartitions(numPartitions)
+                        .serializedRowType(serializedRowType)
+                        .replicateNullsAndAny(replicateNullsAndAny)
+                        .partitionFunctionFactory(partitionFunctionFactory)
+                        .sortingOrders(sortingOrders)
+                        .sortingKeys(sortingKeys)
+                        .source(kShuffleRead)
+                        .build();
+  verify(node);
+
+  const auto node2 = PartitionAndSerializeNode::Builder(*node).build();
+  verify(node2);
+}
+
+TEST(PlanNodeBuilderTest, testShuffleRead) {
+  const core::PlanNodeId id = "shuffle_read_id";
+  const RowTypePtr outputType = ROW({"c0", "c1"}, {INTEGER(), VARCHAR()});
+
+  const auto verify = [&](const std::shared_ptr<const ShuffleReadNode>& node) {
+    EXPECT_EQ(node->id(), id);
+    EXPECT_EQ(node->outputType(), outputType);
+  };
+
+  const auto node =
+      ShuffleReadNode::Builder().id(id).outputType(outputType).build();
+  verify(node);
+
+  const auto node2 = ShuffleReadNode::Builder(*node).build();
+  verify(node2);
+}
+
+TEST(PlanNodeBuilderTest, testShuffleWrite) {
+  const core::PlanNodeId id = "shuffle_write_id";
+  const uint32_t numPartitions = 10;
+  const std::string shuffleName = "shuffle_name";
+  const std::string serializedShuffleWriteInfo = "shuffle_write_info";
+
+  const auto verify = [&](const std::shared_ptr<const ShuffleWriteNode>& node) {
+    EXPECT_EQ(node->id(), id);
+    EXPECT_EQ(node->numPartitions(), numPartitions);
+    EXPECT_EQ(node->shuffleName(), shuffleName);
+    EXPECT_EQ(node->serializedShuffleWriteInfo(), serializedShuffleWriteInfo);
+    EXPECT_EQ(node->sources(), std::vector<core::PlanNodePtr>{kShuffleRead});
+  };
+
+  const auto node = ShuffleWriteNode::Builder()
+                        .id(id)
+                        .numPartitions(numPartitions)
+                        .shuffleName(shuffleName)
+                        .serializedShuffleWriteInfo(serializedShuffleWriteInfo)
+                        .source(kShuffleRead)
+                        .build();
+  verify(node);
+
+  const auto node2 = ShuffleWriteNode::Builder(*node).build();
+  verify(node2);
+}
+} // namespace facebook::presto::operators::test


### PR DESCRIPTION
## Description
In https://github.com/facebookincubator/velox/pull/13093 we added Builder classes for the PlanNode classes in Velox. This change adds Builder classes for the custom PlanNodes Presto Native provides.

The high level motivation is to make it easier and safer to rewrite an existing Velox Plan if needed, which requires reconstructing all of the PlanNodes because they are immutable. For more details so the description of the original PR in Velox.

```
== NO RELEASE NOTE ==
```