### PR TITLE
Fix procedure remove_orphan_files with DELETES

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RemoveOrphanFiles.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RemoveOrphanFiles.java
@@ -225,7 +225,7 @@ public class RemoveOrphanFiles
             case DATA:
                 return ManifestFiles.read(manifest, table.io());
             case DELETES:
-                ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs());
+                return ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs());
             default:
                 throw new PrestoException(ICEBERG_UNKNOWN_MANIFEST_TYPE, "Unknown manifest file content: " + manifest.content());
         }


### PR DESCRIPTION
## Description
Fix the remove_orphan_files procedure after deletion operations
 
Calling the remove_orphan_files procedure on an Iceberg table that has deletes throws the following error:
 
```
java.sql.SQLException: Query failed (): Unknown manifest file content: DELETES
	at com.facebook.presto.jdbc.PrestoResultSet.resultsException(PrestoResultSet.java:1841) ~[?:?]
	at com.facebook.presto.jdbc.PrestoResultSet.getColumns(PrestoResultSet.java:1751) ~[?:?]
	at com.facebook.presto.jdbc.PrestoResultSet.<init>(PrestoResultSet.java:121) ~[?:?]
	at com.facebook.presto.jdbc.PrestoStatement.internalExecute(PrestoStatement.java:272) ~[?:?]
	at com.facebook.presto.jdbc.PrestoStatement.execute(PrestoStatement.java:230) ~[?:?]
	at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:182) ~[commons-dbcp2.jar:2.12.0] 
```
 
A return is missing in the `readerForManifest `method for the DELETES `case`, so the default is executed and a `PrestoException `is thrown.
 
## Motivation and Context
Fixes the problem running remove_orphan_files procedure when the Iceberg table has deletes
 
## Impact
If any DELETE has been performed on an Iceberg table and you try to execute the `remove_orphan_files `procedure you will get a `PrestoException`
 
## Test Plan
New inserts and deletes have been added to the existing test cases in TestRemoveOrphanFilesProcedureBase, this way new test cases with deletes are covered.
 
## Contributor checklist
 
- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
 
## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
 
```
== RELEASE NOTES ==
 
Iceberg Connector Changes
* Fix the remove_orphan_files procedure after deletion operations