### PR TITLE
Wrap no split error in Prestissimo

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Exception.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Exception.cpp
@@ -22,8 +22,9 @@ protocol::ExecutionFailureInfo VeloxToPrestoExceptionTranslator::translate(
   error.errorLocation.lineNumber = e.line() >= 1 ? e.line() : 1;
   error.errorLocation.columnNumber = 1;
   error.type = e.exceptionName();
+  const auto& errorMessage = e.message();
   std::stringstream msg;
-  msg << e.failingExpression() << " " << e.message();
+  msg << e.failingExpression() << " " << errorMessage;
   if (!e.context().empty()) {
     msg << " " << e.context();
   }
@@ -45,6 +46,10 @@ protocol::ExecutionFailureInfo VeloxToPrestoExceptionTranslator::translate(
     auto itrErrorCode = itrErrorCodesMap->second.find(errorCode);
     if (itrErrorCode != itrErrorCodesMap->second.end()) {
       error.errorCode = itrErrorCode->second;
+      if (errorMessage.find("Invalid Split index") != std::string::npos) {
+        error.message = "The table data doesn't exist";
+        error.stack = {};
+      }
       return error;
     }
   }

--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -101,6 +101,27 @@ TEST(VeloxToPrestoExceptionTranslatorTest, exceptionTranslation) {
     EXPECT_EQ(failureInfo.errorCode.type, protocol::ErrorType::INTERNAL_ERROR);
   }
 
+  VeloxRuntimeError noSplitException(
+    "file_name",
+    1,
+    "function_name()",
+    "operator()",
+    "(0 vs. 0) Invalid Split index",
+    "",
+    error_code::kInvalidState,
+    false);
+
+  EXPECT_THROW({ throw noSplitException; }, VeloxException);
+    try {
+    throw noSplitException;
+  } catch (const VeloxException& e) {
+  auto failureInfo = VeloxToPrestoExceptionTranslator::translate(e);
+    EXPECT_EQ(failureInfo.errorCode.name, "GENERIC_INTERNAL_ERROR");
+    EXPECT_EQ(failureInfo.errorCode.code, 0x00010000);
+    EXPECT_EQ(failureInfo.errorCode.type, protocol::ErrorType::INTERNAL_ERROR);
+    EXPECT_EQ(failureInfo.message, "The table data doesn't exist");
+}
+
   EXPECT_THROW(([]() { VELOX_USER_CHECK_EQ(1, 2); })(), VeloxException);
   try {
     VELOX_USER_CHECK_EQ(1, 2, "test user error message");


### PR DESCRIPTION
Summary:
no split error means that the table data doesn't exist on the worker's memory. Wrap it from general internal error because it's a known issue.

Sample failure https://www.internalfb.com/intern/presto/query/?query_id=20250509_183201_00011_nmvd3#stack_trace

Differential Revision: D75033700


