### PR TITLE
Add `connector_name` to `catalogs` system table

### DIFF
--- a/presto-docs/src/main/sphinx/connector/system.rst
+++ b/presto-docs/src/main/sphinx/connector/system.rst
@@ -36,7 +36,40 @@ System Connector Tables
 ``metadata.catalogs``
 ^^^^^^^^^^^^^^^^^^^^^
 
-The catalogs table contains the list of available catalogs.
+The catalogs table contains the list of available catalogs. The columns in ``metadata.catalogs`` are:
+
+======================================= ======================================================================
+Column Name                             Description
+======================================= ======================================================================
+``catalog_name``                        The value of this column is derived from the names of
+                                        catalog.properties files present under ``etc/catalog`` path under
+                                        presto installation directory. Everything except the suffix
+                                        ``.properties`` is treated as the catalog name. For example, if there
+                                        is a file named ``my_catalog.properties``, then ``my_catalog`` will be
+                                        listed as the value for this column.
+
+``connector_id``                        The values in this column are a duplicate of the values in the
+                                        ``catalog_name`` column.
+
+``connector_name``                      This column represents the actual name of the underlying connector
+                                        that a particular catalog is using. This column contains the value of
+                                        ``connector.name`` property from the catalog.properties file.
+======================================= ======================================================================
+
+Example:
+
+Suppose a user configures a single catalog by creating a file named ``my_catalog.properties`` with the
+below contents::
+
+    connector.name=hive-hadoop2
+    hive.metastore.uri=thrift://localhost:9083
+
+``metadata.catalogs`` table will show below output::
+
+    presto> select * from system.metadata.catalogs;
+     catalog_name | connector_id | connector_name
+    --------------+--------------+----------------
+     my_catalog   | my_catalog   | hive-hadoop2
 
 ``metadata.schema_properties``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -215,10 +215,10 @@ public class ConnectorManager
         requireNonNull(connectorName, "connectorName is null");
         ConnectorFactory connectorFactory = connectorFactories.get(connectorName);
         checkArgument(connectorFactory != null, "No factory for connector %s", connectorName);
-        return createConnection(catalogName, connectorFactory, properties);
+        return createConnection(catalogName, connectorFactory, properties, connectorName);
     }
 
-    private synchronized ConnectorId createConnection(String catalogName, ConnectorFactory connectorFactory, Map<String, String> properties)
+    private synchronized ConnectorId createConnection(String catalogName, ConnectorFactory connectorFactory, Map<String, String> properties, String connectorName)
     {
         checkState(!stopped.get(), "ConnectorManager is stopped");
         requireNonNull(catalogName, "catalogName is null");
@@ -229,12 +229,12 @@ public class ConnectorManager
         ConnectorId connectorId = new ConnectorId(catalogName);
         checkState(!connectors.containsKey(connectorId), "A connector %s already exists", connectorId);
 
-        addCatalogConnector(catalogName, connectorId, connectorFactory, properties);
+        addCatalogConnector(catalogName, connectorId, connectorFactory, properties, connectorName);
 
         return connectorId;
     }
 
-    private synchronized void addCatalogConnector(String catalogName, ConnectorId connectorId, ConnectorFactory factory, Map<String, String> properties)
+    private synchronized void addCatalogConnector(String catalogName, ConnectorId connectorId, ConnectorFactory factory, Map<String, String> properties, String connectorName)
     {
         // create all connectors before adding, so a broken connector does not leave the system half updated
         MaterializedConnector connector = new MaterializedConnector(connectorId, createConnector(connectorId, factory, properties));
@@ -269,7 +269,8 @@ public class ConnectorManager
                 informationSchemaConnector.getConnectorId(),
                 informationSchemaConnector.getConnector(),
                 systemConnector.getConnectorId(),
-                systemConnector.getConnector());
+                systemConnector.getConnector(),
+                connectorName);
 
         try {
             addConnectorInternal(connector);

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Catalog.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Catalog.java
@@ -32,6 +32,8 @@ public class Catalog
     private final ConnectorId systemTablesId;
     private final Connector systemTables;
 
+    private final CatalogContext catalogContext;
+
     public Catalog(
             String catalogName,
             ConnectorId connectorId,
@@ -41,6 +43,26 @@ public class Catalog
             ConnectorId systemTablesId,
             Connector systemTables)
     {
+        this(catalogName,
+                connectorId,
+                connector,
+                informationSchemaId,
+                informationSchema,
+                systemTablesId,
+                systemTables,
+                catalogName);
+    }
+
+    public Catalog(
+            String catalogName,
+            ConnectorId connectorId,
+            Connector connector,
+            ConnectorId informationSchemaId,
+            Connector informationSchema,
+            ConnectorId systemTablesId,
+            Connector systemTables,
+            String connectorName)
+    {
         this.catalogName = checkCatalogName(catalogName);
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.connector = requireNonNull(connector, "connector is null");
@@ -48,8 +70,9 @@ public class Catalog
         this.informationSchema = requireNonNull(informationSchema, "informationSchema is null");
         this.systemTablesId = requireNonNull(systemTablesId, "systemTablesId is null");
         this.systemTables = requireNonNull(systemTables, "systemTables is null");
+        requireNonNull(connectorName, "connectorName is null");
+        this.catalogContext = new CatalogContext(catalogName, connectorName);
     }
-
     public String getCatalogName()
     {
         return catalogName;
@@ -58,6 +81,11 @@ public class Catalog
     public ConnectorId getConnectorId()
     {
         return connectorId;
+    }
+
+    public CatalogContext getCatalogContext()
+    {
+        return catalogContext;
     }
 
     public ConnectorId getInformationSchemaId()
@@ -91,5 +119,27 @@ public class Catalog
                 .add("catalogName", catalogName)
                 .add("connectorId", connectorId)
                 .toString();
+    }
+
+    public class CatalogContext
+    {
+        private final String catalogName;
+        private final String connectorName;
+
+        public CatalogContext(String catalogName, String connectorName)
+        {
+            this.catalogName = catalogName;
+            this.connectorName = connectorName;
+        }
+
+        public String getCatalogName()
+        {
+            return catalogName;
+        }
+
+        public String getConnectorName()
+        {
+            return connectorName;
+        }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.metadata.Catalog.CatalogContext;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
@@ -52,6 +53,7 @@ import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 
@@ -359,6 +361,11 @@ public interface Metadata
      * @return Map of catalog name to connector id
      */
     Map<String, ConnectorId> getCatalogNames(Session session);
+
+    default Map<String, CatalogContext> getCatalogNamesWithConnectorContext(Session session)
+    {
+        return ImmutableMap.of();
+    }
 
     /**
      * Get the names that match the specified table prefix (never null).

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataListing.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataListing.java
@@ -15,6 +15,7 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.Catalog.CatalogContext;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.SchemaTableName;
@@ -47,6 +48,20 @@ public final class MetadataListing
 
         ImmutableSortedMap.Builder<String, ConnectorId> result = ImmutableSortedMap.naturalOrder();
         for (Map.Entry<String, ConnectorId> entry : catalogNames.entrySet()) {
+            if (allowedCatalogs.contains(entry.getKey())) {
+                result.put(entry);
+            }
+        }
+        return result.build();
+    }
+
+    public static SortedMap<String, CatalogContext> listCatalogsWithConnectorContext(Session session, Metadata metadata, AccessControl accessControl)
+    {
+        Map<String, CatalogContext> catalogNamesWithConnectorContext = metadata.getCatalogNamesWithConnectorContext(session);
+        Set<String> allowedCatalogs = accessControl.filterCatalogs(session.getIdentity(), session.getAccessControlContext(), catalogNamesWithConnectorContext.keySet());
+
+        ImmutableSortedMap.Builder<String, CatalogContext> result = ImmutableSortedMap.naturalOrder();
+        for (Map.Entry<String, CatalogContext> entry : catalogNamesWithConnectorContext.entrySet()) {
             if (allowedCatalogs.contains(entry.getKey())) {
                 result.put(entry);
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -26,6 +26,7 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.metadata.Catalog.CatalogContext;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorDeleteTableHandle;
@@ -985,6 +986,12 @@ public class MetadataManager
     public Map<String, ConnectorId> getCatalogNames(Session session)
     {
         return transactionManager.getCatalogNames(session.getRequiredTransactionId());
+    }
+
+    @Override
+    public Map<String, CatalogContext> getCatalogNamesWithConnectorContext(Session session)
+    {
+        return transactionManager.getCatalogNamesWithConnectorContext(session.getRequiredTransactionId());
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/transaction/TransactionManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/transaction/TransactionManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.transaction;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.metadata.Catalog.CatalogContext;
 import com.facebook.presto.metadata.CatalogMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -22,6 +23,7 @@ import com.facebook.presto.spi.function.FunctionNamespaceManager;
 import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
@@ -46,6 +48,11 @@ public interface TransactionManager
     TransactionId beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommitContext);
 
     Map<String, ConnectorId> getCatalogNames(TransactionId transactionId);
+
+    default Map<String, CatalogContext> getCatalogNamesWithConnectorContext(TransactionId transactionId)
+    {
+        return ImmutableMap.of();
+    }
 
     Optional<CatalogMetadata> getOptionalCatalogMetadata(TransactionId transactionId, String catalogName);
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/SystemConnectorTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/SystemConnectorTests.java
@@ -108,9 +108,9 @@ public class SystemConnectorTests
     @Test(groups = {SYSTEM_CONNECTOR, JDBC})
     public void selectMetadataCatalogs()
     {
-        String sql = "select catalog_name, connector_id from system.metadata.catalogs";
+        String sql = "select catalog_name, connector_id, connector_name from system.metadata.catalogs";
         assertThat(query(sql))
-                .hasColumns(VARCHAR, VARCHAR)
+                .hasColumns(VARCHAR, VARCHAR, VARCHAR)
                 .hasAnyRows();
     }
 

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -46,6 +46,7 @@ system| metadata| analyze_properties| type| varchar| YES| null| null|
 system| metadata| analyze_properties| description| varchar| YES| null| null|
 system| metadata| catalogs| catalog_name| varchar| YES| null| null|
 system| metadata| catalogs| connector_id| varchar| YES| null| null|
+system| metadata| catalogs| connector_name| varchar| YES| null| null|
 system| metadata| column_properties| catalog_name| varchar| YES| null| null|
 system| metadata| column_properties| property_name| varchar| YES| null| null|
 system| metadata| column_properties| default_value| varchar| YES| null| null|


### PR DESCRIPTION
## Description
`system.metadata.catalogs` table currently displays 2 columns `catalog_name` and `connector_id`, where `catalog_name` is derived from the name of <catalog>.properties file and `connector_id` is just a copy of the same. For example, if a user gives some random name to his catalog.properties file under etc/catalog, say test_catalog.properties, then both `catalog_name` and `connector_id` columns will display `test_catalog` in the output of `select * from system.metadata.catalogs;` query. 
This output is not very intuitive to understand which connector is this catalog tied to. Ideally `connector_id` should be displaying the actual connector name rather than just copying the value from `catalog_name`.

<img width="821" alt="Screenshot 2025-07-09 at 12 29 02 AM" src="https://github.com/user-attachments/assets/c102be48-ce50-4ef4-ae3e-1c9ed847aedc" />


To maintain backwards compatibility, this PR adds a new column `connector_name` in `system.metadata.catalogs` table. This column displays the value of `connector.name` property from <catalog>.properties file and hence gives a proper view of catalog to connector relationship.

<img width="833" alt="Screenshot 2025-07-09 at 12 11 51 AM" src="https://github.com/user-attachments/assets/d4ed9935-9c27-4851-af2a-a3a66202f212" />


## Motivation and Context
Improves the output of catalogs table by displaying the name of connector a particular catalog is using.

## Impact
system.metadata.catalogs table displays one additional column with this PR.

## Test Plan
Manual testing

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

