### PR TITLE
[native] Fix build order issues with presto_server

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -96,24 +96,6 @@ target_link_libraries(
 target_link_libraries(presto_server_lib presto_thrift-cpp2 presto_thrift_extra
                       ${THRIFT_LIBRARY})
 
-set_property(TARGET presto_server_lib PROPERTY JOB_POOL_LINK
-                                               presto_link_job_pool)
-
-add_executable(presto_server PrestoMain.cpp)
-
-# Moving velox_hive_connector and velox_tpch_connector to presto_server_lib
-# results in multiple link errors similar to the one below only on GCC.
-# "undefined reference to `vtable for velox::connector::tpch::TpchTableHandle`"
-# TODO: Fix these errors.
-target_link_libraries(presto_server presto_server_lib velox_hive_connector
-                      velox_tpch_connector)
-
-# Clang requires explicit linking with libatomic.
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
-   AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 15)
-  target_link_libraries(presto_server atomic)
-endif()
-
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   add_library(presto_server_remote_function JsonSignatureParser.cpp
                                             RemoteFunctionRegisterer.cpp)
@@ -121,6 +103,24 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
   target_link_libraries(presto_server_remote_function velox_expression
                         velox_functions_remote ${FOLLY_WITH_DEPENDENCIES})
   target_link_libraries(presto_server_lib presto_server_remote_function)
+endif()
+
+set_property(TARGET presto_server_lib PROPERTY JOB_POOL_LINK
+                                               presto_link_job_pool)
+
+add_executable(presto_server PrestoMain.cpp)
+
+# velox_tpch_connector is an OBJECT target in Velox and so needs to be linked
+# to the executable or use TARGET_OBJECT linkage for the presto_server_lib target.
+# However, we also would need to add its dependencies (tpch_gen etc).
+# TODO change the target in Velox to a library target then we can move this to the
+# presto_server_lib.
+target_link_libraries(presto_server presto_server_lib velox_tpch_connector)
+
+# Clang requires explicit linking with libatomic.
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+   AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 15)
+  target_link_libraries(presto_server atomic)
 endif()
 
 set_property(TARGET presto_server PROPERTY JOB_POOL_LINK presto_link_job_pool)


### PR DESCRIPTION
There is an issue where libraries were added after the final presto_server target had already been created. That is, new libraries were added after presto_server_lib was used to build to presto_server. This means presto_server_lib might not have all expected symbols.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

