### PR TITLE
Disable `AbstractHiveSslTest`

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractHiveSslTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractHiveSslTest.java
@@ -75,7 +75,8 @@ public abstract class AbstractHiveSslTest
         closeAllRuntimeException(dockerizedS3DataLake);
     }
 
-    @Test
+    // TODO: these tests are disabled because they rely on an expired certificate
+    @Test(enabled = false)
     public void testInsertTable()
     {
         String testTable = getTestTableName();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSslWithKeyStore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSslWithKeyStore.java
@@ -14,10 +14,13 @@
 package com.facebook.presto.hive;
 
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
+// TODO: these tests are disabled because they rely on an expired certificate
+@Test(enabled = false)
 public class TestHiveSslWithKeyStore
         extends AbstractHiveSslTest
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSslWithTrustStore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSslWithTrustStore.java
@@ -14,10 +14,13 @@
 package com.facebook.presto.hive;
 
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
+// TODO: these tests are disabled because they rely on an expired certificate
+@Test(enabled = false)
 public class TestHiveSslWithTrustStore
         extends AbstractHiveSslTest
 {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSslWithTrustStoreKeyStore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSslWithTrustStoreKeyStore.java
@@ -14,10 +14,13 @@
 package com.facebook.presto.hive;
 
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
+// TODO: these tests are disabled because they rely on an expired certificate
+@Test(enabled = false)
 public class TestHiveSslWithTrustStoreKeyStore
                 extends AbstractHiveSslTest
 {


### PR DESCRIPTION
These rely on checked-in key stores and trust stores which are expired.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
Fix the build (#24536)

## Impact
Fixes #25297

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

