### PR TITLE
[sidecar] Fix failing lambda test case in TestNativeSidecarPlugin

### DIFF
--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -204,9 +204,9 @@ public class TestNativeSidecarPlugin
         assertQuery("SELECT transform(array[1, 2, 3], x -> x * regionkey + nationkey) FROM nation");
         assertQueryFails(
                 "SELECT array_sort(quantities, (x, y, z) -> if (x < y + z, cast(1 as bigint), if (x > y + z, cast(-1 as bigint), cast(0 as bigint)))) FROM orders_ex",
-                Pattern.quote("Failed to find matching function signature for array_sort, matching failures: \n" +
-                        " Exception 1: line 1:31: Expected a lambda that takes 1 argument(s) but got 3\n" +
-                        " Exception 2: line 1:31: Expected a lambda that takes 2 argument(s) but got 3\n"));
+                "Failed to find matching function signature for array_sort, matching failures: \n" +
+                        " Exception 1: line 1:31: Expected a lambda that takes ([12])" + Pattern.quote(" argument(s) but got 3\n") +
+                        " Exception 2: line 1:31: Expected a lambda that takes ([12])" + Pattern.quote(" argument(s) but got 3\n"));
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes a failing lambda test case in `TestNativeSidecarPlugin` where the exception message wasn't matching.

## Motivation and Context
Resolves: #25118 

## Test Plan
Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

