### PR TITLE
Add aws-java-sdk-core as runtime dependency for Redshift JDBC driver

### DIFF
--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -17,6 +17,13 @@
     </properties>
 
     <dependencies>
+        <!--Needed for com.amazon.redshift:redshift-jdbc42:2.1.0.32-->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-base-jdbc</artifactId>


### PR DESCRIPTION
## Description
Git Issue: https://github.com/prestodb/presto/issues/25247

Amazon Redshift JDBC driver version 2.1.0.32 internally depends on com.amazonaws.util.StringUtils class from the AWS SDK v1.

This com.amazonaws.util.StringUtils class is not bundled inside the Redshift JDBC driver jar, and it must be available on the classpath.

Added aws-java-sdk-core as a runtime dependency to resolve this issue.

## Motivation and Context
The Presto Redshift connector fails with a NoClassDefFoundError during table operations like CREATE TABLE because it tries to invoke a metadata function that uses this class.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Redshift Connector Changes
* Fix Redshift connector runtime failure due to missing dependency on ``com.amazonaws.util.StringUtils``.
Add ``aws-java-sdk-core`` as a runtime dependency to support Redshift JDBC driver (v2.1.0.32) which relies on this class for metadata operations.
```


