### PR TITLE
Upgrade Node.js version to 22.15.1

### DIFF
--- a/.github/bin/download_nodejs
+++ b/.github/bin/download_nodejs
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-NODE_VERSION="18.20.2"
+NODE_VERSION="22.15.1"
 YARN_VERSION="1.22.22"
 
 wget_retry() {

--- a/presto-ui/pom.xml
+++ b/presto-ui/pom.xml
@@ -59,7 +59,7 @@
                         </goals>
                         <phase>initialize</phase>
                         <configuration>
-                            <nodeVersion>v18.20.2</nodeVersion>
+                            <nodeVersion>v22.15.1</nodeVersion>
                             <yarnVersion>v1.22.22</yarnVersion>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Description

Upgrades the node version used to build presto-ui to the latest LTS 22.15.1.

## Motivation and Context

This fixes the following build error that occurs on some architectures (Apple M3).
```
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.15.0:yarn (yarn install) on project presto-ui: Failed to run task: 'yarn ' failed. org.apache.commons.exec.ExecuteException: Process exited with an error: 139 (Exit value: 139) -> [Help 1]
```
The specific yarn error is a segmentation fault, which can be seen if yarn install is run manually.

## Impact

Allows users on certain hardware to build Presto without build failures.

## Test Plan

Before upgrading the node version, `./mvnw clean install -DskipTests` fails while building presto-ui with the above error on macOS with M3 Pro. After upgrading, Presto is able to successfully build.

The Presto UI still works after updating:
<img width="1264" alt="Screenshot 2025-05-20 at 11 52 32 AM" src="https://github.com/user-attachments/assets/622dbc2d-b1df-4ffc-bca4-8748ca266901" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

