### PR TITLE
Support for TLS in Redis Connector 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2249,7 +2249,7 @@
             <dependency>
                 <groupId>redis.clients</groupId>
                 <artifactId>jedis</artifactId>
-                <version>2.6.2</version>
+                <version>3.8.0</version>
             </dependency>
 
             <dependency>

--- a/presto-docs/src/main/sphinx/connector/redis.rst
+++ b/presto-docs/src/main/sphinx/connector/redis.rst
@@ -51,6 +51,9 @@ Property Name                       Description
 ``redis.hide-internal-columns``     Controls whether internal columns are part of the table schema or not
 ``redis.database-index``            Redis database index
 ``redis.password``                  Redis server password
+``redis.user``                      Redis server username
+``redis.tls.enabled``               Whether TLS security is enabled (defaults to ``false``)
+``redis.tls.truststore-path``       Path to the TLS certificate file
 =================================   ==============================================================
 
 ``redis.table-names``
@@ -130,19 +133,39 @@ show up in ``DESCRIBE <table-name>`` or ``SELECT *``.
 This property is optional; the default is ``true``.
 
 ``redis.database-index``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Redis database to query.
 
 This property is optional; the default is ``0``.
 
 ``redis.password``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 The password for password-protected Redis server.
 
 This property is optional; the default is ``null``.
 
+``redis.user``
+^^^^^^^^^^^^^^
+
+Redis server username.
+
+This property is required; there is no default.
+
+``redis.tls.enabled``
+^^^^^^^^^^^^^^^^^^^^^
+
+Enable or disable TLS security.
+
+This property is optional; default is ``false``.
+
+``redis.tls.truststore-path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Path to the TLS certificate file.
+
+This property is required if ``redis.tls.enabled`` is set to ``true``.
 
 Internal Columns
 ----------------

--- a/presto-main/etc/catalog/redis.properties
+++ b/presto-main/etc/catalog/redis.properties
@@ -1,0 +1,7 @@
+connector.name=redis
+redis.table-names=schema1.table1,schema1.table2
+redis.user=user
+redis.password=password
+redis.tls.enabled=true
+redis.tls.truststore-path=<path>
+redis.table-description-dir=<path>

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -51,7 +51,8 @@ plugin.bundles=\
   ../presto-node-ttl-fetchers/pom.xml,\
   ../presto-hive-function-namespace/pom.xml,\
   ../presto-delta/pom.xml,\
-  ../presto-hudi/pom.xml
+  ../presto-hudi/pom.xml,\
+  ../presto-redis/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisConnectorConfig.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisConnectorConfig.java
@@ -59,6 +59,11 @@ public class RedisConnectorConfig
     private String redisPassword;
 
     /**
+     * user for Redis server
+     */
+    private String redisUser;
+
+    /**
      * Timeout to connect to Redis.
      */
     private Duration redisConnectTimeout = Duration.valueOf("2000ms");
@@ -87,6 +92,9 @@ public class RedisConnectorConfig
      * Whether Redis key string follows "schema:table:*" format
      */
     private boolean keyPrefixSchemaTable;
+
+    private boolean tlsEnabled;
+    private File truststorePath;
 
     @NotNull
     public File getTableDescriptionDir()
@@ -194,11 +202,24 @@ public class RedisConnectorConfig
         return redisPassword;
     }
 
+    public String getRedisUser()
+    {
+        return redisUser;
+    }
+
     @Config("redis.password")
     @ConfigSecuritySensitive
     public RedisConnectorConfig setRedisPassword(String redisPassword)
     {
         this.redisPassword = redisPassword;
+        return this;
+    }
+
+    @Config("redis.user")
+    @ConfigSecuritySensitive
+    public RedisConnectorConfig setRedisUser(String redisUser)
+    {
+        this.redisUser = redisUser;
         return this;
     }
 
@@ -235,5 +256,29 @@ public class RedisConnectorConfig
     private static HostAddress toHostAddress(String value)
     {
         return HostAddress.fromString(value).withDefaultPort(REDIS_DEFAULT_PORT);
+    }
+
+    public boolean isTlsEnabled()
+    {
+        return tlsEnabled;
+    }
+
+    @Config("redis.tls.enabled")
+    public RedisConnectorConfig setTlsEnabled(boolean tlsEnabled)
+    {
+        this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public File getTruststorePath()
+    {
+        return truststorePath;
+    }
+
+    @Config("redis.tls.truststore-path")
+    public RedisConnectorConfig setTruststorePath(File truststorePath)
+    {
+        this.truststorePath = truststorePath;
+        return this;
     }
 }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisJedisManager.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisJedisManager.java
@@ -24,11 +24,24 @@ import redis.clients.jedis.JedisPoolConfig;
 
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.Map;
 
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static javax.net.ssl.TrustManagerFactory.getDefaultAlgorithm;
 
 /**
  * Manages connections to the Redis nodes
@@ -36,6 +49,12 @@ import static java.util.Objects.requireNonNull;
 public class RedisJedisManager
 {
     private static final Logger log = Logger.get(RedisJedisManager.class);
+
+    private static final String TLS_PROTOCOL = "TLS";
+    private static final int JEDIS_CONN_TIMEOUT = 2000;
+    private static final int JEDIS_SO_TIMEOUT = 2000;
+    private static final int JEDIS_MIN_IDLE_CONNECTIONS = 1;
+    private static final int JEDIS_MAX_IDLE_CONNECTIONS = 5;
 
     private final LoadingCache<HostAddress, JedisPool> jedisPoolCache;
 
@@ -48,8 +67,8 @@ public class RedisJedisManager
             NodeManager nodeManager)
     {
         this.redisConnectorConfig = requireNonNull(redisConnectorConfig, "redisConfig is null");
-        this.jedisPoolCache = CacheBuilder.newBuilder().build(CacheLoader.from(this::createConsumer));
-        this.jedisPoolConfig = new JedisPoolConfig();
+        this.jedisPoolCache = CacheBuilder.newBuilder().build(CacheLoader.from(this::createJedisPool));
+        this.jedisPoolConfig = createJedisPoolConfig();
     }
 
     @PreDestroy
@@ -76,14 +95,97 @@ public class RedisJedisManager
         return jedisPoolCache.getUnchecked(host);
     }
 
-    private JedisPool createConsumer(HostAddress host)
+    /**
+     * Creates a new JedisPool for the specified host.
+     * Chooses between TLS or non-TLS configuration based on redisConnectorConfig.
+     */
+    private JedisPool createJedisPool(HostAddress host)
     {
-        log.info("Creating new JedisPool for %s", host);
-        return new JedisPool(jedisPoolConfig,
+        boolean isTlsEnabled = redisConnectorConfig.isTlsEnabled();
+        SSLContext sslContext = null;
+
+        if (isTlsEnabled) {
+            KeyStore trustStore = loadTrustStore();
+            sslContext = createSslContext(trustStore);
+        }
+
+        return buildJedisPool(host, isTlsEnabled, sslContext);
+    }
+    /**
+     * Creates SSLContext initialized with the given truststore.
+     */
+    private SSLContext createSslContext(KeyStore trustStore)
+    {
+        if (trustStore == null) {
+            throw new IllegalStateException("Truststore must not be null for TLS connections");
+        }
+
+        try {
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(getDefaultAlgorithm());
+            tmf.init(trustStore);
+
+            SSLContext sslContext = SSLContext.getInstance(TLS_PROTOCOL);
+            sslContext.init(null, tmf.getTrustManagers(), null);
+
+            return sslContext;
+        }
+        catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+            throw new RuntimeException("Failed to initialize SSLContext", e);
+        }
+    }
+
+    private JedisPoolConfig createJedisPoolConfig()
+    {
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMinIdle(JEDIS_MIN_IDLE_CONNECTIONS);
+        config.setMaxTotal(JEDIS_MAX_IDLE_CONNECTIONS);
+        return config;
+    }
+    /**
+     * Loads the truststore containing Redis server certificate.
+     * Returns null if truststore path is not configured.
+     */
+    private KeyStore loadTrustStore()
+    {
+        if (redisConnectorConfig.getTruststorePath() == null) {
+            log.info("No truststore path configured, skipping TLS truststore loading");
+            return null;
+        }
+
+        try {
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            try (InputStream in = Files.newInputStream(redisConnectorConfig.getTruststorePath().toPath())) {
+                trustStore.load(null, null);
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                X509Certificate cert = (X509Certificate) cf.generateCertificate(in);
+                trustStore.setCertificateEntry("redis-server", cert);
+            }
+            log.info("Loaded truststore from %s", redisConnectorConfig.getTruststorePath());
+            return trustStore;
+        }
+        catch (KeyStoreException | IOException | CertificateException | NoSuchAlgorithmException e) {
+            throw new RuntimeException("Failed to load truststore", e);
+        }
+    }
+
+    private JedisPool buildJedisPool(HostAddress host, boolean useTls, SSLContext sslContext)
+    {
+        log.info("Creating new %s JedisPool for %s", useTls ? "TLS" : "non-TLS", host);
+
+        return new JedisPool(
+                jedisPoolConfig,
                 host.getHostText(),
                 host.getPort(),
                 toIntExact(redisConnectorConfig.getRedisConnectTimeout().toMillis()),
+                JEDIS_SO_TIMEOUT,
+                JEDIS_CONN_TIMEOUT,
+                redisConnectorConfig.getRedisUser(),
                 redisConnectorConfig.getRedisPassword(),
-                redisConnectorConfig.getRedisDataBaseIndex());
+                redisConnectorConfig.getRedisDataBaseIndex(),
+                null,
+                useTls,
+                useTls ? sslContext.getSocketFactory() : null,
+                null,
+                null);
     }
 }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisRecordCursor.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisRecordCursor.java
@@ -118,7 +118,7 @@ public class RedisRecordCursor
         // no more keys are unscanned when
         // when redis scan command
         // returns 0 string cursor
-        return (!redisCursor.getStringCursor().equals("0"));
+        return (!redisCursor.getCursor().equals("0"));
     }
 
     @Override
@@ -299,7 +299,7 @@ public class RedisRecordCursor
                 case STRING: {
                     String cursor = SCAN_POINTER_START;
                     if (redisCursor != null) {
-                        cursor = redisCursor.getStringCursor();
+                        cursor = redisCursor.getCursor();
                     }
 
                     log.debug("Scanning new Redis keys from cursor %s . %d values read so far", cursor, totalValues);

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisConnectorConfig.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisConnectorConfig.java
@@ -26,6 +26,9 @@ public class TestRedisConnectorConfig
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(RedisConnectorConfig.class)
+                .setRedisUser(null)
+                .setTlsEnabled(false)
+                .setTruststorePath(null)
                 .setNodes("")
                 .setDefaultSchema("default")
                 .setTableNames("")
@@ -53,6 +56,9 @@ public class TestRedisConnectorConfig
                 .put("redis.hide-internal-columns", "false")
                 .put("redis.connect-timeout", "10s")
                 .put("redis.database-index", "5")
+                .put("redis.user", "nobody")
+                .put("redis.tls.enabled", "true")
+                .put("redis.tls.truststore-path", "/dev/null")
                 .put("redis.password", "secret")
                 .build();
 
@@ -65,6 +71,9 @@ public class TestRedisConnectorConfig
                 .setRedisScanCount(20)
                 .setRedisConnectTimeout("10s")
                 .setRedisDataBaseIndex(5)
+                .setRedisUser("nobody")
+                .setTlsEnabled(true)
+                .setTruststorePath(new File("/dev/null"))
                 .setRedisPassword("secret")
                 .setRedisKeyDelimiter(",")
                 .setKeyPrefixSchemaTable(true);


### PR DESCRIPTION
## Description
Support for TLS in Redis Connector

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Executed basic queries after enabling TLS in Redis.
Queries got executed successfully.

```
presto> select * from redis.default.product;
  product_id  |      product_name       | product_price | is_expired
--------------+-------------------------+---------------+------------
 product_1007 | Smart TV 4K             | NULL          | NULL
 product_1010 | Virtual Reality Headset | NULL          | NULL
 house2       | NULL                    | NULL          | NULL
 house_id     | NULL                    | NULL          | NULL
 house3       | NULL                    | NULL          | NULL
 product_1001 | Smartwatch Pro          | NULL          | NULL
 product_1009 | Drone Pro               | NULL          | NULL
 product_1008 | Bluetooth Speaker       | NULL          | NULL
 product_1006 | Gaming Console Z        | NULL          | NULL
 house1       | NULL                    | NULL          | NULL
 house4       | NULL                    | NULL          | NULL
 product_1005 | Tablet Pro              | NULL          | NULL
 product_1002 | Smartphone X            | NULL          | NULL
 product_1004 | Wireless Headphones     | NULL          | NULL
 product_1011 | Smart Watch             |        199.99 | false
 product_1003 | Laptop Ultra            | NULL          | NULL
(16 rows)

Query 20250702_105331_00000_bnarf, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:09, server-side: 0:09] [16 rows, 1.9KB] [1 rows/s, 226B/s]
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Redis Connector Changes
* Add changes to enable TLS support
```
