### PR TITLE
Fix inconsistent ordering with offset and limit

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -307,11 +307,10 @@ public class AddLocalExchanges
             }
 
             // final limit requires that all data be in one stream
-            // also, a final changes the input organization completely, so we do not pass through parent preferences
             return planAndEnforceChildren(
                     node,
                     singleStream(),
-                    defaultParallelism(session));
+                    parentPreferences.withDefaultParallelism(session));
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -91,6 +91,7 @@ import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.LateralJoinNode;
+import com.facebook.presto.sql.planner.plan.OffsetNode;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
@@ -1304,6 +1305,14 @@ public class PlanPrinter
         public Void visitLateralJoin(LateralJoinNode node, Void context)
         {
             addNode(node, "Lateral", format("[%s]", node.getCorrelation()));
+
+            return processChildren(node, context);
+        }
+
+        @Override
+        public Void visitOffset(OffsetNode node, Void context)
+        {
+            addNode(node, "Offset", format("[%s]", node.getCount()));
 
             return processChildren(node, context);
         }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -1106,6 +1106,24 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testOffsetLimitOrderByConsistency()
+    {
+        Session localSession = Session.builder(getSession())
+                .setSystemProperty(OFFSET_CLAUSE_ENABLED, "true")
+                .build();
+
+        String query = "SELECT name FROM customer ORDER BY name OFFSET 1 LIMIT 256";
+        MaterializedResult expectedResults = computeActual(localSession, query).toTestTypes();
+        List<MaterializedRow> expectedRows = expectedResults.getMaterializedRows();
+
+        for (int i = 0; i < 5; i++) {
+            MaterializedResult actualResults = computeActual(localSession, query).toTestTypes();
+            List<MaterializedRow> actualRows = actualResults.getMaterializedRows();
+            assertEquals(actualRows, expectedRows, "Mismatched results on run " + i);
+        }
+    }
+
+    @Test
     public void testRepeatedAggregations()
     {
         assertQuery("SELECT SUM(orderkey), SUM(orderkey) FROM orders");


### PR DESCRIPTION
## Description
Fixes inconsistent output order when using offset and limit together by passing through parent StreamPreferredProperties in AddLocalExchanges. This prevents visitLimit from overriding the parent `orderSensitive` field, which currently causes the loss of ordering. This change causes order-breaking Round Robin exchanges to be removed from the logical plan.

An implementation of visitOffset in PlanPrinter was also added so that debugging with the session property verbose_optimizer_info_enabled will not cause "not yet implemented" errors.

## Motivation and Context
Fixes #25071.

## Impact
The offset clause when used with limit and order by will now produce accurate results.

## Test Plan
I ran the following test query both before and after this change on the HiveQueryRunner:
`select c_customer_id from hive.tpcds.customer order by c_customer_id offset 1 limit 800;`

Without this change, the query produces completely different output when retried multiple times. With this change, the query returns consistent output every time. I also compared the logical plans using `explain (type logical)` and the Round Robin exchanges were removed after this change.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix inconsistent ordering with offset and limit
```
