### PR TITLE
Add native_max_num_splits_listened_to session property (1/2)

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -479,3 +479,12 @@ Maximum wait time for exchange long poll requests in seconds.
 
 Priority of the query in the memory pool reclaimer. Lower value means higher priority.
 This is used in global arbitration victim selection.
+
+``native_max_num_splits_listened_to``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Maximum number of splits to listen to by the SplitListener per table scan node per
+native worker.

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -79,6 +79,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_STREAMING_AGGREGATION_MIN_OUTPUT_BATCH_ROWS = "native_streaming_aggregation_min_output_batch_rows";
     public static final String NATIVE_REQUEST_DATA_SIZES_MAX_WAIT_SEC = "native_request_data_sizes_max_wait_sec";
     public static final String NATIVE_QUERY_MEMORY_RECLAIMER_PRIORITY = "native_query_memory_reclaimer_priority";
+    public static final String NATIVE_MAX_NUM_SPLITS_LISTENED_TO = "native_max_num_splits_listened_to";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -357,6 +358,11 @@ public class NativeWorkerSessionPropertyProvider
                         "Native Execution only. Priority of memory recliamer when deciding on memory pool to abort." +
                         "Lower value has higher priority and less likely to be choosen for memory pool abort",
                         2147483647,
+                        !nativeExecution),
+                integerProperty(
+                        NATIVE_MAX_NUM_SPLITS_LISTENED_TO,
+                        "Maximum number of splits to listen to per table scan node per worker.",
+                        0,
                         !nativeExecution));
     }
 


### PR DESCRIPTION
## Description
Add a session property native_max_num_splits_listened_to in Prestissimo to control the max number of splits that Velox SplitListener listens to. This PR adds the session property on coordinator side. https://github.com/prestodb/presto/pull/25361 adds the session property support on worker side.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

