### PR TITLE
[native] fix arrow flight setup in docker dependency image

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -22,7 +22,7 @@ COPY velox/scripts /velox/scripts
 RUN bash -c "mkdir build && \
     (cd build && ../scripts/setup-centos.sh && \
                  ../velox/scripts/setup-centos9.sh install_adapters && \
-                 ../scripts/setup-adapters.sh && \
+                 PROMPT_ALWAYS_RESPOND="Y" ../scripts/setup-adapters.sh && \
                  source ../velox/scripts/setup-centos9.sh && \
                  install_clang15 && \
                  install_cuda 12.8) && \


### PR DESCRIPTION
## Description
currently when building the native dependency image the native setup adapters does not actually rebuild arrow with flight support, so one cannot readily enable flight support when building the runtime image, because that would fail.

## Motivation and Context
I'd like to be able to enable flight when building the runtime image, but can't, because the dependency image has the wrong arrow build.

## Impact
## Test Plan
## Contributor checklist

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

