### PR TITLE
[native] Use  CPU & number of queued drivers in worker overload pushback

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -609,6 +609,16 @@ memory use. Ignored if zero.
 CPU threshold in % above which the worker is considered overloaded in terms of
 CPU use. Ignored if zero.
 
+``worker-overloaded-threshold-num-queued-drivers-hw-multiplier``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``double``
+* **Default value:** ``0.0``
+
+Floating point number used in calculating how many drivers must be queued
+for the worker to be considered overloaded.
+Number of drivers is calculated as hw_concurrency x multiplier. Ignored if zero.
+
 ``worker-overloaded-cooldown-period-sec``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -1284,7 +1284,7 @@ std::string TaskManager::toString() const {
   return out.str();
 }
 
-velox::exec::Task::DriverCounts TaskManager::getDriverCounts() const {
+velox::exec::Task::DriverCounts TaskManager::getDriverCounts() {
   const auto taskMap = *taskMap_.rlock();
   velox::exec::Task::DriverCounts ret;
   for (const auto& pair : taskMap) {
@@ -1299,6 +1299,7 @@ velox::exec::Task::DriverCounts TaskManager::getDriverCounts() const {
       }
     }
   }
+  numQueuedDrivers_ = ret.numQueuedDrivers;
   return ret;
 }
 

--- a/presto-native-execution/presto_cpp/main/TaskManager.h
+++ b/presto-native-execution/presto_cpp/main/TaskManager.h
@@ -146,7 +146,7 @@ class TaskManager {
   int64_t getBytesProcessed() const;
 
   /// Stores the number of drivers in various states of execution.
-  velox::exec::Task::DriverCounts getDriverCounts() const;
+  velox::exec::Task::DriverCounts getDriverCounts();
 
   /// Returns array with number of tasks for each of six PrestoTaskState (enum
   /// defined in PrestoTask.h).
@@ -179,6 +179,12 @@ class TaskManager {
   /// so the Task Manager can optionally change Task admission algorithm.
   void setServerOverloaded(bool serverOverloaded) {
     serverOverloaded_ = serverOverloaded;
+  }
+
+  /// Returns last known number of queued drivers. Used in determining if the
+  /// server is CPU overloaded.
+  uint32_t numQueuedDrivers() const {
+    return numQueuedDrivers_;
   }
 
   /// Contains the logic on starting tasks if not overloaded.
@@ -226,6 +232,7 @@ class TaskManager {
   std::unique_ptr<QueryContextManager> queryContextManager_;
   folly::Executor* httpSrvCpuExecutor_;
   std::atomic_bool serverOverloaded_{false};
+  std::atomic_uint32_t numQueuedDrivers_{0};
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -185,6 +185,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kSystemMemPushbackAbortEnabled, false),
           NUM_PROP(kWorkerOverloadedThresholdMemGb, 0),
           NUM_PROP(kWorkerOverloadedThresholdCpuPct, 0),
+          NUM_PROP(kWorkerOverloadedThresholdNumQueuedDriversHwMultiplier, 0.0),
           NUM_PROP(kWorkerOverloadedCooldownPeriodSec, 5),
           BOOL_PROP(kWorkerOverloadedTaskQueuingEnabled, false),
           NUM_PROP(kMallocHeapDumpThresholdGb, 20),
@@ -509,6 +510,13 @@ uint64_t SystemConfig::workerOverloadedThresholdMemGb() const {
 
 uint32_t SystemConfig::workerOverloadedThresholdCpuPct() const {
   return optionalProperty<uint32_t>(kWorkerOverloadedThresholdCpuPct).value();
+}
+
+double SystemConfig::workerOverloadedThresholdNumQueuedDriversHwMultiplier()
+    const {
+  return optionalProperty<double>(
+             kWorkerOverloadedThresholdNumQueuedDriversHwMultiplier)
+      .value();
 }
 
 uint32_t SystemConfig::workerOverloadedCooldownPeriodSec() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -313,6 +313,12 @@ class SystemConfig : public ConfigBase {
   /// Ignored if zero. Default is zero.
   static constexpr std::string_view kWorkerOverloadedThresholdCpuPct{
       "worker-overloaded-threshold-cpu-pct"};
+  /// Floating point number used in calculating how many drivers must be queued
+  /// for the worker to be considered overloaded.
+  /// Ignored if zero. Default is zero.
+  static constexpr std::string_view
+      kWorkerOverloadedThresholdNumQueuedDriversHwMultiplier{
+          "worker-overloaded-threshold-num-queued-drivers-hw-multiplier"};
   /// Specifies how many seconds worker has to be not overloaded (in terms of
   /// memory and CPU) before its status changes to not overloaded.
   /// This is to prevent spiky fluctuation of the overloaded status.
@@ -849,6 +855,8 @@ class SystemConfig : public ConfigBase {
   uint64_t workerOverloadedThresholdMemGb() const;
 
   uint32_t workerOverloadedThresholdCpuPct() const;
+
+  double workerOverloadedThresholdNumQueuedDriversHwMultiplier() const;
 
   uint32_t workerOverloadedCooldownPeriodSec() const;
 


### PR DESCRIPTION
## Description
Just CPU usage is not a good indicator to determine if worker is overloaded.
We want to use as much CPU as possible w/o degrading the performance.
We are introducing a second metric to determine CPU overload: number of queued drivers.
Running trials on shadow cluster showed it is working well (no A/B test unfortunately).

In short, we consider worker CPU overloaded only when CPU is over the threshold AND number of queued drivers exceeds  another threshold. When either of the settings (system properties) is zero we do not detect CPU overload,

```
== NO RELEASE NOTE ==
```

