### PR TITLE
Preserve quotedness in QualifiedName

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -470,7 +470,7 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitIdentifier(Identifier node, StackableAstVisitorContext<Context> context)
         {
-            QualifiedName name = QualifiedName.of(node.getValue());
+            QualifiedName name = QualifiedName.of(ImmutableList.of(new Identifier(node.getValue(), node.isDelimited())));
             Optional<ResolvedField> resolvedField = context.getContext().getScope().tryResolveField(node, name);
             if (!resolvedField.isPresent() && outerScopeSymbolTypes.containsKey(NodeRef.of(node))) {
                 return setExpressionType(node, outerScopeSymbolTypes.get(NodeRef.of(node)));
@@ -1513,7 +1513,8 @@ public class ExpressionAnalyzer
                 fieldToLambdaArgumentDeclaration.putAll(context.getContext().getFieldToLambdaArgumentDeclaration());
             }
             for (LambdaArgumentDeclaration lambdaArgument : lambdaArguments) {
-                ResolvedField resolvedField = lambdaScope.resolveField(lambdaArgument, QualifiedName.of(lambdaArgument.getName().getValue()));
+                QualifiedName name = QualifiedName.of(ImmutableList.of(new Identifier(lambdaArgument.getName().getValue(), lambdaArgument.getName().isDelimited())));
+                ResolvedField resolvedField = lambdaScope.resolveField(lambdaArgument, name);
                 fieldToLambdaArgumentDeclaration.put(FieldId.from(resolvedField), lambdaArgument);
             }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -310,7 +310,6 @@ import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterables.getLast;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
@@ -2764,7 +2763,7 @@ class StatementAnalyzer
 
                     if (!field.isPresent()) {
                         if (name != null) {
-                            field = Optional.of(new Identifier(getLast(name.getOriginalParts())));
+                            field = Optional.of(name.getOriginalSuffix());
                         }
                     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlFormatter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/TestSqlFormatter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql;
+
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Statement;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestSqlFormatter
+{
+    @Test
+    public void testSimpleExpression()
+    {
+        assertQuery("SELECT id\nFROM\n  public.orders\n");
+        assertQuery("SELECT id\nFROM\n  \"public\".\"order\"\n");
+        assertQuery("SELECT id\nFROM\n  \"public\".\"order\"\"2\"\n");
+    }
+
+    @Test
+    public void testQuotedColumnNames()
+    {
+        assertQuery("SELECT \"Id\"\nFROM\n  public.orders\n");
+        assertQuery("SELECT \"order\".\"Name\"\nFROM\n  \"public\".\"orders\"\n");
+        assertQuery("SELECT \"a\".\"b\".\"C\"\nFROM\n  \"schema\".\"table\"\n");
+        assertQuery("ALTER TABLE sales.orders RENAME COLUMN \"OrderId\" TO \"OrderID_New\"");
+        assertQuery("ALTER TABLE sales.orders ADD COLUMN \"Customer\" VARCHAR");
+        assertQuery("ALTER TABLE sales.orders DROP COLUMN \"Customer\"");
+    }
+
+    private void assertQuery(String query)
+    {
+        SqlParser parser = new SqlParser();
+        Statement statement = parser.createStatement(query, new ParsingOptions());
+        String formattedQuery = getFormattedSql(statement, parser, Optional.empty());
+        assertEquals(formattedQuery, query);
+        assertEquals(formattedQuery, query, format("Formatted SQL did not match original for query: %s", query));
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -1156,12 +1156,10 @@ public final class SqlFormatter
             return characteristic.name().replace("_", " ");
         }
 
-        private static String formatName(String name)
+        private static String formatName(Identifier name)
         {
-            if (NAME_PATTERN.matcher(name).matches()) {
-                return name;
-            }
-            return "\"" + name.replace("\"", "\"\"") + "\"";
+            String delimiter = name.isDelimited() ? "\"" : "";
+            return delimiter + name.getValue().replace("\"", "\"\"") + delimiter;
         }
 
         private static String formatName(QualifiedName name)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -2320,11 +2320,7 @@ class AstBuilder
 
     private QualifiedName getQualifiedName(SqlBaseParser.QualifiedNameContext context)
     {
-        List<String> parts = visit(context.identifier(), Identifier.class).stream()
-                .map(Identifier::getValue) // TODO: preserve quotedness
-                .collect(Collectors.toList());
-
-        return QualifiedName.of(parts);
+        return QualifiedName.of(visit(context.identifier(), Identifier.class));
     }
 
     private static boolean isDistinct(SqlBaseParser.SetQuantifierContext setQuantifier)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
@@ -19,44 +19,44 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.isEmpty;
-import static com.google.common.collect.Iterables.transform;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class QualifiedName
 {
     private final List<String> parts;
-    private final List<String> originalParts;
+    private final List<Identifier> originalParts;
 
     public static QualifiedName of(String first, String... rest)
     {
         requireNonNull(first, "first is null");
-        return of(ImmutableList.copyOf(Lists.asList(first, rest)));
+        return of(ImmutableList.copyOf(Lists.asList(first, rest).stream().map(Identifier::new).collect(Collectors.toList())));
     }
 
     public static QualifiedName of(String name)
     {
         requireNonNull(name, "name is null");
-        return of(ImmutableList.of(name));
+        return of(ImmutableList.of(new Identifier(name)));
     }
 
-    public static QualifiedName of(Iterable<String> originalParts)
+    public static QualifiedName of(Iterable<Identifier> originalParts)
     {
         requireNonNull(originalParts, "originalParts is null");
         checkArgument(!isEmpty(originalParts), "originalParts is empty");
-        List<String> parts = ImmutableList.copyOf(transform(originalParts, part -> part.toLowerCase(ENGLISH)));
 
-        return new QualifiedName(ImmutableList.copyOf(originalParts), parts);
+        return new QualifiedName(ImmutableList.copyOf(originalParts));
     }
 
-    private QualifiedName(List<String> originalParts, List<String> parts)
+    private QualifiedName(List<Identifier> originalParts)
     {
         this.originalParts = originalParts;
-        this.parts = parts;
+        this.parts = originalParts.stream().map(identifier -> identifier.getValue().toLowerCase(ENGLISH)).collect(toImmutableList());
     }
 
     public List<String> getParts()
@@ -64,7 +64,7 @@ public class QualifiedName
         return parts;
     }
 
-    public List<String> getOriginalParts()
+    public List<Identifier> getOriginalParts()
     {
         return originalParts;
     }
@@ -85,9 +85,8 @@ public class QualifiedName
             return Optional.empty();
         }
 
-        List<String> originalSubList = originalParts.subList(0, originalParts.size() - 1);
-        List<String> subList = parts.subList(0, parts.size() - 1);
-        return Optional.of(new QualifiedName(originalSubList, subList));
+        List<Identifier> subList = originalParts.subList(0, originalParts.size() - 1);
+        return Optional.of(new QualifiedName(subList));
     }
 
     public boolean hasSuffix(QualifiedName suffix)
@@ -106,7 +105,7 @@ public class QualifiedName
         return getLast(parts);
     }
 
-    public String getOriginalSuffix()
+    public Identifier getOriginalSuffix()
     {
         return getLast(originalParts);
     }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -169,6 +169,7 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.QueryUtil.identifier;
 import static com.facebook.presto.sql.QueryUtil.query;
@@ -2423,7 +2424,7 @@ public class TestSqlParser
         final String[] tableNames = {"t", "s.t", "c.s.t"};
 
         for (String fullName : tableNames) {
-            QualifiedName qualifiedName = QualifiedName.of(Arrays.asList(fullName.split("\\.")));
+            QualifiedName qualifiedName = makeQualifiedName(fullName);
             assertStatement(format("SHOW STATS FOR %s", qualifiedName), new ShowStats(new Table(qualifiedName)));
         }
     }
@@ -2434,7 +2435,7 @@ public class TestSqlParser
         final String[] tableNames = {"t", "s.t", "c.s.t"};
 
         for (String fullName : tableNames) {
-            QualifiedName qualifiedName = QualifiedName.of(Arrays.asList(fullName.split("\\.")));
+            QualifiedName qualifiedName = makeQualifiedName(fullName);
             assertStatement(format("SHOW STATS FOR (SELECT * FROM %s)", qualifiedName),
                     createShowStats(qualifiedName, ImmutableList.of(new AllColumns()), Optional.empty()));
             assertStatement(format("SHOW STATS FOR (SELECT * FROM %s WHERE field > 0)", qualifiedName),
@@ -2456,6 +2457,14 @@ public class TestSqlParser
                                                     new Identifier("field"),
                                                     new LongLiteral("0"))))));
         }
+    }
+
+    private QualifiedName makeQualifiedName(String tableName)
+    {
+        List<Identifier> parts = Arrays.stream(tableName.split("\\."))
+                .map(Identifier::new)
+                .collect(Collectors.toList());
+        return QualifiedName.of(parts);
     }
 
     private ShowStats createShowStats(QualifiedName name, List<SelectItem> selects, Optional<Expression> where)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExtendedVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExtendedVerification.java
@@ -15,6 +15,7 @@ package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.verifier.checksum.ChecksumResult;
@@ -245,14 +246,14 @@ public class ExtendedVerification
     private QualifiedName formPartitionTableName(QualifiedName tableName)
     {
         int nameSizes = tableName.getParts().size();
-        ImmutableList.Builder<String> nameBuilder = ImmutableList.builder();
+        ImmutableList.Builder<Identifier> nameBuilder = ImmutableList.builder();
         for (int index = 0; index < nameSizes; index++) {
-            String part = null;
+            Identifier part = null;
             if (index != nameSizes - 1) {
-                part = tableName.getParts().get(index);
+                part = new Identifier(tableName.getParts().get(index));
             }
             else {
-                part = tableName.getParts().get(index) + "$partitions";
+                part = new Identifier(tableName.getParts().get(index) + "$partitions");
             }
             nameBuilder.add(part);
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/IgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/IgnoredFunctionsMismatchResolver.java
@@ -16,18 +16,20 @@ package com.facebook.presto.verifier.resolver;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.verifier.framework.DataMatchResult;
 import com.facebook.presto.verifier.framework.QueryBundle;
-import com.google.common.base.Splitter;
 
 import javax.inject.Inject;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
 import static com.facebook.presto.verifier.framework.DataMatchResult.MatchType.COLUMN_MISMATCH;
@@ -87,7 +89,9 @@ public class IgnoredFunctionsMismatchResolver
 
     private static String normalizeFunctionName(String name)
     {
-        return normalizeFunctionName(QualifiedName.of(Splitter.on(".").splitToList(name)));
+        return normalizeFunctionName(QualifiedName.of(Arrays.stream(name.split("\\."))
+                .map(Identifier::new)
+                .collect(Collectors.toList())));
     }
 
     private static String normalizeFunctionName(QualifiedName name)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriteConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriteConfig.java
@@ -15,16 +15,18 @@ package com.facebook.presto.verifier.rewrite;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 
 import javax.validation.constraints.NotNull;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class QueryRewriteConfig
 {
@@ -58,7 +60,9 @@ public class QueryRewriteConfig
     {
         this.tablePrefix = tablePrefix == null ?
                 null :
-                QualifiedName.of(Splitter.on(".").splitToList(tablePrefix));
+                QualifiedName.of(Arrays.stream(tablePrefix.split("\\."))
+                        .map(Identifier::new)
+                        .collect(Collectors.toList()));
         return this;
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
@@ -343,14 +343,15 @@ public class QueryRewriter
 
     private QualifiedName generateTemporaryName(Optional<QualifiedName> originalName, QualifiedName prefix)
     {
-        List<String> parts = new ArrayList<>();
+        List<Identifier> parts = new ArrayList<>();
         int originalSize = originalName.map(QualifiedName::getOriginalParts).map(List::size).orElse(0);
         int prefixSize = prefix.getOriginalParts().size();
         if (originalName.isPresent() && originalSize > prefixSize) {
             parts.addAll(originalName.get().getOriginalParts().subList(0, originalSize - prefixSize));
         }
         parts.addAll(prefix.getOriginalParts());
-        parts.set(parts.size() - 1, prefix.getOriginalSuffix() + "_" + randomUUID().toString().replace("-", ""));
+        parts.set(parts.size() - 1, new Identifier(prefix.getOriginalSuffix().getValue() + "_" + randomUUID().toString().replace("-", ""),
+                prefix.getOriginalSuffix().isDelimited()));
         return QualifiedName.of(parts);
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/prestodb/presto/pull/19827 & https://github.com/trinodb/trino/pull/80

Presto doesn't maintain the quotedness of an identifier when using SqlQueryFormatter so it results in throwing parsing error if the quoted table name is a reserved word

Test plan 

Before this PR, Presto threw an error when using a reserved keyword in a prepared statement or while creating a view.

```
presto:imjalpreet> create view group_view security invoker as select * from imjalpreet."group";

Query 20230530_141710_00001_fxwah failed: Formatted query does not parse: Query{queryBody=QuerySpecification{select=Select{distinct=false, selectItems=[*]}, from=Optional[Table{imjalpreet.group}], where=null, groupBy=Optional.empty, having=null, orderBy=Optional.empty, offset=null, limit=null}, orderBy=Optional.empty}

presto:imjalpreet> PREPARE stmt0 FROM select * from imjalpreet."group";

Query 20230530_142117_00003_fxwah failed: Formatted query does not parse: Query{queryBody=QuerySpecification{select=Select{distinct=false, selectItems=[*]}, from=Optional[Table{imjalpreet.group}], where=null, groupBy=Optional.empty, having=null, orderBy=Optional.empty, offset=null, limit=null}, orderBy=Optional.empty}
```

After this PR, queries run successfully.

```
presto:imjalpreet> create view group_view security invoker as select * from imjalpreet."group";
CREATE VIEW

presto:imjalpreet> PREPARE stmt0 FROM select * from imjalpreet."group";
PREPARE
```

```
== RELEASE NOTES ==

General Changes
* Update to preserve table name quoting in the output of ``SHOW CREATE VIEW``.
* Fix failure when preparing statements or creating views that contain a quoted reserved word as a table name.
```