### PR TITLE
Run empty values node simplify optimizer after connector optimizer

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -957,6 +957,9 @@ public class PlanOptimizers
                         costCalculator,
                         ImmutableSet.of(new RemoveRedundantIdentityProjections(), new PruneRedundantProjectionAssignments())));
 
+        // Pass after connector optimizer, as it relies on connector optimizer to identify empty input tables and convert them to empty ValuesNode
+        builder.add(new SimplifyPlanWithEmptyInput());
+
         // DO NOT add optimizers that change the plan shape (computations) after this point
 
         // Precomputed hashes - this assumes that partitioning will not change


### PR DESCRIPTION
## Description
The connector optimizer can convert a table scan which returns no data to an empty values node. We have an optimizer SimplifyPlanWithEmptyInput to simplify plan with empty values node. 
There are two runs of connector optimizer, logical and physical:

https://github.com/prestodb/presto/blob/master/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java#L727-L730

```
builder.add(
                new ApplyConnectorOptimization(() -> planOptimizerManager.getOptimizers(LOGICAL)),
                projectionPushDown,
                new PruneUnreferencedOutputs());
```

https://github.com/prestodb/presto/blob/master/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java#L951-L958

```
builder.add(
                new ApplyConnectorOptimization(() -> planOptimizerManager.getOptimizers(PHYSICAL)),
                new IterativeOptimizer(
                        metadata,
                        ruleStats,
                        statsCalculator,
                        costCalculator,
                        ImmutableSet.of(new RemoveRedundantIdentityProjections(), new PruneRedundantProjectionAssignments())));
```

Previously we only run it after the run of logical connector optimizer. However, turns out that the empty values node conversion also happens after physical run.

One example:
```
set session hive.pushdown_filter_enabled=true;

CREATE TABLE t1 with (partitioned_by = ARRAY['ds']) as select * from (values (1, '2024-01-05')) t(col1, ds);

create table t2 with (partitioned_by = ARRAY['ds']) as select * from (values (1, '2024-01-05')) t(col1, ds);

create table t3 with (partitioned_by = ARRAY['col2']) as select * from (values (1, '2024-01-05')) t(col1, col2);

explain (type distributed) SELECT e.col1 FROM t1 e INNER JOIN t2 m ON e.col1 = m.col1 AND e.ds = '2024-01-05' RIGHT JOIN t3 b ON b.col2 = 'xxx';
```

The reason is because the query relies on the first run of connector optimizer to push filters down into table scan. Later during predicate pushdown, it will find that there are no col2 equals to 'xxx' in table t3, and leads to empty table conversion in the later run of connector optimizer.

So run the SimplifyPlanWithEmptyInput once more after physical run.

## Motivation and Context
Optimize query plans with empty input

## Impact
Optimize query plans with empty input

## Test Plan
Existing unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve query plans using the ``SimplifyPlanWithEmptyInput`` optimizer to convert a table scan which returns no data to an empty values node.
```


