### PR TITLE
Enable subfield pushdown for map_subset function

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -335,6 +335,7 @@ public final class SystemSessionProperties
     public static final String QUERY_CLIENT_TIMEOUT = "query_client_timeout";
     public static final String REWRITE_MIN_MAX_BY_TO_TOP_N = "rewrite_min_max_by_to_top_n";
     public static final String ADD_DISTINCT_BELOW_SEMI_JOIN_BUILD = "add_distinct_below_semi_join_build";
+    public static final String PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET = "pushdown_subfields_for_map_subset";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -1910,6 +1911,10 @@ public final class SystemSessionProperties
                         "Optimize out APPROX_DISTINCT operations over constant conditionals",
                         featuresConfig.isOptimizeConditionalApproxDistinct(),
                         false),
+                booleanProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET,
+                        "Enable subfield pruning for map_subset function",
+                        featuresConfig.isPushdownSubfieldForMapSubset(),
+                        false),
                 new PropertyMetadata<>(
                         QUERY_CLIENT_TIMEOUT,
                         "Configures how long the query runs without contact from the client application, such as the CLI, before it's abandoned",
@@ -3257,6 +3262,11 @@ public final class SystemSessionProperties
     public static boolean isEnabledAddExchangeBelowGroupId(Session session)
     {
         return session.getSystemProperty(ADD_EXCHANGE_BELOW_PARTIAL_AGGREGATION_OVER_GROUP_ID, Boolean.class);
+    }
+
+    public static boolean isPushSubfieldsForMapSubsetEnabled(Session session)
+    {
+        return session.getSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET, Boolean.class);
     }
 
     public static boolean isAddDistinctBelowSemiJoinBuildEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -306,6 +306,7 @@ public class FeaturesConfig
     private String expressionOptimizerName = DEFAULT_EXPRESSION_OPTIMIZER_NAME;
     private boolean addExchangeBelowPartialAggregationOverGroupId;
     private boolean addDistinctBelowSemiJoinBuild;
+    private boolean pushdownSubfieldForMapSubset = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -3055,5 +3056,18 @@ public class FeaturesConfig
     public boolean isAddDistinctBelowSemiJoinBuild()
     {
         return addDistinctBelowSemiJoinBuild;
+    }
+
+    @Config("optimizer.pushdown-subfield-for-map-subset")
+    @ConfigDescription("Enable subfield pruning for map_subset function")
+    public FeaturesConfig setPushdownSubfieldForMapSubset(boolean pushdownSubfieldForMapSubset)
+    {
+        this.pushdownSubfieldForMapSubset = pushdownSubfieldForMapSubset;
+        return this;
+    }
+
+    public boolean isPushdownSubfieldForMapSubset()
+    {
+        return pushdownSubfieldForMapSubset;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -426,6 +426,11 @@ public final class FunctionResolution
         return windowValueFunctions.contains(functionAndTypeResolver.getFunctionMetadata(functionHandle).getName());
     }
 
+    public boolean isMapSubSetFunction(FunctionHandle functionHandle)
+    {
+        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(functionAndTypeResolver.qualifyObjectName(QualifiedName.of("map_subset")));
+    }
+
     @Override
     public FunctionHandle lookupBuiltInFunction(String functionName, List<Type> inputTypes)
     {

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -259,6 +259,7 @@ public class TestFeaturesConfig
                 .setExcludeInvalidWorkerSessionProperties(false)
                 .setAddExchangeBelowPartialAggregationOverGroupId(false)
                 .setAddDistinctBelowSemiJoinBuild(false)
+                .setPushdownSubfieldForMapSubset(true)
                 .setInnerJoinPushdownEnabled(false)
                 .setBroadcastSemiJoinForDelete(true)
                 .setInEqualityJoinPushdownEnabled(false)
@@ -473,6 +474,7 @@ public class TestFeaturesConfig
                 .put("expression-optimizer-name", "custom")
                 .put("exclude-invalid-worker-session-properties", "true")
                 .put("optimizer.add-distinct-below-semi-join-build", "true")
+                .put("optimizer.pushdown-subfield-for-map-subset", "false")
                 .put("optimizer.add-exchange-below-partial-aggregation-over-group-id", "true")
                 .build();
 
@@ -678,6 +680,7 @@ public class TestFeaturesConfig
                 .setExcludeInvalidWorkerSessionProperties(true)
                 .setAddExchangeBelowPartialAggregationOverGroupId(true)
                 .setAddDistinctBelowSemiJoinBuild(true)
+                .setPushdownSubfieldForMapSubset(false)
                 .setInEqualityJoinPushdownEnabled(true)
                 .setBroadcastSemiJoinForDelete(false)
                 .setRewriteMinMaxByToTopNEnabled(true)


### PR DESCRIPTION
## Description
MAP_SUBSET function is commonly used in ML workload, which is used to extract a subset of features. For example, map_subset(feature, array[301, 205]) is used to extract the features with key to be 301 and 205.
If this is the only case where feature is accessed, we only need to read two fields of the map. However currently PushDownSubfields does not recognize this pattern. In this PR I enabled subfield pushdown for map_subset when the input array is a constant array.
In one of the motivating queries we found, this enhancement reduce the resource usage by 17% ([orig](https://www.internalfb.com/intern/presto/query/?query_id=20250618_144825_57067_pp7yy) vs. [improved](https://www.internalfb.com/intern/presto/query/?query_id=20250618_050302_24542_pp7yy))

Without change:
```
presto:tpch> explain (type distributed) select map_subset(map2, array[1]) from t1;
                                                                                                                                             Query Plan                                                            >
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                                                                               >
     Output layout: [map_subset]                                                                                                                                                                                   >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Output encoding: COLUMNAR                                                                                                                                                                                     >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Output[PlanNodeId 5][_col0] => [map_subset:map(integer, integer)]                                                                                                                                           >
             Estimates: {source: CostBasedSourceInfo, rows: 2 (102B), cpu: 128.00, memory: 0.00, network: 102.00}                                                                                                  >
             _col0 := map_subset (1:35)                                                                                                                                                                            >
         - RemoteSource[1] => [map_subset:map(integer, integer)]                                                                                                                                                   >
                                                                                                                                                                                                                   >
 Fragment 1 [SOURCE]                                                                                                                                                                                               >
     Output layout: [map_subset]                                                                                                                                                                                   >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Output encoding: COLUMNAR                                                                                                                                                                                     >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - ScanProject[PlanNodeId 0,1][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=t1, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.t1{}]'},>
             Estimates: {source: CostBasedSourceInfo, rows: 2 (102B), cpu: 26.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 2 (102B), cpu: 128.00, memory: 0.00, network: 0.00}             >
             map_subset := map_subset(map2, [Block: position count: 1; size: 60 bytes]) (1:68)                                                                                                                     >
             LAYOUT: tpch.t1{}                                                                                                                                                                                     >
             map2 := map2:map<int,int>:1:REGULAR (1:67)                                                                                                                                                            >
                                                                                                                                                                                                                   >
                                                                                                                                                                                                                   >
(1 row)
(END)

```

With change:
```
presto:tpch> explain (type distributed) select map_subset(map2, array[1]) from t1;
                                                                                                                                             Query Plan                                                            >
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                                                                               >
     Output layout: [map_subset]                                                                                                                                                                                   >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Output encoding: COLUMNAR                                                                                                                                                                                     >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - Output[PlanNodeId 5][_col0] => [map_subset:map(integer, integer)]                                                                                                                                           >
             Estimates: {source: CostBasedSourceInfo, rows: 2 (102B), cpu: 128.00, memory: 0.00, network: 102.00}                                                                                                  >
             _col0 := map_subset (1:35)                                                                                                                                                                            >
         - RemoteSource[1] => [map_subset:map(integer, integer)]                                                                                                                                                   >
                                                                                                                                                                                                                   >
 Fragment 1 [SOURCE]                                                                                                                                                                                               >
     Output layout: [map_subset]                                                                                                                                                                                   >
     Output partitioning: SINGLE []                                                                                                                                                                                >
     Output encoding: COLUMNAR                                                                                                                                                                                     >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                                                                                 >
     - ScanProject[PlanNodeId 0,1][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=t1, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.t1{}]'},>
             Estimates: {source: CostBasedSourceInfo, rows: 2 (102B), cpu: 26.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 2 (102B), cpu: 128.00, memory: 0.00, network: 0.00}             >
             map_subset := map_subset(map2, [Block: position count: 1; size: 60 bytes]) (1:68)                                                                                                                     >
             LAYOUT: tpch.t1{}                                                                                                                                                                                     >
             map2 := map2:map<int,int>:1:REGULAR:[map2[1]] (1:67)                                                                                                                                                  >
                                                                                                                                                                                                                   >
                                                                                                                                                                                                                   >
(1 row)
(END)
```
`map2 := map2:map<int,int>:1:REGULAR (1:67)  ` vs. `map2 := map2:map<int,int>:1:REGULAR:[map2[1]] (1:67)   `
## Motivation and Context
As in description

## Impact
In one of the motivating queries we found, this enhancement reduce the resource usage by 17% 

## Test Plan
unit tests, also end to end test locally

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve query resource usage by enabling subfield pushdown for :func:`map_subset` when the input array is a constant array. 
```


