### PR TITLE
Add runtime stats metrics for subcomponent in Optimizer

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -55,6 +55,8 @@ public class RuntimeMetricName
     public static final String CREATE_SCHEDULER_TIME_NANOS = "createSchedulerTimeNanos";
     public static final String LOGICAL_PLANNER_TIME_NANOS = "logicalPlannerTimeNanos";
     public static final String OPTIMIZER_TIME_NANOS = "optimizerTimeNanos";
+    public static final String VALIDATE_FINAL_PLAN_TIME_NANOS = "validateFinalPlanTimeNanos";
+    public static final String VALIDATE_INTERMEDIATE_PLAN_TIME_NANOS = "validateIntermediatePlanTimeNanos";
     public static final String GET_CANONICAL_INFO_TIME_NANOS = "getCanonicalInfoTimeNanos";
     public static final String FRAGMENT_PLAN_TIME_NANOS = "fragmentPlanTimeNanos";
     public static final String GET_LAYOUT_TIME_NANOS = "getLayoutTimeNanos";


### PR DESCRIPTION
## Description
This PR adds the following new runtime stats metrics in the Optimizer
- `validateIntermediatePlanTimeNanos`
- `validateIntermediatePlanTimeNanosOnCpu` 
- `validateFinalPlanTimeNanos`
- `validateFinalPlanTimeNanosOnCpu`

## Motivation and Context
Based on the observations, the total wall time in the optimizer is high while the total CPU time is low. Logging these latencies would help in identifying the bottleneck.

## Impact
No Impact

## Test Plan
- Validated that the new metrics are recorded in the coordinator UI
<img width="691" alt="Screenshot 2025-06-11 at 6 39 24 PM" src="https://github.com/user-attachments/assets/90ac8708-1fba-4177-8c4e-72fe073afbf8" />

- Verifier Test Link: https://www.internalfb.com/intern/presto/verifier/results/?test_id=227210

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

