### PR TITLE
Add geometry type to the list of supported types in NativeTypeManager

### DIFF
--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.common.type.StandardTypes.DATE;
 import static com.facebook.presto.common.type.StandardTypes.DECIMAL;
 import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.common.type.StandardTypes.GEOMETRY;
 import static com.facebook.presto.common.type.StandardTypes.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.StandardTypes.INTEGER;
 import static com.facebook.presto.common.type.StandardTypes.INTERVAL_DAY_TO_SECOND;
@@ -96,7 +97,8 @@ public class NativeTypeManager
                     INTERVAL_DAY_TO_SECOND,
                     INTERVAL_YEAR_TO_MONTH,
                     VARCHAR,
-                    UNKNOWN);
+                    UNKNOWN,
+                    GEOMETRY);
 
     private static final Set<String> NATIVE_ENGINE_SUPPORTED_PARAMETRIC_TYPES =
             ImmutableSet.of(

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -286,6 +286,19 @@ public class TestNativeSidecarPlugin
         }
     }
 
+    @Test
+    public void testGeometryQueries()
+    {
+        assertQuery("SELECT ST_DISTANCE(ST_POINT(0,  0), ST_POINT(3, 4))");
+        assertQuery("SELECT ST_CONTAINS(" +
+                "ST_GeometryFromText('POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))'), " +
+                "ST_POINT(5, 5))");
+        assertQuery("SELECT ST_POINT(nationkey, regionkey) from nation");
+        assertQuery("SELECT " +
+                "ST_DISTANCE(ST_POINT(a.nationkey, a.regionkey), ST_POINT(b.nationkey, b.regionkey)) " +
+                "FROM nation a JOIN nation b ON a.nationkey < b.nationkey");
+    }
+
     private String generateRandomTableName()
     {
         String tableName = "tmp_presto_" + UUID.randomUUID().toString().replace("-", "");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -32,6 +32,7 @@ import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.common.type.UuidType;
 import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.geospatial.type.GeometryType;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.analyzer.UpdateInfo;
@@ -296,6 +297,9 @@ public class TestingPrestoClient
             return value;
         }
         else if (JSON.equals(type)) {
+            return value;
+        }
+        else if (type instanceof GeometryType) {
             return value;
         }
         else {


### PR DESCRIPTION
## Description
Add geometry type to the list of supported types in NativeTypeManager

## Motivation and Context
Geometry type is supported in native execution.

## Impact
No impact

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add geometry type to the list of supported types in NativeTypeManager
```

