### PR TITLE
Change array_top_n to return null on bad n

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -149,6 +149,7 @@ import com.facebook.presto.operator.scalar.ArraySortComparatorFunction;
 import com.facebook.presto.operator.scalar.ArraySortFunction;
 import com.facebook.presto.operator.scalar.ArraySumBigIntFunction;
 import com.facebook.presto.operator.scalar.ArraySumDoubleFunction;
+import com.facebook.presto.operator.scalar.ArrayTesting;
 import com.facebook.presto.operator.scalar.ArrayTrimFunction;
 import com.facebook.presto.operator.scalar.ArrayUnionFunction;
 import com.facebook.presto.operator.scalar.ArraysOverlapFunction;
@@ -872,6 +873,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(ArrayLessThanOperator.class)
                 .scalar(ArrayLessThanOrEqualOperator.class)
                 .scalar(ArrayRemoveFunction.class)
+                .scalar(ArrayTesting.class)
                 .scalar(ArrayGreaterThanOperator.class)
                 .scalar(ArrayGreaterThanOrEqualOperator.class)
                 .scalar(ArrayElementAtFunction.class)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/ArrayTesting.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/ArrayTesting.java
@@ -1,0 +1,157 @@
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.NotSupportedException;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.OperatorDependency;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.google.common.primitives.Ints;
+
+import java.lang.invoke.MethodHandle;
+import java.util.AbstractList;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+
+@ScalarFunction("array_testing")
+@Description("Remove specified values from the given array")
+public final class ArrayTesting
+{
+    private ArrayTesting() {}
+
+    @TypeParameter("E")
+    @SqlType("array(E)")
+    public static Block sort(
+            @OperatorDependency(operator = GREATER_THAN, argumentTypes = {"E", "E"}) MethodHandle greaterThanFunction,
+            @TypeParameter("E") Type type,
+            @SqlType("array(E)") Block block,
+            @SqlType("E") long value)
+    {
+        int arrayLength = block.getPositionCount();
+
+        if (value < 0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Parameter n: " + value + " to ARRAY_TOP_N is negative");
+        }
+
+        if (arrayLength < 2) {
+            return block;
+        }
+
+        ListOfPositions listOfPositions = new ListOfPositions(arrayLength);
+        if (block.mayHaveNull()) {
+            listOfPositions.sort(new Comparator<Integer>()
+            {
+                @Override
+                public int compare(Integer p1, Integer p2)
+                {
+                    if (block.isNull(p1)) {
+                        return block.isNull(p2) ? 0 : 1;
+                    }
+                    else if (block.isNull(p2)) {
+                        return -1;
+                    }
+
+                    try {
+                        //TODO: This could be quite slow, it should use parametric equals
+                        return -type.compareTo(block, p1, block, p2);
+                    }
+                    catch (PrestoException | NotSupportedException e) {
+                        if (e instanceof NotSupportedException || ((PrestoException) e).getErrorCode() == NOT_SUPPORTED.toErrorCode()) {
+                            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Array contains elements not supported for comparison", e);
+                        }
+                        throw e;
+                    }
+                }
+            });
+        }
+        else {
+            listOfPositions.sort(new Comparator<Integer>()
+            {
+                @Override
+                public int compare(Integer p1, Integer p2)
+                {
+                    try {
+                        //TODO: This could be quite slow, it should use parametric equals
+                        return -type.compareTo(block, p1, block, p2);
+                    }
+                    catch (PrestoException | NotSupportedException e) {
+                        if (e instanceof NotSupportedException || ((PrestoException) e).getErrorCode() == NOT_SUPPORTED.toErrorCode()) {
+                            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "Array contains elements not supported for comparison", e);
+                        }
+                        throw e;
+                    }
+                }
+            });
+        }
+
+        List<Integer> sortedListOfPositions = listOfPositions.getSortedListOfPositions();
+
+        int size = Math.min(arrayLength, (int) value);
+
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, size);
+
+        for (int i = 0; i < size; i++) {
+            type.appendTo(block, sortedListOfPositions.get(i), blockBuilder);
+        }
+
+        return blockBuilder.build();
+    }
+
+    private static class ListOfPositions
+            extends AbstractList<Integer>
+    {
+        private final int size;
+        private List<Integer> sortedListOfPositions;
+
+        ListOfPositions(int size)
+        {
+            this.size = size;
+        }
+
+        @Override
+        public final int size()
+        {
+            return size;
+        }
+
+        @Override
+        public final Integer get(int i)
+        {
+            return i;
+        }
+
+        @Override
+        public final Integer set(int index, Integer position)
+        {
+            if (index != position) {
+                // The element at position is out of order.
+                if (sortedListOfPositions == null) {
+                    // So we need to store the entire position array in a new list.
+                    sortedListOfPositions = Ints.asList(new int[size()]);
+                    for (int i = 0; i < size(); i++) {
+                        sortedListOfPositions.set(i, i);
+                    }
+                }
+
+                // Set the new position to be used for this index.
+                sortedListOfPositions.set(index, position);
+            }
+
+            return position;
+        }
+
+        List<Integer> getSortedListOfPositions()
+        {
+            return sortedListOfPositions == null ? this : sortedListOfPositions;
+        }
+    }
+}
+


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
In presto an invalid n value for the function array_top_n would throw an error. For prestissimo it would return the value as null. We want the behavior seen in presto to match prestissimo so we will also output null instead of outputting an error.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
closes https://github.com/prestodb/presto/issues/24700

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Update :func:`array_top_n` to return ``NULL`` for invalid values of ``n`` to match the behavior of Prestissimo

