### PR TITLE
Register SplitListener in PrestoServer

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -487,6 +487,10 @@ void PrestoServer::run() {
     }
   }
 
+  if (auto factory = getSplitListenerFactory()) {
+    velox::exec::registerSplitListenerFactory(factory);
+  }
+
   if (systemConfig->enableVeloxExprSetLogging()) {
     if (auto listener = getExprSetListener()) {
       velox::exec::registerExprSetListener(listener);
@@ -1130,6 +1134,11 @@ std::shared_ptr<velox::exec::TaskListener> PrestoServer::getTaskListener() {
 
 std::shared_ptr<velox::exec::ExprSetListener>
 PrestoServer::getExprSetListener() {
+  return nullptr;
+}
+
+std::shared_ptr<facebook::velox::exec::SplitListenerFactory>
+PrestoServer::getSplitListenerFactory() {
   return nullptr;
 }
 

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -130,6 +130,9 @@ class PrestoServer {
 
   virtual std::shared_ptr<velox::exec::ExprSetListener> getExprSetListener();
 
+  virtual std::shared_ptr<facebook::velox::exec::SplitListenerFactory>
+    getSplitListenerFactory();
+
   virtual std::vector<std::string> registerVeloxConnectors(
       const fs::path& configDirectoryPath);
 


### PR DESCRIPTION
## Description
This PR adds an API to register velox::exec::SplitListenerFactory in PrestoServer.cpp to listen to input splits added to Velox Tasks. By default, no SplitListenerFactory is registered.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

