### PR TITLE
[native] Disable TestPrestoNativeAsyncDataCacheCleanupAPI

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
@@ -67,7 +67,7 @@ public class TestPrestoNativeAsyncDataCacheCleanupAPI
         createCustomer(queryRunner);
     }
 
-    @Test(groups = {"async_data_cache"})
+    @Test(groups = {"async_data_cache"}, enabled = false)
     public void testAsyncDataCacheCleanup() throws Exception
     {
         Session session = Session.builder(super.getSession())
@@ -193,7 +193,7 @@ public class TestPrestoNativeAsyncDataCacheCleanupAPI
                 .collect(Collectors.toSet());
     }
 
-    @Test(groups = {"async_data_cache"})
+    @Test(groups = {"async_data_cache"}, enabled = false)
     public void testAsyncDataCacheCleanupApiFormat()
     {
         QueryRunner queryRunner = getQueryRunner();


### PR DESCRIPTION
Disablng the test until we figure out whats happening in https://github.com/prestodb/presto/issues/25407

```
== NO RELEASE NOTE ==
```

