### PR TITLE
[Iceberg]: Disable collection of new stats for native execution

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
@@ -19,6 +19,7 @@ import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
@@ -44,6 +45,7 @@ public class IcebergHiveMetadataFactory
     final StatisticsFileCache statisticsFileCache;
     final ManifestFileCache manifestFileCache;
     final IcebergTableProperties tableProperties;
+    final ConnectorSystemConfig connectorSystemConfig;
 
     @Inject
     public IcebergHiveMetadataFactory(
@@ -59,7 +61,8 @@ public class IcebergHiveMetadataFactory
             IcebergHiveTableOperationsConfig operationsConfig,
             StatisticsFileCache statisticsFileCache,
             ManifestFileCache manifestFileCache,
-            IcebergTableProperties tableProperties)
+            IcebergTableProperties tableProperties,
+            ConnectorSystemConfig connectorSystemConfig)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -74,6 +77,7 @@ public class IcebergHiveMetadataFactory
         this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
         this.manifestFileCache = requireNonNull(manifestFileCache, "manifestFileCache is null");
         this.tableProperties = requireNonNull(tableProperties, "icebergTableProperties is null");
+        this.connectorSystemConfig = requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
     }
 
     public ConnectorMetadata create()
@@ -91,6 +95,7 @@ public class IcebergHiveMetadataFactory
                 operationsConfig,
                 statisticsFileCache,
                 manifestFileCache,
-                tableProperties);
+                tableProperties,
+                connectorSystemConfig);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
@@ -29,6 +29,7 @@ import com.facebook.presto.hive.gcs.HiveGcsModule;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.s3.HiveS3Module;
 import com.facebook.presto.plugin.base.security.AllowAllAccessControl;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PageIndexerFactory;
 import com.facebook.presto.spi.PageSorter;
@@ -99,6 +100,7 @@ public final class InternalIcebergConnectorFactory
                         binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());
                         binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
                         binder.bind(FilterStatsCalculatorService.class).toInstance(context.getFilterStatsCalculatorService());
+                        binder.bind(ConnectorSystemConfig.class).toInstance(context.getConnectorSystemConfig());
                     });
 
             Injector injector = app

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
@@ -418,7 +418,8 @@ public class TestRenameTableOnFragileFileSystem
                 new IcebergHiveTableOperationsConfig(),
                 new StatisticsFileCache(CacheBuilder.newBuilder().build()),
                 new ManifestFileCache(CacheBuilder.newBuilder().build(), false, 0, 1024),
-                new IcebergTableProperties(new IcebergConfig()));
+                new IcebergTableProperties(new IcebergConfig()),
+                () -> false);
         return icebergHiveMetadataFactory.create();
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergGeneralQueries.java
@@ -66,6 +66,10 @@ public class TestPrestoNativeIcebergGeneralQueries
         javaQueryRunner.execute("DROP TABLE IF EXISTS ice_table");
         javaQueryRunner.execute("CREATE TABLE ice_table(c1 INT, ds DATE)");
         javaQueryRunner.execute("INSERT INTO ice_table VALUES(1, date'2022-04-09'), (2, date'2022-03-18'), (3, date'1993-01-01')");
+
+        javaQueryRunner.execute("DROP TABLE IF EXISTS test_analyze");
+        javaQueryRunner.execute("CREATE TABLE test_analyze(i int)");
+        javaQueryRunner.execute("INSERT INTO test_analyze VALUES 1, 2, 3, 4, 5");
     }
 
     @Test
@@ -115,5 +119,11 @@ public class TestPrestoNativeIcebergGeneralQueries
     {
         assertQuery("SELECT * FROM ice_table_partitioned WHERE ds >= date'1994-01-01'", "VALUES (1, date'2022-04-09'), (2, date'2022-03-18')");
         assertQuery("SELECT * FROM ice_table WHERE ds = date'2022-04-09'", "VALUES (1, date'2022-04-09')");
+    }
+
+    @Test
+    public void testAnalyze()
+    {
+        assertUpdate(getSession(), "ANALYZE test_analyze", 5);
     }
 }


### PR DESCRIPTION
## Description
Disable collection of Iceberg supported statistics when ANALYZE command is run. 

## Motivation and Context
Iceberg supported statistics use `sketch_theta` function to collect distinct values, which are not implemented in velox and fail with error `Aggregate function not registered: presto.default.sketch_theta` when ANALYZE is run on Prestissimo.
Fixing this by disabling it for native execution mode.

## Impact


## Test Plan
Added integration test in TestPrestoNativeIcebergGeneralQueries.java

```
== NO RELEASE NOTE ==
```

