### PR TITLE
Extend subfield pushdown to handle map_filter

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -21,6 +21,7 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import com.google.common.collect.ImmutableSet;
+import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -28,6 +29,8 @@ import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.CTE_MATERIALIZATION_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.CTE_PARTITIONING_PROVIDER_CATALOG;
+import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS;
 import static com.facebook.presto.SystemSessionProperties.VERBOSE_OPTIMIZER_INFO_ENABLED;
 import static com.facebook.presto.sql.tree.ExplainType.Type.LOGICAL;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -114,6 +117,174 @@ public class TestHiveDistributedQueries
 
         checkCTEInfo(explain, "tbl", 2, false, true);
         checkCTEInfo(explain, "tbl2", 1, false, true);
+    }
+
+    @Test
+    public void testPushdownSubfieldForMapFunctionsInLambda()
+    {
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, "true")
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "true")
+                .build();
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, "false")
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "false")
+                .build();
+        try {
+            getQueryRunner().execute(
+                    "CREATE TABLE test_pushdown_subfields AS\n" +
+                            "SELECT * FROM (\n" +
+                            "  VALUES \n" +
+                            "    (3, '2025-01-08', \n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY[-2, 1], ARRAY[0.34, 0.92]),\n" +
+                            "        MAP(ARRAY[3, 4], ARRAY[0.12, 0.88])\n" +
+                            "      ],\n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY['a', 'b'], ARRAY[0.56, 0.44]),\n" +
+                            "        MAP(ARRAY['c', 'd'], ARRAY[0.90, 0.10])\n" +
+                            "      ]\n" +
+                            "    ),\n" +
+                            "    (1, '2025-01-02', \n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY[1, 2], ARRAY[0.23, 0.45]),\n" +
+                            "        MAP(ARRAY[5, 6], ARRAY[0.67, 0.89])\n" +
+                            "      ],\n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY['x', 'y'], ARRAY[0.78, 0.22]),\n" +
+                            "        MAP(ARRAY['z', 'w'], ARRAY[0.11, 0.99])\n" +
+                            "      ]\n" +
+                            "    ),\n" +
+                            "    (7, '2025-01-17', \n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY[-1, 0], ARRAY[0.60, 0.70]),\n" +
+                            "        MAP(ARRAY[2, 3], ARRAY[0.21, 0.79])\n" +
+                            "      ],\n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY['m', 'n'], ARRAY[0.43, 0.57]),\n" +
+                            "        MAP(ARRAY['o', 'p'], ARRAY[0.25, 0.75])\n" +
+                            "      ]\n" +
+                            "    ),\n" +
+                            "    (2, '2025-01-06', \n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY[4, 5], ARRAY[0.75, 0.32]),\n" +
+                            "        MAP(ARRAY[6, 7], ARRAY[0.19, 0.46])\n" +
+                            "      ],\n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY['q', 'r'], ARRAY[0.98, 0.02]),\n" +
+                            "        MAP(ARRAY['s', 't'], ARRAY[0.49, 0.51])\n" +
+                            "      ]\n" +
+                            "    ),\n" +
+                            "    (5, '2025-01-14', \n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY[8, 9], ARRAY[0.88, 0.99]),\n" +
+                            "        MAP(ARRAY[10, 11], ARRAY[0.00, 0.33])\n" +
+                            "      ],\n" +
+                            "      ARRAY[\n" +
+                            "        MAP(ARRAY['u', 'v'], ARRAY[0.66, 0.34]),\n" +
+                            "        MAP(ARRAY['w', 'x'], ARRAY[0.17, 0.83])\n" +
+                            "      ]\n" +
+                            "    )\n" +
+                            ") t(id, ds, array_of_maps_int, array_of_maps_str)");
+
+            @Language("SQL") String sql = "select transform(array_of_maps_int, item -> map_filter(item, (k, v) -> k = 1)), " +
+                    "transform(array_of_maps_str, item -> map_filter(item, (k, v) -> k = 'x')) from test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "SELECT \n" +
+                    "  transform(array_of_maps_int, item -> map_filter(item, (k, v) -> contains(array[-2, 1, 0], k))),\n" +
+                    "  transform(array_of_maps_str, item -> map_filter(item, (k, v) -> contains(array['a', 'x'], k)))\n" +
+                    "FROM test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "SELECT \n" +
+                    "  transform(array_of_maps_int, item -> map_subset(item, array[-2, 1, 0])),\n" +
+                    "  transform(array_of_maps_str, item -> map_subset(item, array['a', 'x']))\n" +
+                    "FROM test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "SELECT \n" +
+                    "  transform(array_of_maps_int, item -> map_filter(item, (k, v) -> k in (-2, 1, 0))),\n" +
+                    "  transform(array_of_maps_str, item -> map_filter(item, (k, v) -> k in ('a', 'x')))\n" +
+                    "FROM test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "SELECT \n" +
+                    "  transform(array_of_maps_int, item -> map_filter(item, (k, v) -> k = 1)),\n" +
+                    "  transform(array_of_maps_str, item -> map_filter(item, (k, v) -> k = 'a'))\n" +
+                    "FROM test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "SELECT \n" +
+                    "  transform(array_of_maps_int, item -> map_filter(item, (k, v) -> contains(array[-2, 1, id], k))),\n" +
+                    "  transform(array_of_maps_str, item -> map_filter(item, (k, v) -> contains(array['a', 'x'], k)))\n" +
+                    "FROM test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "SELECT \n" +
+                    "  transform(array_of_maps_int, item -> map_subset(item, array[-2, 1, id])),\n" +
+                    "  transform(array_of_maps_str, item -> map_subset(item, array['a', 'x']))\n" +
+                    "FROM test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "SELECT \n" +
+                    "  transform(array_of_maps_int, item -> map_filter(item, (k, v) -> k in (-2, 1, null))),\n" +
+                    "  transform(array_of_maps_str, item -> map_filter(item, (k, v) -> k in ('a', 'x')))\n" +
+                    "FROM test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "SELECT \n" +
+                    "  transform(array_of_maps_int, item -> map_filter(item, (k, v) -> k = id)),\n" +
+                    "  transform(array_of_maps_str, item -> map_filter(item, (k, v) -> k = 'a'))\n" +
+                    "FROM test_pushdown_subfields";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_pushdown_subfields");
+        }
+    }
+
+    @Test
+    public void testPushdownSubfieldForMapFunctions()
+    {
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, "true")
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "true")
+                .build();
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, "false")
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "false")
+                .build();
+        try {
+            getQueryRunner().execute(
+                    "CREATE TABLE test_pushdown_subfields_map_functions AS\n" +
+                            "SELECT * FROM (\n" +
+                            "  VALUES \n" +
+                            "    (3, '2025-01-08', MAP(ARRAY[2, 1], ARRAY[0.34, 0.92]), MAP(ARRAY['a', 'b'], ARRAY[0.12, 0.88])),\n" +
+                            "    (1, '2025-01-02', MAP(ARRAY[1, 3], ARRAY[0.23, 0.5]), MAP(ARRAY['x', 'y'], ARRAY[0.45, 0.55])),\n" +
+                            "    (7, '2025-01-17', MAP(ARRAY[6, 8], ARRAY[0.60, 0.70]), MAP(ARRAY['m', 'n'], ARRAY[0.21, 0.79])),\n" +
+                            "    (2, '2025-01-06', MAP(ARRAY[2, 3, 5, 7], ARRAY[0.75, 0.32, 0.19, 0.46]), MAP(ARRAY['p', 'q', 'r'], ARRAY[0.11, 0.22, 0.67])),\n" +
+                            "    (5, '2025-01-14', MAP(ARRAY[8, 4, 6], ARRAY[0.88, 0.99, 0.00]), MAP(ARRAY['s', 't', 'u'], ARRAY[0.33, 0.44, 0.23])),\n" +
+                            "    (4, '2025-01-12', MAP(ARRAY[7, 3, 2], ARRAY[0.33, 0.44, 0.55]), MAP(ARRAY['v', 'w'], ARRAY[0.66, 0.34])),\n" +
+                            "    (8, '2025-01-20', MAP(ARRAY[1, 7, 6], ARRAY[0.35, 0.45, 0.55]), MAP(ARRAY['i', 'j', 'k'], ARRAY[0.78, 0.89, 0.12])),\n" +
+                            "    (6, '2025-01-16', MAP(ARRAY[9, 1, 3], ARRAY[0.30, 0.40, 0.50]), MAP(ARRAY['c', 'd'], ARRAY[0.90, 0.10])),\n" +
+                            "    (2, '2025-01-05', MAP(ARRAY[3, 4], ARRAY[0.98, 0.21]), MAP(ARRAY['e', 'f'], ARRAY[0.56, 0.44])),\n" +
+                            "    (1, '2025-01-04', MAP(ARRAY[1, 2], ARRAY[0.45, 0.67]), MAP(ARRAY['g', 'h'], ARRAY[0.23, 0.77]))\n" +
+                            ") AS t(id, ds, feature, extra_feature)");
+
+            @Language("SQL") String sql = "select map_filter(feature, (k, v) -> k in (-2, 1, 0)), map_filter(extra_feature, (k, v) -> k in ('a', 'x')) from test_pushdown_subfields_map_functions";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "select map_filter(feature, (k, v) -> contains(array[-2, 1, 0], k)), map_filter(extra_feature, (k, v) -> contains(array['a', 'x'], k)) from test_pushdown_subfields_map_functions";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "select map_filter(feature, (k, v) -> k = 0), map_filter(extra_feature, (k, v) -> k = 'a') from test_pushdown_subfields_map_functions";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "select map_subset(feature, array[-2, 1, 0]), map_subset(extra_feature, array['a', 'x']) from test_pushdown_subfields_map_functions";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+
+            sql = "select map_filter(feature, (k, v) -> k in (-2, 1, id)), map_filter(extra_feature, (k, v) -> k in ('a', 'x')) from test_pushdown_subfields_map_functions";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "select map_filter(feature, (k, v) -> contains(array[-2, 1, id], k)), map_filter(extra_feature, (k, v) -> contains(array['a', 'x', null], k)) from test_pushdown_subfields_map_functions";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "select map_filter(feature, (k, v) -> k = id), map_filter(extra_feature, (k, v) -> k = 'a') from test_pushdown_subfields_map_functions";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+            sql = "select map_subset(feature, array[id]), map_subset(extra_feature, array['a', null]) from test_pushdown_subfields_map_functions";
+            assertQueryWithSameQueryRunner(enabled, sql, disabled);
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS test_pushdown_subfields_map_functions");
+        }
     }
 
     // Hive specific tests should normally go in TestHiveIntegrationSmokeTest

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -84,7 +84,7 @@ import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_METADATA_QUER
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_METADATA_QUERIES_IGNORE_STATS;
 import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_DEREFERENCE_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
-import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET;
+import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.predicate.Domain.create;
 import static com.facebook.presto.common.predicate.Domain.multipleValues;
@@ -1465,7 +1465,7 @@ public class TestHiveLogicalPlanner
     @Test
     public void testPushdownSubfieldsForMapSubset()
     {
-        Session mapSubset = Session.builder(getSession()).setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET, "true").build();
+        Session mapSubset = Session.builder(getSession()).setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, "true").build();
         assertUpdate("CREATE TABLE test_pushdown_map_subfields(id integer, x map(integer, double))");
         assertPushdownSubfields(mapSubset, "SELECT t.id, map_subset(x, array[1, 2, 3]) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
                 ImmutableMap.of("x", toSubfields("x[1]", "x[2]", "x[3]")));
@@ -1496,6 +1496,122 @@ public class TestHiveLogicalPlanner
         assertPushdownSubfields(mapSubset, "SELECT t.id, map_subset(x, array['ab', 'c', 'd', id]) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
                 ImmutableMap.of("x", toSubfields()));
         assertPushdownSubfields(mapSubset, "SELECT t.id, map_subset(x, array[id]) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertUpdate("DROP TABLE test_pushdown_map_subfields");
+    }
+
+    @Test
+    public void testPushdownSubfieldsForMapFilter()
+    {
+        Session mapSubset = Session.builder(getSession()).setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, "true").build();
+        assertUpdate("CREATE TABLE test_pushdown_map_subfields(id integer, x map(integer, double))");
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in (1, 2, 3)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[1]", "x[2]", "x[3]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> v in (1, 2, 3)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array[1, 2, 3], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[1]", "x[2]", "x[3]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array[1, 2, 3], v)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k = 1) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[1]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> v = 1) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> 1 = k) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[1]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> 1 = v) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in (-1, -2, 3)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[-1]", "x[-2]", "x[3]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array[-1, -2, 3], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[-1]", "x[-2]", "x[3]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k=-2) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[-2]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> -2=k) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[-2]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in (1, 2, null)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k is null) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array[1, 2, null], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in (1, 2, 3, id)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array[1, 2, 3, id], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k = id) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> id = k) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in (id)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array[id], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertUpdate("DROP TABLE test_pushdown_map_subfields");
+
+        assertUpdate("CREATE TABLE test_pushdown_map_subfields(id integer, x array(map(integer, double)))");
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> k in (1, 2, 3))) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[*][1]", "x[*][2]", "x[*][3]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> v in (1, 2, 3))) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> contains(array[1, 2, 3], k))) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[*][1]", "x[*][2]", "x[*][3]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> contains(array[1, 2, 3], v))) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> k=2)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[*][2]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> v=2)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> 2=k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[*][2]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> 2=v)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> k in (1, 2, null))) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> contains(array[1, 2, null], k))) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> k in (1, 2, id))) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> k=id)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> id=k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_filter(mp, (k, v) -> contains(array[1, 2, id], k))) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertUpdate("DROP TABLE test_pushdown_map_subfields");
+
+        assertUpdate("CREATE TABLE test_pushdown_map_subfields(id varchar, x map(varchar, varchar))");
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in ('ab', 'c', 'd')) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[\"ab\"]", "x[\"c\"]", "x[\"d\"]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array['ab', 'c', 'd'], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[\"ab\"]", "x[\"c\"]", "x[\"d\"]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k='d') FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[\"d\"]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> 'd'=k) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields("x[\"d\"]")));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> v in ('ab', 'c', 'd')) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array['ab', 'c', 'd'], v)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> v='d') FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> 'd'=v) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in ('ab', 'c', null)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array['ab', 'c', null], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in ('ab', 'c', 'd', id)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k = id) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> id = k) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array['ab', 'c', 'd', id], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k in (id)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of("x", toSubfields()));
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array[id], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
                 ImmutableMap.of("x", toSubfields()));
         assertUpdate("DROP TABLE test_pushdown_map_subfields");
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -337,6 +337,7 @@ public final class SystemSessionProperties
     public static final String REWRITE_MIN_MAX_BY_TO_TOP_N = "rewrite_min_max_by_to_top_n";
     public static final String ADD_DISTINCT_BELOW_SEMI_JOIN_BUILD = "add_distinct_below_semi_join_build";
     public static final String PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET = "pushdown_subfields_for_map_subset";
+    public static final String PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS = "pushdown_subfields_for_map_functions";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -1919,7 +1920,11 @@ public final class SystemSessionProperties
                         false),
                 booleanProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET,
                         "Enable subfield pruning for map_subset function",
-                        featuresConfig.isPushdownSubfieldForMapSubset(),
+                        featuresConfig.isPushdownSubfieldForMapFunctions(),
+                        false),
+                booleanProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS,
+                        "Enable subfield pruning for map functions, currently include map_subset and map_filter",
+                        featuresConfig.isPushdownSubfieldForMapFunctions(),
                         false),
                 new PropertyMetadata<>(
                         QUERY_CLIENT_TIMEOUT,
@@ -3278,6 +3283,11 @@ public final class SystemSessionProperties
     public static boolean isPushSubfieldsForMapSubsetEnabled(Session session)
     {
         return session.getSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET, Boolean.class);
+    }
+
+    public static boolean isPushSubfieldsForMapFunctionsEnabled(Session session)
+    {
+        return session.getSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, Boolean.class);
     }
 
     public static boolean isAddDistinctBelowSemiJoinBuildEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -307,7 +307,7 @@ public class FeaturesConfig
     private String expressionOptimizerName = DEFAULT_EXPRESSION_OPTIMIZER_NAME;
     private boolean addExchangeBelowPartialAggregationOverGroupId;
     private boolean addDistinctBelowSemiJoinBuild;
-    private boolean pushdownSubfieldForMapSubset = true;
+    private boolean pushdownSubfieldForMapFunctions = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -3071,16 +3071,16 @@ public class FeaturesConfig
         return addDistinctBelowSemiJoinBuild;
     }
 
-    @Config("optimizer.pushdown-subfield-for-map-subset")
-    @ConfigDescription("Enable subfield pruning for map_subset function")
-    public FeaturesConfig setPushdownSubfieldForMapSubset(boolean pushdownSubfieldForMapSubset)
+    @Config("optimizer.pushdown-subfield-for-map-functions")
+    @ConfigDescription("Enable subfield pruning for map functions, currently include map_subset and map_filter")
+    public FeaturesConfig setPushdownSubfieldForMapFunctions(boolean pushdownSubfieldForMapFunctions)
     {
-        this.pushdownSubfieldForMapSubset = pushdownSubfieldForMapSubset;
+        this.pushdownSubfieldForMapFunctions = pushdownSubfieldForMapFunctions;
         return this;
     }
 
-    public boolean isPushdownSubfieldForMapSubset()
+    public boolean isPushdownSubfieldForMapFunctions()
     {
-        return pushdownSubfieldForMapSubset;
+        return pushdownSubfieldForMapFunctions;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -431,6 +431,11 @@ public final class FunctionResolution
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(functionAndTypeResolver.qualifyObjectName(QualifiedName.of("map_subset")));
     }
 
+    public boolean isMapFilterFunction(FunctionHandle functionHandle)
+    {
+        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(functionAndTypeResolver.qualifyObjectName(QualifiedName.of("map_filter")));
+    }
+
     @Override
     public FunctionHandle lookupBuiltInFunction(String functionName, List<Type> inputTypes)
     {

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -260,7 +260,7 @@ public class TestFeaturesConfig
                 .setExcludeInvalidWorkerSessionProperties(false)
                 .setAddExchangeBelowPartialAggregationOverGroupId(false)
                 .setAddDistinctBelowSemiJoinBuild(false)
-                .setPushdownSubfieldForMapSubset(true)
+                .setPushdownSubfieldForMapFunctions(true)
                 .setInnerJoinPushdownEnabled(false)
                 .setBroadcastSemiJoinForDelete(true)
                 .setInEqualityJoinPushdownEnabled(false)
@@ -476,7 +476,7 @@ public class TestFeaturesConfig
                 .put("expression-optimizer-name", "custom")
                 .put("exclude-invalid-worker-session-properties", "true")
                 .put("optimizer.add-distinct-below-semi-join-build", "true")
-                .put("optimizer.pushdown-subfield-for-map-subset", "false")
+                .put("optimizer.pushdown-subfield-for-map-functions", "false")
                 .put("optimizer.add-exchange-below-partial-aggregation-over-group-id", "true")
                 .build();
 
@@ -683,7 +683,7 @@ public class TestFeaturesConfig
                 .setExcludeInvalidWorkerSessionProperties(true)
                 .setAddExchangeBelowPartialAggregationOverGroupId(true)
                 .setAddDistinctBelowSemiJoinBuild(true)
-                .setPushdownSubfieldForMapSubset(false)
+                .setPushdownSubfieldForMapFunctions(false)
                 .setInEqualityJoinPushdownEnabled(true)
                 .setBroadcastSemiJoinForDelete(false)
                 .setRewriteMinMaxByToTopNEnabled(true)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -75,8 +75,6 @@ import static com.facebook.presto.SystemSessionProperties.PREFILTER_FOR_GROUPBY_
 import static com.facebook.presto.SystemSessionProperties.PREFILTER_FOR_GROUPBY_LIMIT_TIMEOUT_MS;
 import static com.facebook.presto.SystemSessionProperties.PRE_PROCESS_METADATA_CALLS;
 import static com.facebook.presto.SystemSessionProperties.PULL_EXPRESSION_FROM_LAMBDA_ENABLED;
-import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
-import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET;
 import static com.facebook.presto.SystemSessionProperties.PUSH_DOWN_FILTER_EXPRESSION_EVALUATION_THROUGH_CROSS_JOIN;
 import static com.facebook.presto.SystemSessionProperties.PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID;
 import static com.facebook.presto.SystemSessionProperties.QUICK_DISTINCT_LIMIT_ENABLED;
@@ -8239,56 +8237,6 @@ public abstract class AbstractTestQueries
         result = computeActual(enabled, "explain(type distributed) " + sql);
         assertNotEquals(((String) result.getMaterializedRows().get(0).getField(0)).indexOf("TopNRowNumber"), -1);
 
-        assertQueryWithSameQueryRunner(enabled, sql, disabled);
-    }
-
-    @Test
-    public void testPushdownSubfieldForMapSubset()
-    {
-        Session enabled = Session.builder(getSession())
-                .setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET, "true")
-                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "true")
-                .build();
-        Session disabled = Session.builder(getSession())
-                .setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET, "false")
-                .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "false")
-                .build();
-        @Language("SQL") String sql = "with t as (SELECT * FROM ( VALUES (3, '2025-01-08', MAP(ARRAY[2, 1], ARRAY[0.34, 0.92])), (1, '2025-01-02', MAP(ARRAY[1, 3], ARRAY[0.23, 0.5])), " +
-                "(7, '2025-01-17', MAP(ARRAY[6, 8], ARRAY[0.60, 0.70])), (2, '2025-01-06', MAP(ARRAY[2, 3, 5, 7], ARRAY[0.75, 0.32, 0.19, 0.46])), " +
-                "(5, '2025-01-14', MAP(ARRAY[8, 4, 6], ARRAY[0.88, 0.99, 0.00])), (4, '2025-01-12', MAP(ARRAY[7, 3, 2], ARRAY[0.33, 0.44, 0.55])), " +
-                "(8, '2025-01-20', MAP(ARRAY[1, 7, 6], ARRAY[0.35, 0.45, 0.55])), (6, '2025-01-16', MAP(ARRAY[9, 1, 3], ARRAY[0.30, 0.40, 0.50])), " +
-                "(2, '2025-01-05', MAP(ARRAY[3, 4], ARRAY[0.98, 0.21])), (1, '2025-01-04', MAP(ARRAY[1, 2], ARRAY[0.45, 0.67])), (7, '2025-01-18', MAP(ARRAY[4, 2, 9], ARRAY[0.80, 0.90, 0.10])), " +
-                "(3, '2025-01-10', MAP(ARRAY[4, 1, 8, 6], ARRAY[0.85, 0.13, 0.42, 0.91])), (8, '2025-01-19', MAP(ARRAY[3, 5], ARRAY[0.15, 0.25])), " +
-                "(4, '2025-01-11', MAP(ARRAY[5, 6], ARRAY[0.11, 0.22])), (5, '2025-01-13', MAP(ARRAY[1, 9], ARRAY[0.66, 0.77])), (6, '2025-01-15', MAP(ARRAY[2, 5], ARRAY[0.10, 0.20])) ) " +
-                "t(id, ds, feature)) select map_subset(feature, array[1, 3, 9]) from t";
-        assertQueryWithSameQueryRunner(enabled, sql, disabled);
-
-        sql = "with t as (SELECT * FROM ( VALUES (3, '2025-01-08', MAP(ARRAY[2, 1], ARRAY[0.34, 0.92]), MAP(ARRAY['a', 'b'], ARRAY[0.12, 0.88])), " +
-                "(1, '2025-01-02', MAP(ARRAY[1, 3], ARRAY[0.23, 0.5]), MAP(ARRAY['x', 'y'], ARRAY[0.45, 0.55])), (7, '2025-01-17', MAP(ARRAY[6, 8], ARRAY[0.60, 0.70]), MAP(ARRAY['m', 'n'], ARRAY[0.21, 0.79])), " +
-                "(2, '2025-01-06', MAP(ARRAY[2, 3, 5, 7], ARRAY[0.75, 0.32, 0.19, 0.46]), MAP(ARRAY['p', 'q', 'r'], ARRAY[0.11, 0.22, 0.67])), (5, '2025-01-14', MAP(ARRAY[8, 4, 6], ARRAY[0.88, 0.99, 0.00]), MAP(ARRAY['s', 't', 'u'], ARRAY[0.33, 0.44, 0.23])), " +
-                "(4, '2025-01-12', MAP(ARRAY[7, 3, 2], ARRAY[0.33, 0.44, 0.55]), MAP(ARRAY['v', 'w'], ARRAY[0.66, 0.34])), (8, '2025-01-20', MAP(ARRAY[1, 7, 6], ARRAY[0.35, 0.45, 0.55]), MAP(ARRAY['i', 'j', 'k'], ARRAY[0.78, 0.89, 0.12])), " +
-                "(6, '2025-01-16', MAP(ARRAY[9, 1, 3], ARRAY[0.30, 0.40, 0.50]), MAP(ARRAY['c', 'd'], ARRAY[0.90, 0.10])), (2, '2025-01-05', MAP(ARRAY[3, 4], ARRAY[0.98, 0.21]), MAP(ARRAY['e', 'f'], ARRAY[0.56, 0.44])), " +
-                "(1, '2025-01-04', MAP(ARRAY[1, 2], ARRAY[0.45, 0.67]), MAP(ARRAY['g', 'h'], ARRAY[0.23, 0.77])) ) t(id, ds, feature, extra_feature)) " +
-                "select map_subset(feature, array[-2, 1, 0]), map_subset(extra_feature, array['a', 'x']) from t";
-        assertQueryWithSameQueryRunner(enabled, sql, disabled);
-
-        sql = "with t as (SELECT * FROM ( VALUES (3, '2025-01-08', MAP(ARRAY[-2, -1], ARRAY[0.34, 0.92])), (1, '2025-01-02', MAP(ARRAY[1, 3], ARRAY[0.23, 0.5])), " +
-                "(7, '2025-01-17', MAP(ARRAY[6, 8], ARRAY[0.60, 0.70])), (2, '2025-01-06', MAP(ARRAY[2, 3, 5, 7], ARRAY[0.75, 0.32, 0.19, 0.46])), " +
-                "(5, '2025-01-14', MAP(ARRAY[-8, 4, 6], ARRAY[0.88, 0.99, 0.00])), (4, '2025-01-12', MAP(ARRAY[7, 3, 2], ARRAY[0.33, 0.44, 0.55])), " +
-                "(8, '2025-01-20', MAP(ARRAY[-1, 7, 6], ARRAY[0.35, 0.45, 0.55])), (6, '2025-01-16', MAP(ARRAY[9, 1, 3], ARRAY[0.30, 0.40, 0.50])), " +
-                "(2, '2025-01-05', MAP(ARRAY[3, 4], ARRAY[0.98, 0.21])), (1, '2025-01-04', MAP(ARRAY[1, -2], ARRAY[0.45, 0.67])), (7, '2025-01-18', MAP(ARRAY[4, 2, 9], ARRAY[0.80, 0.90, 0.10])), " +
-                "(3, '2025-01-10', MAP(ARRAY[4, 1, 8, -6], ARRAY[0.85, 0.13, 0.42, 0.91])), (8, '2025-01-19', MAP(ARRAY[3, 5], ARRAY[0.15, 0.25])), " +
-                "(4, '2025-01-11', MAP(ARRAY[5, 6], ARRAY[0.11, 0.22])), (5, '2025-01-13', MAP(ARRAY[1, 9], ARRAY[0.66, 0.77])), (6, '2025-01-15', MAP(ARRAY[2, 5], ARRAY[0.10, 0.20])) ) " +
-                "t(id, ds, feature)) select map_subset(feature, array[-1, -2, 5]) from t";
-        assertQueryWithSameQueryRunner(enabled, sql, disabled);
-
-        sql = "with t as (SELECT * FROM ( VALUES (3, '2025-01-08', MAP(ARRAY[-2, 1], ARRAY[0.34, 0.92]), MAP(ARRAY['a', 'b'], ARRAY[0.12, 0.88])), " +
-                "(1, '2025-01-02', MAP(ARRAY[1, 3], ARRAY[0.23, 0.5]), MAP(ARRAY['x', 'y'], ARRAY[0.45, 0.55])), (7, '2025-01-17', MAP(ARRAY[6, 8], ARRAY[0.60, 0.70]), MAP(ARRAY['m', 'n'], ARRAY[0.21, 0.79])), " +
-                "(2, '2025-01-06', MAP(ARRAY[2, 3, 5, -7], ARRAY[0.75, 0.32, 0.19, 0.46]), MAP(ARRAY['p', 'q', 'r'], ARRAY[0.11, 0.22, 0.67])), (5, '2025-01-14', MAP(ARRAY[8, 4, 6], ARRAY[0.88, 0.99, 0.00]), MAP(ARRAY['s', 't', 'u'], ARRAY[0.33, 0.44, 0.23])), " +
-                "(4, '2025-01-12', MAP(ARRAY[7, 3, 2], ARRAY[0.33, 0.44, 0.55]), MAP(ARRAY['v', 'w'], ARRAY[0.66, 0.34])), (8, '2025-01-20', MAP(ARRAY[1, 7, 6], ARRAY[0.35, 0.45, 0.55]), MAP(ARRAY['i', 'j', 'k'], ARRAY[0.78, 0.89, 0.12])), " +
-                "(6, '2025-01-16', MAP(ARRAY[9, 1, 3], ARRAY[0.30, 0.40, 0.50]), MAP(ARRAY['c', 'd'], ARRAY[0.90, 0.10])), (2, '2025-01-05', MAP(ARRAY[3, 4], ARRAY[0.98, 0.21]), MAP(ARRAY['e', 'f'], ARRAY[0.56, 0.44])), " +
-                "(1, '2025-01-04', MAP(ARRAY[1, -2], ARRAY[0.45, 0.67]), MAP(ARRAY['g', 'h'], ARRAY[0.23, 0.77])) ) t(id, ds, feature, extra_feature)) " +
-                "select map_subset(feature, array[-2, 1, 0]), map_subset(extra_feature, array['a', 'x']) from t";
         assertQueryWithSameQueryRunner(enabled, sql, disabled);
     }
 


### PR DESCRIPTION
## Description
Yet another case found after https://github.com/prestodb/presto/pull/25394
`map_filter()` function is another commonly used function to extract features in ML workload.
In the production queries, two common use cases are `map_filter(feature, (k, v) -> k in (1, 2, 3))` and `map_filter(feature, (k, v) -> contains(array[1, 2, 3], k))`, which only access feature maps where keys are 1, 2 and 3.
In the production queries I found, applying this optimization reduce latency by 64% and overall resource usage by 82% ([original](https://www.internalfb.com/intern/presto/query/?query_id=20250626_094450_36097_gcpm6) vs. [optimized](https://www.internalfb.com/intern/presto/query/?query_id=20250626_184616_62804_gcpm6))

## Motivation and Context
Pushdown subfields for map_filter function and improve performance

## Impact
Observe 64% reduction in latency and 82% reduction in overall resource usage in one production query.

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve query resource usage by enabling subfield pushdown for :func:`map_filter` when selected keys are constants. 
```

