### PR TITLE
[native] Prepare config param for TextReader and TextWriter integration

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -276,7 +276,7 @@ void PrestoServer::run() {
 
   registerFileSinks();
   registerFileSystems();
-  registerFileReadersAndWriters();
+  registerFileReadersAndWriters(systemConfig);
   registerMemoryArbitrators();
   registerShuffleInterfaceFactories();
   registerCustomOperators();
@@ -1379,7 +1379,7 @@ void PrestoServer::registerMemoryArbitrators() {
   velox::memory::SharedArbitrator::registerFactory();
 }
 
-void PrestoServer::registerFileReadersAndWriters() {
+void PrestoServer::registerFileReadersAndWriters(SystemConfig* /*systemConfig*/) {
   velox::dwrf::registerDwrfReaderFactory();
   velox::dwrf::registerDwrfWriterFactory();
   velox::orc::registerOrcReaderFactory();

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -140,7 +140,7 @@ class PrestoServer {
   /// connectors.
   virtual void registerFileSinks();
 
-  virtual void registerFileReadersAndWriters();
+  virtual void registerFileReadersAndWriters(SystemConfig* systemConfig);
 
   virtual void unregisterFileReadersAndWriters();
 


### PR DESCRIPTION
## Description
Preparing to integrate TextReader and TextWriter to PrestoServer

## Motivation and Context
Config will be used to enable/disable TextReader and TextWriter for a safe rollout plan

## Impact
This PR is the first step moving towards integrating TextReader and TextWriter

## Test Plan


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

