### PR TITLE
[native]Add option to register catalogs in Prestissimo without restart

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -77,6 +77,7 @@ public final class HiveQueryRunner
     }
 
     public static final String HIVE_CATALOG = "hive";
+    public static final String HIVE_CATALOG_2 = "hive2";
     public static final String HIVE_BUCKETED_CATALOG = "hive_bucketed";
     public static final String TPCH_SCHEMA = "tpch";
     public static final String TPCH_BUCKETED_SCHEMA = "tpch_bucketed";
@@ -274,6 +275,7 @@ public final class HiveQueryRunner
             hiveBucketedProperties = ImmutableMap.copyOf(hiveBucketedProperties);
 
             queryRunner.createCatalog(HIVE_CATALOG, HIVE_CATALOG, hiveProperties);
+            queryRunner.createCatalog(HIVE_CATALOG_2, HIVE_CATALOG, hiveProperties);
             queryRunner.createCatalog(HIVE_BUCKETED_CATALOG, HIVE_CATALOG, hiveBucketedProperties);
 
             List<String> tpchTableNames = getTpchTableNames(tpchTables);

--- a/presto-native-execution/presto_cpp/main/Announcer.h
+++ b/presto-native-execution/presto_cpp/main/Announcer.h
@@ -39,12 +39,15 @@ class Announcer : public PeriodicServiceInventoryManager {
 
   ~Announcer() = default;
 
+  void updateConnectorIds(const std::vector<std::string>& newIds);
+
  protected:
   std::tuple<proxygen::HTTPMessage, std::string> httpRequest() override;
 
  private:
-  const std::string announcementBody_;
-  const proxygen::HTTPMessage announcementRequest_;
+  std::string announcementBody_;
+  proxygen::HTTPMessage announcementRequest_;
+  std::mutex announcementMutex_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicServiceInventoryManager.h
@@ -39,6 +39,8 @@ class PeriodicServiceInventoryManager {
   /// If disabled then won't send any requests, but keeps itself running.
   void enableRequest(bool enable);
 
+  void sendRequest();
+
  protected:
   // Denotes whether we retry failed requests due to network errors.
   virtual bool retryFailed() {
@@ -53,8 +55,6 @@ class PeriodicServiceInventoryManager {
   }
 
   virtual std::tuple<proxygen::HTTPMessage, std::string> httpRequest() = 0;
-
-  void sendRequest();
 
   void scheduleNext();
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -133,6 +133,9 @@ class PrestoServer {
   virtual std::vector<std::string> registerVeloxConnectors(
       const fs::path& configDirectoryPath);
 
+  virtual std::string registerCatalog(
+      const fs::path& configPath);
+
   /// Invoked to register the required dwio data sinks which are used by
   /// connectors.
   virtual void registerFileSinks();
@@ -207,6 +210,12 @@ class PrestoServer {
   void handleGracefulShutdown(
       const std::vector<std::unique_ptr<folly::IOBuf>>& body,
       proxygen::ResponseHandler* downstream);
+
+  void registerCatalogFromJson(
+      proxygen::HTTPMessage* message,
+      const std::vector<std::unique_ptr<folly::IOBuf>>& body,
+      proxygen::ResponseHandler* downstream,
+      std::vector<std::string>& catalogNames);
 
   protocol::NodeStatus fetchNodeStatus();
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeApiEndpointUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeApiEndpointUtils.java
@@ -13,14 +13,19 @@
  */
 package com.facebook.presto.nativeworker;
 
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.tests.DistributedQueryRunner;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public final class NativeApiEndpointUtils
 {
@@ -68,5 +73,21 @@ public final class NativeApiEndpointUtils
             e.printStackTrace();
             return 500;
         }
+    }
+
+    private static boolean isCoordinator(DistributedQueryRunner distributedQueryRunner, InternalNode node)
+    {
+        return distributedQueryRunner.getCoordinator().getNodeManager().getCoordinators().contains(node);
+    }
+
+    public static Set<InternalNode> getWorkerNodes(DistributedQueryRunner queryRunner)
+    {
+        return queryRunner.getCoordinator()
+                .getNodeManager()
+                .getAllNodes()
+                .getActiveNodes()
+                .stream()
+                .filter(node -> !isCoordinator(queryRunner, node))
+                .collect(Collectors.toSet());
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -160,7 +160,7 @@ public class PrestoNativeQueryRunnerUtils
     public static QueryRunner createJavaQueryRunner(Optional<Path> dataDirectory, String storageFormat, boolean addStorageFormatToPath)
             throws Exception
     {
-        return createJavaQueryRunner(dataDirectory, "sql-standard", storageFormat, addStorageFormatToPath);
+        return createJavaQueryRunner(dataDirectory, "legacy", storageFormat, addStorageFormatToPath);
     }
 
     public static QueryRunner createJavaQueryRunner(Optional<Path> baseDataDirectory, String security, String storageFormat, boolean addStorageFormatToPath)

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
@@ -24,9 +24,9 @@ import org.testng.annotations.Test;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.nativeworker.NativeApiEndpointUtils.fetchScalarLongMetrics;
+import static com.facebook.presto.nativeworker.NativeApiEndpointUtils.getWorkerNodes;
 import static com.facebook.presto.nativeworker.NativeApiEndpointUtils.sendWorkerRequest;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createCustomer;
 import static org.testng.Assert.assertEquals;
@@ -167,22 +167,6 @@ public class TestPrestoNativeAsyncDataCacheCleanupAPI
             this.ssdCacheWriteEntries = ssdCacheWriteEntries;
             this.ssdCacheCachedEntries = ssdCacheCachedEntries;
         }
-    }
-
-    private boolean isCoordinator(DistributedQueryRunner distributedQueryRunner, InternalNode node)
-    {
-        return distributedQueryRunner.getCoordinator().getNodeManager().getCoordinators().contains(node);
-    }
-
-    private Set<InternalNode> getWorkerNodes(DistributedQueryRunner queryRunner)
-    {
-        return queryRunner.getCoordinator()
-                .getNodeManager()
-                .getAllNodes()
-                .getActiveNodes()
-                .stream()
-                .filter(node -> !isCoordinator(queryRunner, node))
-                .collect(Collectors.toSet());
     }
 
     @Test(groups = {"async_data_cache"})

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeDynamicCatalog.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeDynamicCatalog.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.nativeworker.NativeApiEndpointUtils.getWorkerNodes;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestPrestoNativeDynamicCatalog
+{
+    static void runCatalogRegister(String endpoint) {
+        try {
+            String catalogName = "hive2";
+            URL url = new URL(endpoint + "/v1/catalog/" + catalogName);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setDoOutput(true);
+            connection.setRequestProperty("Content-Type", "application/json");
+
+            // Create JSON payload
+            String jsonPayload = "{"
+                    + "\"connector.name\": \"hive\""
+                    + "}";
+
+            // Send JSON body
+            try (OutputStream os = connection.getOutputStream()) {
+                byte[] input = jsonPayload.getBytes("utf-8");
+                os.write(input, 0, input.length);
+            }
+
+            // Read and validate response
+            int responseCode = connection.getResponseCode();
+            assertEquals(responseCode, 200);
+
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+                String inputLine;
+                StringBuilder response = new StringBuilder();
+                while ((inputLine = in.readLine()) != null) {
+                    response.append(inputLine);
+                }
+                assertEquals(response.toString(), "Registered catalog: " + catalogName);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to call catalog registration", e);
+        }
+    }
+
+
+    @Test
+    public void testDynamicCatalog() throws Exception
+    {
+        QueryRunner javaQueryRunner = PrestoNativeQueryRunnerUtils.createJavaQueryRunner(false);
+        NativeQueryRunnerUtils.createAllTables(javaQueryRunner);
+        javaQueryRunner.close();
+
+        DistributedQueryRunner queryRunner = (DistributedQueryRunner) PrestoNativeQueryRunnerUtils.createQueryRunner(false, false, false, false);
+        List<String> endpoints = getWorkerNodes(queryRunner).stream().map(InternalNode::getInternalUri).map(URI::toString).collect(Collectors.toList());
+
+        // Attempt to run a query on a catalog that does not exist on the workers.
+        assertThatThrownBy(() -> queryRunner.execute("SELECT * FROM hive2.tpch.customer"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("sortedCandidates is null or empty for ModularHashingNodeProvider");
+
+        endpoints.forEach(TestPrestoNativeDynamicCatalog::runCatalogRegister);
+
+        // Leave time for Presto refreshNodes to be called.
+        Thread.sleep(10000);
+
+        queryRunner.execute("SELECT * FROM hive2.tpch.customer");
+
+        queryRunner.close();
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Currently, if we want to add a new catalog in the Prestissimo server we have to bring it down. With the addition of this change, we can add existing catalogs into the etc/catalog directory and load them without a restart. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Modifying and deleting catalogs require a much larger change. So we are allowing for additional catalogs for now. 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Users may call the `/v1/catalog/register` endpoint via a http request such as,

```
curl -X POST http://127.0.0.1:7777/v1/catalog/hive2 \
     -H "Content-Type: application/json" \
     -d '{"connector.name": "hive"}'
```

## Test Plan
<!---Please fill in how you tested your change-->
Added new test case to add workers without the catalog. Afterwards adding the catalog to the workers' working directory and calling the API to register it.

Then checking to make sure the query is working properly.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

