### PR TITLE
Expose plan checker router scheduler plugin counter Mbeans explicitly

### DIFF
--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPlanCheckerRouterPlugin.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPlanCheckerRouterPlugin.java
@@ -185,9 +185,11 @@ public class TestPlanCheckerRouterPlugin
         if (sidecarEnabled) {
             closeAllRuntimeException(nativeQueryRunner);
             nativeQueryRunner = null;
-            for (String query : getNativeIncompatibleQueries()) {
+            List<String> queries = getNativeIncompatibleQueries();
+            for (String query : queries) {
                 runQuery(query, httpServerUri);
             }
+            assertEquals(planCheckerRouterPluginPrestoClient.getFallBackToJavaClusterRedirectRequests().getTotalCount(), queries.size());
         }
     }
 

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginModule.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginModule.java
@@ -16,8 +16,13 @@ package com.facebook.presto.router.scheduler;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
+import javax.management.MBeanServer;
+
+import java.lang.management.ManagementFactory;
+
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.google.inject.Scopes.SINGLETON;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class PlanCheckerRouterPluginModule
         implements Module
@@ -28,5 +33,8 @@ public class PlanCheckerRouterPluginModule
         configBinder(binder).bindConfig(PlanCheckerRouterPluginConfig.class);
         binder.bind(PlanCheckerRouterPluginPrestoClient.class).in(SINGLETON);
         binder.bind(PlanCheckerRouterPluginScheduler.class).in(SINGLETON);
+
+        newExporter(binder).export(PlanCheckerRouterPluginPrestoClient.class).withGeneratedName();
+        binder.bind(MBeanServer.class).toInstance(ManagementFactory.getPlatformMBeanServer());
     }
 }

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
@@ -46,6 +46,7 @@ public class PlanCheckerRouterPluginPrestoClient
 {
     private static final Logger log = Logger.get(PlanCheckerRouterPluginPrestoClient.class);
     private static final String ANALYZE_CALL = "EXPLAIN (TYPE DISTRIBUTED) ";
+    private static final CounterStat fallBackToJavaClusterRedirectRequests = new CounterStat();
     private static final CounterStat javaClusterRedirectRequests = new CounterStat();
     private static final CounterStat nativeClusterRedirectRequests = new CounterStat();
     private final OkHttpClient httpClient = new OkHttpClient();
@@ -107,6 +108,7 @@ public class PlanCheckerRouterPluginPrestoClient
                 // If any exception is thrown, log the message and re-route to a Java clusters router.
                 isNativeCompatible = false;
                 log.info(e.getMessage());
+                fallBackToJavaClusterRedirectRequests.update(1L);
             }
             else {
                 // hard failure
@@ -136,6 +138,13 @@ public class PlanCheckerRouterPluginPrestoClient
     public CounterStat getNativeClusterRedirectRequests()
     {
         return nativeClusterRedirectRequests;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFallBackToJavaClusterRedirectRequests()
+    {
+        return fallBackToJavaClusterRedirectRequests;
     }
 
     private ClientSession parseHeadersToClientSession(Map<String, List<String>> headers, Principal principal)

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginSchedulerFactory.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginSchedulerFactory.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.bootstrap.Bootstrap;
 import com.facebook.presto.spi.router.Scheduler;
 import com.facebook.presto.spi.router.SchedulerFactory;
 import com.google.inject.Injector;
+import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
@@ -37,7 +38,7 @@ public class PlanCheckerRouterPluginSchedulerFactory
     public Scheduler create(Map<String, String> config)
     {
         try {
-            Bootstrap app = new Bootstrap(new PlanCheckerRouterPluginModule());
+            Bootstrap app = new Bootstrap(new PlanCheckerRouterPluginModule(), new MBeanModule());
 
             Injector injector = app
                     .doNotInitializeLogging()


### PR DESCRIPTION
## Description
Expose plan checker router scheduler plugin counter Mbeans explicitly.

## Motivation and Context
The java/ native redirect requests counters weren't exposed.

## Impact
Users will be able to see the counters.

## Test Plan
Screenshots attached

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

