### PR TITLE
[native] Fix Task status reporting for not started Tasks

### DIFF
--- a/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoTaskTest.cpp
@@ -14,14 +14,49 @@
 #include "presto_cpp/main/PrestoTask.h"
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/common/time/Timer.h"
+#include "velox/exec/Split.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/PlanNodeIdGenerator.h"
+#include "velox/type/Type.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 
 using namespace facebook::velox;
 using namespace facebook::presto;
 
+using facebook::velox::exec::test::PlanBuilder;
 using facebook::presto::PrestoTaskId;
+
+namespace {
+// Create a simple velox task for testing.
+std::shared_ptr<exec::Task> createExecTask(
+    const std::string& taskId,
+    PrestoTask& prestoTask) {
+  RowTypePtr rowType = ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), BIGINT()});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto plan = PlanBuilder(planNodeIdGenerator)
+                        .tableScan(rowType)
+                        .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                        .planNode();
+  return exec::Task::create(
+      taskId,
+      core::PlanFragment{plan},
+      prestoTask.id.id(),
+      core::QueryCtx::create(nullptr),
+      exec::Task::ExecutionMode::kParallel,
+      static_cast<exec::Consumer>(nullptr),
+      prestoTask.id.stageId());
+}
+
+// Add a split to the task.
+void addSplitToTask(PrestoTask& prestoTask, long sequenceId) {
+  exec::Split split;
+  split.connectorSplit =
+      std::make_shared<connector::ConnectorSplit>("connector", 0);
+  prestoTask.task->addSplitWithSequence("0", std::move(split), sequenceId);
+}
+} // namespace
 
 class PrestoTaskTest : public testing::Test {
   void SetUp() override {
@@ -75,4 +110,61 @@ TEST_F(PrestoTaskTest, basic) {
   /* sleep override */
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   EXPECT_GE(task.timeSinceLastCoordinatorHeartbeatMs(), 100);
+}
+
+TEST_F(PrestoTaskTest, updateStatus) {
+  memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  const std::string taskId{"20201107_130540_00011_wrpkw.1.2.3.4"};
+  PrestoTask prestoTask{taskId, "node1", 0};
+
+  const facebook::velox::core::PlanFragment planFragment;
+
+  // No exec task yet (no fragment plan), so in planned state.
+  auto status = prestoTask.updateStatus();
+  EXPECT_EQ(status.state, protocol::TaskState::PLANNED);
+  EXPECT_EQ(status.queuedPartitionedDrivers, 0);
+  EXPECT_EQ(status.runningPartitionedDrivers, 0);
+
+  // Create exec task, but not started yet, so still in planned state.
+  prestoTask.task = createExecTask(taskId, prestoTask);
+  prestoTask.info.needsPlan = false;
+  status = prestoTask.updateStatus();
+  EXPECT_EQ(status.state, protocol::TaskState::PLANNED);
+  EXPECT_EQ(status.queuedPartitionedDrivers, 0);
+  EXPECT_EQ(status.runningPartitionedDrivers, 0);
+
+  // We 'start' the task, so should be in the running state.
+  prestoTask.taskStarted = true;
+  status = prestoTask.updateStatus();
+  EXPECT_EQ(status.state, protocol::TaskState::RUNNING);
+  EXPECT_EQ(status.queuedPartitionedDrivers, 0);
+  EXPECT_EQ(status.runningPartitionedDrivers, 0);
+
+  // Add some splits. We should return some splits queued.
+  addSplitToTask(prestoTask, 0);
+  status = prestoTask.updateStatus();
+  EXPECT_EQ(status.state, protocol::TaskState::RUNNING);
+  EXPECT_EQ(status.queuedPartitionedDrivers, 1);
+  EXPECT_EQ(status.runningPartitionedDrivers, 0);
+
+  // Error the task. Should be no new splits since the last update.
+  addSplitToTask(prestoTask, 1);
+  try {
+    VELOX_FAIL("Test error");
+  } catch (const VeloxException& e) {
+    prestoTask.error = std::current_exception();
+  }
+  addSplitToTask(prestoTask, 2);
+  status = prestoTask.updateStatus();
+  EXPECT_EQ(status.state, protocol::TaskState::FAILED);
+  EXPECT_EQ(status.queuedPartitionedDrivers, 1);
+  EXPECT_EQ(status.runningPartitionedDrivers, 0);
+
+  // Create aborted task and test the state is as expected.
+  PrestoTask prestoTask2{taskId, "node2", 0};
+  prestoTask2.info.taskStatus.state = protocol::TaskState::ABORTED;
+  status = prestoTask2.updateStatus();
+  EXPECT_EQ(status.state, protocol::TaskState::ABORTED);
+  EXPECT_EQ(status.queuedPartitionedDrivers, 0);
+  EXPECT_EQ(status.runningPartitionedDrivers, 0);
 }


### PR DESCRIPTION
## Description
If Task is not started we don't report any splits we might have received.
That makes coordinator send all splits to such Task overloading the corresponding worker and split-starving other workers.

We change the behavior and now return splits stats even when the Task is not started yet.

A new unit test added and also been testing this code along with the worker pushback (Task Queuing).

```
== NO RELEASE NOTE ==
```