### PR TITLE
Fix unexpected error and diagram style for query detail page

### DIFF
--- a/presto-ui/src/components/ClusterHUD.jsx
+++ b/presto-ui/src/components/ClusterHUD.jsx
@@ -135,7 +135,7 @@ export class ClusterHUD extends React.Component {
             });
         }
 
-        $('[data-bs-toggle="tooltip"]')?.tooltip();
+        $('[data-bs-toggle="tooltip"]')?.tooltip?.();
     }
 
     render() {

--- a/presto-ui/src/components/LivePlan.jsx
+++ b/presto-ui/src/components/LivePlan.jsx
@@ -307,10 +307,12 @@ export class LivePlan extends React.Component<LivePlanProps, LivePlanState> {
         }
     }
 
-    componentDidUpdate() {
-        this.updateD3Graph();
+    componentDidUpdate(prevProps: LivePlanProps, prevState: LivePlanState) {
+        if (this.state.query !== prevState.query) {
+            this.updateD3Graph();
+        }
         //$FlowFixMe
-        $('[data-bs-toggle="tooltip"]')?.tooltip()
+        $('[data-bs-toggle="tooltip"]')?.tooltip?.()
     }
 
     render(): any {

--- a/presto-ui/src/components/QueryDetail.jsx
+++ b/presto-ui/src/components/QueryDetail.jsx
@@ -1115,7 +1115,7 @@ export class QueryDetail extends React.Component {
             });
         }
 
-        $('[data-bs-toggle="tooltip"]')?.tooltip();
+        $('[data-bs-toggle="tooltip"]')?.tooltip?.();
         new Clipboard('.copy-button');
     }
 
@@ -1798,3 +1798,4 @@ export class QueryDetail extends React.Component {
 }
 
 export default QueryDetail;
+

--- a/presto-ui/src/components/ResourceGroupView.jsx
+++ b/presto-ui/src/components/ResourceGroupView.jsx
@@ -233,7 +233,7 @@ export default function ResourceGroupView() {
         $('#agg-running-queries-sparkline').sparkline(dataSet.current.numAggregatedRunningQueries, $.extend({}, SPARKLINE_PROPERTIES, {chartRangeMin: 0}));
         $('#agg-queued-queries-sparkline').sparkline(dataSet.current.numAggregatedQueuedQueries, $.extend({}, SPARKLINE_PROPERTIES, {chartRangeMin: 0}));
         $('#memory-usage-sparkline').sparkline(dataSet.current.memoryUsage, $.extend({}, SPARKLINE_PROPERTIES, {numberFormatter: formatDataSizeBytes}));
-        $('[data-bs-toggle="tooltip"]')?.tooltip();
+        $('[data-bs-toggle="tooltip"]')?.tooltip?.();
         timerid.current = setTimeout(fetchData, 1000);
     }
 

--- a/presto-ui/src/components/WorkerStatus.jsx
+++ b/presto-ui/src/components/WorkerStatus.jsx
@@ -92,7 +92,7 @@ export class WorkerStatus extends React.Component {
         $('#heap-percent-used-sparkline').sparkline(this.state.heapPercentUsed, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {chartRangeMin: 0, numberFormatter: precisionRound}));
         $('#nonheap-used-sparkline').sparkline(this.state.nonHeapUsed, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {chartRangeMin: 0, numberFormatter: formatDataSize}));
 
-        $('[data-bs-toggle="tooltip"]')?.tooltip();
+        $('[data-bs-toggle="tooltip"]')?.tooltip?.();
         new Clipboard('.copy-button');
     }
 

--- a/presto-ui/src/router/ClusterHUD.jsx
+++ b/presto-ui/src/router/ClusterHUD.jsx
@@ -145,7 +145,7 @@ export class ClusterHUD extends React.Component {
             });
         }
 
-        $('[data-bs-toggle="tooltip"]').tooltip();
+        $('[data-bs-toggle="tooltip"]')?.tooltip?.();
     }
 
     render() {


### PR DESCRIPTION
## Description
In some customer env,  there is script erorr about the tooltip function, seems the bootstrap tooltip function not correctly initialized during opening

![image](https://github.com/user-attachments/assets/ab7519a6-4677-4157-ad7d-fbacb426d0b4)

Another issue is about the text inside plan diagram like the screenshot below
![image](https://github.com/user-attachments/assets/3265963d-5304-46ae-b896-21ad2ee73268)


## Motivation and Context
This issue does not happen in all the environment, possible because of the network blocking external site like google fonts(there is a timeout in that env), which cause the document load event not sent quickly.

## Impact
presto ui only

## Test Plan

Local UI test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

