### PR TITLE
[docs] Add cross-reference in admin/properties.rst

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1102,4 +1102,6 @@ Query Manager Properties
 * **Default value:** ``5m``
 
 This property can be used to configure how long a query runs without contact
-from the client application, such as the CLI, before it's abandoned.
+from the client application, such as the CLI, before it's abandoned. 
+
+The corresponding session property is :ref:`admin/properties-session:\`\`query_client_timeout\`\``.


### PR DESCRIPTION
## Description
Add a cross-reference line from the `query.client.timeout` entry in [admin/properties.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/admin/properties.rst) to the corresponding `query_client_timeout` session property in [admin/properties-session.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/admin/properties-session.rst). 

## Motivation and Context
Helps the reader know that the config property has a corresponding session property, and adds a link for the reader to use to quickly find it. 

## Impact
Documentation. 

## Test Plan
Local doc build - tested and verified the link works. The last sentence in the screenshot is new. 
<img width="690" alt="Screenshot 2025-06-24 at 1 20 10 PM" src="https://github.com/user-attachments/assets/506cc9cf-3775-485c-8b72-9b14473d3561" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

