### PR TITLE
[native] Advance Velox and Dependency Versions

### DIFF
--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -15,7 +15,9 @@ jobs:
   prestocpp-linux-adapters-build:
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.292-20250204112033-cf8ba84
+      # TODO: Presto release team must build and use an official dependency image
+      # after PR:25146 lands.
+      image: ghcr.io/czentgr/prestissimo-deps:centos9
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
     steps:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -17,7 +17,9 @@ jobs:
   prestocpp-linux-build-for-test:
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.292-20250204112033-cf8ba84
+      # TODO: Presto release team must build and use an official dependency image
+      # after PR:25146 lands.
+      image: ghcr.io/czentgr/prestissimo-deps:centos9
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
     steps:
@@ -94,7 +96,9 @@ jobs:
     needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.292-20250204112033-cf8ba84
+      # TODO: Presto release team must build and use an official dependency image
+      # after PR:25146 lands.
+      image: ghcr.io/czentgr/prestissimo-deps:centos9
     env:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
@@ -173,7 +177,9 @@ jobs:
       matrix:
         storage-format: [ "PARQUET", "DWRF" ]
     container:
-      image: prestodb/presto-native-dependency:0.292-20250204112033-cf8ba84
+      # TODO: Presto release team must build and use an official dependency image
+      # after PR:25146 lands.
+      image: ghcr.io/czentgr/prestissimo-deps:centos9
     env:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
@@ -245,7 +251,9 @@ jobs:
     needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.292-20250204112033-cf8ba84
+      # TODO: Presto release team must build and use an official dependency image
+      # after PR:25146 lands.
+      image: ghcr.io/czentgr/prestissimo-deps:centos9
     env:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -32,7 +32,9 @@ jobs:
   prestocpp-linux-build-engine:
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.292-20250204112033-cf8ba84
+      # TODO: Presto release team must build and use an official dependency image
+      # after PR:25146 lands.
+      image: ghcr.io/czentgr/prestissimo-deps:centos9
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
       CC: /usr/bin/clang-15

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -66,7 +66,9 @@ option(PRESTO_ENABLE_JWT "Enable JWT (JSON Web Token) authentication" OFF)
 option(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR "Enable Arrow Flight connector" OFF)
 
 # Set all Velox options below
-add_compile_definitions(FOLLY_HAVE_INT128_T=1)
+# Make sure that if we include folly headers or other dependency headers
+# that include folly headers we turn off the coroutines and turn on int128.
+add_compile_definitions(FOLLY_HAVE_INT128_T=1 FOLLY_CFG_NO_COROUTINES)
 
 if(PRESTO_ENABLE_S3)
   set(VELOX_ENABLE_S3
@@ -184,6 +186,7 @@ find_library(PROXYGEN proxygen)
 find_library(PROXYGEN_HTTP_SERVER proxygenhttpserver)
 find_library(FIZZ fizz)
 find_library(WANGLE wangle)
+find_library(MVFST_EXCEPTION mvfst_exception)
 
 find_library(RE2 re2)
 
@@ -192,7 +195,7 @@ find_package(wangle CONFIG)
 find_package(FBThrift)
 include_directories(SYSTEM ${FBTHRIFT_INCLUDE_DIR})
 
-set(PROXYGEN_LIBRARIES ${PROXYGEN_HTTP_SERVER} ${PROXYGEN} ${WANGLE} ${FIZZ})
+set(PROXYGEN_LIBRARIES ${PROXYGEN_HTTP_SERVER} ${PROXYGEN} ${WANGLE} ${FIZZ} ${MVFST_EXCEPTION})
 find_path(PROXYGEN_DIR NAMES include/proxygen)
 set(PROXYGEN_INCLUDE_DIR "${PROXYGEN_DIR}/include/proxygen")
 

--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -51,9 +51,12 @@ function install_gperf {
 }
 
 function install_proxygen {
-  git clone https://github.com/facebook/proxygen &&
-  cd proxygen &&
-  git checkout $FB_OS_VERSION &&
+  git clone https://github.com/facebook/proxygen
+  cd proxygen
+  git checkout $FB_OS_VERSION
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   cmake_install -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON
 }
 

--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -15,6 +15,7 @@ set -eufx -o pipefail
 
 SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 PYTHON_VENV=${PYTHON_VENV:-"${SCRIPTDIR}/../.venv"}
+
 # Prestissimo fails to build DuckDB with error
 # "math cannot parse the expression" when this
 # script is invoked under the Presto git project.
@@ -26,6 +27,9 @@ GPERF_VERSION="3.1"
 
 function install_proxygen {
   github_checkout facebook/proxygen "${FB_OS_VERSION}"
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   cmake_install -DBUILD_TESTS=OFF
 }
 
@@ -33,7 +37,7 @@ function install_gperf {
   wget_and_untar https://ftpmirror.gnu.org/gperf/gperf-${GPERF_VERSION}.tar.gz gperf
   cd ${DEPENDENCY_DIR}/gperf
   ./configure --prefix=${INSTALL_PREFIX}
-  make install 
+  make install
 }
 
 function install_presto_deps {

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -25,6 +25,9 @@ function install_proxygen {
   ${SUDO} apt update
   ${SUDO} apt install -y gperf python3
   github_checkout facebook/proxygen "${FB_OS_VERSION}"
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   cmake_install -DBUILD_TESTS=OFF
 }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
@@ -95,7 +95,7 @@ public abstract class AbstractTestWindowQueries
     public void testWindowImplicitCoercion()
     {
         assertQueryOrdered(
-                "SELECT orderkey, 1e0 / row_number() OVER (ORDER BY orderkey) FROM orders LIMIT 2",
+                "SELECT orderkey, 1e0 / row_number() OVER (ORDER BY orderkey) FROM orders ORDER BY orderkey LIMIT 2",
                 "VALUES (1, 1.0), (2, 0.5)");
     }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Fix testWindowImplicitCoercion test since https://github.com/facebookincubator/velox/pull/11440 changed the order of rows emitted.
An official dependency image will be built after merging this PR and will be used in CI.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

