### PR TITLE
[doc] Remove duplicate 'async-cache-persistence-interval' property

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -419,14 +419,6 @@ Cache Properties
 
 The configuration properties of AsyncDataCache and SSD cache are described here.
 
-``async-cache-persistence-interval``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* **Type:** ``string``
-* **Default value:** ``0s``
-
-  The interval for persisting in-memory cache to SSD. Set this
-  to a non-zero value to activate periodic cache persistence.
-
 ``async-data-cache-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Currently, 'async-cache-persistence-interval' is described twice in
the presto_cpp documentation(See [1] and [2]). This PR removes the 
redundant one.

[1] https://github.com/prestodb/presto/blob/d9f71c41dca2e7454eb8d2d5bce1b0dd2c1a24bf/presto-docs/src/main/sphinx/presto_cpp/properties.rst?plain=1#L422-L428
[2] https://github.com/prestodb/presto/blob/d9f71c41dca2e7454eb8d2d5bce1b0dd2c1a24bf/presto-docs/src/main/sphinx/presto_cpp/properties.rst?plain=1#L483-L494

```
== NO RELEASE NOTE ==
```

