### PR TITLE
Add config property to enable fallback to Java cluster router when plan checker clusters are unreachable

### DIFF
--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -118,6 +118,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
             <scope>test</scope>

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPlanCheckerRouterPlugin.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPlanCheckerRouterPlugin.java
@@ -89,7 +89,8 @@ public class TestPlanCheckerRouterPlugin
                 planCheckerRouterConfig.getPlanCheckClustersURIs().get(0),
                 planCheckerRouterConfig.getJavaRouterURI(),
                 planCheckerRouterConfig.getNativeRouterURI(),
-                planCheckerRouterConfig.getClientRequestTimeout());
+                planCheckerRouterConfig.getClientRequestTimeout(),
+                planCheckerRouterConfig.isJavaClusterFallbackEnabled());
 
         Path tempFile = Files.createTempFile("temp-config", ".json");
         File configFile = getConfigFile(singletonList(planCheckerRouterConfig.getNativeRouterURI()), tempFile.toFile());
@@ -218,7 +219,8 @@ public class TestPlanCheckerRouterPlugin
         String planCheckerClusterURIs = format("plan-check-clusters-uris=%s", planCheckerRouterConfig.getPlanCheckClustersURIs().get(0));
         String javaClusterURI = format("router-java-url=%s", planCheckerRouterConfig.getJavaRouterURI());
         String nativeClusterURI = format("router-native-url=%s", planCheckerRouterConfig.getNativeRouterURI());
-        Files.write(tempPluginSchedulerConfigFile, ImmutableList.of(schedulerName, planCheckerClusterURIs, javaClusterURI, nativeClusterURI));
+        String javaClusterFallbackEnabled = format("enable-java-cluster-fallback=%s", planCheckerRouterConfig.isJavaClusterFallbackEnabled());
+        Files.write(tempPluginSchedulerConfigFile, ImmutableList.of(schedulerName, planCheckerClusterURIs, javaClusterURI, nativeClusterURI, javaClusterFallbackEnabled));
         return tempPluginSchedulerConfigFile.toFile();
     }
 

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPlanCheckerRouterPlugin.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPlanCheckerRouterPlugin.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
 import static com.facebook.presto.router.scheduler.SchedulerType.CUSTOM_PLUGIN_SCHEDULER;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
@@ -67,6 +68,7 @@ public class TestPlanCheckerRouterPlugin
     private boolean sidecarEnabled;
     // mock object only to check the redirect requests counters.
     private PlanCheckerRouterPluginPrestoClient planCheckerRouterPluginPrestoClient;
+    private QueryRunner nativeQueryRunner;
 
     @BeforeClass
     public void init()
@@ -77,20 +79,19 @@ public class TestPlanCheckerRouterPlugin
         super.init();
         Logging.initialize();
 
+        nativeQueryRunner = getQueryRunner();
+
         // for testing purposes, we can skip the router chaining part and specify the native/java clusters directly here
         URI nativeClusterURI = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getBaseUrl();
         URI javaClusterURI = ((DistributedQueryRunner) getExpectedQueryRunner()).getCoordinator().getBaseUrl();
         PlanCheckerRouterPluginConfig planCheckerRouterConfig = new PlanCheckerRouterPluginConfig()
                 .setPlanCheckClustersURIs(nativeClusterURI.toString())
                 .setJavaRouterURI(javaClusterURI)
-                .setNativeRouterURI(nativeClusterURI);
+                .setNativeRouterURI(nativeClusterURI)
+                .setJavaClusterFallbackEnabled(true);
 
-        planCheckerRouterPluginPrestoClient = new PlanCheckerRouterPluginPrestoClient(
-                planCheckerRouterConfig.getPlanCheckClustersURIs().get(0),
-                planCheckerRouterConfig.getJavaRouterURI(),
-                planCheckerRouterConfig.getNativeRouterURI(),
-                planCheckerRouterConfig.getClientRequestTimeout(),
-                planCheckerRouterConfig.isJavaClusterFallbackEnabled());
+        planCheckerRouterPluginPrestoClient =
+                new PlanCheckerRouterPluginPrestoClient(planCheckerRouterConfig);
 
         Path tempFile = Files.createTempFile("temp-config", ".json");
         File configFile = getConfigFile(singletonList(planCheckerRouterConfig.getNativeRouterURI()), tempFile.toFile());
@@ -171,6 +172,22 @@ public class TestPlanCheckerRouterPlugin
     {
         if (sidecarEnabled) {
             runQuery(query, httpServerUri, Optional.of(exceptionMessage));
+        }
+    }
+
+    @Test(dependsOnMethods =
+            {"testFailingQueriesOnBothClusters",
+                    "testNativeCompatibleQueries",
+                    "testNativeIncompatibleQueries"})
+    public void testPlanCheckerClusterNotAvailable()
+            throws SQLException
+    {
+        if (sidecarEnabled) {
+            closeAllRuntimeException(nativeQueryRunner);
+            nativeQueryRunner = null;
+            for (String query : getNativeIncompatibleQueries()) {
+                runQuery(query, httpServerUri);
+            }
         }
     }
 

--- a/presto-plan-checker-router-plugin/README.md
+++ b/presto-plan-checker-router-plugin/README.md
@@ -15,18 +15,19 @@ Set the scheduler name to `CUSTOM_PLUGIN_SCHEDULER` in `etc/router-config.json`.
 * `PlanCheckerRouterPluginSchedulerFactory` - Factory for creating plan checker custom scheduler.  
   This class implements the interface `com.facebook.presto.spi.SchedulerFactory`.
 * `PlanCheckerRouterPluginScheduler` - Plan checker custom scheduler implementing the scheduling logic for clusters.  
-  This class implements the interface `com.facebook.presto.spi.router.Scheduler`.  
+  This class implements the interface `com.facebook.presto.spi.router.Scheduler`.
 
 ## Configuration:
 The following configuration properties must be set in `etc/router-config/router-scheduler.properties`:
 
-| Property Name            | Type   | Description                                                             |                   
-|--------------------------|--------|-------------------------------------------------------------------------|
-| router-scheduler.name    | String | The name of the custom scheduler factory                                |
-|                          |        | Example: `router-scheduler.name=plan-checker`                           |
-| plan-check-clusters-uris | String | The URIs of the plan checker clusters.                                  |                                           |
-| router-java-url          | String | The router URI dedicated to java clusters.                              |
-| router-native-url        | String | The router URI dedicated to native clusters.                            |
-| client-request-timeout   | String | The maximum time the client will wait for a response before timing out. |
-|                          |        | Default : `2 minutes`                                                   |
-
+| Property Name                | Type    | Description                                                                                                        |                   
+|------------------------------|---------|--------------------------------------------------------------------------------------------------------------------|
+| router-scheduler.name        | String  | The name of the custom scheduler factory                                                                           |
+|                              |         | Example: `router-scheduler.name=plan-checker`                                                                      |
+| plan-check-clusters-uris     | String  | The URIs of the plan checker clusters.                                                                             |                                           |
+| router-java-url              | String  | The router URI dedicated to java clusters.                                                                         |
+| router-native-url            | String  | The router URI dedicated to native clusters.                                                                       |
+| client-request-timeout       | String  | The maximum time the client will wait for a response before timing out.                                            |
+|                              |         | Default : `2 minutes`                                                                                              |
+| enable-java-cluster-fallback | boolean | Enables fallback to the Java clusters when the plan checker clusters are unavailable or fail to process a request. |
+|                              |         | Default : `false`                                                                                                  |

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginConfig.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginConfig.java
@@ -33,6 +33,7 @@ public class PlanCheckerRouterPluginConfig
     private URI javaRouterURI;
     private URI nativeRouterURI;
     private Duration clientRequestTimeout = new Duration(2, MINUTES);
+    private boolean javaClusterFallbackEnabled;
 
     @Config("plan-check-clusters-uris")
     public PlanCheckerRouterPluginConfig setPlanCheckClustersURIs(String uris)
@@ -87,6 +88,18 @@ public class PlanCheckerRouterPluginConfig
     public PlanCheckerRouterPluginConfig setClientRequestTimeout(Duration clientRequestTimeout)
     {
         this.clientRequestTimeout = clientRequestTimeout;
+        return this;
+    }
+
+    public boolean isJavaClusterFallbackEnabled()
+    {
+        return javaClusterFallbackEnabled;
+    }
+
+    @Config("enable-java-cluster-fallback")
+    public PlanCheckerRouterPluginConfig setJavaClusterFallbackEnabled(boolean javaClusterFallbackEnabled)
+    {
+        this.javaClusterFallbackEnabled = javaClusterFallbackEnabled;
         return this;
     }
 }

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginModule.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginModule.java
@@ -26,6 +26,7 @@ public class PlanCheckerRouterPluginModule
     public void configure(Binder binder)
     {
         configBinder(binder).bindConfig(PlanCheckerRouterPluginConfig.class);
+        binder.bind(PlanCheckerRouterPluginPrestoClient.class).in(SINGLETON);
         binder.bind(PlanCheckerRouterPluginScheduler.class).in(SINGLETON);
     }
 }

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
@@ -25,18 +25,22 @@ import okhttp3.OkHttpClient;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
+import javax.inject.Inject;
+
 import java.net.URI;
 import java.security.Principal;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_TRANSACTION_ID;
 import static com.facebook.presto.client.StatementClientFactory.newStatementClient;
 import static com.facebook.presto.router.scheduler.HttpRequestSessionContext.getResourceEstimates;
 import static com.facebook.presto.router.scheduler.HttpRequestSessionContext.getSerializedSessionFunctions;
 import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
 
 public class PlanCheckerRouterPluginPrestoClient
 {
@@ -45,19 +49,25 @@ public class PlanCheckerRouterPluginPrestoClient
     private static final CounterStat javaClusterRedirectRequests = new CounterStat();
     private static final CounterStat nativeClusterRedirectRequests = new CounterStat();
     private final OkHttpClient httpClient = new OkHttpClient();
-    private final URI planCheckerClusterURI;
+    private final AtomicInteger planCheckerClusterCandidateIndex = new AtomicInteger(0);
+    private final List<URI> planCheckerClusterCandidates;
     private final URI javaRouterURI;
     private final URI nativeRouterURI;
     private final Duration clientRequestTimeout;
     private final boolean javaClusterFallbackEnabled;
 
-    public PlanCheckerRouterPluginPrestoClient(URI planCheckerClusterURI, URI javaRouterURI, URI nativeRouterURI, Duration clientRequestTimeout, boolean javaClusterFallbackEnabled)
+    @Inject
+    public PlanCheckerRouterPluginPrestoClient(PlanCheckerRouterPluginConfig planCheckerRouterPluginConfig)
     {
-        this.planCheckerClusterURI = planCheckerClusterURI;
-        this.javaRouterURI = javaRouterURI;
-        this.nativeRouterURI = nativeRouterURI;
-        this.clientRequestTimeout = clientRequestTimeout;
-        this.javaClusterFallbackEnabled = javaClusterFallbackEnabled;
+        requireNonNull(planCheckerRouterPluginConfig, "planCheckerRouterPluginConfig is null");
+        this.planCheckerClusterCandidates =
+                requireNonNull(planCheckerRouterPluginConfig.getPlanCheckClustersURIs(), "planCheckerClusterCandidates is null");
+        this.javaRouterURI =
+                requireNonNull(planCheckerRouterPluginConfig.getJavaRouterURI(), "javaRouterURI is null");
+        this.nativeRouterURI =
+                requireNonNull(planCheckerRouterPluginConfig.getNativeRouterURI(), "nativeRouterURI is null");
+        this.clientRequestTimeout = planCheckerRouterPluginConfig.getClientRequestTimeout();
+        this.javaClusterFallbackEnabled = planCheckerRouterPluginConfig.isJavaClusterFallbackEnabled();
     }
 
     public Optional<URI> getCompatibleClusterURI(Map<String, List<String>> headers, String statement, Principal principal)
@@ -137,7 +147,7 @@ public class PlanCheckerRouterPluginPrestoClient
                         principal);
 
         return new ClientSession(
-                planCheckerClusterURI,
+                getPlanCheckerClusterDestination(),
                 sessionContext.getIdentity().getUser(),
                 sessionContext.getSource(),
                 Optional.empty(),
@@ -158,5 +168,11 @@ public class PlanCheckerRouterPluginPrestoClient
                 getSerializedSessionFunctions(sessionContext),
                 ImmutableMap.of(), // todo: do we need custom headers?
                 true);
+    }
+
+    private URI getPlanCheckerClusterDestination()
+    {
+        int currentIndex = planCheckerClusterCandidateIndex.getAndUpdate(i -> (i + 1) % planCheckerClusterCandidates.size());
+        return planCheckerClusterCandidates.get(currentIndex);
     }
 }

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginScheduler.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginScheduler.java
@@ -36,6 +36,7 @@ public class PlanCheckerRouterPluginScheduler
     private final URI javaRouterURI;
     private final URI nativeRouterURI;
     private final Duration clientRequestTimeout;
+    private final boolean javaClusterFallbackEnabled;
 
     @Inject
     public PlanCheckerRouterPluginScheduler(PlanCheckerRouterPluginConfig planCheckerRouterConfig)
@@ -48,12 +49,13 @@ public class PlanCheckerRouterPluginScheduler
         this.nativeRouterURI =
                 requireNonNull(planCheckerRouterConfig.getNativeRouterURI(), "nativeRouterURI is null");
         this.clientRequestTimeout = planCheckerRouterConfig.getClientRequestTimeout();
+        this.javaClusterFallbackEnabled = planCheckerRouterConfig.isJavaClusterFallbackEnabled();
     }
 
     @Override
     public Optional<URI> getDestination(RouterRequestInfo routerRequestInfo)
     {
-        PlanCheckerRouterPluginPrestoClient planCheckerPrestoClient = new PlanCheckerRouterPluginPrestoClient(getValidatorDestination(), javaRouterURI, nativeRouterURI, clientRequestTimeout);
+        PlanCheckerRouterPluginPrestoClient planCheckerPrestoClient = new PlanCheckerRouterPluginPrestoClient(getValidatorDestination(), javaRouterURI, nativeRouterURI, clientRequestTimeout, javaClusterFallbackEnabled);
         return planCheckerPrestoClient.getCompatibleClusterURI(routerRequestInfo.getHeaders(), routerRequestInfo.getQuery(), routerRequestInfo.getPrincipal());
     }
 

--- a/presto-plan-checker-router-plugin/src/test/java/com/facebook/presto/router/scheduler/TestPlanCheckerProviderRouterPluginConfig.java
+++ b/presto-plan-checker-router-plugin/src/test/java/com/facebook/presto/router/scheduler/TestPlanCheckerProviderRouterPluginConfig.java
@@ -35,7 +35,8 @@ public class TestPlanCheckerProviderRouterPluginConfig
                 .setJavaRouterURI(null)
                 .setNativeRouterURI(null)
                 .setPlanCheckClustersURIs(null)
-                .setClientRequestTimeout(new Duration(2, MINUTES)));
+                .setClientRequestTimeout(new Duration(2, MINUTES))
+                .setJavaClusterFallbackEnabled(false));
     }
 
     @Test
@@ -47,12 +48,14 @@ public class TestPlanCheckerProviderRouterPluginConfig
                 .put("router-native-url", "192.168.0.2")
                 .put("plan-check-clusters-uris", "192.168.0.3, 192.168.0.4")
                 .put("client-request-timeout", "5m")
+                .put("enable-java-cluster-fallback", "true")
                 .build();
         PlanCheckerRouterPluginConfig expected = new PlanCheckerRouterPluginConfig()
                 .setJavaRouterURI(new URI("192.168.0.1"))
                 .setNativeRouterURI(new URI("192.168.0.2"))
                 .setPlanCheckClustersURIs("192.168.0.3, 192.168.0.4")
-                .setClientRequestTimeout(new Duration(5, MINUTES));
+                .setClientRequestTimeout(new Duration(5, MINUTES))
+                .setJavaClusterFallbackEnabled(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-plan-checker-router-plugin/src/test/java/com/facebook/presto/router/scheduler/TestPlanCheckerRouterPlugin.java
+++ b/presto-plan-checker-router-plugin/src/test/java/com/facebook/presto/router/scheduler/TestPlanCheckerRouterPlugin.java
@@ -103,8 +103,9 @@ public class TestPlanCheckerRouterPlugin
     @Test
     public void testPlanCheckerPluginWithNativeCompatibleQueries()
     {
-        Scheduler scheduler = new PlanCheckerRouterPluginScheduler(planCheckerRouterConfig);
-        scheduler.setCandidates(planCheckerRouterConfig.getPlanCheckClustersURIs());
+        PlanCheckerRouterPluginPrestoClient planCheckerRouterPluginPrestoClient =
+                new PlanCheckerRouterPluginPrestoClient(planCheckerRouterConfig);
+        Scheduler scheduler = new PlanCheckerRouterPluginScheduler(planCheckerRouterPluginPrestoClient);
 
         // native compatible query
         Optional<URI> target = scheduler.getDestination(
@@ -122,8 +123,9 @@ public class TestPlanCheckerRouterPlugin
     @Test
     public void testPlanCheckerPluginWithNativeIncompatibleQueries()
     {
-        Scheduler scheduler = new PlanCheckerRouterPluginScheduler(planCheckerRouterConfig);
-        scheduler.setCandidates(planCheckerRouterConfig.getPlanCheckClustersURIs());
+        PlanCheckerRouterPluginPrestoClient planCheckerRouterPluginPrestoClient =
+                new PlanCheckerRouterPluginPrestoClient(planCheckerRouterConfig);
+        Scheduler scheduler = new PlanCheckerRouterPluginScheduler(planCheckerRouterPluginPrestoClient);
 
         // native incompatible query
         Optional<URI> target = scheduler.getDestination(


### PR DESCRIPTION
## Description
Add config property to enable fallback to Java cluster router when plan checker clusters are unreachable

## Motivation and Context
If the plan checker clusters are unreachable, there needs to be a way to ensure proper functioning of the plan-check-router-plugin. We introduce a config property which routers to the underlying Java cluster router when such a scenario happens. Without this property, if plan checker clusters are unreachable we have a hard failure.

## Impact
`presto-plan-checker-router-scheduler-plugin
`
## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

