### PR TITLE
Supports batched serialized size calculation for BinarySortableSerializer

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BinarySortableSerializer.h
+++ b/presto-native-execution/presto_cpp/main/operators/BinarySortableSerializer.h
@@ -43,6 +43,18 @@ class BinarySortableSerializer {
   /// Returns the serialized byte size of a given input row at 'rowId'.
   size_t serializedSizeInBytes(velox::vector_size_t rowId) const;
 
+  /// Returns the serialized byte sizes for a batch of input rows in columnar
+  /// order.
+  /// @param offset Starting offset in the input vector
+  /// @param size Number of rows to process
+  /// @param sizes Output array of size pointers to store results
+  /// @param scratch Scratch memory for temporary allocations
+  void serializedSizeInBytes(
+      velox::vector_size_t offset,
+      velox::vector_size_t size,
+      velox::vector_size_t** sizes,
+      velox::Scratch& scratch) const;
+
  private:
   const velox::RowVectorPtr input_;
   const std::vector<velox::core::SortOrder> sortOrders_;


### PR DESCRIPTION
Summary: BinarySortableSerializer::serializedSizeInBytes only supports estimating serialized size of input RowVector one row at a time. For workloads that require serializing a range of rows, performance can be improved through vectorized processing. Introduce a range-based API to handle such cases more efficiently, and guarantee same results compared to the row-by-row version.

Reviewed By: xiaoxmeng

Differential Revision: D78365988


```
== RELEASE NOTES ==
Prestissimo (Native Execution) Changes
* Improve serialized size estimation by introducing a batched API using vectorized operations. It delivers up to 8x faster size estimation compared to the previous row-by-row implementation. Workloads with high serialization cost will benefit from adopting this range-based API. 
```

