### PR TITLE
Add changes to populate the data source metadata details

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcInputInfo.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcInputInfo.java
@@ -11,31 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+
+package com.facebook.presto.plugin.jdbc;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Optional;
-
 import static java.util.Objects.requireNonNull;
 
-public class IcebergInputInfo
+public class JdbcInputInfo
 {
-    private final Optional<Long> snapshotId;
     private final String tableLocation;
 
-    public IcebergInputInfo(
-            @JsonProperty("snapshotId") Optional<Long> snapshotId,
+    public JdbcInputInfo(
             @JsonProperty("tableLocation") String tableLocation)
-    {
-        this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
-        this.tableLocation = requireNonNull(tableLocation, "tableLocation is null");
-    }
 
-    @JsonProperty
-    public Optional<Long> getSnapshotId()
     {
-        return snapshotId;
+        this.tableLocation = requireNonNull(tableLocation, "tableLocation is null");
     }
 
     @JsonProperty

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
@@ -22,18 +22,20 @@ public class JdbcMetadataFactory
     private final JdbcMetadataCache jdbcMetadataCache;
     private final JdbcClient jdbcClient;
     private final boolean allowDropTable;
+    private final BaseJdbcConfig baseJdbcConfig;
 
     @Inject
-    public JdbcMetadataFactory(JdbcMetadataCache jdbcMetadataCache, JdbcClient jdbcClient, JdbcMetadataConfig config)
+    public JdbcMetadataFactory(JdbcMetadataCache jdbcMetadataCache, JdbcClient jdbcClient, JdbcMetadataConfig config, BaseJdbcConfig baseJdbcConfig)
     {
         this.jdbcMetadataCache = requireNonNull(jdbcMetadataCache, "jdbcMetadataCache is null");
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         requireNonNull(config, "config is null");
         this.allowDropTable = config.isAllowDropTable();
+        this.baseJdbcConfig = requireNonNull(baseJdbcConfig, "baseJdbcConfig is null");
     }
 
     public JdbcMetadata create()
     {
-        return new JdbcMetadata(jdbcMetadataCache, jdbcClient, allowDropTable);
+        return new JdbcMetadata(jdbcMetadataCache, jdbcClient, allowDropTable, baseJdbcConfig);
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcOutputMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcOutputMetadata.java
@@ -11,31 +11,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+
+package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-
-import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-public class IcebergWrittenPartitions
+public class JdbcOutputMetadata
         implements ConnectorOutputMetadata
 {
-    private final List<String> partitionNames;
+    private final String tableLocation;
 
     @JsonCreator
-    public IcebergWrittenPartitions(@JsonProperty("partitionNames") List<String> partitionNames)
+    public JdbcOutputMetadata(@JsonProperty("tableLocation") String tableLocation)
     {
-        this.partitionNames = ImmutableList.copyOf(requireNonNull(partitionNames, "partitionNames is null"));
+        this.tableLocation = requireNonNull(tableLocation, "tableLocation is null");
     }
 
     @JsonProperty
-    public List<String> getInfo()
+    @Override
+    public String getInfo()
     {
-        return partitionNames;
+        return tableLocation;
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -66,7 +66,7 @@ public class TestJdbcMetadata
         database = new TestingDatabase();
         ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
         jdbcMetadataCache = new JdbcMetadataCache(executor, database.getJdbcClient(), new JdbcMetadataCacheStats(), OptionalLong.of(0), OptionalLong.of(0), 100);
-        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false);
+        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), false, new BaseJdbcConfig());
         tableHandle = metadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));
     }
 
@@ -261,7 +261,7 @@ public class TestJdbcMetadata
             assertEquals(e.getErrorCode(), PERMISSION_DENIED.toErrorCode());
         }
 
-        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), true);
+        metadata = new JdbcMetadata(jdbcMetadataCache, database.getJdbcClient(), true, new BaseJdbcConfig());
         metadata.dropTable(SESSION, tableHandle);
 
         try {

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveOutputInfo.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveOutputInfo.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveOutputInfo
+{
+    private final List<String> partitionNames;
+    private final String tableLocation;
+
+    @JsonCreator
+    public HiveOutputInfo(
+            @JsonProperty("partitionNames") List<String> partitionNames,
+            @JsonProperty("tableLocation") String tableLocation)
+    {
+        this.partitionNames = ImmutableList.copyOf(requireNonNull(partitionNames, "partitionNames is null"));
+        this.tableLocation = requireNonNull(tableLocation, "tableLocation is null");
+    }
+
+    @JsonProperty
+    public List<String> getPartitionNames()
+    {
+        return partitionNames;
+    }
+
+    @JsonProperty
+    public String getTableLocation()
+    {
+        return tableLocation;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HiveOutputInfo that = (HiveOutputInfo) o;
+        return Objects.equals(partitionNames, that.partitionNames) && Objects.equals(tableLocation, that.tableLocation);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(partitionNames, tableLocation);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "HiveOutputInfo{" +
+                "partitionNames=" + partitionNames +
+                ", tableLocation='" + tableLocation + '\'' +
+                '}';
+    }
+}

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveOutputMetadata.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveOutputMetadata.java
@@ -16,26 +16,24 @@ package com.facebook.presto.hive;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-
-import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-public class HiveWrittenPartitions
+public class HiveOutputMetadata
         implements ConnectorOutputMetadata
 {
-    private final List<String> partitionNames;
+    private final HiveOutputInfo hiveOutputInfo;
 
     @JsonCreator
-    public HiveWrittenPartitions(@JsonProperty("partitionNames") List<String> partitionNames)
+    public HiveOutputMetadata(@JsonProperty("hiveOutputInfo") HiveOutputInfo hiveOutputInfo)
     {
-        this.partitionNames = ImmutableList.copyOf(requireNonNull(partitionNames, "partitionNames is null"));
+        this.hiveOutputInfo = requireNonNull(hiveOutputInfo, "hiveOutputInfo is null");
     }
 
     @JsonProperty
-    public List<String> getInfo()
+    @Override
+    public HiveOutputInfo getInfo()
     {
-        return partitionNames;
+        return hiveOutputInfo;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
@@ -24,14 +24,17 @@ public class HiveInputInfo
     // Code that serialize HiveInputInfo into log would often need the ability to limit the length of log entries.
     // This boolean field allows such code to mark the log entry as length limited.
     private final boolean truncated;
+    private final String tableLocation;
 
     @JsonCreator
     public HiveInputInfo(
             @JsonProperty("partitionIds") List<String> partitionIds,
-            @JsonProperty("truncated") boolean truncated)
+            @JsonProperty("truncated") boolean truncated,
+            @JsonProperty("tableLocation") String tableLocation)
     {
         this.partitionIds = partitionIds;
         this.truncated = truncated;
+        this.tableLocation = tableLocation;
     }
 
     @JsonProperty
@@ -44,5 +47,11 @@ public class HiveInputInfo
     public boolean isTruncated()
     {
         return truncated;
+    }
+
+    @JsonProperty
+    public String getTableLocation()
+    {
+        return tableLocation;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -813,7 +813,7 @@ public class HiveMetadata
                     tableLayoutHandle.getPartitions().get().stream()
                             .map(hivePartition -> hivePartition.getPartitionId().getPartitionName())
                             .collect(toList()),
-                    false));
+                    false, tableLayoutHandle.getTablePath()));
         }
 
         return Optional.empty();
@@ -1811,7 +1811,7 @@ public class HiveMetadata
         metastore.createTable(session, table, principalPrivileges, Optional.of(writeInfo.getWritePath()), false, tableStatistics, emptyList());
 
         if (handle.getPartitionedBy().isEmpty()) {
-            return Optional.of(new HiveWrittenPartitions(ImmutableList.of(UNPARTITIONED_ID.getPartitionName())));
+            return Optional.of(new HiveOutputMetadata(new HiveOutputInfo(ImmutableList.of(UNPARTITIONED_ID.getPartitionName()), writeInfo.getTargetPath().toString())));
         }
 
         if (isRespectTableFormat(session)) {
@@ -1840,10 +1840,10 @@ public class HiveMetadata
                     partitionStatistics);
         }
 
-        return Optional.of(new HiveWrittenPartitions(
+        return Optional.of(new HiveOutputMetadata(new HiveOutputInfo(
                 partitionUpdates.stream()
                         .map(PartitionUpdate::getName)
-                        .collect(toList())));
+                        .collect(toList()), writeInfo.getTargetPath().toString())));
     }
 
     public static boolean shouldCreateFilesForMissingBuckets(Table table, ConnectorSession session)
@@ -2260,11 +2260,11 @@ public class HiveMetadata
             }
         }
 
-        return Optional.of(new HiveWrittenPartitions(
+        return Optional.of(new HiveOutputMetadata(new HiveOutputInfo(
                 partitionUpdates.stream()
                         .map(PartitionUpdate::getName)
                         .map(name -> name.isEmpty() ? UNPARTITIONED_ID.getPartitionName() : name)
-                        .collect(toList())));
+                        .collect(toList()), table.getStorage().getLocation())));
     }
 
     /**


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
To achieve combined lineage tracking, add changes to populate the data source metadata, including the data source path, which is essential for generating OpenLineage events.
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Issue: https://github.com/prestodb/presto/issues/25123
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add changes to populate data source metadata to support combined lineage tracking

```

