### PR TITLE
[docs] Add Request Header Fields Too Large to /troubleshoot/

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -111,10 +111,11 @@ The default value ``0`` means that retries are disabled.
 * **Type:** ``data size``
 * **Default value:** ``8 kB``
 
-The maximum size of the request header from the HTTP server. Because Presto 
-sessions are encoded in the headers of all requests to Presto servers, 
-the default value can cause errors when large session properties or other 
-large session information is involved. If this happens, increase the value.
+The maximum size of the request header from the HTTP server. 
+
+Note: The default value can cause errors when large session properties 
+or other large session information is involved. 
+See :ref:`troubleshoot/query:\`\`Request Header Fields Too Large\`\``.
 
 Memory Management Properties
 ----------------------------

--- a/presto-docs/src/main/sphinx/sql/prepare.rst
+++ b/presto-docs/src/main/sphinx/sql/prepare.rst
@@ -17,6 +17,14 @@ queries that are saved in a session with a given name. The statement can
 include parameters in place of literals to be replaced at execution time.
 Parameters are represented by question marks.
 
+Note: If a query that includes ``PREPARE`` returns an error similar to the following: 
+
+.. code-block:: none
+
+    Request Header Fields Too Large
+
+see :ref:`troubleshoot/query:\`\`Request Header Fields Too Large\`\``.
+
 Examples
 --------
 

--- a/presto-docs/src/main/sphinx/troubleshoot.rst
+++ b/presto-docs/src/main/sphinx/troubleshoot.rst
@@ -9,3 +9,4 @@ and are grouped by topic.
     :maxdepth: 1
 
     troubleshoot/deploy
+    troubleshoot/query

--- a/presto-docs/src/main/sphinx/troubleshoot/query.rst
+++ b/presto-docs/src/main/sphinx/troubleshoot/query.rst
@@ -1,0 +1,47 @@
+=======
+Queries
+=======
+
+This page presents problems encountered with queries in Presto. 
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+``Request Header Fields Too Large``
+-----------------------------------
+
+Problem
+^^^^^^^
+
+A query may return an error similar to the following example: 
+
+.. code-block:: none
+
+    Error running command: Error starting query at http://localhost:8080/v1/statement 
+    returned an invalid response: JsonResponse{statusCode=431, statusMessage=Request 
+    Header Fields Too Large, headers={connection=[close], content-length=[74], 
+    content-type=[text/html;charset=iso-8859-1]}, hasValue=false} 
+    [Error: <h1>Bad Message 431</h1><pre>reason: Request Header Fields Too Large</pre>]
+
+Some examples of how this can happen are:
+
+* many session properties have been added to the query
+* putting a lot of information in ``clientInfo``
+* large security keys being sent in the session
+
+If such an error happens, increasing the value of ``http-server.max-request-header-size``  
+can help avoid it.
+
+Solution
+^^^^^^^^
+
+Edit ``config.properties`` for the Presto coordinator, and set the value of the 
+``http-server.max-request-header-size`` configuration property to a larger size. For example:
+
+.. code-block:: none
+
+    http-server.max-request-header-size=5MB
+
+See :ref:`admin/properties:\`\`http-server.max-request-header-size\`\``. 


### PR DESCRIPTION
## Description
* Add new page query.rst to [/troubleshoot/](https://github.com/prestodb/presto/tree/master/presto-docs/src/main/sphinx/troubleshoot) and [troubleshoot.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/troubleshoot.rst). 
* In query.rst, document how to fix a common error by setting the ``http-server.max-request-header-size`` configuration property to a larger value. 
Include a link from query.rst to ``http-server.max-request-header-size`` in [admin/properties.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/admin/properties.rst). 
* In [sql/prepare.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/sql/prepare.rst), add a Note about the error and a link to query.rst for more explanation and a possible solution.

## Motivation and Context
Addresses #25044, and also #13097, and probably other open issues. 

This is a common problem that @ZacBlanco recommended to me that we add the error and solution to the documentation. To do so, I first added ``http-server.max-request-header-size`` in [admin/properties.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/admin/properties.rst) in #25152 because that property was undocumented. 

## Impact
Documentation. 

## Test Plan
Local doc builds. Tested and verified that all new links work correctly. 

Screenshots of new material: 

<img width="1069" alt="Screenshot 2025-05-20 at 5 30 20 PM" src="https://github.com/user-attachments/assets/4a9fc715-e2bc-45cd-94ac-a3428aa462e0" />

<img width="794" alt="Screenshot 2025-05-20 at 5 30 49 PM" src="https://github.com/user-attachments/assets/5ab69c40-6cae-4177-8548-96906893f5dd" />



## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

