### PR TITLE
Use RouterRequestInfo in router schedulers to get the URL destination

### DIFF
--- a/presto-router-example-plugin-scheduler/src/main/java/com/facebook/presto/router/scheduler/MetricsBasedScheduler.java
+++ b/presto-router-example-plugin-scheduler/src/main/java/com/facebook/presto/router/scheduler/MetricsBasedScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.presto.spi.router.ClusterInfo;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
@@ -31,17 +32,11 @@ public class MetricsBasedScheduler
 {
     private Map<URI, ClusterInfo> clusterInfos;
 
-    @Override
-    public Optional<URI> getDestination(String user)
-    {
-        return Optional.empty();
-    }
-
     /**
      * Returns the destination cluster URI with the fewest number of active and queued queries.
      */
     @Override
-    public Optional<URI> getDestination(String user, String query)
+    public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
     {
         if (clusterInfos != null && !clusterInfos.isEmpty()) {
             //Cluster with the fewest number of queries will be returned

--- a/presto-router-example-plugin-scheduler/src/test/java/com/facebook/presto/router/scheduler/TestMetricsBasedScheduler.java
+++ b/presto-router-example-plugin-scheduler/src/test/java/com/facebook/presto/router/scheduler/TestMetricsBasedScheduler.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.presto.spi.router.ClusterInfo;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 import org.testng.annotations.Test;
 
@@ -85,25 +86,25 @@ public class TestMetricsBasedScheduler
         clusterInfos.put(uri2, new MockRemoteClusterInfo(20, 20));
         clusterInfos.put(uri3, new MockRemoteClusterInfo(30, 30));
         scheduler.setClusterInfos(clusterInfos);
-        URI target = scheduler.getDestination("test", null).orElseThrow(AssertionError::new);
+        URI target = scheduler.getDestination(new RouterRequestInfo("test")).orElseThrow(AssertionError::new);
         assertEquals(target, uri1);
 
         clusterInfos.put(uri1, new MockRemoteClusterInfo(20, 20));
         clusterInfos.put(uri2, new MockRemoteClusterInfo(10, 10));
         clusterInfos.put(uri3, new MockRemoteClusterInfo(30, 30));
         scheduler.setClusterInfos(clusterInfos);
-        target = scheduler.getDestination("test", null).orElseThrow(AssertionError::new);
+        target = scheduler.getDestination(new RouterRequestInfo("test")).orElseThrow(AssertionError::new);
         assertEquals(target, uri2);
 
         clusterInfos.put(uri1, new MockRemoteClusterInfo(20, 20));
         clusterInfos.put(uri2, new MockRemoteClusterInfo(30, 30));
         clusterInfos.put(uri3, new MockRemoteClusterInfo(10, 10));
         scheduler.setClusterInfos(clusterInfos);
-        target = scheduler.getDestination("test", null).orElseThrow(AssertionError::new);
+        target = scheduler.getDestination(new RouterRequestInfo("test")).orElseThrow(AssertionError::new);
         assertEquals(target, uri3);
 
         scheduler.setClusterInfos(new HashMap<>());
-        target = scheduler.getDestination("test", null).orElse(new URI("invalid"));
+        target = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
         assertEquals(target, new URI("invalid"));
     }
 }

--- a/presto-router/src/main/java/com/facebook/presto/router/cluster/ClusterManager.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/cluster/ClusterManager.java
@@ -222,7 +222,7 @@ public class ClusterManager
                 Map<URI, RemoteClusterInfo> healthyRemoteClusterInfos = Maps.filterValues(remoteClusterInfos, RemoteState::isHealthy);
                 config.getScheduler().setClusterInfos(ImmutableMap.copyOf(healthyRemoteClusterInfos));
 
-                return config.getScheduler().getDestination(requestInfo.getUser(), requestInfo.getQuery());
+                return config.getScheduler().getDestination(requestInfo.toRouterRequestInfo());
             }
             catch (Exception e) {
                 log.error("Custom Plugin Scheduler failed to schedule the query!", e);
@@ -234,7 +234,7 @@ public class ClusterManager
             config.getScheduler().setCandidateGroupName(target.get());
         }
 
-        return config.getScheduler().getDestination(requestInfo.getUser());
+        return config.getScheduler().getDestination(requestInfo.toRouterRequestInfo());
     }
 
     private Optional<String> matchGroup(RequestInfo requestInfo)

--- a/presto-router/src/main/java/com/facebook/presto/router/cluster/RequestInfo.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/cluster/RequestInfo.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.router.cluster;
 
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
@@ -63,6 +64,11 @@ public class RequestInfo
     public List<String> getClientTags()
     {
         return clientTags;
+    }
+
+    public RouterRequestInfo toRouterRequestInfo()
+    {
+        return new RouterRequestInfo(user, source, clientTags, query);
     }
 
     private static List<String> parseClientTags(HttpServletRequest servletRequest)

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/RandomChoiceScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/RandomChoiceScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
@@ -30,13 +31,13 @@ public class RandomChoiceScheduler
     private static final Logger log = Logger.get(RandomChoiceScheduler.class);
 
     @Override
-    public Optional<URI> getDestination(String user)
+    public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
     {
         try {
             return Optional.of(candidates.get(RANDOM.nextInt(candidates.size())));
         }
         catch (IllegalArgumentException e) {
-            log.warn(e, "Error getting destination for user " + user);
+            log.warn(e, "Error getting destination for user " + routerRequestInfo.getUser());
             return Optional.empty();
         }
     }

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/RoundRobinScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/RoundRobinScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -42,7 +43,7 @@ public class RoundRobinScheduler
     private String candidateGroupName;
 
     @Override
-    public Optional<URI> getDestination(String user)
+    public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
     {
         try {
             return Optional.of(candidates.get(candidateIndexByGroup.compute(candidateGroupName, (key, oldValue) -> {
@@ -53,7 +54,7 @@ public class RoundRobinScheduler
             })));
         }
         catch (IllegalArgumentException e) {
-            log.warn(e, "Error getting destination for user " + user);
+            log.warn(e, "Error getting destination for user " + routerRequestInfo.getUser());
             return Optional.empty();
         }
     }

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/UserHashScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/UserHashScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
@@ -28,13 +29,13 @@ public class UserHashScheduler
     private static final Logger log = Logger.get(UserHashScheduler.class);
 
     @Override
-    public Optional<URI> getDestination(String user)
+    public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
     {
         try {
-            return Optional.of(candidates.get(user.hashCode() % candidates.size()));
+            return Optional.of(candidates.get(routerRequestInfo.getUser().hashCode() % candidates.size()));
         }
         catch (ArithmeticException e) {
-            log.warn(e, "Error getting destination for user " + user);
+            log.warn(e, "Error getting destination for user " + routerRequestInfo.getUser());
             return Optional.empty();
         }
     }

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/WeightedRandomChoiceScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/WeightedRandomChoiceScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
@@ -37,7 +38,7 @@ public class WeightedRandomChoiceScheduler
     private static final Logger log = Logger.get(WeightedRandomChoiceScheduler.class);
 
     @Override
-    public Optional<URI> getDestination(String user)
+    public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
     {
         checkArgument(candidates.size() == weights.size());
 
@@ -56,7 +57,7 @@ public class WeightedRandomChoiceScheduler
             return Optional.of(serverList.get(RANDOM.nextInt(serverList.size())));
         }
         catch (IllegalArgumentException e) {
-            log.warn(e, "Error getting destination for user " + user);
+            log.warn(e, "Error getting destination for user " + routerRequestInfo.getUser());
             return Optional.empty();
         }
     }

--- a/presto-router/src/main/java/com/facebook/presto/router/scheduler/WeightedRoundRobinScheduler.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/scheduler/WeightedRoundRobinScheduler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.router.scheduler;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 
 import java.net.URI;
@@ -47,7 +48,7 @@ public class WeightedRoundRobinScheduler
     private static final Logger log = Logger.get(WeightedRoundRobinScheduler.class);
 
     @Override
-    public Optional<URI> getDestination(String user)
+    public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
     {
         int serverIndex = 0;
 

--- a/presto-router/src/test/java/com/facebook/presto/router/TestCustomSchedulerManager.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestCustomSchedulerManager.java
@@ -27,6 +27,7 @@ import com.facebook.presto.router.spec.GroupSpec;
 import com.facebook.presto.router.spec.RouterSpec;
 import com.facebook.presto.router.spec.SelectorRuleSpec;
 import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 import com.facebook.presto.spi.router.SchedulerFactory;
 import com.facebook.presto.tpch.TpchPlugin;
@@ -136,13 +137,7 @@ public class TestCustomSchedulerManager
         private int requestsMade;
 
         @Override
-        public Optional<URI> getDestination(String user)
-        {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<URI> getDestination(String user, String query)
+        public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
         {
             ++requestsMade;
             return Optional.of(candidates.get(0));
@@ -203,7 +198,7 @@ public class TestCustomSchedulerManager
         Scheduler scheduler = schedulerManager.getScheduler();
         scheduler.setCandidates(serverURIs);
 
-        URI target = scheduler.getDestination("test", null).orElse(new URI("invalid"));
+        URI target = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
         assertTrue(serverURIs.contains(target));
     }
 

--- a/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestScheduler.java
@@ -18,6 +18,7 @@ import com.facebook.presto.router.scheduler.RoundRobinScheduler;
 import com.facebook.presto.router.scheduler.UserHashScheduler;
 import com.facebook.presto.router.scheduler.WeightedRandomChoiceScheduler;
 import com.facebook.presto.router.scheduler.WeightedRoundRobinScheduler;
+import com.facebook.presto.spi.router.RouterRequestInfo;
 import com.facebook.presto.spi.router.Scheduler;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -59,7 +60,7 @@ public class TestScheduler
         HashMap<URI, Integer> hitCounter = new HashMap<>();
 
         for (int i = 0; i < 10_000; i++) {
-            URI target = scheduler.getDestination("test").orElse(new URI("invalid"));
+            URI target = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
             assertTrue(servers.contains(target));
             hitCounter.put(target, hitCounter.getOrDefault(target, 0) + 1);
         }
@@ -84,13 +85,13 @@ public class TestScheduler
         Scheduler scheduler = new UserHashScheduler();
         scheduler.setCandidates(servers);
 
-        URI target1 = scheduler.getDestination(user).orElse(new URI("invalid"));
+        URI target1 = scheduler.getDestination(new RouterRequestInfo(user)).orElse(new URI("invalid"));
         assertTrue(servers.contains(target1));
 
-        URI target2 = scheduler.getDestination(user).orElse(new URI("invalid"));
+        URI target2 = scheduler.getDestination(new RouterRequestInfo(user)).orElse(new URI("invalid"));
         assertTrue(servers.contains(target2));
 
-        URI target3 = scheduler.getDestination(user).orElse(new URI("invalid"));
+        URI target3 = scheduler.getDestination(new RouterRequestInfo(user)).orElse(new URI("invalid"));
         assertTrue(servers.contains(target3));
 
         assertEquals(target2, target1);
@@ -113,7 +114,7 @@ public class TestScheduler
         HashMap<URI, Integer> hitCounter = new HashMap<>();
 
         for (int i = 0; i < 100_000; i++) {
-            URI target = scheduler.getDestination("test").orElse(new URI("invalid"));
+            URI target = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
             assertTrue(servers.contains(target));
             assertTrue(weights.containsKey(target));
             hitCounter.put(target, hitCounter.getOrDefault(target, 0) + 1);
@@ -139,7 +140,7 @@ public class TestScheduler
 
         scheduler.setCandidates(servers);
 
-        URI target = scheduler.getDestination("test").orElse(new URI("invalid"));
+        URI target = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
         assertEquals(target.getPath(), "192.168.0.1");
     }
 
@@ -151,19 +152,19 @@ public class TestScheduler
         scheduler.setCandidates(servers);
         scheduler.setCandidateGroupName("");
 
-        URI target1 = scheduler.getDestination("test").orElse(new URI("invalid"));
+        URI target1 = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
         assertTrue(servers.contains(target1));
         assertEquals(target1.getPath(), "192.168.0.1");
 
-        URI target2 = scheduler.getDestination("test").orElse(new URI("invalid"));
+        URI target2 = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
         assertTrue(servers.contains(target2));
         assertEquals(target2.getPath(), "192.168.0.2");
 
-        URI target3 = scheduler.getDestination("test").orElse(new URI("invalid"));
+        URI target3 = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
         assertTrue(servers.contains(target3));
         assertEquals(target3.getPath(), "192.168.0.3");
 
-        URI target4 = scheduler.getDestination("test").orElse(new URI("invalid"));
+        URI target4 = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
         assertTrue(servers.contains(target4));
         assertEquals(target4.getPath(), "192.168.0.1");
     }
@@ -199,13 +200,14 @@ public class TestScheduler
         testScheduler(weightSum, scheduler, weights);
     }
 
-    private void testScheduler(int weightSum, Scheduler scheduler, HashMap<URI, Integer> weights) throws URISyntaxException
+    private void testScheduler(int weightSum, Scheduler scheduler, HashMap<URI, Integer> weights)
+            throws URISyntaxException
     {
         int serverDiffCount = 0;
         int serverRepeatCount = 0;
         URI priorURI = null;
         for (int i = 0; i < weightSum; i++) {
-            URI target = scheduler.getDestination("test").orElse(new URI("invalid"));
+            URI target = scheduler.getDestination(new RouterRequestInfo("test")).orElse(new URI("invalid"));
             assertTrue(servers.contains(target));
             assertTrue(weights.containsKey(target));
             if (!target.equals(priorURI)) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/router/RouterRequestInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/router/RouterRequestInfo.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.router;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class RouterRequestInfo
+{
+    private final String user;
+    private final Optional<String> source;
+    private final List<String> clientTags;
+    private final String query;
+
+    public RouterRequestInfo(String user)
+    {
+        this(user, Optional.empty(), Collections.emptyList(), "");
+    }
+
+    public RouterRequestInfo(String user, Optional<String> source, List<String> clientTags, String query)
+    {
+        this.user = user;
+        this.source = source;
+        this.clientTags = clientTags;
+        this.query = query;
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+
+    public Optional<String> getSource()
+    {
+        return source;
+    }
+
+    public String getQuery()
+    {
+        return query;
+    }
+
+    public List<String> getClientTags()
+    {
+        return clientTags;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/router/Scheduler.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/router/Scheduler.java
@@ -24,17 +24,7 @@ public interface Scheduler
      * Schedules a query from a user to a concrete candidate. Returns the
      * URI of this candidate.
      */
-    Optional<URI> getDestination(String user);
-
-    /**
-     * Schedules a query from a user to a concrete candidate. Returns the
-     * URI of this candidate.
-     * TODO : Refactor to use a RequestInfo POJO and remove the extra getDestination variant
-     */
-    default Optional<URI> getDestination(String user, String query)
-    {
-        return Optional.empty();
-    };
+    Optional<URI> getDestination(RouterRequestInfo routerRequestInfo);
 
     /**
      * Sets the candidates with the list of URIs for scheduling.


### PR DESCRIPTION
## Description
Use `RouterRequestInfo` in router schedulers to get the URL destination instead of having multiple `getDestination` variants.

## Motivation and Context
Refactor to use a `RouterRequestInfo` POJO and remove the extra `getDestination` variant in router schedulers.

## Impact
No impact

## Test Plan
Unit tests.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Replace the parameters in router schedulers to use `RouterRequestInfo` to get the URL destination.
```

