### PR TITLE
Add new API 'getBytes' to com.facebook.presto.common.block.Block

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleArrayBlock.java
@@ -52,6 +52,13 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
+    public byte[] getBytes(int position, int offset, int length)
+    {
+        checkReadablePosition(position);
+        return getBlock().getBytes(position + start, offset, length);
+    }
+
+    @Override
     public short getShort(int position)
     {
         checkReadablePosition(position);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleRowBlock.java
@@ -53,6 +53,13 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
+    public byte[] getBytes(int position, int offset, int length)
+    {
+        checkFieldIndex(position);
+        return getRawFieldBlock(position).getBytes(rowIndex, offset, length);
+    }
+
+    @Override
     public short getShort(int position)
     {
         checkFieldIndex(position);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractVariableWidthBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractVariableWidthBlock.java
@@ -46,6 +46,13 @@ public abstract class AbstractVariableWidthBlock
     }
 
     @Override
+    public byte[] getBytes(int position, int offset, int length)
+    {
+        checkReadablePosition(position);
+        return getRawSlice(position).getBytes(getPositionOffset(position) + offset, length);
+    }
+
+    @Override
     public short getShort(int position)
     {
         checkReadablePosition(position);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -60,6 +60,16 @@ public interface Block
     }
 
     /**
+     * Gets a byte byte of {@code length} at {@code offset} in the value at {@code position}
+     *
+     * @throws IllegalArgumentException if position is negative or greater than or equal to the positionCount
+     */
+    default byte[] getBytes(int position, int offset, int length)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
      * Gets a short in the value at {@code position}.
      *
      * @throws IllegalArgumentException if position is negative or greater than or equal to the positionCount

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -60,7 +60,7 @@ public interface Block
     }
 
     /**
-     * Gets a byte byte of {@code length} at {@code offset} in the value at {@code position}
+     * Gets a byte array of {@code length} at {@code offset} in the value at {@code position}
      *
      * @throws IllegalArgumentException if position is negative or greater than or equal to the positionCount
      */

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -131,6 +131,12 @@ public class DictionaryBlock
     }
 
     @Override
+    public byte[] getBytes(int position, int offset, int length)
+    {
+        return dictionary.getBytes(getId(position), offset, length);
+    }
+
+    @Override
     public short getShort(int position)
     {
         return dictionary.getShort(getId(position));

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
@@ -59,6 +59,13 @@ public class LazyBlock
     }
 
     @Override
+    public byte[] getBytes(int position, int offset, int length)
+    {
+        assureLoaded();
+        return block.getBytes(position, offset, length);
+    }
+
+    @Override
     public short getShort(int position)
     {
         assureLoaded();

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
@@ -197,6 +197,13 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public byte[] getBytes(int position, int offset, int length)
+    {
+	checkReadablePosition(position);
+        return value.getBytes(0, offset, length);
+    }
+
+    @Override
     public short getShort(int position)
     {
         checkReadablePosition(position);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This change added a new API 'getBytes' so that we could directly get the byte array of length at offset from a position.
Currently we had to call 'getSlice' first and then get the byte array from the slice, which could create unnecessary allocation of a new Slice. For example, in AbstractVariableWidthBlock, 'getSlice' executes 'getRawSlice(position).slice(getPositionOffset(position) + offset, length)' and triggered a new Slice allocation based on (https://github.com/airlift/slice/blob/master/src/main/java/io/airlift/slice/Slice.java#L1042).
This change should have no side effect on existing code, so no risk on reliabilities. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
In our application, we saw >5% allocation overhead by calling 'block.getSlice(...).getBytes()', and this change eliminate the overhead by calling 'getBytes()' directly

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

