### PR TITLE
[docs] Add documentation for offset configuration and session properties

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -93,6 +93,16 @@ be executed within a single node.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`single-node-execution-enabled\`\``.
 
+``offset_clause_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+To enable the ``OFFSET`` clause in SQL query expressions, set this property to ``true``.
+
+The corresponding configuration property is :ref:`admin/properties:\`\`offset-clause-enabled\`\``.
+
 Spilling Properties
 -------------------
 

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -117,6 +117,16 @@ Note: The default value can cause errors when large session properties
 or other large session information is involved. 
 See :ref:`troubleshoot/query:\`\`Request Header Fields Too Large\`\``.
 
+``offset-clause-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+To enable the ``OFFSET`` clause in SQL query expressions, set this property to ``true``.
+
+The corresponding session property is :ref:`admin/properties-session:\`\`offset_clause_enabled\`\``. 
+
 Memory Management Properties
 ----------------------------
 


### PR DESCRIPTION
## Description
Add doc for `offset-clause-enabled` and `offset_clause_enabled` configuration and session properties. Fixes #25453. 

## Motivation and Context
In [a comment](https://github.com/prestodb/presto/pull/25216#issuecomment-3005688511) on #25216, @xieandrew mentioned 
_Separately, it may be important to document the offset_clause_enabled session prop and offset-clause-enabled configuration prop since those are needed by the user to actually use the main feature this fix relates to. I only see those properties in a release note: https://prestodb.io/docs/current/release/release-0.257.html#general-changes_. 

## Impact
Documentation. 

## Test Plan
Local doc builds. Screenshots: 

Configuration property `offset-clause-enabled`
<img width="631" alt="Screenshot 2025-06-30 at 3 12 34 PM" src="https://github.com/user-attachments/assets/a371db01-228d-4690-99ae-b8b5bd0a4fdd" />

Session property `offset_clause_enabled`
<img width="632" alt="Screenshot 2025-06-30 at 3 12 39 PM" src="https://github.com/user-attachments/assets/7962ee37-a77b-4de5-ae50-37a2ad4600e5" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

