### PR TITLE
feat(native): Insert into bucketed but unpartitioned Hive table

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2048,20 +2048,30 @@ public class HiveMetadata
             int bucketCount,
             Set<String> existingFileNames)
     {
-        if (existingFileNames.size() == bucketCount) {
-            // fast path for common case
+        // Extract unique bucket numbers from existing file names
+        Set<Integer> existingBuckets = existingFileNames.stream()
+                .map(HiveWriterFactory::getBucketNumber)
+                .filter(OptionalInt::isPresent)
+                .map(OptionalInt::getAsInt)
+                .collect(toImmutableSet());
+
+        if (existingBuckets.size() == bucketCount) {
+            // fast path for common case - all buckets have files
             return ImmutableList.of();
         }
+
         String fileExtension = getFileExtension(fromHiveStorageFormat(storageFormat), compressionCodec);
         ImmutableList.Builder<String> missingFileNamesBuilder = ImmutableList.builder();
         for (int i = 0; i < bucketCount; i++) {
-            String targetFileName = isFileRenamingEnabled(session) ? String.valueOf(i) : computeBucketedFileName(session.getQueryId(), i) + fileExtension;
-            if (!existingFileNames.contains(targetFileName)) {
+            if (!existingBuckets.contains(i)) {
+                String targetFileName = isFileRenamingEnabled(session) ? String.valueOf(i) : computeBucketedFileName(session.getQueryId(), i) + fileExtension;
                 missingFileNamesBuilder.add(targetFileName);
             }
         }
         List<String> missingFileNames = missingFileNamesBuilder.build();
-        verify(existingFileNames.size() + missingFileNames.size() == bucketCount);
+        verify(existingBuckets.size() + missingFileNames.size() == bucketCount,
+                "Expected %s buckets, but found %s existing and %s missing",
+                bucketCount, existingBuckets.size(), missingFileNames.size());
         return missingFileNames;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -476,9 +476,6 @@ public class HiveWriterFactory
     {
         // Note: temporary table is always empty at this step
         if (!table.getTableType().equals(TEMPORARY_TABLE)) {
-            if (bucketNumber.isPresent()) {
-                throw new PrestoException(HIVE_PARTITION_READ_ONLY, "Cannot insert into bucketed unpartitioned Hive table");
-            }
             if (immutablePartitions) {
                 throw new PrestoException(HIVE_PARTITION_READ_ONLY, "Unpartitioned Hive tables are immutable");
             }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -909,6 +909,152 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testEmptyBucketedTable()
+    {
+        // go through all storage formats to make sure the empty buckets are correctly created
+        testWithAllStorageFormats(this::testEmptyBucketedTable);
+    }
+
+    private void testEmptyBucketedTable(Session session, HiveStorageFormat storageFormat)
+    {
+        testEmptyBucketedTable(session, storageFormat, true, true);
+        testEmptyBucketedTable(session, storageFormat, true, false);
+        testEmptyBucketedTable(session, storageFormat, false, true);
+        testEmptyBucketedTable(session, storageFormat, false, false);
+    }
+
+    private void testEmptyBucketedTable(Session session, HiveStorageFormat storageFormat, boolean optimizedPartitionUpdateSerializationEnabled, boolean createEmpty)
+    {
+        String tableName = "test_empty_bucketed_table_" + System.nanoTime();
+
+        try {
+            @Language("SQL") String createTable = "" +
+                    "CREATE TABLE " + tableName + " " +
+                    "(bucket_key VARCHAR, col_1 VARCHAR, col_2 VARCHAR) " +
+                    "WITH (" +
+                    "format = '" + storageFormat + "', " +
+                    "bucketed_by = ARRAY[ 'bucket_key' ], " +
+                    "bucket_count = 11 " +
+                    ") ";
+
+            assertUpdate(createTable);
+
+            TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
+            assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
+
+            assertNull(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY));
+            assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY), ImmutableList.of("bucket_key"));
+            assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY), 11);
+
+            assertEquals(computeActual("SELECT * from " + tableName).getRowCount(), 0);
+
+            // make sure that we will get one file per bucket regardless of writer count configured
+            Session parallelWriter = Session.builder(getTableWriteTestingSession(optimizedPartitionUpdateSerializationEnabled))
+                    .setCatalogSessionProperty(catalog, "create_empty_bucket_files", String.valueOf(createEmpty))
+                    .build();
+            assertUpdate(parallelWriter, "INSERT INTO " + tableName + " VALUES ('a0', 'b0', 'c0')", 1);
+            assertUpdate(parallelWriter, "INSERT INTO " + tableName + " VALUES ('a1', 'b1', 'c1')", 1);
+
+            assertQuery("SELECT * from " + tableName, "VALUES ('a0', 'b0', 'c0'), ('a1', 'b1', 'c1')");
+
+            // Validate one file per bucket by checking bucket numbers in filenames
+            // Note: $path only returns paths for rows with data, so empty bucket files won't appear
+            MaterializedResult paths = computeActual(format("SELECT DISTINCT \"$path\" FROM %s", tableName));
+            java.util.regex.Pattern bucketPattern = java.util.regex.Pattern.compile(".*[/_](\\d{5})(?:[_.]|$)");
+            java.util.Map<Integer, Integer> bucketFileCount = new java.util.HashMap<>();
+
+            for (MaterializedRow row : paths) {
+                String path = (String) row.getField(0);
+                String filename = new File(path).getName();
+                if (!filename.startsWith("_") && !filename.startsWith(".")) {
+                    java.util.regex.Matcher matcher = bucketPattern.matcher(filename);
+                    if (matcher.find()) {
+                        int bucketNum = Integer.parseInt(matcher.group(1));
+                        bucketFileCount.merge(bucketNum, 1, Integer::sum);
+                    }
+                }
+            }
+
+            // Validate: each bucket that has data must have exactly one file (no duplicate files per bucket)
+            for (java.util.Map.Entry<Integer, Integer> entry : bucketFileCount.entrySet()) {
+                assertEquals(entry.getValue().intValue(), 1,
+                        format("Bucket %d has %d files, expected exactly 1 file per bucket", entry.getKey(), entry.getValue()));
+            }
+
+            assertUpdate(session, "DROP TABLE " + tableName);
+            assertFalse(getQueryRunner().tableExists(session, tableName));
+        }
+        finally {
+            // Ensure cleanup even if the test fails before the explicit DROP
+            assertUpdate(session, "DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testBucketedTable()
+    {
+        // go through all storage formats to make sure the empty buckets are correctly created
+        testWithAllStorageFormats(this::testBucketedTable);
+    }
+
+    private void testBucketedTable(Session session, HiveStorageFormat storageFormat)
+    {
+        testBucketedTable(session, storageFormat, true, true);
+        testBucketedTable(session, storageFormat, true, false);
+        testBucketedTable(session, storageFormat, false, true);
+        testBucketedTable(session, storageFormat, false, false);
+    }
+
+    private void testBucketedTable(Session session, HiveStorageFormat storageFormat, boolean optimizedPartitionUpdateSerializationEnabled, boolean createEmpty)
+    {
+        String tableName = "test_bucketed_table_" + System.nanoTime();
+
+        try {
+            @Language("SQL") String createTable = "" +
+                    "CREATE TABLE " + tableName + " " +
+                    "WITH (" +
+                    "format = '" + storageFormat + "', " +
+                    "bucketed_by = ARRAY[ 'bucket_key' ], " +
+                    "bucket_count = 11 " +
+                    ") " +
+                    "AS " +
+                    "SELECT * " +
+                    "FROM (" +
+                    "VALUES " +
+                    "  (VARCHAR 'a', VARCHAR 'b', VARCHAR 'c'), " +
+                    "  ('aa', 'bb', 'cc'), " +
+                    "  ('aaa', 'bbb', 'ccc')" +
+                    ") t (bucket_key, col_1, col_2)";
+
+            Session parallelWriter = Session.builder(getTableWriteTestingSession(optimizedPartitionUpdateSerializationEnabled))
+                    .setCatalogSessionProperty(catalog, "create_empty_bucket_files", String.valueOf(createEmpty))
+                    .build();
+            assertUpdate(parallelWriter, createTable, 3);
+
+            TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
+            assertEquals(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY), storageFormat);
+
+            assertNull(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY));
+            assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY), ImmutableList.of("bucket_key"));
+            assertEquals(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY), 11);
+
+            assertQuery("SELECT * from " + tableName, "VALUES ('a', 'b', 'c'), ('aa', 'bb', 'cc'), ('aaa', 'bbb', 'ccc')");
+
+            assertUpdate(parallelWriter, "INSERT INTO " + tableName + " VALUES ('a0', 'b0', 'c0')", 1);
+            assertUpdate(parallelWriter, "INSERT INTO " + tableName + " VALUES ('a1', 'b1', 'c1')", 1);
+
+            assertQuery("SELECT * from " + tableName, "VALUES ('a', 'b', 'c'), ('aa', 'bb', 'cc'), ('aaa', 'bbb', 'ccc'), ('a0', 'b0', 'c0'), ('a1', 'b1', 'c1')");
+
+            assertUpdate(session, "DROP TABLE " + tableName);
+            assertFalse(getQueryRunner().tableExists(session, tableName));
+        }
+        finally {
+            // Ensure cleanup even if the test fails before the explicit DROP
+            assertUpdate(session, "DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
     public void testCreatePartitionedBucketedTableAsFewRows()
     {
         // go through all storage formats to make sure the empty buckets are correctly created

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
@@ -31,6 +31,8 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PartitioningHandle;
+import com.facebook.presto.spi.plan.PartitioningScheme;
 import com.facebook.presto.spi.plan.PlanChecker;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanVisitor;
@@ -104,6 +106,10 @@ public final class NativePlanChecker
             LOG.debug("Skipping native plan validation [fragment: %s, root: %s]", planFragment.getId(), planFragment.getRoot().getId());
             return;
         }
+        if (isMissingRuntimePartitioningInfo(planFragment)) {
+            LOG.debug("Skipping native plan validation [fragment: %s, reason: missing runtime partitioning info]", planFragment.getId());
+            return;
+        }
         runValidation(removeTableWriter(planFragment));
     }
 
@@ -142,6 +148,29 @@ public final class NativePlanChecker
                 planFragment.isOutputTableWriterFragment());
     }
 
+    /**
+     * Checks if the fragment is missing runtime partitioning information.
+     * Returns true only when the partitioningScheme uses non-system partitioning and
+     * bucketToPartition is not present. This is runtime information that gets populated
+     * during scheduling, after validation occurs.
+     * Note: We check the partitioningScheme's partitioning handle, not the fragment's
+     * partitioning handle, because the native sidecar processes the partitioningScheme
+     * when creating the PartitionedOutputNode.
+     */
+    private boolean isMissingRuntimePartitioningInfo(SimplePlanFragment planFragment)
+    {
+        PartitioningScheme scheme = planFragment.getPartitioningScheme();
+
+        // Check the partitioning handle WITHIN the partitioningScheme, not the fragment's partitioning
+        PartitioningHandle schemePartitioningHandle = scheme.getPartitioning().getHandle();
+
+        // Only skip validation if the scheme's partitioning is NOT system partitioning
+        // AND bucketToPartition is missing
+        boolean isSystemPartitioning = schemePartitioningHandle.isSingleOrBroadcastOrArbitrary();
+        boolean hasBucketToPartition = scheme.getBucketToPartition().isPresent();
+
+        return !isSystemPartitioning && !hasBucketToPartition;
+    }
     private boolean isInternalSystemConnector(PlanNode planNode)
     {
         return planNode.accept(new CheckInternalVisitor(), null);

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestPlanCheckerProvider.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestPlanCheckerProvider.java
@@ -122,6 +122,14 @@ public class TestPlanCheckerProvider
         {
             return false;
         }
+
+        @JsonProperty
+        @Override
+        public boolean isArbitrary()
+        {
+            // Mark this as arbitrary (system partitioning) so validation proceeds
+            return true;
+        }
     }
 
     private static class TestingPlanNode

--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -234,6 +234,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.prestodb.tempto</groupId>
+            <artifactId>tempto-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>provided</scope>

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestHiveBucketedUnpartitionedInsertNative.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestHiveBucketedUnpartitionedInsertNative.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestHiveBucketedTables;
+import org.testng.annotations.BeforeClass;
+
+import static java.lang.Boolean.parseBoolean;
+
+/**
+ * Test class for testing inserts into bucketed unpartitioned Hive tables with native worker.
+ * Extends AbstractTestHiveBucketedTables from presto-tests and provides native-specific QueryRunner.
+ */
+public class TestHiveBucketedUnpartitionedInsertNative
+        extends AbstractTestHiveBucketedTables
+{
+    private String storageFormat;
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init() throws Exception
+    {
+        storageFormat = System.getProperty("storageFormat", "PARQUET");
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "true"));
+        super.init();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        return NativeTestsUtils.createNativeQueryRunner(storageFormat, sidecarEnabled);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        NativeTestsUtils.createTables(storageFormat);
+    }
+
+    @Override
+    protected String getTableName()
+    {
+        return "hive.tpch.bucketed_nation";
+    }
+
+    @Override
+    protected String getSourceTableName()
+    {
+        return "hive.tpch.nation";
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBasicTableStatistics.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBasicTableStatistics.java
@@ -269,13 +269,18 @@ public class TestHiveBasicTableStatistics
             assertThat(statisticsAfterCreate.getNumRows().getAsLong()).isEqualTo(25);
             assertThat(statisticsAfterCreate.getNumFiles().getAsLong()).isEqualTo(50);
 
-            // Insert into bucketed unpartitioned table is unsupported
-            assertThatThrownBy(() -> insertNationData(onPresto(), tableName))
-                    .hasMessageContaining("Cannot insert into bucketed unpartitioned Hive table");
+            insertNationData(onPresto(), tableName);
 
             BasicStatistics statisticsAfterInsert = getBasicStatisticsForTable(onHive(), tableName);
-            assertThat(statisticsAfterInsert.getNumRows().getAsLong()).isEqualTo(25);
-            assertThat(statisticsAfterCreate.getNumFiles().getAsLong()).isEqualTo(50);
+
+            assertThat(statisticsAfterInsert.getNumRows().getAsLong()).isEqualTo(50);
+            assertThat(statisticsAfterInsert.getNumFiles().getAsLong()).isEqualTo(100);
+
+            insertNationData(onPresto(), tableName);
+
+            BasicStatistics statisticsAfterInsert2 = getBasicStatisticsForTable(onHive(), tableName);
+            assertThat(statisticsAfterInsert2.getNumRows().getAsLong()).isEqualTo(75);
+            assertThat(statisticsAfterInsert2.getNumFiles().getAsLong()).isEqualTo(150);
         }
         finally {
             onPresto().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveBucketedTables.java
@@ -44,35 +44,34 @@ public class TestHiveBucketedTables
         implements RequirementsProvider
 {
     @TableDefinitionsRepository.RepositoryTableDefinition
-    public static final HiveTableDefinition BUCKETED_PARTITIONED_NATION = HiveTableDefinition.builder("bucket_partition_nation")
-            .setCreateTableDDLTemplate("CREATE TABLE %NAME%(" +
-                    "n_nationkey     BIGINT," +
-                    "n_name          STRING," +
-                    "n_regionkey     BIGINT," +
-                    "n_comment       STRING) " +
-                    "PARTITIONED BY (part_key STRING) " +
-                    "CLUSTERED BY (n_regionkey) " +
-                    "INTO 2 BUCKETS " +
-                    "ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'")
-            .setNoData()
-            .build();
+    public static final HiveTableDefinition BUCKETED_NATION = bucketTableDefinition("bucket_nation", false, true);
 
     @TableDefinitionsRepository.RepositoryTableDefinition
-    public static final HiveTableDefinition PARTITIONED_NATION = HiveTableDefinition.builder("partitioned_nation")
-            .setCreateTableDDLTemplate("CREATE TABLE %NAME%(" +
-                    "n_nationkey     BIGINT," +
-                    "n_name          STRING," +
-                    "n_regionkey     BIGINT," +
-                    "n_comment       STRING) " +
-                    "PARTITIONED BY (part_key STRING) " +
-                    "ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'")
-            .setNoData()
-            .build();
+    public static final HiveTableDefinition BUCKETED_PARTITIONED_NATION = bucketTableDefinition("bucket_partitioned_nation", true, true);
+
+    @TableDefinitionsRepository.RepositoryTableDefinition
+    public static final HiveTableDefinition PARTITIONED_NATION = bucketTableDefinition("partitioned_nation", true, false);
+
+    private static HiveTableDefinition bucketTableDefinition(String tableName, boolean partitioned, boolean bucketed)
+    {
+        return HiveTableDefinition.builder(tableName)
+                .setCreateTableDDLTemplate("CREATE TABLE %NAME%(" +
+                        "n_nationkey     BIGINT," +
+                        "n_name          STRING," +
+                        "n_regionkey     BIGINT," +
+                        "n_comment       STRING) " +
+                        (partitioned ? "PARTITIONED BY (part_key STRING) " : " ") +
+                        (bucketed ? "CLUSTERED BY (n_regionkey) INTO 2 BUCKETS " : " ") +
+                        "ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'")
+                .setNoData()
+                .build();
+    }
 
     @Override
     public Requirement getRequirements(Configuration configuration)
     {
         return Requirements.compose(
+                MutableTableRequirement.builder(BUCKETED_NATION).withState(CREATED).build(),
                 MutableTableRequirement.builder(BUCKETED_PARTITIONED_NATION).withState(CREATED).build(),
                 immutableTable(NATION));
     }
@@ -166,5 +165,18 @@ public class TestHiveBucketedTables
         catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void testInsertIntoBucketedTables()
+    {
+        String tableName = mutableTablesState().get(BUCKETED_NATION).getNameInDatabase();
+
+        query(format("INSERT INTO %s SELECT * FROM %s", tableName, NATION.getName()));
+        // make sure that insert will not overwrite existing data
+        query(format("INSERT INTO %s SELECT * FROM %s", tableName, NATION.getName()));
+
+        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactly(row(50));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactly(row(10));
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestHiveBucketedTables.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestHiveBucketedTables.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.testing.MaterializedResult;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public abstract class AbstractTestHiveBucketedTables
+        extends AbstractTestQueryFramework
+{
+    protected abstract String getTableName();
+
+    protected abstract String getSourceTableName();
+
+    /**
+     * Override this method in subclasses to create necessary tables.
+     * Default implementation does nothing.
+     */
+    protected void createTables()
+    {
+        // Default: no-op
+    }
+
+    /**
+     * Test inserting into bucketed unpartitioned tables.
+     */
+    @Test
+    public void testInsertIntoBucketedTables()
+    {
+        createTables();
+        String tableName = getTableName();
+        String sourceTable = getSourceTableName();
+
+        try {
+            getQueryRunner().execute("DROP TABLE IF EXISTS " + tableName);
+            // Create the bucketed table
+            @Language("SQL") String createTableSql = "CREATE TABLE " + tableName + " (\n" +
+                    "    n_nationkey BIGINT,\n" +
+                    "    n_name VARCHAR,\n" +
+                    "    n_regionkey BIGINT,\n" +
+                    "    n_comment VARCHAR\n" +
+                    ")\n" +
+                    "WITH (\n" +
+                    "    format = 'PARQUET',\n" +
+                    "    bucketed_by = ARRAY['n_regionkey'],\n" +
+                    "    bucket_count = 2\n" +
+                    ")";
+            getQueryRunner().execute(createTableSql);
+
+            // Insert data twice
+            getQueryRunner().execute("INSERT INTO " + tableName + " SELECT * FROM " + sourceTable);
+            getQueryRunner().execute("INSERT INTO " + tableName + " SELECT * FROM " + sourceTable);
+            // Validate total row count
+            MaterializedResult totalCountResult = getQueryRunner().execute(getQueryRunner().getDefaultSession(), "SELECT count(*) FROM " + tableName);
+            assertEquals(totalCountResult.getRowCount(), 1, "Expected single row result");
+            assertEquals(((Long) totalCountResult.getMaterializedRows().get(0).getField(0)).longValue(), 50L, "Expected 50 total rows");
+            // Validate filtered row count
+            MaterializedResult filteredCountResult = getQueryRunner().execute(getQueryRunner().getDefaultSession(), "SELECT count(*) FROM " + tableName + " WHERE n_regionkey = 0");
+            assertEquals(filteredCountResult.getRowCount(), 1, "Expected single row result");
+            assertEquals(((Long) filteredCountResult.getMaterializedRows().get(0).getField(0)).longValue(), 10L, "Expected 10 rows with n_regionkey = 0");
+        }
+        finally {
+            // Ensure cleanup even if the test fails
+            getQueryRunner().execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Addresses https://github.com/prestodb/presto/issues/25104 
Currently, Presto does not support INSERT INTO operations on bucketed but unpartitioned Hive tables. This limitation originates from a hard check in HiveWriterFactory:

https://github.com/prestodb/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java#L480

## Motivation and Context

Supporting writes to bucketed unpartitioned Hive tables in Presto would improve compatibility and enhance Presto’s ability to handle modern Hive table layouts. It's a reasonable and useful feature for users who wish to leverage bucketing for performance optimizations even without partitioning.

## Impact

This change would align Presto’s behavior with the broader SQL-on-Hadoop ecosystem and remove an artificial limitation that may block valid use cases — particularly in data warehousing environments where bucketing is used independently of partitioning.

## Release Notes
```
== RELEASE NOTES ==

Hive Connector Changes

* Add support for INSERT into bucketed but unpartitioned Hive tables in Hive, including follow-up fixes for native validation and insert handling.

```
