### PR TITLE
[native] Add native memory pool reclaimer priority

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -470,3 +470,12 @@ to produce a batch of the size specified by this property. If set to ``0``, then
 * **Default value:** ``10``
 
 Maximum wait time for exchange long poll requests in seconds.
+
+``native_query_memory_reclaimer_priority``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``2147483647``
+
+Priority of the query in the memory pool reclaimer. Lower value means higher priority.
+This is used in global arbitration victim selection.

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -78,6 +78,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_TABLE_SCAN_SCALE_UP_MEMORY_USAGE_RATIO = "native_table_scan_scale_up_memory_usage_ratio";
     public static final String NATIVE_STREAMING_AGGREGATION_MIN_OUTPUT_BATCH_ROWS = "native_streaming_aggregation_min_output_batch_rows";
     public static final String NATIVE_REQUEST_DATA_SIZES_MAX_WAIT_SEC = "native_request_data_sizes_max_wait_sec";
+    public static final String NATIVE_QUERY_MEMORY_RECLAIMER_PRIORITY = "native_query_memory_reclaimer_priority";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -350,6 +351,12 @@ public class NativeWorkerSessionPropertyProvider
                         NATIVE_REQUEST_DATA_SIZES_MAX_WAIT_SEC,
                         "Maximum wait time for exchange long poll requests in seconds.",
                         10,
+                        !nativeExecution),
+                integerProperty(
+                        NATIVE_QUERY_MEMORY_RECLAIMER_PRIORITY,
+                        "Native Execution only. Priority of memory recliamer when deciding on memory pool to abort." +
+                        "Lower value has higher priority and less likely to be choosen for memory pool abort",
+                        2147483647,
                         !nativeExecution));
     }
 

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -489,6 +489,14 @@ SessionProperties::SessionProperties() {
       10,
       QueryConfig::kRequestDataSizesMaxWaitSec,
       std::to_string(c.requestDataSizesMaxWaitSec()));
+
+  addSessionProperty(
+      kNativeQueryMemoryReclaimerPriority,
+      "Memory pool reclaimer priority.",
+      INTEGER(),
+      2147483647,
+      QueryConfig::kQueryMemoryReclaimerPriority,
+      std::to_string(c.queryMemoryReclaimerPriority()));
 }
 
 const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -313,6 +313,12 @@ class SessionProperties {
   static constexpr const char* kRequestDataSizesMaxWaitSec = 
       "native_request_data_sizes_max_wait_sec";
 
+  /// Priority of memory pool reclaimer when deciding on memory pool to abort.
+  /// Lower value has higher priority and less likely to be chosen as candidate
+  /// for memory pool abort.
+  static constexpr const char* kNativeQueryMemoryReclaimerPriority =
+      "native_query_memory_reclaimer_priority";
+
   SessionProperties();
 
   const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -35,7 +35,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       SessionProperties::kTableScanScaledProcessingEnabled,
       SessionProperties::kTableScanScaleUpMemoryUsageRatio,
       SessionProperties::kStreamingAggregationMinOutputBatchRows,
-      SessionProperties::kRequestDataSizesMaxWaitSec};
+      SessionProperties::kRequestDataSizesMaxWaitSec,
+      SessionProperties::kNativeQueryMemoryReclaimerPriority};
   const std::vector<std::string> veloxConfigNames = {
       core::QueryConfig::kAdjustTimestampToTimezone,
       core::QueryConfig::kDriverCpuTimeSliceLimitMs,
@@ -48,7 +49,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       core::QueryConfig::kTableScanScaledProcessingEnabled,
       core::QueryConfig::kTableScanScaleUpMemoryUsageRatio,
       core::QueryConfig::kStreamingAggregationMinOutputBatchRows,
-      core::QueryConfig::kRequestDataSizesMaxWaitSec};
+      core::QueryConfig::kRequestDataSizesMaxWaitSec,
+      core::QueryConfig::kQueryMemoryReclaimerPriority};
   auto sessionProperties = SessionProperties().getSessionProperties();
   const auto len = names.size();
   for (auto i = 0; i < len; i++) {


### PR DESCRIPTION
## Description
Adds ```native_query_memory_reclaimer_priority``` property. 
This is used to pass query memory reclaimer priority to Velox. Velox memory manager uses specified property to determine which query to kill when system runs on memory pressure.

## Motivation and Context
When native worker runs into memory pressure, it starts killing queries to avoid cgroup OOM/process crash. When choosing the victim, we want to specify which queries are more likely to be chosen as victim. This change enables specifying memory reclaimer priority which is used for memory kills. 
It could be further extended to choose which queries reclaimer spills first, which is outside the scope of this PR

## Impact
Critical queries are less likely to be killed in a cluster

## Test Plan
* Unit test for property
* Deployed on test cluster and replayed production traffic. Observed no critical queries getting killed.

```
== RELEASE NOTES ==

General Changes
* Add property ```native_query_memory_reclaimer_priority```  which controls which queries are killed first when a worker is running low on memory. Higher value means lower priority to be consistent with velox memory reclaimer's convention

