### PR TITLE
Revert #25245 Move Bootstrap.class to presto-bytecode to avoid duplicate definitions 

### DIFF
--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/AccumulatorCompiler.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/AccumulatorCompiler.java
@@ -55,7 +55,6 @@ import static com.facebook.presto.bytecode.Access.FINAL;
 import static com.facebook.presto.bytecode.Access.PRIVATE;
 import static com.facebook.presto.bytecode.Access.PUBLIC;
 import static com.facebook.presto.bytecode.Access.a;
-import static com.facebook.presto.bytecode.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.bytecode.Parameter.arg;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.and;
@@ -66,6 +65,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.consta
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeDynamic;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeStatic;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.not;
+import static com.facebook.presto.hive.functions.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.hive.functions.gen.CompilerUtils.defineClass;
 import static com.facebook.presto.hive.functions.gen.CompilerUtils.makeClassName;
 import static com.facebook.presto.hive.functions.gen.SqlTypeBytecodeExpression.constantType;

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/Bootstrap.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/Bootstrap.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.gen;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class Bootstrap
+{
+    public static final Method BOOTSTRAP_METHOD;
+
+    static {
+        try {
+            BOOTSTRAP_METHOD = Bootstrap.class.getMethod("bootstrap", MethodHandles.Lookup.class, String.class, MethodType.class, long.class);
+        }
+        catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private Bootstrap()
+    {
+    }
+
+    public static CallSite bootstrap(MethodHandles.Lookup callerLookup, String name, MethodType type, long bindingId)
+    {
+        ClassLoader classLoader = callerLookup.lookupClass().getClassLoader();
+        checkArgument(classLoader instanceof DynamicClassLoader, "Expected %s's classloader to be of type %s", callerLookup.lookupClass().getName(), DynamicClassLoader.class.getName());
+
+        DynamicClassLoader dynamicClassLoader = (DynamicClassLoader) classLoader;
+        MethodHandle target = dynamicClassLoader.getCallSiteBindings().get(bindingId);
+        checkArgument(target != null, "Binding %s for function %s%s not found", bindingId, name, type.parameterList());
+
+        return new ConstantCallSite(target);
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/SqlTypeBytecodeExpression.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/SqlTypeBytecodeExpression.java
@@ -26,8 +26,8 @@ import io.airlift.slice.Slice;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import static com.facebook.presto.bytecode.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
+import static com.facebook.presto.hive.functions.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static java.util.Objects.requireNonNull;
 
 public class SqlTypeBytecodeExpression

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
@@ -57,7 +57,6 @@ import static com.facebook.presto.bytecode.Access.FINAL;
 import static com.facebook.presto.bytecode.Access.PRIVATE;
 import static com.facebook.presto.bytecode.Access.PUBLIC;
 import static com.facebook.presto.bytecode.Access.a;
-import static com.facebook.presto.bytecode.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.bytecode.Parameter.arg;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.and;
@@ -70,6 +69,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invoke
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.not;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
 import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.countInputChannels;
+import static com.facebook.presto.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.sql.gen.BytecodeUtils.invoke;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.facebook.presto.util.CompilerUtils.defineClass;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/gen/Bootstrap.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/gen/Bootstrap.java
@@ -11,7 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.bytecode;
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
 
 import java.lang.invoke.CallSite;
 import java.lang.invoke.ConstantCallSite;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.bytecode.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.bytecode.OpCode.NOP;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantFalse;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
@@ -51,6 +50,7 @@ import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationCh
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.BLOCK_AND_POSITION;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ReturnPlaceConvention.PROVIDED_BLOCKBUILDER;
 import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ReturnPlaceConvention.STACK;
+import static com.facebook.presto.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/gen/SqlTypeBytecodeExpression.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/gen/SqlTypeBytecodeExpression.java
@@ -26,8 +26,8 @@ import io.airlift.slice.Slice;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import static com.facebook.presto.bytecode.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
+import static com.facebook.presto.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static java.util.Objects.requireNonNull;
 
 public class SqlTypeBytecodeExpression


### PR DESCRIPTION
## Description
This reverts https://github.com/prestodb/presto/pull/25245?fbclid=IwY2xjawKwI6BleHRuA2FlbQIxMQBicmlkETBoYW9yclAzdjR2bW9rU1ZlAR5T6z9TdGaufXbSNH8Y7s5HI1NhghLSwgqbKWZLniAvsDvnZshdKowS2qj08A_aem_CLbW4rp6V1haCMjCgdqPDg

Internal pr: D75970190

Causing errors for aggregation UDF's e.g.
Caused by: java.lang.IllegalArgumentException: Expected com.facebook.presto.$gen.WeightedAverageStateSerializer_20250605_114214_4193's classloader to be of type com.facebook.presto.bytecode.DynamicClassLoader, but is com.facebook.presto.bytecode.DynamicClassLoader

Initial investigation suggests we're missing a safe class loader somewhere, unknown whether we're missing this in OSS or in facebook internal code.


## Motivation and Context
Commit is causing issues in facebooks internal verifier. Not sure if issue is with facebook internal, or oss spi. Temporary revert so we can continue with our internal release while we look into the issue.

## Impact
Revert code move, any other class 

## Test Plan
Build to cluster and pass the failed queries

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix: Revert the move of boostrap fromm presto-main to presto-bytecode

```


