### PR TITLE
Fix candidate selection when matching function signature with coercion

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionSignatureMatcher.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionSignatureMatcher.java
@@ -203,9 +203,10 @@ public final class FunctionSignatureMatcher
             for (int i = 0; i < representatives.size(); i++) {
                 ApplicableFunction representative = representatives.get(i);
                 if (isMoreSpecificThan(current, representative)) {
+                    found = true;
                     representatives.set(i, current);
                 }
-                if (isMoreSpecificThan(current, representative) || isMoreSpecificThan(representative, current)) {
+                if (isMoreSpecificThan(representative, current)) {
                     found = true;
                     break;
                 }
@@ -216,7 +217,9 @@ public final class FunctionSignatureMatcher
             }
         }
 
-        return representatives;
+        return representatives.stream()
+                .distinct()
+                .collect(toImmutableList());
     }
 
     private List<ApplicableFunction> getUnknownOnlyCastFunctions(List<ApplicableFunction> applicableFunction, List<Type> actualParameters)


### PR DESCRIPTION
## Description

The function `selectMostSpecificFunctions()` in `FunctionSignatureMatcher.java` is used to select a list of possible function signature candidates to resolve a function by coercing the input type parameters. The signature matching criteria used in `selectMostSpecificFunctions` does not return the proper list of applicable function candidates; this was uncovered when running the following query in `presto-native-tests` with sidecar enabled:
```
SELECT orderstatus, approx_percentile(orderkey, 2, 0.5) FROM orders GROUP BY orderstatus
```

## Motivation and Context

For the above query, the input parameter types are `bigint, integer, decimal(1,1)` and there are six possible function signatures that can be used for function resolution in `selectMostSpecificFunctions()`. The expected function signature to resolve this function call is `approx_percentile(bigint,bigint,double):bigint`.

In Presto java, the first function signature candidate in the input list to `selectMostSpecificFunctions()` is `approx_percentile(bigint,bigint,double):bigint`. Since this is the expected function signature for resolution, the list of possible representatives that is maintained only contains this signature.
In Presto C++ with sidecar, the last function signature candidate in the input list to `selectMostSpecificFunctions()` is `approx_percentile(bigint,bigint,double):bigint`. As a result, the function signature `approx_percentile(bigint,double,double):bigint` is added to the list of representatives (at index 1) before `approx_percentile(bigint,bigint,double):bigint` is added (to replace the function signature candidate at index 0); this results in the following error:
```
java.lang.RuntimeException: line 1:99: Could not choose a best candidate operator. Explicit type casts must be added.
Candidates are:
	 * native.default.approx_percentile(bigint,bigint,double):bigint
	 * native.default.approx_percentile(bigint,double,double):bigint
```

In `selectMostSpecificFunctions()`, when a more specific function signature candidate is found than the representative function signature it is being compared with, the representative in the list is replaced with the current candidate. After this is done, the signature matcher stops comparing the current candidate with the other function signature representatives. This results in possible duplicate candidates for resolving the aforementioned `approx_percentile` function call. 

This change compares the more specific function signature candidate with all the function signature representatives encountered till that point and replaces the representatives at each applicable index in the list with the more suitable function signature candidate. 


## Release Notes

```
== NO RELEASE NOTE ==
```