### PR TITLE
Add xxhash64 override with seed argument

### DIFF
--- a/presto-docs/src/main/sphinx/functions/binary.rst
+++ b/presto-docs/src/main/sphinx/functions/binary.rst
@@ -146,6 +146,10 @@ Binary Functions
 
     Computes the xxhash64 hash of ``binary``.
 
+.. function:: xxhash64(binary, bigint) -> varbinary
+
+    Computes the xxhash64 hash of ``binary`` with seed ``bigint``.
+
 .. function:: spooky_hash_v2_32(binary) -> varbinary
 
     Computes the 32-bit SpookyHashV2 hash of ``binary``.

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
@@ -359,8 +359,8 @@ public final class VarbinaryFunctions
     @ScalarFunction
     @SqlType(StandardTypes.VARBINARY)
     public static Slice xxhash64(
-            @SqlType(StandardTypes.BIGINT) long seed,
-            @SqlType(StandardTypes.VARBINARY) Slice slice)
+            @SqlType(StandardTypes.VARBINARY) Slice slice,
+            @SqlType(StandardTypes.BIGINT) long seed)
     {
         Slice hash = Slices.allocate(Long.BYTES);
         hash.setLong(0, Long.reverseBytes(XxHash64.hash(seed, slice)));

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
@@ -355,6 +355,18 @@ public final class VarbinaryFunctions
         return hash;
     }
 
+    @Description("compute xxhash64 hash with a seed")
+    @ScalarFunction
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice xxhash64(
+            @SqlType(StandardTypes.BIGINT) long seed,
+            @SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        Slice hash = Slices.allocate(Long.BYTES);
+        hash.setLong(0, Long.reverseBytes(XxHash64.hash(seed, slice)));
+        return hash;
+    }
+
     @Description("compute SpookyHashV2 32-bit hash")
     @ScalarFunction
     @SqlType(StandardTypes.VARBINARY)

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
@@ -375,11 +375,8 @@ public class TestVarbinaryFunctions
     {
         assertFunction("xxhash64(CAST('' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("EF46DB3751D8E999"));
         assertFunction("xxhash64(CAST('hashme' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("F9D96E0E1165E892"));
-        assertFunction("xxhash64(0, CAST('' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("EF46DB3751D8E999"));
-        assertFunction("xxhash64(0, CAST('hashme' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("F9D96E0E1165E892"));
-        assertFunction("from_big_endian_64(xxhash64(-778468683, cast('ams' as VARBINARY)))", BIGINT, 904783967507135058L);
-        assertFunction("from_big_endian_64(xxhash64(-778468683, cast('gmp' as VARBINARY)))", BIGINT, 2343847643367348890L);
-        assertFunction("from_big_endian_64(xxhash64(-778468683, cast('den' as VARBINARY)))", BIGINT, -1197678627029189584L);
+        assertFunction("xxhash64(CAST('' AS VARBINARY), 0)", VARBINARY, sqlVarbinaryHex("EF46DB3751D8E999"));
+        assertFunction("xxhash64(CAST('hashme' AS VARBINARY), 0)", VARBINARY, sqlVarbinaryHex("F9D96E0E1165E892"));
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
@@ -375,6 +375,8 @@ public class TestVarbinaryFunctions
     {
         assertFunction("xxhash64(CAST('' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("EF46DB3751D8E999"));
         assertFunction("xxhash64(CAST('hashme' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("F9D96E0E1165E892"));
+        assertFunction("xxhash64(0, CAST('' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("EF46DB3751D8E999"));
+        assertFunction("xxhash64(0, CAST('hashme' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("F9D96E0E1165E892"));
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
@@ -377,6 +377,9 @@ public class TestVarbinaryFunctions
         assertFunction("xxhash64(CAST('hashme' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("F9D96E0E1165E892"));
         assertFunction("xxhash64(0, CAST('' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("EF46DB3751D8E999"));
         assertFunction("xxhash64(0, CAST('hashme' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("F9D96E0E1165E892"));
+        assertFunction("from_big_endian_64(xxhash64(-778468683, cast('ams' as VARBINARY)))", BIGINT, 904783967507135058L);
+        assertFunction("from_big_endian_64(xxhash64(-778468683, cast('gmp' as VARBINARY)))", BIGINT, 2343847643367348890L);
+        assertFunction("from_big_endian_64(xxhash64(-778468683, cast('den' as VARBINARY)))", BIGINT, -1197678627029189584L);
     }
 
     @Test


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Added a xxhash64 override with seed argument.

## Motivation and Context
The seeded version of xxhash64 allows hashing of binary input with a specified seed value. This functionality is useful for scenarios requiring consistent and uniform sharding or partitioning based on a seeded hash.

## Impact
This is a new function override and should not have any impact on existing systems.

## Test Plan
Added unit testing to verify the function works as intended.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add xxhash64 override with seed argument.


