### PR TITLE
Check for nulls in input arrays of array functions l2_squared and cosine_similarity

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -42,21 +42,22 @@ Mathematical Functions
 
 .. function:: cosine_similarity(x, y) -> double
 
-    Returns the cosine similarity between the arrays ``x`` and ``y``::
+    Returns the cosine similarity between the arrays ``x`` and ``y``.
+    If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
 
         SELECT cosine_similarity(ARRAY[1.2], ARRAY[2.0]); -- 1.0
 
 .. function:: l2_squared(array(real), array(real)) -> real
 
     Returns the squared `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`_ between the vectors represented as array(real).
-    If the input arrays have different sizes, the function throws user error::
+    If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
 
         SELECT l2_squared(ARRAY[1.0], ARRAY[2.0]); -- 1.0
 
 .. function:: l2_squared(array(double), array(double)) -> double
 
     Returns the squared `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`_ between the vectors represented as array(double).
-    If the input arrays have different sizes, the function throws user error::
+    If the input arrays have different sizes or if the input arrays contain a null, the function throws user error::
 
         SELECT l2_squared(ARRAY[1.0], ARRAY[2.0]); -- 1.0
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -1632,6 +1632,11 @@ public final class MathFunctions
                 INVALID_FUNCTION_ARGUMENT,
                 "Both array arguments need to have identical size");
 
+        checkCondition(
+                !(leftArray.mayHaveNull() || rightArray.mayHaveNull()),
+                INVALID_FUNCTION_ARGUMENT,
+                "Both arrays must not have nulls");
+
         Double normLeftArray = array2Norm(leftArray);
         Double normRightArray = array2Norm(rightArray);
 
@@ -1653,6 +1658,11 @@ public final class MathFunctions
                 leftArray.getPositionCount() == rightArray.getPositionCount(),
                 INVALID_FUNCTION_ARGUMENT,
                 "Both array arguments need to have identical size");
+
+        checkCondition(
+                !(leftArray.mayHaveNull() || rightArray.mayHaveNull()),
+                INVALID_FUNCTION_ARGUMENT,
+                "Both arrays must not have nulls");
 
         float sum = 0.0f;
         for (int i = 0; i < leftArray.getPositionCount(); i++) {
@@ -1676,6 +1686,12 @@ public final class MathFunctions
                 leftArray.getPositionCount() == rightArray.getPositionCount(),
                 INVALID_FUNCTION_ARGUMENT,
                 "Both array arguments need to have identical size");
+
+        checkCondition(
+                !(leftArray.mayHaveNull() || rightArray.mayHaveNull()),
+                INVALID_FUNCTION_ARGUMENT,
+                "Both arrays must not have nulls");
+
         double sum = 0.0;
         for (int i = 0; i < leftArray.getPositionCount(); i++) {
             double left = DOUBLE.getDouble(leftArray, i);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1392,9 +1392,7 @@ public class TestMathFunctions
                 DOUBLE,
                 null);
 
-        assertFunction("cosine_similarity(array [1.0E0, null], array [1.0E0, 3.0E0])",
-                DOUBLE,
-                null);
+        assertInvalidFunction("cosine_similarity(array [1.0E0, null], array [1.0E0, 3.0E0])", "Both arrays must not have nulls");
 
         assertInvalidFunction("cosine_similarity(array [], array [1.0E0, 3.0E0])", "Both array arguments need to have identical size");
 
@@ -1405,6 +1403,12 @@ public class TestMathFunctions
         assertFunction("cosine_similarity(array [], null)",
                 DOUBLE,
                 null);
+
+        assertInvalidFunction(
+                "cosine_similarity(array[1.0, null, 3.0], array[1.0, 2.0, 3.0])", "Both arrays must not have nulls");
+
+        assertInvalidFunction(
+                "cosine_similarity(array[1.0, 2.0, 3.0], array[1.0, null, 3.0])", "Both arrays must not have nulls");
     }
 
     @Test
@@ -1434,6 +1438,10 @@ public class TestMathFunctions
         assertFunction(
                 "l2_squared(CAST(null AS array(real)), CAST(null AS array(real)))",
                 REAL, null);
+        assertInvalidFunction(
+                "l2_squared(array[REAL '1.0', null, REAL '3.0'], array[REAL '1.0', REAL '2.0', REAL '3.0'])", "Both arrays must not have nulls");
+        assertInvalidFunction(
+                "l2_squared(array[REAL '1.0', REAL '2.0', REAL '3.0'], array[REAL '1.0', null, REAL '3.0'])", "Both arrays must not have nulls");
     }
 
     @Test
@@ -1463,6 +1471,10 @@ public class TestMathFunctions
         assertFunction(
                 "l2_squared(CAST(null AS array(double)), CAST(null AS array(double)))",
                 DOUBLE, null);
+        assertInvalidFunction(
+                "l2_squared(array[DOUBLE '1.0', null, DOUBLE '3.0'], array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'])", "Both arrays must not have nulls");
+        assertInvalidFunction(
+                "l2_squared(array[DOUBLE '1.0', DOUBLE '2.0', DOUBLE '3.0'], array[DOUBLE '1.0', null, DOUBLE '3.0'])", "Both arrays must not have nulls");
     }
 
     @Test


### PR DESCRIPTION
## Description
Ensures that `l2_squared` and `cosine_similarity` array functions checks for null values in the array and throw an error if so. Additionally, added test cases for both l2_squared and cosine_similarity array functions to verify the behavior. 

## Motivation and Context
Inputs offered in presto SQL are very general, so edge case handling will improve the code quality.

## Impact
The described functions can handle more input types.

## Test Plan
Maven Build and Unit Tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

