### PR TITLE
Fix IllegalAccessError in SqlFunctionHandle.Resolver cross-class-loader access

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlFunctionHandle.java
@@ -108,7 +108,7 @@ public class SqlFunctionHandle
     {
         private static final Resolver INSTANCE = new Resolver();
 
-        private Resolver() {}
+        public Resolver() {}
 
         public static Resolver getInstance()
         {


### PR DESCRIPTION
Summary:
**Root Cause:**
• XdbFunctionNamespaceManagerFactory (loaded by PluginClassLoader) cannot access private constructor of SqlFunctionHandle.Resolver (loaded by app class loader)
• Java's access control prevents cross-class-loader access to private members
• getInstance() method fails with IllegalAccessError when trying to instantiate the resolver

**Fix:**
• Changed SqlFunctionHandle.Resolver constructor from private to public
• Maintains backward compatibility with existing getInstance() method
• Follows pattern used by other resolver classes in Presto (NativeFunctionHandle.Resolver, RestFunctionHandle.Resolver)
• Enables proper cross-class-loader instantiation required by Presto's plugin architecture

This resolves the startup failure of XDB function namespace manager while maintaining all existing functionality.

Differential Revision: D78506053


