### PR TITLE
Presto router - Add security related headers for static resources served from Presto Router UI

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -144,7 +144,7 @@ public class CoordinatorModule
             "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
             "font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'; img-src http: https: data:";
 
-    private HttpResourceBinding webUIBinder(Binder binder, String path, String classPathResourceBase)
+    public static HttpResourceBinding webUIBinder(Binder binder, String path, String classPathResourceBase)
     {
         return httpServerBinder(binder).bindResource(path, classPathResourceBase)
                 .withExtraHeader(HttpHeaders.X_CONTENT_TYPE_OPTIONS, "nosniff")

--- a/presto-router/src/main/java/com/facebook/presto/router/RouterModule.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/RouterModule.java
@@ -41,9 +41,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import static com.facebook.airlift.concurrent.Threads.threadsNamed;
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
-import static com.facebook.airlift.http.server.HttpServerBinder.httpServerBinder;
 import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static com.facebook.presto.router.cluster.ClusterManager.ClusterStatusTracker;
+import static com.facebook.presto.server.CoordinatorModule.webUIBinder;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -72,7 +72,7 @@ public class RouterModule
         ServerConfig serverConfig = buildConfigObject(ServerConfig.class);
 
         binder.bind(RouterPluginManager.class).in(Scopes.SINGLETON);
-        httpServerBinder(binder).bindResource(UI_PATH, ROUTER_UI).withWelcomeFile(INDEX_HTML);
+        webUIBinder(binder, UI_PATH, ROUTER_UI).withWelcomeFile(INDEX_HTML);
         configBinder(binder).bindConfig(RouterConfig.class);
 
         if (customSchedulerManager.isPresent()) {


### PR DESCRIPTION
## Description
Add the following security headers to static resources, for Presto Router UI.

Add X-Content-Type-Options header and assign the value to 'nosniff'
Add Content-Security-Policy header and proper values
default-src: 'self'
style-src: 'self' 'unsafe-inline' https://fonts.googleapis.com/
font-src: self fonts.gstatic.com
frame-ancestors: self

## Motivation and Context

## Impact


## Test Plan
Check the response headers for the static resources

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Security Changes
* Add security-related headers to the static resources served from the Presto Router UI, including: ``Content-Security-Policy``, ``X-Content-Type-Options``. See reference docs `Content-Security-Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>`_ and  `X-Content-Type-Options <https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)>`_. :pr:`24272`
```
