### PR TITLE
[native]: Cancel in progress CI runs for the same PR

### DIFF
--- a/.github/workflows/prestocpp-format-and-header-check.yml
+++ b/.github/workflows/prestocpp-format-and-header-check.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   prestocpp-format-and-header-check:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-prestocpp-format-header-check-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     container:
       image: public.ecr.aws/oss-presto/velox-dev:check
     steps:

--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+    concurrency:
+      group: ${{ github.workflow }}-prestocpp-linux-adapters-build-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
     steps:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+    concurrency:
+      group: ${{ github.workflow }}-prestocpp-linux-build-test-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
     steps:

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+    concurrency:
+      group: ${{ github.workflow }}-prestocpp-linux-build-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
       CC: /usr/bin/clang-15

--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -12,6 +12,9 @@ jobs:
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
       CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+    concurrency:
+      group: ${{ github.workflow }}-prestocpp-macos-build-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description
In-progress CI jobs for a PR must be cancelled if a new commit is pushed.

Many PR have multiple jobs running for each commit.
https://github.com/prestodb/presto/actions/workflows/prestocpp-macos-build.yml

## Testing
Worked for this PR

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

