### PR TITLE
Support JVM tzdata 2025a

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
         modules:
           - ":presto-base-arrow-flight"  # Only run tests for the `presto-base-arrow-flight` module
 
@@ -183,7 +183,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8.0.442
+          java-version: 8.0.452
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8.0.442
+          java-version: 8.0.452
           cache: 'maven'
       - name: Maven Install
         run: |

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 20

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8.0.442
+          java-version: 8.0.452
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs
@@ -205,7 +205,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8.0.442'
+          java-version: '8.0.452'
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs
@@ -277,7 +277,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8.0.442'
+          java-version: '8.0.452'
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs
@@ -346,7 +346,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8.0.442'
+          java-version: '8.0.452'
           cache: 'maven'
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 30

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8.0.442, 17.0.13 ]
+        java: [ 8.0.452, 17.0.15 ]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8.0.442, 17.0.13]
+        java: [ 8.0.452, 17.0.15 ]
         modules:
           - ":presto-tests -P presto-tests-execution-memory"
           - ":presto-tests -P presto-tests-general"

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dep.drift.version>1.43</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
-        <dep.joda.version>2.12.7</dep.joda.version>
+        <dep.joda.version>2.13.1</dep.joda.version>
         <dep.tempto.version>1.54</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
         <dep.lucene.version>8.11.3</dep.lucene.version>
@@ -93,7 +93,7 @@
 
         <!--
           America/Bahia_Banderas has:
-           - offset change since 1970 (offset Jan 1970: -08:00, offset Jan 2018: -06:00)
+           - offset change since 1970 (offset Jan 1970: -07:00, offset Jan 2018: -06:00)
            - DST (e.g. at 2017-04-02 02:00:00 clocks turned forward 1 hour; 2017-10-29 02:00:00 clocks turned backward 1 hour)
            - has forward offset change on first day of epoch (1970-01-01 00:00:00 clocks turned forward 1 hour)
            - had forward change at midnight (1970-01-01 00:00:00 clocks turned forward 1 hour)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcResultSet.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcResultSet.java
@@ -214,11 +214,11 @@ public class TestJdbcResultSet
         });
 
         checkRepresentation("TIMESTAMP '1970-01-01 00:14:15.227 Europe/Warsaw'", Types.TIMESTAMP /* TODO TIMESTAMP_WITH_TIMEZONE */, (rs, column) -> {
-            assertEquals(rs.getObject(column), Timestamp.valueOf(LocalDateTime.of(1969, 12, 31, 15, 14, 15, 227_000_000))); // TODO this should represent TIMESTAMP '1970-01-01 00:14:15.227 Europe/Warsaw'
+            assertEquals(rs.getObject(column), Timestamp.valueOf(LocalDateTime.of(1969, 12, 31, 16, 14, 15, 227_000_000))); // TODO this should represent TIMESTAMP '1970-01-01 00:14:15.227 Europe/Warsaw'
             assertThrows(() -> rs.getDate(column));
             assertThrows(() -> rs.getTime(column));
             // TODO this should fail, as there no java.sql.Timestamp representation for TIMESTAMP '1970-01-01 00:14:15.227ó' in America/Bahia_Banderas
-            assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(1969, 12, 31, 15, 14, 15, 227_000_000)));
+            assertEquals(rs.getTimestamp(column), Timestamp.valueOf(LocalDateTime.of(1969, 12, 31, 16, 14, 15, 227_000_000)));
         });
 
         statement.execute("CREATE TYPE cat.sch.dist AS integer");

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
@@ -230,8 +230,8 @@ public class TestMySqlTypeMapping
 
         ZoneId jvmZone = ZoneId.systemDefault();
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
-        verify(jvmZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay()).isEmpty());
+        LocalDate dateOfLocalTimeChangeForwardAtHour2InJvmZone = LocalDate.of(2012, 4, 1);
+        verify(jvmZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtHour2InJvmZone.atTime(2, 1)).isEmpty());
 
         ZoneId someZone = ZoneId.of("Europe/Vilnius");
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);
@@ -240,12 +240,12 @@ public class TestMySqlTypeMapping
         verify(someZone.getRules().getValidOffsets(dateOfLocalTimeChangeBackwardAtMidnightInSomeZone.atStartOfDay().minusMinutes(1)).size() == 2);
 
         DataTypeTest testCases = DataTypeTest.create()
-                .addRoundTrip(dateDataType(), LocalDate.of(1952, 4, 3)) // before epoch
+                .addRoundTrip(dateDataType(), LocalDate.of(1937, 4, 3)) // before epoch
                 .addRoundTrip(dateDataType(), LocalDate.of(1970, 1, 1))
                 .addRoundTrip(dateDataType(), LocalDate.of(1970, 2, 3))
                 .addRoundTrip(dateDataType(), LocalDate.of(2017, 7, 1)) // summer on northern hemisphere (possible DST)
                 .addRoundTrip(dateDataType(), LocalDate.of(2017, 1, 1)) // winter on northern hemisphere (possible DST on southern hemisphere)
-                .addRoundTrip(dateDataType(), dateOfLocalTimeChangeForwardAtMidnightInJvmZone)
+                .addRoundTrip(dateDataType(), dateOfLocalTimeChangeForwardAtHour2InJvmZone)
                 .addRoundTrip(dateDataType(), dateOfLocalTimeChangeForwardAtMidnightInSomeZone)
                 .addRoundTrip(dateDataType(), dateOfLocalTimeChangeBackwardAtMidnightInSomeZone);
 

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestDistributedEngineOnlyQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestDistributedEngineOnlyQueries.java
@@ -23,7 +23,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Boolean.parseBoolean;
@@ -88,10 +87,9 @@ public class TestDistributedEngineOnlyQueries
     @Test
     public void testLocallyUnrepresentableTimeLiterals()
     {
-        LocalTime localTimeThatDidNotOccurOn19700101 = LocalTime.of(0, 10);
-        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotOccurOn19700101.atDate(LocalDate.ofEpochDay(0))).isEmpty(), "This test assumes certain JVM time zone");
-        checkState(!Objects.equals(java.sql.Time.valueOf(localTimeThatDidNotOccurOn19700101).toLocalTime(), localTimeThatDidNotOccurOn19700101), "This test assumes certain JVM time zone");
-        @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT TIME '''HH:mm:ss''").format(localTimeThatDidNotOccurOn19700101);
+        LocalTime localTimeThatDidNotOccurOn20120401 = LocalTime.of(2, 10);
+        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotOccurOn20120401.atDate(LocalDate.of(2012, 4, 1))).isEmpty(), "This test assumes certain JVM time zone");
+        @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT TIME '''HH:mm:ss''").format(localTimeThatDidNotOccurOn20120401);
         assertQueryFails(sql, timeTypeUnsupportedError);
     }
 }

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -244,8 +244,8 @@ public class TestPostgreSqlTypeMapping
 
         ZoneId jvmZone = ZoneId.systemDefault();
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
-        verify(jvmZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay()).isEmpty());
+        LocalDate dateOfLocalTimeChangeForwardAtHour2InJvmZone = LocalDate.of(2012, 4, 1);
+        verify(jvmZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtHour2InJvmZone.atTime(2, 1)).isEmpty());
 
         ZoneId someZone = ZoneId.of("Europe/Vilnius");
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);
@@ -254,12 +254,12 @@ public class TestPostgreSqlTypeMapping
         verify(someZone.getRules().getValidOffsets(dateOfLocalTimeChangeBackwardAtMidnightInSomeZone.atStartOfDay().minusMinutes(1)).size() == 2);
 
         DataTypeTest testCases = DataTypeTest.create()
-                .addRoundTrip(dateDataType(), LocalDate.of(1952, 4, 3)) // before epoch
+                .addRoundTrip(dateDataType(), LocalDate.of(1937, 4, 3)) // before epoch
                 .addRoundTrip(dateDataType(), LocalDate.of(1970, 1, 1))
                 .addRoundTrip(dateDataType(), LocalDate.of(1970, 2, 3))
                 .addRoundTrip(dateDataType(), LocalDate.of(2017, 7, 1)) // summer on northern hemisphere (possible DST)
                 .addRoundTrip(dateDataType(), LocalDate.of(2017, 1, 1)) // winter on northern hemisphere (possible DST on southern hemisphere)
-                .addRoundTrip(dateDataType(), dateOfLocalTimeChangeForwardAtMidnightInJvmZone)
+                .addRoundTrip(dateDataType(), dateOfLocalTimeChangeForwardAtHour2InJvmZone)
                 .addRoundTrip(dateDataType(), dateOfLocalTimeChangeForwardAtMidnightInSomeZone)
                 .addRoundTrip(dateDataType(), dateOfLocalTimeChangeBackwardAtMidnightInSomeZone);
 

--- a/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreTypeMapping.java
+++ b/presto-singlestore/src/test/java/com/facebook/presto/plugin/singlestore/TestSingleStoreTypeMapping.java
@@ -214,8 +214,8 @@ public class TestSingleStoreTypeMapping
     {
         ZoneId jvmZone = ZoneId.systemDefault();
         checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
-        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
-        verify(jvmZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay()).isEmpty());
+        LocalDate dateOfLocalTimeChangeForwardAtHour2InJvmZone = LocalDate.of(2012, 4, 1);
+        verify(jvmZone.getRules().getValidOffsets(dateOfLocalTimeChangeForwardAtHour2InJvmZone.atTime(2, 1)).isEmpty());
 
         ZoneId someZone = ZoneId.of("Europe/Vilnius");
         LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);
@@ -229,7 +229,7 @@ public class TestSingleStoreTypeMapping
                 .addRoundTrip(singleStoreDateDataType(), LocalDate.of(1970, 2, 3))
                 .addRoundTrip(singleStoreDateDataType(), LocalDate.of(2017, 7, 1)) // summer on northern hemisphere (possible DST)
                 .addRoundTrip(singleStoreDateDataType(), LocalDate.of(2017, 1, 1)) // winter on northern hemisphere (possible DST on southern hemisphere)
-                .addRoundTrip(singleStoreDateDataType(), dateOfLocalTimeChangeForwardAtMidnightInJvmZone)
+                .addRoundTrip(singleStoreDateDataType(), dateOfLocalTimeChangeForwardAtHour2InJvmZone)
                 .addRoundTrip(singleStoreDateDataType(), dateOfLocalTimeChangeForwardAtMidnightInSomeZone)
                 .addRoundTrip(singleStoreDateDataType(), dateOfLocalTimeChangeBackwardAtMidnightInSomeZone);
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestEngineOnlyQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestEngineOnlyQueries.java
@@ -26,7 +26,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkState;
 import static org.testng.Assert.assertEquals;
@@ -79,7 +78,7 @@ public abstract class AbstractTestEngineOnlyQueries
     @Test
     public void testLocallyUnrepresentableDateLiterals()
     {
-        LocalDate localDateThatDidNotHaveMidnight = LocalDate.of(1970, 1, 1);
+        LocalDate localDateThatDidNotHaveMidnight = LocalDate.of(1932, 4, 1);
         checkState(ZoneId.systemDefault().getRules().getValidOffsets(localDateThatDidNotHaveMidnight.atStartOfDay()).isEmpty(), "This test assumes certain JVM time zone");
         // This tests that both Presto runner and H2 can return DATE value for a day which midnight never happened in JVM's zone (e.g. is not exactly representable using java.sql.Date)
         @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(localDateThatDidNotHaveMidnight);
@@ -90,11 +89,11 @@ public abstract class AbstractTestEngineOnlyQueries
     @Test
     public void testLocallyUnrepresentableTimeLiterals()
     {
-        LocalTime localTimeThatDidNotOccurOn19700101 = LocalTime.of(0, 10);
-        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotOccurOn19700101.atDate(LocalDate.ofEpochDay(0))).isEmpty(), "This test assumes certain JVM time zone");
-        checkState(!Objects.equals(java.sql.Time.valueOf(localTimeThatDidNotOccurOn19700101).toLocalTime(), localTimeThatDidNotOccurOn19700101), "This test assumes certain JVM time zone");
-        @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT TIME '''HH:mm:ss''").format(localTimeThatDidNotOccurOn19700101);
-        assertEquals(computeScalar(sql), localTimeThatDidNotOccurOn19700101); // this tests Presto and the QueryRunner
+        LocalDate localDateWithGap = LocalDate.of(2017, 4, 2);
+        LocalTime localTimeThatDidNotOccurOn20170402 = LocalTime.of(2, 10);
+        checkState(ZoneId.systemDefault().getRules().getValidOffsets(localTimeThatDidNotOccurOn20170402.atDate(localDateWithGap)).isEmpty(), "This test assumes certain JVM time zone");
+        @Language("SQL") String sql = DateTimeFormatter.ofPattern("'SELECT TIME '''HH:mm:ss''").format(localTimeThatDidNotOccurOn20170402);
+        assertEquals(computeScalar(sql), localTimeThatDidNotOccurOn20170402); // this tests Presto and the QueryRunner
         assertQuery(sql); // this tests H2QueryRunner
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestH2QueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestH2QueryRunner.java
@@ -55,7 +55,7 @@ public class TestH2QueryRunner
         assertEquals(rows.getOnlyValue(), LocalDate.of(2018, 1, 13).atStartOfDay());
 
         // date, which midnight was skipped in JVM zone
-        LocalDate forwardOffsetChangeAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        LocalDate forwardOffsetChangeAtMidnightInJvmZone = LocalDate.of(1932, 4, 1);
         checkState(ZoneId.systemDefault().getRules().getValidOffsets(forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay()).isEmpty(), "This test assumes certain JVM time zone");
         rows = h2QueryRunner.execute(TEST_SESSION, DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(forwardOffsetChangeAtMidnightInJvmZone), ImmutableList.of(TIMESTAMP));
         assertEquals(rows.getOnlyValue(), forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay());


### PR DESCRIPTION
## Description
Continuation of #24635

Upgrades joda-time to support JVM tzdata 2025a. We skipped 2024b which included updates to the America/Bahia_Banderas zone that is used frequently for testing

Fixes #24628

## Motivation and Context
While working on the latest changes for Java 17 support, we noticed new test failures with the latest Java 17 releases due to the new TZ data. This PR fixes those issues. I have observed the same failures on the latest releases of corretto and temurin Java 8u too.

## Impact
New TZdata support. Requires using latest JVMs

## Test Plan
existing tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

