### PR TITLE
CI: Skip prestocpp builds for PRs that only modify presto-docs

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -3,6 +3,8 @@ name: prestocpp-linux-build-and-unit-test
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
   push:
     branches:
       - master

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -3,6 +3,8 @@ name: prestocpp-linux-build
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'presto-docs/**'
 
 jobs:
   prestocpp-linux-build-engine:


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Skip prestocpp builds for PRs that only modify presto-docs

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

