### PR TITLE
feat: Oracle connector enhancements

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
@@ -25,6 +25,7 @@ import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Set;
@@ -54,6 +55,8 @@ public class BaseJdbcConfig
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
     private Set<String> listSchemasIgnoredSchemas = ImmutableSet.of("information_schema");
     private boolean caseSensitiveNameMatchingEnabled;
+    @Min(1)
+    private int fetchSize = 20000;
 
     @NotNull
     public String getConnectionUrl()
@@ -190,5 +193,18 @@ public class BaseJdbcConfig
         if (connectionUrl == null) {
             throw new ConfigurationException(ImmutableList.of(new Message("connection-url is required but was not provided")));
         }
+    }
+
+    public int getFetchSize()
+    {
+        return fetchSize;
+    }
+
+    @Config("jdbc-fetch-size")
+    @ConfigDescription("Number of rows to fetch from the database at a time")
+    public BaseJdbcConfig setFetchSize(int fetchSize)
+    {
+        this.fetchSize = fetchSize;
+        return this;
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestBaseJdbcConfig.java
@@ -40,7 +40,8 @@ public class TestBaseJdbcConfig
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
                 .setlistSchemasIgnoredSchemas("information_schema")
-                .setCaseSensitiveNameMatching(false));
+                .setCaseSensitiveNameMatching(false)
+                .setFetchSize(20000));
     }
 
     @Test
@@ -56,6 +57,7 @@ public class TestBaseJdbcConfig
                 .put("case-insensitive-name-matching.cache-ttl", "1s")
                 .put("list-schemas-ignored-schemas", "test,test2")
                 .put("case-sensitive-name-matching", "true")
+                .put("jdbc-fetch-size", "5000")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
@@ -67,7 +69,8 @@ public class TestBaseJdbcConfig
                 .setCaseInsensitiveNameMatching(true)
                 .setlistSchemasIgnoredSchemas("test,test2")
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS))
-                .setCaseSensitiveNameMatching(true);
+                .setCaseSensitiveNameMatching(true)
+                .setFetchSize(5000);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -74,7 +74,35 @@ Property Name                                      Description                  
 ``case-sensitive-name-matching``                   Enable case sensitive identifier support for schema and table        ``false``
                                                    names for the connector. When disabled, names are matched
                                                    case-insensitively using lowercase normalization.
+
+``jdbc-fetch-size``                                Number of rows to fetch from the database at a time. Higher          ``20000``
+                                                   values can improve performance for large result sets but may
+                                                   increase memory usage.
+
+``oracle.tls.enabled``                             Enable TLS/SSL for secure connections to the Oracle database.        ``false``
+
+``oracle.tls.truststore-path``                     Path to the truststore file containing trusted certificates for
+                                                   TLS/SSL connections. Required when ``oracle.tls.enabled`` is
+                                                   ``true``.
+
+``oracle.tls.truststore-password``                 Password for the truststore file. Required when
+                                                   ``oracle.tls.truststore-path`` is specified.
 ================================================== ==================================================================== ===========
+
+TLS Configuration
+-----------------
+
+The Oracle connector supports secure connections to Oracle databases using TLS/SSL.
+To enable TLS, configure the following properties in your catalog properties file:
+
+.. code-block:: none
+
+    oracle.tls.enabled=true
+    oracle.tls.truststore-path=/path/to/truststore.jks
+    oracle.tls.truststore-password=truststore-password
+
+The truststore file should contain the trusted certificates for your Oracle database server.
+When TLS is enabled, the connector will establish secure encrypted connections to the database.
 
 Querying Oracle
 ---------------

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -197,6 +197,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.oracle.ojdbc</groupId>
+            <artifactId>orai18n</artifactId>
+            <version>19.3.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
@@ -39,7 +39,6 @@ import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.google.common.collect.Maps;
 import jakarta.inject.Inject;
-import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleTypes;
 
 import java.sql.Connection;
@@ -116,10 +115,6 @@ public class OracleClient
     protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName)
             throws SQLException
     {
-        if (connection.isWrapperFor(OracleConnection.class)) {
-            OracleConnection oracleConnection = connection.unwrap(OracleConnection.class);
-            oracleConnection.setDefaultRowPrefetch(fetchSize);
-        }
         DatabaseMetaData metadata = connection.getMetaData();
         String escape = metadata.getSearchStringEscape();
         ResultSet resultSet = metadata.getTables(
@@ -127,6 +122,7 @@ public class OracleClient
                 escapeNamePattern(schemaName, Optional.of(escape)).orElse(null),
                 escapeNamePattern(tableName, Optional.of(escape)).orElse(null),
                 getTableTypes());
+        resultSet.setFetchSize(fetchSize);
         return resultSet;
     }
 
@@ -134,11 +130,9 @@ public class OracleClient
     public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
-        if (connection.isWrapperFor(OracleConnection.class)) {
-            OracleConnection oracleConnection = connection.unwrap(OracleConnection.class);
-            oracleConnection.setDefaultRowPrefetch(fetchSize);
-        }
-        return connection.prepareStatement(sql);
+        PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(fetchSize);
+        return statement;
     }
 
     @Override

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClient.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.statistics.Estimate;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.google.common.collect.Maps;
 import jakarta.inject.Inject;
+import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleTypes;
 
 import java.sql.Connection;
@@ -83,7 +84,7 @@ public class OracleClient
         extends BaseJdbcClient
 {
     private static final Logger LOG = Logger.get(OracleClient.class);
-    private static final int FETCH_SIZE = 1000;
+    private final int fetchSize;
 
     private final boolean synonymsEnabled;
     private final int numberDefaultScale;
@@ -100,6 +101,7 @@ public class OracleClient
         requireNonNull(oracleConfig, "oracle config is null");
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
         this.numberDefaultScale = oracleConfig.getNumberDefaultScale();
+        this.fetchSize = config.getFetchSize();
     }
 
     private String[] getTableTypes()
@@ -114,22 +116,29 @@ public class OracleClient
     protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName)
             throws SQLException
     {
+        if (connection.isWrapperFor(OracleConnection.class)) {
+            OracleConnection oracleConnection = connection.unwrap(OracleConnection.class);
+            oracleConnection.setDefaultRowPrefetch(fetchSize);
+        }
         DatabaseMetaData metadata = connection.getMetaData();
         String escape = metadata.getSearchStringEscape();
-        return metadata.getTables(
+        ResultSet resultSet = metadata.getTables(
                 connection.getCatalog(),
                 escapeNamePattern(schemaName, Optional.of(escape)).orElse(null),
                 escapeNamePattern(tableName, Optional.of(escape)).orElse(null),
                 getTableTypes());
+        return resultSet;
     }
 
     @Override
     public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
             throws SQLException
     {
-        PreparedStatement statement = connection.prepareStatement(sql);
-        statement.setFetchSize(FETCH_SIZE);
-        return statement;
+        if (connection.isWrapperFor(OracleConnection.class)) {
+            OracleConnection oracleConnection = connection.unwrap(OracleConnection.class);
+            oracleConnection.setDefaultRowPrefetch(fetchSize);
+        }
+        return connection.prepareStatement(sql);
     }
 
     @Override

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
 
 public class OracleClientModule
         implements Module
@@ -49,8 +50,22 @@ public class OracleClientModule
             throws SQLException
     {
         Properties connectionProperties = new Properties();
-        connectionProperties.setProperty(OracleConnection.CONNECTION_PROPERTY_INCLUDE_SYNONYMS, String.valueOf(oracleConfig.isSynonymsEnabled()));
 
+        requireNonNull(oracleConfig, "oracle config is null");
+        requireNonNull(config, "BaseJdbc config  is null");
+        if (config.getConnectionUser() != null && config.getConnectionPassword() != null) {
+            connectionProperties.setProperty("user", config.getConnectionUser());
+            connectionProperties.setProperty("password", config.getConnectionPassword());
+        }
+        if (oracleConfig.isTlsEnabled()) {
+            if (oracleConfig.getTrustStorePath() != null) {
+                connectionProperties.setProperty("javax.net.ssl.trustStore", oracleConfig.getTrustStorePath());
+            }
+            if (oracleConfig.getTruststorePassword() != null) {
+                connectionProperties.setProperty("javax.net.ssl.trustStorePassword", oracleConfig.getTruststorePassword());
+            }
+        }
+        connectionProperties.setProperty(OracleConnection.CONNECTION_PROPERTY_INCLUDE_SYNONYMS, String.valueOf(oracleConfig.isSynonymsEnabled()));
         return new DriverConnectionFactory(
                 new OracleDriver(),
                 config.getConnectionUrl(),

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
@@ -22,7 +22,6 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleDriver;
 
 import java.sql.SQLException;
@@ -31,6 +30,7 @@ import java.util.Properties;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static java.util.Objects.requireNonNull;
+import static oracle.jdbc.OracleConnection.CONNECTION_PROPERTY_INCLUDE_SYNONYMS;
 
 public class OracleClientModule
         implements Module
@@ -58,14 +58,11 @@ public class OracleClientModule
             connectionProperties.setProperty("password", config.getConnectionPassword());
         }
         if (oracleConfig.isTlsEnabled()) {
-            if (oracleConfig.getTrustStorePath() != null) {
-                connectionProperties.setProperty("javax.net.ssl.trustStore", oracleConfig.getTrustStorePath());
-            }
-            if (oracleConfig.getTruststorePassword() != null) {
-                connectionProperties.setProperty("javax.net.ssl.trustStorePassword", oracleConfig.getTruststorePassword());
-            }
+            requireNonNull(oracleConfig.getTrustStorePath(), "oracle.tls.truststore-path is null");
+            connectionProperties.setProperty("javax.net.ssl.trustStore", oracleConfig.getTrustStorePath());
+            connectionProperties.setProperty("javax.net.ssl.trustStorePassword", oracleConfig.getTruststorePassword());
         }
-        connectionProperties.setProperty(OracleConnection.CONNECTION_PROPERTY_INCLUDE_SYNONYMS, String.valueOf(oracleConfig.isSynonymsEnabled()));
+        connectionProperties.setProperty(CONNECTION_PROPERTY_INCLUDE_SYNONYMS, String.valueOf(oracleConfig.isSynonymsEnabled()));
         return new DriverConnectionFactory(
                 new OracleDriver(),
                 config.getConnectionUrl(),

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleConfig.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.oracle;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -27,6 +28,9 @@ public class OracleConfig
     private int timestampDefaultPrecision = 6;
     private int numberDefaultScale = 10;
     private RoundingMode numberRoundingMode = RoundingMode.HALF_UP;
+    private boolean tlsEnabled;
+    private String trustStorePath;
+    private String truststorePassword;
 
     @NotNull
     public boolean isSynonymsEnabled()
@@ -92,6 +96,43 @@ public class OracleConfig
     public OracleConfig setTimestampDefaultPrecision(int timestampDefaultPrecision)
     {
         this.timestampDefaultPrecision = timestampDefaultPrecision;
+        return this;
+    }
+
+    public boolean isTlsEnabled()
+    {
+        return tlsEnabled;
+    }
+
+    @Config("oracle.tls.enabled")
+    public OracleConfig setTlsEnabled(boolean tlsEnabled)
+    {
+        this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public String getTrustStorePath()
+    {
+        return trustStorePath;
+    }
+
+    @Config("oracle.tls.truststore-path")
+    public OracleConfig setTrustStorePath(String path)
+    {
+        this.trustStorePath = path;
+        return this;
+    }
+
+    public String getTruststorePassword()
+    {
+        return truststorePassword;
+    }
+
+    @Config("oracle.tls.truststore-password")
+    @ConfigSecuritySensitive
+    public OracleConfig setTruststorePassword(String password)
+    {
+        this.truststorePassword = password;
         return this;
     }
 }

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleCharacterSetCompatibility.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleCharacterSetCompatibility.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.oracle;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.plugin.oracle.OracleQueryRunner.createOracleQueryRunner;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test to verify Oracle connector compatibility with non-UTF character sets.
+ * This test ensures the orai18n.jar dependency enables proper handling of
+ * character sets like WE8ISO8859P9.
+ */
+public class TestOracleCharacterSetCompatibility
+        extends AbstractTestQueryFramework
+{
+    private final OracleServerTester oracleServer;
+    private final QueryRunner queryRunner;
+
+    protected TestOracleCharacterSetCompatibility()
+            throws Exception
+    {
+        this.oracleServer = new OracleServerTester();
+        this.queryRunner = createOracleQueryRunner(oracleServer);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return queryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        if (oracleServer != null) {
+            oracleServer.close();
+        }
+    }
+
+    @Test
+    public void testSpecialCharacterHandling()
+    {
+        assertUpdate("CREATE TABLE test_charset (id bigint, text varchar(100))");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_charset"));
+
+        try {
+            // Insert characters WE8ISO8859P9 specific
+            assertUpdate("INSERT INTO test_charset VALUES (1, 'İstanbul')", 1);
+            assertUpdate("INSERT INTO test_charset VALUES (2, 'Çağrı')", 1);
+            assertUpdate("INSERT INTO test_charset VALUES (3, 'Şehir')", 1);
+
+            // Verify data can be read correctly
+            assertQuery("SELECT COUNT(*) FROM test_charset", "VALUES (3)");
+            assertQuery("SELECT text FROM test_charset WHERE id = 1", "VALUES ('İstanbul')");
+            assertQuery("SELECT COUNT(*) FROM test_charset WHERE text LIKE '%İ%'", "VALUES (1)");
+        }
+        finally {
+            assertUpdate("DROP TABLE test_charset");
+            assertFalse(getQueryRunner().tableExists(getSession(), "test_charset"));
+        }
+    }
+}

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleConfig.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOracleConfig.java
@@ -33,7 +33,10 @@ public class TestOracleConfig
                 .setVarcharMaxSize(4000)
                 .setTimestampDefaultPrecision(6)
                 .setNumberDefaultScale(10)
-                .setNumberRoundingMode(RoundingMode.HALF_UP));
+                .setNumberRoundingMode(RoundingMode.HALF_UP)
+                .setTlsEnabled(false)
+                .setTrustStorePath(null)
+                .setTruststorePassword(null));
     }
 
     @Test
@@ -45,6 +48,9 @@ public class TestOracleConfig
                 .put("oracle.timestamp.precision", "3")
                 .put("oracle.number.default-scale", "2")
                 .put("oracle.number.rounding-mode", "CEILING")
+                .put("oracle.tls.enabled", "true")
+                .put("oracle.tls.truststore-path", "/my/path/to/truststore.jks")
+                .put("oracle.tls.truststore-password", "changeit")
                 .build();
 
         OracleConfig expected = new OracleConfig()
@@ -52,7 +58,10 @@ public class TestOracleConfig
                 .setVarcharMaxSize(10000)
                 .setTimestampDefaultPrecision(3)
                 .setNumberDefaultScale(2)
-                .setNumberRoundingMode(RoundingMode.CEILING);
+                .setNumberRoundingMode(RoundingMode.CEILING)
+                .setTlsEnabled(true)
+                .setTrustStorePath("/my/path/to/truststore.jks")
+                .setTruststorePassword("changeit");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
 Oracle connector enhancements.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan


```
presto> CREATE TABLE oracle.tm_lakehouse_engine.orcaemp2 (
     ->     empid DOUBLE,
     ->     empname VARCHAR(255),
     ->     empbandcode DOUBLE,
     ->     location DOUBLE,
     ->     empdepcode DOUBLE,
     ->     address VARCHAR(255),
     ->     email VARCHAR(255),
     ->     ssn VARCHAR(255),
     ->     phone VARCHAR(255)
     -> );
CREATE TABLE

Query 20260326_071832_00019_85sxf, FINISHED, 0 nodes
http://localhost:8080/ui/query.html?20260326_071832_00019_85sxf
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:12, server-side: 0:12] [0 rows, 0B] [0 rows/s, 0B/s]


presto> INSERT INTO oracle.tm_lakehouse_engine.orcaemp2
     ->     (empid, empname, empbandcode, location, empdepcode, address, email, ssn, phone)
     -> VALUES
     ->     (1.0, 'John Doe', 3.0, 101.0, 20.0, '123 Main St, New York, NY', 'john.doe@example.com', '123-45-6789', '555-123-4567');

Query 20260326_071911_00020_85sxf, RUNNING, 1 node, 35 splits
http://localhost:8080/ui/query.html?20260326_071911_00020_85sxf

INSERT: 1 row

Query 20260326_071911_00020_85sxf, FINISHED, 1 node
http://localhost:8080/ui/query.html?20260326_071911_00020_85sxf
Splits: 35 total, 35 done (100.00%)
[Latency: client-side: 0:44, server-side: 0:44] [0 rows, 0B] [0 rows/s, 0B/s]


presto> SELECT * FROM oracle.tm_lakehouse_engine.orcaemp2;

Query 20260326_072023_00021_85sxf, RUNNING, 1 node, 17 splits

empid | empname  | empbandcode | location | empdepcode |          address          |        email         |     ssn     |    phone     
-------+----------+-------------+----------+------------+---------------------------+----------------------+-------------+--------------
   1.0 | John Doe |         3.0 |    101.0 |       20.0 | 123 Main St, New York, NY | john.doe@example.com | 123-45-6789 | 555-123-4567 
(1 row)

Query 20260326_072023_00021_85sxf, FINISHED, 1 node
http://localhost:8080/ui/query.html?20260326_072023_00021_85sxf
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:21, server-side: 0:21] [1 rows, 0B] [0 rows/s, 0B/s]
```

**Testing for fetch_size:**

**Presto-CLI:**

_jdbc-fetch-size = 10_

```
presto> select * from oracle_small_fetch.TM_LAKEHOUSE_ENGINE.TEST_FETCH;
    ID    |  DATA   
------------------+------------
 1211.0000000000 | data_1211  
 1212.0000000000 | data_1212  
 1213.0000000000 | data_1213  
 1214.0000000000 | data_1214  
 1215.0000000000 | data_1215  
 1216.0000000000 | data_1216  
 1217.0000000000 | data_1217  
 1218.0000000000 | data_1218  
 1219.0000000000 | data_1219  
 1220.0000000000 | data_1220
(query aborted by user)

Query 20260407_144910_00006_m2vrb, RUNNING, 1 node
Splits: 17 total, 0 done (0.00%)
[Latency: client-side: 1:15, server-side: 1:11] [0 rows, 0B] [0 rows/s, 0B/s]

```
<img width="1144" height="580" alt="Screenshot 2026-04-07 at 9 33 16 PM" src="https://github.com/user-attachments/assets/8a95574a-e17b-43de-a29f-7a9e5ff94161" />


[20260407_144910_00006_m2vrb_small_fetch.json](https://github.com/user-attachments/files/26543492/20260407_144910_00006_m2vrb_small_fetch.json)


_jdbc-fetch-size = 1000_

```
presto> select * from oracle_large_fetch.TM_LAKEHOUSE_ENGINE.TEST_FETCH;
    ID    |  DATA   
------------------+------------
 1211.0000000000 | data_1211  
 1212.0000000000 | data_1212  
 1213.0000000000 | data_1213  
 1214.0000000000 | data_1214  
 1215.0000000000 | data_1215  
 1216.0000000000 | data_1216  
 1217.0000000000 | data_1217  
 1218.0000000000 | data_1218  
 1219.0000000000 | data_1219  
 1220.0000000000 | data_1220  
 1221.0000000000 | data_1221  
 1222.0000000000 | data_1222
(query aborted by user)

Query 20260407_144746_00005_m2vrb, RUNNING, 1 node
Splits: 17 total, 0 done (0.00%)
[Latency: client-side: 0:11, server-side: 0:06] [0 rows, 0B] [0 rows/s, 0B/s]
```
[20260407_144746_00005_m2vrb_large_fetch.json](https://github.com/user-attachments/files/26543501/20260407_144746_00005_m2vrb_large_fetch.json)


<img width="1186" height="469" alt="Screenshot 2026-04-07 at 9 31 40 PM" src="https://github.com/user-attachments/assets/5defb615-f3bb-4627-940d-fc222c13bdc7" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Oracle Connector Changes
*  Add oraorai18n.jar dependency, jdbc fetchsize and SSL config for Oracle connector.
