### PR TITLE
Enable push down subfields from lambda in related test case

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.SystemSessionProperties.CTE_MATERIALIZATION_ST
 import static com.facebook.presto.SystemSessionProperties.CTE_PARTITIONING_PROVIDER_CATALOG;
 import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS;
+import static com.facebook.presto.SystemSessionProperties.PUSHDOWN_SUBFIELDS_FROM_LAMBDA_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.VERBOSE_OPTIMIZER_INFO_ENABLED;
 import static com.facebook.presto.sql.tree.ExplainType.Type.LOGICAL;
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -125,10 +126,12 @@ public class TestHiveDistributedQueries
         Session enabled = Session.builder(getSession())
                 .setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, "true")
                 .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "true")
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_FROM_LAMBDA_ENABLED, "true")
                 .build();
         Session disabled = Session.builder(getSession())
                 .setSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, "false")
                 .setSystemProperty(PUSHDOWN_SUBFIELDS_ENABLED, "false")
+                .setSystemProperty(PUSHDOWN_SUBFIELDS_FROM_LAMBDA_ENABLED, "false")
                 .build();
         try {
             getQueryRunner().execute(


### PR DESCRIPTION
## Description

PR #25451 added `TestHiveDistributedQueries.testPushdownSubfieldForMapFunctionsInLambda` to test subfields pushdown for map functions in lambda expression. However, the pushing down would not actually happen without set session property `PUSHDOWN_SUBFIELDS_FROM_LAMBDA_ENABLED` to 'true'. This PR set the target sessions' `PUSHDOWN_SUBFIELDS_FROM_LAMBDA_ENABLED` to appropriate values, so that the pushing down behavior would act as expected.

## Motivation and Context

N/A

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

