### PR TITLE
Add output size calculation to BinarySortableSerializer

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BinarySortableSerializer.h
+++ b/presto-native-execution/presto_cpp/main/operators/BinarySortableSerializer.h
@@ -37,7 +37,11 @@ class BinarySortableSerializer {
 
   /// Serialize the data into an raw buffer, the caller needs to ensure there
   /// serialized data won't overflow the buffer.
-  void serialize(velox::vector_size_t rowId, velox::StringVectorBuffer* out);
+  void serialize(velox::vector_size_t rowId, velox::StringVectorBuffer* out)
+      const;
+
+  /// Returns the serialized byte size of a given input row at 'rowId'.
+  size_t serializedSizeInBytes(velox::vector_size_t rowId) const;
 
  private:
   const velox::RowVectorPtr input_;

--- a/presto-native-execution/presto_cpp/main/operators/benchmarks/BinarySortableSerializerBenchmark.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/benchmarks/BinarySortableSerializerBenchmark.cpp
@@ -23,31 +23,57 @@
 using namespace facebook::velox;
 namespace facebook::presto::operators {
 namespace {
+
 class BinarySortableSerializerBenchmark {
  public:
-  void serializeWithStringVectorBuffer(
+  BinarySortableSerializerBenchmark(
       const RowTypePtr& rowType,
-      const std::vector<velox::core::SortOrder>& ordering) {
+      const std::vector<velox::core::SortOrder>& ordering)
+      : ordering_(ordering) {
     folly::BenchmarkSuspender suspender;
-    auto data = makeData(rowType);
-    auto fields = getFields(rowType);
-    suspender.dismiss();
-
-    BinarySortableSerializer binarySortableSerializer(data, ordering, fields);
-
-    auto vector =
+    data_ = makeData(rowType);
+    fields_ = getFields(rowType);
+    outputVec_ =
         velox::BaseVector::create<velox::FlatVector<velox::StringView>>(
-            velox::VARBINARY(), data->size(), pool());
+            velox::VARBINARY(), data_->size(), pool());
+    suspender.dismiss();
+  }
+
+  void serializeWithStringVectorBuffer() {
+    BinarySortableSerializer binarySortableSerializer(
+        data_, ordering_, fields_);
     // Create a ResizableVectorBuffer with initial and max capacity.
-    velox::StringVectorBuffer buffer(vector.get(), 1024, 1 << 20);
-    serialize(binarySortableSerializer, data->size(), &buffer);
-    VELOX_CHECK_EQ(vector->size(), data->size());
+    velox::StringVectorBuffer buffer(outputVec_.get(), 0, 1 << 20);
+    serialize(binarySortableSerializer, data_->size(), &buffer);
+    VELOX_CHECK_EQ(outputVec_->size(), data_->size());
+  }
+
+  void serializeWithSizeCalculation() {
+    BinarySortableSerializer binarySortableSerializer(
+        data_, ordering_, fields_);
+    const auto bufferSize =
+        calculateSize(binarySortableSerializer, data_->size());
+    // Create a ResizableVectorBuffer with bufferSize.
+    velox::StringVectorBuffer buffer(outputVec_.get(), bufferSize, bufferSize);
+    serialize(binarySortableSerializer, data_->size(), &buffer);
+    VELOX_CHECK_EQ(outputVec_->size(), data_->size());
+  }
+
+  void calculateSerializedSize() {
+    BinarySortableSerializer binarySortableSerializer(
+        data_, ordering_, fields_);
+    calculateSize(binarySortableSerializer, data_->size());
+  }
+
+  memory::MemoryPool* pool() {
+    return pool_.get();
   }
 
  private:
   RowVectorPtr makeData(const RowTypePtr& rowType) {
     VectorFuzzer::Options options;
     options.vectorSize = 1'000;
+    options.stringLength = 10'000;
 
     const auto seed = 1; // For reproducibility.
     VectorFuzzer fuzzer(options, pool_.get(), seed);
@@ -68,7 +94,7 @@ class BinarySortableSerializerBenchmark {
   }
 
   void serialize(
-      BinarySortableSerializer binarySortableSerializer,
+      const BinarySortableSerializer& binarySortableSerializer,
       vector_size_t numRows,
       velox::StringVectorBuffer* out) {
     for (auto i = 0; i < numRows; ++i) {
@@ -77,41 +103,107 @@ class BinarySortableSerializerBenchmark {
     }
   }
 
-  memory::MemoryPool* pool() {
-    return pool_.get();
+  size_t calculateSize(
+      const BinarySortableSerializer& binarySortableSerializer,
+      vector_size_t numRows) {
+    size_t size = 0;
+    for (auto i = 0; i < numRows; ++i) {
+      size += binarySortableSerializer.serializedSizeInBytes(i);
+    }
+    return size;
   }
+  const std::vector<velox::core::SortOrder> ordering_;
+  
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+    memory::memoryManager()->addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("test")};
 
-  std::shared_ptr<memory::MemoryPool> pool_{
-      memory::memoryManager()->addLeafPool()};
+  RowVectorPtr data_;
+  std::vector<std::shared_ptr<const velox::core::FieldAccessTypedExpr>> fields_;
+  std::shared_ptr<FlatVector<StringView>> outputVec_;
 };
 
-BENCHMARK(decimalsSerialize) {
-  BinarySortableSerializerBenchmark benchmark;
+BENCHMARK_DRAW_TEXT("=============Serialize decimal=============");
 
-  auto ordering = {
+BENCHMARK_COUNTERS(decimalsSerialize, counters) {
+  const auto ordering = {
       velox::core::SortOrder(velox::core::kAscNullsFirst),
       velox::core::SortOrder(velox::core::kAscNullsFirst),
       velox::core::SortOrder(velox::core::kAscNullsFirst)};
 
-  benchmark.serializeWithStringVectorBuffer(
+  BinarySortableSerializerBenchmark benchmark(
       ROW({BIGINT(), DECIMAL(12, 2), DECIMAL(38, 18)}), ordering);
+
+  benchmark.serializeWithStringVectorBuffer();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
 }
 
-BENCHMARK(string1Serialize) {
-  BinarySortableSerializerBenchmark benchmark;
+BENCHMARK_RELATIVE(decimalsSizeCalculation) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
 
-  auto ordering = {
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), DECIMAL(12, 2), DECIMAL(38, 18)}), ordering);
+
+  benchmark.calculateSerializedSize();
+}
+
+BENCHMARK_COUNTERS_RELATIVE(decimalsSerializeWithSizeCalculation, counters) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), DECIMAL(12, 2), DECIMAL(38, 18)}), ordering);
+
+  benchmark.serializeWithSizeCalculation();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
+}
+
+BENCHMARK_DRAW_TEXT("=============Serialize string1=============");
+
+BENCHMARK_COUNTERS(string1Serialize, counters) {
+  const auto ordering = {
       velox::core::SortOrder(velox::core::kAscNullsFirst),
       velox::core::SortOrder(velox::core::kDescNullsFirst)};
 
-  benchmark.serializeWithStringVectorBuffer(
+  BinarySortableSerializerBenchmark benchmark(
       ROW({BIGINT(), VARCHAR()}), ordering);
+
+  benchmark.serializeWithStringVectorBuffer();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
 }
 
-BENCHMARK(strings5Serialize) {
-  BinarySortableSerializerBenchmark benchmark;
+BENCHMARK_RELATIVE(string1SizeCalculation) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kDescNullsFirst)};
 
-  auto ordering = {
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), VARCHAR()}), ordering);
+
+  benchmark.calculateSerializedSize();
+}
+
+BENCHMARK_COUNTERS_RELATIVE(string1SerializeWithSizeCalculation, counters) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kDescNullsFirst)};
+
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), VARCHAR()}), ordering);
+
+  benchmark.serializeWithSizeCalculation();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
+}
+
+BENCHMARK_DRAW_TEXT("=============Serialize string5=============");
+
+BENCHMARK_COUNTERS(strings5Serialize, counters) {
+  const auto ordering = {
       velox::core::SortOrder(velox::core::kAscNullsFirst),
       velox::core::SortOrder(velox::core::kAscNullsLast),
       velox::core::SortOrder(velox::core::kAscNullsFirst),
@@ -119,43 +211,161 @@ BENCHMARK(strings5Serialize) {
       velox::core::SortOrder(velox::core::kAscNullsFirst),
       velox::core::SortOrder(velox::core::kAscNullsLast)};
 
-  benchmark.serializeWithStringVectorBuffer(
+  BinarySortableSerializerBenchmark benchmark(
       ROW({BIGINT(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR()}),
       ordering);
+
+  benchmark.serializeWithStringVectorBuffer();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
 }
 
-BENCHMARK(arraysSerialize) {
-  BinarySortableSerializerBenchmark benchmark;
+BENCHMARK_RELATIVE(strings5SizeCalculation) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast)};
 
-  auto ordering = {
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR()}),
+      ordering);
+
+  benchmark.calculateSerializedSize();
+}
+
+BENCHMARK_COUNTERS_RELATIVE(strings5SerializeWithSizeCalculation, counters) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast),
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast)};
+
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR(), VARCHAR()}),
+      ordering);
+
+  benchmark.serializeWithSizeCalculation();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
+}
+
+BENCHMARK_DRAW_TEXT("=============Serialize array=============");
+
+BENCHMARK_COUNTERS(arraysSerialize, counters) {
+  const auto ordering = {
       velox::core::SortOrder(velox::core::kAscNullsFirst),
       velox::core::SortOrder(velox::core::kAscNullsFirst)};
 
-  benchmark.serializeWithStringVectorBuffer(
+  BinarySortableSerializerBenchmark benchmark(
       ROW({BIGINT(), ARRAY(BIGINT())}), ordering);
+
+  benchmark.serializeWithStringVectorBuffer();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
 }
 
-BENCHMARK(nestedArraysSerialize) {
-  BinarySortableSerializerBenchmark benchmark;
+BENCHMARK_RELATIVE(arraysSizeCalculation) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
 
-  auto ordering = {
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), ARRAY(BIGINT())}), ordering);
+
+  benchmark.calculateSerializedSize();
+}
+
+BENCHMARK_COUNTERS_RELATIVE(arraysSerializeWithSizeCalculation, counters) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsFirst)};
+
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), ARRAY(BIGINT())}), ordering);
+
+  benchmark.serializeWithSizeCalculation();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
+}
+
+BENCHMARK_DRAW_TEXT("=============Serialize nested array=============");
+
+BENCHMARK_COUNTERS(nestedArraysSerialize, counters) {
+  const auto ordering = {
       velox::core::SortOrder(velox::core::kAscNullsFirst),
       velox::core::SortOrder(velox::core::kAscNullsLast)};
 
-  benchmark.serializeWithStringVectorBuffer(
+  BinarySortableSerializerBenchmark benchmark(
       ROW({BIGINT(), ARRAY(ARRAY(BIGINT()))}), ordering);
+
+  benchmark.serializeWithStringVectorBuffer();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
 }
 
-BENCHMARK(structsSerialize) {
-  BinarySortableSerializerBenchmark benchmark;
+BENCHMARK_RELATIVE(nestedArraysSizeCalculation) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast)};
 
-  auto ordering = {
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), ARRAY(ARRAY(BIGINT()))}), ordering);
+
+  benchmark.calculateSerializedSize();
+}
+
+BENCHMARK_COUNTERS_RELATIVE(
+    nestedArraysSerializeWithSizeCalculation,
+    counters) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kAscNullsFirst),
+      velox::core::SortOrder(velox::core::kAscNullsLast)};
+
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), ARRAY(ARRAY(BIGINT()))}), ordering);
+
+  benchmark.serializeWithSizeCalculation();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
+}
+
+BENCHMARK_DRAW_TEXT("=============Serialize struct=============");
+
+BENCHMARK_COUNTERS(structsSerialize, counters) {
+  const auto ordering = {
       velox::core::SortOrder(velox::core::kDescNullsFirst),
       velox::core::SortOrder(velox::core::kDescNullsFirst)};
 
-  benchmark.serializeWithStringVectorBuffer(
+  BinarySortableSerializerBenchmark benchmark(
       ROW({BIGINT(), ROW({BIGINT(), DOUBLE(), BOOLEAN(), TINYINT(), REAL()})}),
       ordering);
+
+  benchmark.serializeWithStringVectorBuffer();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
+}
+
+BENCHMARK_RELATIVE(structsSizeCalculation) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kDescNullsFirst),
+      velox::core::SortOrder(velox::core::kDescNullsFirst)};
+
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), ROW({BIGINT(), DOUBLE(), BOOLEAN(), TINYINT(), REAL()})}),
+      ordering);
+
+  benchmark.calculateSerializedSize();
+}
+
+BENCHMARK_COUNTERS_RELATIVE(structsSerializeWithSizeCalculation, counters) {
+  const auto ordering = {
+      velox::core::SortOrder(velox::core::kDescNullsFirst),
+      velox::core::SortOrder(velox::core::kDescNullsFirst)};
+
+  BinarySortableSerializerBenchmark benchmark(
+      ROW({BIGINT(), ROW({BIGINT(), DOUBLE(), BOOLEAN(), TINYINT(), REAL()})}),
+      ordering);
+
+  benchmark.serializeWithSizeCalculation();
+  counters["memUsage"] = benchmark.pool()->stats().usedBytes;
 }
 
 } // namespace


### PR DESCRIPTION
Summary: `BinarySortableSerializer::serializedSizeInBytes` does a pass over the input data to calculate the output size in bytes. This is used to pre-determine the output buffer size to allocate.

Differential Revision: D76008301

```

== RELEASE NOTES ==
Prestissimo (Native Execution) Changes
* Add BinarySortableSerializer::serializedSizeInBytes method that returns the serialized byte size of a given input row at 'rowId'. This allows us to pre-allocated the exact output buffer size needed for serialization, avoiding wasted memory space. 
```
