### PR TITLE
fb_reshape_row always push down subfields

### DIFF
--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/TranslatorAnnotationParser.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/translator/TranslatorAnnotationParser.java
@@ -208,6 +208,7 @@ class TranslatorAnnotationParser
         private final Optional<OperatorType> operatorType;
         private final boolean deterministic;
         private final boolean calledOnNullInput;
+        private final int pushdownSubfieldArgIndex;
 
         public static List<ScalarTranslationHeader> fromAnnotatedElement(AnnotatedElement annotated)
         {
@@ -218,15 +219,15 @@ class TranslatorAnnotationParser
 
             if (scalarFunction != null) {
                 String baseName = scalarFunction.value().isEmpty() ? camelToSnake(annotatedName(annotated)) : scalarFunction.value();
-                builder.add(new ScalarTranslationHeader(baseName, scalarFunction.deterministic(), scalarFunction.calledOnNullInput()));
+                builder.add(new ScalarTranslationHeader(baseName, scalarFunction.deterministic(), scalarFunction.calledOnNullInput(), scalarFunction.pushdownSubfieldArgIndex()));
 
                 for (String alias : scalarFunction.alias()) {
-                    builder.add(new ScalarTranslationHeader(alias, scalarFunction.deterministic(), scalarFunction.calledOnNullInput()));
+                    builder.add(new ScalarTranslationHeader(alias, scalarFunction.deterministic(), scalarFunction.calledOnNullInput(), scalarFunction.pushdownSubfieldArgIndex()));
                 }
             }
 
             if (scalarOperator != null) {
-                builder.add(new ScalarTranslationHeader(scalarOperator.value(), true, scalarOperator.value().isCalledOnNullInput()));
+                builder.add(new ScalarTranslationHeader(scalarOperator.value(), true, scalarOperator.value().isCalledOnNullInput(), -1));
             }
 
             List<ScalarTranslationHeader> result = builder.build();
@@ -234,21 +235,23 @@ class TranslatorAnnotationParser
             return result;
         }
 
-        private ScalarTranslationHeader(String name, boolean deterministic, boolean calledOnNullInput)
+        private ScalarTranslationHeader(String name, boolean deterministic, boolean calledOnNullInput, int pushdownSubfieldArgIndex)
         {
             // TODO This is a hack. Engine should provide an API for connectors to overwrite functions. Connector should not hard code the builtin function namespace.
             this.name = requireNonNull(QualifiedObjectName.valueOf("presto", "default", name));
             this.operatorType = Optional.empty();
             this.deterministic = deterministic;
             this.calledOnNullInput = calledOnNullInput;
+            this.pushdownSubfieldArgIndex = pushdownSubfieldArgIndex;
         }
 
-        private ScalarTranslationHeader(OperatorType operatorType, boolean deterministic, boolean calledOnNullInput)
+        private ScalarTranslationHeader(OperatorType operatorType, boolean deterministic, boolean calledOnNullInput, int pushdownSubfieldArgIndex)
         {
             this.name = operatorType.getFunctionName();
             this.operatorType = Optional.of(operatorType);
             this.deterministic = deterministic;
             this.calledOnNullInput = calledOnNullInput;
+            this.pushdownSubfieldArgIndex = pushdownSubfieldArgIndex;
         }
 
         private static String annotatedName(AnnotatedElement annotatedElement)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -1187,6 +1187,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                     JAVA,
                     function.isDeterministic(),
                     function.isCalledOnNullInput(),
+                    function.getPushdownSubfieldArgIndex(),
                     function.getComplexTypeFunctionDescriptor());
         }
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/annotations/CodegenScalarFromAnnotationsParser.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/annotations/CodegenScalarFromAnnotationsParser.java
@@ -166,6 +166,15 @@ public class CodegenScalarFromAnnotationsParser
             {
                 return codegenScalarFunction.calledOnNullInput();
             }
+
+            @Override
+            public Optional<Integer> getPushdownSubfieldArgIndex()
+            {
+                if (codegenScalarFunction.pushdownSubfieldArgIndex() < 0) {
+                    return Optional.empty();
+                }
+                return Optional.of(codegenScalarFunction.pushdownSubfieldArgIndex());
+            }
         };
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -582,6 +582,13 @@ public class PushdownSubfields
                 if (expression instanceof VariableReferenceExpression) {
                     return Optional.of(new Subfield(((VariableReferenceExpression) expression).getName(), elements.build().reverse()));
                 }
+                if (expression instanceof CallExpression) {
+                    Optional<Integer> pushdownSubfieldArgIndex = functionAndTypeManager.getFunctionMetadata(((CallExpression) expression).getFunctionHandle()).getPushdownSubfieldArgIndex();
+                    if (pushdownSubfieldArgIndex.isPresent()) {
+                        expression = ((CallExpression) expression).getArguments().get(pushdownSubfieldArgIndex.get());
+                        continue;
+                    }
+                }
 
                 if (expression instanceof SpecialFormExpression && ((SpecialFormExpression) expression).getForm() == DEREFERENCE) {
                     SpecialFormExpression dereference = (SpecialFormExpression) expression;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/CodegenScalarFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/CodegenScalarFunction.java
@@ -33,4 +33,6 @@ public @interface CodegenScalarFunction
     boolean deterministic() default true;
 
     boolean calledOnNullInput() default false;
+
+    int pushdownSubfieldArgIndex() default -1;
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionMetadata.java
@@ -40,6 +40,7 @@ public class FunctionMetadata
     private final FunctionImplementationType implementationType;
     private final boolean deterministic;
     private final boolean calledOnNullInput;
+    private final Optional<Integer> pushdownSubfieldArgIndex;
     private final FunctionVersion version;
     private final ComplexTypeFunctionDescriptor descriptor;
 
@@ -63,9 +64,23 @@ public class FunctionMetadata
             FunctionImplementationType implementationType,
             boolean deterministic,
             boolean calledOnNullInput,
+            Optional<Integer> pushdownSubfieldArgIndex,
             ComplexTypeFunctionDescriptor functionDescriptor)
     {
-        this(name, Optional.empty(), argumentTypes, Optional.empty(), returnType, functionKind, Optional.empty(), implementationType, deterministic, calledOnNullInput, notVersioned(), functionDescriptor);
+        this(
+                name,
+                Optional.empty(),
+                argumentTypes,
+                Optional.empty(),
+                returnType,
+                functionKind,
+                Optional.empty(),
+                implementationType,
+                deterministic,
+                calledOnNullInput,
+                pushdownSubfieldArgIndex,
+                notVersioned(),
+                functionDescriptor);
     }
 
     public FunctionMetadata(
@@ -97,7 +112,7 @@ public class FunctionMetadata
             ComplexTypeFunctionDescriptor functionDescriptor)
     {
         this(name, Optional.empty(), argumentTypes, Optional.of(argumentNames), returnType, functionKind, Optional.of(language), implementationType, deterministic,
-                calledOnNullInput, version, functionDescriptor);
+                calledOnNullInput, Optional.empty(), version, functionDescriptor);
     }
 
     public FunctionMetadata(
@@ -122,7 +137,7 @@ public class FunctionMetadata
             boolean calledOnNullInput,
             ComplexTypeFunctionDescriptor functionDescriptor)
     {
-        this(operatorType.getFunctionName(), Optional.of(operatorType), argumentTypes, Optional.empty(), returnType, functionKind, Optional.empty(), implementationType, deterministic, calledOnNullInput, notVersioned(), functionDescriptor);
+        this(operatorType.getFunctionName(), Optional.of(operatorType), argumentTypes, Optional.empty(), returnType, functionKind, Optional.empty(), implementationType, deterministic, calledOnNullInput, Optional.empty(), notVersioned(), functionDescriptor);
     }
 
     private FunctionMetadata(
@@ -149,6 +164,7 @@ public class FunctionMetadata
                 implementationType,
                 deterministic,
                 calledOnNullInput,
+                Optional.empty(),
                 version,
                 defaultFunctionDescriptor());
     }
@@ -164,6 +180,7 @@ public class FunctionMetadata
             FunctionImplementationType implementationType,
             boolean deterministic,
             boolean calledOnNullInput,
+            Optional<Integer> pushdownSubfieldArgIndex,
             FunctionVersion version,
             ComplexTypeFunctionDescriptor functionDescriptor)
     {
@@ -177,6 +194,7 @@ public class FunctionMetadata
         this.implementationType = requireNonNull(implementationType, "implementationType is null");
         this.deterministic = deterministic;
         this.calledOnNullInput = calledOnNullInput;
+        this.pushdownSubfieldArgIndex = requireNonNull(pushdownSubfieldArgIndex, "pushdownSubfieldArgIndex is null");
         this.version = requireNonNull(version, "version is null");
         requireNonNull(functionDescriptor, "functionDescriptor is null");
         this.descriptor = new ComplexTypeFunctionDescriptor(
@@ -186,6 +204,7 @@ public class FunctionMetadata
                 functionDescriptor.getOutputToInputTransformationFunction(),
                 argumentTypes);
     }
+
     public FunctionKind getFunctionKind()
     {
         return functionKind;
@@ -234,6 +253,11 @@ public class FunctionMetadata
     public boolean isCalledOnNullInput()
     {
         return calledOnNullInput;
+    }
+
+    public Optional<Integer> getPushdownSubfieldArgIndex()
+    {
+        return pushdownSubfieldArgIndex;
     }
 
     public FunctionVersion getVersion()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/ScalarFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/ScalarFunction.java
@@ -34,4 +34,6 @@ public @interface ScalarFunction
     boolean deterministic() default true;
 
     boolean calledOnNullInput() default false;
+
+    int pushdownSubfieldArgIndex() default -1;
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunction.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.function;
 
+import java.util.Optional;
+
 import static com.facebook.presto.spi.function.ComplexTypeFunctionDescriptor.defaultFunctionDescriptor;
 
 public interface SqlFunction
@@ -24,6 +26,11 @@ public interface SqlFunction
     boolean isDeterministic();
 
     boolean isCalledOnNullInput();
+
+    default Optional<Integer> getPushdownSubfieldArgIndex()
+    {
+        return Optional.empty();
+    }
 
     String getDescription();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedScalarFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedScalarFunction.java
@@ -31,4 +31,6 @@ public @interface SqlInvokedScalarFunction
     boolean deterministic();
 
     boolean calledOnNullInput();
+
+    int pushdownSubfieldArgIndex() default -1;
 }


### PR DESCRIPTION
Summary:
T224244100
For fb_reshape_row udf, Presto should pushdown the utilized subfields of a struct during the optimizer phase.

Presto version 0.293-20250521.210824-350

Differential Revision: D74738214


