### PR TITLE
Add RemoveRedundantJoin rule to the optimizer

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -113,6 +113,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantCastToVarch
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantDistinctLimit;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantJoin;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantLimit;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSort;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSortColumns;
@@ -417,6 +418,7 @@ public class PlanOptimizers
                                         new PushLimitThroughSemiJoin(),
                                         new PushLimitThroughUnion(),
                                         new RemoveTrivialFilters(),
+                                        new RemoveRedundantJoin(),
                                         new ImplementFilteredAggregations(metadata.getFunctionAndTypeManager()),
                                         new SingleDistinctAggregationToGroupBy(),
                                         new MultipleDistinctAggregationToMarkDistinct(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantJoin.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.sql.planner.iterative.Lookup;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isEmpty;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+
+public class RemoveRedundantJoin
+        implements Rule<JoinNode>
+{
+    private static final Pattern<JoinNode> PATTERN = join();
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        if (canRemoveJoin(node, context.getLookup())) {
+            return Result.ofPlanNode(new ValuesNode(node.getSourceLocation(), node.getId(), node.getOutputVariables(), ImmutableList.of(), Optional.empty()));
+        }
+
+        return Result.empty();
+    }
+
+    private boolean canRemoveJoin(JoinNode joinNode, Lookup lookup)
+    {
+        PlanNode left = joinNode.getLeft();
+        PlanNode right = joinNode.getRight();
+        switch (joinNode.getType()) {
+            case INNER:
+                return isEmpty(left, lookup) || isEmpty(right, lookup);
+            case LEFT:
+                return isEmpty(left, lookup);
+            case RIGHT:
+                return isEmpty(right, lookup);
+            case FULL:
+                return isEmpty(left, lookup) && isEmpty(right, lookup);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/QueryCardinalityUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/QueryCardinalityUtil.java
@@ -64,6 +64,11 @@ public final class QueryCardinalityUtil
         return Range.closed(0L, maxCardinality).encloses(extractCardinality(node, lookup));
     }
 
+    public static boolean isEmpty(PlanNode node, Lookup lookup)
+    {
+        return isAtMost(node, lookup, 0);
+    }
+
     public static Range<Long> extractCardinality(PlanNode node)
     {
         return extractCardinality(node, noLookup());

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveRedundantJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestRemoveRedundantJoin.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantJoin;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.plan.JoinType.FULL;
+import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.spi.plan.JoinType.LEFT;
+import static com.facebook.presto.spi.plan.JoinType.RIGHT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRemoveRedundantJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoesNotFire()
+    {
+        tester().assertThat(new RemoveRedundantJoin())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(10, p.variable("a")),
+                                p.values(10, p.variable("b"))))
+                .doesNotFire();
+
+        tester().assertThat(new RemoveRedundantJoin())
+                .on(p ->
+                        p.join(
+                                FULL,
+                                p.values(10, p.variable("a")),
+                                p.values(10, p.variable("b"))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testInnerJoinRemoval()
+    {
+        tester().assertThat(new RemoveRedundantJoin())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(10, p.variable("a")),
+                                p.values(0)))
+                .matches(values("a"));
+
+        tester().assertThat(new RemoveRedundantJoin())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(0),
+                                p.values(10, p.variable("b"))))
+                .matches(values("b"));
+    }
+
+    @Test
+    public void testLeftJoinRemoval()
+    {
+        tester().assertThat(new RemoveRedundantJoin())
+                .on(p ->
+                        p.join(
+                                LEFT,
+                                p.values(0),
+                                p.values(10, p.variable("b"))))
+                .matches(values("a"));
+    }
+
+    @Test
+    public void testRightJoinRemoval()
+    {
+        tester().assertThat(new RemoveRedundantJoin())
+                .on(p ->
+                        p.join(
+                                RIGHT,
+                                p.values(10, p.variable("a")),
+                                p.values(0)))
+                .matches(values("a"));
+    }
+
+    @Test
+    public void testFullJoinRemoval()
+    {
+        tester().assertThat(new RemoveRedundantJoin())
+                .on(p ->
+                        p.join(
+                                FULL,
+                                p.values(0, p.variable("a")),
+                                p.values(0, p.variable("b"))))
+                .matches(values("a", "b"));
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
For table functions, when we have co-partitioning, we create joins on the partition keys to combine multiple sources into a single one for the table function. 

After some optimizations we may be left with one side of the join being empty. As a result of this, depending on the join, we can remove the join altogether and replace it with an empty values node. 

Taken out from PR:
https://github.com/prestodb/presto/pull/25032

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Further optimization of plan node tree.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Added new TestRemoveRedundantJoin.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

