### PR TITLE
Enable subfield pushdown for map when key is negative

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -1463,6 +1463,18 @@ public class TestHiveLogicalPlanner
     }
 
     @Test
+    public void testPushdownNegativeSubfiels()
+    {
+        assertUpdate("CREATE TABLE test_pushdown_subfields_negative_key(id bigint, arr array(bigint), mp map(integer, varchar))");
+        assertPushdownSubfields("select element_at(arr, -1) from test_pushdown_subfields_negative_key", "test_pushdown_subfields_negative_key", ImmutableMap.of("arr", toSubfields()));
+        assertPushdownSubfields("select element_at(mp, -1) from test_pushdown_subfields_negative_key", "test_pushdown_subfields_negative_key", ImmutableMap.of("mp", toSubfields("mp[-1]")));
+        assertPushdownSubfields("select element_at(arr, -1), element_at(arr, 2) from test_pushdown_subfields_negative_key", "test_pushdown_subfields_negative_key", ImmutableMap.of("arr", toSubfields()));
+        assertPushdownSubfields("select element_at(mp, -1), element_at(mp, 2) from test_pushdown_subfields_negative_key", "test_pushdown_subfields_negative_key", ImmutableMap.of("mp", toSubfields("mp[-1]", "mp[2]")));
+
+        assertUpdate("DROP TABLE test_pushdown_subfields_negative_key");
+    }
+
+    @Test
     public void testPushdownSubfieldsForMapSubset()
     {
         Session mapSubset = Session.builder(getSession()).setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET, "true").build();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -638,7 +638,7 @@ public class PushdownSubfields
                         if (index instanceof Number) {
                             //Fix for issue https://github.com/prestodb/presto/issues/22690
                             //Avoid negative index pushdown
-                            if (((Number) index).longValue() < 0) {
+                            if (((Number) index).longValue() < 0 && arguments.get(0).getType() instanceof ArrayType) {
                                 return Optional.empty();
                             }
 


### PR DESCRIPTION
## Description
When fixing this issue https://github.com/prestodb/presto/issues/22690 where array subscripts is negative index, the PR https://github.com/prestodb/presto/pull/23479 also disabled it for map with negative keys too. However, subfield pushdown is working for map with negative keys. This PR fix it by enabling subfield pushdown for map with negative subscripts.

## Motivation and Context
As in description

## Impact
Enable subfield pushdown for map with negative keys

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix PushdownSubfields optimizer to enable subfield pushdown for maps which is accessed with negative keys
```


