### PR TITLE
Add support for tuple type in the Cassandra connector

### DIFF
--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/NativeCassandraSession.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/NativeCassandraSession.java
@@ -28,6 +28,7 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.TableOptionsMetadata;
 import com.datastax.driver.core.TokenRange;
 import com.datastax.driver.core.VersionNumber;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
@@ -65,6 +66,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
@@ -216,10 +218,10 @@ public class NativeCassandraSession
         }
 
         // check if there is a comment to establish column ordering
-        String comment = tableMeta.getOptions().getComment();
+        Optional<String> comment = Optional.ofNullable(tableMeta.getOptions()).map(TableOptionsMetadata::getComment);
         Set<String> hiddenColumns = ImmutableSet.of();
-        if (comment != null && comment.startsWith(PRESTO_COMMENT_METADATA)) {
-            String columnOrderingString = comment.substring(PRESTO_COMMENT_METADATA.length());
+        if (comment.isPresent() && comment.get().startsWith(PRESTO_COMMENT_METADATA)) {
+            String columnOrderingString = comment.get().substring(PRESTO_COMMENT_METADATA.length());
 
             // column ordering
             List<ExtraColumnMetadata> extras = extraColumnMetadataCodec.fromJson(columnOrderingString);
@@ -361,7 +363,7 @@ public class NativeCassandraSession
     {
         CassandraType cassandraType = CassandraType.getCassandraType(columnMeta.getType().getName());
         List<CassandraType> typeArguments = null;
-        if (cassandraType != null && cassandraType.getTypeArgumentSize() > 0) {
+        if (cassandraType.getTypeArgumentSize() > 0) {
             List<DataType> typeArgs = columnMeta.getType().getTypeArguments();
             switch (cassandraType.getTypeArgumentSize()) {
                 case 1:

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraServer.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraServer.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cassandra;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.facebook.airlift.json.JsonCodec;
@@ -58,6 +59,7 @@ public class CassandraServer
     private final GenericContainer<?> dockerContainer;
 
     private final CassandraSession session;
+    private final Metadata metadata;
 
     public CassandraServer()
             throws Exception
@@ -82,6 +84,7 @@ public class CassandraServer
                 JsonCodec.listJsonCodec(ExtraColumnMetadata.class),
                 cluster,
                 new Duration(1, MINUTES));
+        this.metadata = cluster.getMetadata();
 
         try {
             checkConnectivity(session);
@@ -115,6 +118,11 @@ public class CassandraServer
     public CassandraSession getSession()
     {
         return requireNonNull(session, "cluster is null");
+    }
+
+    public Metadata getMetadata()
+    {
+        return metadata;
     }
 
     public String getHost()

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
@@ -110,7 +110,7 @@ public class TestCassandraConnector
         this.server = new CassandraServer();
 
         String keyspace = "test_connector";
-        createTestTables(server.getSession(), keyspace, DATE);
+        createTestTables(server.getSession(), server.getMetadata(), keyspace, DATE);
 
         String connectorId = "cassandra-test";
         CassandraConnectorFactory connectorFactory = new CassandraConnectorFactory(connectorId);

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -96,7 +96,7 @@ public class TestCassandraIntegrationSmokeTest
         CassandraServer server = new CassandraServer();
         this.server = server;
         this.session = server.getSession();
-        createTestTables(session, KEYSPACE, DATE_TIME_LOCAL);
+        createTestTables(session, server.getMetadata(), KEYSPACE, DATE_TIME_LOCAL);
         return createCassandraQueryRunner(server);
     }
 

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -220,6 +220,7 @@ SET<?>            VARCHAR
 TEXT              VARCHAR
 TIMESTAMP         TIMESTAMP
 TIMEUUID          VARCHAR
+TUPLE             VARCHAR
 VARCHAR           VARCHAR
 VARINT            VARCHAR
 SMALLINT          INTEGER
@@ -230,7 +231,7 @@ DATE              DATE
 Any collection (LIST/MAP/SET) can be designated as FROZEN, and the value is
 mapped to VARCHAR. Additionally, blobs have the limitation that they cannot be empty.
 
-Types not mentioned in the table above are not supported (e.g. tuple or UDT).
+Data types not listed in the table above, such as UDT, are not supported.
 
 Partition keys can only be of the following types:
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This adds support to read columns of type tuple from Cassandra as VARCHAR. Remaining unsupported types will now throw a NotSupportedException error instead of failing a null pointer check.

From https://github.com/prestodb/presto/issues/25515

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Previously get a null check exception if reading a tuple type.
```
java.lang.RuntimeException: cassandraType is null

	at com.facebook.presto.tests.AbstractTestingPrestoClient.execute(AbstractTestingPrestoClient.java:126)
	...
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
Caused by: java.lang.NullPointerException: cassandraType is null
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at com.facebook.presto.cassandra.CassandraColumnHandle.<init>(CassandraColumnHandle.java:62)
	at com.facebook.presto.cassandra.NativeCassandraSession.buildColumnHandle(NativeCassandraSession.java:388)
	at com.facebook.presto.cassandra.NativeCassandraSession.getTable(NativeCassandraSession.java:259)
```

Error for unsupported types will now look like:
```
java.lang.RuntimeException: Unsupported Cassandra type: udt

	at com.facebook.presto.tests.AbstractTestingPrestoClient.execute(AbstractTestingPrestoClient.java:126)
	...
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:105)
Caused by: com.facebook.presto.common.NotSupportedException: Unsupported Cassandra type: udt
	at com.facebook.presto.cassandra.CassandraType.getCassandraType(CassandraType.java:174)
	at com.facebook.presto.cassandra.NativeCassandraSession.buildColumnHandle(NativeCassandraSession.java:364)
	at com.facebook.presto.cassandra.NativeCassandraSession.getTable(NativeCassandraSession.java:261)
```
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Added tuple type to existing unit tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Cassandra Connector Changes
* Add support to read TUPLE type as a Presto VARCHAR
```


