### PR TITLE
Upgrade mongodb java driver from 3.6.0 to 3.12.14

### DIFF
--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <mongo-java.version>3.6.0</mongo-java.version>
+        <mongo-java.version>3.12.14</mongo-java.version>
         <mongo-server.version>1.5.0</mongo-server.version>
     </properties>
 

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -583,8 +583,8 @@ public class MongoSession
         Document newColumn = new Document()
                 .append(FIELDS_NAME_KEY, columnMetadata.getName())
                 .append(FIELDS_TYPE_KEY, columnMetadata.getType().getTypeSignature().toString())
-                .append(COMMENT_KEY, columnMetadata.getComment())
                 .append(FIELDS_HIDDEN_KEY, false);
+        columnMetadata.getComment().ifPresent(comment -> newColumn.append(COMMENT_KEY, comment));
         columns.add(newColumn);
 
         metadata.append(FIELDS_KEY, columns);


### PR DESCRIPTION
## Description
Upgrade mongodb java driver from 3.6.0 to 3.12.14

## Motivation and Context
This PR upgrades the MongoDB driver from `mongo-java-driver:3.6.0` to `3.12.14`.

`mongo-java-driver:3.6.0` attempts to authenticate using the `SCRAM-SHA-1` mechanism, which are disabled on recent MongoDB deployments. This results in authentication errors and timeout during query execution. Upgrading to `3.12.14` resolves this by enabling support for `SCRAM-SHA-256` modern authentication mechanism.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

MongoDb Connector Changes
* Upgrade mongodb java driver to 3.12.14.
```

