### PR TITLE
Fix Hive Metastore Impersonation in Hive Docs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive-security.rst
+++ b/presto-docs/src/main/sphinx/connector/hive-security.rst
@@ -349,12 +349,6 @@ Keytab files must be distributed to every node in the cluster that runs Presto.
 
 :ref:`Additional Information About Keytab Files.<hive-security-additional-keytab>`
 
-Impersonation Accessing the Hive Metastore
-------------------------------------------
-
-Presto does not currently support impersonating the end user when accessing the
-Hive metastore.
-
 .. _configuring-hadoop-impersonation:
 
 Impersonation in Hadoop


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Fix Hive Security Documentation

Hive Metastore Impersonation was added as part of https://github.com/prestodb/presto/pull/15736

```
== NO RELEASE NOTE ==
```

