### PR TITLE
Handle binary varying type for newer redshift driver

### DIFF
--- a/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/com/facebook/presto/plugin/redshift/RedshiftClient.java
@@ -19,6 +19,8 @@ import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcIdentity;
+import com.facebook.presto.plugin.jdbc.JdbcTypeHandle;
+import com.facebook.presto.plugin.jdbc.ReadMapping;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
@@ -28,8 +30,10 @@ import javax.inject.Inject;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static com.facebook.presto.plugin.jdbc.StandardReadMappings.varbinaryReadMapping;
 import static java.lang.String.format;
 
 public class RedshiftClient
@@ -65,5 +69,18 @@ public class RedshiftClient
         catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);
         }
+    }
+
+    // Maps "binary varying" (Redshift driver >= 2.1.0.32) to VARBINARY.
+    @Override
+    public Optional<ReadMapping> toPrestoType(ConnectorSession session, JdbcTypeHandle typeHandle)
+    {
+        String typeName = typeHandle.getJdbcTypeName();
+
+        if (typeName.equalsIgnoreCase("binary varying")) {
+            return Optional.of(varbinaryReadMapping());
+        }
+
+        return super.toPrestoType(session, typeHandle);
     }
 }


### PR DESCRIPTION
## Description

> Redshift driver version is 2.1.0.32


```
JdbcTypeHandle {
   jdbcType=1111, 
   jdbcTypeName=binary varying, 
   columnSize=2147483647, 
   decimalDigits=0
}
```

> Redshift driver version is 2.1.0.28

```
JdbcTypeHandle {
    jdbcType = -4,
    jdbcTypeName = "varbyte",
    columnSize = 0,
    decimalDigits = 0,
    arrayDimensions = null
}
```

Newer redshift drivers  uses Types.OTHER (1111) to represent VARBYTE and describes it as "`binary varying`"

| JDBC Driver Version | Reported JDBC Type | JDBC Type Name     |
|---------------------|--------------------|---------------------|
| 2.1.0.28            | -4 (LONGVARBINARY) | "varbyte"           |
| 2.1.0.32            | 1111 (OTHER)       | "binary varying"    |

## Motivation and Context
create table redshift.test.redtest4 (varbincolumn varbinary);

The Redshift JDBC driver returns the JDBC type for VARBYTE columns as:
JdbcTypeHandle{jdbcType=1111, jdbcTypeName=binary varying, columnSize=2147483647, decimalDigits=0} 

This type is not recognized by Presto's default jdbcTypeToPrestoType() mapping,
resulting in the column being ignored as unsupported during DESCRIBE or INSERT queries

**DESCRIBE redshift.test.redtest1; output is:**
```
presto> DESCRIBE redshift.test.redtest1;
 Column | Type | Extra | Comment 
--------+------+-------+---------
(0 rows)

Query 20250626_070357_00001_29zdf, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:36, server-side: 0:36] [0 rows, 0B] [0 rows/s, 0B/s]
```

**SHOW CREATE TABLE redshift.test.redtest1; output is:**
```
presto> SHOW CREATE TABLE redshift.test.redtest1;
Query 20250626_070441_00002_29zdf failed: Table 'test.redtest1' has no supported columns (all 1 columns are not supported)
```
**INSERT query output is:**
```
presto> insert into redshift.test.redtest1 (varbincolumn) values (cast('Test varbinary' as varbinary));
Query 20250626_071129_00006_29zdf failed: Table 'test.redtest1' has no supported columns (all 1 columns are not supported)
```

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Redshift Connector Changes
* Fix Redshift VARBYTE column handling for JDBC driver version 2.1.0.32+ by mapping jdbcType=1111 and jdbcTypeName="binary varying" to Presto's VARBINARY type.

