### PR TITLE
[native] Improve stucking test testUnicodeInJson

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1827,17 +1827,17 @@ public abstract class AbstractTestNativeGeneralQueries
     @Test
     public void testUnicodeInJson()
     {
-        // Test casting to JSON returning the same results for all unicode characters in the entire range.
-        List<int[]> unicodeRanges = new ArrayList<int[]>()
-        {{
-                add(new int[] {0, 0x7F});
-                add(new int[] {0x80, 0xD7FF});
-                add(new int[] {0xE000, 0xFFFF});
-            }};
-        for (int start = 0x10000; start < 0x110000; ) {
-            int end = start + 0x10000;
-            unicodeRanges.add(new int[] {start, end - 1});
-            start = end;
+        // Test casting to JSON returning the same results for all unicode characters in the
+        // entire range.
+        List<int[]> unicodeRanges = new ArrayList<int[]>() {
+            {
+                add(new int[]{0, 0x7F});
+                add(new int[]{0x80, 0xD7FF});
+                add(new int[]{0xE000, 0xFFFF});
+            }
+        };
+        for (int start = 0x10000; start < 0x110000; start += 0x10000) {
+            unicodeRanges.add(new int[]{start, start + 0xFFFF});
         }
         List<String> unicodeStrings = unicodeRanges.stream().map(range -> {
             StringBuilder unicodeString = new StringBuilder();
@@ -1868,7 +1868,8 @@ public abstract class AbstractTestNativeGeneralQueries
         }).collect(ImmutableList.toImmutableList());
 
         for (String unicodeString : unicodeStrings) {
-            assertQuery(String.format("SELECT CAST(a as JSON) FROM ( VALUES(U&'%s') ) t(a)", unicodeString));
+            assertQuery(String.format("SELECT CAST(a as JSON) FROM ( VALUES(U&'%s') ) t(a)",
+                    unicodeString));
         }
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -13,14 +13,21 @@
  */
 package com.facebook.presto.spark;
 
+import com.facebook.airlift.log.Level;
+import com.facebook.airlift.log.Logging;
 import com.facebook.presto.nativeworker.AbstractTestNativeGeneralQueries;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import org.testng.annotations.Ignore;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TestPrestoSparkNativeGeneralQueries
         extends AbstractTestNativeGeneralQueries
 {
+    private static final Logging logging = Logging.initialize();
+
     @Override
     protected QueryRunner createQueryRunner()
     {
@@ -32,6 +39,26 @@ public class TestPrestoSparkNativeGeneralQueries
             throws Exception
     {
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+    }
+
+    @Override
+    public void testUnicodeInJson()
+    {
+        // Suppress the logging for large volume of query text to avoid console hangs.
+        List<String> suppressLogList = new ArrayList<>();
+        suppressLogList.add("com.facebook.presto.spark.execution.PrestoSparkStaticQueryExecution");
+        suppressLogList.add("com.facebook.presto.spark.PrestoSparkQueryExecutionFactory");
+        try {
+            for (String logLocation : suppressLogList) {
+                logging.setLevel(logLocation, Level.WARN);
+            }
+            super.testUnicodeInJson();
+        }
+        finally {
+            for (String logLocation : suppressLogList) {
+                logging.setLevel(logLocation, Level.INFO);
+            }
+        }
     }
 
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)


### PR DESCRIPTION
## Description
AbstractTestNativeGeneralQueries.testUnicodeInJson hangs some IDEs and thrashing its memory due to extremely large query text printing. Suppressing the large log lines to make this test debuggable.
```
== NO RELEASE NOTE ==
```

