### PR TITLE
[native] Add header "Host" to PrestoExchangeSource

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -197,6 +197,7 @@ void PrestoExchangeSource::doRequest(
           protocol::PRESTO_MAX_WAIT_HTTP_HEADER,
           protocol::Duration(maxWait.count(), protocol::TimeUnit::MICROSECONDS)
               .toString())
+      .header(proxygen::HTTP_HEADER_HOST, fmt::format("{}:{}", host_, port_))
       .send(httpClient_.get(), "", delayMs)
       .via(driverExecutor_)
       .thenTry(

--- a/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoExchangeSourceTest.cpp
@@ -129,9 +129,11 @@ class Producer {
   }
 
   proxygen::RequestHandler* getResults(
-      proxygen::HTTPMessage* /*message*/,
+      proxygen::HTTPMessage* message,
       const std::vector<std::string>& pathMatch,
       bool getDataSizeOnly) {
+    const auto& headers = message->getHeaders();
+    VELOX_CHECK(headers.exists(proxygen::HTTP_HEADER_HOST));
     protocol::TaskId taskId = pathMatch[1];
     long sequence = std::stol(pathMatch[3]);
 


### PR DESCRIPTION
## Description
HTTP 1.1 requires `Host` header. We are seeing a 400 Bad Request response otherwise in our setup.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution)
* Fix PrestoExchangeSource 400 Bad Request by adding the "Host" header.
```


