### PR TITLE
[Native] Add static mapping of a native query config

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -97,6 +97,20 @@ If set to ``true``, disables the optimization in expression evaluation to delay 
 
 This should only be used for debugging purposes.
 
+``native_debug_lambda_function_evaluation_batch_size``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``10000``
+
+Some lambda functions over arrays and maps are evaluated in batches of the underlying elements that comprise the
+arrays/maps. This is done to make the batch size manageable as array vectors can have thousands of elements each
+and hit scaling limits as implementations typically expect BaseVectors to a couple of thousand entries. This
+lets up tune those batch sizes. Setting this to zero is setting unlimited batch size. Setting this to zero will
+set an unlimited batch size. Default is 10,000.
+
+This should only be used for debugging purposes.
+
 ``native_execution_type_rewrite_enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -78,6 +78,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_TABLE_SCAN_SCALE_UP_MEMORY_USAGE_RATIO = "native_table_scan_scale_up_memory_usage_ratio";
     public static final String NATIVE_STREAMING_AGGREGATION_MIN_OUTPUT_BATCH_ROWS = "native_streaming_aggregation_min_output_batch_rows";
     public static final String NATIVE_REQUEST_DATA_SIZES_MAX_WAIT_SEC = "native_request_data_sizes_max_wait_sec";
+    public static final String NATIVE_DEBUG_LAMBDA_FUNCTION_EVALUATION_BATCH_SIZE = "native_debug_lambda_function_evaluation_batch_size";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -350,7 +351,18 @@ public class NativeWorkerSessionPropertyProvider
                         NATIVE_REQUEST_DATA_SIZES_MAX_WAIT_SEC,
                         "Maximum wait time for exchange long poll requests in seconds.",
                         10,
-                        !nativeExecution));
+                        !nativeExecution)),
+                integerProperty(
+                        NATIVE_DEBUG_LAMBDA_FUNCTION_EVALUATION_BATCH_SIZE,
+                        "Some lambda functions over arrays and maps are evaluated in batches of " +
+                                "the underlying elements that comprise the arrays/maps. This is done " +
+                                "to make the batch size manageable as array vectors can have thousands " +
+                                "of elements each and hit scaling limits as implementations typically " +
+                                "expect BaseVectors to be a couple of thousand entries. This lets us tune " +
+                                "those batch sizes. Setting this to zero will set an unlimited batch size. " +
+                                "Default is 10,000",
+                        10000,
+                        !nativeExecution);
     }
 
     @Override

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -489,6 +489,20 @@ SessionProperties::SessionProperties() {
       10,
       QueryConfig::kRequestDataSizesMaxWaitSec,
       std::to_string(c.requestDataSizesMaxWaitSec()));
+
+  addSessionProperty(
+      kDebugLambdaFunctionEvaluationBatchSize,
+      "Some lambda functions over arrays and maps are evaluated in batches of "
+      "the underlying elements that comprise the arrays/maps. This is done "
+      "to make the batch size manageable as array vectors can have thousands "
+      "of elements each and hit scaling limits as implementations typically "
+      "expect BaseVectors to be a couple of thousand entries. This lets us "
+      "tune those batch sizes. Setting this to zero will set an unlimited "
+      "batch size. Default is 10,000",
+      INTEGER(),
+      true,
+      QueryConfig::kDebugLambdaFunctionEvaluationBatchSize,
+      std::to_string(c.debugLambdaFunctionEvaluationBatchSize()));
 }
 
 const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -313,6 +313,16 @@ class SessionProperties {
   static constexpr const char* kRequestDataSizesMaxWaitSec = 
       "native_request_data_sizes_max_wait_sec";
 
+  /// Some lambda functions over arrays and maps are evaluated in batches of the
+  /// underlying elements that comprise the arrays/maps. This is done to make
+  /// the batch size manageable as array vectors can have thousands of elements
+  /// each and hit scaling limits as implementations typically expect
+  /// BaseVectors to a couple of thousand entries. This lets up tune those batch
+  /// sizes. Setting this to zero will set an unlimited batch size. Default is
+  /// 10,000.
+  static constexpr const char* kDebugLambdaFunctionEvaluationBatchSize =
+      "native_debug_lambda_function_evaluation_batch_size";
+
   SessionProperties();
 
   const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&


### PR DESCRIPTION
This change adds a session property
'native_debug_lambda_function_evaluation_batch_size' that maps to a
velox query config to allow tuning a parameter used for execution
of lambda functions in expression evaluation.
These are debug only configs and should not be used in production.