### PR TITLE
ci(native): Add container tests for sidecar

### DIFF
--- a/.github/workflows/prestocpp-linux-container-tests.yml
+++ b/.github/workflows/prestocpp-linux-container-tests.yml
@@ -1,0 +1,189 @@
+name: prestocpp-linux-container-tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - presto-native-execution/**
+      - presto-native-sidecar-plugin/**
+      - .github/workflows/prestocpp-linux-container-tests.yml
+
+env:
+  CONTINUOUS_INTEGRATION: true
+  DOCKER_BUILDKIT: 1
+  MAVEN_OPTS: -Xmx2G -XX:+ExitOnOutOfMemoryError
+  MAVEN_FAST_INSTALL: -B -V -T 1C -DskipTests -Dair.check.skip-all --no-transfer-progress -Dmaven.javadoc.skip=true
+  MAVEN_TEST: -B -Dair.check.skip-all -Dmaven.javadoc.skip=true --no-transfer-progress --fail-at-end
+
+# -----------------------------
+# Job 1: Build worker image
+# -----------------------------
+jobs:
+
+  build-worker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Free base disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          docker system prune -af
+          df -h
+
+      - name: Update velox
+        run: |
+          cd presto-native-execution
+          make velox-submodule
+
+      - name: Build dependency image
+        run: |
+          cd presto-native-execution
+          docker build \
+            -t presto-native-dependency:latest \
+            -f scripts/dockerfiles/centos-dependency.dockerfile \
+            --progress=plain \
+            .
+
+      - name: Build worker image (BuildKit)
+        run: |
+          cd presto-native-execution
+          export DOCKER_BUILDKIT=1
+          docker build \
+            -t presto-worker:latest \
+            --build-arg BUILD_TYPE=Release \
+            --build-arg DEPENDENCY_IMAGE=presto-native-dependency:latest \
+            --build-arg EXTRA_CMAKE_FLAGS="-DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_S3=ON -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON" \
+            --build-arg NUM_THREADS=2 \
+            -f scripts/dockerfiles/prestissimo-runtime.dockerfile \
+            --progress=plain \
+            .
+
+      - name: Save Docker image
+        run: |
+          docker save presto-worker:latest -o presto-worker.tar
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: presto-worker
+          retention-days: 1
+          path: presto-worker.tar
+
+  # -----------------------------
+  # Job 2: Build coordinator image
+  # -----------------------------
+  build-coordinator-image:
+    runs-on: ubuntu-latest
+    needs: build-worker-image
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Build Java artifacts only
+        run: |
+          ./mvnw clean install ${MAVEN_FAST_INSTALL} \
+            -pl '!:presto-product-tests,!:presto-router,!:presto-docs,!:presto-verifier,!:presto-test-coverage,!:presto-native-tests'
+
+      - name: Build coordinator image (BuildKit)
+        run: |
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+          cd docker
+
+          cp ../presto-server/target/presto-server-${VERSION}.tar.gz .
+          cp ../presto-cli/target/presto-cli-${VERSION}-executable.jar .
+          cp ../presto-function-server/target/presto-function-server-${VERSION}-executable.jar .
+
+          export DOCKER_BUILDKIT=1
+
+          docker build \
+            -t presto-coordinator:latest \
+            --build-arg PRESTO_VERSION=${VERSION} \
+            --progress=plain \
+            .
+
+      - name: Save Docker image
+        run: |
+          docker save presto-coordinator:latest -o presto-coordinator.tar
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: presto-coordinator
+          retention-days: 1
+          path: presto-coordinator.tar
+
+      - name: Archive Maven local repository
+        run: tar -czf maven-repo.tar.gz -C "$HOME" .m2/repository
+
+      - name: Upload Maven local repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-repo
+          retention-days: 1
+          path: maven-repo.tar.gz
+
+  # -----------------------------
+  # Job 3: Run container tests
+  # -----------------------------
+  run-container-tests:
+    runs-on: ubuntu-latest
+    needs: build-coordinator-image
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Download Maven local repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repo
+
+      - name: Restore Maven local repository
+        run: tar -xzf maven-repo.tar.gz -C "$HOME"
+
+      - name: Download worker image
+        uses: actions/download-artifact@v4
+        with:
+          name: presto-worker
+
+      - name: Download coordinator image
+        uses: actions/download-artifact@v4
+        with:
+          name: presto-coordinator
+
+      - name: Load Docker images
+        run: |
+          docker load -i "presto-coordinator.tar"
+          docker load -i "presto-worker.tar"
+
+      - name: Run presto-native container tests
+        run: |
+          export TESTFILES=$(find ./presto-native-execution/src/test -type f -name 'TestPrestoContainer*.java')
+          TESTCLASSES=$(echo "$TESTFILES" | sed 's|.*/||; s|\.java||' | paste -sd, -)
+          echo "TESTCLASSES=$TESTCLASSES"
+
+          ./mvnw test \
+            ${MAVEN_TEST} \
+            -pl presto-native-execution \
+            -Dtest="$TESTCLASSES" \
+            -DDATA_DIR="$RUNNER_TEMP" \
+            -Duser.timezone=America/Bahia_Banderas

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunner.java
@@ -47,6 +47,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.logging.Logger;
@@ -57,43 +58,114 @@ public class ContainerQueryRunner
         implements QueryRunner
 {
     protected static final Network network = Network.newNetwork();
+    protected static final Network networkExpected = Network.newNetwork();
     protected static final String PRESTO_COORDINATOR_IMAGE = System.getProperty("coordinatorImage", "presto-coordinator:latest");
     protected static final String PRESTO_WORKER_IMAGE = System.getProperty("workerImage", "presto-worker:latest");
     protected static final String CONTAINER_TIMEOUT = System.getProperty("containerTimeout", "120");
     protected static final String CLUSTER_SHUTDOWN_TIMEOUT = System.getProperty("clusterShutDownTimeout", "10");
     protected static final String BASE_DIR = System.getProperty("user.dir");
     protected static final int DEFAULT_COORDINATOR_PORT = 8080;
+    protected static final int DEFAULT_BASE_WORKER_PORT = 7778;
+    protected static final int DEFAULT_SIDECAR_PORT = 7777;
     protected static final int DEFAULT_FUNCTION_SERVER_PORT = 1122;
     protected static final String TPCH_CATALOG = "tpch";
     protected static final String TINY_SCHEMA = "tiny";
     protected static final int DEFAULT_NUMBER_OF_WORKERS = 4;
-
     protected static final Logger logger = Logger.getLogger(ContainerQueryRunner.class.getName());
-
     protected final GenericContainer<?> coordinator;
     protected final List<GenericContainer<?>> workers = new ArrayList<>();
+    protected final Optional<GenericContainer<?>> sidecar;
     protected final int coordinatorPort;
     protected final String catalog;
     protected final String schema;
+    protected final int numberOfWorkers;
     protected GenericContainer<?> functionServer;
     protected int functionServerPort;
     protected boolean enableFunctionServer;
     protected Connection connection;
 
+    public static class Config
+    {
+        private int coordinatorPort = DEFAULT_COORDINATOR_PORT;
+        private String catalog = TPCH_CATALOG;
+        private String schema = TINY_SCHEMA;
+        private int numberOfWorkers = DEFAULT_NUMBER_OF_WORKERS;
+        private boolean nativeCluster = true;
+        private boolean sidecarEnabled;
+        private int functionServerPort = DEFAULT_FUNCTION_SERVER_PORT;
+        private boolean functionServerEnabled;
+
+        public Config setCoordinatorPort(int coordinatorPort)
+        {
+            this.coordinatorPort = coordinatorPort;
+            return this;
+        }
+
+        public Config setCatalog(String catalog)
+        {
+            this.catalog = catalog;
+            return this;
+        }
+
+        public Config setSchema(String schema)
+        {
+            this.schema = schema;
+            return this;
+        }
+
+        public Config setNumberOfWorkers(int numberOfWorkers)
+        {
+            this.numberOfWorkers = numberOfWorkers;
+            return this;
+        }
+
+        public Config setNativeCluster(boolean nativeCluster)
+        {
+            this.nativeCluster = nativeCluster;
+            return this;
+        }
+
+        public Config setSidecarEnabled(boolean sidecarEnabled)
+        {
+            this.sidecarEnabled = sidecarEnabled;
+            return this;
+        }
+
+        public Config setFunctionServerPort(int functionServerPort)
+        {
+            this.functionServerPort = functionServerPort;
+            return this;
+        }
+
+        public Config setFunctionServerEnabled(boolean functionServerEnabled)
+        {
+            this.functionServerEnabled = functionServerEnabled;
+            return this;
+        }
+    }
+
     public ContainerQueryRunner()
             throws InterruptedException, IOException
     {
-        this(DEFAULT_COORDINATOR_PORT, TPCH_CATALOG, TINY_SCHEMA, DEFAULT_NUMBER_OF_WORKERS, DEFAULT_FUNCTION_SERVER_PORT, false);
+        this(new Config());
     }
 
-    public ContainerQueryRunner(int coordinatorPort, String catalog, String schema, int numberOfWorkers, int functionServerPort, boolean enableFunctionServer)
-            throws InterruptedException, IOException
+    public ContainerQueryRunner(Config config)
+            throws IOException, InterruptedException
+    {
+        this(config.coordinatorPort, config.catalog, config.schema, config.numberOfWorkers,
+                config.nativeCluster, config.sidecarEnabled, config.functionServerPort, config.functionServerEnabled);
+    }
+
+    public ContainerQueryRunner(int coordinatorPort, String catalog, String schema, int numberOfWorkers, boolean isNativeCluster, boolean isSidecarEnabled, int functionServerPort, boolean enableFunctionServer)
+            throws IOException, InterruptedException
     {
         this.coordinatorPort = coordinatorPort;
         this.catalog = catalog;
         this.schema = schema;
         this.functionServerPort = functionServerPort;
         this.enableFunctionServer = enableFunctionServer;
+        this.numberOfWorkers = numberOfWorkers;
 
         // Start function server first if enabled
         if (enableFunctionServer) {
@@ -102,22 +174,75 @@ public class ContainerQueryRunner
             logger.info("Presto function server is deployed at http://" + functionServer.getHost() + ":" + functionServer.getMappedPort(functionServerPort));
         }
 
-        this.coordinator = createCoordinator();
-        for (int i = 0; i < numberOfWorkers; i++) {
-            workers.add(createNativeWorker(7777 + i, "native-worker-" + i));
+        if (isSidecarEnabled) {
+            GenericContainer<?> sidecarContainer = createSidecar(DEFAULT_SIDECAR_PORT, "sidecar", isNativeCluster);
+            sidecarContainer.start();
+            this.sidecar = Optional.of(sidecarContainer);
+        }
+        else {
+            this.sidecar = Optional.empty();
         }
 
+        this.coordinator = createCoordinator(isNativeCluster, isSidecarEnabled);
         coordinator.start();
-        workers.forEach(GenericContainer::start);
+        startWorkers(numberOfWorkers, isNativeCluster, isSidecarEnabled);
 
         TimeUnit.SECONDS.sleep(5);
 
+        startCoordinatorAndLogUI();
+        initializeConnection();
+        cleanupDirectories(numberOfWorkers, isNativeCluster, isSidecarEnabled, enableFunctionServer);
+    }
+
+    private void startWorkers(int numberOfWorkers, boolean isNativeCluster, boolean isSidecarEnabled)
+            throws InterruptedException, IOException
+    {
+        ContainerQueryRunnerUtils.deleteDirectory(BASE_DIR + "/testcontainers/coordinator");
+
+        if (isNativeCluster) {
+            for (int i = 0; i < numberOfWorkers; i++) {
+                workers.add(createNativeWorker(DEFAULT_BASE_WORKER_PORT + i, "native-worker-" + i, true, isSidecarEnabled, false));
+            }
+        }
+        else {
+            for (int i = 0; i < numberOfWorkers; i++) {
+                workers.add(createJavaWorker(DEFAULT_BASE_WORKER_PORT + i, "java-worker-" + i));
+            }
+        }
+
+        workers.forEach(GenericContainer::start);
+    }
+
+    private void cleanupDirectories(int numberOfWorkers, boolean isNativeCluster, boolean isSidecarEnabled, boolean isFunctionServerEnabled)
+    {
+        for (int i = 0; i < numberOfWorkers; i++) {
+            String workerType = isNativeCluster ? "native-worker-" : "java-worker-";
+            ContainerQueryRunnerUtils.deleteDirectory(BASE_DIR + "/testcontainers/" + workerType + i);
+        }
+
+        if (isSidecarEnabled) {
+            ContainerQueryRunnerUtils.deleteDirectory(BASE_DIR + "/testcontainers/sidecar");
+        }
+
+        if (isFunctionServerEnabled) {
+            ContainerQueryRunnerUtils.deleteDirectory(BASE_DIR + "/testcontainers/function-server");
+        }
+    }
+
+    private void startCoordinatorAndLogUI()
+    {
         String dockerHostIp = coordinator.getHost();
         logger.info("Presto UI is accessible at http://" + dockerHostIp + ":" + coordinator.getMappedPort(coordinatorPort));
+    }
+
+    private void initializeConnection()
+    {
+        String dockerHostIp = coordinator.getHost();
+        int mappedPort = coordinator.getMappedPort(coordinatorPort);
 
         String url = String.format("jdbc:presto://%s:%s/%s/%s?%s",
                 dockerHostIp,
-                coordinator.getMappedPort(coordinatorPort),
+                mappedPort,
                 catalog,
                 schema,
                 enableFunctionServer ? "timeZoneId=UTC&sessionProperties=remote_functions_enabled:true" : "timeZoneId=UTC");
@@ -128,24 +253,17 @@ public class ContainerQueryRunner
         catch (SQLException e) {
             throw new RuntimeException(e);
         }
-
-        // Delete the temporary files once the containers are started.
-        ContainerQueryRunnerUtils.deleteDirectory(BASE_DIR + "/testcontainers/coordinator");
-        for (GenericContainer<?> worker : workers) {
-            String alias = worker.getNetworkAliases().get(1);
-            ContainerQueryRunnerUtils.deleteDirectory(BASE_DIR + "/testcontainers/" + alias);
-        }
-        if (enableFunctionServer) {
-            ContainerQueryRunnerUtils.deleteDirectory(BASE_DIR + "/testcontainers/function-server");
-        }
     }
 
-    protected GenericContainer<?> createCoordinator()
+    protected GenericContainer<?> createCoordinator(boolean isNativeCluster, boolean isSidecarEnabled)
             throws IOException
     {
         ContainerQueryRunnerUtils.createCoordinatorTpchProperties();
         ContainerQueryRunnerUtils.createCoordinatorTpcdsProperties();
-        ContainerQueryRunnerUtils.createCoordinatorConfigProperties(coordinatorPort);
+        ContainerQueryRunnerUtils.createCoordinatorConfigProperties(coordinatorPort, isNativeCluster, isSidecarEnabled);
+        if (isSidecarEnabled && isNativeCluster) {
+            ContainerQueryRunnerUtils.createCoordinatorSidecarProperties();
+        }
         ContainerQueryRunnerUtils.createCoordinatorJvmConfig();
         ContainerQueryRunnerUtils.createCoordinatorLogProperties();
         ContainerQueryRunnerUtils.createCoordinatorNodeProperties();
@@ -155,7 +273,7 @@ public class ContainerQueryRunner
         }
 
         return new GenericContainer<>(PRESTO_COORDINATOR_IMAGE)
-                .withNetwork(network)
+                .withNetwork(isNativeCluster ? network : networkExpected)
                 .withNetworkAliases("presto-coordinator")
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/coordinator/etc"), "/opt/presto-server/etc")
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/coordinator/entrypoint.sh"), "/opt/entrypoint.sh")
@@ -163,21 +281,43 @@ public class ContainerQueryRunner
                 .withStartupTimeout(Duration.ofSeconds(Long.parseLong(CONTAINER_TIMEOUT)))
                 .withExposedPorts(coordinatorPort);
     }
-
-    protected GenericContainer<?> createNativeWorker(int port, String nodeId)
+    protected GenericContainer<?> createJavaWorker(int port, String nodeId)
             throws IOException
     {
-        ContainerQueryRunnerUtils.createNativeWorkerConfigPropertiesWithFunctionServer(coordinatorPort, functionServerPort, nodeId);
+        ContainerQueryRunnerUtils.createJavaWorkerConfigProperties(port, coordinatorPort, nodeId);
         ContainerQueryRunnerUtils.createNativeWorkerTpchProperties(nodeId);
+        ContainerQueryRunnerUtils.createJavaEntryPointScript(nodeId);
+        ContainerQueryRunnerUtils.createNativeWorkerNodeProperties(nodeId);
+        return new GenericContainer<>(PRESTO_COORDINATOR_IMAGE)
+                .withExposedPorts(port)
+                .withNetwork(networkExpected)
+                .withNetworkAliases(nodeId)
+                .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/etc"), "/opt/presto-server/etc")
+                .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh"), "/opt/entrypoint.sh");
+    }
+
+    protected GenericContainer<?> createSidecar(int port, String nodeId, boolean isNativeCluster)
+            throws IOException
+    {
+        return createNativeWorker(port, nodeId, isNativeCluster, true, true);
+    }
+
+    private GenericContainer<?> createNativeWorker(int port, String nodeId, boolean isNativeCluster, boolean isSidecarEnabled, boolean isSidecarNode)
+            throws IOException
+    {
+        ContainerQueryRunnerUtils.createNativeWorkerConfigProperties(coordinatorPort, port, functionServerPort, nodeId, isSidecarEnabled, isSidecarNode);
+        if (!isSidecarEnabled) {
+            ContainerQueryRunnerUtils.createNativeWorkerTpchProperties(nodeId);
+        }
         ContainerQueryRunnerUtils.createNativeWorkerEntryPointScript(nodeId);
         ContainerQueryRunnerUtils.createNativeWorkerNodeProperties(nodeId);
         return new GenericContainer<>(PRESTO_WORKER_IMAGE)
                 .withExposedPorts(port)
-                .withNetwork(network)
+                .withNetwork(isNativeCluster ? network : networkExpected)
                 .withNetworkAliases(nodeId)
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/etc"), "/opt/presto-server/etc")
                 .withCopyFileToContainer(MountableFile.forHostPath(BASE_DIR + "/testcontainers/" + nodeId + "/entrypoint.sh"), "/opt/entrypoint.sh")
-                .waitingFor(Wait.forLogMessage(".*Announcement succeeded: HTTP 202.*", 1));
+                .waitingFor(isSidecarNode ? Wait.forListeningPort() : Wait.forLogMessage(".*Announcement succeeded: HTTP 202.*", 1));
     }
 
     protected GenericContainer<?> createFunctionServer()
@@ -208,6 +348,7 @@ public class ContainerQueryRunner
         }
         coordinator.stop();
         workers.forEach(GenericContainer::stop);
+        sidecar.ifPresent(GenericContainer::stop);
         if (functionServer != null) {
             functionServer.stop();
         }
@@ -371,7 +512,7 @@ public class ContainerQueryRunner
             return ContainerQueryRunnerUtils.toMaterializedResult(resultSet);
         }
         catch (SQLException e) {
-            throw new RuntimeException("Error executing query: " + sql, e);
+            throw new RuntimeException("Error executing query: " + sql + "\n" + e.getMessage(), e);
         }
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/ContainerQueryRunnerUtils.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.SmallintType;
 import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.TimestampType;
@@ -48,7 +49,9 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 public class ContainerQueryRunnerUtils
@@ -82,19 +85,37 @@ public class ContainerQueryRunnerUtils
         createPropertiesFile("testcontainers/" + nodeId + "/etc/catalog/tpch.properties", properties);
     }
 
-    public static void createNativeWorkerConfigPropertiesWithFunctionServer(int coordinatorPort, int functionServerPort, String nodeId)
+    public static void createNativeWorkerConfigProperties(
+            int coordinatorPort,
+            int workerPort,
+            int functionServerPort,
+            String nodeId,
+            boolean isSidecarEnabled,
+            boolean isSidecarNode)
             throws IOException
     {
         Properties properties = new Properties();
         properties.setProperty("presto.version", "testversion");
-        properties.setProperty("http-server.http.port", "7777");
+        properties.setProperty("http-server.http.port", Integer.toString(workerPort));
         properties.setProperty("discovery.uri", "http://presto-coordinator:" + coordinatorPort);
         properties.setProperty("system-memory-gb", "2");
+
+        if (isSidecarEnabled) {
+            properties.setProperty("presto.default-namespace", "native.default");
+            properties.setProperty("native-sidecar", String.valueOf(isSidecarNode));
+        }
+
         properties.setProperty("remote-function-server.rest.url", "http://presto-remote-function-server:" + functionServerPort);
         createPropertiesFile("testcontainers/" + nodeId + "/etc/config.properties", properties);
     }
 
     public static void createCoordinatorConfigProperties(int port)
+            throws IOException
+    {
+        createCoordinatorConfigProperties(port, true, false);
+    }
+
+    public static void createCoordinatorConfigProperties(int port, boolean isNativeCluster, boolean isSidecarEnabled)
             throws IOException
     {
         Properties properties = new Properties();
@@ -105,15 +126,63 @@ public class ContainerQueryRunnerUtils
         properties.setProperty("discovery-server.enabled", "true");
         properties.setProperty("discovery.uri", "http://presto-coordinator:" + port);
         properties.setProperty("list-built-in-functions-only", "false");
-        properties.setProperty("native-execution-enabled", "true");
+        if (isSidecarEnabled) {
+            Map<String, String> sidecarProperties = NativeQueryRunnerUtils.getNativeSidecarProperties();
+            for (Map.Entry<String, String> entry : sidecarProperties.entrySet()) {
+                properties.setProperty(entry.getKey(), entry.getValue());
+            }
+            properties.setProperty("expression-optimizer-name", "native");
+        }
 
-        // Get native worker system properties and add them to the coordinator properties
-        Map<String, String> nativeWorkerProperties = NativeQueryRunnerUtils.getNativeWorkerSystemProperties();
-        for (Map.Entry<String, String> entry : nativeWorkerProperties.entrySet()) {
-            properties.setProperty(entry.getKey(), entry.getValue());
+        if (isNativeCluster) {
+            // Get native worker system properties and add them to the coordinator properties
+            Map<String, String> nativeWorkerProperties = NativeQueryRunnerUtils.getNativeWorkerSystemProperties();
+            for (Map.Entry<String, String> entry : nativeWorkerProperties.entrySet()) {
+                if (!properties.containsKey(entry.getKey())) {
+                    properties.setProperty(entry.getKey(), entry.getValue());
+                }
+            }
         }
 
         createPropertiesFile("testcontainers/coordinator/etc/config.properties", properties);
+    }
+
+    public static void createJavaWorkerConfigProperties(int port, int coordinatorPort, String nodeId)
+            throws IOException
+    {
+        Properties properties = new Properties();
+        properties.setProperty("coordinator", "false");
+        properties.setProperty("presto.version", "testversion");
+        properties.setProperty("node-scheduler.include-coordinator", "false");
+        properties.setProperty("http-server.http.port", Integer.toString(port));
+        properties.setProperty("discovery.uri", "http://presto-coordinator:" + coordinatorPort);
+        createPropertiesFile("testcontainers/" + nodeId + "/etc/config.properties", properties);
+    }
+
+    public static void createCoordinatorSidecarProperties()
+            throws IOException
+    {
+        Properties functionNamespaceProps = new Properties();
+        functionNamespaceProps.setProperty("function-namespace-manager.name", "native");
+        functionNamespaceProps.setProperty("function-implementation-type", "CPP");
+        functionNamespaceProps.setProperty("supported-function-languages", "CPP");
+        createPropertiesFile("testcontainers/coordinator/etc/function-namespace/native.properties", functionNamespaceProps);
+
+        Properties sessionProviderProps = new Properties();
+        sessionProviderProps.setProperty("session-property-provider.name", "native-worker");
+        createPropertiesFile("testcontainers/coordinator/etc/session-property-providers/native-worker.properties", sessionProviderProps);
+
+        Properties typeManagerProps = new Properties();
+        typeManagerProps.setProperty("type-manager.name", "native");
+        createPropertiesFile("testcontainers/coordinator/etc/type-managers/native.properties", typeManagerProps);
+
+        Properties planCheckerProps = new Properties();
+        planCheckerProps.setProperty("plan-checker-provider.name", "native");
+        createPropertiesFile("testcontainers/coordinator/etc/plan-checker-providers/native.properties", planCheckerProps);
+
+        Properties expressionManagerProps = new Properties();
+        expressionManagerProps.setProperty("expression-manager-factory.name", "native");
+        createPropertiesFile("testcontainers/coordinator/etc/expression-manager/native.properties", expressionManagerProps);
     }
 
     public static void createRestRemoteProperties(int functionServerPort)
@@ -192,13 +261,7 @@ public class ContainerQueryRunnerUtils
     public static void createCoordinatorEntryPointScript()
             throws IOException
     {
-        String scriptContent = "#!/bin/sh\n" +
-                "set -e\n" +
-                "trap 'kill -TERM $app 2>/dev/null' TERM\n" +
-                "$PRESTO_HOME/bin/launcher run &\n" +
-                "app=$!\n" +
-                "wait $app";
-        createScriptFile("testcontainers/coordinator/entrypoint.sh", scriptContent);
+        createJavaEntryPointScript("coordinator");
     }
 
     public static void createFunctionServerEntryPointScript()
@@ -221,6 +284,18 @@ public class ContainerQueryRunnerUtils
         String scriptContent = "#!/bin/sh\n\n" +
                 "GLOG_logtostderr=1 presto_server \\\n" +
                 "    --etc-dir=/opt/presto-server/etc\n";
+        createScriptFile("testcontainers/" + nodeId + "/entrypoint.sh", scriptContent);
+    }
+
+    public static void createJavaEntryPointScript(String nodeId)
+            throws IOException
+    {
+        String scriptContent = "#!/bin/sh\n" +
+                "set -e\n" +
+                "trap 'kill -TERM $app 2>/dev/null' TERM\n" +
+                "$PRESTO_HOME/bin/launcher run &\n" +
+                "app=$!\n" +
+                "wait $app";
         createScriptFile("testcontainers/" + nodeId + "/entrypoint.sh", scriptContent);
     }
 
@@ -392,6 +467,9 @@ public class ContainerQueryRunnerUtils
             case java.sql.Types.VARBINARY:
             case java.sql.Types.LONGVARBINARY:
                 return VarbinaryType.VARBINARY;
+            case java.sql.Types.NULL:
+                // This happens in select fail() or similar cases
+                return VarcharType.createUnboundedVarcharType();
             case java.sql.Types.OTHER:
                 // Attempt to map based on type name
                 return mapSqlTypeNameToType(typeName);
@@ -400,9 +478,74 @@ public class ContainerQueryRunnerUtils
         }
     }
 
+    /**
+     * Splits a comma-separated list of ROW field tokens at the top level only,
+     * ignoring commas that appear inside parentheses (e.g. DECIMAL(10,2), ARRAY(...)).
+     */
+    private static List<String> splitTopLevelCommas(String input)
+    {
+        List<String> result = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == '(') {
+                depth++;
+            }
+            else if (c == ')') {
+                depth--;
+            }
+            else if (c == ',' && depth == 0) {
+                result.add(input.substring(start, i));
+                start = i + 1;
+            }
+        }
+        result.add(input.substring(start));
+        return result;
+    }
+
     private static Type mapSqlTypeNameToType(String typeName)
     {
-        switch (typeName.toUpperCase()) {
+        String upperTypeName = typeName.toUpperCase(Locale.ENGLISH).trim();
+
+        // Handle flat ROW types like ROW(VARCHAR, INTEGER) or ROW(a VARCHAR, b INTEGER).
+        // Fields are split using a depth-aware scan so that parameterized types such as
+        // DECIMAL(10,2) or ARRAY(VARCHAR) are not incorrectly split on the inner commas.
+        if (upperTypeName.startsWith("ROW(") && upperTypeName.endsWith(")")) {
+            String fieldsPart = upperTypeName.substring(4, upperTypeName.length() - 1).trim();
+
+            List<String> fieldTokens = splitTopLevelCommas(fieldsPart);
+
+            List<RowType.Field> rowFields = new ArrayList<>();
+            for (int i = 0; i < fieldTokens.size(); i++) {
+                String token = fieldTokens.get(i).trim();
+
+                // Handle both: "a VARCHAR" and "VARCHAR"
+                String[] parts = token.split("\\s+", 2);
+                String fieldName;
+                String fieldType;
+
+                if (parts.length == 2) {
+                    fieldName = parts[0];
+                    fieldType = parts[1];
+                }
+                else {
+                    fieldName = "field" + i;
+                    fieldType = parts[0];
+                }
+
+                Type innerType = mapSqlTypeNameToType(fieldType);
+                rowFields.add(new RowType.Field(Optional.of(fieldName), innerType));
+            }
+
+            return RowType.from(rowFields);
+        }
+
+        // remove parameters like VARCHAR(7), DECIMAL(10,2)
+        int paramStart = upperTypeName.indexOf('(');
+        String baseType = paramStart > 0 ? upperTypeName.substring(0, paramStart) : upperTypeName;
+
+        switch (baseType) {
             case "INT":
             case "INTEGER":
             case "INT4":

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -61,6 +61,7 @@ public class NativeQueryRunnerUtils
                 .put("presto.default-namespace", "native.default")
                 // inline-sql-functions is overridden to be true in sidecar enabled native clusters.
                 .put("inline-sql-functions", "true")
+                .put("plugin.dir", "/opt/presto-server/native-plugin/")
                 .build();
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoContainerRemoteFunction.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoContainerRemoteFunction.java
@@ -30,13 +30,9 @@ public class TestPrestoContainerRemoteFunction
     protected ContainerQueryRunner createQueryRunner()
             throws Exception
     {
-        return new ContainerQueryRunner(
-                ContainerQueryRunner.DEFAULT_COORDINATOR_PORT,
-                ContainerQueryRunner.TPCH_CATALOG,
-                ContainerQueryRunner.TINY_SCHEMA,
-                ContainerQueryRunner.DEFAULT_NUMBER_OF_WORKERS,
-                ContainerQueryRunner.DEFAULT_FUNCTION_SERVER_PORT,
-                true);
+        return new ContainerQueryRunner(new ContainerQueryRunner.Config()
+                .setNativeCluster(true)
+                .setFunctionServerEnabled(true));
     }
 
     @Test

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoContainerSidecarDisabledInfrastructure.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoContainerSidecarDisabledInfrastructure.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+public class TestPrestoContainerSidecarDisabledInfrastructure
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected ContainerQueryRunner createQueryRunner()
+            throws Exception
+    {
+        return new ContainerQueryRunner(new ContainerQueryRunner.Config()
+                .setNativeCluster(true)
+                .setSidecarEnabled(false));
+    }
+
+    @Override
+    protected ContainerQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return new ContainerQueryRunner(new ContainerQueryRunner.Config()
+                .setNativeCluster(false)
+                .setSidecarEnabled(false));
+    }
+
+    @Test
+    public void testNativeCluster()
+            throws Exception
+    {
+        assertQuerySucceeds("SHOW FUNCTIONS");
+        assertQueryFails("SELECT fail('forced failure')", "(?s).*Top-level Expression: presto\\.default\\.fail\\(forced failure:VARCHAR\\).*", true);
+        assertQuerySucceeds("SHOW SESSION");
+    }
+
+    @Test
+    public void testJavaCluster()
+            throws Exception
+    {
+        assertQuerySucceedsExpected("SHOW FUNCTIONS");
+        assertQueryFailsExpected("SELECT fail('forced failure')", "Query failed .*.: forced failure", true);
+        assertQuerySucceedsExpected("SHOW SESSION");
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoContainerSidecarEnabledInfrastructure.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoContainerSidecarEnabledInfrastructure.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+public class TestPrestoContainerSidecarEnabledInfrastructure
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected ContainerQueryRunner createQueryRunner()
+            throws Exception
+    {
+        return new ContainerQueryRunner(new ContainerQueryRunner.Config()
+                .setNativeCluster(true)
+                .setSidecarEnabled(true));
+    }
+
+    @Test
+    public void testNativeCluster()
+            throws Exception
+    {
+        assertQuerySucceeds("SHOW FUNCTIONS");
+        assertQueryFails("SELECT fail('forced failure')", "(?s).*Top-level Expression: native\\.default\\.fail\\(forced failure:VARCHAR\\).*", true);
+        assertQuerySucceeds("SHOW SESSION");
+        // Cast to VARCHAR to avoid Java/native VARCHAR type mismatch.
+        assertQuerySucceeds("select array_sort(array[row(cast('apples' as varchar), 23), row(cast('bananas' as varchar), 12), row(cast('grapes' as varchar), 44)], x -> x[2])");
+        assertQuerySucceeds("SELECT now()");
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -311,6 +311,19 @@ public abstract class AbstractTestQueryFramework
         QueryAssertions.assertQuerySucceeds(queryRunner, getSession(), sql);
     }
 
+    /**
+     * Runs {@code sql} against the <em>expected</em> query runner (the runner returned by
+     * {@link #createExpectedQueryRunner()}) and asserts that it succeeds.
+     * <p>
+     * Note: the "Expected" suffix refers to <em>which runner</em> executes the query, not to
+     * the asserted outcome. Use {@link #assertQuerySucceeds(String)} to run against the primary runner.
+     */
+    protected void assertQuerySucceedsExpected(@Language("SQL") String sql)
+    {
+        QueryRunner expectedRunner = (QueryRunner) expectedQueryRunner;
+        QueryAssertions.assertQuerySucceeds(expectedRunner, expectedRunner.getDefaultSession(), sql);
+    }
+
     protected void assertQueryFailsEventually(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, Duration timeout)
     {
         QueryAssertions.assertQueryFailsEventually(queryRunner, getSession(), sql, expectedMessageRegExp, timeout);
@@ -339,6 +352,20 @@ public abstract class AbstractTestQueryFramework
     protected void assertQueryFails(Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)
     {
         QueryAssertions.assertQueryFails(queryRunner, session, sql, expectedMessageRegExp);
+    }
+
+    /**
+     * Runs {@code sql} against the <em>expected</em> query runner (the runner returned by
+     * {@link #createExpectedQueryRunner()}) and asserts that it fails with an error message
+     * matching {@code expectedMessageRegExp}.
+     * <p>
+     * Note: the "Expected" suffix refers to <em>which runner</em> executes the query, not to
+     * the asserted outcome. Use {@link #assertQueryFails(String, String)} to run against the primary runner.
+     */
+    protected void assertQueryFailsExpected(@Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp, boolean usePatternMatcher)
+    {
+        QueryRunner expectedRunner = (QueryRunner) expectedQueryRunner;
+        QueryAssertions.assertQueryFails(expectedRunner, expectedRunner.getDefaultSession(), sql, expectedMessageRegExp, usePatternMatcher, false);
     }
 
     protected void assertQueryError(QueryRunner queryRunner, Session session, @Language("SQL") String sql, @Language("RegExp") String expectedMessageRegExp)


### PR DESCRIPTION
## Description
Implement container based test cases for Java/native clusters.

**Test matrix: Native cluster**
1. Coordinator with sidecar running
 - Function analysis works correctly
      - select query with fail function fails (not registered in C++)
      - select query with X function succeeds (X is registered in C++ but not in Java)
           - array_sort example
- Show functions works correctly
    - Returns functions in the native.default namespace. 
2.  Coordinator with no sidecar running
- Queries pause for a time, and eventually fail after N seconds

**Test Matrix :Java cluster**

1. Coordinator with sidecar running
- Queries fail due to invalid configuration
2. Coordinator with no sidecar running
- Function analysis works correctly
     - select query with fail function succeeds
     -  select query with X function fails (X is registered in C++ but not in Java)
- Show functions works correctly
     - Returns functions in the presto.default namespace
- Show session works correctly
     - Java spilling properties present in session properties

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

