### PR TITLE
[Iceberg] Add support for $deleted and $delete_file_path metadata columns

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -675,6 +675,42 @@ The Iceberg data sequence number in which this row was added.
      ----------------------------------+------------
                   2                    | 3
 
+``$deleted`` column
+^^^^^^^^^^^^^^^^^^^
+Whether this row is a deleted row. When this column is used, deleted rows
+from delete files will be marked as ``true`` instead of being filtered out of the results.
+
+.. code-block:: sql
+
+    DELETE FROM "ctas_nation" WHERE regionkey = 0;
+
+    SELECT "$deleted", regionkey FROM "ctas_nation";
+
+.. code-block:: text
+
+     $deleted | regionkey
+    ----------+-----------
+     true     |         0
+     false    |         1
+
+``$delete_file_path`` column
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The path of the delete file corresponding to a deleted row, or NULL if the row was not deleted.
+When this column is used, deleted rows will not be filtered out of the results.
+
+.. code-block:: sql
+
+    DELETE FROM "ctas_nation" WHERE regionkey = 0;
+
+    SELECT "$delete_file_path", regionkey FROM "ctas_nation";
+
+.. code-block:: text
+
+                                     $delete_file_path                                 | regionkey
+    -----------------------------------------------------------------------------------+-----------
+     file:/path/to/table/data/delete_file_d8510b3e-510a-4fc2-b2b2-e59ead7fd386.parquet |         0
+     NULL                                                                              |         1
+
 Presto C++ Support
 ^^^^^^^^^^^^^^^^^^
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -130,12 +130,18 @@ import static com.facebook.presto.hive.MetadataUtils.isEntireColumn;
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.DATA_SEQUENCE_NUMBER_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.DATA_SEQUENCE_NUMBER_COLUMN_METADATA;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.DELETE_FILE_PATH_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.DELETE_FILE_PATH_COLUMN_METADATA;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.IS_DELETED_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.IS_DELETED_COLUMN_METADATA;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_METADATA;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.DATA_SEQUENCE_NUMBER;
+import static com.facebook.presto.iceberg.IcebergMetadataColumn.DELETE_FILE_PATH;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.FILE_PATH;
+import static com.facebook.presto.iceberg.IcebergMetadataColumn.IS_DELETED;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.UPDATE_ROW_DATA;
 import static com.facebook.presto.iceberg.IcebergPartitionType.ALL;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
@@ -431,6 +437,8 @@ public abstract class IcebergAbstractMetadata
             else {
                 columns.add(PATH_COLUMN_METADATA);
                 columns.add(DATA_SEQUENCE_NUMBER_COLUMN_METADATA);
+                columns.add(IS_DELETED_COLUMN_METADATA);
+                columns.add(DELETE_FILE_PATH_COLUMN_METADATA);
             }
             return new ConnectorTableMetadata(table, columns.build(), createMetadataProperties(icebergTable, session), getTableComment(icebergTable));
         }
@@ -932,6 +940,8 @@ public abstract class IcebergAbstractMetadata
         if (table.getIcebergTableName().getTableType() != CHANGELOG) {
             columnHandles.put(FILE_PATH.getColumnName(), PATH_COLUMN_HANDLE);
             columnHandles.put(DATA_SEQUENCE_NUMBER.getColumnName(), DATA_SEQUENCE_NUMBER_COLUMN_HANDLE);
+            columnHandles.put(IS_DELETED.getColumnName(), IS_DELETED_COLUMN_HANDLE);
+            columnHandles.put(DELETE_FILE_PATH.getColumnName(), DELETE_FILE_PATH_COLUMN_HANDLE);
         }
         return columnHandles.build();
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
@@ -34,7 +34,9 @@ import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZ
 import static com.facebook.presto.iceberg.ColumnIdentity.createColumnIdentity;
 import static com.facebook.presto.iceberg.ColumnIdentity.primitiveColumnIdentity;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.DATA_SEQUENCE_NUMBER;
+import static com.facebook.presto.iceberg.IcebergMetadataColumn.DELETE_FILE_PATH;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.FILE_PATH;
+import static com.facebook.presto.iceberg.IcebergMetadataColumn.IS_DELETED;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.UPDATE_ROW_DATA;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -50,6 +52,10 @@ public class IcebergColumnHandle
     public static final ColumnMetadata PATH_COLUMN_METADATA = getColumnMetadata(FILE_PATH);
     public static final IcebergColumnHandle DATA_SEQUENCE_NUMBER_COLUMN_HANDLE = getIcebergColumnHandle(DATA_SEQUENCE_NUMBER);
     public static final ColumnMetadata DATA_SEQUENCE_NUMBER_COLUMN_METADATA = getColumnMetadata(DATA_SEQUENCE_NUMBER);
+    public static final IcebergColumnHandle IS_DELETED_COLUMN_HANDLE = getIcebergColumnHandle(IS_DELETED);
+    public static final ColumnMetadata IS_DELETED_COLUMN_METADATA = getColumnMetadata(IS_DELETED);
+    public static final IcebergColumnHandle DELETE_FILE_PATH_COLUMN_HANDLE = getIcebergColumnHandle(DELETE_FILE_PATH);
+    public static final ColumnMetadata DELETE_FILE_PATH_COLUMN_METADATA = getColumnMetadata(DELETE_FILE_PATH);
 
     private final ColumnIdentity columnIdentity;
     private final Type type;
@@ -178,6 +184,16 @@ public class IcebergColumnHandle
     public boolean isDataSequenceNumberColumn()
     {
         return getColumnIdentity().getId() == DATA_SEQUENCE_NUMBER.getId();
+    }
+
+    public boolean isDeletedColumn()
+    {
+        return getColumnIdentity().getId() == IS_DELETED.getId();
+    }
+
+    public boolean isDeleteFilePathColumn()
+    {
+        return getColumnIdentity().getId() == DELETE_FILE_PATH.getId();
     }
 
     public static IcebergColumnHandle primitiveIcebergColumnHandle(int id, String name, Type type, Optional<String> comment)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataColumn.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataColumn.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
@@ -32,6 +33,8 @@ public enum IcebergMetadataColumn
 {
     FILE_PATH(MetadataColumns.FILE_PATH.fieldId(), "$path", VARCHAR, PRIMITIVE),
     DATA_SEQUENCE_NUMBER(Integer.MAX_VALUE - 1001, "$data_sequence_number", BIGINT, PRIMITIVE),
+    IS_DELETED(MetadataColumns.IS_DELETED.fieldId(), "$deleted", BOOLEAN, PRIMITIVE),
+    DELETE_FILE_PATH(MetadataColumns.DELETE_FILE_PATH.fieldId(), "$delete_file_path", VARCHAR, PRIMITIVE),
     /**
      * Iceberg reserved row ids begin at INTEGER.MAX_VALUE and count down. Starting with MIN_VALUE here to avoid conflicts.
      * Inner type for row is not known until runtime.

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFilter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFilter.java
@@ -16,8 +16,11 @@ package com.facebook.presto.iceberg.delete;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DeleteFilter
 {
     RowPredicate createPredicate(List<IcebergColumnHandle> columns);
+
+    Optional<String> getDeleteFilePath();
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/EqualityDeleteFilter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/EqualityDeleteFilter.java
@@ -22,7 +22,10 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.util.StructLikeSet;
 import org.apache.iceberg.util.StructProjection;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.iceberg.IcebergUtil.schemaFromHandles;
 import static java.util.Objects.requireNonNull;
@@ -32,11 +35,14 @@ public final class EqualityDeleteFilter
 {
     private final Schema schema;
     private final StructLikeSet deleteSet;
+    @Nullable
+    private final String deleteFilePath;
 
-    private EqualityDeleteFilter(Schema schema, StructLikeSet deleteSet)
+    private EqualityDeleteFilter(Schema schema, StructLikeSet deleteSet, @Nullable String deleteFilePath)
     {
         this.schema = requireNonNull(schema, "schema is null");
         this.deleteSet = requireNonNull(deleteSet, "deleteSet is null");
+        this.deleteFilePath = deleteFilePath;
     }
 
     @Override
@@ -55,7 +61,13 @@ public final class EqualityDeleteFilter
         };
     }
 
-    public static DeleteFilter readEqualityDeletes(ConnectorPageSource pageSource, List<IcebergColumnHandle> columns, Schema tableSchema)
+    @Override
+    public Optional<String> getDeleteFilePath()
+    {
+        return Optional.ofNullable(deleteFilePath);
+    }
+
+    public static DeleteFilter readEqualityDeletes(ConnectorPageSource pageSource, List<IcebergColumnHandle> columns, String deleteFilePath)
     {
         Type[] types = columns.stream()
                 .map(IcebergColumnHandle::getType)
@@ -75,6 +87,6 @@ public final class EqualityDeleteFilter
             }
         }
 
-        return new EqualityDeleteFilter(deleteSchema, deleteSet);
+        return new EqualityDeleteFilter(deleteSchema, deleteSet, deleteFilePath);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/PositionDeleteFilter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/PositionDeleteFilter.java
@@ -21,7 +21,10 @@ import io.airlift.slice.Slice;
 import org.roaringbitmap.longlong.ImmutableLongBitmapDataProvider;
 import org.roaringbitmap.longlong.LongBitmapDataProvider;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -32,10 +35,13 @@ public final class PositionDeleteFilter
         implements DeleteFilter
 {
     private final ImmutableLongBitmapDataProvider deletedRows;
+    @Nullable
+    private final String deleteFilePath;
 
-    public PositionDeleteFilter(ImmutableLongBitmapDataProvider deletedRows)
+    public PositionDeleteFilter(ImmutableLongBitmapDataProvider deletedRows, @Nullable String deleteFilePath)
     {
         this.deletedRows = requireNonNull(deletedRows, "deletedRows is null");
+        this.deleteFilePath = deleteFilePath;
     }
 
     @Override
@@ -46,6 +52,11 @@ public final class PositionDeleteFilter
             long filePos = BIGINT.getLong(page.getBlock(filePosChannel), position);
             return !deletedRows.contains(filePos);
         };
+    }
+
+    public Optional<String> getDeleteFilePath()
+    {
+        return Optional.ofNullable(deleteFilePath);
     }
 
     private static int rowPositionChannel(List<IcebergColumnHandle> columns)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
@@ -83,6 +83,8 @@ import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.iceberg.FileContent.EQUALITY_DELETES;
 import static com.facebook.presto.iceberg.FileContent.fromIcebergFileContent;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.DATA_SEQUENCE_NUMBER_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.DELETE_FILE_PATH_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.IS_DELETED_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.DATA_SEQUENCE_NUMBER;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isDeleteToJoinPushdownEnabled;
@@ -172,6 +174,11 @@ public class IcebergEqualityDeleteAsJoin
             IcebergTableName tableName = icebergTableHandle.getIcebergTableName();
             if (!tableName.getSnapshotId().isPresent() || tableName.getTableType() != IcebergTableType.DATA) {
                 // Node is already optimized or not ready for planning
+                return node;
+            }
+
+            if (node.getAssignments().containsValue(IS_DELETED_COLUMN_HANDLE) || node.getAssignments().containsValue(DELETE_FILE_PATH_COLUMN_HANDLE)) {
+                // Skip this optimization if metadata columns `$deleted` or `$delete_file_path` exist
                 return node;
             }
 


### PR DESCRIPTION
## Description
Adds support for additional Iceberg metadata as hidden columns. The "$deleted" column shows whether each row is deleted, instead of a filtering out deleted rows. The "$delete_file_path" column shows the path of the delete file corresponding to a deleted row, or NULL if the row was not deleted.

Will need some feedback to confirm that this logic is what is intended for these columns and the naming of these columns ($is_deleted or $deleted)?

## Motivation and Context
Closes #24733.

## Impact
Exposes important debugging information not previously available.

## Test Plan
Added tests in IcebergDistributedTestBase. Equality delete files have not been tested yet.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support for ``$deleted`` metadata column
* Add support for ``$delete_file_path`` metadata column
```
