### PR TITLE
Fix filter source variable not found bug in left join to semi join optimizer

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/LeftJoinNullFilterToSemiJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/LeftJoinNullFilterToSemiJoin.java
@@ -150,7 +150,7 @@ public class LeftJoinNullFilterToSemiJoin
                 || (semiJoinFilteringSource instanceof ProjectNode &&
                 ((ProjectNode) semiJoinFilteringSource).getSource() instanceof AggregationNode &&
                 AggregationNode.isDistinct((AggregationNode) ((ProjectNode) semiJoinFilteringSource).getSource())))) {
-            AggregationNode.GroupingSetDescriptor groupingSetDescriptor = new AggregationNode.GroupingSetDescriptor(ImmutableList.of(semiJoinFilteringSource.getOutputVariables().get(0)), 1, ImmutableSet.of());
+            AggregationNode.GroupingSetDescriptor groupingSetDescriptor = new AggregationNode.GroupingSetDescriptor(ImmutableList.of(rightKey), 1, ImmutableSet.of());
             semiJoinFilteringSource = new AggregationNode(
                     semiJoinFilteringSource.getSourceLocation(),
                     context.getIdAllocator().getNextId(),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7447,6 +7447,10 @@ public abstract class AbstractTestQueries
         assertQuery(enableOptimization, sql, "values 3, 3");
         assertNotEquals(computeActual("EXPLAIN(TYPE DISTRIBUTED) " + sql).getOnlyValue().toString().indexOf("Aggregate"), -1);
 
+        // filter in right child of join
+        sql = "with t1 as (select * from (values (1, 2), (2, 3), (1, 0)) t(k1, k2)), t2 as (select * from (values (1, 2), (2, 3)) t(k1, k2)) select t1.k1, t1.k2 from t1 left join t2 on t1.k2=t2.k2 and t2.k1 > 1 where t2.k2 is null";
+        assertQuery(enableOptimization, sql, "values (1, 2), (1, 0)");
+
         // null in left side
         sql = "with t1 as (select * from (values 1, 1, 2, 2, 3, 3, null) t(k)), t2 as (select * from (values 1, 1, 2, 2) t(k)) select t1.* from t1 left join t2 on t1.k=t2.k where t2.k is null";
         assertQuery(enableOptimization, sql, "values 3, 3, null");


### PR DESCRIPTION
## Description
Fix a bug introduced in https://github.com/prestodb/presto/pull/24884

An example to trigger the bug is
```
WITH t1 AS (
    SELECT * FROM (
        VALUES
            (1, 2),
            (2, 3),
            (1, 0)
    ) t(k1, k2)),
t2 AS (
    SELECT * FROM (
        VALUES
            (1, 2),
            (2, 3)
    ) t(k1, k2))
SELECT t1.k1, t1.k2
FROM t1
LEFT JOIN t2
    ON t1.k2 = t2.k2 AND t2.k1 > 1
WHERE
    t2.k2 IS NULL
```
which will return error like:
```
Query 20250514_161545_00066_b5vpi failed: Filtering source does not contain filtering join symbol
java.lang.IllegalArgumentException: Filtering source does not contain filtering join symbol
	at com.facebook.presto.common.Utils.checkArgument(Utils.java:61)
	at com.facebook.presto.spi.plan.SemiJoinNode.<init>(SemiJoinNode.java:89)
	at com.facebook.presto.spi.plan.SemiJoinNode.<init>(SemiJoinNode.java:60)
	at com.facebook.presto.sql.planner.iterative.rule.LeftJoinNullFilterToSemiJoin.apply(LeftJoinNullFilterToSemiJoin.java:175)
	at com.facebook.presto.sql.planner.iterative.rule.LeftJoinNullFilterToSemiJoin.apply(LeftJoinNullFilterToSemiJoin.java:86)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.transform(IterativeOptimizer.java:237)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreNode(IterativeOptimizer.java:189)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:151)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:281)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:153)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreChildren(IterativeOptimizer.java:281)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.exploreGroup(IterativeOptimizer.java:153)
	at com.facebook.presto.sql.planner.iterative.IterativeOptimizer.optimize(IterativeOptimizer.java:138)
	at com.facebook.presto.sql.Optimizer.validateAndOptimizePlan(Optimizer.java:112)
	at com.facebook.presto.execution.SqlQueryExecution.lambda$doCreateLogicalPlanAndOptimize$5(SqlQueryExecution.java:589)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
	at com.facebook.presto.execution.SqlQueryExecution.doCreateLogicalPlanAndOptimize(SqlQueryExecution.java:587)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
	at com.facebook.presto.execution.SqlQueryExecution.createLogicalPlanAndOptimize(SqlQueryExecution.java:558)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:486)
	at com.facebook.presto.$gen.Presto_null__testversion____20250514_160949_4.run(Unknown Source)
	at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:320)
	at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:210)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
In this case, the right child of the left join will have more than one output variables (although only one variable will be used in the left join, which will be the join key), we cannot assume that the first output variable is the join key.


## Motivation and Context
Fix a bug

## Impact
Bug fix

## Test Plan
Add unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix a bug in left join to semi join optimizer which leads to filter source variable not found error
```

