### PR TITLE
Fix qDigest values_at_quantiles function to throw INVALID_FUNCTION_ARGUMENT on null input

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/QuantileDigestFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/QuantileDigestFunctions.java
@@ -107,8 +107,16 @@ public final class QuantileDigestFunctions
     {
         QuantileDigest digest = new QuantileDigest(input);
         BlockBuilder output = DOUBLE.createBlockBuilder(null, percentilesArrayBlock.getPositionCount());
-        for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
-            DOUBLE.writeDouble(output, sortableLongToDouble(digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i))));
+        if (percentilesArrayBlock.mayHaveNull()) {
+            for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+                checkCondition(!percentilesArrayBlock.isNull(i), INVALID_FUNCTION_ARGUMENT, "All quantiles should be non-null.");
+                DOUBLE.writeDouble(output, sortableLongToDouble(digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i))));
+            }
+        }
+        else {
+            for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+                DOUBLE.writeDouble(output, sortableLongToDouble(digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i))));
+            }
         }
         return output.build();
     }
@@ -120,8 +128,16 @@ public final class QuantileDigestFunctions
     {
         QuantileDigest digest = new QuantileDigest(input);
         BlockBuilder output = REAL.createBlockBuilder(null, percentilesArrayBlock.getPositionCount());
-        for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
-            REAL.writeLong(output, floatToRawIntBits(sortableIntToFloat((int) digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)))));
+        if (percentilesArrayBlock.mayHaveNull()) {
+            for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+                checkCondition(!percentilesArrayBlock.isNull(i), INVALID_FUNCTION_ARGUMENT, "All quantiles should be non-null.");
+                REAL.writeLong(output, floatToRawIntBits(sortableIntToFloat((int) digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)))));
+            }
+        }
+        else {
+            for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+                REAL.writeLong(output, floatToRawIntBits(sortableIntToFloat((int) digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)))));
+            }
         }
         return output.build();
     }
@@ -133,8 +149,16 @@ public final class QuantileDigestFunctions
     {
         QuantileDigest digest = new QuantileDigest(input);
         BlockBuilder output = BIGINT.createBlockBuilder(null, percentilesArrayBlock.getPositionCount());
-        for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
-            BIGINT.writeLong(output, digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)));
+        if (percentilesArrayBlock.mayHaveNull()) {
+            for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+                checkCondition(!percentilesArrayBlock.isNull(i), INVALID_FUNCTION_ARGUMENT, "All quantiles should be non-null.");
+                BIGINT.writeLong(output, digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)));
+            }
+        }
+        else {
+            for (int i = 0; i < percentilesArrayBlock.getPositionCount(); i++) {
+                BIGINT.writeLong(output, digest.getQuantile(DOUBLE.getDouble(percentilesArrayBlock, i)));
+            }
         }
         return output.build();
     }


### PR DESCRIPTION
When a `null` value exists in the qDigest `values_at_quantiles` function, we currently treat it as 0.0, which can lead to confusion and errors. 
Instead, we should throw an error when encountering a null value in the parameter, ensuring consistency with the behavior of value_at_quantile in both Tdigest and Qdigest, as well as values_at_quantiles in [Tdigest](http://github.com/prestodb/presto/pull/24969)

## Description
addd null check in values_at_quantiles

## Motivation and Context
bug fix 

## Impact
low impact

## Test Plan
unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

