### PR TITLE
[docs] Add per-query-retry-limit to properties.rst

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -95,6 +95,16 @@ session properties are included.
 
 .. _tuning-memory:
 
+``per-query-retry-limit``
+^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Minimum value:** ``0``
+* **Default value:** ``0``
+
+The number of times that a query is automatically retried in the case of a transient query or communications failure. 
+The default value ``0`` means that retries are disabled. 
+
 Memory Management Properties
 ----------------------------
 


### PR DESCRIPTION
## Description
Add documentation for ``per-query-retry-limit`` to [properties.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/admin/properties.rst).

Note: There is no corresponding session property to document in [Presto Session Properties](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/admin/properties-session.rst). 
## Motivation and Context
Discussion today brought up that this configuration property added in #15857 was not documented, and that it would be nice to have it in the documentation. 

This property was added to Presto in 0.252, see the [0.252 Release Notes](https://prestodb.io/docs/current/release/release-0.252.html#general-changes). 

## Impact
Documentation. 

## Test Plan
Local doc build. Screenshot: 
<img width="795" alt="Screenshot 2025-05-19 at 2 30 27 PM" src="https://github.com/user-attachments/assets/46a0ed4b-a1f8-44d8-8fc1-d8e197317d30" />



## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

