### PR TITLE
[native] Optimize Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,23 +7,20 @@ ARG JMX_PROMETHEUS_JAVAAGENT_VERSION=0.20.0
 
 ENV PRESTO_HOME="/opt/presto-server"
 
-COPY $PRESTO_PKG .
-COPY $PRESTO_CLI_JAR /opt/presto-cli
-
-RUN dnf install -y java-11-openjdk less procps python3 \
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    dnf install -y java-11-openjdk less procps python3 \
     && ln -s $(which python3) /usr/bin/python \
-    # Download Presto and move \
-    && tar -zxf $PRESTO_PKG \
-    && mv ./presto-server-$PRESTO_VERSION $PRESTO_HOME \
-    && rm -rf $PRESTO_PKG \
-    && rm -rf ./presto-server-$PRESTO_VERSION \
-    && chmod +x /opt/presto-cli \
-    && ln -s /opt/presto-cli /usr/local/bin/ \
     # clean cache jobs
-    && mv /etc/yum/protected.d/systemd.conf /etc/yum/protected.d/systemd.conf.bak \
-    && dnf clean all \
+    && mv /etc/yum/protected.d/systemd.conf /etc/yum/protected.d/systemd.conf.bak
+
+COPY --chmod=755 $PRESTO_CLI_JAR /opt/presto-cli
+
+RUN --mount=type=bind,source=$PRESTO_PKG,target=/$PRESTO_PKG \
+    # Download Presto and move \
+    mkdir -p "$PRESTO_HOME" && \
+    tar --strip-components=1 -C "$PRESTO_HOME" -zxf /$PRESTO_PKG \
+    && ln -s /opt/presto-cli /usr/local/bin/ \
     #  mkdir for config
-    && mkdir -p $PRESTO_HOME/etc \
     && mkdir -p $PRESTO_HOME/etc/catalog \
     && mkdir -p /var/lib/presto/data \
         && mkdir -p /usr/lib/presto/utils \
@@ -37,5 +34,7 @@ COPY etc/catalog $PRESTO_HOME/etc/catalog
 COPY entrypoint.sh /opt
 
 EXPOSE 8080
+
+VOLUME ["/var/lib/presto/data"]
 
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
 set -e
+trap 'kill -TERM $app 2>/dev/null' TERM
 
-$PRESTO_HOME/bin/launcher run
+$PRESTO_HOME/bin/launcher run &
+app=$!
+wait $app


### PR DESCRIPTION
## Description

Changes in `Dockerfile` commands to optimize the container image.

Additionally, uses `trap` to forward the TERM signal (stop) to the application, instead of waiting until KILL.

## Motivation and Context

💾 Saves ~500MB in Docker image, and makes updates even faster if reusing cached layers (eg. keep `java` version)

## Impact

Pulling the image will be faster.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve and optimize Docker image layers
```