### PR TITLE
Add DotProduct function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -60,6 +60,20 @@ Mathematical Functions
 
         SELECT l2_squared(ARRAY[1.0], ARRAY[2.0]); -- 1.0
 
+.. function:: dot_product(array(real), array(real)) -> real
+
+    Returns the dot product of two vectors represented as array(real).
+    If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
+
+        SELECT dot_product(ARRAY[1.0, 2.0], ARRAY[3.0, 4.0]); -- 11.0
+
+.. function:: dot_product(array(double), array(double)) -> double
+
+    Returns the dot product of two vectors represented as array(double).
+    If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
+
+        SELECT dot_product(ARRAY[1.0, 2.0], ARRAY[3.0, 4.0]); -- 11.0
+
 .. function:: degrees(x) -> double
 
     Converts angle ``x`` in radians to degrees.

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1466,6 +1466,100 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testArrayDotProduct()
+    {
+        // functionality test
+        assertFunction(
+                "dot_product(array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'], array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'])",
+                DOUBLE, 14.0d);
+        assertFunction(
+                "dot_product(array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'], array[DOUBLE '4.0', DOUBLE '5.0', DOUBLE '6.0'])",
+                DOUBLE, 32.0d);
+        assertFunction(
+                "dot_product(array[DOUBLE '-1.0', DOUBLE '-2.0', DOUBLE '-3.0'], array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'])",
+                DOUBLE, -14.0d);
+        assertFunction(
+                "dot_product(array[DOUBLE '0.0', DOUBLE '0.0', DOUBLE '0.0'], array[DOUBLE '0.0', DOUBLE '0.0', DOUBLE '0.0'])",
+                DOUBLE, 0.0d);
+        // identical size test
+        assertInvalidFunction(
+                "dot_product(array[DOUBLE '1.0', DOUBLE '2.0'], array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'])",
+                "Both array arguments must have identical sizes");
+        // null test
+        assertFunction(
+                "dot_product(CAST(null AS array(double)), array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'])",
+                DOUBLE, null);
+        assertFunction(
+                "dot_product(array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'], CAST(null AS array(double)))",
+                DOUBLE, null);
+        assertFunction(
+                "dot_product(CAST(null AS array(double)), CAST(null AS array(double)))",
+                DOUBLE, null);
+        // any null inside the equal sized arrays must throw error
+        assertInvalidFunction(
+                "dot_product(array[DOUBLE '1.0', null, DOUBLE '3.0'], array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'])",
+                "Both array arguments must not have nulls");
+        assertInvalidFunction(
+                "dot_product(array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'], array[DOUBLE '1.0', null, DOUBLE '3.0'])",
+                "Both array arguments must not have nulls");
+        // NaN test
+        assertFunction("dot_product(array[nan()], array[nan()])",
+                DOUBLE, Double.NaN);
+        // infinity test
+        assertFunction("dot_product(array[infinity()], array[infinity()])",
+                DOUBLE, Double.POSITIVE_INFINITY);
+        assertFunction("dot_product(array[infinity()], array[-1.0])",
+                DOUBLE, Double.NEGATIVE_INFINITY);
+    }
+
+    @Test
+    public void testArrayDotProductReal()
+    {
+        // functionality test
+        assertFunction(
+                "dot_product(array[REAL '1.0', REAL '2.0', REAL '3.0'], array[REAL '1.0', REAL '2.0', REAL '3.0'])",
+                REAL, 14.0f);
+        assertFunction(
+                "dot_product(array[REAL '1.0', REAL '2.0', REAL '3.0'], array[REAL '4.0', REAL '5.0', REAL '6.0'])",
+                REAL, 32.0f);
+        assertFunction(
+                "dot_product(array[REAL '-1.0', REAL '-2.0', REAL '-3.0'], array[REAL '1.0', REAL '2.0', REAL '3.0'])",
+                REAL, -14.0f);
+        assertFunction(
+                "dot_product(array[REAL '0.0', REAL '0.0', REAL '0.0'], array[REAL '0.0', REAL '0.0', REAL '0.0'])",
+                REAL, 0.0f);
+        // identical size test
+        assertInvalidFunction(
+                "dot_product(array[REAL '1.0', REAL '2.0'], array[REAL '1.0', REAL '2.0', REAL '3.0'])",
+                "Both array arguments must have identical sizes");
+        // null test
+        assertFunction(
+                "dot_product(CAST(null AS array(real)), array[REAL '1.0', REAL '2.0', REAL '3.0'])",
+                REAL, null);
+        assertFunction(
+                "dot_product(array[REAL '1.0', REAL '2.0', REAL '3.0'], CAST(null AS array(real)))",
+                REAL, null);
+        assertFunction(
+                "dot_product(CAST(null AS array(real)), CAST(null AS array(real)))",
+                REAL, null);
+        // any null inside the equal sized arrays must throw error
+        assertInvalidFunction(
+                "dot_product(array[REAL '1.0', null, REAL '3.0'], array[REAL '1.0', REAL '2.0', REAL '3.0'])",
+                "Both array arguments must not have nulls");
+        assertInvalidFunction(
+                "dot_product(array[REAL '1.0', REAL '2.0', REAL '3.0'], array[REAL '1.0', null, REAL '3.0'])",
+                "Both array arguments must not have nulls");
+        // NaN test
+        assertFunction("dot_product(array[CAST(nan() AS REAL)], array[CAST(nan() AS REAL)])",
+                REAL, Float.NaN);
+        // infinity test
+        assertFunction("dot_product(array[CAST(infinity() AS REAL)], array[CAST(infinity() AS REAL)])",
+                REAL, Float.POSITIVE_INFINITY);
+        assertFunction("dot_product(array[CAST(infinity() AS REAL)], array[REAL '-1.0'])",
+                REAL, Float.NEGATIVE_INFINITY);
+    }
+
+    @Test
     public void testInverseNormalCdf()
     {
         assertFunction("inverse_normal_cdf(0, 1, 0.3)", DOUBLE, -0.52440051270804089);


### PR DESCRIPTION
## Description
This PR introduces the dot product (dot_product) function between identical sized vectors represented both either as array(real) type or as array(double) type. The dot_product is used to measure similarities between embeddings from models such as [DRAGON](https://huggingface.co/facebook/dragon-plus-context-encoder) that are built using dot product as the similarity measure.

## Motivation and Context
Since we are introducing vector search capabilities into Presto this PR adds another common distance function. This functionality will enable users to perform efficient similarity searches for embedding models that measures similarity using dot products.

## Impact
The addition of the dot_product function will enhance Presto's capabilities in handling embeddings built from dot product similarity and enable users to perform more complex analytics tasks.

## Test Plan
- Unit tests
- Manual tests: running HiveQueryRunner with various input scenarios to ensure correctness and performance.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
General Changes
* Add :func:`dot_product` to calculate to calculate the sum of element wise product between two identically sized vectors represented as arrays. This function supports both array(real) and array(double) input types. For more information, refer to the [Dot Product definition](https://en.wikipedia.org/wiki/Dot_product). 
```