### PR TITLE
Support native non-equal lookup join planning

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -69,6 +69,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.skipHashGenerationForJoinWithTableScanInput;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.plan.JoinType.INNER;
@@ -472,6 +473,13 @@ public class HashGenerationOptimizer
         @Override
         public PlanWithProperties visitIndexJoin(IndexJoinNode node, HashComputationSet parentPreference)
         {
+            if (isNativeExecutionEnabled(session)) {
+                PlanWithProperties left = planAndEnforce(node.getProbeSource(), new HashComputationSet(), true, new HashComputationSet());
+                PlanWithProperties right = planAndEnforce(node.getIndexSource(), new HashComputationSet(), true, new HashComputationSet());
+                verify(left.getHashVariables().isEmpty(), "probe side of the index join should not include hash variables");
+                verify(right.getHashVariables().isEmpty(), "build side of the index join should not include hash variables");
+                return new PlanWithProperties(replaceChildren(node, ImmutableList.of(left.getNode(), right.getNode())), ImmutableMap.of());
+            }
             List<IndexJoinNode.EquiJoinClause> clauses = node.getCriteria();
 
             // join does not pass through preferred hash variables since they take more memory and since

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner.sanity;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.AggregationNode;
@@ -95,19 +96,22 @@ public final class ValidateDependenciesChecker
     @Override
     public void validate(PlanNode plan, Session session, Metadata metadata, WarningCollector warningCollector)
     {
-        validate(plan);
+        validate(plan, session);
     }
 
-    public static void validate(PlanNode plan)
+    public static void validate(PlanNode plan, Session session)
     {
-        plan.accept(new Visitor(), ImmutableSet.of());
+        plan.accept(new Visitor(session), ImmutableSet.of());
     }
 
     private static class Visitor
             extends InternalPlanVisitor<Void, Set<VariableReferenceExpression>>
     {
-        public Visitor()
+        private final Session session;
+
+        public Visitor(Session session)
         {
+            this.session = session;
         }
 
         @Override
@@ -462,6 +466,10 @@ public final class ValidateDependenciesChecker
         @Override
         public Void visitIndexJoin(IndexJoinNode node, Set<VariableReferenceExpression> boundVariables)
         {
+            if (SystemSessionProperties.isNativeExecutionEnabled(session)) {
+                // TODO: Validate index join plan for native execution.
+                return null;
+            }
             node.getProbeSource().accept(this, boundVariables);
             node.getIndexSource().accept(this, boundVariables);
 


### PR DESCRIPTION
This change adds an extractor to traverse the Join plan and get lookup variables in different PlanNode, which enables index look join without any equal join condition for native execution.

```
== NO RELEASE NOTE ==
```

