### PR TITLE
Optimize reads for SymlinkTextInputFormat tables

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -117,98 +117,100 @@ filesystem directory as a Hive Metastore. See :ref:`installation/deployment:File
 Hive Configuration Properties
 -----------------------------
 
-================================================== ============================================================ ============
-Property Name                                      Description                                                  Default
-================================================== ============================================================ ============
-``hive.metastore.uri``                             The URI(s) of the Hive metastore to connect to using the
-                                                   Thrift protocol. If multiple URIs are provided, the first
-                                                   URI is used by default and the rest of the URIs are
-                                                   fallback metastores. This property is required.
-                                                   Example: ``thrift://192.0.2.3:9083`` or
-                                                   ``thrift://192.0.2.3:9083,thrift://192.0.2.4:9083``
+======================================================== ============================================================ ============
+Property Name                                            Description                                                  Default
+======================================================== ============================================================ ============
+``hive.metastore.uri``                                   The URI(s) of the Hive metastore to connect to using the
+                                                         Thrift protocol. If multiple URIs are provided, the first
+                                                         URI is used by default and the rest of the URIs are
+                                                         fallback metastores. This property is required.
+                                                         Example: ``thrift://192.0.2.3:9083`` or
+                                                         ``thrift://192.0.2.3:9083,thrift://192.0.2.4:9083``
 
-``hive.metastore.username``                        The username Presto will use to access the Hive metastore.
+``hive.metastore.username``                              The username Presto will use to access the Hive metastore.
 
-``hive.config.resources``                          An optional comma-separated list of HDFS
-                                                   configuration files. These files must exist on the
-                                                   machines running Presto. Only specify this if
-                                                   absolutely necessary to access HDFS.
-                                                   Example: ``/etc/hdfs-site.xml``
+``hive.config.resources``                                An optional comma-separated list of HDFS
+                                                         configuration files. These files must exist on the
+                                                         machines running Presto. Only specify this if
+                                                         absolutely necessary to access HDFS.
+                                                         Example: ``/etc/hdfs-site.xml``
 
-``hive.storage-format``                            The default file format used when creating new tables.       ``ORC``
+``hive.storage-format``                                  The default file format used when creating new tables.       ``ORC``
 
-``hive.compression-codec``                         The compression codec to use when writing files.             ``GZIP``
+``hive.compression-codec``                               The compression codec to use when writing files.             ``GZIP``
 
-``hive.force-local-scheduling``                    Force splits to be scheduled on the same node as the Hadoop  ``false``
-                                                   DataNode process serving the split data.  This is useful for
-                                                   installations where Presto is collocated with every
-                                                   DataNode.
+``hive.force-local-scheduling``                          Force splits to be scheduled on the same node as the Hadoop  ``false``
+                                                         DataNode process serving the split data.  This is useful for
+                                                         installations where Presto is collocated with every
+                                                         DataNode.
 
-``hive.order-based-execution-enabled``             Enable order-based execution. When it's enabled, hive files  ``false``
-                                                   become non-splittable and the table ordering properties
-                                                   would be exposed to plan optimizer
+``hive.order-based-execution-enabled``                   Enable order-based execution. When it's enabled, hive files  ``false``
+                                                         become non-splittable and the table ordering properties
+                                                         would be exposed to plan optimizer
 
-``hive.respect-table-format``                      Should new partitions be written using the existing table    ``true``
-                                                   format or the default Presto format?
+``hive.respect-table-format``                            Should new partitions be written using the existing table    ``true``
+                                                         format or the default Presto format?
 
-``hive.immutable-partitions``                      Can new data be inserted into existing partitions?           ``false``
+``hive.immutable-partitions``                            Can new data be inserted into existing partitions?           ``false``
 
-``hive.create-empty-bucket-files``                 Should empty files be created for buckets that have no data? ``true``
+``hive.create-empty-bucket-files``                       Should empty files be created for buckets that have no data? ``true``
 
-``hive.max-partitions-per-writers``                Maximum number of partitions per writer.                     100
+``hive.max-partitions-per-writers``                      Maximum number of partitions per writer.                     100
 
-``hive.max-partitions-per-scan``                   Maximum number of partitions for a single table scan.        100,000
+``hive.max-partitions-per-scan``                         Maximum number of partitions for a single table scan.        100,000
 
-``hive.dynamic-split-sizes-enabled``               Enable dynamic sizing of splits based on data scanned by     ``false``
-                                                   the query.
+``hive.dynamic-split-sizes-enabled``                     Enable dynamic sizing of splits based on data scanned by     ``false``
+                                                         the query.
 
-``hive.metastore.authentication.type``             Hive metastore authentication type.                          ``NONE``
-                                                   Possible values are ``NONE`` or ``KERBEROS``.
+``hive.metastore.authentication.type``                   Hive metastore authentication type.                          ``NONE``
+                                                         Possible values are ``NONE`` or ``KERBEROS``.
 
-``hive.metastore.service.principal``               The Kerberos principal of the Hive metastore service.
+``hive.metastore.service.principal``                     The Kerberos principal of the Hive metastore service.
 
-``hive.metastore.client.principal``                The Kerberos principal that Presto will use when connecting
-                                                   to the Hive metastore service.
+``hive.metastore.client.principal``                      The Kerberos principal that Presto will use when connecting
+                                                         to the Hive metastore service.
 
-``hive.metastore.client.keytab``                   Hive metastore client keytab location.
+``hive.metastore.client.keytab``                         Hive metastore client keytab location.
 
-``hive.hdfs.authentication.type``                  HDFS authentication type.                                    ``NONE``
-                                                   Possible values are ``NONE`` or ``KERBEROS``.
+``hive.hdfs.authentication.type``                        HDFS authentication type.                                    ``NONE``
+                                                         Possible values are ``NONE`` or ``KERBEROS``.
 
-``hive.hdfs.impersonation.enabled``                Enable HDFS end user impersonation.                          ``false``
+``hive.hdfs.impersonation.enabled``                      Enable HDFS end user impersonation.                          ``false``
 
-``hive.hdfs.presto.principal``                     The Kerberos principal that Presto will use when connecting
-                                                   to HDFS.
+``hive.hdfs.presto.principal``                           The Kerberos principal that Presto will use when connecting
+                                                         to HDFS.
 
-``hive.hdfs.presto.keytab``                        HDFS client keytab location.
+``hive.hdfs.presto.keytab``                              HDFS client keytab location.
 
-``hive.security``                                  See :doc:`hive-security`.
+``hive.security``                                        See :doc:`hive-security`.
 
-``security.config-file``                           Path of config file to use when ``hive.security=file``.
-                                                   See :ref:`hive-file-based-authorization` for details.
+``security.config-file``                                 Path of config file to use when ``hive.security=file``.
+                                                         See :ref:`hive-file-based-authorization` for details.
 
-``hive.non-managed-table-writes-enabled``          Enable writes to non-managed (external) Hive tables.         ``false``
+``hive.non-managed-table-writes-enabled``                Enable writes to non-managed (external) Hive tables.         ``false``
 
-``hive.non-managed-table-creates-enabled``         Enable creating non-managed (external) Hive tables.          ``true``
+``hive.non-managed-table-creates-enabled``               Enable creating non-managed (external) Hive tables.          ``true``
 
-``hive.collect-column-statistics-on-write``        Enables automatic column level statistics collection         ``false``
-                                                   on write. See `Table Statistics <#table-statistics>`__ for
-                                                   details.
+``hive.collect-column-statistics-on-write``              Enables automatic column level statistics collection         ``false``
+                                                         on write. See `Table Statistics <#table-statistics>`__ for
+                                                         details.
 
-``hive.s3select-pushdown.enabled``                 Enable query pushdown to AWS S3 Select service.              ``false``
+``hive.s3select-pushdown.enabled``                       Enable query pushdown to AWS S3 Select service.              ``false``
 
-``hive.s3select-pushdown.max-connections``         Maximum number of simultaneously open connections to S3 for    500
-                                                   S3SelectPushdown.
+``hive.s3select-pushdown.max-connections``               Maximum number of simultaneously open connections to S3 for    500
+                                                         S3SelectPushdown.
 
-``hive.metastore.load-balancing-enabled``          Enable load balancing between multiple Metastore instances
+``hive.metastore.load-balancing-enabled``                Enable load balancing between multiple Metastore instances
 
-``hive.skip-empty-files``                          Enable skipping empty files. Otherwise, it will produce an   ``false``
-                                                   error iterating through empty files.
+``hive.skip-empty-files``                                Enable skipping empty files. Otherwise, it will produce an   ``false``
+                                                         error iterating through empty files.
 
- ``hive.file-status-cache.max-retained-size``      Maximum size in bytes of the directory listing cache          ``0KB``
+ ``hive.file-status-cache.max-retained-size``            Maximum size in bytes of the directory listing cache          ``0KB``
 
- ``hive.metastore.catalog.name``                   Specifies the catalog name to be passed to the metastore.
-================================================== ============================================================ ============
+ ``hive.metastore.catalog.name``                         Specifies the catalog name to be passed to the metastore.
+
+``hive.experimental.symlink.optimized-reader.enabled``   Experimental: Enable optimized SymlinkTextInputFormat reader  ``true``
+======================================================== ============================================================ ============
 
 Avro Configuration Properties
 -----------------------------

--- a/presto-hive/src/main/java/com/facebook/presto/hive/CachingDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CachingDirectoryLister.java
@@ -142,6 +142,12 @@ public class CachingDirectoryLister
         };
     }
 
+    public boolean isPathCached(Path path)
+    {
+        ValueHolder value = Optional.ofNullable(cache.getIfPresent(path.toString())).orElse(null);
+        return value != null;
+    }
+
     public void invalidateDirectoryListCache(Optional<String> directoryPath)
     {
         if (directoryPath.isPresent()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/DirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DirectoryLister.java
@@ -30,4 +30,9 @@ public interface DirectoryLister
             Optional<Partition> partition,
             NamenodeStats namenodeStats,
             HiveDirectoryContext hiveDirectoryContext);
+
+    default boolean isPathCached(Path path)
+    {
+        return false;
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -224,6 +224,7 @@ public class HiveClientConfig
     private boolean legacyTimestampBucketing;
     private boolean optimizeParsingOfPartitionValues;
     private int optimizeParsingOfPartitionValuesThreshold = 500;
+    private boolean symlinkOptimizedReaderEnabled = true;
 
     @Min(0)
     public int getMaxInitialSplits()
@@ -1859,5 +1860,18 @@ public class HiveClientConfig
     public int getOptimizeParsingOfPartitionValuesThreshold()
     {
         return optimizeParsingOfPartitionValuesThreshold;
+    }
+
+    public boolean isSymlinkOptimizedReaderEnabled()
+    {
+        return symlinkOptimizedReaderEnabled;
+    }
+
+    @Config("hive.experimental.symlink.optimized-reader.enabled")
+    @ConfigDescription("Experimental: Enable optimized SymlinkTextInputFormat reader")
+    public HiveClientConfig setSymlinkOptimizedReaderEnabled(boolean symlinkOptimizedReaderEnabled)
+    {
+        this.symlinkOptimizedReaderEnabled = symlinkOptimizedReaderEnabled;
+        return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -70,6 +70,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
     private static final String MAX_SPLIT_SIZE = "max_split_size";
     private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
+    private static final String SYMLINK_OPTIMIZED_READER_ENABLED = "symlink_optimized_reader_enabled";
     public static final String RCFILE_OPTIMIZED_WRITER_ENABLED = "rcfile_optimized_writer_enabled";
     private static final String RCFILE_OPTIMIZED_WRITER_VALIDATE = "rcfile_optimized_writer_validate";
     private static final String SORTED_WRITING_ENABLED = "sorted_writing_enabled";
@@ -627,6 +628,11 @@ public final class HiveSessionProperties
                         "Use quick stats to resolve stats",
                         hiveClientConfig.isQuickStatsEnabled(),
                         false),
+                booleanProperty(
+                        SYMLINK_OPTIMIZED_READER_ENABLED,
+                        "Experimental: Enable optimized SymlinkTextInputFormat reader",
+                        hiveClientConfig.isSymlinkOptimizedReaderEnabled(),
+                        false),
                 new PropertyMetadata<>(
                         QUICK_STATS_INLINE_BUILD_TIMEOUT,
                         "Duration that the first query that initiated a quick stats call should wait before failing and returning EMPTY stats. " +
@@ -1168,5 +1174,10 @@ public final class HiveSessionProperties
     public static int getOptimizeParsingOfPartitionValuesThreshold(ConnectorSession session)
     {
         return session.getProperty(OPTIMIZE_PARSING_OF_PARTITION_VALUES_THRESHOLD, Integer.class);
+    }
+
+    public static boolean isSymlinkOptimizedReaderEnabled(ConnectorSession session)
+    {
+        return session.getProperty(SYMLINK_OPTIMIZED_READER_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -28,6 +28,7 @@ import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.hadoop.TextLineLengthLimitExceededException;
 import com.facebook.presto.hive.avro.PrestoAvroSerDe;
+import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.hive.metastore.Table;
@@ -105,6 +106,8 @@ import java.math.BigInteger;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -145,12 +148,14 @@ import static com.facebook.presto.hive.HiveColumnHandle.pathColumnHandle;
 import static com.facebook.presto.hive.HiveColumnHandle.rowIdColumnHandle;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_VIEW_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_SERDE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TABLE_BUCKETING_IS_IGNORED;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
+import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.checkCondition;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeaders;
@@ -178,6 +183,7 @@ import static java.math.BigDecimal.ROUND_UNNECESSARY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
+import static org.apache.hadoop.fs.Path.getPathWithoutSchemeAndAuthority;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.FILE_INPUT_FORMAT;
 import static org.apache.hadoop.hive.serde.serdeConstants.COLLECTION_DELIM;
 import static org.apache.hadoop.hive.serde.serdeConstants.DECIMAL_TYPE_NAME;
@@ -263,7 +269,7 @@ public final class HiveUtil
         // Only propagate serialization schema configs by default
         Predicate<String> schemaFilter = schemaProperty -> schemaProperty.startsWith("serialization.");
 
-        InputFormat<?, ?> inputFormat = getInputFormat(configuration, getInputFormatName(schema), true);
+        InputFormat<?, ?> inputFormat = getInputFormat(configuration, getInputFormatName(schema), getDeserializerClassName(schema), true);
         JobConf jobConf = toJobConf(configuration);
         FileSplit fileSplit = new FileSplit(path, start, length, (String[]) null);
         if (!customSplitInfo.isEmpty()) {
@@ -346,15 +352,25 @@ public final class HiveUtil
         return Optional.ofNullable(compressionCodecFactory.getCodec(file));
     }
 
-    public static InputFormat<?, ?> getInputFormat(Configuration configuration, String inputFormatName, boolean symlinkTarget)
+    public static InputFormat<?, ?> getInputFormat(Configuration configuration, String inputFormatName, String serDe, boolean symlinkTarget)
     {
         try {
             JobConf jobConf = toJobConf(configuration);
 
             Class<? extends InputFormat<?, ?>> inputFormatClass = getInputFormatClass(jobConf, inputFormatName);
             if (symlinkTarget && (inputFormatClass == SymlinkTextInputFormat.class)) {
-                // symlink targets are always TextInputFormat
-                inputFormatClass = TextInputFormat.class;
+                if (serDe == null) {
+                    throw new PrestoException(HIVE_UNSUPPORTED_FORMAT, "Missing SerDe for SymlinkTextInputFormat");
+                }
+
+                for (HiveStorageFormat hiveStorageFormat : HiveStorageFormat.values()) {
+                    if (serDe.equals(hiveStorageFormat.getSerDe())) {
+                        inputFormatClass = getInputFormatClass(jobConf, hiveStorageFormat.getInputFormat());
+                        return ReflectionUtils.newInstance(inputFormatClass, jobConf);
+                    }
+                }
+
+                throw new PrestoException(HIVE_UNSUPPORTED_FORMAT, format("Unsupported SerDe for SymlinkTextInputFormat: %s", serDe));
             }
 
             return ReflectionUtils.newInstance(inputFormatClass, jobConf);
@@ -395,7 +411,7 @@ public final class HiveUtil
             return false;
         }
 
-        InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(configuration, storage.getStorageFormat().getInputFormat(), false);
+        InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(configuration, storage.getStorageFormat().getInputFormat(), storage.getStorageFormat().getSerDe(), false);
         return Arrays.stream(inputFormat.getClass().getAnnotations())
                 .map(Annotation::annotationType)
                 .map(Class::getSimpleName)
@@ -1310,5 +1326,83 @@ public final class HiveUtil
             directoryContextProperties.put(PRESTO_CLIENT_TAGS, join(CLIENT_TAGS_DELIMITER, session.getClientTags()));
         }
         return directoryContextProperties.build();
+    }
+
+    public static List<HiveFileInfo> getTargetPathsHiveFileInfos(
+            Path path,
+            HivePartitionMetadata partition,
+            Path targetParent,
+            List<Path> currentTargetPaths,
+            HiveDirectoryContext hiveDirectoryContext,
+            ExtendedFileSystem targetFilesystem,
+            DirectoryLister directoryLister,
+            Table table,
+            NamenodeStats namenodeStats,
+            ConnectorSession session)
+    {
+        boolean parentPathCached = directoryLister.isPathCached(targetParent);
+
+        Map<String, HiveFileInfo> targetParentHiveFileInfos = new HashMap<>(getTargetParentHiveFileInfoMap(
+                partition,
+                targetParent,
+                hiveDirectoryContext,
+                targetFilesystem,
+                directoryLister,
+                table,
+                namenodeStats));
+
+        // If caching is enabled and the parent path was cached, we verify that all target paths exist in the listing.
+        // If any target path is missing (likely due to stale cache), we invalidate the cache for that directory
+        // and re-fetch the listing to ensure we don't miss any files.
+        if (parentPathCached && isUseListDirectoryCache(session)) {
+            boolean allPathsExist = currentTargetPaths.stream()
+                    .map(Path::getPathWithoutSchemeAndAuthority)
+                    .map(Path::toString)
+                    .allMatch(targetParentHiveFileInfos::containsKey);
+
+            if (!allPathsExist) {
+                ((CachingDirectoryLister) directoryLister).invalidateDirectoryListCache(Optional.of(targetParent.toString()));
+
+                targetParentHiveFileInfos.clear();
+                targetParentHiveFileInfos.putAll(getTargetParentHiveFileInfoMap(
+                        partition,
+                        targetParent,
+                        hiveDirectoryContext,
+                        targetFilesystem,
+                        directoryLister,
+                        table,
+                        namenodeStats));
+            }
+        }
+
+        return currentTargetPaths.stream().map(targetPath -> {
+            HiveFileInfo hiveFileInfo = targetParentHiveFileInfos.get(getPathWithoutSchemeAndAuthority(targetPath).toString());
+
+            if (hiveFileInfo == null) {
+                throw new PrestoException(HIVE_FILE_NOT_FOUND, String.format("Invalid path in Symlink manifest file %s: %s does not exist", path, targetPath));
+            }
+
+            return hiveFileInfo;
+        }).collect(toImmutableList());
+    }
+
+    private static Map<String, HiveFileInfo> getTargetParentHiveFileInfoMap(
+            HivePartitionMetadata partition,
+            Path targetParent,
+            HiveDirectoryContext hiveDirectoryContext,
+            ExtendedFileSystem targetFilesystem,
+            DirectoryLister directoryLister,
+            Table table,
+            NamenodeStats namenodeStats)
+    {
+        Map<String, HiveFileInfo> targetParentHiveFileInfos = new HashMap<>();
+        Iterator<HiveFileInfo> hiveFileInfoIterator = directoryLister.list(targetFilesystem, table, targetParent, partition.getPartition(), namenodeStats, hiveDirectoryContext);
+
+        // We will use the path without the scheme and authority since the manifest file may contain entries both with and without them
+        hiveFileInfoIterator.forEachRemaining(hiveFileInfo -> targetParentHiveFileInfos.put(
+                getPathWithoutSchemeAndAuthority(new Path(hiveFileInfo.getPath())).toString(),
+                hiveFileInfo));
+
+        return targetParentHiveFileInfos;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -155,6 +155,7 @@ public class ManifestPartitionLoader
         String partitionName = partition.getHivePartition().getPartitionId().getPartitionName();
         Storage storage = partition.getPartition().map(Partition::getStorage).orElse(table.getStorage());
         String inputFormatName = storage.getStorageFormat().getInputFormat();
+        String serDe = storage.getStorageFormat().getSerDe();
         int partitionDataColumnCount = partition.getPartition()
                 .map(p -> p.getColumns().size())
                 .orElseGet(table.getDataColumns()::size);
@@ -162,7 +163,7 @@ public class ManifestPartitionLoader
         String location = getPartitionLocation(table, partition.getPartition());
         Path path = new Path(location);
         Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
-        InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);
+        InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, serDe, false);
         ExtendedFileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, path);
 
         return new InternalHiveSplitFactory(

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.function.IntPredicate;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.hive.HiveBucketing.getVirtualBucketNumber;
 import static com.facebook.presto.hive.HiveColumnHandle.pathColumnHandle;
@@ -68,11 +69,13 @@ import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.isFileSplittable;
 import static com.facebook.presto.hive.HiveSessionProperties.isOrderBasedExecutionEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isSkipEmptyFilesEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isSymlinkOptimizedReaderEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
 import static com.facebook.presto.hive.HiveUtil.buildDirectoryContextProperties;
 import static com.facebook.presto.hive.HiveUtil.getFooterCount;
 import static com.facebook.presto.hive.HiveUtil.getHeaderCount;
 import static com.facebook.presto.hive.HiveUtil.getInputFormat;
+import static com.facebook.presto.hive.HiveUtil.getTargetPathsHiveFileInfos;
 import static com.facebook.presto.hive.HiveUtil.isHudiParquetInputFormat;
 import static com.facebook.presto.hive.HiveUtil.shouldUseFileSplitsFromInputFormat;
 import static com.facebook.presto.hive.HiveWriterFactory.getBucketNumber;
@@ -143,7 +146,11 @@ public class StoragePartitionLoader
         if (!isNullOrEmpty(table.getStorage().getLocation())) {
             Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, new Path(table.getStorage().getLocation()));
             try {
-                InputFormat<?, ?> inputFormat = getInputFormat(configuration, table.getStorage().getStorageFormat().getInputFormat(), false);
+                InputFormat<?, ?> inputFormat = getInputFormat(
+                        configuration,
+                        table.getStorage().getStorageFormat().getInputFormat(),
+                        table.getStorage().getStorageFormat().getSerDe(),
+                        false);
                 if (isHudiParquetInputFormat(inputFormat)) {
                     directoryListerOverride = Optional.of(new HudiDirectoryLister(configuration, session, table));
                 }
@@ -159,7 +166,8 @@ public class StoragePartitionLoader
         this.directoryLister = directoryListerOverride.orElseGet(() -> requireNonNull(directoryLister, "directoryLister is null"));
     }
 
-    private ListenableFuture<?> handleSymlinkTextInputFormat(ExtendedFileSystem fs,
+    private ListenableFuture<?> handleSymlinkTextInputFormat(
+            ExtendedFileSystem fs,
             Path path,
             InputFormat<?, ?> inputFormat,
             boolean s3SelectPushdownEnabled,
@@ -169,16 +177,132 @@ public class StoragePartitionLoader
             int partitionDataColumnCount,
             boolean stopped,
             HivePartitionMetadata partition,
-            HiveSplitSource hiveSplitSource)
+            HiveSplitSource hiveSplitSource,
+            Configuration configuration,
+            boolean splittable)
             throws IOException
     {
         if (tableBucketInfo.isPresent()) {
             throw new PrestoException(NOT_SUPPORTED, "Bucketed table in SymlinkTextInputFormat is not yet supported");
         }
 
-        // TODO: This should use an iterator like the HiveFileIterator
+        List<Path> targetPaths = getTargetPathsFromSymlink(fs, path, partition.getPartition());
+
+        if (isSymlinkOptimizedReaderEnabled(session)) {
+            Map<Path, List<Path>> parentToTargets = targetPaths.stream().collect(Collectors.groupingBy(Path::getParent));
+
+            InputFormat<?, ?> targetInputFormat = getInputFormat(
+                    configuration,
+                    storage.getStorageFormat().getInputFormat(),
+                    storage.getStorageFormat().getSerDe(),
+                    true);
+
+            HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(
+                    IGNORED,
+                    isUseListDirectoryCache(session),
+                    isSkipEmptyFilesEnabled(session),
+                    hdfsContext.getIdentity(),
+                    buildDirectoryContextProperties(session),
+                    session.getRuntimeStats());
+
+            for (Map.Entry<Path, List<Path>> entry : parentToTargets.entrySet()) {
+                Iterator<InternalHiveSplit> symlinkIterator = getSymlinkIterator(
+                        path,
+                        s3SelectPushdownEnabled,
+                        storage,
+                        partitionKeys,
+                        partitionName,
+                        partitionDataColumnCount,
+                        partition,
+                        splittable,
+                        entry.getKey(),
+                        entry.getValue(),
+                        targetInputFormat,
+                        hiveDirectoryContext);
+
+                fileIterators.addLast(symlinkIterator);
+            }
+            return COMPLETED_FUTURE;
+        }
+
+        return getSymlinkSplits(
+                path,
+                inputFormat,
+                s3SelectPushdownEnabled,
+                storage,
+                partitionKeys,
+                partitionName,
+                partitionDataColumnCount,
+                stopped,
+                partition,
+                hiveSplitSource,
+                targetPaths);
+    }
+
+    private Iterator<InternalHiveSplit> getSymlinkIterator(
+            Path path,
+            boolean s3SelectPushdownEnabled,
+            Storage storage,
+            List<HivePartitionKey> partitionKeys,
+            String partitionName,
+            int partitionDataColumnCount,
+            HivePartitionMetadata partition,
+            boolean splittable,
+            Path targetParent,
+            List<Path> currentTargetPaths,
+            InputFormat<?, ?> targetInputFormat,
+            HiveDirectoryContext hiveDirectoryContext)
+            throws IOException
+    {
+        ExtendedFileSystem targetFilesystem = hdfsEnvironment.getFileSystem(hdfsContext, targetParent);
+
+        List<HiveFileInfo> targetPathsHiveFileInfos = getTargetPathsHiveFileInfos(
+                path,
+                partition,
+                targetParent,
+                currentTargetPaths,
+                hiveDirectoryContext,
+                targetFilesystem,
+                directoryLister,
+                table,
+                namenodeStats,
+                session);
+
+        InternalHiveSplitFactory splitFactory = getHiveSplitFactory(
+                targetFilesystem,
+                targetInputFormat,
+                s3SelectPushdownEnabled,
+                storage,
+                targetParent.toUri().toString(),
+                partitionName,
+                partitionKeys,
+                partitionDataColumnCount,
+                partition,
+                Optional.empty());
+
+        return targetPathsHiveFileInfos.stream()
+                .map(hiveFileInfo -> splitFactory.createInternalHiveSplit(hiveFileInfo, splittable))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .iterator();
+    }
+
+    private ListenableFuture<?> getSymlinkSplits(
+            Path path,
+            InputFormat<?, ?> inputFormat,
+            boolean s3SelectPushdownEnabled,
+            Storage storage,
+            List<HivePartitionKey> partitionKeys,
+            String partitionName,
+            int partitionDataColumnCount,
+            boolean stopped,
+            HivePartitionMetadata partition,
+            HiveSplitSource hiveSplitSource,
+            List<Path> targetPaths)
+            throws IOException
+    {
         ListenableFuture<?> lastResult = COMPLETED_FUTURE;
-        for (Path targetPath : getTargetPathsFromSymlink(fs, path, partition.getPartition())) {
+        for (Path targetPath : targetPaths) {
             // The input should be in TextInputFormat.
             TextInputFormat targetInputFormat = new TextInputFormat();
             // the splits must be generated using the file system for the target path
@@ -201,8 +325,17 @@ public class StoragePartitionLoader
             FileInputFormat.setInputPaths(targetJob, targetPath);
             InputSplit[] targetSplits = targetInputFormat.getSplits(targetJob, 0);
 
-            InternalHiveSplitFactory splitFactory = getHiveSplitFactory(targetFilesystem, inputFormat, s3SelectPushdownEnabled, storage, path.toUri().toString(), partitionName,
-                    partitionKeys, partitionDataColumnCount, partition, Optional.empty());
+            InternalHiveSplitFactory splitFactory = getHiveSplitFactory(
+                    targetFilesystem,
+                    inputFormat,
+                    s3SelectPushdownEnabled,
+                    storage,
+                    path.toUri().toString(),
+                    partitionName,
+                    partitionKeys,
+                    partitionDataColumnCount,
+                    partition,
+                    Optional.empty());
             lastResult = addSplitsToSource(targetSplits, splitFactory, hiveSplitSource, stopped);
             if (stopped) {
                 return COMPLETED_FUTURE;
@@ -273,6 +406,7 @@ public class StoragePartitionLoader
         Storage storage = partition.getPartition().map(Partition::getStorage).orElse(table.getStorage());
         Properties schema = getPartitionSchema(table, partition.getPartition());
         String inputFormatName = storage.getStorageFormat().getInputFormat();
+        String serDe = storage.getStorageFormat().getSerDe();
         int partitionDataColumnCount = partition.getPartition()
                 .map(p -> p.getColumns().size())
                 .orElseGet(table.getDataColumns()::size);
@@ -294,13 +428,22 @@ public class StoragePartitionLoader
                 configuration = ((CopyOnFirstWriteConfiguration) configuration).getConfig();
             }
         }
-        InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);
+        InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, serDe, false);
         ExtendedFileSystem fs = hdfsEnvironment.getFileSystem(hdfsContext.getIdentity().getUser(), path, configuration);
         boolean s3SelectPushdownEnabled = shouldEnablePushdownForTable(session, table, path.toString(), partition.getPartition());
 
+        // Streaming aggregation works at the granularity of individual files
+        // Partial aggregation pushdown works at the granularity of individual files
+        // therefore we must not split files when either is enabled.
+        // Skip header / footer lines are not splittable except for a special case when skip.header.line.count=1
+        boolean splittable = isFileSplittable(session) &&
+                !isOrderBasedExecutionEnabled(session) &&
+                !partialAggregationsPushedDown &&
+                getFooterCount(schema) == 0 && getHeaderCount(schema) <= 1;
+
         if (inputFormat instanceof SymlinkTextInputFormat) {
             return handleSymlinkTextInputFormat(fs, path, inputFormat, s3SelectPushdownEnabled, storage, partitionKeys, partitionName,
-                    partitionDataColumnCount, stopped, partition, hiveSplitSource);
+                    partitionDataColumnCount, stopped, partition, hiveSplitSource, configuration, splittable);
         }
 
         Optional<HiveSplit.BucketConversion> bucketConversion = Optional.empty();
@@ -335,15 +478,6 @@ public class StoragePartitionLoader
         if (shouldUseFileSplitsFromInputFormat(inputFormat, directoryLister)) {
             return handleGetSplitsFromInputFormat(configuration, path, schema, inputFormat, stopped, hiveSplitSource, splitFactory);
         }
-
-        // Streaming aggregation works at the granularity of individual files
-        // Partial aggregation pushdown works at the granularity of individual files
-        // therefore we must not split files when either is enabled.
-        // Skip header / footer lines are not splittable except for a special case when skip.header.line.count=1
-        boolean splittable = isFileSplittable(session) &&
-                !isOrderBasedExecutionEnabled(session) &&
-                !partialAggregationsPushedDown &&
-                getFooterCount(schema) == 0 && getHeaderCount(schema) <= 1;
 
         // Bucketed partitions are fully loaded immediately since all files must be loaded to determine the file to bucket mapping
         if (tableBucketInfo.isPresent()) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -24,6 +24,7 @@ import com.facebook.presto.hive.util.InternalHiveSplitFactory;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
@@ -239,7 +240,8 @@ public class StoragePartitionLoader
                 targetPaths);
     }
 
-    private Iterator<InternalHiveSplit> getSymlinkIterator(
+    @VisibleForTesting
+    Iterator<InternalHiveSplit> getSymlinkIterator(
             Path path,
             boolean s3SelectPushdownEnabled,
             Storage storage,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -123,7 +123,7 @@ public class TestBackgroundHiveSplitLoader
     private static final Optional<HiveBucketProperty> BUCKET_PROPERTY = Optional.of(
             new HiveBucketProperty(ImmutableList.of("col1"), BUCKET_COUNT, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty()));
 
-    private static final Table SIMPLE_TABLE = table(ImmutableList.of(), Optional.empty());
+    public static final Table SIMPLE_TABLE = table(ImmutableList.of(), Optional.empty());
     private static final Table PARTITIONED_TABLE = table(PARTITION_COLUMNS, BUCKET_PROPERTY);
 
     @Test
@@ -541,7 +541,7 @@ public class TestBackgroundHiveSplitLoader
                 false);
     }
 
-    private static List<HivePartitionMetadata> samplePartitionMetadatas()
+    public static List<HivePartitionMetadata> samplePartitionMetadatas()
     {
         return ImmutableList.of(
                         new HivePartitionMetadata(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -168,7 +168,8 @@ public class TestHiveClientConfig
                 .setSkipEmptyFilesEnabled(false)
                 .setOptimizeParsingOfPartitionValues(false)
                 .setOptimizeParsingOfPartitionValuesThreshold(500)
-                .setLegacyTimestampBucketing(false));
+                .setLegacyTimestampBucketing(false)
+                .setSymlinkOptimizedReaderEnabled(true));
     }
 
     @Test
@@ -297,6 +298,7 @@ public class TestHiveClientConfig
                 .put("hive.optimize-parsing-of-partition-values-enabled", "true")
                 .put("hive.optimize-parsing-of-partition-values-threshold", "100")
                 .put("hive.legacy-timestamp-bucketing", "true")
+                .put("hive.experimental.symlink.optimized-reader.enabled", "false")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -420,7 +422,8 @@ public class TestHiveClientConfig
                 .setCteVirtualBucketCount(256)
                 .setOptimizeParsingOfPartitionValues(true)
                 .setOptimizeParsingOfPartitionValuesThreshold(100)
-                .setLegacyTimestampBucketing(true);
+                .setLegacyTimestampBucketing(true)
+                .setSymlinkOptimizedReaderEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestStoragePartitionLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestStoragePartitionLoader.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.TestBackgroundHiveSplitLoader.TestingHdfsEnvironment;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.testing.TestingConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
+import org.apache.hadoop.mapred.InputFormat;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.hive.HiveSessionProperties.isSkipEmptyFilesEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
+import static com.facebook.presto.hive.HiveStorageFormat.PARQUET;
+import static com.facebook.presto.hive.HiveTestUtils.getAllSessionProperties;
+import static com.facebook.presto.hive.HiveUtil.buildDirectoryContextProperties;
+import static com.facebook.presto.hive.NestedDirectoryPolicy.IGNORED;
+import static com.facebook.presto.hive.StoragePartitionLoader.BucketSplitInfo.createBucketSplitInfo;
+import static com.facebook.presto.hive.TestBackgroundHiveSplitLoader.SIMPLE_TABLE;
+import static com.facebook.presto.hive.TestBackgroundHiveSplitLoader.samplePartitionMetadatas;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static org.testng.Assert.assertEquals;
+
+public class TestStoragePartitionLoader
+{
+    @Test
+    public void testGetSymlinkIterator()
+            throws Exception
+    {
+        CachingDirectoryLister directoryLister = new CachingDirectoryLister(
+                new HadoopDirectoryLister(),
+                new Duration(5, TimeUnit.MINUTES),
+                new DataSize(100, KILOBYTE),
+                ImmutableList.of());
+
+        Configuration configuration = new Configuration(false);
+
+        InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(
+                configuration,
+                SymlinkTextInputFormat.class.getName(),
+                PARQUET.getSerDe(),
+                true);
+
+        Path firstFilePath = new Path("hdfs://hadoop:9000/db_name/table_name/file1");
+        Path secondFilePath = new Path("hdfs://hadoop:9000/db_name/table_name/file2");
+        List<Path> paths = ImmutableList.of(firstFilePath, secondFilePath);
+        List<LocatedFileStatus> files = paths.stream()
+                .map(path -> locatedFileStatus(path, 0L))
+                .collect(toImmutableList());
+
+        ConnectorSession connectorSession = new TestingConnectorSession(getAllSessionProperties(
+                new HiveClientConfig().setMaxSplitSize(new DataSize(1.0, GIGABYTE))
+                        .setFileStatusCacheTables(""),
+                new HiveCommonClientConfig()));
+
+        StoragePartitionLoader storagePartitionLoader = storagePartitionLoader(files, directoryLister, connectorSession);
+
+        HdfsContext hdfsContext = new HdfsContext(
+                connectorSession,
+                SIMPLE_TABLE.getDatabaseName(),
+                SIMPLE_TABLE.getTableName(),
+                SIMPLE_TABLE.getStorage().getLocation(),
+                false);
+
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(
+                IGNORED,
+                isUseListDirectoryCache(connectorSession),
+                isSkipEmptyFilesEnabled(connectorSession),
+                hdfsContext.getIdentity(),
+                buildDirectoryContextProperties(connectorSession),
+                connectorSession.getRuntimeStats());
+
+        Iterator<InternalHiveSplit> symlinkIterator = storagePartitionLoader.getSymlinkIterator(
+                new Path("hdfs://hadoop:9000/db_name/table_name/symlink_manifest"),
+                false,
+                SIMPLE_TABLE.getStorage(),
+                ImmutableList.of(),
+                "UNPARTITIONED",
+                SIMPLE_TABLE.getDataColumns().size(),
+                getOnlyElement(samplePartitionMetadatas()),
+                true,
+                new Path("hdfs://hadoop:9000/db_name/table_name/"),
+                paths,
+                inputFormat,
+                hiveDirectoryContext);
+
+        List<InternalHiveSplit> splits = ImmutableList.copyOf(symlinkIterator);
+        assertEquals(splits.size(), 2);
+        assertEquals(splits.get(0).getPath(), firstFilePath.toString());
+        assertEquals(splits.get(1).getPath(), secondFilePath.toString());
+    }
+
+    private static LocatedFileStatus locatedFileStatus(Path path, long fileSize)
+    {
+        return new LocatedFileStatus(
+                fileSize,
+                false,
+                0,
+                0L,
+                0L,
+                0L,
+                null,
+                null,
+                null,
+                null,
+                path,
+                new org.apache.hadoop.fs.BlockLocation[]{new BlockLocation(new String[1], new String[]{"localhost"}, 0, fileSize)});
+    }
+
+    private static StoragePartitionLoader storagePartitionLoader(
+            List<LocatedFileStatus> files,
+            DirectoryLister directoryLister,
+            ConnectorSession connectorSession)
+    {
+        return new StoragePartitionLoader(
+                SIMPLE_TABLE,
+                ImmutableMap.of(),
+                createBucketSplitInfo(Optional.empty(), Optional.empty()),
+                connectorSession,
+                new TestingHdfsEnvironment(files),
+                new NamenodeStats(),
+                directoryLister,
+                new ConcurrentLinkedDeque<>(),
+                false,
+                false,
+                false);
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/TestGroups.java
@@ -69,6 +69,7 @@ public final class TestGroups
     public static final String HIVE_LIST_CACHING = "hive_list_caching";
     public static final String INVALIDATE_METASTORE_CACHE = "invalidate_metastore_cache";
     public static final String MIXED_CASE = "mixed_case";
+    public static final String HIVE_SYMLINK_TABLE = "hive_symlink_table";
 
     private TestGroups() {}
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/SymlinkTestUtils.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/SymlinkTestUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.hive;
+
+import io.prestodb.tempto.hadoop.hdfs.HdfsClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static com.facebook.presto.tests.utils.QueryExecutors.onHive;
+import static com.google.common.io.Resources.getResource;
+import static java.lang.String.format;
+
+public class SymlinkTestUtils
+{
+    private SymlinkTestUtils()
+    {
+    }
+
+    public static void createParquetSymlinkTable(
+            HdfsClient hdfsClient,
+            String table,
+            String warehouseDirectoryPath,
+            boolean multipleParents)
+            throws IOException
+    {
+        onHive().executeQuery("DROP TABLE IF EXISTS " + table);
+
+        onHive().executeQuery("" +
+                "CREATE TABLE " + table +
+                "(col int) " +
+                "ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe' " +
+                "STORED AS " +
+                "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat' " +
+                "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat' ");
+
+        String tableRoot = warehouseDirectoryPath + "/" + table;
+        String dataDir = warehouseDirectoryPath + "/data_" + table;
+
+        // Save a parquet file
+        saveResourceOnHdfs(hdfsClient, "data.parquet", dataDir + "/data.parquet");
+
+        if (multipleParents) {
+            String secondDataDir = warehouseDirectoryPath + "/secondData_" + table;
+            saveResourceOnHdfs(hdfsClient, "data.parquet", secondDataDir + "/data.parquet");
+
+            // Save Symlink Manifest
+            hdfsClient.saveFile(
+                    tableRoot + "/manifest",
+                    format("hdfs://hadoop-master:9000%s/data.parquet\nhdfs://hadoop-master:9000%s/data.parquet", dataDir, secondDataDir));
+        }
+        else {
+            // Save Symlink Manifest
+            hdfsClient.saveFile(tableRoot + "/manifest", format("hdfs://hadoop-master:9000%s/data.parquet", dataDir));
+        }
+    }
+
+    public static void deleteSymlinkTable(HdfsClient hdfsClient, String table, List<String> dataDirs)
+    {
+        onHive().executeQuery("DROP TABLE IF EXISTS " + table);
+
+        dataDirs.forEach(hdfsClient::delete);
+    }
+
+    public static void saveResourceOnHdfs(HdfsClient hdfsClient, String resource, String location)
+            throws IOException
+    {
+        hdfsClient.delete(location);
+        try (InputStream inputStream = getResource(Paths.get("com/facebook/presto/tests/hive/data/single_int_column/", resource).toString()).openStream()) {
+            hdfsClient.saveFile(location, inputStream);
+        }
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSymlinkTables.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSymlinkTables.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.name.Named;
+import io.prestodb.tempto.ProductTest;
+import io.prestodb.tempto.hadoop.hdfs.HdfsClient;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+
+import static com.facebook.presto.tests.TestGroups.HIVE_SYMLINK_TABLE;
+import static com.facebook.presto.tests.hive.SymlinkTestUtils.createParquetSymlinkTable;
+import static com.facebook.presto.tests.hive.SymlinkTestUtils.deleteSymlinkTable;
+import static com.facebook.presto.tests.hive.SymlinkTestUtils.saveResourceOnHdfs;
+import static com.facebook.presto.tests.utils.QueryExecutors.onPresto;
+import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
+import static io.prestodb.tempto.assertions.QueryAssert.assertThat;
+
+public class TestSymlinkTables
+        extends ProductTest
+{
+    @Inject
+    @Named("databases.hive.warehouse_directory_path")
+    private String warehouseDirectoryPath;
+
+    @Inject
+    private HdfsClient hdfsClient;
+
+    @Test(groups = {HIVE_SYMLINK_TABLE})
+    public void testHiveSymlinkTable()
+            throws IOException
+    {
+        String table = "test_parquet_symlink";
+        createParquetSymlinkTable(hdfsClient, table, warehouseDirectoryPath, false);
+
+        String dataDir = warehouseDirectoryPath + "/data_" + table;
+
+        // Save a non-parquet file in dataDir path which should throw an error if tried to access as parquet
+        saveResourceOnHdfs(hdfsClient, "data.orc", dataDir + "/data.orc");
+
+        assertThat(onPresto().executeQuery("SELECT * FROM hive.default." + table)).containsExactly(row(42));
+
+        deleteSymlinkTable(hdfsClient, table, ImmutableList.of(dataDir));
+    }
+
+    @Test(groups = {HIVE_SYMLINK_TABLE})
+    public void testHiveSymlinkTableWithTargetsInMultipleDirectories()
+            throws IOException
+    {
+        String table = "test_parquet_symlink_with_multiple_directories";
+        createParquetSymlinkTable(hdfsClient, table, warehouseDirectoryPath, true);
+
+        String dataDir = warehouseDirectoryPath + "/data_" + table;
+        String secondDataDir = warehouseDirectoryPath + "/secondData_" + table;
+
+        // Save a non-parquet file in dataDir path which should throw an error if tried to access as parquet
+        saveResourceOnHdfs(hdfsClient, "data.orc", dataDir + "/data.orc");
+
+        assertThat(onPresto().executeQuery("SELECT count(*) as count FROM hive.default." + table)).containsExactly(row(2));
+
+        deleteSymlinkTable(hdfsClient, table, ImmutableList.of(dataDir, secondDataDir));
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Presto currently relies on Hadoop’s implementation to generate splits from entries in a SymlinkTextInputFormat manifest. The existing approach retrieves file statuses one at a time, which introduces noticeable latency. The new implementation improves this by using DirectoryLister to bulk list symlinked files that share common parent directories, allowing splits to be created more efficiently. This change significantly reduces the overhead compared to the previous method and aims to bring performance closer to that of standard Hive tables.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Optimize split generation and read throughput for Delta Lake and other Symlink Tables accessed using the Hive connector.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
I’ve tested it across multiple workloads (TPC-H and TPC-DS at sf1k) on both partitioned and non-partitioned tables, and everything looks good.
Also validated with a concurrent(Concurrency of 10-15)  TPCH sf1k workload, no issues observed.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Improve split generation and read throughput for Symlink Tables
```
