### PR TITLE
Fix some issues of prepare release action

### DIFF
--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -37,6 +37,16 @@ jobs:
           show-progress: false
           fetch-depth: 5
 
+      - name: Ensure checkout latest code
+        run: |
+          git fetch origin ${{ github.ref_name }}
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/${{ github.ref_name }})" ]; then
+            echo "Branch ${{ github.ref_name }} has new commits. Resetting to latest."
+            git reset --hard origin/${{ github.ref_name }}
+          else
+            echo "Branch ${{ github.ref_name }} is already up to date."
+          fi
+
       - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
@@ -106,7 +116,9 @@ jobs:
       - name: Checkout presto source
         uses: actions/checkout@v4
         with:
+          fetch-tags: true
           show-progress: false
+          fetch-depth: 0
 
       - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Description

1. The prepare action will fail if there is PR merged or commits pushed during the review & approval for the action

   Log: https://github.com/prestodb/presto/actions/runs/15301329058/job/43042428741#step:8:79
   Root cause: push failed because new commits added not inside the action
   Solution: reset the branch to get latest code before cut release (though there are still a short time window that new commits being pushed) 

2.  Release notes not generated correctly
   Log: https://github.com/prestodb/presto/actions/runs/15327479474/job/43128873381#step:6:110
   Root cause: probably related to the fetch depth, 
   Solution: fetch full commit history

```log
2025-05-29T15:42:04.819Z	INFO	main	com.facebook.presto.release.tasks.GenerateReleaseNotesTask	Release version: 0.293, Last Version: 0.292
2025-05-29T15:42:04.820Z	INFO	main	com.facebook.presto.release.AbstractCommands	Running Command: git log upstream/release-0.292..upstream/release-0.293 --format=%H --date-order; Log: /tmp/presto-release-log16231096948632379759
2025-05-29T15:42:04.823Z	INFO	main	com.facebook.presto.release.AbstractCommands	Finished running command: git log upstream/release-0.292..upstream/release-0.293 --format=%H --date-order
2025-05-29T15:42:04.824Z	INFO	main	com.facebook.presto.release.tasks.GenerateReleaseNotesTask	Fetching Github commits
2025-05-29T15:42:08.621Z	INFO	main	com.facebook.presto.release.tasks.GenerateReleaseNotesTask	Fetched 2 commits
2025-05-29T15:42:08.622Z	INFO	main	com.facebook.presto.release.tasks.GenerateReleaseNotesTask	Processing 1 commits
2025-05-29T15:42:08.623Z	INFO	main	com.facebook.presto.release.tasks.GenerateReleaseNotesTask	pull request description matches with no release note pattern
```


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Issues from release 0.293


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

Release actions


## Test Plan
<!---Please fill in how you tested your change-->
Tested with: https://github.com/unix280/presto/actions/runs/15754867690

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

