### PR TITLE
[presto] Classify IllegalArgumentException when reading ORC metadata as Corruption

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
@@ -51,7 +51,7 @@ public class ExceptionWrappingMetadataReader
         try {
             return delegate.readPostScript(data, offset, length);
         }
-        catch (InvalidProtocolBufferException e) {
+        catch (InvalidProtocolBufferException | IllegalArgumentException e) {
             throw new OrcCorruptionException(e, orcDataSourceId, "Invalid postscript");
         }
     }
@@ -63,7 +63,7 @@ public class ExceptionWrappingMetadataReader
         try {
             return delegate.readMetadata(hiveWriterVersion, inputStream);
         }
-        catch (InvalidProtocolBufferException e) {
+        catch (InvalidProtocolBufferException | IllegalArgumentException e) {
             throw new OrcCorruptionException(e, orcDataSourceId, "Invalid file metadata");
         }
     }
@@ -80,7 +80,7 @@ public class ExceptionWrappingMetadataReader
         try {
             return delegate.readFooter(hiveWriterVersion, inputStream, dwrfEncryptionProvider, dwrfKeyProvider, orcDataSource, decompressor);
         }
-        catch (InvalidProtocolBufferException e) {
+        catch (InvalidProtocolBufferException | IllegalArgumentException e) {
             throw new OrcCorruptionException(e, orcDataSourceId, "Invalid file footer");
         }
     }
@@ -92,7 +92,7 @@ public class ExceptionWrappingMetadataReader
         try {
             return delegate.readStripeFooter(orcDataSourceId, types, inputStream);
         }
-        catch (InvalidProtocolBufferException e) {
+        catch (InvalidProtocolBufferException | IllegalArgumentException e) {
             throw new OrcCorruptionException(e, orcDataSourceId, "Invalid stripe footer");
         }
     }
@@ -104,7 +104,7 @@ public class ExceptionWrappingMetadataReader
         try {
             return delegate.readRowIndexes(hiveWriterVersion, inputStream, bloomFilters);
         }
-        catch (InvalidProtocolBufferException e) {
+        catch (InvalidProtocolBufferException | IllegalArgumentException e) {
             throw new OrcCorruptionException(e, orcDataSourceId, "Invalid stripe row index");
         }
     }
@@ -116,7 +116,7 @@ public class ExceptionWrappingMetadataReader
         try {
             return delegate.readBloomFilterIndexes(inputStream);
         }
-        catch (InvalidProtocolBufferException e) {
+        catch (InvalidProtocolBufferException | IllegalArgumentException e) {
             throw new OrcCorruptionException(e, orcDataSourceId, "Invalid bloom filter");
         }
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestExceptionWrappingMetadataReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestExceptionWrappingMetadataReader.java
@@ -106,8 +106,16 @@ public class TestExceptionWrappingMetadataReader
 
     private static void assertExceptions(ThrowingRunnable lambda)
     {
+        // RuntimeException should pass through unchanged
         expectThrows(RuntimeException.class, lambda);
+
+        // IOException should pass through unchanged
         expectThrows(IOException.class, lambda);
+
+        // InvalidProtocolBufferException should be wrapped as OrcCorruptionException
+        expectThrows(OrcCorruptionException.class, lambda);
+
+        // IllegalArgumentException should be wrapped as OrcCorruptionException
         expectThrows(OrcCorruptionException.class, lambda);
     }
 
@@ -117,7 +125,8 @@ public class TestExceptionWrappingMetadataReader
         private static final List<Exception> EXCEPTIONS = ImmutableList.of(
                 new RuntimeException("test runtime exception"),
                 new IOException("test io exception"),
-                new InvalidProtocolBufferException("test protobuf exception"));
+                new InvalidProtocolBufferException("test protobuf exception"),
+                new IllegalArgumentException("test illegal argument exception"));
         private int currentExceptionIndex;
 
         private void throwNextException()


### PR DESCRIPTION
Summary: We recently encountered an incident where a file with corrupt metadata was not picked up by our corrupt file detectors. This was because the ExceptionWrappingMetadataReader class does not re-throw IllegalArgumentExceptions as an OrcCorruptionException. This diff fixes that by classifying all IllegalArgumentExceptions that happen during metadata read as corruptions.

Differential Revision: D78340670


