### PR TITLE
Migrate maven publishing service from OSSRH to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2938,22 +2938,14 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <!-- This plugin must be configured manually ("Maven 2" style in the docs) due to the usage of the
-                             Maven Provisio plugin, which includes its own deployment lifecycle -->
-                        <executions>
-                            <execution>
-                                <id>default-deploy</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <publishingServerId>ossrh</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>validated</waitUntil>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
## Description

Migrate maven publishing service from OSSRH to Central Portal

## Motivation and Context

By the OSSRH Sunset Notice on https://central.sonatype.org/publish/publish-maven/

The legacy OSSRH publishing service will be sunset on June 30th, 2025. This documentation is for informational purposes and will be removed at that time. If you are currently publishing via this service, please migrate to the new [Central Portal Publisher Service](https://central.sonatype.org/publish/publish-portal-guide/).

## Impact

Presto maven artifacts

## Test Plan

Test locally, the package can be signed, upload return 401 as expected without the publishing user/token.
Do full test with next release

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

