### PR TITLE
Fix serialization of function handle

### DIFF
--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManagerFactory.java
@@ -36,7 +36,7 @@ public class JsonFileBasedFunctionNamespaceManagerFactory
 {
     public static final String NAME = "json_file";
 
-    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = new SqlFunctionHandle.Resolver();
+    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = SqlFunctionHandle.Resolver.getInstance();
 
     @Override
     public String getName()

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerFactory.java
@@ -32,7 +32,7 @@ public class MySqlFunctionNamespaceManagerFactory
 {
     public static final String NAME = "mysql";
 
-    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = new SqlFunctionHandle.Resolver();
+    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = SqlFunctionHandle.Resolver.getInstance();
 
     @Override
     public String getName()

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -49,6 +49,7 @@ import com.facebook.presto.spi.function.JavaScalarFunctionImplementation;
 import com.facebook.presto.spi.function.ScalarFunctionImplementation;
 import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlFunctionSupplier;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -400,7 +401,12 @@ public class FunctionAndTypeManager
         if (functionNamespaceManagerFactories.putIfAbsent(factory.getName(), factory) != null) {
             throw new IllegalArgumentException(format("Resource group configuration manager '%s' is already registered", factory.getName()));
         }
-        handleResolver.addFunctionNamespace(factory.getName(), factory.getHandleResolver());
+        String name = factory.getName();
+        // SqlFunctionHandle is in SPI and used by multiple function namespace managers, use the same name for it.
+        if (factory.getHandleResolver().getFunctionHandleClass().equals(SqlFunctionHandle.class)) {
+            name = "sql_function_handle";
+        }
+        handleResolver.addFunctionNamespace(name, factory.getHandleResolver());
     }
 
     public void loadTypeManager(String typeManagerName)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/HandleResolver.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/HandleResolver.java
@@ -76,8 +76,9 @@ public class HandleResolver
     {
         requireNonNull(name, "name is null");
         requireNonNull(resolver, "resolver is null");
-        MaterializedFunctionHandleResolver existingResolver = functionHandleResolvers.putIfAbsent(name, new MaterializedFunctionHandleResolver(resolver));
-        checkState(existingResolver == null || existingResolver.equals(resolver), "Name %s is already assigned to function resolver: %s", name, existingResolver);
+        MaterializedFunctionHandleResolver materializedFunctionHandleResolver = new MaterializedFunctionHandleResolver(resolver);
+        MaterializedFunctionHandleResolver existingResolver = functionHandleResolvers.putIfAbsent(name, materializedFunctionHandleResolver);
+        checkState(existingResolver == null || existingResolver.equals(materializedFunctionHandleResolver), "Name %s is already assigned to function resolver: %s", name, existingResolver);
     }
 
     public String getId(ConnectorTableHandle tableHandle)

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxQueryPlanTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxQueryPlanTest.cpp
@@ -61,7 +61,7 @@ class PrestoToVeloxQueryPlanTest : public testing::Test {
 TEST_F(PrestoToVeloxQueryPlanTest, parseSqlFunctionHandleWithZeroParam) {
   const std::string str = R"(
       {
-        "@type": "json_file",
+        "@type": "sql_function_handle",
         "functionId": "json_file.test.count;",
         "version": "1"
       }
@@ -76,7 +76,7 @@ TEST_F(PrestoToVeloxQueryPlanTest, parseSqlFunctionHandleWithZeroParam) {
 TEST_F(PrestoToVeloxQueryPlanTest, parseSqlFunctionHandleWithOneParam) {
   const std::string str = R"(
           {
-            "@type": "json_file",
+            "@type": "sql_function_handle",
             "functionId": "json_file.test.sum;tinyint",
             "version": "1"
           }
@@ -93,7 +93,7 @@ TEST_F(PrestoToVeloxQueryPlanTest, parseSqlFunctionHandleWithOneParam) {
 TEST_F(PrestoToVeloxQueryPlanTest, parseSqlFunctionHandleWithMultipleParam) {
   const std::string str = R"(
         {
-          "@type": "json_file",
+          "@type": "sql_function_handle",
           "functionId": "json_file.test.avg;array(decimal(15, 2));varchar",
           "version": "1"
         }
@@ -111,7 +111,7 @@ TEST_F(PrestoToVeloxQueryPlanTest, parseSqlFunctionHandleWithMultipleParam) {
 TEST_F(PrestoToVeloxQueryPlanTest, parseSqlFunctionHandleAllComplexTypes) {
   const std::string str = R"(
         {
-          "@type": "json_file",
+          "@type": "sql_function_handle",
           "functionId": "json_file.test.all_complex_types;row(map(hugeint, ipaddress), ipprefix);row(array(varbinary), timestamp, date, json, hyperloglog, timestamp with time zone, interval year to month, interval day to second);function(double, boolean);uuid",
           "version": "1"
         }

--- a/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/RowExpressionTest.cpp
@@ -499,7 +499,7 @@ TEST_F(RowExpressionTest, call) {
         ],
         "displayName": "EQUAL",
         "functionHandle": {
-          "@type": "json_file",
+          "@type": "sql_function_handle",
           "functionId": "json.x4.eq;INTEGER;INTEGER",
           "version": "1"
         },

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -508,15 +508,14 @@ namespace facebook::presto::protocol::iceberg {
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<PartitionTransformType, json>
-    PartitionTransformType_enum_table[] =
-        { // NOLINT: cert-err58-cpp
-            {PartitionTransformType::IDENTITY, "IDENTITY"},
-            {PartitionTransformType::YEAR, "YEAR"},
-            {PartitionTransformType::MONTH, "MONTH"},
-            {PartitionTransformType::DAY, "DAY"},
-            {PartitionTransformType::HOUR, "HOUR"},
-            {PartitionTransformType::BUCKET, "BUCKET"},
-            {PartitionTransformType::TRUNCATE, "TRUNCATE"}};
+    PartitionTransformType_enum_table[] = { // NOLINT: cert-err58-cpp
+        {PartitionTransformType::IDENTITY, "IDENTITY"},
+        {PartitionTransformType::YEAR, "YEAR"},
+        {PartitionTransformType::MONTH, "MONTH"},
+        {PartitionTransformType::DAY, "DAY"},
+        {PartitionTransformType::HOUR, "HOUR"},
+        {PartitionTransformType::BUCKET, "BUCKET"},
+        {PartitionTransformType::TRUNCATE, "TRUNCATE"}};
 void to_json(json& j, const PartitionTransformType& e) {
   static_assert(
       std::is_enum<PartitionTransformType>::value,

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -118,6 +118,10 @@ void to_json(json& j, const std::shared_ptr<FunctionHandle>& p) {
     j = *std::static_pointer_cast<SqlFunctionHandle>(p);
     return;
   }
+  if (type == "sql_function_handle") {
+    j = *std::static_pointer_cast<SqlFunctionHandle>(p);
+    return;
+  }
 
   throw TypeError(type + " no abstract type FunctionHandle ");
 }
@@ -145,6 +149,13 @@ void from_json(const json& j, std::shared_ptr<FunctionHandle>& p) {
     return;
   }
   if (type == "json_file") {
+    std::shared_ptr<SqlFunctionHandle> k =
+        std::make_shared<SqlFunctionHandle>();
+    j.get_to(*k);
+    p = std::static_pointer_cast<FunctionHandle>(k);
+    return;
+  }
+  if (type == "sql_function_handle") {
     std::shared_ptr<SqlFunctionHandle> k =
         std::make_shared<SqlFunctionHandle>();
     j.get_to(*k);
@@ -6341,6 +6352,13 @@ void to_json(json& j, const JsonBasedUdfFunctionMetadata& p) {
       "JsonBasedUdfFunctionMetadata",
       "List<LongVariableConstraint>",
       "longVariableConstraints");
+  to_json_key(
+      j,
+      "executionEndpoint",
+      p.executionEndpoint,
+      "JsonBasedUdfFunctionMetadata",
+      "URI",
+      "executionEndpoint");
 }
 
 void from_json(const json& j, JsonBasedUdfFunctionMetadata& p) {
@@ -6428,6 +6446,13 @@ void from_json(const json& j, JsonBasedUdfFunctionMetadata& p) {
       "JsonBasedUdfFunctionMetadata",
       "List<LongVariableConstraint>",
       "longVariableConstraints");
+  from_json_key(
+      j,
+      "executionEndpoint",
+      p.executionEndpoint,
+      "JsonBasedUdfFunctionMetadata",
+      "URI",
+      "executionEndpoint");
 }
 } // namespace facebook::presto::protocol
 // dependency KeyedSubclass
@@ -9326,12 +9351,12 @@ void from_json(const json& j, SpecialFormExpression& p) {
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 SqlFunctionHandle::SqlFunctionHandle() noexcept {
-  _type = "json_file";
+  _type = "sql_function_handle";
 }
 
 void to_json(json& j, const SqlFunctionHandle& p) {
   j = json::object();
-  j["@type"] = "json_file";
+  j["@type"] = "sql_function_handle";
   to_json_key(
       j,
       "functionId",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -68,21 +68,21 @@ extern const char* const PRESTO_ABORT_TASK_URL_PARAM;
 class Exception : public std::runtime_error {
  public:
   explicit Exception(const std::string& message)
-      : std::runtime_error(message){};
+      : std::runtime_error(message) {};
 };
 
 class TypeError : public Exception {
  public:
-  explicit TypeError(const std::string& message) : Exception(message){};
+  explicit TypeError(const std::string& message) : Exception(message) {};
 };
 
 class OutOfRange : public Exception {
  public:
-  explicit OutOfRange(const std::string& message) : Exception(message){};
+  explicit OutOfRange(const std::string& message) : Exception(message) {};
 };
 class ParseError : public Exception {
  public:
-  explicit ParseError(const std::string& message) : Exception(message){};
+  explicit ParseError(const std::string& message) : Exception(message) {};
 };
 
 using String = std::string;
@@ -1587,6 +1587,7 @@ struct JsonBasedUdfFunctionMetadata {
   std::shared_ptr<String> version = {};
   std::shared_ptr<List<TypeVariableConstraint>> typeVariableConstraints = {};
   std::shared_ptr<List<LongVariableConstraint>> longVariableConstraints = {};
+  std::shared_ptr<URI> executionEndpoint = {};
 };
 void to_json(json& j, const JsonBasedUdfFunctionMetadata& p);
 void from_json(const json& j, JsonBasedUdfFunctionMetadata& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -198,6 +198,7 @@ AbstractClasses:
       - { name: BuiltInFunctionHandle,      key: $static }
       - { name: SqlFunctionHandle,          key: native }
       - { name: SqlFunctionHandle,          key: json_file }
+      - { name: SqlFunctionHandle,          key: sql_function_handle }
 
 
 JavaClasses:

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -193,6 +193,7 @@ AbstractClasses:
         - { name: BuiltInFunctionHandle,      key: $static }
         - { name: SqlFunctionHandle,          key: json_file }
         - { name: SqlFunctionHandle,          key: native }
+        - { name: SqlFunctionHandle,          key: sql_function_handle }
 
 JavaClasses:
   - presto-spi/src/main/java/com/facebook/presto/spi/ErrorCause.java

--- a/presto-native-execution/presto_cpp/presto_protocol/tests/CallExpressionTest.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/tests/CallExpressionTest.cpp
@@ -94,7 +94,7 @@ TEST_F(CallExpressionTest, json_file) {
             ],
             "displayName": "sum",
             "functionHandle": {
-              "@type": "json_file",
+              "@type": "sql_function_handle",
               "functionId": "json.x4.sum;INTEGER;INTEGER",
               "version": "1"
             },
@@ -121,7 +121,7 @@ TEST_F(CallExpressionTest, json_file) {
 
   ASSERT_NE(p.functionHandle, nullptr);
   {
-    ASSERT_EQ(p.functionHandle->_type, "json_file");
+    ASSERT_EQ(p.functionHandle->_type, "sql_function_handle");
     std::shared_ptr<SqlFunctionHandle> k =
         std::static_pointer_cast<SqlFunctionHandle>(p.functionHandle);
     ASSERT_EQ(k->functionId, "json.x4.sum;INTEGER;INTEGER");

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionNamespaceManagerFactory.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionNamespaceManagerFactory.java
@@ -37,7 +37,7 @@ public class NativeFunctionNamespaceManagerFactory
 {
     public static final String NAME = "native";
 
-    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = new SqlFunctionHandle.Resolver();
+    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = SqlFunctionHandle.Resolver.getInstance();
 
     @Override
     public String getName()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionHandle.java
@@ -106,6 +106,15 @@ public class SqlFunctionHandle
     public static class Resolver
             implements FunctionHandleResolver
     {
+        private static final Resolver INSTANCE = new Resolver();
+
+        private Resolver() {}
+
+        public static Resolver getInstance()
+        {
+            return INSTANCE;
+        }
+
         @Override
         public Class<? extends FunctionHandle> getFunctionHandleClass()
         {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceManagerFactory.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceManagerFactory.java
@@ -34,7 +34,7 @@ public class H2FunctionNamespaceManagerFactory
 {
     public static final String NAME = "h2";
 
-    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = new SqlFunctionHandle.Resolver();
+    private static final SqlFunctionHandle.Resolver HANDLE_RESOLVER = SqlFunctionHandle.Resolver.getInstance();
 
     @Override
     public String getName()


### PR DESCRIPTION
## Description
Currently when we add function namespace factory, it will call this function
https://github.com/prestodb/presto/blob/29e9d97a926028794f1e8d35c32b57636f062a10/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java#L398-L404
which will add to the handleResolver where the key is the name of the FunctionNamespaceManagerFactory, and the function handle resolver is provided by the FunctionNamespaceManagerFactory. Notice that this function is called when we execute the plugin to install function namespace manager, even we do not load and use it.

This information will be used in HandleResolver to map a function handle to name.
https://github.com/prestodb/presto/blob/29e9d97a926028794f1e8d35c32b57636f062a10/presto-main-base/src/main/java/com/facebook/presto/metadata/HandleResolver.java#L231-L243
It iterates over the functionHandleResolvers, and return the first name whose function handle resolver returns true for the handle in the input argument.

This name information will be used to populate the type field for FunctionHandle during JSON serialization
https://github.com/prestodb/presto/blob/29e9d97a926028794f1e8d35c32b57636f062a10/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionHandleJacksonModule.java#L24-L27

However, the problem is, the Resolver of SqlFunctionHandle is used in multiple function namespace factories.
https://github.com/prestodb/presto/blob/29e9d97a926028794f1e8d35c32b57636f062a10/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionHandle.java#L106-L114
For example, NativeFunctionNamespaceManagerFactory, JsonFileBasedFunctionNamespaceManagerFactory, MySqlFunctionNamespaceManagerFactory, H2FunctionNamespaceManagerFactory. This means that when we serialize a SqlFunctionHandle, it can return either "native", "json_file", "mysql", or "h2", depends on whichever one comes first when iterate over the map.

Between Presto coordinator and Prestissimo, it relies on this type information to do deserialize:
https://github.com/prestodb/presto/blob/29e9d97a926028794f1e8d35c32b57636f062a10/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp#L103-L123
which currently only handles "$static" (corresponds to java built-in functions), "json_file" and "native". It can throw error when the returned type is not present in the code here.

In our production queries, we have observe failures due to this conflict of our internal function namespace manager which happens to always be the first one in iteration for SqlFunctionHandle.

Since this name is used to identify the specific type of FunctionHandle during serialization, instead of giving name of the function namespace manager, let's use the class name of the FunctionHandle, for example, for SqlFunctionHandle, let's use name "SqlFunctionHandle" here.

## Motivation and Context
Fix bug in FunctionHandle Serialization/deserialization

## Impact
Bug fix

## Test Plan
Test with previously failing test queries ([q1](https://www.internalfb.com/intern/presto/query/?query_id=20250711_173921_00001_d3pfc), [q2](https://www.internalfb.com/intern/presto/query/?query_id=20250711_174128_00001_irknf))

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix a bug in FunctionHandle serialization where multiple types corresponds to the same type of FunctionHandle
```


