### PR TITLE
Revert "Change array_top_n to return null on bad n"

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -163,7 +163,7 @@ public class ArraySqlFunctions
     @SqlParameters({@SqlParameter(name = "input", type = "array(T)"), @SqlParameter(name = "n", type = "int")})
     @SqlType("array<T>")
     public static String arrayTopN()
-    { return "RETURN IF(n < 0, NULL, SLICE(ARRAY_SORT_DESC(input), 1, n))"; }
+    { return "RETURN IF(n < 0, fail('Parameter n: ' || cast(n as varchar) || ' to ARRAY_TOP_N is negative'), SLICE(ARRAY_SORT_DESC(input), 1, n))"; }
 
     @SqlInvokedScalarFunction(value = "array_top_n", deterministic = true, calledOnNullInput = true)
     @Description("Returns the top N values of the given map sorted using the provided lambda comparator.")
@@ -172,6 +172,6 @@ public class ArraySqlFunctions
     @SqlType("array<T>")
     public static String arrayTopNComparator()
     {
-        return "RETURN IF(n < 0, NULL, SLICE(REVERSE(ARRAY_SORT(input, f)), 1, n))";
+        return "RETURN IF(n < 0, fail('Parameter n: ' || cast(n as varchar) || ' to ARRAY_TOP_N is negative'), SLICE(REVERSE(ARRAY_SORT(input, f)), 1, n))";
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
@@ -393,23 +393,12 @@ public class TestArraySqlFunctions
         // Test exceptions
         assertInvalidFunction("ARRAY_TOP_N(ARRAY [ROW('a', 1), ROW('a', null), null, ROW('a', 0)], 2)", StandardErrorCode.INVALID_FUNCTION_ARGUMENT);
         assertInvalidFunction("ARRAY_TOP_N(ARRAY [MAP(ARRAY['foo', 'bar'], ARRAY[1, 2]), MAP(ARRAY['foo', 'bar'], ARRAY[0, 3])], 2)", SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction("ARRAY_TOP_N(ARRAY ['a', 'a', 'd', 'a', 'a', 'a'], -1)", StandardErrorCode.GENERIC_USER_ERROR, "Parameter n: -1 to ARRAY_TOP_N is negative");
 
         // Test edge cases
         assertFunction("ARRAY_TOP_N(ARRAY [null, null], 3)", new ArrayType(UNKNOWN), asList(null, null));
         assertFunction("ARRAY_TOP_N(ARRAY [3, 5, 1, 2], 0)", new ArrayType(INTEGER), emptyList());
         assertFunction("ARRAY_TOP_N(ARRAY [], 3)", new ArrayType(UNKNOWN), emptyList());
         assertFunction("ARRAY_TOP_N(ARRAY [1, 4], 3)", new ArrayType(INTEGER), ImmutableList.of(4, 1));
-    }
-
-    @Test
-    public void testArrayTopNNegativeParameter()
-    {
-        assertFunction("ARRAY_TOP_N(ARRAY ['a', 'a', 'd', 'a', 'a', 'a'], -1)", new ArrayType(createVarcharType(1)), null);
-        assertFunction("ARRAY_TOP_N(ARRAY [1,2,3,4,5,6], -5)", new ArrayType(INTEGER), null);
-        assertFunction("ARRAY_TOP_N(ARRAY [DOUBLE '1.0', 100, 2, DOUBLE '5.0', DOUBLE '3.0'], -3)", new ArrayType(DOUBLE), null);
-        assertFunction("ARRAY_TOP_N(ARRAY [true, true, false, true, false], -4)", new ArrayType(BOOLEAN), null);
-        assertFunction("ARRAY_TOP_N(ARRAY [null, null], -3)", new ArrayType(UNKNOWN), null);
-        assertFunction("ARRAY_TOP_N(ARRAY [], -3)", new ArrayType(UNKNOWN), null);
-        assertFunction("ARRAY_TOP_N(null, -3)", new ArrayType(UNKNOWN), null);
     }
 }


### PR DESCRIPTION
Reverts prestodb/presto#24729

array_top_n is a SQL function in Presto, vs Velox has a native implementation. Both implementations throw Exception for n < 0, which is consistent. https://github.com/facebookincubator/velox/blob/main/velox/functions/prestosql/ArrayFunctions.h#L755

The issue is mostly because Presto Java doesn't process "try" correctly on SQL functions in general. We should investigate at that broad level. The current fix is incorrect imo.

```
== NO RELEASE NOTE ==
```