### PR TITLE
Add name to pom.xml to fix release validation

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-accumulo</artifactId>
+    <name>presto-accumulo</name>
     <description>Presto - Accumulo Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-atop/pom.xml
+++ b/presto-atop/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-atop</artifactId>
+    <name>presto-atop</name>
     <description>Presto - Atop Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-bigquery</artifactId>
+    <name>presto-bigquery</name>
     <description>Presto - Bigquery Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-blackhole/pom.xml
+++ b/presto-blackhole/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-blackhole</artifactId>
+    <name>presto-blackhole</name>
     <description>Presto - Black Hole Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-cache</artifactId>
+    <name>presto-cache</name>
     <description>Presto cache library</description>
 
     <properties>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-cassandra</artifactId>
+    <name>presto-cassandra</name>
     <description>Presto - Cassandra Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-clickhouse/pom.xml
+++ b/presto-clickhouse/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-clickhouse</artifactId>
+    <name>presto-clickhouse</name>
     <description>Presto - Clickhouse Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-cluster-ttl-providers/pom.xml
+++ b/presto-cluster-ttl-providers/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>presto-cluster-ttl-providers</artifactId>
+    <name>presto-cluster-ttl-providers</name>
     <description>Presto - Cluster Ttl Providers</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-delta</artifactId>
+    <name>presto-delta</name>
     <description>Presto - Delta Table Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-druid</artifactId>
+    <name>presto-druid</name>
     <description>Presto - Druid Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -7,6 +7,7 @@
         <version>0.294-SNAPSHOT</version>
     </parent>
     <artifactId>presto-elasticsearch</artifactId>
+    <name>presto-elasticsearch</name>
     <description>Presto - Elasticsearch Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-example-http/pom.xml
+++ b/presto-example-http/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-example-http</artifactId>
+    <name>presto-example-http</name>
     <description>Presto - Example HTTP Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-function-namespace-managers-common/pom.xml
+++ b/presto-function-namespace-managers-common/pom.xml
@@ -13,6 +13,7 @@
     </properties>
 
     <artifactId>presto-function-namespace-managers-common</artifactId>
+    <name>presto-function-namespace-managers-common</name>
     <dependencies>
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-geospatial-toolkit</artifactId>
+    <name>presto-geospatial-toolkit</name>
     <description>Presto - Geospatial utilities</description>
 
     <properties>

--- a/presto-google-sheets/pom.xml
+++ b/presto-google-sheets/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-google-sheets</artifactId>
+    <name>presto-google-sheets</name>
     <description>Presto - Google Sheets Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-hana/pom.xml
+++ b/presto-hana/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-hana</artifactId>
+    <name>presto-hana</name>
     <description>Presto - HANA Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-hdfs-core/pom.xml
+++ b/presto-hdfs-core/pom.xml
@@ -13,6 +13,7 @@
     </properties>
 
     <artifactId>presto-hdfs-core</artifactId>
+    <name>presto-hdfs-core</name>
     <dependencies>
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-hive-common/pom.xml
+++ b/presto-hive-common/pom.xml
@@ -13,6 +13,7 @@
     </properties>
 
     <artifactId>presto-hive-common</artifactId>
+    <name>presto-hive-common</name>
     <dependencies>
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-hive-function-namespace/pom.xml
+++ b/presto-hive-function-namespace/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-hive-function-namespace</artifactId>
+    <name>presto-hive-function-namespace</name>
     <description>Hive functions for Presto</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-hive-hadoop2</artifactId>
+    <name>presto-hive-hadoop2</name>
     <description>Presto - Hive Connector - Apache Hadoop 2.x</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -7,6 +7,7 @@
         <version>0.294-SNAPSHOT</version>
     </parent>
     <artifactId>presto-hudi</artifactId>
+    <name>presto-hudi</name>
     <description>Presto - Hudi Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-i18n-functions/pom.xml
+++ b/presto-i18n-functions/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-i18n-functions</artifactId>
+    <name>presto-i18n-functions</name>
     <description>Internationalization functions for Presto</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -7,6 +7,7 @@
         <version>0.294-SNAPSHOT</version>
     </parent>
     <artifactId>presto-iceberg</artifactId>
+    <name>presto-iceberg</name>
     <description>Presto - Iceberg Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-jmx/pom.xml
+++ b/presto-jmx/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-jmx</artifactId>
+    <name>presto-jmx</name>
     <description>Presto - JMX Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-kafka</artifactId>
+    <name>presto-kafka</name>
     <description>Presto - Kafka Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-kudu</artifactId>
+    <name>presto-kudu</name>
     <description>Presto - Kudu Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-lark-sheets/pom.xml
+++ b/presto-lark-sheets/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>presto-lark-sheets</artifactId>
+    <name>presto-lark-sheets</name>
     <description>Presto - Lark Sheets Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-local-file/pom.xml
+++ b/presto-local-file/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-local-file</artifactId>
+    <name>presto-local-file</name>
     <description>Presto - Local File Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-memory/pom.xml
+++ b/presto-memory/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-memory</artifactId>
+    <name>presto-memory</name>
     <description>Presto - Memory Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-ml</artifactId>
+    <name>presto-ml</name>
     <description>Presto - Machine Learning Plugin</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-mongodb</artifactId>
+    <name>presto-mongodb</name>
     <description>Presto - mongodb Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-mysql</artifactId>
+    <name>presto-mysql</name>
     <description>Presto - MySQL Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-native-sidecar-plugin</artifactId>
+    <name>presto-native-sidecar-plugin</name>
     <description>Presto - Native Sidecar Plugin</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-node-ttl-fetchers/pom.xml
+++ b/presto-node-ttl-fetchers/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-node-ttl-fetchers</artifactId>
+    <name>presto-node-ttl-fetchers</name>
     <description>Presto - Node Ttl Fetchers</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-open-telemetry/pom.xml
+++ b/presto-open-telemetry/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-open-telemetry</artifactId>
+    <name>presto-open-telemetry</name>
     <description>Presto - Open Telemetry Tracing</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-oracle</artifactId>
+    <name>presto-oracle</name>
     <description>Presto - Oracle Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-password-authenticators/pom.xml
+++ b/presto-password-authenticators/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-password-authenticators</artifactId>
+    <name>presto-password-authenticators</name>
     <description>Presto - Password Authenticators</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-postgresql</artifactId>
+    <name>presto-postgresql</name>
     <description>Presto - PostgreSQL Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-prometheus/pom.xml
+++ b/presto-prometheus/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-prometheus</artifactId>
+    <name>presto-prometheus</name>
     <description>Presto - Prometheus Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-proxy/pom.xml
+++ b/presto-proxy/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-proxy</artifactId>
+    <name>presto-proxy</name>
     <description>Presto - Proxy Service</description>
 
     <properties>

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-redis</artifactId>
+    <name>presto-redis</name>
     <description>Presto - Redis Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-redshift</artifactId>
+    <name>presto-redshift</name>
     <description>Presto - Redshift Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-resource-group-managers</artifactId>
+    <name>presto-resource-group-managers</name>
     <description>Presto - Resource Group Configuration Managers</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-router/pom.xml
+++ b/presto-router/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-router</artifactId>
+    <name>presto-router</name>
     <description>Presto Router</description>
 
     <properties>

--- a/presto-session-property-managers/pom.xml
+++ b/presto-session-property-managers/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-session-property-managers</artifactId>
+    <name>presto-session-property-managers</name>
     <description>Presto - Session Property Managers</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-singlestore/pom.xml
+++ b/presto-singlestore/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-singlestore</artifactId>
+    <name>presto-singlestore</name>
     <description>Presto - SingleStore Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>presto-spark-base</artifactId>
+    <name>presto-spark-base</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>presto-spark-classloader-interface</artifactId>
+    <name>presto-spark-classloader-interface</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>

--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>presto-spark-launcher</artifactId>
+    <name>presto-spark-launcher</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>presto-spark-testing</artifactId>
+    <name>presto-spark-testing</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>

--- a/presto-spark/pom.xml
+++ b/presto-spark/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>presto-spark</artifactId>
+    <name>presto-spark</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>presto-sqlserver</artifactId>
+    <name>presto-sqlserver</name>
     <description>Presto - SQL Server Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-teradata-functions</artifactId>
+    <name>presto-teradata-functions</name>
     <description>Teradata's specific functions for Presto</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-testing-docker/pom.xml
+++ b/presto-testing-docker/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-testing-docker</artifactId>
+    <name>presto-testing-docker</name>
     <description>presto-testing-docker</description>
 
     <properties>

--- a/presto-thrift-api/pom.xml
+++ b/presto-thrift-api/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-thrift-api</artifactId>
+    <name>presto-thrift-api</name>
     <description>Presto - Thrift APIs for Connector and Udf</description>
     <packaging>jar</packaging>
 

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-thrift-connector</artifactId>
+    <name>presto-thrift-connector</name>
     <description>Presto - Thrift Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-thrift-spec/pom.xml
+++ b/presto-thrift-spec/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>presto-thrift-spec</artifactId>
+    <name>presto-thrift-spec</name>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-tpcds</artifactId>
+    <name>presto-tpcds</name>
     <description>Presto - TPC-DS Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-tpch/pom.xml
+++ b/presto-tpch/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-tpch</artifactId>
+    <name>presto-tpch</name>
     <description>Presto - TPC-H Connector</description>
     <packaging>presto-plugin</packaging>
 

--- a/redis-hbo-provider/pom.xml
+++ b/redis-hbo-provider/pom.xml
@@ -14,6 +14,7 @@
     </properties>
 
     <artifactId>redis-hbo-provider</artifactId>
+    <name>redis-hbo-provider</name>
     <packaging>presto-plugin</packaging>
 
     <dependencies>


### PR DESCRIPTION
## Description
When publishing with Central Portal, the validation requires the project name exists in the pom.xml


## Motivation and Context


## Impact
Release

## Test Plan
Test with 0.294

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

