### PR TITLE
Route user errors from the EXPLAIN call to Java cluster for fallback

### DIFF
--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
@@ -17,17 +17,10 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.client.ClientSession;
-import com.facebook.presto.client.ErrorLocation;
-import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.client.QueryError;
-import com.facebook.presto.client.QueryResults;
-import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.client.StatementClient;
-import com.facebook.presto.common.ErrorCode;
-import com.facebook.presto.common.ErrorType;
 import com.facebook.presto.server.HttpRequestSessionContext;
 import com.facebook.presto.server.SessionContext;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.session.ResourceEstimates;
@@ -48,7 +41,6 @@ import java.util.Optional;
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_TRANSACTION_ID;
 import static com.facebook.presto.client.StatementClientFactory.newStatementClient;
-import static com.facebook.presto.common.ErrorType.USER_ERROR;
 import static com.facebook.presto.spi.session.ResourceEstimates.CPU_TIME;
 import static com.facebook.presto.spi.session.ResourceEstimates.EXECUTION_TIME;
 import static com.facebook.presto.spi.session.ResourceEstimates.PEAK_MEMORY;
@@ -59,13 +51,11 @@ import static java.util.stream.Collectors.toMap;
 public class PlanCheckerRouterPluginPrestoClient
 {
     private static final Logger log = Logger.get(PlanCheckerRouterPluginPrestoClient.class);
-    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
     private static final JsonCodec<SqlFunctionId> SQL_FUNCTION_ID_JSON_CODEC = jsonCodec(SqlFunctionId.class);
     private static final JsonCodec<SqlInvokedFunction> SQL_INVOKED_FUNCTION_JSON_CODEC = jsonCodec(SqlInvokedFunction.class);
     private static final String ANALYZE_CALL = "EXPLAIN (TYPE DISTRIBUTED) ";
     private static final CounterStat javaClusterRedirectRequests = new CounterStat();
     private static final CounterStat nativeClusterRedirectRequests = new CounterStat();
-
     private final OkHttpClient httpClient = new OkHttpClient();
     private final URI planCheckerClusterURI;
     private final URI javaRouterURI;
@@ -108,15 +98,6 @@ public class PlanCheckerRouterPluginPrestoClient
             verify(client.isFinished());
             QueryError resultsError = client.finalStatusInfo().getError();
             if (resultsError != null) {
-                if (ErrorType.valueOf(resultsError.getErrorType()) == USER_ERROR) {
-                    throw new PrestoException(
-                            () -> new ErrorCode(
-                                    resultsError.getErrorCode(),
-                                    resultsError.getErrorName(),
-                                    USER_ERROR,
-                                    resultsError.isRetriable()),
-                            newQueryResults(client));
-                }
                 isNativeCompatible = false;
                 log.info(resultsError.getMessage());
             }
@@ -144,54 +125,6 @@ public class PlanCheckerRouterPluginPrestoClient
     public CounterStat getNativeClusterRedirectRequests()
     {
         return nativeClusterRedirectRequests;
-    }
-
-    private String newQueryResults(StatementClient client)
-    {
-        QueryStatusInfo queryStatusInfo = client.finalStatusInfo();
-        QueryResults queryResults = new QueryResults(
-                queryStatusInfo.getId(),
-                queryStatusInfo.getInfoUri(),
-                queryStatusInfo.getPartialCancelUri(),
-                queryStatusInfo.getNextUri(),
-                queryStatusInfo.getColumns(),
-                null, // if error thrown no data is returned.
-                null,
-                queryStatusInfo.getStats(),
-                newQueryError(queryStatusInfo.getError()),
-                queryStatusInfo.getWarnings(),
-                queryStatusInfo.getUpdateType(),
-                queryStatusInfo.getUpdateCount());
-
-        return QUERY_RESULTS_CODEC.toJson(queryResults);
-    }
-
-    private QueryError newQueryError(QueryError error)
-    {
-        // todo: the getMessage() calls will still return the previous error location
-        ErrorLocation errorLocation = error.getErrorLocation();
-        ErrorLocation newErrorLocation = null;
-        FailureInfo failureInfo = error.getFailureInfo();
-        if (errorLocation != null) {
-            newErrorLocation = new ErrorLocation(
-                    errorLocation.getLineNumber(),
-                    errorLocation.getColumnNumber() - ANALYZE_CALL.length());
-        }
-        return new QueryError(
-                error.getMessage(),
-                error.getSqlState(),
-                error.getErrorCode(),
-                error.getErrorName(),
-                error.getErrorType(),
-                error.isRetriable(),
-                newErrorLocation,
-                new FailureInfo(
-                        failureInfo.getType(),
-                        failureInfo.getMessage(),
-                        failureInfo.getCause(),
-                        failureInfo.getSuppressed(),
-                        failureInfo.getStack(),
-                        newErrorLocation));
     }
 
     private ClientSession parseHeadersToClientSession(HttpServletRequest httpServletRequest)

--- a/presto-router/src/main/java/com/facebook/presto/router/RouterResource.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/RouterResource.java
@@ -60,16 +60,7 @@ public class RouterResource
     public Response routeQuery(String statement, @Context HttpServletRequest servletRequest)
     {
         RequestInfo requestInfo = new RequestInfo(servletRequest, statement);
-        URI coordinatorUri;
-        try {
-            coordinatorUri = clusterManager.getDestination(requestInfo).orElseThrow(() -> badRequest(BAD_GATEWAY, "No Presto cluster available"));
-        }
-        catch (RuntimeException e) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                    .entity(e.getMessage())
-                    .type(APPLICATION_JSON)
-                    .build();
-        }
+        URI coordinatorUri = clusterManager.getDestination(requestInfo).orElseThrow(() -> badRequest(BAD_GATEWAY, "No Presto cluster available"));
         URI statementUri = uriBuilderFrom(coordinatorUri).replacePath("/v1/statement").build();
         successRedirectRequests.update(1);
         log.info("route query to %s", statementUri);


### PR DESCRIPTION
## Description
Route user errors from the EXPLAIN call to Java cluster for fallback

## Motivation and Context
User errors thrown during the EXPLAIN call in the presto-plan-checker-router-plugin are no longer returned immediately to the client. This is because some user errors - such as `FUNCTION_NOT_FOUND` - may still succeed when routed to a Java cluster. Instead of failing early, such queries are now retried on the Java cluster.

## Impact
No impact

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
== NO RELEASE NOTE ==
```

