### PR TITLE
[native] Add --depth 1 to github_checkout usages in setup scripts

### DIFF
--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -26,7 +26,7 @@ source "$(dirname "${BASH_SOURCE}")/../velox/scripts/setup-macos.sh"
 GPERF_VERSION="3.1"
 
 function install_proxygen {
-  github_checkout facebook/proxygen "${FB_OS_VERSION}"
+  github_checkout facebook/proxygen "${FB_OS_VERSION}" --depth 1
   # Folly Portability.h being used to decide whether or not support coroutines
   # causes issues (build, lin) if the selection is not consistent across users of folly.
   EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -24,7 +24,7 @@ function install_proxygen {
   # proxygen requires python and gperf
   ${SUDO} apt update
   ${SUDO} apt install -y gperf python3
-  github_checkout facebook/proxygen "${FB_OS_VERSION}"
+  github_checkout facebook/proxygen "${FB_OS_VERSION}" --depth 1
   # Folly Portability.h being used to decide whether or not support coroutines
   # causes issues (build, lin) if the selection is not consistent across users of folly.
   EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
The change here 
https://github.com/facebookincubator/velox/pull/13466

Does not support empty git arguments and will result in error
`line 67: GIT_CLONE_PARAMS[@]: unbound variable` when installing Proxygen. Followed other usages of github_checkout and added `--depth 1` which reduces commit history and adds a git argument. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fix script issue.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Ran setup script successfully afterwards on Mac. Have not tested Ubuntu.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

