### PR TITLE
Add new rule to remove empty Window Functions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -118,6 +118,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSort;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantSortColumns;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantTopN;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantTopNColumns;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantWindow;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveTrivialFilters;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveUnreferencedScalarApplyNodes;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveUnreferencedScalarLateralNodes;
@@ -417,6 +418,7 @@ public class PlanOptimizers
                                         new PushLimitThroughSemiJoin(),
                                         new PushLimitThroughUnion(),
                                         new RemoveTrivialFilters(),
+                                        new RemoveRedundantWindow(),
                                         new ImplementFilteredAggregations(metadata.getFunctionAndTypeManager()),
                                         new SingleDistinctAggregationToGroupBy(),
                                         new MultipleDistinctAggregationToMarkDistinct(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantWindow.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveRedundantWindow.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.plan.WindowNode;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isEmpty;
+import static com.facebook.presto.sql.planner.plan.Patterns.window;
+
+public class RemoveRedundantWindow
+        implements Rule<WindowNode>
+{
+    private static final Pattern<WindowNode> PATTERN = window();
+
+    @Override
+    public Pattern<WindowNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(WindowNode window, Captures captures, Context context)
+    {
+        if (isEmpty(window.getSource(), context.getLookup())) {
+            return Result.ofPlanNode(new ValuesNode(window.getSource().getSourceLocation(), window.getId(), window.getOutputVariables(), ImmutableList.of(), Optional.empty()));
+        }
+        return Result.empty();
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/QueryCardinalityUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/QueryCardinalityUtil.java
@@ -64,6 +64,11 @@ public final class QueryCardinalityUtil
         return Range.closed(0L, maxCardinality).encloses(extractCardinality(node, lookup));
     }
 
+    public static boolean isEmpty(PlanNode node, Lookup lookup)
+    {
+        return isAtMost(node, lookup, 0);
+    }
+
     public static Range<Long> extractCardinality(PlanNode node)
     {
         return extractCardinality(node, noLookup());

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRemoveRedundantWindow.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestRemoveRedundantWindow.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule.test;
+
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantWindow;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRemoveRedundantWindow
+        extends BaseRuleTest
+{
+    @Test
+    public void testPruneWhenSourceEmpty()
+    {
+        tester().assertThat(new RemoveRedundantWindow())
+                .on(p -> p.window(
+                        new DataOrganizationSpecification(ImmutableList.of(), Optional.empty()),
+                        ImmutableMap.of(),
+                        p.values(p.variable("a"))))
+                .matches(
+                        values("a"));
+    }
+
+    @Test
+    public void testDoNotPruneWhenSourceNotEmpty()
+    {
+        tester().assertThat(new RemoveRedundantWindow())
+                .on(p -> p.window(
+                        new DataOrganizationSpecification(ImmutableList.of(), Optional.empty()),
+                        ImmutableMap.of(),
+                        p.values(5, p.variable("a"))))
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
For table function co-partitioning, we create a window function utilizing both rowNumber and countFunctions. However after further optimizations, ex removeRedundantJoins, it is possible that we end up with an empty source. We therefore can replace the window function with an empty values node containing just the column information. 

Taken out from PR:
https://github.com/prestodb/presto/pull/25032

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Further optimize table functions.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Added new test TestRemoveRedundantWindow.java
## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

