### PR TITLE
[presto] Add runtime stats instrumentation plugin

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeStatsInstrument.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeStatsInstrument.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+public interface RuntimeStatsInstrument
+{
+    void observeMetricValue(String name, RuntimeUnit unit, long value);
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/TestRuntimeStatsInstrument.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestRuntimeStatsInstrument.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestRuntimeStatsInstrument
+        implements RuntimeStatsInstrument
+{
+    private final Map<String, Long> inMemoryMetrics = new HashMap<>();
+
+    public TestRuntimeStatsInstrument(Map<String, String> config) {}
+
+    @Override
+    public void observeMetricValue(String name, RuntimeUnit unit, long value)
+    {
+        inMemoryMetrics.put(name, inMemoryMetrics.getOrDefault(name, 0L) + value);
+    }
+
+    public Long getMetricValue(String name)
+    {
+        return inMemoryMetrics.getOrDefault(name, null);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/runtimestats/RuntimeStatsManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/runtimestats/RuntimeStatsManager.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.runtimestats;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.RuntimeStatsInstrument;
+import com.facebook.presto.spi.RuntimeStatsInstrumentFactory;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RuntimeStatsManager
+{
+    private static final Logger log = Logger.get(RuntimeStatsManager.class);
+    private final List<RuntimeStatsInstrumentFactory> runtimeStatsInstrumentFactories = new ArrayList<>();
+    private final List<RuntimeStatsInstrument> runtimeStatsInstruments = new ArrayList<>();
+
+    @Inject
+    public RuntimeStatsManager() {}
+
+    public void addRuntimeStatsInstrumentFactory(RuntimeStatsInstrumentFactory runtimeStatsInstrumentFactories)
+    {
+        this.runtimeStatsInstrumentFactories.add(runtimeStatsInstrumentFactories);
+    }
+
+    public static RuntimeStats newRuntimeStats()
+    {
+        return new RuntimeStats();
+    }
+
+    public RuntimeStats newRuntimeStatsWithInstruments()
+    {
+        return new RuntimeStats(runtimeStatsInstruments);
+    }
+
+    public void loadRuntimeStatsInstruments()
+    {
+        Map<String, String> config = new HashMap<>();
+        for (RuntimeStatsInstrumentFactory runtimeStatsInstrumentFactory : runtimeStatsInstrumentFactories) {
+            log.info("-- Loading runtime stats instrument factory %s --", runtimeStatsInstrumentFactory.getName());
+            this.runtimeStatsInstruments.add(runtimeStatsInstrumentFactory.createRuntimeStatsInstrument(config));
+            log.info("-- Loaded runtime stats instrument factory %s --", runtimeStatsInstrumentFactory.getName());
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.server;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.presto.spi.NodePoolType;
 import io.airlift.units.Duration;
 
@@ -43,6 +44,7 @@ public class ServerConfig
     private Duration clusterStatsExpirationDuration = new Duration(0, MILLISECONDS);
     private boolean nestedDataSerializationEnabled = true;
     private Duration clusterResourceGroupStateInfoExpirationDuration = new Duration(0, MILLISECONDS);
+    private boolean runtimeStatsInstrumentsEnabled;
 
     public boolean isResourceManager()
     {
@@ -240,5 +242,18 @@ public class ServerConfig
     {
         this.clusterResourceGroupStateInfoExpirationDuration = clusterResourceGroupStateInfoExpirationDuration;
         return this;
+    }
+
+    @Config("runtime-stats-instruments-enabled")
+    @ConfigDescription("Enable monitoring instruments for runtime stats")
+    public ServerConfig setRuntimeStatsInstrumentsEnabled(boolean runtimeStatsInstrumentsEnabled)
+    {
+        this.runtimeStatsInstrumentsEnabled = runtimeStatsInstrumentsEnabled;
+        return this;
+    }
+
+    public boolean isRuntimeStatsInstrumentsEnabled()
+    {
+        return runtimeStatsInstrumentsEnabled;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -122,6 +122,7 @@ import com.facebook.presto.operator.SourceOperatorFactory;
 import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.runtimestats.RuntimeStatsManager;
 import com.facebook.presto.server.NodeStatusNotificationManager;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.PluginManagerConfig;
@@ -549,7 +550,8 @@ public class LocalQueryRunner
                 new NodeStatusNotificationManager(),
                 new ClientRequestFilterManager(),
                 planCheckerProviderManager,
-                expressionOptimizerManager);
+                expressionOptimizerManager,
+                new RuntimeStatsManager());
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());

--- a/presto-main-base/src/test/java/com/facebook/presto/runtimestats/TestRuntimeStatsManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/runtimestats/TestRuntimeStatsManager.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.runtimestats;
+
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.TestRuntimeStatsInstrument;
+import com.facebook.presto.spi.TestRuntimeStatsInstrumentFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestRuntimeStatsManager
+{
+    private RuntimeStatsManager runtimeStatsManager;
+
+    @BeforeClass
+    public void setup()
+    {
+        runtimeStatsManager = new RuntimeStatsManager();
+    }
+
+    @Test
+    public void testStaticNewRuntimeStats()
+    {
+        RuntimeStats runtimeStats = RuntimeStatsManager.newRuntimeStats();
+        assertNotNull(runtimeStats);
+        assertTrue(runtimeStats.getRuntimeStatsInstruments().isEmpty());
+    }
+
+    @Test
+    public void testNewRuntimeStatsWithInstruments()
+    {
+        // case 1: No instrument factory added.
+        RuntimeStats runtimeStats1 = runtimeStatsManager.newRuntimeStatsWithInstruments();
+        assertNotNull(runtimeStats1);
+        assertTrue(runtimeStats1.getRuntimeStatsInstruments().isEmpty());
+
+        // case 2: Instrument factory registered.
+        TestRuntimeStatsInstrumentFactory testRuntimeStatsInstrumentFactory = new TestRuntimeStatsInstrumentFactory();
+        runtimeStatsManager.addRuntimeStatsInstrumentFactory(testRuntimeStatsInstrumentFactory);
+        RuntimeStats runtimeStats2 = runtimeStatsManager.newRuntimeStatsWithInstruments();
+        assertNotNull(runtimeStats2);
+        assertTrue(runtimeStats2.getRuntimeStatsInstruments().isEmpty());
+
+        // case 3: Load instrument factory.
+        runtimeStatsManager.loadRuntimeStatsInstruments();
+        RuntimeStats runtimeStats3 = runtimeStatsManager.newRuntimeStatsWithInstruments();
+        assertNotNull(runtimeStats3);
+        assertFalse(runtimeStats3.getRuntimeStatsInstruments().isEmpty());
+        assertEquals(runtimeStats3.getRuntimeStatsInstruments().size(), 1);
+        assertTrue(runtimeStats3.getRuntimeStatsInstruments().get(0) instanceof TestRuntimeStatsInstrument);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -72,6 +72,7 @@ public class TestServerConfig
                 .put("cluster-stats-expiration-duration", "10s")
                 .put("nested-data-serialization-enabled", "false")
                 .put("cluster-resource-group-state-info-expiration-duration", "10s")
+                .put("runtime-stats-instruments-enabled", "true")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -90,7 +91,8 @@ public class TestServerConfig
                 .setPoolType(LEAF)
                 .setClusterStatsExpirationDuration(new Duration(10, SECONDS))
                 .setNestedDataSerializationEnabled(false)
-                .setClusterResourceGroupStateInfoExpirationDuration(new Duration(10, SECONDS));
+                .setClusterResourceGroupStateInfoExpirationDuration(new Duration(10, SECONDS))
+                .setRuntimeStatsInstrumentsEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session.ResourceEstimateBuilder;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.transaction.TransactionId;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.runtimestats.RuntimeStatsManager;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.AuthorizedIdentity;
@@ -125,11 +126,11 @@ public final class HttpRequestSessionContext
 
     private final Optional<SessionPropertyManager> sessionPropertyManager;
     private final Optional<Tracer> tracer;
-    private final RuntimeStats runtimeStats = new RuntimeStats();
+    private final RuntimeStats runtimeStats;
 
     public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions)
     {
-        this(servletRequest, sqlParserOptions, NoopTracerProvider.NOOP_TRACER_PROVIDER, Optional.empty());
+        this(servletRequest, sqlParserOptions, NoopTracerProvider.NOOP_TRACER_PROVIDER, Optional.empty(), RuntimeStatsManager.newRuntimeStats());
     }
 
     /**
@@ -141,7 +142,8 @@ public final class HttpRequestSessionContext
      * session context creation stage.
      * @throws WebApplicationException
      */
-    public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions, TracerProvider tracerProvider, Optional<SessionPropertyManager> sessionPropertyManager)
+    public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions, TracerProvider tracerProvider, Optional<SessionPropertyManager> sessionPropertyManager,
+            RuntimeStats runtimeStats)
             throws WebApplicationException
     {
         catalog = trimEmptyToNull(servletRequest.getHeader(PRESTO_CATALOG));
@@ -240,6 +242,7 @@ public final class HttpRequestSessionContext
                 traceToken = Optional.ofNullable(tracerHandle.getTraceToken());
             }
         }
+        this.runtimeStats = runtimeStats;
     }
 
     private static Map<String, String> getRequestHeaders(HttpServletRequest servletRequest)

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -49,6 +49,7 @@ import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.metadata.StaticTypeManagerStore;
 import com.facebook.presto.nodeManager.PluginNodeManager;
+import com.facebook.presto.runtimestats.RuntimeStatsManager;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.security.AccessControlModule;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
@@ -192,6 +193,9 @@ public class PrestoServer
             injector.getInstance(NodeStatusNotificationManager.class).loadNodeStatusNotificationProvider();
             injector.getInstance(GracefulShutdownHandler.class).loadNodeStatusNotification();
             injector.getInstance(SessionPropertyManager.class).loadSessionPropertyProviders();
+            if (serverConfig.isRuntimeStatsInstrumentsEnabled()) {
+                injector.getInstance(RuntimeStatsManager.class).loadRuntimeStatsInstruments();
+            }
             PlanCheckerProviderManager planCheckerProviderManager = injector.getInstance(PlanCheckerProviderManager.class);
             InternalNodeManager nodeManager = injector.getInstance(DiscoveryNodeManager.class);
             NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -139,6 +139,7 @@ import com.facebook.presto.resourcemanager.ResourceManagerClusterStatusSender;
 import com.facebook.presto.resourcemanager.ResourceManagerConfig;
 import com.facebook.presto.resourcemanager.ResourceManagerInconsistentException;
 import com.facebook.presto.resourcemanager.ResourceManagerResourceGroupService;
+import com.facebook.presto.runtimestats.RuntimeStatsManager;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
 import com.facebook.presto.server.remotetask.ReactorNettyHttpClientConfig;
 import com.facebook.presto.server.thrift.FixedAddressSelector;
@@ -837,6 +838,9 @@ public class ServerMainModule
                 mapBinder.addBinding("native-worker").to(NativeWorkerSessionPropertyProvider.class).in(Scopes.SINGLETON);
             }
         }
+
+        // RuntimeStats Manager binding.
+        binder.bind(RuntimeStatsManager.class).in(Scopes.SINGLETON);
 
         // Node manager binding
         binder.bind(PluginNodeManager.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -99,6 +99,7 @@ import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.resourcemanager.NoopResourceGroupService;
 import com.facebook.presto.resourcemanager.ResourceGroupService;
+import com.facebook.presto.runtimestats.RuntimeStatsManager;
 import com.facebook.presto.server.NodeStatusNotificationManager;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.PluginManagerConfig;
@@ -488,6 +489,7 @@ public class PrestoSparkModule
         binder.bind(QueryMonitor.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(QueryMonitorConfig.class);
         binder.bind(SplitMonitor.class).in(Scopes.SINGLETON);
+        binder.bind(RuntimeStatsManager.class).in(Scopes.SINGLETON);
 
         // Determine the NodeVersion
         ServerConfig serverConfig = buildConfigObject(ServerConfig.class);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -153,4 +153,9 @@ public interface Plugin
     {
         return emptyList();
     }
+
+    default Iterable<RuntimeStatsInstrumentFactory> getRuntimeStatsInstrumentFactories()
+    {
+        return emptyList();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/RuntimeStatsInstrumentFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/RuntimeStatsInstrumentFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.facebook.presto.common.RuntimeStatsInstrument;
+
+import java.util.Map;
+
+public interface RuntimeStatsInstrumentFactory
+{
+    String getName();
+    RuntimeStatsInstrument createRuntimeStatsInstrument(Map<String, String> config);
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestRuntimeStatsInstrumentFactory.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestRuntimeStatsInstrumentFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.facebook.presto.common.RuntimeStatsInstrument;
+import com.facebook.presto.common.TestRuntimeStatsInstrument;
+
+import java.util.Map;
+
+public class TestRuntimeStatsInstrumentFactory
+        implements RuntimeStatsInstrumentFactory
+{
+    @Override
+    public String getName()
+    {
+        return "test_instrument";
+    }
+
+    @Override
+    public RuntimeStatsInstrument createRuntimeStatsInstrument(Map<String, String> config)
+    {
+        return new TestRuntimeStatsInstrument(config);
+    }
+}


### PR DESCRIPTION
Summary:
This diff adds support for monitoring instruments to track runtime stats through SPI plugin. This will help us analyze performance better and find bottlenecks.

Right now, we can only see runtime stats after a query is finished. This change will also let us monitor runtime stats in real-time.

A few considerations:
1. To make this POC simpler, it is built around the current runtime stats design. However, there's room to improve the instrumentation framework, but that needs more discussion.
2. Only the `addMetricValue` method sends data to the instrument, assuming it can handle aggregations. So, the `mergeMetric` method doesn't call the instrument.
3. As part of this experiment, only runtime stats objects created using `runtimeStatsManager` during query session creation can use the instruments. Other runtime stats objects created later (eg, connectors, tasks, etc.) won't log data to the instrument unless it is passed down by the session.

Differential Revision: D77341223


