### PR TITLE
[thrift] Migrate OSS project to handle protocol split

### DIFF
--- a/presto-native-execution/presto_cpp/main/thrift/ThriftLibrary.cmake
+++ b/presto-native-execution/presto_cpp/main/thrift/ThriftLibrary.cmake
@@ -218,6 +218,8 @@ macro(thrift_generate
     ${output_path}/gen-${language}/${file_name}_constants.cpp
     ${output_path}/gen-${language}/${file_name}_data.cpp
     ${output_path}/gen-${language}/${file_name}_types.cpp
+    ${output_path}/gen-${language}/${file_name}_types_compact.cpp
+    ${output_path}/gen-${language}/${file_name}_types_binary.cpp
   )
   if(NOT "${options}" MATCHES "no_metadata")
     set("${file_name}-${language}-SOURCES"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/CacheLib/pull/386

X-link: https://github.com/facebook/fb303/pull/67

fbthrift has moved compact/binary protocol instantiation outside _types.cpp (to _types_compact.cpp and _types_binary.cpp). We need to add these two files to the build system.

Differential Revision: D74687663


