### PR TITLE
Fix flaky test of table registration in Nessie

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1588,6 +1588,9 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         String schemaName = getSession().getSchema().get();
         String tableName = "register";
+        // Create a `noise` table in the same schema to test that the `getLocation` method finds and returns the right metadata location.
+        String noiseTableName = "register1";
+        assertUpdate("CREATE TABLE " + noiseTableName + " (id integer, value integer)");
         assertUpdate("CREATE TABLE " + tableName + " (id integer, value integer)");
         assertUpdate("INSERT INTO " + tableName + " VALUES(1, 1)", 1);
 
@@ -1599,6 +1602,7 @@ public abstract class IcebergDistributedSmokeTestBase
 
         unregisterTable(schemaName, newTableName);
         dropTable(getSession(), tableName);
+        dropTable(getSession(), noiseTableName);
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
@@ -82,7 +82,7 @@ public class TestIcebergSmokeNessie
         Path dataDirectory = ((DistributedQueryRunner) queryRunner).getCoordinator().getDataDirectory();
         Path icebergDataDirectory = getIcebergDataDirectoryPath(dataDirectory, NESSIE.name(), new IcebergConfig().getFileFormat(), false);
         Optional<File> tempTableLocation = Arrays.stream(requireNonNull(icebergDataDirectory.resolve(schema).toFile().listFiles()))
-                .filter(file -> file.toURI().toString().contains(table)).findFirst();
+                .filter(file -> endsWithTableUUID(table, file.toURI().toString())).findFirst();
 
         String dataLocation = icebergDataDirectory.toFile().toURI().toString();
         String relativeTableLocation = tempTableLocation.get().toURI().toString().replace(dataLocation, "");
@@ -118,5 +118,10 @@ public class TestIcebergSmokeNessie
         return IcebergUtil.getNativeIcebergTable(catalogFactory,
                 session,
                 SchemaTableName.valueOf(schema + "." + tableName));
+    }
+
+    private static boolean endsWithTableUUID(String tableName, String tablePath)
+    {
+        return tablePath.matches(format(".*%s_[-a-fA-F0-9]{36}/$", tableName));
     }
 }


### PR DESCRIPTION
## Description

Fix #22848 

The Previous logic of `getLocation(schema, table)` in `TestIcebergSmokeNessie` may be affected under concurrent execution of test methods, because it use `contains()` to match the first table name under the given schema. For example, if another test logic concurrently create table `register_insert` or `register_filename` in the same schema, the `getLocation(schemaName, 'register')` in `testRegisterTable()` may get the metadata location for table `register_insert` or `register_filename` rather than `register`.

This PR uses regex matching to avoid such cases, so it should most likely resolve the flaky test issue in #22848.

## Motivation and Context

Fix #22848 

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

