### PR TITLE
[native] Enable sidecar in presto-native-tests module

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -172,6 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         storage-format: [ "PARQUET", "DWRF" ]
+        enable-sidecar: [ "true", "false" ]
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     env:
@@ -235,6 +236,7 @@ jobs:
             ${MAVEN_TEST} \
             -pl 'presto-native-tests' \
             -DstorageFormat=${{ matrix.storage-format }} \
+            -DsidecarEnabled=${{ matrix.enable-sidecar }} \
             -Dtest="${TESTCLASSES}" \
             -DPRESTO_SERVER=${PRESTO_SERVER_PATH} \
             -DDATA_DIR=${RUNNER_TEMP} \

--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -54,6 +54,26 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-native-sidecar-plugin</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-native-sidecar-plugin</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestOrderByQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestOrderByQueries.java
@@ -20,18 +20,27 @@ import com.facebook.presto.tests.AbstractTestOrderByQueries;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static java.lang.Boolean.parseBoolean;
+
 public class TestOrderByQueries
         extends AbstractTestOrderByQueries
 {
-    @Parameters("storageFormat")
+    @Parameters({"storageFormat", "sidecarEnabled"})
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+        boolean sidecar = parseBoolean(System.getProperty("sidecarEnabled"));
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
                 .setStorageFormat(System.getProperty("storageFormat"))
                 .setAddStorageFormatToPath(true)
                 .setUseThrift(true)
+                .setCoordinatorSidecarEnabled(sidecar)
                 .build();
+        if (sidecar) {
+            setupNativeSidecarPlugin(queryRunner);
+        }
+        return queryRunner;
     }
 
     @Parameters("storageFormat")

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestRepartitionQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestRepartitionQueries.java
@@ -19,18 +19,27 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestRepartitionQueries;
 import org.testng.annotations.Parameters;
 
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static java.lang.Boolean.parseBoolean;
+
 public class TestRepartitionQueries
         extends AbstractTestRepartitionQueries
 {
-    @Parameters("storageFormat")
+    @Parameters({"storageFormat", "sidecarEnabled"})
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+        boolean sidecar = parseBoolean(System.getProperty("sidecarEnabled"));
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
                 .setStorageFormat(System.getProperty("storageFormat"))
                 .setAddStorageFormatToPath(true)
                 .setUseThrift(true)
+                .setCoordinatorSidecarEnabled(sidecar)
                 .build();
+        if (sidecar) {
+            setupNativeSidecarPlugin(queryRunner);
+        }
+        return queryRunner;
     }
 
     @Parameters("storageFormat")


### PR DESCRIPTION
## Description
Enable sidecar in presto-native-tests module.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add sidecar in presto-native-tests module 
```

