### PR TITLE
Enhance PruneUnreferencedOutputs for index join

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -326,12 +326,20 @@ public class PruneUnreferencedOutputs
         @Override
         public PlanNode visitIndexJoin(IndexJoinNode node, RewriteContext<Set<VariableReferenceExpression>> context)
         {
+            Set<VariableReferenceExpression> expectedFilterInputs = new HashSet<>();
+            if (node.getFilter().isPresent()) {
+                expectedFilterInputs = ImmutableSet.<VariableReferenceExpression>builder()
+                        .addAll(VariablesExtractor.extractUnique(node.getFilter().get()))
+                        .build();
+            }
+
             ImmutableSet.Builder<VariableReferenceExpression> probeInputsBuilder = ImmutableSet.builder();
             probeInputsBuilder.addAll(context.get())
                     .addAll(Iterables.transform(node.getCriteria(), IndexJoinNode.EquiJoinClause::getProbe));
             if (node.getProbeHashVariable().isPresent()) {
                 probeInputsBuilder.add(node.getProbeHashVariable().get());
             }
+            probeInputsBuilder.addAll(expectedFilterInputs);
             Set<VariableReferenceExpression> probeInputs = probeInputsBuilder.build();
 
             ImmutableSet.Builder<VariableReferenceExpression> indexInputBuilder = ImmutableSet.builder();
@@ -340,6 +348,7 @@ public class PruneUnreferencedOutputs
             if (node.getIndexHashVariable().isPresent()) {
                 indexInputBuilder.add(node.getIndexHashVariable().get());
             }
+            indexInputBuilder.addAll(expectedFilterInputs);
             Set<VariableReferenceExpression> indexInputs = indexInputBuilder.build();
 
             PlanNode probeSource = context.rewrite(node.getProbeSource(), probeInputs);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -187,6 +187,22 @@ public final class PlanMatchPattern
                 .with(new IndexSourceMatcher(expectedTableName));
     }
 
+    public static PlanMatchPattern indexSource(String expectedTableName, Map<String, String> columnReferences)
+    {
+        return node(IndexSourceNode.class)
+                .with(new IndexSourceMatcher(expectedTableName))
+                .addColumnReferences(expectedTableName, columnReferences);
+    }
+
+    public static PlanMatchPattern strictIndexSource(String expectedTableName, Map<String, String> columnReferences)
+    {
+        return node(IndexSourceNode.class)
+                .with(new IndexSourceMatcher(expectedTableName))
+                .withExactAssignedOutputs(columnReferences.values().stream()
+                        .map(columnName -> columnReference(expectedTableName, columnName))
+                        .collect(toImmutableList()));
+    }
+
     public static PlanMatchPattern constrainedIndexSource(String expectedTableName, Map<String, Domain> constraint, Map<String, String> columnReferences)
     {
         return node(IndexSourceNode.class)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -845,7 +845,16 @@ public class PlanBuilder
         return new JoinNode(Optional.empty(), idAllocator.getNextId(), type, left, right, criteria, outputVariables, filter, leftHashVariable, rightHashVariable, distributionType, dynamicFilters);
     }
 
-    public PlanNode indexJoin(JoinType type, TableScanNode probe, TableScanNode index)
+    public PlanNode indexJoin(JoinType type, PlanNode probe, PlanNode index)
+    {
+        return indexJoin(type, probe, index, emptyList(), Optional.empty());
+    }
+
+    public PlanNode indexJoin(JoinType type,
+            PlanNode probe,
+            PlanNode index,
+            List<IndexJoinNode.EquiJoinClause> criteria,
+            Optional<RowExpression> filter)
     {
         return new IndexJoinNode(
                 Optional.empty(),
@@ -853,8 +862,8 @@ public class PlanBuilder
                 type,
                 probe,
                 index,
-                emptyList(),
-                Optional.empty(),
+                criteria,
+                filter,
                 Optional.empty(),
                 Optional.empty());
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
@@ -14,9 +14,13 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.DataOrganizationSpecification;
+import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.WindowNode;
@@ -25,25 +29,35 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.assertions.OptimizerAssert;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.IndexJoinNode;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.plan.WindowNode.Frame.BoundType.UNBOUNDED_FOLLOWING;
 import static com.facebook.presto.spi.plan.WindowNode.Frame.BoundType.UNBOUNDED_PRECEDING;
 import static com.facebook.presto.spi.plan.WindowNode.Frame.WindowType.RANGE;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.except;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.indexJoin;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.intersect;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictIndexSource;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictTableScan;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCALE_FACTOR;
 
 public class TestPruneUnreferencedOutputs
         extends BaseRuleTest
@@ -138,6 +152,46 @@ public class TestPruneUnreferencedOutputs
                                         except(
                                                 values("nationkey", "regionkey"),
                                                 values("regionkey_6")))));
+    }
+
+    @Test
+    public void testIndexJoinNodePruning()
+    {
+        assertRuleApplication()
+                .on(p ->
+                        p.output(ImmutableList.of("totoalprice"), ImmutableList.of(p.variable("totoalprice")),
+                                p.indexJoin(JoinType.LEFT,
+                                        p.tableScan(
+                                                new TableHandle(
+                                                        new ConnectorId("local"),
+                                                        new TpchTableHandle("lineitem", TINY_SCALE_FACTOR),
+                                                        TestingTransactionHandle.create(),
+                                                        Optional.empty()),
+                                                ImmutableList.of(p.variable("partkey"), p.variable("suppkey")),
+                                                ImmutableMap.of(
+                                                        p.variable("partkey", BIGINT), new TpchColumnHandle("partkey", BIGINT),
+                                                        p.variable("suppkey", BIGINT), new TpchColumnHandle("suppkey", BIGINT))),
+                                        p.indexSource(
+                                                new TableHandle(
+                                                        new ConnectorId("local"),
+                                                        new TpchTableHandle("orders", TINY_SCALE_FACTOR),
+                                                        TestingTransactionHandle.create(),
+                                                        Optional.empty()),
+                                                ImmutableSet.of(p.variable("custkey"), p.variable("orderkey"), p.variable("orderstatus", VARCHAR)),
+                                                ImmutableList.of(p.variable("custkey"), p.variable("orderkey"), p.variable("orderstatus", VARCHAR), p.variable("totalprice", DOUBLE)),
+                                                ImmutableMap.of(
+                                                        p.variable("custkey", BIGINT), new TpchColumnHandle("custkey", BIGINT),
+                                                        p.variable("orderkey", BIGINT), new TpchColumnHandle("orderkey", BIGINT),
+                                                        p.variable("totalprice", DOUBLE), new TpchColumnHandle("totalprice", DOUBLE),
+                                                        p.variable("orderstatus", VARCHAR), new TpchColumnHandle("orderstatus", VARCHAR)),
+                                                TupleDomain.all()),
+                                        ImmutableList.of(new IndexJoinNode.EquiJoinClause(p.variable("partkey", BIGINT), p.variable("orderkey", BIGINT))),
+                                        Optional.of(p.rowExpression("custkey BETWEEN suppkey AND 20")))))
+                .matches(
+                        output(
+                                indexJoin(
+                                        strictTableScan("lineitem", ImmutableMap.of("partkey", "partkey", "suppkey", "suppkey")),
+                                        strictIndexSource("orders", ImmutableMap.of("custkey", "custkey", "orderkey", "orderkey")))));
     }
 
     private OptimizerAssert assertRuleApplication()


### PR DESCRIPTION
Index join has been extended to support filter which must not be pruned by PruneUnreferencedOutputs optimizer.

```
== NO RELEASE NOTE ==
```

