### PR TITLE
Migrate io.airlift:resolver to com.facebook.airlift.resolver:resolver:1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dep.asm.version>9.7.1</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
         <dep.alluxio.version>313</dep.alluxio.version>
-        <dep.slf4j.version>1.7.36</dep.slf4j.version>
+        <dep.slf4j.version>2.0.16</dep.slf4j.version>
         <dep.kafka.version>3.9.0</dep.kafka.version>
         <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>30.0.1</dep.druid.version>
@@ -1378,15 +1378,21 @@
             </dependency>
 
             <dependency>
-                <groupId>org.sonatype.aether</groupId>
-                <artifactId>aether-api</artifactId>
-                <version>1.13.1</version>
+                <groupId>org.apache.maven.resolver</groupId>
+                <artifactId>maven-resolver-api</artifactId>
+                <version>1.9.22</version>
             </dependency>
 
             <dependency>
-                <groupId>io.airlift.resolver</groupId>
+                <groupId>com.facebook.airlift.resolver</groupId>
                 <artifactId>resolver</artifactId>
-                <version>1.4</version>
+                <version>1.7</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -186,15 +186,6 @@
     </dependencies>
 
     <!-- dependencyManagement is to fix the Require upper bound dependencies error for slf4j -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.36</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/presto-function-server/pom.xml
+++ b/presto-function-server/pom.xml
@@ -125,13 +125,13 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift.resolver</groupId>
+            <groupId>com.facebook.airlift.resolver</groupId>
             <artifactId>resolver</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
-            <artifactId>aether-api</artifactId>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-function-server/src/main/java/com/facebook/presto/server/FunctionPluginManager.java
+++ b/presto-function-server/src/main/java/com/facebook/presto/server/FunctionPluginManager.java
@@ -14,15 +14,15 @@
 package com.facebook.presto.server;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.resolver.ArtifactResolver;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
-import io.airlift.resolver.ArtifactResolver;
-import io.airlift.resolver.DefaultArtifact;
-import org.sonatype.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -132,7 +132,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift.resolver</groupId>
+            <groupId>com.facebook.airlift.resolver</groupId>
             <artifactId>resolver</artifactId>
         </dependency>
 
@@ -273,8 +273,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.sonatype.aether</groupId>
-            <artifactId>aether-api</artifactId>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginDiscovery.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginDiscovery.java
@@ -15,8 +15,8 @@ package com.facebook.presto.server;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.eclipse.aether.artifact.Artifact;
 import org.objectweb.asm.ClassReader;
-import org.sonatype.aether.artifact.Artifact;
 
 import java.io.File;
 import java.io.IOException;

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.server;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.node.NodeInfo;
+import com.facebook.airlift.resolver.ArtifactResolver;
 import com.facebook.presto.ClientRequestFilterManager;
 import com.facebook.presto.common.block.BlockEncoding;
 import com.facebook.presto.common.block.BlockEncodingManager;
@@ -63,7 +64,6 @@ import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderMana
 import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.resolver.ArtifactResolver;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerConfig.java
@@ -15,10 +15,10 @@ package com.facebook.presto.server;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.resolver.ArtifactResolver;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.resolver.ArtifactResolver;
 
 import javax.validation.constraints.NotNull;
 

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.server;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.resolver.ArtifactResolver;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.CoordinatorPlugin;
 import com.facebook.presto.spi.Plugin;
@@ -21,9 +22,8 @@ import com.facebook.presto.spi.RouterPlugin;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
-import io.airlift.resolver.ArtifactResolver;
-import io.airlift.resolver.DefaultArtifact;
-import org.sonatype.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 
 import java.io.File;
 import java.io.IOException;

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestPluginManagerConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestPluginManagerConfig.java
@@ -14,9 +14,9 @@
 package com.facebook.presto.server;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.airlift.resolver.ArtifactResolver;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.resolver.ArtifactResolver;
 import org.testng.annotations.Test;
 
 import java.io.File;

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -248,11 +248,6 @@
             <artifactId>presto-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/presto-router/pom.xml
+++ b/presto-router/pom.xml
@@ -178,7 +178,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift.resolver</groupId>
+            <groupId>com.facebook.airlift.resolver</groupId>
             <artifactId>resolver</artifactId>
         </dependency>
 

--- a/presto-router/src/main/java/com/facebook/presto/router/RouterPluginManager.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/RouterPluginManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.resolver.ArtifactResolver;
 import com.facebook.presto.server.PluginInstaller;
 import com.facebook.presto.server.PluginManagerConfig;
 import com.facebook.presto.server.PluginManagerUtil;
@@ -26,7 +27,6 @@ import com.facebook.presto.spi.router.SchedulerFactory;
 import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.PrestoAuthenticatorFactory;
 import com.google.common.collect.ImmutableList;
-import io.airlift.resolver.ArtifactResolver;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;


### PR DESCRIPTION
## Description

This upgrades the airlift resolver to use our fork and the recently released version with updated dependencies and security patches.

## Motivation and Context

Modernizing the codebase and resolving CVEs

## Impact

N/A

## Test Plan

- Existing tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

