### PR TITLE
CI: Disable prestocpp tests triggered on push/merge to master

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -5,11 +5,6 @@ on:
   pull_request:
     paths-ignore:
       - 'presto-docs/**'
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - 'presto-docs/**'
 
 jobs:
   prestocpp-linux-build-for-test:


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Disable PrestoCPP tests triggered on push/merge to master

Slack: https://prestodb.slack.com/archives/CLYMEEJ6S/p1751235926923909

```
== NO RELEASE NOTE ==
```

