### PR TITLE
Always build the docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: docs
 
 on:
   pull_request:
-    paths:
-      - 'presto-docs/**'
 
 env:
   # An envar that signals to tests we are executing in the CI environment


### PR DESCRIPTION


## Description
There was a build failure on trunk because the docs failed to build.  Docs only build currently if there's a change detected in the docs directory.  However, there are some subtle interactions between the docs and the libraries and code that we use, so it's safest to always build the docs.

## Motivation and Context
There was a build failure on trunk reported due to this issue (#25177).

## Impact
Docs are relatively quick to build, so it should be safe to always build them.

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

