### PR TITLE
Fix replaceColumn not retaining positionCount of Page

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -471,7 +471,7 @@ public final class Page
 
         Block[] newBlocks = Arrays.copyOf(blocks, blocks.length);
         newBlocks[channelIndex] = column;
-        return Page.wrapBlocksWithoutCopy(newBlocks.length, newBlocks);
+        return Page.wrapBlocksWithoutCopy(positionCount, newBlocks);
     }
 
     private static class DictionaryBlockIndexes

--- a/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
@@ -182,6 +182,7 @@ public class TestPage
         Page newPage = page.replaceColumn(1, newBlock);
 
         assertEquals(newPage.getChannelCount(), 3);
+        assertEquals(newPage.getPositionCount(), entries);
         assertEquals(newPage.getBlock(1).getLong(0), 0);
         assertEquals(newPage.getBlock(1).getLong(1), -1);
     }


### PR DESCRIPTION
## Description
Fixes the logic of `Page#replaceColumn` by retaining the existing positionCount of the Page instead of setting positionCount to the number of channels.

## Motivation and Context
When replacing a column in a Page, the positionCount (number of rows) shouldn't change. Currently it is being set to the number of channels (columns).

## Impact
This method is only being used by `OrcSelectivePageSource` currently though it will also be used in the implementation of #24733, which requires correctness in the positionCount.

## Test Plan
Added an assert to the existing unit test for replaceColumn that ensures the positionCount is maintained.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

