### PR TITLE
Always evaluate built-in functions using the presto.default namespace

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/StatsCalculatorModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cost;
 
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -45,9 +46,10 @@ public class StatsCalculatorModule
             StatsNormalizer normalizer,
             FilterStatsCalculator filterStatsCalculator,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
-            FragmentStatsProvider fragmentStatsProvider)
+            FragmentStatsProvider fragmentStatsProvider,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
-        StatsCalculator delegate = createComposableStatsCalculator(metadata, scalarStatsCalculator, normalizer, filterStatsCalculator, fragmentStatsProvider);
+        StatsCalculator delegate = createComposableStatsCalculator(metadata, scalarStatsCalculator, normalizer, filterStatsCalculator, fragmentStatsProvider, expressionOptimizerManager);
         return historyBasedPlanStatisticsManager.getHistoryBasedPlanStatisticsCalculator(delegate);
     }
 
@@ -56,14 +58,15 @@ public class StatsCalculatorModule
             ScalarStatsCalculator scalarStatsCalculator,
             StatsNormalizer normalizer,
             FilterStatsCalculator filterStatsCalculator,
-            FragmentStatsProvider fragmentStatsProvider)
+            FragmentStatsProvider fragmentStatsProvider,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
         ImmutableList.Builder<ComposableStatsCalculator.Rule<?>> rules = ImmutableList.builder();
         rules.add(new OutputStatsRule());
         rules.add(new TableScanStatsRule(metadata, normalizer));
         rules.add(new SimpleFilterProjectSemiJoinStatsRule(normalizer, filterStatsCalculator, metadata.getFunctionAndTypeManager())); // this must be before FilterStatsRule
         rules.add(new FilterStatsRule(normalizer, filterStatsCalculator));
-        rules.add(new ValuesStatsRule(metadata));
+        rules.add(new ValuesStatsRule(metadata, expressionOptimizerManager));
         rules.add(new LimitStatsRule(normalizer));
         rules.add(new EnforceSingleRowStatsRule(normalizer));
         rules.add(new ProjectStatsRule(scalarStatsCalculator, normalizer));

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/ValuesStatsRule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/ValuesStatsRule.java
@@ -19,7 +19,9 @@ import com.facebook.presto.cost.ComposableStatsCalculator.Rule;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.iterative.Lookup;
 
@@ -32,10 +34,12 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.cost.StatsUtil.toStatsRepresentation;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
 import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.FACT;
-import static com.facebook.presto.sql.planner.RowExpressionInterpreter.evaluateConstantRowExpression;
 import static com.facebook.presto.sql.planner.plan.Patterns.values;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public class ValuesStatsRule
@@ -44,10 +48,12 @@ public class ValuesStatsRule
     private static final Pattern<ValuesNode> PATTERN = values();
 
     private final Metadata metadata;
+    private final ExpressionOptimizerManager expressionOptimizerManager;
 
-    public ValuesStatsRule(Metadata metadata)
+    public ValuesStatsRule(Metadata metadata, ExpressionOptimizerManager expressionOptimizerManager)
     {
-        this.metadata = metadata;
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
     }
 
     @Override
@@ -82,7 +88,10 @@ public class ValuesStatsRule
         }
         return valuesNode.getRows().stream()
                 .map(row -> row.get(symbolId))
-                .map(rowExpression -> evaluateConstantRowExpression(rowExpression, metadata.getFunctionAndTypeManager(), session.toConnectorSession()))
+                .map(rowExpression -> expressionOptimizerManager.getExpressionOptimizer(session.toConnectorSession())
+                        .optimize(rowExpression, EVALUATED, session.toConnectorSession(), i -> i))
+                .peek(rowExpression -> verify(rowExpression instanceof ConstantExpression, "Expected constant expression, but got: %s", rowExpression))
+                .map(rowExpression -> ((ConstantExpression) rowExpression).getValue())
                 .collect(toList());
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
@@ -91,20 +91,26 @@ public class ExpressionOptimizerManager
     private void loadExpressionOptimizerFactory(File configurationFile)
             throws IOException
     {
-        String name = getNameWithoutExtension(configurationFile.getName());
-        checkArgument(!isNullOrEmpty(name), "File name is empty, full path: %s", configurationFile.getAbsolutePath());
-        checkArgument(!name.equals(DEFAULT_EXPRESSION_OPTIMIZER_NAME), "Cannot name an expression optimizer instance %s", DEFAULT_EXPRESSION_OPTIMIZER_NAME);
+        String optimizerName = getNameWithoutExtension(configurationFile.getName());
+        checkArgument(!isNullOrEmpty(optimizerName), "File name is empty, full path: %s", configurationFile.getAbsolutePath());
+        checkArgument(!optimizerName.equals(DEFAULT_EXPRESSION_OPTIMIZER_NAME), "Cannot name an expression optimizer instance %s", DEFAULT_EXPRESSION_OPTIMIZER_NAME);
 
         Map<String, String> properties = new HashMap<>(loadProperties(configurationFile));
         String factoryName = properties.remove(EXPRESSION_MANAGER_FACTORY_NAME);
         checkArgument(!isNullOrEmpty(factoryName), "%s does not contain %s", configurationFile, EXPRESSION_MANAGER_FACTORY_NAME);
+
+        loadExpressionOptimizerFactory(factoryName, optimizerName, properties);
+    }
+
+    public void loadExpressionOptimizerFactory(String factoryName, String optimizerName, Map<String, String> properties)
+    {
         checkArgument(expressionOptimizerFactories.containsKey(factoryName),
                 "ExpressionOptimizerFactory %s is not registered, registered factories: ", factoryName, expressionOptimizerFactories.keySet());
 
         ExpressionOptimizer optimizer = expressionOptimizerFactories.get(factoryName).createOptimizer(
                 properties,
                 new ExpressionOptimizerContext(nodeManager, functionAndTypeManager, functionResolution));
-        expressionOptimizers.put(name, optimizer);
+        expressionOptimizers.put(optimizerName, optimizer);
     }
 
     public void addExpressionOptimizerFactory(ExpressionOptimizerFactory expressionOptimizerFactory)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -766,7 +766,7 @@ public class PlanOptimizers
         builder.add(predicatePushDown); // Run predicate push down one more time in case we can leverage new information from layouts' effective predicate
         builder.add(simplifyRowExpressionOptimizer); // Should be always run after PredicatePushDown
 
-        builder.add(new MetadataQueryOptimizer(metadata));
+        builder.add(new MetadataQueryOptimizer(metadata, expressionOptimizerManager));
 
         // This can pull up Filter and Project nodes from between Joins, so we need to push them down again
         builder.add(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -113,7 +113,6 @@ import static com.facebook.presto.type.LikeFunctions.unescapeLiteralLikePattern;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.instanceOf;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -133,15 +132,6 @@ public class RowExpressionInterpreter
     private final FunctionResolution resolution;
 
     private final Visitor visitor;
-
-    public static Object evaluateConstantRowExpression(RowExpression expression, FunctionAndTypeManager functionAndTypeManager, ConnectorSession session)
-    {
-        // evaluate the expression
-        Object result = new RowExpressionInterpreter(expression, functionAndTypeManager, session, EVALUATED).evaluate();
-        verify(!(result instanceof RowExpression), "RowExpression interpreter returned an unresolved expression");
-        return result;
-    }
-
     public static RowExpressionInterpreter rowExpressionInterpreter(RowExpression expression, FunctionAndTypeManager functionAndTypeManager, ConnectorSession session)
     {
         return new RowExpressionInterpreter(expression, functionAndTypeManager, session, EVALUATED);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/RowExpressionOptimizer.java
@@ -13,24 +13,41 @@
  */
 package com.facebook.presto.sql.relational;
 
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.analyzer.TypeSignatureProvider;
 import com.facebook.presto.sql.planner.RowExpressionInterpreter;
+import jakarta.annotation.Nullable;
 
+import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.function.Function;
 
+import static com.facebook.presto.common.Utils.checkState;
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
 import static com.facebook.presto.sql.planner.LiteralEncoder.toRowExpression;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class RowExpressionOptimizer
         implements ExpressionOptimizer
 {
     private final FunctionAndTypeManager functionAndTypeManager;
+    private final CatalogSchemaName defaultNamespace;
 
     public RowExpressionOptimizer(Metadata metadata)
     {
@@ -39,14 +56,15 @@ public final class RowExpressionOptimizer
 
     public RowExpressionOptimizer(FunctionAndTypeManager functionAndTypeManager)
     {
-        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionMetadataManager is null");
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        this.defaultNamespace = functionAndTypeManager.getDefaultNamespace();
     }
 
     @Override
     public RowExpression optimize(RowExpression rowExpression, Level level, ConnectorSession session)
     {
         if (level.ordinal() <= OPTIMIZED.ordinal()) {
-            return toRowExpression(rowExpression.getSourceLocation(), new RowExpressionInterpreter(rowExpression, functionAndTypeManager, session, level).optimize(), rowExpression.getType());
+            return getRowExpression(rowExpression, level, session, null);
         }
         throw new IllegalArgumentException("Not supported optimization level: " + level);
     }
@@ -54,7 +72,120 @@ public final class RowExpressionOptimizer
     @Override
     public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
     {
-        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(expression, functionAndTypeManager, session, level);
-        return toRowExpression(expression.getSourceLocation(), interpreter.optimize(variableResolver::apply), expression.getType());
+        return getRowExpression(expression, level, session, variableResolver);
+    }
+
+    private RowExpression getRowExpression(RowExpression expression, Level level, ConnectorSession session, @Nullable Function<VariableReferenceExpression, Object> variableResolver)
+    {
+        BuiltInNamespaceRewriter visitor = new BuiltInNamespaceRewriter();
+        RowExpressionInterpreter interpreter = new RowExpressionInterpreter(
+                visitor.convertToInterpreterNamespace(expression),
+                functionAndTypeManager,
+                session,
+                level);
+        return visitor.restoreOriginalNamespaces(toRowExpression(
+                expression.getSourceLocation(),
+                interpreter.optimize(variableResolver != null ? variableResolver::apply : null),
+                expression.getType()));
+    }
+
+    /**
+     * TODO: GIANT HACK
+     * This class is a hack and should eventually be removed.  It is used to ensure consistent constant folding behavior when the built-in
+     * function namespace has been switched (for example, to native.default. in the case of native functions).  This will no longer be needed
+     * when the native sidecar is capable of providing its own expression optimizer.
+     */
+    private class BuiltInNamespaceRewriter
+    {
+        private final Map<FunctionHandle, FunctionHandle> defaultToOriginalFunctionHandles = new IdentityHashMap<>();
+
+        public RowExpression convertToInterpreterNamespace(RowExpression expression)
+        {
+            if (defaultNamespace.equals(JAVA_BUILTIN_NAMESPACE)) {
+                // No need to replace built-in namespaces if the default namespace is already the Java built-in namespace
+                return expression;
+            }
+            return expression.accept(new ReplaceBuiltInNamespaces(), null);
+        }
+
+        public RowExpression restoreOriginalNamespaces(RowExpression expression)
+        {
+            if (defaultToOriginalFunctionHandles.isEmpty()) {
+                return expression;
+            }
+            return expression.accept(new ReplaceOriginalNamespaces(), null);
+        }
+
+        private class ReplaceBuiltInNamespaces
+                implements RowExpressionVisitor<RowExpression, Void>
+        {
+            @Override
+            public RowExpression visitExpression(RowExpression expression, Void context)
+            {
+                return expression;
+            }
+
+            @Override
+            public RowExpression visitCall(CallExpression call, Void context)
+            {
+                FunctionHandle functionHandle = call.getFunctionHandle();
+                FunctionMetadata functionMetadata = functionAndTypeManager.getFunctionMetadata(functionHandle);
+                if (!functionMetadata.getImplementationType().canBeEvaluatedInCoordinator()) {
+                    checkState(!functionHandle.getCatalogSchemaName().equals(JAVA_BUILTIN_NAMESPACE),
+                            format("FunctionHandle %s is already in the Java built-in namespace (%s), yet is marked as ineligible to be evaluated in the coordinator", functionHandle, functionHandle.getCatalogSchemaName()));
+
+                    // Replace the namespace with the Java built-in namespace
+                    FunctionHandle javaNamespaceFunctionHandle;
+                    try {
+                        javaNamespaceFunctionHandle = functionAndTypeManager.lookupFunction(
+                                QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, call.getDisplayName()),
+                                functionHandle.getArgumentTypes().stream().map(TypeSignatureProvider::new).collect(toImmutableList()));
+                    }
+                    catch (PrestoException e) {
+                        if (e.getErrorCode().equals(FUNCTION_NOT_FOUND.toErrorCode())) {
+                            return call; // If the function is not found in the Java built-in namespace, return the original call
+                        }
+                        throw e; // Rethrow other exceptions
+                    }
+
+                    checkState(functionAndTypeManager.getFunctionMetadata(javaNamespaceFunctionHandle).getImplementationType().canBeEvaluatedInCoordinator(),
+                            format("FunctionHandle %s in the Java built-in namespace (%s) is not eligible to be evaluated in the coordinator", javaNamespaceFunctionHandle, JAVA_BUILTIN_NAMESPACE));
+
+                    defaultToOriginalFunctionHandles.put(javaNamespaceFunctionHandle, functionHandle);
+                    return new CallExpression(
+                            call.getSourceLocation(),
+                            call.getDisplayName(),
+                            javaNamespaceFunctionHandle,
+                            call.getType(),
+                            call.getArguments());
+                }
+                return call;
+            }
+        }
+
+        private class ReplaceOriginalNamespaces
+                implements RowExpressionVisitor<RowExpression, Void>
+        {
+            @Override
+            public RowExpression visitExpression(RowExpression expression, Void context)
+            {
+                return expression;
+            }
+
+            @Override
+            public RowExpression visitCall(CallExpression call, Void context)
+            {
+                if (defaultToOriginalFunctionHandles.containsKey(call.getFunctionHandle())) {
+                    FunctionHandle originalFunctionHandle = defaultToOriginalFunctionHandles.get(call.getFunctionHandle());
+                    return new CallExpression(
+                            call.getSourceLocation(),
+                            call.getDisplayName(),
+                            originalFunctionHandle,
+                            call.getType(),
+                            call.getArguments());
+                }
+                return call;
+            }
+        }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -473,7 +473,7 @@ public class LocalQueryRunner
         this.filterStatsCalculator = new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer);
         this.historyBasedPlanStatisticsManager = new HistoryBasedPlanStatisticsManager(objectMapper, createTestingSessionPropertyManager(), metadata, new HistoryBasedOptimizationConfig(), featuresConfig, new NodeVersion("1"));
         this.fragmentStatsProvider = new FragmentStatsProvider();
-        this.statsCalculator = createNewStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, filterStatsCalculator, historyBasedPlanStatisticsManager, fragmentStatsProvider);
+        this.statsCalculator = createNewStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer, filterStatsCalculator, historyBasedPlanStatisticsManager, fragmentStatsProvider, expressionOptimizerManager);
         this.taskCountEstimator = new TaskCountEstimator(() -> nodeCountForStats);
         this.costCalculator = new CostCalculatorUsingExchanges(taskCountEstimator);
         this.estimatedExchangesCostCalculator = new CostCalculatorWithEstimatedExchanges(costCalculator, taskCountEstimator);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
@@ -23,10 +23,16 @@ import com.facebook.presto.functionNamespace.execution.SqlFunctionExecutors;
 import com.facebook.presto.functionNamespace.testing.InMemoryFunctionNamespaceManager;
 import com.facebook.presto.metadata.SqlScalarFunction;
 import com.facebook.presto.operator.scalar.CombineHashFunction;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.function.FunctionImplementationType;
 import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerContext;
+import com.facebook.presto.spi.sql.planner.ExpressionOptimizerFactory;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.FunctionsConfig;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
@@ -37,6 +43,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
@@ -74,6 +82,8 @@ import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 public class TestAddExchangesPlansWithFunctions
         extends BasePlanTest
 {
+    private static final String NO_OP_OPTIMIZER = "no-op-optimizer";
+
     public TestAddExchangesPlansWithFunctions()
     {
         super(TestAddExchangesPlansWithFunctions::createTestQueryRunner);
@@ -138,6 +148,7 @@ public class TestAddExchangesPlansWithFunctions
         LocalQueryRunner queryRunner = new LocalQueryRunner(testSessionBuilder()
                 .setCatalog("tpch")
                 .setSchema("tiny")
+                .setSystemProperty("expression_optimizer_name", NO_OP_OPTIMIZER)
                 .build(),
                 new FeaturesConfig(),
                 new FunctionsConfig().setDefaultNamespacePrefix("dummy.unittest"));
@@ -164,6 +175,8 @@ public class TestAddExchangesPlansWithFunctions
         parseFunctionDefinitions(CombineHashFunction.class).stream()
                 .map(TestAddExchangesPlansWithFunctions::convertToSqlInvokedFunction)
                 .forEach(function -> queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(function, true));
+        queryRunner.getExpressionManager().addExpressionOptimizerFactory(new NoOpExpressionOptimizerFactory());
+        queryRunner.getExpressionManager().loadExpressionOptimizerFactory(NO_OP_OPTIMIZER, NO_OP_OPTIMIZER, ImmutableMap.of());
         return queryRunner;
     }
 
@@ -663,5 +676,31 @@ public class TestAddExchangesPlansWithFunctions
                                                         "ordinal_position", "ordinal_position",
                                                         "table_schema", "table_schema",
                                                         "table_name", "table_name")))))));
+    }
+
+    private static class NoOpExpressionOptimizerFactory
+            implements ExpressionOptimizerFactory
+    {
+        @Override
+        public ExpressionOptimizer createOptimizer(Map<String, String> config, ExpressionOptimizerContext context)
+        {
+            return new NoOpExpressionOptimizer();
+        }
+
+        @Override
+        public String getName()
+        {
+            return NO_OP_OPTIMIZER;
+        }
+    }
+
+    private static class NoOpExpressionOptimizer
+            implements ExpressionOptimizer
+    {
+        @Override
+        public RowExpression optimize(RowExpression expression, Level level, ConnectorSession session, Function<VariableReferenceExpression, Object> variableResolver)
+        {
+            return expression;
+        }
     }
 }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -319,7 +319,7 @@ public class TestNativeSidecarPlugin
     public void testInformationSchemaTables()
     {
         assertQuery("select lower(table_name) from information_schema.tables "
-                + "where table_name = 'lineitem' or table_name = 'LINEITEM' ");
+                        + "where table_name = 'lineitem' or table_name = 'LINEITEM' ");
     }
 
     @Test

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkStatsCalculatorModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkStatsCalculatorModule.java
@@ -22,6 +22,7 @@ import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsNormalizer;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -54,9 +55,10 @@ public class PrestoSparkStatsCalculatorModule
             FilterStatsCalculator filterStatsCalculator,
             FragmentStatsProvider fragmentStatsProvider,
             HistoryBasedPlanStatisticsManager historyBasedPlanStatisticsManager,
-            HistoryBasedOptimizationConfig historyBasedOptimizationConfig)
+            HistoryBasedOptimizationConfig historyBasedOptimizationConfig,
+            ExpressionOptimizerManager expressionOptimizerManager)
     {
-        StatsCalculator delegate = createComposableStatsCalculator(metadata, scalarStatsCalculator, normalizer, filterStatsCalculator, fragmentStatsProvider);
+        StatsCalculator delegate = createComposableStatsCalculator(metadata, scalarStatsCalculator, normalizer, filterStatsCalculator, fragmentStatsProvider, expressionOptimizerManager);
         return new PrestoSparkStatsCalculator(historyBasedPlanStatisticsManager.getHistoryBasedPlanStatisticsCalculator(delegate), delegate, historyBasedOptimizationConfig);
     }
 }


### PR DESCRIPTION
## Description
When the sidecar is used for query analysis, the default namespace is switched to reflect the different set of functions used in Velox.  While eventually we wish to use Velox for both expression evaluation and also as a registry of functions, the former is taking a long time due to refactoring in Velox.  In the meantime, we need function evaluation over C++ namespaces to work properly, which means we need to use the Java functions for now.  This is a stopgap solution until function evaluation in Velox works end to end (tracked by #24238).

Depends on #25384.

## Motivation and Context
See above.

## Impact
This allows constant folding to work while using Velox functions for analysis with the sidecar.

## Test Plan
Tests have been added.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Use Presto built-in functions for constant folding when native execution is enabled with sidecar.
```

