### PR TITLE
CI: Skip prestocpp builds for PRs that only modify presto-docs

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -3,8 +3,6 @@ name: prestocpp-linux-build-and-unit-test
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - 'presto-docs/**'
   push:
     branches:
       - master
@@ -12,8 +10,26 @@ on:
       - 'presto-docs/**'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!presto-docs/**'
+
   prestocpp-linux-build-for-test:
     runs-on: ubuntu-22.04
+    needs: changes
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     concurrency:
@@ -92,7 +108,7 @@ jobs:
             presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
 
   prestocpp-linux-presto-e2e-tests:
-    needs: prestocpp-linux-build-for-test
+    needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
@@ -167,7 +183,7 @@ jobs:
             -T1C
 
   prestocpp-linux-presto-native-tests:
-    needs: prestocpp-linux-build-for-test
+    needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -245,7 +261,7 @@ jobs:
             -T1C
 
   prestocpp-linux-presto-sidecar-tests:
-    needs: prestocpp-linux-build-for-test
+    needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
@@ -314,7 +330,7 @@ jobs:
             -T1C
 
   prestocpp-linux-presto-plan-checker-router-plugin-tests:
-    needs: prestocpp-linux-build-for-test
+    needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -3,12 +3,28 @@ name: prestocpp-linux-build
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - 'presto-docs/**'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          codechange:
+            - '!presto-docs/**'
+
   prestocpp-linux-build-engine:
     runs-on: ubuntu-22.04
+    needs: changes
     container:
       image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
     concurrency:


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Use jobs.<job_id>.if to control job execution instead of on.pull_request.paths-ignore. This ensures that skipped jobs are marked as Success rather than remaining in a Pending state.

Slack: https://prestodb.slack.com/archives/CLYMEEJ6S/p1751299584003649

```
== NO RELEASE NOTE ==
```

