### PR TITLE
Add native_max_num_splits_listened_to session property (2/2)

### DIFF
--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -497,6 +497,14 @@ SessionProperties::SessionProperties() {
       2147483647,
       QueryConfig::kQueryMemoryReclaimerPriority,
       std::to_string(c.queryMemoryReclaimerPriority()));
+
+  addSessionProperty(
+      kMaxNumSplitsListenedTo,
+      "Maximum number of splits to listen to by SplitListener on native workers.",
+      INTEGER(),
+      0,
+      QueryConfig::kMaxNumSplitsListenedTo,
+      std::to_string(c.maxNumSplitsListenedTo()));
 }
 
 const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -319,6 +319,10 @@ class SessionProperties {
   static constexpr const char* kNativeQueryMemoryReclaimerPriority =
       "native_query_memory_reclaimer_priority";
 
+  /// Maximum number of splits to listen to by SplitListener on native workers.
+  static constexpr const char* kMaxNumSplitsListenedTo =
+      "native_max_num_splits_listened_to";
+
   SessionProperties();
 
   const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -36,7 +36,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       SessionProperties::kTableScanScaleUpMemoryUsageRatio,
       SessionProperties::kStreamingAggregationMinOutputBatchRows,
       SessionProperties::kRequestDataSizesMaxWaitSec,
-      SessionProperties::kNativeQueryMemoryReclaimerPriority};
+      SessionProperties::kNativeQueryMemoryReclaimerPriority,
+      SessionProperties::kMaxNumSplitsListenedTo};
   const std::vector<std::string> veloxConfigNames = {
       core::QueryConfig::kAdjustTimestampToTimezone,
       core::QueryConfig::kDriverCpuTimeSliceLimitMs,
@@ -50,7 +51,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       core::QueryConfig::kTableScanScaleUpMemoryUsageRatio,
       core::QueryConfig::kStreamingAggregationMinOutputBatchRows,
       core::QueryConfig::kRequestDataSizesMaxWaitSec,
-      core::QueryConfig::kQueryMemoryReclaimerPriority};
+      core::QueryConfig::kQueryMemoryReclaimerPriority,
+      core::QueryConfig::kMaxNumSplitsListenedTo};
   auto sessionProperties = SessionProperties().getSessionProperties();
   const auto len = names.size();
   for (auto i = 0; i < len; i++) {


### PR DESCRIPTION
## Description
Following https://github.com/prestodb/presto/pull/25360, this PR adds the native_max_num_splits_listened_to session property on the worker side. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

