### PR TITLE
[native] Limit macos CI tests to C++ changes

### DIFF
--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -3,7 +3,9 @@ name: prestocpp-macos-build
 on:
   workflow_dispatch:
   pull_request:
-
+    paths:
+      - 'presto-native-execution/**'
+      - '.github/workflows/prestocpp-macos-build.yml'
 jobs:
   prestocpp-macos-build-engine:
     runs-on: macos-13


### PR DESCRIPTION
## Description
Recently, the path restrictions have been removed for C++ CI runs here https://github.com/prestodb/presto/pull/25299
This means all PRs will run these.
However, the number of macos runners in CI are limited. These runs also take a long time since we install all the dependencies.
As a result, there has been a long wait queue https://github.com/prestodb/presto/actions/workflows/prestocpp-macos-build.yml

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

