### PR TITLE
Optimize partition value evaluation in filter pushdown

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -222,6 +222,8 @@ public class HiveClientConfig
     private int parquetQuickStatsMaxConcurrentCalls = 500;
     private int quickStatsMaxConcurrentCalls = 100;
     private boolean legacyTimestampBucketing;
+    private boolean optimizeParsingOfPartitionValues;
+    private int optimizeParsingOfPartitionValuesThreshold = 500;
 
     @Min(0)
     public int getMaxInitialSplits()
@@ -1830,5 +1832,32 @@ public class HiveClientConfig
     {
         this.legacyTimestampBucketing = legacyTimestampBucketing;
         return this;
+    }
+
+    @Config("hive.optimize-parsing-of-partition-values-enabled")
+    @ConfigDescription("Enables optimization of parsing partition values when number of candidate partitions is large")
+    public HiveClientConfig setOptimizeParsingOfPartitionValues(boolean optimizeParsingOfPartitionValues)
+    {
+        this.optimizeParsingOfPartitionValues = optimizeParsingOfPartitionValues;
+        return this;
+    }
+
+    public boolean isOptimizeParsingOfPartitionValues()
+    {
+        return optimizeParsingOfPartitionValues;
+    }
+
+    @Config("hive.optimize-parsing-of-partition-values-threshold")
+    @ConfigDescription("Enables optimization of parsing partition values when number of candidate partitions exceed the threshold set here")
+    public HiveClientConfig setOptimizeParsingOfPartitionValuesThreshold(int optimizeParsingOfPartitionValuesThreshold)
+    {
+        this.optimizeParsingOfPartitionValuesThreshold = optimizeParsingOfPartitionValuesThreshold;
+        return this;
+    }
+
+    @Min(1)
+    public int getOptimizeParsingOfPartitionValuesThreshold()
+    {
+        return optimizeParsingOfPartitionValuesThreshold;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -134,6 +134,8 @@ public final class HiveSessionProperties
     public static final String DYNAMIC_SPLIT_SIZES_ENABLED = "dynamic_split_sizes_enabled";
     public static final String SKIP_EMPTY_FILES = "skip_empty_files";
     public static final String LEGACY_TIMESTAMP_BUCKETING = "legacy_timestamp_bucketing";
+    public static final String OPTIMIZE_PARSING_OF_PARTITION_VALUES = "optimize_parsing_of_partition_values";
+    public static final String OPTIMIZE_PARSING_OF_PARTITION_VALUES_THRESHOLD = "optimize_parsing_of_partition_values_threshold";
 
     public static final String NATIVE_STATS_BASED_FILTER_REORDER_DISABLED = "native_stats_based_filter_reorder_disabled";
 
@@ -657,6 +659,15 @@ public final class HiveSessionProperties
                         hiveClientConfig.isLegacyTimestampBucketing(),
                         false),
                 booleanProperty(
+                        OPTIMIZE_PARSING_OF_PARTITION_VALUES,
+                        "Optimize partition values parsing when number of candidates are large",
+                        hiveClientConfig.isOptimizeParsingOfPartitionValues(),
+                        false),
+                integerProperty(OPTIMIZE_PARSING_OF_PARTITION_VALUES_THRESHOLD,
+                        "When OPTIMIZE_PARSING_OF_PARTITION_VALUES is set to true, enable this optimizations when number of partitions exceed the threshold here",
+                        hiveClientConfig.getOptimizeParsingOfPartitionValuesThreshold(),
+                        false),
+                booleanProperty(
                         NATIVE_STATS_BASED_FILTER_REORDER_DISABLED,
                         "Native Execution only. Disable stats based filter reordering.",
                         false,
@@ -1147,5 +1158,15 @@ public final class HiveSessionProperties
     public static boolean isLegacyTimestampBucketing(ConnectorSession session)
     {
         return session.getProperty(LEGACY_TIMESTAMP_BUCKETING, Boolean.class);
+    }
+
+    public static boolean isOptimizeParsingOfPartitionValues(ConnectorSession session)
+    {
+        return session.getProperty(OPTIMIZE_PARSING_OF_PARTITION_VALUES, Boolean.class);
+    }
+
+    public static int getOptimizeParsingOfPartitionValuesThreshold(ConnectorSession session)
+    {
+        return session.getProperty(OPTIMIZE_PARSING_OF_PARTITION_VALUES_THRESHOLD, Integer.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -166,6 +166,8 @@ public class TestHiveClientConfig
                 .setMaxConcurrentParquetQuickStatsCalls(500)
                 .setCteVirtualBucketCount(128)
                 .setSkipEmptyFilesEnabled(false)
+                .setOptimizeParsingOfPartitionValues(false)
+                .setOptimizeParsingOfPartitionValuesThreshold(500)
                 .setLegacyTimestampBucketing(false));
     }
 
@@ -292,6 +294,8 @@ public class TestHiveClientConfig
                 .put("hive.quick-stats.max-concurrent-calls", "101")
                 .put("hive.cte-virtual-bucket-count", "256")
                 .put("hive.skip-empty-files", "true")
+                .put("hive.optimize-parsing-of-partition-values-enabled", "true")
+                .put("hive.optimize-parsing-of-partition-values-threshold", "100")
                 .put("hive.legacy-timestamp-bucketing", "true")
                 .build();
 
@@ -414,6 +418,8 @@ public class TestHiveClientConfig
                 .setMaxConcurrentQuickStatsCalls(101)
                 .setSkipEmptyFilesEnabled(true)
                 .setCteVirtualBucketCount(256)
+                .setOptimizeParsingOfPartitionValues(true)
+                .setOptimizeParsingOfPartitionValuesThreshold(100)
                 .setLegacyTimestampBucketing(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Constraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Constraint.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi;
 import com.facebook.presto.common.predicate.NullableValue;
 import com.facebook.presto.common.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,6 +28,8 @@ public class Constraint<T>
 {
     private final TupleDomain<T> summary;
     private final Optional<Predicate<Map<T, NullableValue>>> predicate;
+    // Optional.empty() when not set
+    private final Optional<List<T>> predicateInputs;
 
     public static <V> Constraint<V> alwaysTrue()
     {
@@ -50,11 +53,18 @@ public class Constraint<T>
 
     public Constraint(TupleDomain<T> summary, Optional<Predicate<Map<T, NullableValue>>> predicate)
     {
+        this(summary, predicate, Optional.empty());
+    }
+
+    public Constraint(TupleDomain<T> summary, Optional<Predicate<Map<T, NullableValue>>> predicate, Optional<List<T>> predicateInputs)
+    {
         requireNonNull(summary, "summary is null");
         requireNonNull(predicate, "predicate is null");
+        requireNonNull(predicateInputs, "predicateInputs is null");
 
         this.summary = summary;
         this.predicate = predicate;
+        this.predicateInputs = predicateInputs;
     }
 
     public TupleDomain<T> getSummary()
@@ -65,6 +75,11 @@ public class Constraint<T>
     public Optional<Predicate<Map<T, NullableValue>>> predicate()
     {
         return predicate;
+    }
+
+    public Optional<List<T>> getPredicateInputs()
+    {
+        return predicateInputs;
     }
 
     @Override


### PR DESCRIPTION
## Description
Constraint is used to validate whether a hive partition matches the filters specified in query during filter pushdown.
https://github.com/prestodb/presto/blob/c08c6ef45ac9f9cbf2efc4f8d6e8594183d6de99/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java#L417
Here `constraint.predicate().get().test(partition.getKeys())` is called for one partition, and this function is called for all candidate partitions. However, it may not be necessary to call this function for all partitions.
For example, let's say we have a table with two partition keys, `ds` and `ts`, where `ds` is the date and `ts` is the hour of the day. When the query is querying data in the past 180 days, there can be 180*24=4320 candidate partitions. However, if the `predicate` in `constraint` only contains `ds` but not `ts`, we actually only need to call this function 180 times. It can lead to big difference especially when the predicate is expensive, for example large expressions or include complex string/json operations.
In the motivating example, we see query planning time decrease from [3 minutes](https://www.internalfb.com/intern/presto/query/?query_id=20250601_163732_00007_4yudm#runtime_stats) to [10 seconds](https://www.internalfb.com/intern/presto/query/?query_id=20250601_163615_00004_4yudm#runtime_stats) if we reduce the number of such function calls.
In this PR, I added a function to constraint to return the column handles which are used in predicate, and populate it during filter pushdown, so as to enable the above optimization.


## Motivation and Context
Reduce query planning time.

## Impact
Reduce query planning time.

## Test Plan
Test with production queries end to end

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add a function to Constraint to return the input arguments for the predicate
```


