### PR TITLE
Add planner support to prevent mixed CPP/Java execution

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSystemTableFilterRuleSet.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSystemTableFilterRuleSet.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PartitioningScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.planner.PlannerUtils;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.sql.planner.plan.Patterns.exchange;
+import static com.facebook.presto.sql.planner.plan.Patterns.filter;
+import static com.facebook.presto.sql.planner.plan.Patterns.project;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.planner.plan.Patterns.tableScan;
+import static com.facebook.presto.sql.relational.RowExpressionUtils.containsNonCoordinatorEligibleCallExpression;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * RuleSet for extracting system table filters when they contain non-coordinator-eligible functions (e.g., CPP functions).
+ * This ensures that system table scans happen on the coordinator while CPP functions execute on workers.
+ *
+ * Patterns handled:
+ * 1. Exchange -> Project -> Filter -> TableScan (system) => Project -> Filter -> Exchange -> TableScan
+ * 2. Exchange -> Project -> TableScan (system) => Project -> Exchange -> TableScan
+ * 3. Exchange -> Filter -> TableScan (system) => Filter -> Exchange -> TableScan
+ */
+public class ExtractSystemTableFilterRuleSet
+{
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public ExtractSystemTableFilterRuleSet(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
+
+    public Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(
+                new ProjectFilterScanRule(),
+                new ProjectScanRule(),
+                new FilterScanRule());
+    }
+
+    private abstract class SystemTableFilterRule<T extends PlanNode>
+            implements Rule<T>
+    {
+        protected final Capture<TableScanNode> tableScanCapture = newCapture();
+
+        protected boolean containsFunctionsIneligibleOnCoordinator(Optional<FilterNode> filterNode, Optional<ProjectNode> projectNode)
+        {
+            boolean hasIneligiblePredicates = filterNode
+                    .map(filter -> containsNonCoordinatorEligibleCallExpression(functionAndTypeManager, filter.getPredicate()))
+                    .orElse(false);
+
+            boolean hasIneligibleProjections = projectNode
+                    .map(project -> project.getAssignments().getExpressions().stream()
+                            .anyMatch(expression -> containsNonCoordinatorEligibleCallExpression(functionAndTypeManager, expression)))
+                    .orElse(false);
+
+            return hasIneligiblePredicates || hasIneligibleProjections;
+        }
+    }
+
+    private final class ProjectFilterScanRule
+            extends SystemTableFilterRule<ExchangeNode>
+    {
+        private final Capture<ExchangeNode> exchangeCapture = newCapture();
+        private final Capture<ProjectNode> projectCapture = newCapture();
+        private final Capture<FilterNode> filterCapture = newCapture();
+
+        @Override
+        public Pattern<ExchangeNode> getPattern()
+        {
+            return exchange()
+                    .capturedAs(exchangeCapture)
+                    .with(source().matching(
+                            project()
+                                    .capturedAs(projectCapture)
+                                    .with(source().matching(
+                                            filter()
+                                                    .capturedAs(filterCapture)
+                                                    .with(source().matching(
+                                                            tableScan()
+                                                                    .capturedAs(tableScanCapture)
+                                                                    .matching(PlannerUtils::containsSystemTableScan)))))));
+        }
+
+        @Override
+        public Result apply(ExchangeNode node, Captures captures, Context context)
+        {
+            TableScanNode tableScanNode = captures.get(tableScanCapture);
+            ExchangeNode exchangeNode = captures.get(exchangeCapture);
+            ProjectNode projectNode = captures.get(projectCapture);
+            FilterNode filterNode = captures.get(filterCapture);
+
+            if (!containsFunctionsIneligibleOnCoordinator(Optional.of(filterNode), Optional.of(projectNode))) {
+                return Result.empty();
+            }
+
+            // The exchange's output variables must match what the filter expects
+            // Since the filter was originally between project and table scan, it expects
+            // the table scan's output variables
+            PartitioningScheme newPartitioningScheme = new PartitioningScheme(
+                    exchangeNode.getPartitioningScheme().getPartitioning(),
+                    tableScanNode.getOutputVariables(),
+                    exchangeNode.getPartitioningScheme().getHashColumn(),
+                    exchangeNode.getPartitioningScheme().isScaleWriters(),
+                    exchangeNode.getPartitioningScheme().isReplicateNullsAndAny(),
+                    exchangeNode.getPartitioningScheme().getEncoding(),
+                    exchangeNode.getPartitioningScheme().getBucketToPartition());
+
+            // Create new exchange with table scan as source
+            ExchangeNode newExchange = new ExchangeNode(
+                    exchangeNode.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    exchangeNode.getType(),
+                    exchangeNode.getScope(),
+                    newPartitioningScheme,
+                    ImmutableList.of(tableScanNode),
+                    ImmutableList.of(tableScanNode.getOutputVariables()),
+                    exchangeNode.isEnsureSourceOrdering(),
+                    exchangeNode.getOrderingScheme());
+
+            // Recreate filter with exchange as source
+            FilterNode newFilter = new FilterNode(
+                    filterNode.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    newExchange,
+                    filterNode.getPredicate());
+
+            // Recreate project with filter as source
+            ProjectNode newProject = new ProjectNode(
+                    projectNode.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    newFilter,
+                    projectNode.getAssignments(),
+                    projectNode.getLocality());
+
+            return Result.ofPlanNode(newProject);
+        }
+    }
+
+    private final class ProjectScanRule
+            extends SystemTableFilterRule<ExchangeNode>
+    {
+        private final Capture<ExchangeNode> exchangeCapture = newCapture();
+        private final Capture<ProjectNode> projectCapture = newCapture();
+
+        @Override
+        public Pattern<ExchangeNode> getPattern()
+        {
+            return exchange()
+                    .capturedAs(exchangeCapture)
+                    .with(source().matching(
+                            project()
+                                    .capturedAs(projectCapture)
+                                    .with(source().matching(
+                                            tableScan()
+                                                    .capturedAs(tableScanCapture)
+                                                    .matching(PlannerUtils::containsSystemTableScan)))));
+        }
+
+        @Override
+        public Result apply(ExchangeNode node, Captures captures, Context context)
+        {
+            TableScanNode tableScanNode = captures.get(tableScanCapture);
+            ExchangeNode exchangeNode = captures.get(exchangeCapture);
+            ProjectNode projectNode = captures.get(projectCapture);
+
+            if (!containsFunctionsIneligibleOnCoordinator(Optional.empty(), Optional.of(projectNode))) {
+                return Result.empty();
+            }
+
+            // Update partitioning scheme to match table scan outputs
+            PartitioningScheme newPartitioningScheme = new PartitioningScheme(
+                    exchangeNode.getPartitioningScheme().getPartitioning(),
+                    tableScanNode.getOutputVariables(),
+                    exchangeNode.getPartitioningScheme().getHashColumn(),
+                    exchangeNode.getPartitioningScheme().isScaleWriters(),
+                    exchangeNode.getPartitioningScheme().isReplicateNullsAndAny(),
+                    exchangeNode.getPartitioningScheme().getEncoding(),
+                    exchangeNode.getPartitioningScheme().getBucketToPartition());
+
+            // Create new exchange with table scan as source
+            ExchangeNode newExchange = new ExchangeNode(
+                    exchangeNode.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    exchangeNode.getType(),
+                    exchangeNode.getScope(),
+                    newPartitioningScheme,
+                    ImmutableList.of(tableScanNode),
+                    ImmutableList.of(tableScanNode.getOutputVariables()),
+                    exchangeNode.isEnsureSourceOrdering(),
+                    exchangeNode.getOrderingScheme());
+
+            // Recreate project with exchange as source
+            ProjectNode newProject = new ProjectNode(
+                    projectNode.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    newExchange,
+                    projectNode.getAssignments(),
+                    projectNode.getLocality());
+
+            return Result.ofPlanNode(newProject);
+        }
+    }
+
+    private final class FilterScanRule
+            extends SystemTableFilterRule<ExchangeNode>
+    {
+        private final Capture<ExchangeNode> exchangeCapture = newCapture();
+        private final Capture<FilterNode> filterCapture = newCapture();
+
+        @Override
+        public Pattern<ExchangeNode> getPattern()
+        {
+            return exchange()
+                    .capturedAs(exchangeCapture)
+                    .with(source().matching(
+                            filter()
+                                    .capturedAs(filterCapture)
+                                    .with(source().matching(
+                                            tableScan()
+                                                    .capturedAs(tableScanCapture)
+                                                    .matching(PlannerUtils::containsSystemTableScan)))));
+        }
+
+        @Override
+        public Result apply(ExchangeNode node, Captures captures, Context context)
+        {
+            TableScanNode tableScanNode = captures.get(tableScanCapture);
+            ExchangeNode exchangeNode = captures.get(exchangeCapture);
+            FilterNode filterNode = captures.get(filterCapture);
+
+            if (!containsFunctionsIneligibleOnCoordinator(Optional.of(filterNode), Optional.empty())) {
+                return Result.empty();
+            }
+
+            // Update partitioning scheme to match table scan outputs
+            PartitioningScheme newPartitioningScheme = new PartitioningScheme(
+                    exchangeNode.getPartitioningScheme().getPartitioning(),
+                    tableScanNode.getOutputVariables(),
+                    exchangeNode.getPartitioningScheme().getHashColumn(),
+                    exchangeNode.getPartitioningScheme().isScaleWriters(),
+                    exchangeNode.getPartitioningScheme().isReplicateNullsAndAny(),
+                    exchangeNode.getPartitioningScheme().getEncoding(),
+                    exchangeNode.getPartitioningScheme().getBucketToPartition());
+
+            // Create new exchange with table scan as source
+            ExchangeNode newExchange = new ExchangeNode(
+                    exchangeNode.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    exchangeNode.getType(),
+                    exchangeNode.getScope(),
+                    newPartitioningScheme,
+                    ImmutableList.of(tableScanNode),
+                    ImmutableList.of(tableScanNode.getOutputVariables()),
+                    exchangeNode.isEnsureSourceOrdering(),
+                    exchangeNode.getOrderingScheme());
+
+            // Recreate filter with exchange as source
+            FilterNode newFilter = new FilterNode(
+                    filterNode.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    newExchange,
+                    filterNode.getPredicate());
+
+            return Result.ofPlanNode(newFilter);
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/CheckNoIneligibleFunctionsInCoordinatorFragments.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/CheckNoIneligibleFunctionsInCoordinatorFragments.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.planner.SimplePlanVisitor;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+
+import static com.facebook.presto.sql.planner.PlannerUtils.containsSystemTableScan;
+import static com.facebook.presto.sql.relational.RowExpressionUtils.containsNonCoordinatorEligibleCallExpression;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Validates that there are no filter or projection nodes containing non-Java functions
+ * (which must be evaluated on native nodes) within the same fragment as a system table scan
+ * (which must be evaluated on the coordinator).
+ */
+public class CheckNoIneligibleFunctionsInCoordinatorFragments
+        implements PlanChecker.Checker
+{
+    @Override
+    public void validate(PlanNode planNode, Session session, Metadata metadata, WarningCollector warningCollector)
+    {
+        FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
+        // Validate each fragment independently
+        validateFragment(planNode, functionAndTypeManager);
+    }
+
+    private void validateFragment(PlanNode root, FunctionAndTypeManager functionAndTypeManager)
+    {
+        // First, collect information about this fragment
+        FragmentValidator validator = new FragmentValidator(functionAndTypeManager);
+        root.accept(validator, null);
+
+        // Check if this fragment violates the constraint
+        checkState(
+                !(validator.hasSystemTableScan() && validator.hasNonCoordinatorEligibleFunction()),
+                "Fragment contains both system table scan and non-Java functions. " +
+                "System table scans must execute on the coordinator while non-Java functions must execute on native nodes. " +
+                "These operations must be in separate fragments separated by an exchange.");
+
+        // Recursively validate child fragments
+        ChildFragmentVisitor childVisitor = new ChildFragmentVisitor(functionAndTypeManager);
+        root.accept(childVisitor, null);
+    }
+
+    /**
+     * Visits nodes within a single fragment to collect information about
+     * system table scans and non-coordinator-eligible functions.
+     * Stops at exchange boundaries.
+     */
+    private static class FragmentValidator
+            extends SimplePlanVisitor<Void>
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private boolean hasSystemTableScan;
+        private boolean hasNonCoordinatorEligibleFunction;
+
+        public FragmentValidator(FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        }
+
+        public boolean hasSystemTableScan()
+        {
+            return hasSystemTableScan;
+        }
+
+        public boolean hasNonCoordinatorEligibleFunction()
+        {
+            return hasNonCoordinatorEligibleFunction;
+        }
+
+        @Override
+        public Void visitExchange(ExchangeNode node, Void context)
+        {
+            // Don't traverse into exchange sources - they are different fragments
+            return null;
+        }
+
+        @Override
+        public Void visitTableScan(TableScanNode node, Void context)
+        {
+            if (containsSystemTableScan(node)) {
+                hasSystemTableScan = true;
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitFilter(FilterNode node, Void context)
+        {
+            RowExpression predicate = node.getPredicate();
+            if (containsNonCoordinatorEligibleCallExpression(functionAndTypeManager, predicate)) {
+                hasNonCoordinatorEligibleFunction = true;
+            }
+            return visitPlan(node, context);
+        }
+
+        @Override
+        public Void visitProject(ProjectNode node, Void context)
+        {
+            boolean hasIneligibleProjections = node.getAssignments().getExpressions().stream()
+                    .anyMatch(expression -> containsNonCoordinatorEligibleCallExpression(functionAndTypeManager, expression));
+
+            if (hasIneligibleProjections) {
+                hasNonCoordinatorEligibleFunction = true;
+            }
+            return visitPlan(node, context);
+        }
+
+        @Override
+        public Void visitPlan(PlanNode node, Void context)
+        {
+            for (PlanNode source : node.getSources()) {
+                source.accept(this, context);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Visits nodes to find and validate child fragments (those below exchanges).
+     */
+    private class ChildFragmentVisitor
+            extends SimplePlanVisitor<Void>
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+
+        public ChildFragmentVisitor(FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        }
+
+        @Override
+        public Void visitExchange(ExchangeNode node, Void context)
+        {
+            // Each source of an exchange is a separate fragment
+            for (PlanNode source : node.getSources()) {
+                validateFragment(source, functionAndTypeManager);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitPlan(PlanNode node, Void context)
+        {
+            for (PlanNode source : node.getSources()) {
+                source.accept(this, context);
+            }
+            return null;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
@@ -75,9 +75,12 @@ public final class PlanChecker
                         new VerifyProjectionLocality(),
                         new DynamicFiltersChecker(),
                         new WarnOnScanWithoutPartitionPredicate(featuresConfig));
-        if (featuresConfig.isNativeExecutionEnabled() && (featuresConfig.isDisableTimeStampWithTimeZoneForNative() ||
-                featuresConfig.isDisableIPAddressForNative())) {
-            builder.put(Stage.INTERMEDIATE, new CheckUnsupportedPrestissimoTypes(featuresConfig));
+        if (featuresConfig.isNativeExecutionEnabled()) {
+            if (featuresConfig.isDisableTimeStampWithTimeZoneForNative() ||
+                    featuresConfig.isDisableIPAddressForNative()) {
+                builder.put(Stage.INTERMEDIATE, new CheckUnsupportedPrestissimoTypes(featuresConfig));
+            }
+            builder.put(Stage.FINAL, new CheckNoIneligibleFunctionsInCoordinatorFragments());
         }
         checkers = builder.build();
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/RowExpressionUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/RowExpressionUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.relational;
+
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionVisitor;
+
+import static java.util.Objects.requireNonNull;
+
+public class RowExpressionUtils
+{
+    private RowExpressionUtils() {}
+
+    public static boolean containsNonCoordinatorEligibleCallExpression(FunctionAndTypeManager functionAndTypeManager, RowExpression expression)
+    {
+        return expression.accept(new ContainsNonCoordinatorEligibleCallExpressionVisitor(functionAndTypeManager), null);
+    }
+
+    private static class ContainsNonCoordinatorEligibleCallExpressionVisitor
+            implements RowExpressionVisitor<Boolean, Void>
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+
+        public ContainsNonCoordinatorEligibleCallExpressionVisitor(FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        }
+
+        @Override
+        public Boolean visitCall(CallExpression call, Void context)
+        {
+            // If the call is not a Java function, we return true to indicate that we found a non-Java expression
+            FunctionHandle functionHandle = call.getFunctionHandle();
+            FunctionMetadata functionMetadata = functionAndTypeManager.getFunctionMetadata(functionHandle);
+            if (!functionMetadata.getImplementationType().canBeEvaluatedInCoordinator()) {
+                return true;
+            }
+            for (RowExpression argument : call.getArguments()) {
+                if (argument.accept(this, context)) {
+                    return true; // Found a non-Java expression in arguments
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Boolean visitExpression(RowExpression expression, Void context)
+        {
+            for (RowExpression child : expression.getChildren()) {
+                if (child.accept(this, context)) {
+                    return true; // Found a non-Java expression
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -1125,11 +1125,16 @@ public class LocalQueryRunner
 
     public Plan createPlan(Session session, @Language("SQL") String sql, Optimizer.PlanStage stage, boolean noExchange, WarningCollector warningCollector)
     {
+        return createPlan(session, sql, stage, noExchange, false, warningCollector);
+    }
+
+    public Plan createPlan(Session session, @Language("SQL") String sql, Optimizer.PlanStage stage, boolean noExchange, boolean nativeExecutionEnabled, WarningCollector warningCollector)
+    {
         AnalyzerOptions analyzerOptions = createAnalyzerOptions(session, warningCollector);
         BuiltInPreparedQuery preparedQuery = new BuiltInQueryPreparer(sqlParser).prepareQuery(analyzerOptions, sql, session.getPreparedStatements(), warningCollector);
         assertFormattedSql(sqlParser, createParsingOptions(session), preparedQuery.getStatement());
 
-        return createPlan(session, sql, getPlanOptimizers(noExchange), stage, warningCollector);
+        return createPlan(session, sql, getPlanOptimizers(noExchange, nativeExecutionEnabled), stage, warningCollector);
     }
 
     public void setAdditionalOptimizer(List<PlanOptimizer> additionalOptimizer)
@@ -1139,9 +1144,15 @@ public class LocalQueryRunner
 
     public List<PlanOptimizer> getPlanOptimizers(boolean noExchange)
     {
+        return getPlanOptimizers(noExchange, false);
+    }
+
+    public List<PlanOptimizer> getPlanOptimizers(boolean noExchange, boolean nativeExecutionEnabled)
+    {
         FeaturesConfig featuresConfig = new FeaturesConfig()
                 .setDistributedIndexJoinsEnabled(false)
-                .setOptimizeHashGeneration(true);
+                .setOptimizeHashGeneration(true)
+                .setNativeExecutionEnabled(nativeExecutionEnabled);
         ImmutableList.Builder<PlanOptimizer> planOptimizers = ImmutableList.builder();
         if (!additionalOptimizer.isEmpty()) {
             planOptimizers.addAll(additionalOptimizer);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/BasePlanTest.java
@@ -226,9 +226,19 @@ public class BasePlanTest
         assertDistributedPlan(sql, getQueryRunner().getDefaultSession(), pattern);
     }
 
+    protected void assertNativeDistributedPlan(String sql, PlanMatchPattern pattern)
+    {
+        assertNativeDistributedPlan(sql, getQueryRunner().getDefaultSession(), pattern);
+    }
+
     protected void assertDistributedPlan(String sql, Session session, PlanMatchPattern pattern)
     {
         assertPlanWithSession(sql, session, false, pattern);
+    }
+
+    protected void assertNativeDistributedPlan(String sql, Session session, PlanMatchPattern pattern)
+    {
+        assertPlanWithSession(sql, session, false, true, pattern);
     }
 
     protected void assertMinimallyOptimizedPlan(@Language("SQL") String sql, PlanMatchPattern pattern)
@@ -263,8 +273,13 @@ public class BasePlanTest
 
     protected void assertPlanWithSession(@Language("SQL") String sql, Session session, boolean noExchange, PlanMatchPattern pattern)
     {
+        assertPlanWithSession(sql, session, noExchange, false, pattern);
+    }
+
+    protected void assertPlanWithSession(@Language("SQL") String sql, Session session, boolean noExchange, boolean nativeExecutionEnabled, PlanMatchPattern pattern)
+    {
         queryRunner.inTransaction(session, transactionSession -> {
-            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, Optimizer.PlanStage.OPTIMIZED_AND_VALIDATED, noExchange, WarningCollector.NOOP);
+            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, Optimizer.PlanStage.OPTIMIZED_AND_VALIDATED, noExchange, nativeExecutionEnabled, WarningCollector.NOOP);
             PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), queryRunner.getStatsCalculator(), actualPlan, pattern);
             return null;
         });

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestAddExchangesPlansWithFunctions.java
@@ -1,0 +1,636 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
+import com.facebook.presto.functionNamespace.execution.NoopSqlFunctionExecutor;
+import com.facebook.presto.functionNamespace.execution.SqlFunctionExecutors;
+import com.facebook.presto.functionNamespace.testing.InMemoryFunctionNamespaceManager;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.operator.scalar.CombineHashFunction;
+import com.facebook.presto.spi.function.FunctionImplementationType;
+import com.facebook.presto.spi.function.Parameter;
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.FunctionsConfig;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.facebook.presto.type.BigintOperators;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.scalar.annotations.ScalarFromAnnotationsParser.parseFunctionDefinitions;
+import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.CPP;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.JAVA;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT;
+import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+/**
+ * These are plan tests similar to what we have for other optimizers (e.g. {@link com.facebook.presto.sql.planner.TestPredicatePushdown})
+ * They test that the plan for a query after the optimizer runs is as expected.
+ * These are separate from {@link TestAddExchanges} because those are unit tests for
+ * how layouts get chosen.
+ * <p>
+ * Key behavior tested: When CPP functions are used with system tables, the filter containing
+ * the CPP function is preserved above the exchange (not pushed down) to ensure the filter
+ * executes in a different fragment from the system table scan. This validates the fragment
+ * boundary between CPP function evaluation and system table access.
+ */
+public class TestAddExchangesPlansWithFunctions
+        extends BasePlanTest
+{
+    public TestAddExchangesPlansWithFunctions()
+    {
+        super(TestAddExchangesPlansWithFunctions::createTestQueryRunner);
+    }
+
+    private static final SqlInvokedFunction CPP_FOO = new SqlInvokedFunction(
+            new QualifiedObjectName("dummy", "unittest", "cpp_foo"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BIGINT))),
+            parseTypeSignature(StandardTypes.BIGINT),
+            "cpp_foo(x)",
+            RoutineCharacteristics.builder().setLanguage(CPP).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
+            "",
+            notVersioned());
+
+    private static final SqlInvokedFunction CPP_BAZ = new SqlInvokedFunction(
+            new QualifiedObjectName("dummy", "unittest", "cpp_baz"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BIGINT))),
+            parseTypeSignature(StandardTypes.BIGINT),
+            "cpp_baz(x)",
+            RoutineCharacteristics.builder().setLanguage(CPP).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
+            "",
+            notVersioned());
+
+    private static final SqlInvokedFunction JAVA_BAR = new SqlInvokedFunction(
+            new QualifiedObjectName("dummy", "unittest", "java_bar"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BIGINT))),
+            parseTypeSignature(StandardTypes.BIGINT),
+            "java_bar(x)",
+            RoutineCharacteristics.builder().setLanguage(JAVA).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
+            "",
+            notVersioned());
+
+    private static final SqlInvokedFunction JAVA_FEE = new SqlInvokedFunction(
+            new QualifiedObjectName("dummy", "unittest", "java_fee"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BIGINT))),
+            parseTypeSignature(StandardTypes.BIGINT),
+            "java_fee(x)",
+            RoutineCharacteristics.builder().setLanguage(JAVA).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
+            "",
+            notVersioned());
+
+    private static final SqlInvokedFunction NOT = new SqlInvokedFunction(
+            new QualifiedObjectName("dummy", "unittest", "not"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BOOLEAN))),
+            parseTypeSignature(StandardTypes.BOOLEAN),
+            "not(x)",
+            RoutineCharacteristics.builder().setLanguage(CPP).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
+            "",
+            notVersioned());
+
+    private static final SqlInvokedFunction CPP_ARRAY_CONSTRUCTOR = new SqlInvokedFunction(
+            new QualifiedObjectName("dummy", "unittest", "array_constructor"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BIGINT)), new Parameter("y", parseTypeSignature(StandardTypes.BIGINT))),
+            parseTypeSignature("array(bigint)"),
+            "array_constructor(x, y)",
+            RoutineCharacteristics.builder().setLanguage(CPP).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
+            "",
+            notVersioned());
+
+    private static LocalQueryRunner createTestQueryRunner()
+    {
+        LocalQueryRunner queryRunner = new LocalQueryRunner(testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .build(),
+                new FeaturesConfig(),
+                new FunctionsConfig().setDefaultNamespacePrefix("dummy.unittest"));
+        queryRunner.createCatalog("tpch", new TpchConnectorFactory(), ImmutableMap.of());
+        queryRunner.getMetadata().getFunctionAndTypeManager().addFunctionNamespace(
+                "dummy",
+                new InMemoryFunctionNamespaceManager(
+                        "dummy",
+                        new SqlFunctionExecutors(
+                                ImmutableMap.of(
+                                        CPP, FunctionImplementationType.CPP,
+                                        JAVA, FunctionImplementationType.JAVA),
+                                new NoopSqlFunctionExecutor()),
+                        new SqlInvokedFunctionNamespaceManagerConfig().setSupportedFunctionLanguages("cpp")));
+        queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(CPP_FOO, true);
+        queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(CPP_BAZ, true);
+        queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(JAVA_BAR, true);
+        queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(JAVA_FEE, true);
+        queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(NOT, true);
+        queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(CPP_ARRAY_CONSTRUCTOR, true);
+        parseFunctionDefinitions(BigintOperators.class).stream()
+                .map(TestAddExchangesPlansWithFunctions::convertToSqlInvokedFunction)
+                .forEach(function -> queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(function, true));
+        parseFunctionDefinitions(CombineHashFunction.class).stream()
+                .map(TestAddExchangesPlansWithFunctions::convertToSqlInvokedFunction)
+                .forEach(function -> queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(function, true));
+        return queryRunner;
+    }
+
+    public static SqlInvokedFunction convertToSqlInvokedFunction(SqlScalarFunction scalarFunction)
+    {
+        QualifiedObjectName functionName = new QualifiedObjectName("dummy", "unittest", scalarFunction.getSignature().getName().getObjectName());
+        TypeSignature returnType = scalarFunction.getSignature().getReturnType();
+        RoutineCharacteristics characteristics = RoutineCharacteristics.builder()
+                .setLanguage(RoutineCharacteristics.Language.JAVA) // Assuming JAVA as the language
+                .setDeterminism(RoutineCharacteristics.Determinism.DETERMINISTIC)
+                .setNullCallClause(RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT)
+                .build();
+
+        // Convert scalar function arguments to SqlInvokedFunction parameters
+        ImmutableList<Parameter> parameters = scalarFunction.getSignature().getArgumentTypes().stream()
+                .map(type -> new Parameter(type.toString(), TypeSignature.parseTypeSignature(type.toString())))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf));
+
+        // Create the SqlInvokedFunction
+        return new SqlInvokedFunction(
+                functionName,
+                parameters,
+                returnType,
+                scalarFunction.getSignature().getName().toString(), // Using the function name as the body for simplicity
+                characteristics,
+                "", // Empty description
+                notVersioned());
+    }
+
+    @Test
+    public void testFilterWithCppFunctionDoesNotGetPushedIntoSystemTableScan()
+    {
+        // java_fee and java_bar are java functions, they are both pushed down past the exchange
+        assertNativeDistributedPlan("SELECT java_fee(ordinal_position) FROM information_schema.columns WHERE java_bar(ordinal_position) = 1",
+                anyTree(
+                        exchange(REMOTE_STREAMING, GATHER,
+                                project(ImmutableMap.of("java_fee", expression("java_fee(ordinal_position)")),
+                                        filter("java_bar(ordinal_position) = BIGINT'1'",
+                                                tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position")))))));
+        // cpp_foo is a CPP function, it is not pushed down past the exchange because the source is a system table scan
+        // The filter is preserved above the exchange to prove that the filter is not in the same fragment as the system table scan
+        assertNativeDistributedPlan("SELECT cpp_baz(ordinal_position) FROM information_schema.columns WHERE cpp_foo(ordinal_position) = 1",
+                anyTree(
+                        project(ImmutableMap.of("cpp_baz", expression("cpp_baz(ordinal_position)")),
+                                filter("cpp_foo(ordinal_position) = BIGINT'1'",
+                                        exchange(REMOTE_STREAMING, GATHER,
+                                                tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position")))))));
+    }
+
+    @Test
+    public void testJoinWithCppFunctionDoesNotGetPushedIntoSystemTableScan()
+    {
+        // java_bar is a java function, it is pushed down past the exchange
+        assertNativeDistributedPlan(
+                "SELECT c1.table_name FROM information_schema.columns c1 JOIN information_schema.columns c2 ON c1.ordinal_position = c2.ordinal_position WHERE java_bar(c1.ordinal_position) = 1",
+                anyTree(
+                        exchange(
+                                join(INNER, ImmutableList.of(equiJoinClause("ordinal_position", "ordinal_position_4")),
+                                        anyTree(
+                                                exchange(REMOTE_STREAMING, GATHER,
+                                                        project(
+                                                                filter("java_bar(ordinal_position) = BIGINT'1'",
+                                                                        tableScan("columns", ImmutableMap.of(
+                                                                                "ordinal_position", "ordinal_position",
+                                                                                "table_name", "table_name")))))),
+                                        anyTree(
+                                                exchange(REMOTE_STREAMING, GATHER,
+                                                        project(
+                                                                filter("java_bar(ordinal_position_4) = BIGINT'1'",
+                                                                        tableScan("columns", ImmutableMap.of(
+                                                                                "ordinal_position_4", "ordinal_position"))))))))));
+
+        // cpp_foo is a CPP function, it is not pushed down past the exchange because the source is a system table scan
+        assertNativeDistributedPlan(
+                "SELECT cpp_baz(c1.ordinal_position) FROM information_schema.columns c1 JOIN information_schema.columns c2 ON c1.ordinal_position = c2.ordinal_position WHERE cpp_foo(c1.ordinal_position) = 1",
+                output(
+                        exchange(
+                                project(ImmutableMap.of("cpp_baz", expression("cpp_baz(ordinal_position)")),
+                                        join(INNER, ImmutableList.of(equiJoinClause("ordinal_position", "ordinal_position_4")),
+                                                anyTree(
+                                                        filter("cpp_foo(ordinal_position) = BIGINT'1'",
+                                                                exchange(REMOTE_STREAMING, GATHER,
+                                                                        project(
+                                                                                tableScan("columns", ImmutableMap.of(
+                                                                                        "ordinal_position", "ordinal_position")))))),
+                                                anyTree(
+                                                        filter("cpp_foo(ordinal_position_4) = BIGINT'1'",
+                                                                exchange(REMOTE_STREAMING, GATHER,
+                                                                        project(
+                                                                                tableScan("columns", ImmutableMap.of(
+                                                                                        "ordinal_position_4", "ordinal_position")))))))))));
+    }
+
+    @Test
+    public void testMixedFunctionTypesInComplexPredicates()
+    {
+        // Test AND condition with mixed Java and CPP functions
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE java_bar(ordinal_position) = 1 AND cpp_foo(ordinal_position) > 0",
+                anyTree(
+                        filter("java_bar(ordinal_position) = BIGINT'1' AND cpp_foo(ordinal_position) > BIGINT'0'",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+
+        // Test OR condition with mixed functions - entire predicate should be evaluated after exchange
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE java_bar(ordinal_position) = 1 OR cpp_foo(ordinal_position) = 2",
+                anyTree(
+                        filter("java_bar(ordinal_position) = BIGINT'1' OR cpp_foo(ordinal_position) = BIGINT'2'",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testNestedFunctionCalls()
+    {
+        // CPP function nested inside Java function - should not push down
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE java_bar(cpp_foo(ordinal_position)) = 1",
+                anyTree(
+                        filter("java_bar(cpp_foo(ordinal_position)) = BIGINT'1'",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+
+        // Java function nested inside CPP function - should not push down
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE cpp_foo(java_bar(ordinal_position)) = 1",
+                anyTree(
+                        filter("cpp_foo(java_bar(ordinal_position)) = BIGINT'1'",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+
+        // Multiple levels of nesting
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE cpp_foo(java_bar(cpp_foo(ordinal_position))) = 1",
+                anyTree(
+                        filter("cpp_foo(java_bar(cpp_foo(ordinal_position))) = BIGINT'1'",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testMixedSystemAndRegularTables()
+    {
+        // System table with CPP function joined with regular table
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns c JOIN nation n ON c.ordinal_position = n.nationkey WHERE cpp_foo(c.ordinal_position) = 1",
+                output(
+                        join(INNER, ImmutableList.of(equiJoinClause("ordinal_position", "nationkey")),
+                                filter("cpp_foo(ordinal_position) = BIGINT'1'",
+                                        exchange(REMOTE_STREAMING, GATHER,
+                                                project(ImmutableMap.of("ordinal_position", expression("ordinal_position")),
+                                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))),
+                                anyTree(
+                                        project(ImmutableMap.of("nationkey", expression("nationkey")),
+                                                filter(
+                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))))))));
+
+        // Regular table with CPP function (should work normally without extra exchange)
+        assertNativeDistributedPlan(
+                "SELECT * FROM nation WHERE cpp_foo(nationkey) = 1",
+                anyTree(
+                        exchange(REMOTE_STREAMING, GATHER,
+                                filter("cpp_foo(nationkey) = BIGINT'1'",
+                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))))));
+    }
+
+    @Test
+    public void testAggregationsWithMixedFunctions()
+    {
+        // Aggregation with CPP function in GROUP BY
+        assertNativeDistributedPlan(
+                "SELECT DISTINCT cpp_foo(ordinal_position) FROM information_schema.columns",
+                anyTree(
+                        project(ImmutableMap.of("cpp_foo", expression("cpp_foo(ordinal_position)")),
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+
+        // Aggregation with Java function in GROUP BY - can be pushed down
+        assertNativeDistributedPlan(
+                "SELECT DISTINCT java_bar(ordinal_position) FROM information_schema.columns",
+                anyTree(
+                        exchange(REMOTE_STREAMING, GATHER,
+                                project(ImmutableMap.of("java_bar", expression("java_bar(ordinal_position)")),
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testComplexPredicateWithMultipleFunctions()
+    {
+        // Complex predicate with multiple CPP and Java functions
+        // Since the predicate contains CPP functions (cpp_foo, baz), the exchange is inserted before the system table scan
+        // The RemoveRedundantExchanges rule removes the inner exchange that was added by ExtractIneligiblePredicatesFromSystemTableScans
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE (cpp_foo(ordinal_position) > 0 AND java_bar(ordinal_position) < 100) OR cpp_baz(ordinal_position) = 50",
+                anyTree(
+                        filter(
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testProjectionWithMixedFunctions()
+    {
+        // Projection with both Java and CPP functions
+        assertNativeDistributedPlan(
+                "SELECT java_bar(ordinal_position) as java_result, cpp_foo(ordinal_position) as cpp_result FROM information_schema.columns",
+                anyTree(
+                        project(ImmutableMap.of(
+                                        "java_result", expression("java_bar(ordinal_position)"),
+                                        "cpp_result", expression("cpp_foo(ordinal_position)")),
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testCaseStatementsWithCppFunctions()
+    {
+        // CASE statement with CPP function in condition
+        // The RemoveRedundantExchanges optimizer removes the redundant exchange
+        assertNativeDistributedPlan(
+                "SELECT CASE WHEN cpp_foo(ordinal_position) > 0 THEN 'positive' ELSE 'negative' END FROM information_schema.columns",
+                anyTree(
+                        project(
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+
+        // CASE statement with CPP function in result
+        // The RemoveRedundantExchanges optimizer removes the redundant exchange
+        assertNativeDistributedPlan(
+                "SELECT CASE WHEN ordinal_position > 0 THEN cpp_foo(ordinal_position) ELSE 0 END FROM information_schema.columns",
+                anyTree(
+                        project(
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testBuiltinFunctionWithExplicitNamespace()
+    {
+        // Test that built-in functions with explicit namespace are handled correctly
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE presto.default.length(table_name) > 10",
+                anyTree(
+                        exchange(REMOTE_STREAMING, GATHER,
+                                filter("length(table_name) > BIGINT'10'",
+                                        tableScan("columns", ImmutableMap.of("table_name", "table_name"))))));
+    }
+
+    @Test(enabled = false)  // TODO: Window functions are resolved with namespace which causes issues in tests
+    public void testWindowFunctionsWithCppFunctions()
+    {
+        // Window function with CPP function in partition by
+        assertNativeDistributedPlan(
+                "SELECT row_number() OVER (PARTITION BY cpp_foo(ordinal_position)) FROM information_schema.columns",
+                anyTree(
+                        exchange(
+                                project(
+                                        anyTree(
+                                                project(
+                                                        exchange(REMOTE_STREAMING, GATHER,
+                                                                tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position")))))))));
+
+        // Window function with CPP function in order by
+        assertNativeDistributedPlan(
+                "SELECT row_number() OVER (ORDER BY cpp_foo(ordinal_position)) FROM information_schema.columns",
+                anyTree(
+                        exchange(
+                                project(
+                                        anyTree(
+                                                project(
+                                                        exchange(REMOTE_STREAMING, GATHER,
+                                                                tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position")))))))));
+    }
+
+    @Test
+    public void testMultipleSystemTableJoins()
+    {
+        // Multiple system tables with CPP functions
+        // This test verifies that when joining two system tables with a CPP function comparison,
+        // an exchange is added between the table scan and the join to ensure CPP functions
+        // execute in a separate fragment from system table access
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns c1 " +
+                        "JOIN information_schema.columns c2 ON cpp_foo(c1.ordinal_position) = cpp_foo(c2.ordinal_position)",
+                anyTree(
+                        exchange(
+                                join(INNER, ImmutableList.of(equiJoinClause("cpp_foo", "foo_4")),
+                                        exchange(
+                                                project(ImmutableMap.of("cpp_foo", expression("cpp_foo")),
+                                                        project(ImmutableMap.of("cpp_foo", expression("cpp_foo(ordinal_position)")),
+                                                                exchange(REMOTE_STREAMING, GATHER,
+                                                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position")))))),
+                                        anyTree(
+                                                exchange(
+                                                        project(ImmutableMap.of("foo_4", expression("foo_4")),
+                                                                project(ImmutableMap.of("foo_4", expression("cpp_foo(ordinal_position_4)")),
+                                                                        exchange(REMOTE_STREAMING, GATHER,
+                                                                                tableScan("columns", ImmutableMap.of("ordinal_position_4", "ordinal_position")))))))))));
+    }
+
+    @Test
+    public void testInPredicateWithCppFunction()
+    {
+        // IN predicate with CPP function
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE cpp_foo(ordinal_position) IN (1, 2, 3)",
+                anyTree(
+                        filter("cpp_foo(ordinal_position) IN (BIGINT'1', BIGINT'2', BIGINT'3')",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testBetweenPredicateWithCppFunction()
+    {
+        // BETWEEN predicate with CPP function
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE cpp_foo(ordinal_position) BETWEEN 1 AND 10",
+                anyTree(
+                        filter("cpp_foo(ordinal_position) BETWEEN BIGINT'1' AND BIGINT'10'",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testNullHandlingWithCppFunctions()
+    {
+        // IS NULL check with CPP function
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE cpp_foo(ordinal_position) IS NULL",
+                anyTree(
+                        filter("cpp_foo(ordinal_position) IS NULL",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+
+        // COALESCE with CPP function
+        // The RemoveRedundantExchanges optimizer removes the redundant exchange
+        assertNativeDistributedPlan(
+                "SELECT COALESCE(cpp_foo(ordinal_position), 0) FROM information_schema.columns",
+                anyTree(
+                        project(
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testUnionWithCppFunctions()
+    {
+        // UNION ALL with CPP functions from system tables
+        assertNativeDistributedPlan(
+                "SELECT cpp_foo(ordinal_position) FROM information_schema.columns " +
+                        "UNION ALL SELECT cpp_foo(nationkey) FROM nation",
+                output(
+                        exchange(
+                                anyTree(
+                                        exchange(REMOTE_STREAMING, GATHER,
+                                                tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position")))),
+                                anyTree(
+                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))))));
+    }
+
+    @Test
+    public void testExistsSubqueryWithCppFunction()
+    {
+        // EXISTS subquery with CPP function
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns c WHERE EXISTS (SELECT 1 FROM nation n WHERE cpp_foo(c.ordinal_position) = n.nationkey)",
+                anyTree(
+                        join(
+                                anyTree(
+                                        exchange(REMOTE_STREAMING, GATHER,
+                                                tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position")))),
+                                anyTree(
+                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))))));
+    }
+
+    @Test
+    public void testLimitWithCppFunction()
+    {
+        // LIMIT with CPP function in ORDER BY
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns ORDER BY cpp_foo(ordinal_position) LIMIT 10",
+                output(
+                        project(
+                                anyTree(
+                                        project(
+                                                exchange(REMOTE_STREAMING, GATHER,
+                                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))))));
+    }
+
+    @Test
+    public void testCastOperationsWithCppFunctions()
+    {
+        // CAST operations with CPP functions
+        // The RemoveRedundantExchanges optimizer removes the redundant exchange
+        assertNativeDistributedPlan(
+                "SELECT CAST(cpp_foo(ordinal_position) AS VARCHAR) FROM information_schema.columns",
+                anyTree(
+                        project(
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testArrayConstructorWithCppFunction()
+    {
+        // Array constructor with CPP function
+        assertNativeDistributedPlan(
+                "SELECT ARRAY[cpp_foo(ordinal_position), cpp_baz(ordinal_position)] FROM information_schema.columns",
+                anyTree(
+                        project(
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testRowConstructorWithCppFunction()
+    {
+        // ROW constructor with CPP function
+        // The RemoveRedundantExchanges optimizer removes the redundant exchange
+        assertNativeDistributedPlan(
+                "SELECT ROW(cpp_foo(ordinal_position), table_name) FROM information_schema.columns",
+                anyTree(
+                        project(
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of(
+                                                "ordinal_position", "ordinal_position",
+                                                "table_name", "table_name"))))));
+    }
+
+    @Test
+    public void testIsNotNullWithCppFunction()
+    {
+        // IS NOT NULL check with CPP function
+        assertNativeDistributedPlan(
+                "SELECT * FROM information_schema.columns WHERE cpp_foo(ordinal_position) IS NOT NULL",
+                anyTree(
+                        filter("cpp_foo(ordinal_position) IS NOT NULL",
+                                exchange(REMOTE_STREAMING, GATHER,
+                                        tableScan("columns", ImmutableMap.of("ordinal_position", "ordinal_position"))))));
+    }
+
+    @Test
+    public void testComplexJoinWithMultipleCppFunctions()
+    {
+        // Complex join with multiple CPP functions in different positions
+        // The filters are pushed into FilterProject nodes and the join happens on the expression cpp_foo(c1.ordinal_position)
+        assertNativeDistributedPlan(
+                "SELECT c1.table_name, n.name FROM information_schema.columns c1 " +
+                        "JOIN nation n ON cpp_foo(c1.ordinal_position) = n.nationkey " +
+                        "WHERE cpp_baz(c1.ordinal_position) > 0 AND cpp_foo(n.nationkey) < 100",
+                anyTree(
+                        join(INNER, ImmutableList.of(equiJoinClause("cpp_foo", "nationkey")),
+                                project(ImmutableMap.of("table_name", expression("table_name"), "cpp_foo", expression("cpp_foo")),
+                                        project(ImmutableMap.of("cpp_foo", expression("cpp_foo(ordinal_position)")),
+                                                filter("cpp_baz(ordinal_position) > BIGINT'0' AND cpp_foo(cpp_foo(ordinal_position)) < BIGINT'100'",
+                                                        exchange(REMOTE_STREAMING, GATHER,
+                                                                tableScan("columns", ImmutableMap.of(
+                                                                        "ordinal_position", "ordinal_position",
+                                                                        "table_name", "table_name")))))),
+                                anyTree(
+                                        project(ImmutableMap.of("nationkey", expression("nationkey"),
+                                                        "name", expression("name")),
+                                                filter("cpp_foo(nationkey) < BIGINT'100'",
+                                                        tableScan("nation", ImmutableMap.of(
+                                                                "nationkey", "nationkey",
+                                                                "name", "name"))))))));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/sanity/TestCheckNoIneligibleFunctionsInCoordinatorFragments.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/sanity/TestCheckNoIneligibleFunctionsInCoordinatorFragments.java
@@ -1,0 +1,474 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
+import com.facebook.presto.functionNamespace.execution.NoopSqlFunctionExecutor;
+import com.facebook.presto.functionNamespace.execution.SqlFunctionExecutors;
+import com.facebook.presto.functionNamespace.testing.InMemoryFunctionNamespaceManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TestingColumnHandle;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.function.FunctionImplementationType;
+import com.facebook.presto.spi.function.Parameter;
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.plan.JoinType;
+import com.facebook.presto.spi.plan.Partitioning;
+import com.facebook.presto.spi.plan.PartitioningScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.FunctionsConfig;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.CPP;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.JAVA;
+import static com.facebook.presto.spi.function.RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestCheckNoIneligibleFunctionsInCoordinatorFragments
+        extends BasePlanTest
+{
+    // CPP function for testing (similar to TestAddExchangesPlansWithFunctions)
+    private static final SqlInvokedFunction CPP_FUNC = new SqlInvokedFunction(
+            new QualifiedObjectName("dummy", "unittest", "cpp_func"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.VARCHAR))),
+            parseTypeSignature(StandardTypes.VARCHAR),
+            "cpp_func(x)",
+            RoutineCharacteristics.builder().setLanguage(CPP).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
+            "",
+            notVersioned());
+
+    // JAVA function for testing
+    private static final SqlInvokedFunction JAVA_FUNC = new SqlInvokedFunction(
+            new QualifiedObjectName("dummy", "unittest", "java_func"),
+            ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.VARCHAR))),
+            parseTypeSignature(StandardTypes.VARCHAR),
+            "java_func(x)",
+            RoutineCharacteristics.builder().setLanguage(JAVA).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
+            "",
+            notVersioned());
+
+    public TestCheckNoIneligibleFunctionsInCoordinatorFragments()
+    {
+        super(TestCheckNoIneligibleFunctionsInCoordinatorFragments::createTestQueryRunner);
+    }
+
+    private static LocalQueryRunner createTestQueryRunner()
+    {
+        LocalQueryRunner queryRunner = new LocalQueryRunner(
+                testSessionBuilder()
+                        .setCatalog("local")
+                        .setSchema("tiny")
+                        .build(),
+                new FeaturesConfig().setNativeExecutionEnabled(true),
+                new FunctionsConfig().setDefaultNamespacePrefix("dummy.unittest"));
+
+        queryRunner.createCatalog("local", new TpchConnectorFactory(), ImmutableMap.of());
+
+        // Add function namespace with both CPP and JAVA functions
+        queryRunner.getMetadata().getFunctionAndTypeManager().addFunctionNamespace(
+                "dummy",
+                new InMemoryFunctionNamespaceManager(
+                        "dummy",
+                        new SqlFunctionExecutors(
+                                ImmutableMap.of(
+                                        CPP, FunctionImplementationType.CPP,
+                                        JAVA, FunctionImplementationType.JAVA),
+                                new NoopSqlFunctionExecutor()),
+                        new SqlInvokedFunctionNamespaceManagerConfig().setSupportedFunctionLanguages("CPP,JAVA")));
+
+        // Register the functions
+        queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(CPP_FUNC, false);
+        queryRunner.getMetadata().getFunctionAndTypeManager().createFunction(JAVA_FUNC, false);
+
+        return queryRunner;
+    }
+
+    @Test
+    public void testSystemTableScanWithJavaFunctionPasses()
+    {
+        // System table scan with Java function in same fragment should pass
+        validatePlan(
+                p -> {
+                    VariableReferenceExpression col = p.variable("col", VARCHAR);
+                    VariableReferenceExpression result = p.variable("result", VARCHAR);
+
+                    // Create a system table scan - using proper system connector ID
+                    TableHandle systemTableHandle = new TableHandle(
+                            ConnectorId.createSystemTablesConnectorId(new ConnectorId("local")),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    PlanNode tableScan = p.tableScan(
+                            systemTableHandle,
+                            ImmutableList.of(col),
+                            ImmutableMap.of(col, new TestingColumnHandle("col")));
+
+                    // Java function (using our registered java_func)
+                    return p.project(
+                            assignment(result, p.rowExpression("java_func(col)")),
+                            tableScan);
+                });
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "Fragment contains both system table scan and non-Java functions.*")
+    public void testSystemTableScanWithCppFunctionInProjectFails()
+    {
+        // System table scan with C++ function in same fragment should fail
+        validatePlan(
+                p -> {
+                    VariableReferenceExpression col = p.variable("col", VARCHAR);
+                    VariableReferenceExpression result = p.variable("result", VARCHAR);
+
+                    // System table scan
+                    TableHandle systemTableHandle = new TableHandle(
+                            ConnectorId.createSystemTablesConnectorId(new ConnectorId("local")),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    PlanNode systemScan = p.tableScan(
+                            systemTableHandle,
+                            ImmutableList.of(col),
+                            ImmutableMap.of(col, new TestingColumnHandle("col")));
+
+                    // C++ function (using our registered cpp_func)
+                    return p.project(
+                            assignment(result, p.rowExpression("cpp_func(col)")),
+                            systemScan);
+                });
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "Fragment contains both system table scan and non-Java functions.*")
+    public void testSystemTableScanWithCppFunctionInFilterFails()
+    {
+        // System table scan with C++ function in filter should fail
+        validatePlan(
+                p -> {
+                    VariableReferenceExpression col = p.variable("col", VARCHAR);
+
+                    // System table scan
+                    TableHandle systemTableHandle = new TableHandle(
+                            ConnectorId.createSystemTablesConnectorId(new ConnectorId("local")),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    PlanNode systemScan = p.tableScan(
+                            systemTableHandle,
+                            ImmutableList.of(col),
+                            ImmutableMap.of(col, new TestingColumnHandle("col")));
+
+                    // Filter with C++ function
+                    return p.filter(
+                            p.rowExpression("cpp_func(col) = 'test'"),
+                            systemScan);
+                });
+    }
+
+    @Test
+    public void testSystemTableScanWithCppFunctionSeparatedByExchangePasses()
+    {
+        // System table scan and C++ function separated by exchange should pass
+        validatePlan(
+                p -> {
+                    VariableReferenceExpression col = p.variable("col", VARCHAR);
+                    VariableReferenceExpression result = p.variable("result", VARCHAR);
+
+                    // System table scan
+                    TableHandle systemTableHandle = new TableHandle(
+                            ConnectorId.createSystemTablesConnectorId(new ConnectorId("local")),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    PlanNode systemScan = p.tableScan(
+                            systemTableHandle,
+                            ImmutableList.of(col),
+                            ImmutableMap.of(col, new TestingColumnHandle("col")));
+
+                    // Exchange creates fragment boundary
+                    PartitioningScheme partitioningScheme = new PartitioningScheme(
+                            Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()),
+                            ImmutableList.of(col));
+
+                    ExchangeNode exchange = new ExchangeNode(
+                            Optional.empty(),
+                            p.getIdAllocator().getNextId(),
+                            ExchangeNode.Type.GATHER,
+                            ExchangeNode.Scope.LOCAL,
+                            partitioningScheme,
+                            ImmutableList.of(systemScan),
+                            ImmutableList.of(ImmutableList.of(col)),
+                            false,
+                            Optional.empty());
+
+                    // C++ function in different fragment
+                    return p.project(
+                            assignment(result, p.rowExpression("cpp_func(col)")),
+                            exchange);
+                });
+    }
+
+    @Test
+    public void testRegularTableScanWithCppFunctionPasses()
+    {
+        // Regular table scan with C++ function should pass (no system table)
+        validatePlan(
+                p -> {
+                    VariableReferenceExpression col = p.variable("col", VARCHAR);
+                    VariableReferenceExpression result = p.variable("result", VARCHAR);
+
+                    // Regular table scan (not system)
+                    TableHandle regularTableHandle = new TableHandle(
+                            new ConnectorId("local"),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    PlanNode regularScan = p.tableScan(
+                            regularTableHandle,
+                            ImmutableList.of(col),
+                            ImmutableMap.of(col, new TestingColumnHandle("col")));
+
+                    // C++ function
+                    return p.project(
+                            assignment(result, p.rowExpression("cpp_func(col)")),
+                            regularScan);
+                });
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "Fragment contains both system table scan and non-Java functions.*")
+    public void testMultipleFragmentsWithCppFunctionInSystemFragment()
+    {
+        // Complex plan where CPP function is in same fragment as system table scan (should fail)
+        validatePlan(
+                p -> {
+                    VariableReferenceExpression col1 = p.variable("col1", VARCHAR);
+                    VariableReferenceExpression col2 = p.variable("col2", BIGINT);
+                    VariableReferenceExpression col3 = p.variable("col3", BIGINT);
+
+                    // Fragment 1: System table scan
+                    TableHandle systemTableHandle = new TableHandle(
+                            ConnectorId.createSystemTablesConnectorId(new ConnectorId("local")),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    PlanNode systemScan = p.tableScan(
+                            systemTableHandle,
+                            ImmutableList.of(col1),
+                            ImmutableMap.of(col1, new TestingColumnHandle("col1")));
+
+                    // Convert to numeric for join (using CPP function - this should fail)
+                    PlanNode project1 = p.project(
+                            assignment(col2, p.rowExpression("cast(cpp_func(col1) as bigint)")),
+                            systemScan);
+
+                    // Fragment 2: Regular values with computation
+                    PlanNode values = p.values(col3);
+
+                    // Exchange to separate fragments
+                    PartitioningScheme partitioningScheme1 = new PartitioningScheme(
+                            Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()),
+                            ImmutableList.of(col2));
+
+                    ExchangeNode exchange1 = new ExchangeNode(
+                            Optional.empty(),
+                            p.getIdAllocator().getNextId(),
+                            ExchangeNode.Type.GATHER,
+                            ExchangeNode.Scope.LOCAL,
+                            partitioningScheme1,
+                            ImmutableList.of(project1),
+                            ImmutableList.of(ImmutableList.of(col2)),
+                            false,
+                            Optional.empty());
+
+                    PartitioningScheme partitioningScheme2 = new PartitioningScheme(
+                            Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()),
+                            ImmutableList.of(col3));
+
+                    ExchangeNode exchange2 = new ExchangeNode(
+                            Optional.empty(),
+                            p.getIdAllocator().getNextId(),
+                            ExchangeNode.Type.GATHER,
+                            ExchangeNode.Scope.LOCAL,
+                            partitioningScheme2,
+                            ImmutableList.of(values),
+                            ImmutableList.of(ImmutableList.of(col3)),
+                            false,
+                            Optional.empty());
+
+                    // Join the results
+                    return p.join(
+                            JoinType.INNER,
+                            exchange1,
+                            exchange2,
+                            p.rowExpression("col2 = col3"));
+                });
+    }
+
+    @Test
+    public void testMultipleFragmentsWithExchange()
+    {
+        // Complex plan with multiple fragments properly separated (Java function - should pass)
+        validatePlan(
+                p -> {
+                    VariableReferenceExpression col1 = p.variable("col1", VARCHAR);
+                    VariableReferenceExpression col2 = p.variable("col2", BIGINT);
+                    VariableReferenceExpression col3 = p.variable("col3", BIGINT);
+
+                    // Fragment 1: System table scan
+                    TableHandle systemTableHandle = new TableHandle(
+                            ConnectorId.createSystemTablesConnectorId(new ConnectorId("local")),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    PlanNode systemScan = p.tableScan(
+                            systemTableHandle,
+                            ImmutableList.of(col1),
+                            ImmutableMap.of(col1, new TestingColumnHandle("col1")));
+
+                    // Convert to numeric for join (using Java function)
+                    PlanNode project1 = p.project(
+                            assignment(col2, p.rowExpression("cast(java_func(col1) as bigint)")),
+                            systemScan);
+
+                    // Fragment 2: Regular values with computation
+                    PlanNode values = p.values(col3);
+
+                    // Exchange to separate fragments
+                    PartitioningScheme partitioningScheme1 = new PartitioningScheme(
+                            Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()),
+                            ImmutableList.of(col2));
+
+                    ExchangeNode exchange1 = new ExchangeNode(
+                            Optional.empty(),
+                            p.getIdAllocator().getNextId(),
+                            ExchangeNode.Type.GATHER,
+                            ExchangeNode.Scope.LOCAL,
+                            partitioningScheme1,
+                            ImmutableList.of(project1),
+                            ImmutableList.of(ImmutableList.of(col2)),
+                            false,
+                            Optional.empty());
+
+                    PartitioningScheme partitioningScheme2 = new PartitioningScheme(
+                            Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()),
+                            ImmutableList.of(col3));
+
+                    ExchangeNode exchange2 = new ExchangeNode(
+                            Optional.empty(),
+                            p.getIdAllocator().getNextId(),
+                            ExchangeNode.Type.GATHER,
+                            ExchangeNode.Scope.LOCAL,
+                            partitioningScheme2,
+                            ImmutableList.of(values),
+                            ImmutableList.of(ImmutableList.of(col3)),
+                            false,
+                            Optional.empty());
+
+                    // Join the results
+                    return p.join(
+                            JoinType.INNER,
+                            exchange1,
+                            exchange2,
+                            p.rowExpression("col2 = col3"));
+                });
+    }
+
+    @Test
+    public void testFilterAndProjectWithSystemTable()
+    {
+        // Test filter and project both with Java functions on system table
+        validatePlan(
+                p -> {
+                    VariableReferenceExpression col = p.variable("col", VARCHAR);
+                    VariableReferenceExpression len = p.variable("len", BIGINT);
+
+                    // System table scan
+                    TableHandle systemTableHandle = new TableHandle(
+                            ConnectorId.createSystemTablesConnectorId(new ConnectorId("local")),
+                            new TestingTableHandle(),
+                            TestingTransactionHandle.create(),
+                            Optional.empty());
+
+                    PlanNode systemScan = p.tableScan(
+                            systemTableHandle,
+                            ImmutableList.of(col),
+                            ImmutableMap.of(col, new TestingColumnHandle("col")));
+
+                    // Filter with Java function
+                    PlanNode filtered = p.filter(
+                            p.rowExpression("java_func(col) = 'test'"),
+                            systemScan);
+
+                    // Project with Java function
+                    return p.project(
+                            assignment(len, p.rowExpression("cast(java_func(col) as bigint)")),
+                            filtered);
+                });
+    }
+
+    private void validatePlan(Function<PlanBuilder, PlanNode> planProvider)
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .build();
+
+        PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+        Metadata metadata = getQueryRunner().getMetadata();
+        PlanBuilder builder = new PlanBuilder(TEST_SESSION, idAllocator, metadata);
+        PlanNode planNode = planProvider.apply(builder);
+
+        getQueryRunner().inTransaction(session, transactionSession -> {
+            new CheckNoIneligibleFunctionsInCoordinatorFragments().validate(planNode, transactionSession, metadata, WarningCollector.NOOP);
+            return null;
+        });
+    }
+}

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -221,9 +221,8 @@ public class TestNativeSidecarPlugin
     @Test
     public void testInformationSchemaTables()
     {
-        assertQueryFails("select lower(table_name) from information_schema.tables "
-                        + "where table_name = 'lineitem' or table_name = 'LINEITEM' ",
-                "Compiler failed");
+        assertQuery("select lower(table_name) from information_schema.tables "
+                + "where table_name = 'lineitem' or table_name = 'LINEITEM' ");
     }
 
     @Test


### PR DESCRIPTION
## Description
System table scans must execute on the coordinator, but CPP (native/non-Java) functions cannot run on the coordinator - they must execute on workers. When a query contains both system table scans and non-Java functions, the planner needs to ensure that there's an exchange boundary between the scan and filter/projection, and undo any filter pushdown that may have occured.

## Motivation and Context
This problem was discovered during testing support of only CPP function validation, without supporting constant folding.  This is an inevitable problem, as with the Presto sidecar built-in functions are now being reported as being C++, which are ineligible for execution on the coordinator.

## Impact
Fix the above issue.

## Test Plan
Tests have been added in this PR.

## Contributor checklist

```
== NO RELEASE NOTE ==
```

