### PR TITLE
Add alias collect_list for array_agg

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -159,6 +159,22 @@ General Aggregate Functions
         ) AS t(name, age, gender);
         --(C0ACD56CF866E759)//hex format
 
+.. function:: collect_list(x) -> array<[same as input]>
+
+    This is an alias for :func:`!array_agg`.
+    ::
+
+        SELECT collect_list(name)
+        FROM
+        (
+            VALUES
+                ('Alice', 30,'male'),
+                ('Bob', 25,'male'),
+                ('Charlie', 22,'female'),
+                ('Lucy', 20,'female')
+        ) AS t(name, age, gender);
+        --['Alice','Bob','Charlie','Lucy']
+
 .. function:: count(*) -> bigint
 
     Returns the number of input rows.

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -91,6 +91,7 @@ import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequent;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunction;
+import com.facebook.presto.operator.aggregation.arrayagg.CollectListAggregationFunction;
 import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyAggregation;
 import com.facebook.presto.operator.aggregation.histogram.Histogram;
 import com.facebook.presto.operator.aggregation.multimapagg.AlternativeMultimapAggregationFunction;
@@ -931,6 +932,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, ARRAY_TO_JSON, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY)
                 .functions(SET_AGG, SET_UNION)
                 .function(new ArrayAggregationFunction(functionsConfig.isLegacyArrayAgg(), functionsConfig.getArrayAggGroupImplementation()))
+                .function(new CollectListAggregationFunction(functionsConfig.isLegacyArrayAgg(), functionsConfig.getArrayAggGroupImplementation()))
                 .functions(new MapSubscriptOperator(functionsConfig.isLegacyMapSubscript()))
                 .functions(MAP_CONSTRUCTOR, MAP_TO_JSON, JSON_TO_MAP, JSON_STRING_TO_MAP)
                 .functions(MAP_AGG, MAP_UNION, MAP_UNION_SUM)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/CollectListAggregationFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/CollectListAggregationFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.arrayagg;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.spi.function.Signature.typeVariable;
+
+/**
+ * Alias for array_agg function to match Spark SQL's collect_list
+ */
+public class CollectListAggregationFunction
+        extends SqlAggregationFunction
+{
+    private static final String NAME = "collect_list";
+    private final ArrayAggregationFunction delegate;
+
+    public CollectListAggregationFunction(boolean legacyArrayAgg, ArrayAggGroupImplementation groupMode)
+    {
+        super(NAME,
+                ImmutableList.of(typeVariable("T")),
+                ImmutableList.of(),
+                parseTypeSignature("array(T)"),
+                ImmutableList.of(parseTypeSignature("T")));
+        this.delegate = new ArrayAggregationFunction(legacyArrayAgg, groupMode);
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "return an array of values (alias for array_agg)";
+    }
+
+    @Override
+    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        return delegate.specialize(boundVariables, arity, functionAndTypeManager);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/aggregation/arrayagg/TestCollectListAggregationFunction.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/aggregation/arrayagg/TestCollectListAggregationFunction.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.arrayagg;
+
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.operator.aggregation.BuiltInAggregationFunctionImplementation;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.operator.aggregation.arrayagg.ArrayAggGroupImplementation.NEW;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@Test(singleThreaded = true)
+public class TestCollectListAggregationFunction
+{
+    private FunctionAndTypeManager functionAndTypeManager;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        functionAndTypeManager = createTestFunctionAndTypeManager();
+    }
+
+    @Test
+    public void testFunctionName()
+    {
+        CollectListAggregationFunction function = new CollectListAggregationFunction(false, NEW);
+        assertEquals(function.getSignature().getName().getObjectName(), "collect_list");
+    }
+
+    @Test
+    public void testDescription()
+    {
+        CollectListAggregationFunction function = new CollectListAggregationFunction(false, NEW);
+        assertEquals(function.getDescription(), "return an array of values (alias for array_agg)");
+    }
+
+    @Test
+    public void testSignature()
+    {
+        CollectListAggregationFunction function = new CollectListAggregationFunction(false, NEW);
+
+        // Verify signature has correct structure
+        assertEquals(function.getSignature().getTypeVariableConstraints().size(), 1);
+        assertEquals(function.getSignature().getTypeVariableConstraints().get(0).getName(), "T");
+
+        // Verify return type is array(T)
+        assertEquals(function.getSignature().getReturnType().toString(), "array(T)");
+
+        // Verify single argument of type T
+        assertEquals(function.getSignature().getArgumentTypes().size(), 1);
+        assertEquals(function.getSignature().getArgumentTypes().get(0).toString(), "T");
+    }
+
+    @Test
+    public void testSpecializeWithBigint()
+    {
+        CollectListAggregationFunction function = new CollectListAggregationFunction(false, NEW);
+
+        BoundVariables boundVariables = BoundVariables.builder()
+                .setTypeVariable("T", BIGINT)
+                .build();
+
+        // Verify it doesn't throw an exception and returns a valid implementation
+        BuiltInAggregationFunctionImplementation implementation = function.specialize(boundVariables, 1, functionAndTypeManager);
+        assertNotNull(implementation);
+    }
+
+    @Test
+    public void testSpecializeWithVarchar()
+    {
+        CollectListAggregationFunction function = new CollectListAggregationFunction(false, NEW);
+
+        BoundVariables boundVariables = BoundVariables.builder()
+                .setTypeVariable("T", VARCHAR)
+                .build();
+
+        // Verify it doesn't throw an exception and returns a valid implementation
+        BuiltInAggregationFunctionImplementation implementation = function.specialize(boundVariables, 1, functionAndTypeManager);
+        assertNotNull(implementation);
+    }
+
+    @Test
+    public void testLegacyMode()
+    {
+        // Test with legacy mode enabled
+        CollectListAggregationFunction legacyFunction = new CollectListAggregationFunction(true, NEW);
+
+        BoundVariables boundVariables = BoundVariables.builder()
+                .setTypeVariable("T", BIGINT)
+                .build();
+
+        BuiltInAggregationFunctionImplementation implementation = legacyFunction.specialize(boundVariables, 1, functionAndTypeManager);
+        assertNotNull(implementation);
+    }
+
+    @Test
+    public void testDifferentGroupImplementations()
+    {
+        // Test with different ArrayAggGroupImplementation values
+        for (ArrayAggGroupImplementation groupImpl : ArrayAggGroupImplementation.values()) {
+            CollectListAggregationFunction function = new CollectListAggregationFunction(false, groupImpl);
+
+            BoundVariables boundVariables = BoundVariables.builder()
+                    .setTypeVariable("T", BIGINT)
+                    .build();
+
+            BuiltInAggregationFunctionImplementation implementation = function.specialize(boundVariables, 1, functionAndTypeManager);
+            assertNotNull(implementation);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #25495

## Description
Add "collect_list" as an alias for the "array_agg" aggregate function to improve compatibility with Spark SQL. This change introduces a new CollectListAggregationFunction class that delegates to the existing ArrayAggregationFunction implementation while providing the alternate function name.

## Motivation and Context
Spark SQL uses "collect_list" as a synonym for array_agg function (https://docs.databricks.com/aws/en/sql/language-manual/functions/collect_list). The "collect_list" usage is very popular in the Spark ecosystem. Adding this alias to Presto SQL improves compatibility and ease of migration for users coming from Spark environments.

## Impact
This change adds a new SQL function alias without modifying any existing functionality. Users can now use both array_agg() and collect_list() interchangeably. No performance impact is expected as the implementation delegates to the existing array aggregation logic.

## Test Plan
1. Added unit tests for the new CollectListAggregationFunction class
2. Verified that collect_list() produces identical results to array_agg() with the same inputs
3. Confirmed that existing array_agg() functionality remains unchanged

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add ``collect_list`` as an alias for ``array_agg`` aggregate function to improve Spark SQL compatibility

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

