### PR TITLE
Simplify uri builder logic used for fetching TaskStatus

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcherWithEventLoop.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ContinuousTaskStatusFetcherWithEventLoop.java
@@ -39,6 +39,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
 import io.netty.channel.EventLoop;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -179,7 +181,7 @@ class ContinuousTaskStatusFetcherWithEventLoop
             responseHandler = createAdaptingJsonResponseHandler((JsonCodec<TaskStatus>) taskStatusCodec);
         }
 
-        Request request = requestBuilder.setUri(uriBuilderFrom(taskStatus.getSelf()).appendPath("status").build())
+        Request request = requestBuilder.setUri(getStatusUri(taskStatus.getSelf()))
                 .setHeader(PRESTO_CURRENT_STATE, taskStatus.getState().toString())
                 .setHeader(PRESTO_MAX_WAIT, refreshMaxWait.toString())
                 .build();
@@ -306,5 +308,22 @@ class ContinuousTaskStatusFetcherWithEventLoop
         verify(taskEventLoop.inEventLoop());
 
         stats.statusRoundTripMillis(nanosSince(currentRequestStartNanos).toMillis());
+    }
+
+    private URI getStatusUri(URI baseUri)
+    {
+        try {
+            String baseUriPath = baseUri.getPath();
+            if (baseUriPath.endsWith("/")) {
+                return baseUri.resolve("status");
+            }
+
+            baseUriPath += "/";
+            URI updatedBaseUri = new URI(baseUri.getScheme(), baseUri.getAuthority(), baseUriPath, null);
+            return updatedBaseUri.resolve("status");
+        }
+        catch (URISyntaxException e) {
+            return uriBuilderFrom(baseUri).appendPath("status").build();
+        }
     }
 }


### PR DESCRIPTION
## Description
Simplify uri builder logic used for fetching TaskStatus by not creating a new HttpUriBuilder object for every request

## Motivation and Context
We observed that creating a new HttpUriBuilder object for every getTaskStatus call is adding up and causing young gc. So this pr is an effort to reduce GC by simplifying .  

## Impact
Reduced young GC on coordinator

## Test Plan
exisiting tests and verifier testing

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

