### PR TITLE
[native] Add evb violation counter for exchange io and http server io threadpool

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -413,6 +413,12 @@ void PrestoServer::run() {
                            << exchangeHttpIoExecutor_->getName() << "' has "
                            << exchangeHttpIoExecutor_->numThreads()
                            << " threads.";
+  for (auto evb : exchangeHttpIoExecutor_->getAllEventBases()) {
+    evb->setMaxLatency(
+        std::chrono::milliseconds(systemConfig->exchangeIoEvbViolationThresholdMs()),
+        []() { RECORD_METRIC_VALUE(kCounterExchangeIoEvbViolation, 1); },
+        /*dampen=*/false);
+  }
 
   const auto numExchangeHttpClientCpuThreads = std::max<size_t>(
       systemConfig->exchangeHttpClientNumCpuThreadsHwMultiplier() *
@@ -532,6 +538,12 @@ void PrestoServer::run() {
     PRESTO_STARTUP_LOG(INFO)
         << "HTTP Server CPU executor '" << httpSrvCpuExecutor_->getName()
         << "' has " << httpSrvCpuExecutor_->numThreads() << " threads.";
+    for (auto evb : httpSrvIoExecutor_->getAllEventBases()) {
+      evb->setMaxLatency(
+          std::chrono::milliseconds(systemConfig->httpSrvIoEvbViolationThresholdMs()),
+          []() { RECORD_METRIC_VALUE(kCounterHttpServerIoEvbViolation, 1); },
+          /*dampen=*/false);
+    }
   }
   if (spillerExecutor_ != nullptr) {
     PRESTO_STARTUP_LOG(INFO)

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -261,6 +261,8 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kOrderBySpillEnabled, true),
           NUM_PROP(kRequestDataSizesMaxWaitSec, 10),
           STR_PROP(kPluginDir, ""),
+          NUM_PROP(kExchangeIoEvbViolationThresholdMs, 1000),
+          NUM_PROP(kHttpSrvIoEvbViolationThresholdMs, 1000),
       };
 }
 
@@ -895,6 +897,16 @@ std::string SystemConfig::prestoDefaultNamespacePrefix() const {
 
 std::string SystemConfig::pluginDir() const {
   return optionalProperty(kPluginDir).value();
+}
+
+int32_t SystemConfig::exchangeIoEvbViolationThresholdMs() const {
+  return optionalProperty<int32_t>(kExchangeIoEvbViolationThresholdMs)
+      .value();
+}
+
+int32_t SystemConfig::httpSrvIoEvbViolationThresholdMs() const {
+  return optionalProperty<int32_t>(kHttpSrvIoEvbViolationThresholdMs)
+      .value();
 }
 
 NodeConfig::NodeConfig() {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -750,6 +750,11 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kRequestDataSizesMaxWaitSec{
     "exchange.http-client.request-data-sizes-max-wait-sec"};
 
+  static constexpr std::string_view kExchangeIoEvbViolationThresholdMs{
+      "exchange.io-evb-violation-threshold-ms"};
+  static constexpr std::string_view kHttpSrvIoEvbViolationThresholdMs{
+      "http-server.io-evb-violation-threshold-ms"};
+
   SystemConfig();
 
   virtual ~SystemConfig() = default;
@@ -1026,6 +1031,10 @@ class SystemConfig : public ConfigBase {
   int requestDataSizesMaxWaitSec() const;
 
   std::string pluginDir() const;
+
+  int32_t exchangeIoEvbViolationThresholdMs() const;
+
+  int32_t httpSrvIoEvbViolationThresholdMs() const;
 };
 
 /// Provides access to node properties defined in node.properties file.

--- a/presto-native-execution/presto_cpp/main/common/Counters.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Counters.cpp
@@ -161,6 +161,9 @@ void registerPrestoMetrics() {
       99,
       100);
 
+  DEFINE_METRIC(kCounterExchangeIoEvbViolation, facebook::velox::StatType::COUNT);
+  DEFINE_METRIC(kCounterHttpServerIoEvbViolation, facebook::velox::StatType::COUNT);
+
   // NOTE: Metrics type exporting for thread pool executor counters are in
   // PeriodicTaskManager because they have dynamic names and report configs. The
   // following counters have their type exported there:

--- a/presto-native-execution/presto_cpp/main/common/Counters.h
+++ b/presto-native-execution/presto_cpp/main/common/Counters.h
@@ -196,6 +196,12 @@ constexpr std::string_view kCounterThreadPoolNumTotalTasksFormat{
 constexpr std::string_view kCounterThreadPoolMaxIdleTimeNsFormat{
     "presto_cpp.{}.max_idle_time_ns"};
 
+/// ================== EVB Counters ====================
+constexpr folly::StringPiece kCounterExchangeIoEvbViolation{
+  "presto_cpp.exchange_io_evb_violation_count"};
+constexpr folly::StringPiece kCounterHttpServerIoEvbViolation{
+  "presto_cpp.http_server_io_evb_violation_count"};
+
 /// ================== Memory Pushback Counters =================
 
 /// Number of times memory pushback mechanism is triggered.


### PR DESCRIPTION
When worker is busy on CPU, we observed delays in exchange connection. 
Add evb violation counter for http server and exchange server IO thread pool 
to give visibility


```
== NO RELEASE NOTE ==
```

