### PR TITLE
Fix an issue while accessing Symlink tables

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -184,7 +184,17 @@ public class StoragePartitionLoader
             // the splits must be generated using the file system for the target path
             // get the configuration for the target path -- it may be a different hdfs instance
             ExtendedFileSystem targetFilesystem = hdfsEnvironment.getFileSystem(hdfsContext, targetPath);
-            JobConf targetJob = toJobConf(targetFilesystem.getConf());
+
+            Configuration targetConfiguration = targetFilesystem.getConf();
+            if (targetConfiguration instanceof HiveCachingHdfsConfiguration.CachingJobConf) {
+                targetConfiguration = ((HiveCachingHdfsConfiguration.CachingJobConf) targetConfiguration).getConfig();
+            }
+            if (targetConfiguration instanceof CopyOnFirstWriteConfiguration) {
+                targetConfiguration = ((CopyOnFirstWriteConfiguration) targetConfiguration).getConfig();
+            }
+
+            JobConf targetJob = toJobConf(targetConfiguration);
+
             targetJob.setInputFormat(TextInputFormat.class);
             targetInputFormat.configure(targetJob);
             targetJob.set(SPLIT_MINSIZE, Long.toString(getMaxSplitSize(session).toBytes()));


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Introduction of WrapperJobConf and CopyOnFirstWriteConfiguration lead to issues while accessing Symlink tables since the actual configuration object is wrapped inside a configuration object

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fixes #25306 

## Test Plan
<!---Please fill in how you tested your change-->

Ran manual tests and was able to access the Symlink tables on the S3 filesystem.

```
presto:tpch_sf1000_parquet_delta> select * from customer limit 2;
  custkey  |        name        |             address             | nationkey |      phone      | acctbal | mktsegment |                                    comment                                     
-----------+--------------------+---------------------------------+-----------+-----------------+---------+------------+--------------------------------------------------------------------------------
  99281969 | Customer#099281969 | 2zrmoAd9sF10aS4id8zLiin0pGxZyJ6 |        19 | 29-421-607-7641 | -230.99 | HOUSEHOLD  | c instructions cajole along the ruthlessly ironic platelets; blithely ironic d 
 122862757 | Customer#122862757 | EWzBgsC,AZcCdAG8j               |         9 | 19-250-866-9749 | -946.34 | AUTOMOBILE | egular theodolites. furiously ironic ide                                       

(2 rows)

Query 20250611_003932_00002_kthgg, FINISHED, 1 node
Splits: 217 total, 96 done (44.24%)
[Latency: client-side: 1:07, server-side: 1:06] [34 rows, 461MB] [0 rows/s, 6.93MB/s]

```
## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Fix an issue while accessing Symlink tables
```

