### PR TITLE
[native] Fix AbstractTestNativeGeneralQueries.testCatalogWithCacheEna…

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -143,14 +143,15 @@ public abstract class AbstractTestNativeGeneralQueries
 
         getQueryRunner().createCatalog("hivecached", "hive", hiveProperties);
 
-        Session session = Session.builder(getSession())
+        Session actualSession = Session.builder(getSession())
                 .setCatalog("hivecached")
                 .setCatalogSessionProperty("hivecached", "orc_compression_codec", "ZSTD")
                 .setCatalogSessionProperty("hivecached", "collect_column_statistics_on_write", "false")
                 .build();
         try {
-            getQueryRunner().execute(session, "CREATE TABLE tmp AS SELECT * FROM nation");
-            assertQuery("SELECT * FROM tmp");
+            getQueryRunner().execute(actualSession, "CREATE TABLE tmp AS SELECT * FROM nation");
+            Session expectedSession = getSession();
+            assertQuery(actualSession, "SELECT * FROM tmp", expectedSession, "SELECT * FROM tmp");
         }
         finally {
             dropTableIfExists("tmp");

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -37,10 +37,6 @@ public class TestPrestoSparkNativeGeneralQueries
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
     @Override
     @Ignore
-    public void testCatalogWithCacheEnabled() {}
-
-    @Override
-    @Ignore
     public void testAnalyzeStatsOnDecimals() {}
 
     // VeloxUserError:  Unsupported file format in TableWrite: "ORC".


### PR DESCRIPTION
## Description
This test did not specify session properties when executing the assert query. It picks up the default session properties which might not have the catalog set correctly, resulting in connector not found error.

```
== NO RELEASE NOTE ==
```

