### PR TITLE
Avoid unnecessary object creation when call replaceChildren for CteConsumerNode

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteConsumerNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/CteConsumerNode.java
@@ -77,7 +77,7 @@ public final class CteConsumerNode
     {
         // this function expects a new instance
         checkArgument(newChildren.size() == 0, "expected newChildren to contain 0 node");
-        return new CteConsumerNode(getSourceLocation(), getId(), getStatsEquivalentPlanNode(), originalOutputVariables, cteId, originalSource);
+        return this;
     }
 
     @Override


### PR DESCRIPTION
## Description

`CteConsumerNode` doesn't have a source node and it's method `replaceChildren` doesn't change any fields, so there is no need to create a new instance in this method.

## Motivation and Context

Avoid unnecessary object creation.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

