### PR TITLE
[native] Fix 'ORC' not supported issue in pos tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1915,6 +1915,7 @@ public abstract class AbstractTestNativeGeneralQueries
         assertThat(getQueryRunner().execute(session, "EXPLAIN (TYPE DISTRIBUTED) " + wideAggregation).getOnlyValue().toString())
                 .contains("Output encoding: ROW_WISE");
     }
+
     @Test
     public void testUuid()
     {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -29,7 +29,7 @@ public class NativeQueryRunnerUtils
     public static Map<String, String> getNativeWorkerHiveProperties()
     {
         return ImmutableMap.of("hive.parquet.pushdown-filter-enabled", "true",
-                "hive.orc-compression-codec", "ZSTD");
+            "hive.orc-compression-codec", "ZSTD", "hive.storage-format", "DWRF");
     }
 
     public static Map<String, String> getNativeWorkerIcebergProperties()

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -182,7 +182,7 @@ public class PrestoSparkNativeQueryRunnerUtils
         return sparkConfigs.build();
     }
 
-    public static synchronized Path getBaseDataPath()
+    private static synchronized Path getBaseDataPath()
     {
         if (dataDirectory.isPresent()) {
             return dataDirectory.get();

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -62,34 +62,16 @@ public class TestPrestoSparkNativeGeneralQueries
     }
 
     // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
+
+    // This test is broken likely due to Parquet related issues.
     @Override
     @Ignore
     public void testAnalyzeStatsOnDecimals() {}
 
-    // VeloxUserError:  Unsupported file format in TableWrite: "ORC".
+    // Access Denied: Cannot set catalog session property hive.pushdown_filter_enabled
     @Override
     @Ignore
     public void testColumnFilter() {}
-
-    // VeloxUserError:  Unsupported file format in TableWrite: "ORC".
-    @Override
-    @Ignore
-    public void testIPAddressIPPrefix() {}
-
-    // VeloxUserError:  Unsupported file format in TableWrite: "ORC".
-    @Override
-    @Ignore
-    public void testInvalidUuid() {}
-
-    // VeloxUserError:  Unsupported file format in TableWrite: "ORC".
-    @Override
-    @Ignore
-    public void testStringFunctions() {}
-
-    // VeloxUserError:  Unsupported file format in TableWrite: "ORC".
-    @Override
-    @Ignore
-    public void testUuid() {}
 
     // Access Denied: Cannot set catalog session property
     // hive.parquet_pushdown_filter_enabled
@@ -109,14 +91,25 @@ public class TestPrestoSparkNativeGeneralQueries
     @Ignore
     public void testTimestampWithTimeZone() {}
 
+    // pattern assertion is only supported for DistributedQueryRunner
     @Override
     @Ignore
     public void testDistributedSortSingleNode() {}
 
-    //VeloxRuntimeError: ReaderFactory is not registered for format text
+    // VeloxRuntimeError: ReaderFactory is not registered for format text
     @Override
     @Ignore
     public void testReadTableWithTextfileFormat() {}
+
+    // https://github.com/prestodb/presto/issues/22275
+    @Override
+    @Ignore
+    public void testUnionAllInsert() {}
+
+    // java.lang.IllegalArgumentException: pattern assertion is only supported for DistributedQueryRunner
+    @Override
+    @Ignore
+    public void testRowWiseExchange() {}
 
     @Override
     @Ignore
@@ -127,17 +120,8 @@ public class TestPrestoSparkNativeGeneralQueries
     public void testShowAndDescribe() {}
 
     @Override
+    @Ignore
     public void testSystemTables() {}
-
-    // @TODO Refer https://github.com/prestodb/presto/issues/20294
-    @Override
-    @Ignore
-    public void testAnalyzeStats() {}
-
-    // https://github.com/prestodb/presto/issues/22275
-    @Override
-    @Ignore
-    public void testUnionAllInsert() {}
 
     @Override
     @Ignore
@@ -146,8 +130,4 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testSetSessionJavaWorkerSessionProperty() {}
-
-    @Override
-    @Ignore
-    public void testRowWiseExchange() {}
 }


### PR DESCRIPTION
## Description
When running custom create tables queries in pos tests the hive format is not set, defaulting the format to be orc which is not supported by Velox. Set default hive storage format property to be DWRF to address this issue.
The PR also added comments for other failed tests to facilitate future work.

```
== NO RELEASE NOTE ==
```

