### PR TITLE
Support native non-equal lookup join planning

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -506,7 +506,8 @@ public class HashGenerationOptimizer
                             node.getCriteria(),
                             node.getFilter(),
                             Optional.of(probeHashVariable),
-                            Optional.of(indexHashVariable)),
+                            Optional.of(indexHashVariable),
+                            node.getLookupVariables()),
                     allHashVariables);
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -349,6 +349,8 @@ public class PruneUnreferencedOutputs
                 indexInputBuilder.add(node.getIndexHashVariable().get());
             }
             indexInputBuilder.addAll(expectedFilterInputs);
+            // Lookup variables must not be pruned.
+            indexInputBuilder.addAll(node.getLookupVariables());
             Set<VariableReferenceExpression> indexInputs = indexInputBuilder.build();
 
             PlanNode probeSource = context.rewrite(node.getProbeSource(), probeInputs);
@@ -364,7 +366,8 @@ public class PruneUnreferencedOutputs
                     node.getCriteria(),
                     node.getFilter(),
                     node.getProbeHashVariable(),
-                    node.getIndexHashVariable());
+                    node.getIndexHashVariable(),
+                    node.getLookupVariables());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -660,7 +660,8 @@ public class UnaliasSymbolReferences
                     canonicalizeIndexJoinCriteria(node.getCriteria()),
                     node.getFilter().map(this::canonicalize),
                     canonicalize(node.getProbeHashVariable()),
-                    canonicalize(node.getIndexHashVariable()));
+                    canonicalize(node.getIndexHashVariable()),
+                    node.getLookupVariables());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/IndexJoinNode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/IndexJoinNode.java
@@ -42,6 +42,7 @@ public class IndexJoinNode
     private final Optional<RowExpression> filter;
     private final Optional<VariableReferenceExpression> probeHashVariable;
     private final Optional<VariableReferenceExpression> indexHashVariable;
+    private final List<VariableReferenceExpression> lookupVariables;
 
     @JsonCreator
     public IndexJoinNode(
@@ -53,7 +54,8 @@ public class IndexJoinNode
             @JsonProperty("criteria") List<EquiJoinClause> criteria,
             @JsonProperty("filter") Optional<RowExpression> filter,
             @JsonProperty("probeHashVariable") Optional<VariableReferenceExpression> probeHashVariable,
-            @JsonProperty("indexHashVariable") Optional<VariableReferenceExpression> indexHashVariable)
+            @JsonProperty("indexHashVariable") Optional<VariableReferenceExpression> indexHashVariable,
+            @JsonProperty("lookupVariables") List<VariableReferenceExpression> lookupVariables)
     {
         this(sourceLocation,
                 id,
@@ -64,7 +66,8 @@ public class IndexJoinNode
                 criteria,
                 filter,
                 probeHashVariable,
-                indexHashVariable);
+                indexHashVariable,
+                lookupVariables);
     }
 
     public IndexJoinNode(
@@ -77,7 +80,8 @@ public class IndexJoinNode
             List<EquiJoinClause> criteria,
             Optional<RowExpression> filter,
             Optional<VariableReferenceExpression> probeHashVariable,
-            Optional<VariableReferenceExpression> indexHashVariable)
+            Optional<VariableReferenceExpression> indexHashVariable,
+            List<VariableReferenceExpression> lookupVariables)
     {
         super(sourceLocation, id, statsEquivalentPlanNode);
         this.type = requireNonNull(type, "type is null");
@@ -87,6 +91,7 @@ public class IndexJoinNode
         this.filter = requireNonNull(filter, "filter is null");
         this.probeHashVariable = requireNonNull(probeHashVariable, "probeHashVariable is null");
         this.indexHashVariable = requireNonNull(indexHashVariable, "indexHashVariable is null");
+        this.lookupVariables = requireNonNull(lookupVariables, "lookupVariables is null");
     }
 
     @JsonProperty
@@ -131,6 +136,12 @@ public class IndexJoinNode
         return indexHashVariable;
     }
 
+    @JsonProperty
+    public List<VariableReferenceExpression> getLookupVariables()
+    {
+        return lookupVariables;
+    }
+
     @Override
     public List<PlanNode> getSources()
     {
@@ -166,7 +177,8 @@ public class IndexJoinNode
                 criteria,
                 filter,
                 probeHashVariable,
-                indexHashVariable);
+                indexHashVariable,
+                lookupVariables);
     }
 
     @Override
@@ -182,7 +194,8 @@ public class IndexJoinNode
                 criteria,
                 filter,
                 probeHashVariable,
-                indexHashVariable);
+                indexHashVariable,
+                lookupVariables);
     }
 
     public static class EquiJoinClause

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -472,9 +472,7 @@ public final class ValidateDependenciesChecker
                 checkArgument(indexSourceInputs.contains(clause.getIndex()), "Index variable from index join clause (%s) not in index source (%s)", clause.getIndex(), node.getIndexSource().getOutputVariables());
             }
 
-            Set<VariableReferenceExpression> lookupVariables = node.getCriteria().stream()
-                    .map(IndexJoinNode.EquiJoinClause::getIndex)
-                    .collect(toImmutableSet());
+            Set<VariableReferenceExpression> lookupVariables = ImmutableSet.copyOf(node.getLookupVariables());
             Map<VariableReferenceExpression, VariableReferenceExpression> trace = IndexKeyTracer.trace(node.getIndexSource(), lookupVariables);
             checkArgument(!trace.isEmpty() && lookupVariables.containsAll(trace.keySet()),
                     "Index lookup symbols are not traceable to index source: %s",

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -865,7 +865,8 @@ public class PlanBuilder
                 criteria,
                 filter,
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                index.getOutputVariables());
     }
 
     public CteProducerNode cteProducerNode(String ctename,

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
@@ -191,7 +191,8 @@ public class TestPruneUnreferencedOutputs
                         output(
                                 indexJoin(
                                         strictTableScan("lineitem", ImmutableMap.of("partkey", "partkey", "suppkey", "suppkey")),
-                                        strictIndexSource("orders", ImmutableMap.of("custkey", "custkey", "orderkey", "orderkey")))));
+                                        strictIndexSource("orders",
+                                                ImmutableMap.of("custkey", "custkey", "orderkey", "orderkey", "orderstatus", "orderstatus", "totalprice", "totalprice")))));
     }
 
     private OptimizerAssert assertRuleApplication()

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestNativeIndexJoinLogicalPlanner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestNativeIndexJoinLogicalPlanner.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.tpch.IndexedTpchPlugin;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_HASH_GENERATION;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.indexJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.indexSource;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.AbstractTestIndexedQueries.INDEX_SPEC;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+public class TestNativeIndexJoinLogicalPlanner
+        extends AbstractTestQueryFramework
+{
+    public static final List<String> SUPPORTED_JOIN_TYPES = ImmutableList.of("INNER", "LEFT");
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch_indexed")
+                .setSchema(TINY_SCHEMA_NAME)
+                .setSystemProperty(NATIVE_EXECUTION_ENABLED, "true")
+                .setSystemProperty(OPTIMIZE_HASH_GENERATION, "false")
+                .build();
+
+        DistributedQueryRunner queryRunner = new DistributedQueryRunner.Builder(session)
+                .setNodeCount(1)
+                .build();
+
+        queryRunner.installPlugin(new IndexedTpchPlugin(INDEX_SPEC));
+        queryRunner.createCatalog("tpch_indexed", "tpch_indexed");
+        return queryRunner;
+    }
+
+    @Test
+    public void testBasicIndexJoin()
+    {
+        for (String joinType : SUPPORTED_JOIN_TYPES) {
+            assertPlan("" +
+                            "SELECT *\n" +
+                            "FROM (\n" +
+                            "  SELECT *\n" +
+                            "  FROM lineitem\n" +
+                            "  WHERE partkey % 8 = 0) l\n" +
+                            joinType + " JOIN orders o\n" +
+                            "  ON l.orderkey = o.orderkey",
+                    anyTree(indexJoin(
+                            filter(tableScan("lineitem")),
+                            indexSource("orders"))));
+
+            assertPlan("" +
+                            "SELECT *\n" +
+                            "FROM (\n" +
+                            "  SELECT CASE WHEN suppkey % 2 = 0 THEN 'F' ELSE 'O' END AS orderstatus, *\n" +
+                            "  FROM lineitem\n" +
+                            "  WHERE partkey % 8 = 0) l\n" +
+                            joinType + " JOIN orders o\n" +
+                            "  ON l.orderkey = o.orderkey\n" +
+                            "  AND l.orderstatus = o.orderstatus",
+                    anyTree(indexJoin(
+                            project(filter(tableScan("lineitem"))),
+                            indexSource("orders"))));
+        }
+    }
+
+    @Test
+    public void testNonEqualIndexJoin()
+    {
+        for (String joinType : SUPPORTED_JOIN_TYPES) {
+            assertPlan("" +
+                            "SELECT *\n" +
+                            "FROM (\n" +
+                            "  SELECT *\n" +
+                            "  FROM lineitem\n" +
+                            "  WHERE partkey % 8 = 0) l\n" +
+                            joinType + " JOIN orders o\n" +
+                            "  ON l.orderkey = o.orderkey" +
+                            "  AND o.custkey BETWEEN 1 AND l.partkey",
+                    anyTree(indexJoin(
+                            filter(tableScan("lineitem")),
+                            indexSource("orders"))));
+
+            assertPlan("" +
+                            "SELECT *\n" +
+                            "FROM (\n" +
+                            "  SELECT *\n" +
+                            "  FROM lineitem\n" +
+                            "  WHERE partkey % 8 = 0) l\n" +
+                            joinType + " JOIN orders o\n" +
+                            "  ON l.orderkey = o.orderkey" +
+                            "  AND CONTAINS(ARRAY[1, l.partkey, 3], o.custkey)",
+                    anyTree(indexJoin(
+                            filter(tableScan("lineitem")),
+                            indexSource("orders"))));
+
+            assertPlan("" +
+                            "SELECT *\n" +
+                            "FROM (\n" +
+                            "  SELECT *\n" +
+                            "  FROM lineitem\n" +
+                            "  WHERE partkey % 8 = 0) l\n" +
+                            joinType + " JOIN orders o\n" +
+                            "  ON l.orderkey = o.orderkey" +
+                            "  AND o.custkey BETWEEN 1 AND 100",
+                    anyTree(indexJoin(
+                            filter(tableScan("lineitem")),
+                            filter(indexSource("orders")))));
+
+            assertPlan("" +
+                            "SELECT *\n" +
+                            "FROM (\n" +
+                            "  SELECT *\n" +
+                            "  FROM lineitem\n" +
+                            "  WHERE partkey % 8 = 0) l\n" +
+                            joinType + " JOIN orders o\n" +
+                            "  ON l.orderkey = o.orderkey" +
+                            "  AND CONTAINS(ARRAY[1, 2, 3], o.custkey)",
+                    anyTree(indexJoin(
+                            filter(tableScan("lineitem")),
+                            filter(indexSource("orders")))));
+        }
+    }
+}


### PR DESCRIPTION
This change adds an extractor to traverse the Join plan and get lookup variables in different PlanNode, then stores the lookup variables in LookupJoinNode, which enables index lookup join with non-equal join condition for native execution. Additional changes are made to ensure lookup variables are not pruned by other optimizers.

```
== NO RELEASE NOTE ==
```

