### PR TITLE
[prestissimo] Add async pushback for jemalloc purge

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.cpp
@@ -22,8 +22,8 @@
 #include "velox/common/time/Timer.h"
 
 namespace facebook::presto {
-PeriodicMemoryChecker::PeriodicMemoryChecker(Config config)
-    : config_(std::move(config)) {
+PeriodicMemoryChecker::PeriodicMemoryChecker(const Config& config)
+    : config_(config) {
   if (config_.systemMemPushbackEnabled) {
     VELOX_CHECK_GT(config_.systemMemLimitBytes, 0);
   }

--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
@@ -65,7 +65,7 @@ class PeriodicMemoryChecker {
     size_t mallocBytesUsageDumpThreshold{20UL * 1024 * 1024 * 1024};
   };
 
-  explicit PeriodicMemoryChecker(Config config);
+  explicit PeriodicMemoryChecker(const Config& config);
 
   virtual ~PeriodicMemoryChecker() = default;
 
@@ -74,7 +74,7 @@ class PeriodicMemoryChecker {
   virtual void start();
 
   /// Stops the 'PeriodicMemoryChecker'.
-  void stop();
+  virtual void stop();
 
   /// Returns the last known cached 'current' system memory usage in bytes.
   int64_t cachedSystemUsedMemoryBytes() const {


### PR DESCRIPTION
Summary:
Make control of the internal memory pushback as following:
1) PeriodicMemoryChecker::systemMemLimitBytes controls the main server pushback.
2) FacebookPeriodicMemoryChecker::jemallocPurgeResidentLimitBytes_ and FacebookPeriodicMemoryChecker::jemallocPurgeDirtyLimitBytes_ controls the asynchronous pushback for jemalloc purge

Reviewed By: xiaoxmeng

Differential Revision: D75322220


