### PR TITLE
Fix vulnerability issues on presto-redshift, commons-compress and snappy-java

### DIFF
--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -71,7 +71,6 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.10.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -42,11 +42,10 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
 
-        <!-- old version of the PostgreSQL driver known to work with Redshift -->
         <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>9.3-1102-jdbc41</version>
+            <groupId>com.amazon.redshift</groupId>
+            <artifactId>redshift-jdbc42</artifactId>
+            <version>2.1.0.32</version>
         </dependency>
 
         <!-- Presto SPI -->

--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.redshift;
 
+import com.amazon.redshift.jdbc.Driver;
 import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
 import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
@@ -21,7 +22,6 @@ import com.facebook.presto.plugin.jdbc.JdbcIdentity;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
-import org.postgresql.Driver;
 
 import javax.inject.Inject;
 

--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.19</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
Fix the vulnerability issues in postgresql, commons-compress and snappy-java 
1. Upgrade commons-compress version at 1.26.2 across the codebase to address CVE-2021-35517, CVE-2021-35516, CVE-2021-36090, CVE-2021-35515 and CVE-2024-25710
2. Replace dependency from PostgreSQL to redshift-jdbc42 to address CVE-2024-1597, CVE-2022-31197 and CVE-2020-13692
3. Upgrade snappy-java version at 1.1.10.4 across the codebase to address CVE-2023-43642

## Motivation and Context
These dependency upgrades were implemented to mitigate CVEs present in previous versions

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Upgrade commons-compress version to 1.26.2 across the codebase to address 'CVE-2021-35517 <https://github.com/advisories/GHSA-xqfj-vm6h-2x34>' , 'CVE-2021-35516<https://github.com/advisories/GHSA-crv7-7245-f45f>', 'CVE-2021-36090 <https://github.com/advisories/GHSA-mc84-pj99-q6hh>', 'CVE-2021-35515 <https://github.com/advisories/GHSA-7hfm-57qf-j43q>' and 'CVE-2024-25710 <https://github.com/advisories/GHSA-4g9r-vxhx-9pgx>'
* Replace dependency from PostgreSQL to redshift-jdbc42 to address 'CVE-2024-1597 <https://github.com/advisories/GHSA-24rp-q3w6-vc56>', 'CVE-2022-31197 <https://github.com/advisories/GHSA-r38f-c4h4-hqq2>' and 'CVE-2020-13692 <https://github.com/advisories/GHSA-88cc-g835-76rp>'
* Upgrade snappy-java version at 1.1.10.4 across the codebase to address 'CVE-2023-43642 <https://github.com/advisories/GHSA-55g7-9cwv-5qfv>' 

```