### PR TITLE
[docs] Add that $ is reserved to language/reserved.rst

### DIFF
--- a/presto-docs/src/main/sphinx/language/reserved.rst
+++ b/presto-docs/src/main/sphinx/language/reserved.rst
@@ -6,6 +6,8 @@ The following table lists all of the keywords that are reserved in Presto,
 along with their status in the SQL standard. These reserved keywords must
 be quoted (using double quotes) in order to be used as an identifier.
 
+The use of `$` as a prefix for column names is reserved. This is a convention only and it is not enforced. 
+
 ============================== ============= =============
 Keyword                        SQL:2016      SQL-92
 ============================== ============= =============


### PR DESCRIPTION
## Description
Adding a note that `$` is reserved to [language/reserved.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/language/reserved.rst).

## Motivation and Context
Fixes #22348, see discussion there. 

## Impact
Documentation. 

## Test Plan
Local doc build. See screenshot: the sentences

_The use of $ as a prefix for column names is reserved. This is a convention only and it is not enforced._

are added by this PR. 

<img width="731" alt="Screenshot 2025-07-08 at 10 55 56 AM" src="https://github.com/user-attachments/assets/d36bc9fd-ff4c-4f70-9c62-8e9e5bff36eb" />

I'm open to rephrasing, let me know what you think!


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

