### PR TITLE
Fix vulnerability issues in commons-httpclient and commons-configuration

### DIFF
--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -274,6 +274,44 @@
                     <groupId>org.webjars</groupId>
                     <artifactId>swagger-ui</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-configuration</groupId>
+                    <artifactId>commons-configuration</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.12.0</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Fix the vulnerability issues in commons-httpclient and commons-configuration

1. Replace dependency from commons-httpclient to httpclient:4.5.14 to address CVE-2012-5783 and CVE-2012-6153
The latest version of commons-httpclient:3.1 is known to have vulnerabilities. This artifact has been migrated to httpclient, and the latest version httpclient:4.5.14 is free from known vulnerabilities. Therefore, it has been replaced with the updated artifact.

2. Replace dependency from commons-configuration to commons-configuration2:2.12.0 to address CVE-2025-46392
The latest version of commons-configuration:1.10 is known to have vulnerabilities. This artifact has been migrated to commons-configuration2, and the latest version commons-configuration2:2.12.0 free from known vulnerabilities. Therefore, it has been replaced with the updated artifact.

## Description
These dependency upgrades were implemented to mitigate CVEs present in previous versions

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Replace dependency from commons-httpclient to httpclient:4.5.14 to address  'CVE-2012-6153 <https://github.com/advisories/GHSA-2x83-r56g-cv47>' and 'CVE-2012-5783 <https://github.com/advisories/GHSA-3832-9276-x7gf>'
* Replace dependency from commons-configuration to commons-configuration2:2.12.0 to address 'CVE-2025-46392 <https://github.com/advisories/GHSA-pvp8-3xj6-8c6x>'
```