### PR TITLE
Allow different namespaces in builtin function namespace manager

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespace.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespace.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface FunctionNamespace
+{
+    String value() default "";
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/function/TestFunctions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/function/TestFunctions.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.function;
+
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.FunctionNamespace;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.tests.function.TestScalarFunctions.TEST_FUNCTION_NAMESPACE;
+
+@FunctionNamespace(TEST_FUNCTION_NAMESPACE)
+public final class TestFunctions
+{
+    private TestFunctions()
+    {}
+
+    @Description("Returns modulo of value by numberOfBuckets")
+    @ScalarFunction
+    @SqlType(StandardTypes.BIGINT)
+    public static long modulo(
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType(StandardTypes.BIGINT) long numberOfBuckets)
+    {
+        return value % numberOfBuckets;
+    }
+
+    @Description(("Return the input string"))
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice identity(@SqlType(StandardTypes.VARCHAR) Slice slice)
+    {
+        return slice;
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/function/TestScalarFunctions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/function/TestScalarFunctions.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.function;
+
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.TestingPrestoClient;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Key;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestScalarFunctions
+{
+    public static final String TEST_FUNCTION_NAMESPACE = "test.namespace";
+
+    protected TestingPrestoServer server;
+    protected TestingPrestoClient client;
+    protected TypeManager typeManager;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        server = new TestingPrestoServer();
+        server.installPlugin(new TestFunctionPlugin());
+        client = new TestingPrestoClient(server, testSessionBuilder()
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey("America/Bahia_Banderas"))
+                .build());
+        typeManager = server.getInstance(Key.get(TypeManager.class));
+    }
+
+    public void assertInvalidFunction(String expr, String exceptionPattern)
+    {
+        try {
+            client.execute("SELECT " + expr);
+            fail("Function expected to fail but not");
+        }
+        catch (Exception e) {
+            if (!(e.getMessage().matches(exceptionPattern))) {
+                fail(format("Expected exception message '%s' to match '%s' but not",
+                        e.getMessage(), exceptionPattern));
+            }
+        }
+    }
+
+    private class TestFunctionPlugin
+            implements Plugin
+    {
+        @Override
+        public Set<Class<?>> getFunctions()
+        {
+            return ImmutableSet.<Class<?>>builder()
+                    .add(TestFunctions.class)
+                    .build();
+        }
+    }
+
+    public void check(@Language("SQL") String query, Type expectedType, Object expectedValue)
+    {
+        MaterializedResult result = client.execute(query).getResult();
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getTypes().get(0), expectedType);
+        Object actual = result.getMaterializedRows().get(0).getField(0);
+        assertEquals(actual, expectedValue);
+    }
+
+    @Test
+    public void testNewFunctionNamespaceFunction()
+    {
+        check("SELECT test.namespace.modulo(10,3)", BIGINT, 1L);
+        check("SELECT test.namespace.identity('test-functions')", VARCHAR, "test-functions");
+    }
+
+    @Test
+    public void testInvalidFunctionAndNamespace()
+    {
+        assertInvalidFunction("invalid.namespace.modulo(10,3)", "line 1:8: Function invalid.namespace.modulo not registered");
+        assertInvalidFunction("test.namespace.dummy(10)", "line 1:8: Function test.namespace.dummy not registered");
+    }
+}


### PR DESCRIPTION
## Description
This change allows functions registered via `Plugin->getFunctions()` SPI to use a different namespace.

## Motivation and Context
At present, functions registered via getFunctions() SPI are registered in `"presto.default" `namespace which is restrictive. Iceberg's DAY(), MONTH(), YEAR() functions would conflict with the builtin functions with the same name. We want to support functions specific to connectors in a custom namespace. Example: Iceberg partition transform functions as described in https://github.com/prestodb/presto/issues/25166

## Impact
No impact

## Test Plan
Added new tests in TestScalarFunctions.java


```
== NO RELEASE NOTE ==
```

