### PR TITLE
[native] Fix set catalog session access denied issue

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -73,7 +73,7 @@ public class PrestoSparkNativeQueryRunnerUtils
 
     private PrestoSparkNativeQueryRunnerUtils() {}
 
-    public static Map<String, String> getNativeExecutionSessionConfigs()
+    public static Map<String, String> getNativeExecutionSparkConfigs()
     {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>()
                 // Do not use default Prestissimo config files. Presto-Spark will generate the configs on-the-fly.
@@ -114,7 +114,7 @@ public class PrestoSparkNativeQueryRunnerUtils
         return createRunner(
                 defaultCatalog,
                 Optional.of(getBaseDataPath()),
-                getNativeExecutionSessionConfigs(),
+                getNativeExecutionSparkConfigs(),
                 getNativeExecutionShuffleConfigs(),
                 ImmutableList.of(nativeExecutionModule));
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -68,29 +68,6 @@ public class TestPrestoSparkNativeGeneralQueries
     @Ignore
     public void testAnalyzeStatsOnDecimals() {}
 
-    // Access Denied: Cannot set catalog session property hive.pushdown_filter_enabled
-    @Override
-    @Ignore
-    public void testColumnFilter() {}
-
-    // Access Denied: Cannot set catalog session property
-    // hive.parquet_pushdown_filter_enabled
-    @Override
-    @Ignore
-    public void testDecimalApproximateAggregates() {}
-
-    // Access Denied: Cannot set catalog session property
-    // hive.parquet_pushdown_filter_enabled
-    @Override
-    @Ignore
-    public void testDecimalRangeFilters() {}
-
-    // Access Denied: Cannot set catalog session property
-    // hive.pushdown_filter_enabled
-    @Override
-    @Ignore
-    public void testTimestampWithTimeZone() {}
-
     // pattern assertion is only supported for DistributedQueryRunner
     @Override
     @Ignore
@@ -100,11 +77,6 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testReadTableWithTextfileFormat() {}
-
-    // https://github.com/prestodb/presto/issues/22275
-    @Override
-    @Ignore
-    public void testUnionAllInsert() {}
 
     // java.lang.IllegalArgumentException: pattern assertion is only supported for DistributedQueryRunner
     @Override

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -65,6 +65,8 @@ import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.function.FunctionImplementationType;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.PrincipalType;
+import com.facebook.presto.spi.security.SelectedRole;
+import com.facebook.presto.spi.security.SelectedRole.Type;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
@@ -333,10 +335,16 @@ public class PrestoSparkQueryRunner
                 .setSchema("tpch")
                 // Sql-Standard Access Control Checker
                 // needs us to specify our role
-                .setIdentity(new Identity(
+                .setIdentity(
+                    new Identity(
                         "hive",
                         Optional.empty(),
-                        ImmutableMap.of(defaultCatalog, "admin")))
+                        ImmutableMap.of(defaultCatalog,
+                            new SelectedRole(Type.ROLE, Optional.of("admin"))),
+                        ImmutableMap.of(),
+                        ImmutableMap.of(),
+                        Optional.empty(),
+                        Optional.empty()))
                 .build();
 
         transactionManager = injector.getInstance(TransactionManager.class);


### PR DESCRIPTION
## Description
Spark query runner does not set admin role for hive, making setting sessions failing. 
```
== NO RELEASE NOTE ==
```

