### PR TITLE
[native] Fail-fast for file formats unsupported by hive connector

### DIFF
--- a/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
+++ b/presto-hive-hadoop2/src/test/java/com/facebook/presto/hive/s3select/S3SelectTestHelper.java
@@ -68,6 +68,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.TestingConnectorContext;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
@@ -199,7 +200,8 @@ public class S3SelectTestHelper
                 config.getRecursiveDirWalkerEnabled(),
                 new ConfigBasedCacheQuotaRequirementProvider(cacheConfig),
                 new HiveEncryptionInformationProvider(ImmutableSet.of()),
-                new HivePartitionSkippabilityChecker());
+                new HivePartitionSkippabilityChecker(),
+                new TestingConnectorContext().getConnectorSystemConfig());
         pageSourceProvider = new HivePageSourceProvider(
                 config,
                 hdfsEnvironment,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -39,6 +39,7 @@ import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.PrestoException;
@@ -96,6 +97,8 @@ import static com.facebook.presto.hive.HiveSessionProperties.getLeaseDuration;
 import static com.facebook.presto.hive.HiveSessionProperties.isDynamicSplitSizesEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isOfflineDataDebugModeEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isPartitionStatisticsBasedOptimizationEnabled;
+import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
+import static com.facebook.presto.hive.HiveStorageFormat.ORC;
 import static com.facebook.presto.hive.HiveStorageFormat.PARQUET;
 import static com.facebook.presto.hive.HiveStorageFormat.getHiveStorageFormat;
 import static com.facebook.presto.hive.HiveType.getPrimitiveType;
@@ -151,6 +154,7 @@ public class HiveSplitManager
     private final CacheQuotaRequirementProvider cacheQuotaRequirementProvider;
     private final HiveEncryptionInformationProvider encryptionInformationProvider;
     private final PartitionSkippabilityChecker partitionSkippabilityChecker;
+    private final ConnectorSystemConfig connectorSystemConfig;
 
     @Inject
     public HiveSplitManager(
@@ -163,7 +167,8 @@ public class HiveSplitManager
             @ForHiveClient ExecutorService executorService,
             CoercionPolicy coercionPolicy,
             HiveEncryptionInformationProvider encryptionInformationProvider,
-            PartitionSkippabilityChecker partitionSkippabilityChecker)
+            PartitionSkippabilityChecker partitionSkippabilityChecker,
+            ConnectorSystemConfig connectorSystemConfig)
     {
         this(
                 hiveTransactionManager,
@@ -181,7 +186,8 @@ public class HiveSplitManager
                 hiveClientConfig.getRecursiveDirWalkerEnabled(),
                 cacheQuotaRequirementProvider,
                 encryptionInformationProvider,
-                partitionSkippabilityChecker);
+                partitionSkippabilityChecker,
+                connectorSystemConfig);
     }
 
     public HiveSplitManager(
@@ -200,7 +206,8 @@ public class HiveSplitManager
             boolean recursiveDfsWalkerEnabled,
             CacheQuotaRequirementProvider cacheQuotaRequirementProvider,
             HiveEncryptionInformationProvider encryptionInformationProvider,
-            PartitionSkippabilityChecker partitionSkippabilityChecker)
+            PartitionSkippabilityChecker partitionSkippabilityChecker,
+            ConnectorSystemConfig connectorSystemConfig)
     {
         this.hiveTransactionManager = requireNonNull(hiveTransactionManager, "hiveTransactionManager is null");
         this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
@@ -219,6 +226,7 @@ public class HiveSplitManager
         this.cacheQuotaRequirementProvider = requireNonNull(cacheQuotaRequirementProvider, "cacheQuotaRequirementProvider is null");
         this.encryptionInformationProvider = requireNonNull(encryptionInformationProvider, "encryptionInformationProvider is null");
         this.partitionSkippabilityChecker = requireNonNull(partitionSkippabilityChecker, "partitionSkippabilityChecker is null");
+        this.connectorSystemConfig = requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
     }
 
     @Override
@@ -249,6 +257,16 @@ public class HiveSplitManager
                 session.getWarningCollector(),
                 session.getRuntimeStats());
         Table table = layout.getTable(metastore, metastoreContext);
+
+        if (connectorSystemConfig.isNativeExecution()) {
+            StorageFormat storageFormat = table.getStorage().getStorageFormat();
+            Optional<HiveStorageFormat> hiveStorageFormat = getHiveStorageFormat(storageFormat);
+            if (hiveStorageFormat.isPresent() && !(hiveStorageFormat.equals(Optional.of(DWRF))
+                    || hiveStorageFormat.equals(Optional.of(ORC)) || hiveStorageFormat.equals(Optional.of(PARQUET)))) {
+                throw new HiveNotReadableException(tableName, Optional.empty(),
+                        format("FileFormat %s unsupported in Presto C++.", hiveStorageFormat.get()));
+            }
+        }
 
         if (!isOfflineDataDebugModeEnabled(session)) {
             // verify table is not marked as non-readable

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -129,6 +129,7 @@ import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.TestingConnectorContext;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.testing.TestingNodeManager;
 import com.google.common.base.Predicate;
@@ -1067,7 +1068,8 @@ public abstract class AbstractTestHiveClient
                 false,
                 new ConfigBasedCacheQuotaRequirementProvider(cacheConfig),
                 encryptionInformationProvider,
-                new HivePartitionSkippabilityChecker());
+                new HivePartitionSkippabilityChecker(),
+                new TestingConnectorContext().getConnectorSystemConfig());
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(hiveClientConfig, metastoreClientConfig),
                 hdfsEnvironment,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -63,6 +63,7 @@ import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.TestingConnectorContext;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.testing.TestingNodeManager;
 import com.google.common.collect.ImmutableList;
@@ -247,7 +248,8 @@ public abstract class AbstractTestHiveFileSystem
                 config.getRecursiveDirWalkerEnabled(),
                 new ConfigBasedCacheQuotaRequirementProvider(cacheConfig),
                 new HiveEncryptionInformationProvider(ImmutableSet.of()),
-                new HivePartitionSkippabilityChecker());
+                new HivePartitionSkippabilityChecker(),
+                new TestingConnectorContext().getConnectorSystemConfig());
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(config, metastoreClientConfig),
                 hdfsEnvironment,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.testing.TestingConnectorContext;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -552,7 +553,8 @@ public class TestHiveSplitManager
                 false,
                 new ConfigBasedCacheQuotaRequirementProvider(new CacheConfig()),
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
-                new HivePartitionSkippabilityChecker());
+                new HivePartitionSkippabilityChecker(),
+                new TestingConnectorContext().getConnectorSystemConfig());
 
         HiveColumnHandle partitionColumn = new HiveColumnHandle(
                 "ds",
@@ -700,7 +702,8 @@ public class TestHiveSplitManager
                 false,
                 new ConfigBasedCacheQuotaRequirementProvider(new CacheConfig()),
                 encryptionInformationProvider,
-                new HivePartitionSkippabilityChecker());
+                new HivePartitionSkippabilityChecker(),
+                new TestingConnectorContext().getConnectorSystemConfig());
 
         HiveColumnHandle partitionColumn = new HiveColumnHandle(
                 "ds",


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

