### PR TITLE
Fix confusing word for task state

### DIFF
--- a/presto-ui/src/components/QueryOverview.jsx
+++ b/presto-ui/src/components/QueryOverview.jsx
@@ -779,8 +779,9 @@ function StageSummary({ index, prestoStage }: { index: number, prestoStage: Outp
                                     </thead>
                                     <tbody>
                                         <tr>
+                                            // Planned is the first state of a task. There is no "Pending" state. Also see line 787.
                                             <td className="stage-table-stat-title">
-                                                Pending
+                                                Planned
                                             </td>
                                             <td className="stage-table-stat-text">
                                                 {prestoStage.latestAttemptExecutionInfo.tasks.filter(task => task.taskStatus.state === "PLANNED").length}


### PR DESCRIPTION
## Description
1. "Pending" can be confusing in the way that it implies coordinator is stuck but all tasks will be in the "planned" after creation.

## Motivation and Context
1. Better wording

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

