### PR TITLE
[native] Replace EXPLAIN (TYPE DISTRIBUTED) with EXPLAIN (TYPE VALIDATE) for faster, lightweight analysis

### DIFF
--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
@@ -45,7 +45,7 @@ import static java.util.Objects.requireNonNull;
 public class PlanCheckerRouterPluginPrestoClient
 {
     private static final Logger log = Logger.get(PlanCheckerRouterPluginPrestoClient.class);
-    private static final String ANALYZE_CALL = "EXPLAIN (TYPE DISTRIBUTED) ";
+    private static final String ANALYZE_CALL = "EXPLAIN (TYPE VALIDATE) ";
     private static final CounterStat fallBackToJavaClusterRedirectRequests = new CounterStat();
     private static final CounterStat javaClusterRedirectRequests = new CounterStat();
     private static final CounterStat nativeClusterRedirectRequests = new CounterStat();

--- a/presto-plan-checker-router-plugin/src/test/java/com/facebook/presto/router/scheduler/TestPlanCheckerRouterPlugin.java
+++ b/presto-plan-checker-router-plugin/src/test/java/com/facebook/presto/router/scheduler/TestPlanCheckerRouterPlugin.java
@@ -135,7 +135,7 @@ public class TestPlanCheckerRouterPlugin
                                 PRESTO_TIME_ZONE, "America/Bahia_Banderas",
                                 PRESTO_CATALOG, "tpch",
                                 PRESTO_SCHEMA, "tiny"),
-                        "SELECT EXISTS(SELECT 1 WHERE l.orderkey > 0 OR l.orderkey != 3) FROM lineitem l LIMIT 1"));
+                        "SELECT x AS y FROM (values (1,2), (2,3)) t(x, y) GROUP BY x ORDER BY apply(x, x -> -x) + 2*x"));
         assertTrue(target.isPresent());
         assertEquals(target.get(), planCheckerRouterConfig.getJavaRouterURI());
     }


### PR DESCRIPTION
## Description
Replaces the use of `EXPLAIN (TYPE DISTRIBUTED) `with `EXPLAIN (TYPE VALIDATE)` to improve performance and reduce overhead. While `EXPLAIN (TYPE VALIDATE)` performs fewer checks and is less exhaustive than `EXPLAIN (TYPE DISTRIBUTED)`, it is sufficient for basic functions, type validation and access controls checks.

## Motivation and Context
`EXPLAIN (TYPE DISTRIBUTED)` triggers full logical and physical planning, including fragment generation, which can be expensive for large or complex queries. We replace this usage with `EXPLAIN (TYPE VALIDATE)`. Although it provers less coverage and fewer validations, the tradeoff is acceptable where exhaustive plan validation isn't necessary.

## Impact
This helps speed up analysis iterations without compromising core validation logic.

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Replace `EXPLAIN (TYPE DISTRIBUTED)` with `EXPLAIN (TYPE VALIDATE)` for faster, lightweight analysis.
```

