### PR TITLE
[Native] Session property manager pass configs to bootstrap

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -69,6 +69,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.weakref.jmx.Managed;
@@ -653,6 +654,12 @@ public class FunctionAndTypeManager
         return builtInTypeAndFunctionNamespaceManager.listFunctions(Optional.empty(), Optional.empty()).stream()
                 .filter(function -> operatorNames.contains(function.getSignature().getName()))
                 .collect(toImmutableList());
+    }
+
+    @VisibleForTesting
+    public Map<String, FunctionNamespaceManager<? extends SqlFunction>> getFunctionNamespaceManagers()
+    {
+        return ImmutableMap.copyOf(functionNamespaceManagers);
     }
 
     public FunctionHandle resolveOperator(OperatorType operatorType, List<TypeSignatureProvider> argumentTypes)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/SessionPropertyManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/SessionPropertyManager.java
@@ -45,6 +45,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.Parameter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -181,11 +182,17 @@ public final class SessionPropertyManager
         log.info("-- Loading %s session property provider --", sessionPropertyProviderName);
         WorkerSessionPropertyProviderFactory factory = workerSessionPropertyProviderFactories.get(sessionPropertyProviderName);
         checkState(factory != null, "No factory for session property provider : " + sessionPropertyProviderName);
-        WorkerSessionPropertyProvider sessionPropertyProvider = factory.create(new SessionPropertyContext(typeManager, nodeManager));
+        WorkerSessionPropertyProvider sessionPropertyProvider = factory.create(new SessionPropertyContext(typeManager, nodeManager), properties);
         if (workerSessionPropertyProviders.putIfAbsent(sessionPropertyProviderName, sessionPropertyProvider) != null) {
             throw new IllegalArgumentException("System session property provider is already registered for property provider : " + sessionPropertyProviderName);
         }
         log.info("-- Added session property provider [%s] --", sessionPropertyProviderName);
+    }
+
+    @VisibleForTesting
+    public Map<String, WorkerSessionPropertyProvider> getWorkerSessionPropertyProviders()
+    {
+        return ImmutableMap.copyOf(workerSessionPropertyProviders);
     }
 
     public void addSessionPropertyProviderFactory(WorkerSessionPropertyProviderFactory factory)

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -109,7 +109,7 @@ public interface QueryRunner
 
     void loadFunctionNamespaceManager(String functionNamespaceManagerName, String catalogName, Map<String, String> properties);
 
-    default void loadSessionPropertyProvider(String sessionPropertyProviderName)
+    default void loadSessionPropertyProvider(String sessionPropertyProviderName, Map<String, String> properties)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionDefinitionProvider.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionDefinitionProvider.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sidecar.ForSidecarInfo;
 import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PrestoException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
@@ -77,5 +78,11 @@ public class NativeFunctionDefinitionProvider
                 .uriBuilderFrom(sidecarNode.getHttpUri())
                 .appendPath(FUNCTION_SIGNATURES_ENDPOINT)
                 .build();
+    }
+
+    @VisibleForTesting
+    public HttpClient getHttpClient()
+    {
+        return httpClient;
     }
 }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionNamespaceManager.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionNamespaceManager.java
@@ -49,6 +49,7 @@ import com.facebook.presto.spi.function.SqlFunctionSupplier;
 import com.facebook.presto.spi.function.SqlInvokedAggregationFunctionImplementation;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.function.TypeVariableConstraint;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -364,6 +365,12 @@ public class NativeFunctionNamespaceManager
             }
         }
         return newTypeSignaturesList;
+    }
+
+    @VisibleForTesting
+    public FunctionDefinitionProvider getFunctionDefinitionProvider()
+    {
+        return functionDefinitionProvider;
     }
 
     private static List<TypeSignatureParameter> getTypeSignatureParameters(

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/sessionpropertyproviders/NativeSystemSessionPropertyProvider.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/sessionpropertyproviders/NativeSystemSessionPropertyProvider.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.session.SessionPropertyMetadata;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProvider;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.inject.Inject;
@@ -143,5 +144,11 @@ public class NativeSystemSessionPropertyProvider
                 .uriBuilderFrom(sidecarNode.getHttpUri())
                 .appendPath(SESSION_PROPERTIES_ENDPOINT)
                 .build();
+    }
+
+    @VisibleForTesting
+    public HttpClient getHttpClient()
+    {
+        return httpClient;
     }
 }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/sessionpropertyproviders/NativeSystemSessionPropertyProviderFactory.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/sessionpropertyproviders/NativeSystemSessionPropertyProviderFactory.java
@@ -20,6 +20,8 @@ import com.facebook.presto.spi.session.WorkerSessionPropertyProvider;
 import com.facebook.presto.spi.session.WorkerSessionPropertyProviderFactory;
 import com.google.inject.Injector;
 
+import java.util.Map;
+
 public class NativeSystemSessionPropertyProviderFactory
         implements WorkerSessionPropertyProviderFactory
 {
@@ -32,7 +34,7 @@ public class NativeSystemSessionPropertyProviderFactory
     }
 
     @Override
-    public WorkerSessionPropertyProvider create(SessionPropertyContext context)
+    public WorkerSessionPropertyProvider create(SessionPropertyContext context, Map<String, String> config)
     {
         Bootstrap app = new Bootstrap(
                 new NativeSystemSessionPropertyProviderModule(
@@ -42,6 +44,7 @@ public class NativeSystemSessionPropertyProviderFactory
         Injector injector = app
                 .doNotInitializeLogging()
                 .noStrictConfig()
+                .setRequiredConfigurationProperties(config)
                 .initialize();
         return injector.getInstance(NativeSystemSessionPropertyProvider.class);
     }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/NativeSidecarPluginQueryRunnerUtils.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/NativeSidecarPluginQueryRunnerUtils.java
@@ -21,12 +21,14 @@ import com.google.common.collect.ImmutableMap;
 
 public class NativeSidecarPluginQueryRunnerUtils
 {
-    private NativeSidecarPluginQueryRunnerUtils() {};
+    private NativeSidecarPluginQueryRunnerUtils() {}
 
     public static void setupNativeSidecarPlugin(QueryRunner queryRunner)
     {
         queryRunner.installCoordinatorPlugin(new NativeSidecarPlugin());
-        queryRunner.loadSessionPropertyProvider(NativeSystemSessionPropertyProviderFactory.NAME);
+        queryRunner.loadSessionPropertyProvider(
+                NativeSystemSessionPropertyProviderFactory.NAME,
+                ImmutableMap.of());
         queryRunner.loadFunctionNamespaceManager(
                 NativeFunctionNamespaceManagerFactory.NAME,
                 "native",

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/WorkerSessionPropertyProviderFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/WorkerSessionPropertyProviderFactory.java
@@ -13,9 +13,11 @@
  */
 package com.facebook.presto.spi.session;
 
+import java.util.Map;
+
 public interface WorkerSessionPropertyProviderFactory
 {
     String getName();
 
-    WorkerSessionPropertyProvider create(SessionPropertyContext context);
+    WorkerSessionPropertyProvider create(SessionPropertyContext context, Map<String, String> config);
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -1013,12 +1013,12 @@ public class DistributedQueryRunner
     }
 
     @Override
-    public void loadSessionPropertyProvider(String sessionPropertyProviderName)
+    public void loadSessionPropertyProvider(String sessionPropertyProviderName, Map<String, String> properties)
     {
         for (TestingPrestoServer server : servers) {
             server.getMetadata().getSessionPropertyManager().loadSessionPropertyProvider(
                     sessionPropertyProviderName,
-                    ImmutableMap.of(),
+                    properties,
                     Optional.ofNullable(server.getMetadata().getFunctionAndTypeManager()),
                     Optional.ofNullable(server.getPluginNodeManager()));
         }


### PR DESCRIPTION
Summary: Currently, session property manager has an unused parameter called `properties` so that even if a config is set in a file, for example `/etc/session-property-providers/native-worker.properties`, the configs are not correctly used.

Differential Revision: D78415640

```
== RELEASE NOTES ==

General Changes
* Fix native session property manager reading plugin configs from file

