### PR TITLE
[native] Use builder pattern for native queryRunner

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/HiveExternalWorkerQueryRunner.java
@@ -29,12 +29,12 @@ public class HiveExternalWorkerQueryRunner
         Logging.initialize();
 
         // Create tables before launching distributed runner.
-        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(false);
+        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder().build();
         NativeQueryRunnerUtils.createAllTables(javaQueryRunner);
         javaQueryRunner.close();
 
         // Launch distributed runner.
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(false, false, false, false);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder().build();
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/IcebergExternalWorkerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/IcebergExternalWorkerQueryRunner.java
@@ -29,12 +29,14 @@ public class IcebergExternalWorkerQueryRunner
         Logging.initialize();
 
         // Create tables before launching distributed runner.
-        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner(false);
+        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder().build();
         NativeQueryRunnerUtils.createAllIcebergTables(javaQueryRunner);
         javaQueryRunner.close();
 
         // Launch distributed runner.
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(true, false);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setUseThrift(true)
+                .build();
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -26,11 +26,9 @@ public class NativeQueryRunnerUtils
 {
     private NativeQueryRunnerUtils() {}
 
-    public static Map<String, String> getNativeWorkerHiveProperties(String storageFormat)
+    public static Map<String, String> getNativeWorkerHiveProperties()
     {
-        return ImmutableMap.of("hive.storage-format", storageFormat,
-                "hive.pushdown-filter-enabled", "true",
-                "hive.parquet.pushdown-filter-enabled", "true",
+        return ImmutableMap.of("hive.parquet.pushdown-filter-enabled", "true",
                 "hive.orc-compression-codec", "ZSTD");
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestNativeHistoryBasedStatsTracking.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestNativeHistoryBasedStatsTracking.java
@@ -37,7 +37,10 @@ public class TestNativeHistoryBasedStatsTracking
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @BeforeMethod(alwaysRun = true)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestNativePlanValidation.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestNativePlanValidation.java
@@ -19,6 +19,9 @@ public class TestNativePlanValidation
 {
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false, true);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setFailOnNestedLoopJoin(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAggregations.java
@@ -22,12 +22,16 @@ public class TestPrestoNativeAggregations
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeArrayFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeArrayFunctionQueries.java
@@ -22,12 +22,16 @@ public class TestPrestoNativeArrayFunctionQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
@@ -43,13 +43,21 @@ public class TestPrestoNativeAsyncDataCacheCleanupAPI
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createQueryRunner(true, false, true, true);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setCacheMaxSize(4096)
+                .setUseThrift(true)
+                .setAddStorageFormatToPath(true)
+                .setEnableRuntimeMetricsCollection(true)
+                .setEnableSsdCache(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeBitwiseFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeBitwiseFunctionQueries.java
@@ -22,12 +22,16 @@ public class TestPrestoNativeBitwiseFunctionQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeCtasQueriesParquet.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeCtasQueriesParquet.java
@@ -21,17 +21,26 @@ import org.testng.annotations.Test;
 public class TestPrestoNativeCtasQueriesParquet
         extends AbstractTestNativeCtasQueries
 {
+    private final String storageFormat = "PARQUET";
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true, "PARQUET");
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("PARQUET");
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesJSON.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesJSON.java
@@ -23,13 +23,17 @@ public class TestPrestoNativeGeneralQueriesJSON
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGeneralQueriesThrift.java
@@ -23,13 +23,18 @@ public class TestPrestoNativeGeneralQueriesThrift
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGracefulShutdown.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeGracefulShutdown.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.nativeworker;
 
 import com.facebook.presto.spi.NodeState;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import org.testng.annotations.Test;
 
@@ -26,8 +25,10 @@ public class TestPrestoNativeGracefulShutdown
     @Test
     public void testGracefulShutdown() throws Exception
     {
-        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
-        DistributedQueryRunner distributedQueryRunner = (DistributedQueryRunner) queryRunner;
+        DistributedQueryRunner distributedQueryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
 
         int responseCode = distributedQueryRunner.sendWorkerRequest(0, "INVALID_BODY");
         assertEquals(responseCode, 400, "Expected a 400 Bad Request response for invalid body");
@@ -40,6 +41,6 @@ public class TestPrestoNativeGracefulShutdown
         NodeState state = distributedQueryRunner.getWorkerInfoState(0);
         assertEquals(state.getValue(), SHUTTING_DOWN.getValue());
 
-        queryRunner.close();
+        distributedQueryRunner.close();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeHistoryBasedStatistics.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeHistoryBasedStatistics.java
@@ -55,7 +55,10 @@ public class TestPrestoNativeHistoryBasedStatistics
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
         queryRunner.installPlugin(new Plugin()
         {
             @Override
@@ -71,7 +74,9 @@ public class TestPrestoNativeHistoryBasedStatistics
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @BeforeMethod(alwaysRun = true)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeHiveExternalTableTpchQueriesParquet.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeHiveExternalTableTpchQueriesParquet.java
@@ -21,15 +21,24 @@ import org.testng.annotations.Test;
 public class TestPrestoNativeHiveExternalTableTpchQueriesParquet
         extends AbstractTestNativeHiveExternalTableTpchQueries
 {
+    private final String storageFormat = "PARQUET";
+
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true, "PARQUET");
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("PARQUET");
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergGeneralQueries.java
@@ -18,6 +18,7 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 
@@ -28,14 +29,20 @@ public class TestPrestoNativeIcebergGeneralQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(false, true);
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner(true);
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergPositionDeleteQueriesOrcUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergPositionDeleteQueriesOrcUsingThrift.java
@@ -16,9 +16,6 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 
-import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner;
-import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner;
-
 public class TestPrestoNativeIcebergPositionDeleteQueriesOrcUsingThrift
         extends AbstractTestNativeIcebergPositionDeleteQueries
 {
@@ -28,13 +25,18 @@ public class TestPrestoNativeIcebergPositionDeleteQueriesOrcUsingThrift
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createNativeIcebergQueryRunner(true, storageFormat);
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return createJavaIcebergQueryRunner(storageFormat);
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergPositionDeleteQueriesParquetUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergPositionDeleteQueriesParquetUsingThrift.java
@@ -16,9 +16,6 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 
-import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner;
-import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner;
-
 public class TestPrestoNativeIcebergPositionDeleteQueriesParquetUsingThrift
         extends AbstractTestNativeIcebergPositionDeleteQueries
 {
@@ -28,13 +25,18 @@ public class TestPrestoNativeIcebergPositionDeleteQueriesParquetUsingThrift
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return createNativeIcebergQueryRunner(true, storageFormat);
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return createJavaIcebergQueryRunner(storageFormat);
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpcdsQueriesOrcUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpcdsQueriesOrcUsingThrift.java
@@ -26,7 +26,10 @@ public class TestPrestoNativeIcebergTpcdsQueriesOrcUsingThrift
             throws Exception
     {
         this.storageFormat = "ORC";
-        return PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(true, "ORC");
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(this.storageFormat)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
@@ -34,7 +37,9 @@ public class TestPrestoNativeIcebergTpcdsQueriesOrcUsingThrift
             throws Exception
     {
         this.storageFormat = "ORC";
-        return PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner("ORC");
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(this.storageFormat)
+                .build();
     }
 
     @Test

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpcdsQueriesParquetUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpcdsQueriesParquetUsingThrift.java
@@ -26,7 +26,10 @@ public class TestPrestoNativeIcebergTpcdsQueriesParquetUsingThrift
             throws Exception
     {
         this.storageFormat = "PARQUET";
-        return PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(true, "PARQUET");
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(this.storageFormat)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
@@ -34,7 +37,9 @@ public class TestPrestoNativeIcebergTpcdsQueriesParquetUsingThrift
             throws Exception
     {
         this.storageFormat = "PARQUET";
-        return PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner("PARQUET");
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(this.storageFormat)
+                .build();
     }
 
     @Test

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpchQueriesOrcUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpchQueriesOrcUsingThrift.java
@@ -24,12 +24,17 @@ public class TestPrestoNativeIcebergTpchQueriesOrcUsingThrift
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(true, storageFormat);
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner(storageFormat);
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpchQueriesParquetUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpchQueriesParquetUsingThrift.java
@@ -19,15 +19,22 @@ import com.facebook.presto.testing.QueryRunner;
 public class TestPrestoNativeIcebergTpchQueriesParquetUsingThrift
         extends AbstractTestNativeIcebergTpchQueries
 {
+    private final String storageFormat = "PARQUET";
+
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeIcebergQueryRunner(true, "PARQUET");
+        return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaIcebergQueryRunner("PARQUET");
+        return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeJoinQueries.java
@@ -22,12 +22,17 @@ public class TestPrestoNativeJoinQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeProbabilityFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeProbabilityFunctionQueries.java
@@ -21,12 +21,16 @@ public class TestPrestoNativeProbabilityFunctionQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected QueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeRemoteFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeRemoteFunctions.java
@@ -16,18 +16,24 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 
+import java.util.Optional;
+
 public class TestPrestoNativeRemoteFunctions
         extends AbstractTestNativeRemoteFunctions
 {
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(remoteFunctionServerUds);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setRemoteFunctionServerUds(Optional.of(remoteFunctionServerUds))
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeSystemQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeSystemQueries.java
@@ -23,13 +23,17 @@ public class TestPrestoNativeSystemQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeSystemQueriesSingleNode.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeSystemQueriesSingleNode.java
@@ -16,30 +16,30 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 
-import java.util.Optional;
-
 public class TestPrestoNativeSystemQueriesSingleNode
         extends AbstractTestNativeSystemQueries
 {
+    private final String storageFormat = "DWRF";
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(
-                true,
-                "DWRF",
-                Optional.empty(),
-                false,
-                false,
-                true,
-                false,
-                false);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setSingleNodeExecutionEnabled(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpcdsQueriesOrcUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpcdsQueriesOrcUsingThrift.java
@@ -25,7 +25,11 @@ public class TestPrestoNativeTpcdsQueriesOrcUsingThrift
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true, "ORC");
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat("ORC")
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
@@ -33,6 +37,9 @@ public class TestPrestoNativeTpcdsQueriesOrcUsingThrift
             throws Exception
     {
         this.storageFormat = "ORC";
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("ORC");
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(this.storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpcdsQueriesParquetUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpcdsQueriesParquetUsingThrift.java
@@ -25,7 +25,11 @@ public class TestPrestoNativeTpcdsQueriesParquetUsingThrift
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true, "PARQUET");
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat("PARQUET")
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
@@ -33,6 +37,9 @@ public class TestPrestoNativeTpcdsQueriesParquetUsingThrift
             throws Exception
     {
         this.storageFormat = "PARQUET";
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("PARQUET");
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(this.storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchConnectorQueries.java
@@ -23,14 +23,19 @@ public class TestPrestoNativeTpchConnectorQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesDwrfUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesDwrfUsingThrift.java
@@ -19,15 +19,24 @@ import com.facebook.presto.testing.QueryRunner;
 public class TestPrestoNativeTpchQueriesDwrfUsingThrift
         extends AbstractTestNativeTpchQueries
 {
+    private final String storageFormat = "DWRF";
+
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true, "DWRF");
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("DWRF");
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesOrcUsingJSON.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesOrcUsingJSON.java
@@ -21,15 +21,23 @@ import org.testng.annotations.Test;
 public class TestPrestoNativeTpchQueriesOrcUsingJSON
         extends AbstractTestNativeTpchQueries
 {
+    private final String storageFormat = "ORC";
+
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false, "ORC");
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("ORC");
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesOrcUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesOrcUsingThrift.java
@@ -19,15 +19,24 @@ import com.facebook.presto.testing.QueryRunner;
 public class TestPrestoNativeTpchQueriesOrcUsingThrift
         extends AbstractTestNativeTpchQueries
 {
+    private final String storageFormat = "ORC";
+
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true, "ORC");
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("ORC");
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesParquetUsingJSON.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesParquetUsingJSON.java
@@ -21,15 +21,23 @@ import org.testng.annotations.Test;
 public class TestPrestoNativeTpchQueriesParquetUsingJSON
         extends AbstractTestNativeTpchQueries
 {
+    private final String storageFormat = "PARQUET";
+
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false, "PARQUET");
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner("PARQUET");
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeWindowQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeWindowQueries.java
@@ -22,12 +22,17 @@ public class TestPrestoNativeWindowQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(true);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeWriter.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeWriter.java
@@ -70,13 +70,17 @@ public class TestPrestoNativeWriter
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(false);
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Override

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/NativeSidecarPluginQueryRunner.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/NativeSidecarPluginQueryRunner.java
@@ -33,12 +33,16 @@ public class NativeSidecarPluginQueryRunner
         Logging.initialize();
 
         // Create tables before launching distributed runner.
-        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(false);
+        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(false)
+                .build();
         NativeQueryRunnerUtils.createAllTables(javaQueryRunner);
         javaQueryRunner.close();
 
         // Launch distributed runner.
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(false, true, false, false);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setCoordinatorSidecarEnabled(true)
+                .build();
         setupNativeSidecarPlugin(queryRunner);
         Thread.sleep(10);
         Logger log = Logger.get(DistributedQueryRunner.class);

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -61,7 +61,10 @@ public class TestNativeSidecarPlugin
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(true, true, false, false);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .setCoordinatorSidecarEnabled(true)
+                .build();
         setupNativeSidecarPlugin(queryRunner);
         return queryRunner;
     }
@@ -70,7 +73,9 @@ public class TestNativeSidecarPlugin
     protected QueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
     }
 
     @Test

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPluginWithoutLoadingFunctionalities.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPluginWithoutLoadingFunctionalities.java
@@ -39,7 +39,9 @@ public class TestNativeSidecarPluginWithoutLoadingFunctionalities
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(true, false, false, false);
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
         // Installing the native sidecar plugin on a native cluster does not load the plugin functionalities because
         // we aren't loading the individual functionalities.
         queryRunner.installCoordinatorPlugin(new NativeSidecarPlugin());
@@ -50,7 +52,9 @@ public class TestNativeSidecarPluginWithoutLoadingFunctionalities
     protected QueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createJavaQueryRunner();
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setAddStorageFormatToPath(true)
+                .build();
         // Installing the native sidecar plugin on a Java cluster, does not load the plugin functionalities because
         // we aren't loading the individual functionalities.
         queryRunner.installCoordinatorPlugin(new NativeSidecarPlugin());

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestDistributedEngineOnlyQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestDistributedEngineOnlyQueries.java
@@ -17,7 +17,6 @@ import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestEngineOnlyQueries;
-import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -39,7 +38,11 @@ public class TestDistributedEngineOnlyQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(ImmutableMap.of(), System.getProperty("storageFormat"));
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(System.getProperty("storageFormat"))
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Parameters("storageFormat")
@@ -48,7 +51,10 @@ public class TestDistributedEngineOnlyQueries
     {
         try {
             String storageFormat = System.getProperty("storageFormat");
-            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                    .setStorageFormat(storageFormat)
+                    .setAddStorageFormatToPath(true)
+                    .build();
             if (storageFormat.equals("DWRF")) {
                 NativeQueryRunnerUtils.createAllTables(javaQueryRunner, true);
             }

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestOrderByQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestOrderByQueries.java
@@ -17,7 +17,6 @@ import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestOrderByQueries;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -28,7 +27,11 @@ public class TestOrderByQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(ImmutableMap.of(), System.getProperty("storageFormat"));
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(System.getProperty("storageFormat"))
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Parameters("storageFormat")
@@ -37,7 +40,10 @@ public class TestOrderByQueries
     {
         try {
             String storageFormat = System.getProperty("storageFormat");
-            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                    .setStorageFormat(storageFormat)
+                    .setAddStorageFormatToPath(true)
+                    .build();
             if (storageFormat.equals("DWRF")) {
                 NativeQueryRunnerUtils.createAllTables(javaQueryRunner, true);
             }

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestRepartitionQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestRepartitionQueries.java
@@ -17,7 +17,6 @@ import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestRepartitionQueries;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Parameters;
 
 public class TestRepartitionQueries
@@ -27,7 +26,11 @@ public class TestRepartitionQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(ImmutableMap.of(), System.getProperty("storageFormat"));
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(System.getProperty("storageFormat"))
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Parameters("storageFormat")
@@ -36,7 +39,10 @@ public class TestRepartitionQueries
     {
         try {
             String storageFormat = System.getProperty("storageFormat");
-            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                    .setStorageFormat(storageFormat)
+                    .setAddStorageFormatToPath(true)
+                    .build();
             if (storageFormat.equals("DWRF")) {
                 NativeQueryRunnerUtils.createAllTables(javaQueryRunner, true);
             }

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestRepartitionQueriesWithSmallPages.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestRepartitionQueriesWithSmallPages.java
@@ -27,10 +27,14 @@ public class TestRepartitionQueriesWithSmallPages
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(
-                // Use small SerializedPages to force flushing
-                ImmutableMap.of("driver.max-page-partitioning-buffer-size", "200B"),
-                System.getProperty("storageFormat"));
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(System.getProperty("storageFormat"))
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setExtraProperties(
+                        // Use small SerializedPages to force flushing
+                        ImmutableMap.of("driver.max-page-partitioning-buffer-size", "200B"))
+                .build();
     }
 
     @Parameters("storageFormat")
@@ -39,7 +43,10 @@ public class TestRepartitionQueriesWithSmallPages
     {
         try {
             String storageFormat = System.getProperty("storageFormat");
-            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                    .setStorageFormat(storageFormat)
+                    .setAddStorageFormatToPath(true)
+                    .build();
             if (storageFormat.equals("DWRF")) {
                 NativeQueryRunnerUtils.createAllTables(javaQueryRunner, true);
             }

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestWindowQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestWindowQueries.java
@@ -17,7 +17,6 @@ import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestWindowQueries;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -30,7 +29,11 @@ public class TestWindowQueries
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.createNativeQueryRunner(ImmutableMap.of(), System.getProperty("storageFormat"));
+        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(System.getProperty("storageFormat"))
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .build();
     }
 
     @Parameters("storageFormat")
@@ -39,7 +42,10 @@ public class TestWindowQueries
     {
         try {
             String storageFormat = System.getProperty("storageFormat");
-            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(storageFormat);
+            QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                    .setStorageFormat(storageFormat)
+                    .setAddStorageFormatToPath(true)
+                    .build();
             if (storageFormat.equals("DWRF")) {
                 NativeQueryRunnerUtils.createAllTables(javaQueryRunner, true);
             }


### PR DESCRIPTION
## Description
Consolidate various methods in `PrestoNativeQueryRunnerUtils` used to create query runners for native e2e tests using builder pattern.

## Motivation and Context
`PrestoNativeQueryRunnerUtils` currently has multiple overloaded methods to create (native | java) (hive | iceberg) query runner using different arguments. All of these overloaded methods use a common function to create the query runner, while allowing developers to modify a set of configs via function arguments and retaining the default values for remaining configs. Moving these parameters to a builder pattern, following the example of `IcebergQueryRunner`, will consolidate the different `createQueryRunner` methods and improve readability for the configs being set in different test suites.


```
== NO RELEASE NOTE ==
```

