### PR TITLE
feat(Oracle): Add missing BLOB type mappings

### DIFF
--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -102,6 +102,27 @@ Finally, you can access the ``clicks`` table in the ``web`` database::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``oracle`` in the above examples.
 
+Type mapping
+------------
+
+PrestoDB and Oracle each support types that the other does not. When reading from Oracle, Presto converts
+the data types from Oracle to equivalent Presto data types.
+Refer to the following section for type mapping in each direction.
+
+Oracle to PrestoDB type mapping
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector maps Oracle types to the corresponding PrestoDB types:
+
+.. list-table:: Oracle to PrestoDB type mapping
+  :widths: 50, 50
+  :header-rows: 1
+
+  * - Oracle type
+    - PrestoDB type
+  * - ``BLOB``
+    - ``VARBINARY``
+
 Oracle Connector Limitations
 ----------------------------
 

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.plugin.jdbc.mapping.StandardColumnMappings.dec
 import static com.facebook.presto.plugin.jdbc.mapping.StandardColumnMappings.doubleReadMapping;
 import static com.facebook.presto.plugin.jdbc.mapping.StandardColumnMappings.realReadMapping;
 import static com.facebook.presto.plugin.jdbc.mapping.StandardColumnMappings.smallintReadMapping;
+import static com.facebook.presto.plugin.jdbc.mapping.StandardColumnMappings.varbinaryReadMapping;
 import static com.facebook.presto.plugin.jdbc.mapping.StandardColumnMappings.varcharReadMapping;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
@@ -144,6 +145,8 @@ public class OracleClient
         switch (typeHandle.getJdbcType()) {
             case Types.CLOB:
                 return Optional.of(varcharReadMapping(createUnboundedVarcharType()));
+            case Types.BLOB:
+                return Optional.of(varbinaryReadMapping());
             case Types.SMALLINT:
                 return Optional.of(smallintReadMapping());
             case Types.FLOAT:


### PR DESCRIPTION
Co-authored-by: Sayari Mukherjee <sayarimukherjee2000@gmail.com>

## Description
Previously : 
```
presto> describe oracle.tm_lakehouse_engine.blob_clob;
  Column  |  Type   | Extra | Comment 
----------+---------+-------+---------
 clob_col | varchar |       |         
(1 row)
```
Now : 
```
presto> describe oracle.tm_lakehouse_engine.blob_clob;
  Column  |   Type    | Extra | Comment
----------+-----------+-------+---------
 blob_col | varbinary |       |
 clob_col | varchar   |       |
(2 rows)
```
## Motivation and Context
Oracle connector was unable to read native BLOB columns , these columns were completely missing from Presto's metadata view, making it impossible to query tables containing these data types.

## Impact
Added proper type mappings to internally convert BLOB types to VARBINARY, enabling read access without introducing first-class BLOB/CLOB support to Presto's type system.

## Test Plan
Manually tested the changes. Please refer to the screenshot below :
<img width="988" height="704" alt="Screenshot 2025-10-14 at 7 45 57 PM" src="https://github.com/user-attachments/assets/36d74200-84f2-4634-95b0-9f13c80c886c" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Oracle Connector Changes
* Added type mappings to internally convert BLOB types to VARBINARY, enabling read access without introducing first-class BLOB/CLOB support to Presto's type system.
```
