### PR TITLE
[native] Add PRESTO_ENABLE_SPATIAL option

### DIFF
--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -76,6 +76,7 @@ jobs:
             -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
             -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
             -DPRESTO_ENABLE_TESTING=OFF \
+            -DPRESTO_ENABLE_SPATIAL=ON \
             -DCMAKE_PREFIX_PATH=/usr/local \
             -DThrift_ROOT=/usr/local \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -91,6 +91,7 @@ jobs:
             -DPRESTO_ENABLE_JWT=ON \
             -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
             -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
+            -DPRESTO_ENABLE_SPATIAL=ON \
             -DCMAKE_PREFIX_PATH=/usr/local \
             -DThrift_ROOT=/usr/local \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -51,6 +51,7 @@ jobs:
           -DPRESTO_ENABLE_JWT=ON \
           -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
           -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
+          -DPRESTO_ENABLE_SPATIAL=ON \
           -DPRESTO_ENABLE_TESTING=OFF \
           -DCMAKE_PREFIX_PATH=/usr/local \
           -DThrift_ROOT=/usr/local \

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -70,6 +70,8 @@ option(PRESTO_ENABLE_JWT "Enable JWT (JSON Web Token) authentication" OFF)
 
 option(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR "Enable Arrow Flight connector" OFF)
 
+option(PRESTO_ENABLE_SPATIAL "Enable spatial support" OFF)
+
 # Set all Velox options below and make sure that if we include folly headers or
 # other dependency headers that include folly headers we turn off the coroutines
 # and turn on int128.
@@ -120,6 +122,12 @@ if(PRESTO_ENABLE_CUDF)
   enable_language(CUDA)
   # Determine CUDA_ARCHITECTURES automatically.
   cmake_policy(SET CMP0104 NEW)
+endif()
+
+if(PRESTO_ENABLE_SPATIAL)
+  set(VELOX_ENABLE_GEO
+      ON
+      CACHE BOOL "Enable Velox Geometry (aka spatial) support")
 endif()
 
 set(VELOX_BUILD_TESTING

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -138,6 +138,12 @@ The make command will look like:
 
 The required dependencies are bundled from the Velox setup scripts.
 
+#### Spatial type and function support
+To enable support for spatial types and functions, add to the extra cmake flags:
+`EXTRA_CMAKE_FLAGS = -PRESTO_ENABLE_SPATIAL`
+
+The spatial support adds new types (OGC geometry types) and functionality for spatial calculations.
+
 ### Makefile Targets
 A reminder of the available Makefile targets can be obtained using `make help`
 ```


### PR DESCRIPTION
With Velox PR [14103](https://github.com/facebookincubator/velox/pull/14103) the VELOX_ENABLE_GEO option is off by default. PrestoC++ needs a method to enable the build of the GEO functions in the Velox submodule.
Generally, this is called spatial functionality and, therefore, PRESTO_ENABLE_SPATIAL is introduced which
enables VELOX_ENABLE_GEO.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

