### PR TITLE
Update presto-cli troubleshooting docs

### DIFF
--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -317,3 +317,37 @@ with the appropriate :abbr:`SAN (Subject Alternative Name)` added.
 Adding a SAN to this certificate is required in cases where ``https://`` uses IP address in the URL rather
 than the domain contained in the coordinator's certificate, and the certificate does not contain the
 :abbr:`SAN (Subject Alternative Name)` parameter with the matching IP address as an alternative attribute.
+
+No console from which to read password
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you use the command line options ``--user`` and ``--password`` along with
+supplying the query statements to execute using ``--file`` or ``--execute`` command line options as below -
+
+.. code-block:: none
+
+    ./presto \
+    --server https://presto-coordinator.example.com:8443 \
+    --execute "select * from tpch.tiny.nation"
+    --user <LDAP user> \
+    --password
+
+    OR
+
+    ./presto \
+    --server https://presto-coordinator.example.com:8443 \
+    --file input_queries.txt
+    --user <LDAP user> \
+    --password > output.txt
+
+The following error might be displayed:
+
+.. code-block:: none
+
+    java.lang.RuntimeException: No console from which to read password
+
+To avoid this error, export the password using the ``PRESTO_PASSWORD`` environment variable:
+
+.. code-block:: none
+
+    export PRESTO_PASSWORD=<password>


### PR DESCRIPTION
## Description
Users can hit errors when trying to pass user and password via presto-cli along with supplying queries to execute using `--file` or `--execute` command line options. The error is - 
```
java.lang.RuntimeException: No console from which to read password
```

This PR adds a fix for the same under troubleshooting guide.

## Motivation and Context
Adds the fix for a common error users might face with presto-cli

## Impact
Docs update

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

