### PR TITLE
Remove path restrictions for cpp tests

### DIFF
--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -7,9 +7,6 @@ on:
   # - use smaller image - in the works
   # - remove the adapters downloaded files after install - JWT needs fixing because of the cmake files end up
   #pull_request:
-  #  paths:
-  #    - 'presto-native-execution/scripts/**'
-  #    - '.github/workflows/prestocpp-linux-adapters-build.yml'
 
 jobs:
   prestocpp-linux-adapters-build:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -3,10 +3,6 @@ name: prestocpp-linux-build-and-unit-test
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'presto-native-execution/**'
-      - 'presto-native-sidecar-plugin/**'
-      - '.github/workflows/prestocpp-linux-build-and-unit-test.yml'
   push:
     branches:
       - master

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -3,30 +3,6 @@ name: prestocpp-linux-build
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'presto-native-execution/**'
-      - '.github/workflows/prestocpp-linux-build.yml'
-      # Build also changes to files that can change the protocol and are referenced in the protocol yaml:
-      # protocol_core
-      - 'presto-spi/src/main/java/com/facebook/presto/spi/**'
-      - 'presto-common/src/main/java/com/facebook/presto/**'
-      - 'presto-main/src/main/java/com/facebook/presto/**'
-      - 'presto-client/src/main/java/com/facebook/presto/client/**'
-      - 'presto-spark-base/src/main/java/com/facebook/presto/spark/execution/**'
-      - 'presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/**'
-      - 'presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/**'
-      - 'presto-hdfs-core/src/main/java/com/facebook/presto/hive/**'
-      - 'presto-verifier/src/main/java/com/facebook/presto/verifier/framework/**'
-      # arrow-flight
-      - 'presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/**'
-      # hive
-      - 'presto-hive-metastore/src/main/java/com/facebook/presto/hive/**'
-      - 'presto-hive-common/src/main/java/com/facebook/presto/hive/**'
-      - 'presto-hive/src/main/java/com/facebook/presto/hive/**'
-      # iceberg
-      - 'presto-iceberg/src/main/java/com/facebook/presto/iceberg/**'
-      # tpch
-      - 'presto-tpch/src/main/java/com/facebook/presto/tpch/**'
 
 jobs:
   prestocpp-linux-build-engine:
@@ -38,28 +14,28 @@ jobs:
       CC: /usr/bin/clang-15
       CXX: /usr/bin/clang++-15
       BUILD_SCRIPT: |
-          cd presto-native-execution
-          cmake \
-            -B _build/debug \
-            -GNinja \
-            -DTREAT_WARNINGS_AS_ERRORS=1 \
-            -DENABLE_ALL_WARNINGS=1 \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DPRESTO_ENABLE_PARQUET=ON \
-            -DPRESTO_ENABLE_S3=ON \
-            -DPRESTO_ENABLE_GCS=ON \
-            -DPRESTO_ENABLE_ABFS=OFF \
-            -DPRESTO_ENABLE_HDFS=ON \
-            -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
-            -DPRESTO_ENABLE_JWT=ON \
-            -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
-            -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
-            -DPRESTO_ENABLE_TESTING=OFF \
-            -DCMAKE_PREFIX_PATH=/usr/local \
-            -DThrift_ROOT=/usr/local \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DMAX_LINK_JOBS=4
-          ninja -C _build/debug -j 4
+        cd presto-native-execution
+        cmake \
+          -B _build/debug \
+          -GNinja \
+          -DTREAT_WARNINGS_AS_ERRORS=1 \
+          -DENABLE_ALL_WARNINGS=1 \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DPRESTO_ENABLE_PARQUET=ON \
+          -DPRESTO_ENABLE_S3=ON \
+          -DPRESTO_ENABLE_GCS=ON \
+          -DPRESTO_ENABLE_ABFS=OFF \
+          -DPRESTO_ENABLE_HDFS=ON \
+          -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
+          -DPRESTO_ENABLE_JWT=ON \
+          -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
+          -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
+          -DPRESTO_ENABLE_TESTING=OFF \
+          -DCMAKE_PREFIX_PATH=/usr/local \
+          -DThrift_ROOT=/usr/local \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DMAX_LINK_JOBS=4
+        ninja -C _build/debug -j 4
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -3,9 +3,6 @@ name: prestocpp-macos-build
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'presto-native-execution/**'
-      - '.github/workflows/prestocpp-macos-build.yml'
 
 jobs:
   prestocpp-macos-build-engine:


### PR DESCRIPTION
## Description
Trigger cpp tests for all changes, even if they don't touch presto-native-excution or presto-native-sidecar-plugin.  Only exception is the prestocpp-format-and-header-check because that is specifically a formatting check on changes to cpp files, and not affected by changes in other parts of the codebase.

## Motivation and Context
Previously non-cpp changes weren't triggering the tests, but could still cause wrong results, as seen with https://github.com/prestodb/presto/pull/25289.

## Impact
cpp tests will trigger for all prs

## Test Plan
ci

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

