### PR TITLE
fix: TDigest - Add Quantiles At Values to Documentation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/tdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/tdigest.rst
@@ -58,6 +58,11 @@ Functions
     T-digest and array of values between 0 and 1 which represent the quantiles
     to return.
 
+.. function:: quantiles_at_values(tdigest<double>, values) -> array<double>
+
+    Returns an array of approximate quantile numbers between 0 and 1 from the T-digest
+    and array of ``values``.
+
 .. function:: trimmed_mean(tdigest<double>, lower_quantile, upper_quantile) -> double
 
     Returns an estimate of the mean, excluding portions of the distribution


### PR DESCRIPTION
Summary:
- Add quantiles_at_values in Presto documentation https://prestodb.io/docs/current/functions/tdigest.html
- This function exists in Java, and is being ported to C++ inh ttps://github.com/facebookincubator/velox/pull/13838, but was not captured in documentation

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```




