### PR TITLE
Fix vulnerability issue in logback dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,13 @@
         <dep.testng.version>7.5</dep.testng.version>
         <dep.lucene.version>8.11.3</dep.lucene.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
-        <dep.logback.version>1.2.13</dep.logback.version>
+        <dep.logback.version>1.3.15</dep.logback.version>
         <dep.parquet.version>1.13.1</dep.parquet.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.7.1</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
         <dep.alluxio.version>313</dep.alluxio.version>
-        <dep.slf4j.version>1.7.36</dep.slf4j.version>
+        <dep.slf4j.version>2.0.16</dep.slf4j.version>
         <dep.kafka.version>3.9.0</dep.kafka.version>
         <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>30.0.1</dep.druid.version>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -185,17 +185,6 @@
         </dependency>
     </dependencies>
 
-    <!-- dependencyManagement is to fix the Require upper bound dependencies error for slf4j -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>1.7.36</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Fix vulnerability issue in logback dependency
- Upgrade logback version to 1.3.15 to address CVE-2024-12798 and CVE-2024-12801. 

- Upgrade the SLF4J version to 2.0.16 to resolve the upper-bound dependency issue caused by the Logback dependency upgrade.

## Description
These dependency upgrade was implemented to mitigate CVEs present in previous version.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade logback version to 1.3.15 to address 'CVE-2024-12798 <https://github.com/advisories/GHSA-pr98-23f8-jwxv>' and 'CVE-2024-12801  <https://github.com/advisories/GHSA-6v67-2wr5-gvf4>'
* Upgrade the SLF4J version to 2.0.16 to resolve the upper-bound dependency issue

```

