### PR TITLE
[native] Enable the use of the cuDF parquet reader

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -114,6 +114,8 @@ if(PRESTO_ENABLE_CUDF)
   set(VELOX_ENABLE_CUDF
       ON
       CACHE BOOL "Enable cuDF support")
+  set(VELOX_ENABLE_PARSE ON)
+  set(VELOX_ENABLE_DUCKDB ON)
   add_compile_definitions(PRESTO_ENABLE_CUDF)
   enable_language(CUDA)
   # Determine CUDA_ARCHITECTURES automatically.

--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -73,6 +73,8 @@ target_link_libraries(
   velox_hive_connector
   velox_hive_iceberg_splitreader
   velox_hive_partition_function
+  velox_parse_expression
+  velox_parse_parser
   velox_presto_serializer
   velox_s3fs
   velox_serialization

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -147,15 +147,17 @@ bool cachePeriodicPersistenceEnabled() {
 
 void registerVeloxCudf() {
 #ifdef PRESTO_ENABLE_CUDF
- facebook::velox::cudf_velox::registerCudf();
- PRESTO_STARTUP_LOG(INFO) << "cuDF is registered.";
+  facebook::velox::cudf_velox::CudfOptions::getInstance().setPrefix(
+      SystemConfig::instance()->prestoDefaultNamespacePrefix());
+  facebook::velox::cudf_velox::registerCudf();
+  PRESTO_STARTUP_LOG(INFO) << "cuDF is registered.";
 #endif
 }
 
 void unregisterVeloxCudf() {
 #ifdef PRESTO_ENABLE_CUDF
- facebook::velox::cudf_velox::unregisterCudf();
- PRESTO_SHUTDOWN_LOG(INFO) << "cuDF is unregistered.";
+  facebook::velox::cudf_velox::unregisterCudf();
+  PRESTO_SHUTDOWN_LOG(INFO) << "cuDF is unregistered.";
 #endif
 }
 
@@ -1215,7 +1217,12 @@ std::vector<std::string> PrestoServer::registerVeloxConnectors(
                                << " using connector " << connectorName;
 
       // make sure connector type is supported
-      getPrestoToVeloxConnector(connectorName);
+      // cudf-parquet is not a real Presto connector, as it does not have
+      // a protocol associated, so it does not go via the standard
+      // PrestoToVelox conversion
+      if (connectorName != "cudf-parquet") {
+        getPrestoToVeloxConnector(connectorName);
+      }
 
       std::shared_ptr<velox::connector::Connector> connector =
           velox::connector::getConnectorFactory(connectorName)
@@ -1225,6 +1232,11 @@ std::vector<std::string> PrestoServer::registerVeloxConnectors(
                   connectorIoExecutor_.get(),
                   connectorCpuExecutor_.get());
       velox::connector::registerConnector(connector);
+
+      if (connectorName == "cudf-parquet") {
+        facebook::velox::cudf_velox::CudfOptions::getInstance()
+            .setParquetConnectorRegistered(true);
+      }
     }
   }
   return catalogNames;

--- a/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
@@ -17,5 +17,10 @@ if(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR)
   target_link_libraries(presto_connectors presto_flight_connector)
 endif()
 
+if(PRESTO_ENABLE_CUDF)
+  target_link_libraries(presto_connectors velox_cudf_parquet_connector
+                        cudf::cudf)
+endif()
+
 target_link_libraries(presto_connectors presto_velox_expr_conversion
                       velox_type_fbhive)

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
@@ -28,6 +28,16 @@
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/experimental/cudf/connectors/parquet/ParquetConnector.h"
+#include "velox/experimental/cudf/connectors/parquet/ParquetTableHandle.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/IExpr.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/type/Filter.h"
 
 namespace facebook::presto {
@@ -69,6 +79,14 @@ const PrestoToVeloxConnector& getPrestoToVeloxConnector(
 
 namespace {
 using namespace velox;
+
+bool canUseCudfTableScan() {
+  const bool isParquetConnectorRegistered =
+      facebook::velox::connector::getAllConnectors().count("parquet-test") > 0;
+  const bool isCudfTableScanEnabled =
+      facebook::velox::cudf_velox::CudfOptions::getInstance().cudfTableScan;
+  return isParquetConnectorRegistered && isCudfTableScanEnabled;
+}
 
 dwio::common::FileFormat toVeloxFileFormat(
     const presto::protocol::hive::StorageFormat& format) {
@@ -653,6 +671,108 @@ std::unique_ptr<common::Filter> combineBytesRanges(
       std::move(bytesGeneric), nullAllowed, false);
 }
 
+std::string valueTypeToString(
+    const TypePtr& type,
+    const std::shared_ptr<facebook::presto::protocol::Block> block,
+    const VeloxExprConverter& exprConverter) {
+  if (type->isDate()) {
+    int64_t daysSinceEpoch = dateToInt64(block, exprConverter, type);
+    auto secondsSinceEpoch = daysSinceEpoch * 24 * 60 * 60;
+    char formattedDate[13];
+    std::strftime(
+        formattedDate,
+        13,
+        "'%Y-%m-%d'",
+        gmtime((std::time_t*)&secondsSinceEpoch));
+    return std::string(formattedDate);
+  }
+
+  switch (type->kind()) {
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+      return std::to_string(toInt64(block, exprConverter, type));
+    case TypeKind::HUGEINT:
+      return std::to_string(toInt128(block, exprConverter, type));
+    case TypeKind::DOUBLE:
+      return std::to_string(
+          toFloatingPoint<double>(block, exprConverter, type));
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+      return "'" + toString(block, exprConverter, type) + "'";
+    case TypeKind::BOOLEAN:
+      return std::to_string(toBoolean(block, exprConverter, type));
+    case TypeKind::REAL:
+      return std::to_string(toFloatingPoint<float>(block, exprConverter, type));
+    case TypeKind::TIMESTAMP:
+      return toTimestamp(block, exprConverter, type);
+    default:
+      VELOX_UNSUPPORTED("Unsupported range type: {}", type->toString());
+  }
+}
+
+std::string toStringFilter(
+    const std::string columnName,
+    const protocol::Domain& domain,
+    const VeloxExprConverter& exprConverter,
+    const TypeParser& typeParser) {
+  std::string stringFilter;
+
+  auto nullAllowed = domain.nullAllowed;
+  if (auto sortedRangeSet =
+          std::dynamic_pointer_cast<protocol::SortedRangeSet>(domain.values)) {
+    LOG(INFO) << "toStringFilter 1";
+    auto type = stringToType(sortedRangeSet->type, typeParser);
+    LOG(INFO) << "toStringFilter 2";
+    auto ranges = sortedRangeSet->ranges;
+
+    if (ranges.empty()) {
+      VELOX_CHECK(nullAllowed, "Unexpected always-false filter");
+      stringFilter = columnName + " is null";
+      return stringFilter;
+    }
+
+    for (auto range : ranges) {
+      LOG(INFO) << "toStringFilter 3";
+      if (!stringFilter.empty()) {
+        stringFilter += " or ";
+      }
+      // 'is not null' arrives as unbounded range with 'nulls not allowed'.
+      // We catch this case and create 'is not null' filter instead of the range
+      // filter.
+
+      bool lowExclusive = range.low.bound == protocol::Bound::ABOVE;
+      bool lowUnbounded = range.low.valueBlock == nullptr && lowExclusive;
+      bool highExclusive = range.high.bound == protocol::Bound::BELOW;
+      bool highUnbounded = range.high.valueBlock == nullptr && highExclusive;
+      if (lowUnbounded && highUnbounded && !nullAllowed) {
+        stringFilter += columnName + " is not null";
+      }
+
+      if (!lowUnbounded) {
+        LOG(INFO) << "toStringFilter 4";
+        stringFilter += columnName;
+        stringFilter += lowExclusive ? " > " : " >= ";
+        stringFilter +=
+            valueTypeToString(type, range.low.valueBlock, exprConverter) +
+            "::" + type->toString();
+      }
+      if (!highUnbounded) {
+        LOG(INFO) << "toStringFilter 5";
+        stringFilter += lowUnbounded ? "" : " and ";
+        stringFilter += columnName;
+        stringFilter += highExclusive ? " < " : " <= ";
+        stringFilter +=
+            valueTypeToString(type, range.high.valueBlock, exprConverter) +
+            "::" + type->toString();
+      }
+    }
+    return stringFilter;
+  }
+  VELOX_UNSUPPORTED("Unsupported filter found.");
+}
+
 std::unique_ptr<common::Filter> toFilter(
     const TypePtr& type,
     const protocol::Range& range,
@@ -800,6 +920,41 @@ std::unique_ptr<common::Filter> toFilter(
   VELOX_UNSUPPORTED("Unsupported filter found.");
 }
 
+facebook::velox::core::TypedExprPtr getTypedExprFromSubfieldFilter(
+    std::shared_ptr<facebook::presto::protocol::Map<
+        facebook::presto::protocol::Subfield,
+        facebook::presto::protocol::Domain>> domains,
+    const VeloxExprConverter& exprConverter,
+    const TypeParser& typeParser,
+    RowTypePtr finalDataColumns) {
+  facebook::velox::parse::registerTypeResolver();
+  auto parseOptions = parse::ParseOptions{.functionPrefix = "presto.default."};
+
+  std::string stringFilter;
+  for (const auto& domain : *domains) {
+    if (!stringFilter.empty()) {
+      stringFilter += " and ";
+    }
+    stringFilter += toStringFilter(
+        common::Subfield(domain.first).toString(),
+        domain.second,
+        exprConverter,
+        typeParser);
+  }
+
+  LOG(INFO) << "stringFilter = " << stringFilter;
+  facebook::velox::core::ExprPtr filter =
+      facebook::velox::parse::parseExpr(stringFilter, parseOptions);
+  LOG(INFO) << "Produced Expr = " << filter->toString();
+  facebook::velox::core::TypedExprPtr filterExpr =
+      facebook::velox::core::Expressions::inferTypes(
+          filter,
+          finalDataColumns,
+          memory::memoryManager()->addRootPool().get());
+  LOG(INFO) << "Produced filterExpr = " << filterExpr->toString();
+  return filterExpr;
+}
+
 std::unique_ptr<connector::ConnectorTableHandle> toHiveTableHandle(
     const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
     const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
@@ -846,17 +1001,49 @@ std::unique_ptr<connector::ConnectorTableHandle> toHiveTableHandle(
       types.push_back(VELOX_DYNAMIC_TYPE_DISPATCH(
           fieldNamesToLowerCase, parsedType->kind(), parsedType));
     }
+    if (!subfieldFilters.empty()) {
+      for (const auto& domain : *domains) {
+        std::string name = common::Subfield(domain.first).toString();
+        folly::toLowerAscii(name);
+        names.emplace_back(std::move(name));
+        if (auto sortedRangeSet =
+                std::dynamic_pointer_cast<protocol::SortedRangeSet>(
+                    domain.second.values)) {
+          auto type = stringToType(sortedRangeSet->type, typeParser);
+          types.push_back(VELOX_DYNAMIC_TYPE_DISPATCH(
+              fieldNamesToLowerCase, type->kind(), type));
+        } else {
+          VELOX_UNSUPPORTED("Unsupported filter found.");
+        }
+      }
+    }
     finalDataColumns = ROW(std::move(names), std::move(types));
   }
 
   if (tableParameters.empty()) {
-    return std::make_unique<connector::hive::HiveTableHandle>(
-        tableHandle.connectorId,
-        tableName,
-        isPushdownFilterEnabled,
-        std::move(subfieldFilters),
-        remainingFilter,
-        finalDataColumns);
+    if (canUseCudfTableScan()) {
+      facebook::velox::core::TypedExprPtr filterExpr = nullptr;
+      if (!subfieldFilters.empty()) {
+        filterExpr = getTypedExprFromSubfieldFilter(
+            domains, exprConverter, typeParser, finalDataColumns);
+      }
+      return std::make_unique<
+          cudf_velox::connector::parquet::ParquetTableHandle>(
+          "parquet-test",
+          tableName,
+          isPushdownFilterEnabled,
+          filterExpr,
+          remainingFilter,
+          finalDataColumns);
+    } else {
+      return std::make_unique<connector::hive::HiveTableHandle>(
+          tableHandle.connectorId,
+          tableName,
+          isPushdownFilterEnabled,
+          std::move(subfieldFilters),
+          remainingFilter,
+          finalDataColumns);
+    }
   }
 
   std::unordered_map<std::string, std::string> finalTableParameters = {};
@@ -864,15 +1051,29 @@ std::unique_ptr<connector::ConnectorTableHandle> toHiveTableHandle(
   for (const auto& [key, value] : tableParameters) {
     finalTableParameters[key] = value;
   }
-
-  return std::make_unique<connector::hive::HiveTableHandle>(
-      tableHandle.connectorId,
-      tableName,
-      isPushdownFilterEnabled,
-      std::move(subfieldFilters),
-      remainingFilter,
-      finalDataColumns,
-      finalTableParameters);
+  if (canUseCudfTableScan()) {
+    facebook::velox::core::TypedExprPtr filterExpr = nullptr;
+    if (!subfieldFilters.empty()) {
+      filterExpr = getTypedExprFromSubfieldFilter(
+          domains, exprConverter, typeParser, finalDataColumns);
+    }
+    return std::make_unique<cudf_velox::connector::parquet::ParquetTableHandle>(
+        "parquet-test",
+        tableName,
+        isPushdownFilterEnabled,
+        filterExpr,
+        remainingFilter,
+        finalDataColumns);
+  } else {
+    return std::make_unique<connector::hive::HiveTableHandle>(
+        tableHandle.connectorId,
+        tableName,
+        isPushdownFilterEnabled,
+        std::move(subfieldFilters),
+        remainingFilter,
+        finalDataColumns,
+        finalTableParameters);
+  }
 }
 
 connector::hive::LocationHandle::TableType toTableType(
@@ -1139,27 +1340,44 @@ HivePrestoToVeloxConnector::toVeloxSplit(
   if (hiveSplit->tableBucketNumber) {
     infoColumns["$bucket"] = std::to_string(*hiveSplit->tableBucketNumber);
   }
-  auto veloxSplit =
-      std::make_unique<velox::connector::hive::HiveConnectorSplit>(
-          catalogId,
-          hiveSplit->fileSplit.path,
-          toVeloxFileFormat(hiveSplit->storage.storageFormat),
-          hiveSplit->fileSplit.start,
-          hiveSplit->fileSplit.length,
-          partitionKeys,
-          hiveSplit->tableBucketNumber
-              ? std::optional<int>(*hiveSplit->tableBucketNumber)
-              : std::nullopt,
-          customSplitInfo,
-          extraFileInfo,
-          serdeParameters,
-          hiveSplit->splitWeight,
-          splitContext->cacheable,
-          infoColumns);
-  if (hiveSplit->bucketConversion) {
-    VELOX_CHECK_NOT_NULL(hiveSplit->tableBucketNumber);
-    veloxSplit->bucketConversion =
-        toVeloxBucketConversion(*hiveSplit->bucketConversion);
+  std::unique_ptr<velox::connector::ConnectorSplit> veloxSplit;
+  if (canUseCudfTableScan()) {
+    std::string realPath;
+    if (boost::algorithm::starts_with(hiveSplit->fileSplit.path, "file:")) {
+      realPath = hiveSplit->fileSplit.path.substr(std::string("file:").size());
+    } else {
+      realPath = hiveSplit->fileSplit.path;
+    }
+    veloxSplit = std::make_unique<
+        facebook::velox::cudf_velox::connector::parquet::ParquetConnectorSplit>(
+        "parquet-test", realPath, 0);
+    LOG(INFO) << "Using cuDF Parquet splits for file: "
+              << hiveSplit->fileSplit.path;
+  } else {
+    auto veloxHiveSplit =
+        std::make_unique<velox::connector::hive::HiveConnectorSplit>(
+            catalogId,
+            hiveSplit->fileSplit.path,
+            toVeloxFileFormat(hiveSplit->storage.storageFormat),
+            hiveSplit->fileSplit.start,
+            hiveSplit->fileSplit.length,
+            partitionKeys,
+            hiveSplit->tableBucketNumber
+                ? std::optional<int>(*hiveSplit->tableBucketNumber)
+                : std::nullopt,
+            customSplitInfo,
+            extraFileInfo,
+            serdeParameters,
+            hiveSplit->splitWeight,
+            splitContext->cacheable,
+            infoColumns);
+    if (veloxHiveSplit->bucketConversion) {
+      VELOX_CHECK_NOT_NULL(hiveSplit->tableBucketNumber);
+      veloxHiveSplit->bucketConversion =
+          toVeloxBucketConversion(*hiveSplit->bucketConversion);
+    }
+    veloxSplit = std::move(veloxHiveSplit);
+    LOG(INFO) << "Using Hive splits";
   }
   return veloxSplit;
 }

--- a/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
@@ -19,6 +19,10 @@
 #include "presto_cpp/main/connectors/arrow_flight/ArrowPrestoToVeloxConnector.h"
 #endif
 
+#ifdef PRESTO_ENABLE_CUDF
+#include "velox/experimental/cudf/connectors/parquet/ParquetConnector.h"
+#endif
+
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 
@@ -27,6 +31,7 @@ namespace {
 
 constexpr char const* kHiveHadoop2ConnectorName = "hive-hadoop2";
 constexpr char const* kIcebergConnectorName = "iceberg";
+constexpr char const* kCudfParquetConnectorName = "cudf-parquet";
 
 void registerConnectorFactories() {
   // These checks for connector factories can be removed after we remove the
@@ -58,6 +63,17 @@ void registerConnectorFactories() {
           ArrowFlightConnectorFactory::kArrowFlightConnectorName)) {
     velox::connector::registerConnectorFactory(
         std::make_shared<ArrowFlightConnectorFactory>());
+  }
+#endif
+
+#ifdef PRESTO_ENABLE_CUDF
+  LOG(INFO) << "Registering the cuDF parquet reader factory with name: "
+            << kCudfParquetConnectorName;
+  if (!velox::connector::hasConnectorFactory(kCudfParquetConnectorName)) {
+    velox::connector::registerConnectorFactory(
+        std::make_shared<
+            velox::cudf_velox::connector::parquet::ParquetConnectorFactory>(
+            kCudfParquetConnectorName));
   }
 #endif
 }


### PR DESCRIPTION
## Description
This PR lets the native worker use the cuDF parquet reader. The design of the parquet reader resembles as of a new catalog, however, it is not. The problem is that it can't be easily shoehorned into the standard Velox reader interface because it's not a bitstream change, but a complete system read change.

## Motivation and Context
By default the Velox readers produce a RowVector which needs to be both converted and copied into a CudfVector. This conversion can be very expensive and we'd like to avoid this. By leveraging the GPU side Parquet code in cuDF, plus leveraging GPUDirect RDMA, we can skip the CPU path entirely.
The speedup is significant.

## Impact
By default it's disabled. When cuDF gets enabled then there is still an extra command line flag that is needed to enable this.

## Test Plan
I've run TPC-H queries both with, and without the cuDF tablescan enabled.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* if both cuDF and cuDF tablescan is enabled, Hive splits can be read by cuDF's parquet library instead of Velox's parquet library
```