### PR TITLE
Add support for ReactorNettyHttpClient

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -258,6 +258,78 @@
             <artifactId>fastutil</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-core</artifactId>
+            <version>1.1.29</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+            <version>1.1.29</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.11.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hdrhistogram</groupId>
+                    <artifactId>HdrHistogram</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-jmx</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.8.0-M2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-epoll</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+        </dependency>
+
+        <!-- Use Native Epoll event loop -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${dep.netty.version}</version>
+            <classifier>linux-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Use OpenSSL for ssl connections -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Testing dependencies -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -311,7 +383,7 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server;
 import com.facebook.airlift.concurrent.BoundedExecutor;
 import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.airlift.discovery.server.EmbeddedDiscoveryModule;
+import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.server.HttpServerBinder.HttpResourceBinding;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.cost.CostCalculator;
@@ -83,6 +84,8 @@ import com.facebook.presto.server.protocol.QueryBlockingRateLimiter;
 import com.facebook.presto.server.protocol.QueuedStatementResource;
 import com.facebook.presto.server.protocol.RetryCircuitBreaker;
 import com.facebook.presto.server.remotetask.HttpRemoteTaskFactory;
+import com.facebook.presto.server.remotetask.ReactorNettyHttpClient;
+import com.facebook.presto.server.remotetask.ReactorNettyHttpClientConfig;
 import com.facebook.presto.server.remotetask.RemoteTaskStats;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.security.SelectedRole;
@@ -142,7 +145,7 @@ public class CoordinatorModule
 {
     private static final String DEFAULT_WEBUI_CSP =
             "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-            "font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'; img-src http: https: data:";
+                    "font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'; img-src http: https: data:";
 
     public static HttpResourceBinding webUIBinder(Binder binder, String path, String classPathResourceBase)
     {
@@ -268,13 +271,20 @@ public class CoordinatorModule
         binder.bind(RemoteTaskStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(RemoteTaskStats.class).withGeneratedName();
 
-        httpClientBinder(binder).bindHttpClient("scheduler", ForScheduler.class)
-                .withTracing()
-                .withFilter(GenerateTraceTokenRequestFilter.class)
-                .withConfigDefaults(config -> {
-                    config.setRequestTimeout(new Duration(10, SECONDS));
-                    config.setMaxConnectionsPerServer(250);
-                });
+        ReactorNettyHttpClientConfig reactorNettyHttpClientConfig = buildConfigObject(ReactorNettyHttpClientConfig.class);
+        if (reactorNettyHttpClientConfig.isReactorNettyHttpClientEnabled()) {
+            binder.bind(ReactorNettyHttpClient.class).in(Scopes.SINGLETON);
+            binder.bind(HttpClient.class).annotatedWith(ForScheduler.class).to(ReactorNettyHttpClient.class);
+        }
+        else {
+            httpClientBinder(binder).bindHttpClient("scheduler", ForScheduler.class)
+                    .withTracing()
+                    .withFilter(GenerateTraceTokenRequestFilter.class)
+                    .withConfigDefaults(config -> {
+                        config.setRequestTimeout(new Duration(10, SECONDS));
+                        config.setMaxConnectionsPerServer(250);
+                    });
+        }
 
         binder.bind(ScheduledExecutorService.class).annotatedWith(ForScheduler.class)
                 .toInstance(newSingleThreadScheduledExecutor(threadsNamed("stage-scheduler")));

--- a/presto-main/src/main/java/com/facebook/presto/server/InternalCommunicationModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/InternalCommunicationModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server;
 import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.airlift.http.client.HttpClientConfig;
 import com.facebook.airlift.http.client.spnego.KerberosConfig;
+import com.facebook.presto.server.remotetask.ReactorNettyHttpClientConfig;
 import com.facebook.presto.server.security.InternalAuthenticationFilter;
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -50,6 +51,16 @@ public class InternalCommunicationModule
             }
             if (internalCommunicationConfig.getExcludeCipherSuites().isPresent()) {
                 config.setHttpsExcludedCipherSuites(internalCommunicationConfig.getExcludeCipherSuites().get());
+            }
+        });
+
+        configBinder(binder).bindConfigGlobalDefaults(ReactorNettyHttpClientConfig.class, config -> {
+            config.setHttpsEnabled(internalCommunicationConfig.isHttpsRequired());
+            config.setKeyStorePath(internalCommunicationConfig.getKeyStorePath());
+            config.setKeyStorePassword(internalCommunicationConfig.getKeyStorePassword());
+            config.setTrustStorePath(internalCommunicationConfig.getTrustStorePath());
+            if (internalCommunicationConfig.getIncludedCipherSuites().isPresent()) {
+                config.setCipherSuites(internalCommunicationConfig.getIncludedCipherSuites().get());
             }
         });
 

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -140,6 +140,7 @@ import com.facebook.presto.resourcemanager.ResourceManagerConfig;
 import com.facebook.presto.resourcemanager.ResourceManagerInconsistentException;
 import com.facebook.presto.resourcemanager.ResourceManagerResourceGroupService;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
+import com.facebook.presto.server.remotetask.ReactorNettyHttpClientConfig;
 import com.facebook.presto.server.thrift.FixedAddressSelector;
 import com.facebook.presto.server.thrift.HandleThriftModule;
 import com.facebook.presto.server.thrift.ThriftServerInfoClient;
@@ -544,6 +545,7 @@ public class ServerMainModule
         binder.bind(PageFunctionCompiler.class).in(Scopes.SINGLETON);
         newExporter(binder).export(PageFunctionCompiler.class).withGeneratedName();
         configBinder(binder).bindConfig(TaskManagerConfig.class);
+        configBinder(binder).bindConfig(ReactorNettyHttpClientConfig.class);
         binder.bind(IndexJoinLookupStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(IndexJoinLookupStats.class).withGeneratedName();
         binder.bind(AsyncHttpExecutionMBean.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClient.java
@@ -1,0 +1,400 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.http.client.HeaderName;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.RequestStats;
+import com.facebook.airlift.http.client.Response;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.http.client.StaticBodyGenerator;
+import com.facebook.airlift.log.Logger;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.inject.Inject;
+import io.airlift.units.Duration;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.jmx.JmxMeterRegistry;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.epoll.Epoll;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufFlux;
+import reactor.netty.channel.MicrometerChannelMetricsRecorder;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.Http2AllocationStrategy;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.client.HttpClientResponse;
+import reactor.netty.resources.ConnectionProvider;
+import reactor.netty.resources.LoopResources;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.facebook.airlift.security.pem.PemReader.loadPrivateKey;
+import static com.facebook.airlift.security.pem.PemReader.readCertificateChain;
+import static io.micrometer.core.instrument.Clock.SYSTEM;
+import static io.micrometer.jmx.JmxConfig.DEFAULT;
+import static io.netty.handler.ssl.ApplicationProtocolConfig.Protocol.ALPN;
+import static io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT;
+import static io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE;
+import static io.netty.handler.ssl.ApplicationProtocolNames.HTTP_1_1;
+import static io.netty.handler.ssl.ApplicationProtocolNames.HTTP_2;
+import static io.netty.handler.ssl.SslProtocols.TLS_v1_2;
+import static io.netty.handler.ssl.SslProtocols.TLS_v1_3;
+import static io.netty.handler.ssl.SslProvider.JDK;
+import static io.netty.handler.ssl.SslProvider.OPENSSL;
+import static io.netty.handler.ssl.SslProvider.isAlpnSupported;
+import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.MILLIS;
+
+public class ReactorNettyHttpClient
+        implements com.facebook.airlift.http.client.HttpClient, Closeable
+{
+    private static final Logger log = Logger.get(ReactorNettyHttpClient.class);
+    private static final HeaderName CONTENT_TYPE_HEADER_NAME = HeaderName.of("Content-Type");
+    private static final HeaderName CONTENT_LENGTH_HEADER_NAME = HeaderName.of("Content-Length");
+
+    private final Duration requestTimeout;
+    private HttpClient httpClient;
+
+    @Inject
+    public ReactorNettyHttpClient(ReactorNettyHttpClientConfig config)
+    {
+        SslContext sslContext = null;
+        if (config.isHttpsEnabled()) {
+            try {
+                File keyFile = new File(config.getKeyStorePath());
+                File trustCertificateFile = new File(config.getTrustStorePath());
+                if (!Files.exists(keyFile.toPath()) || !Files.isReadable(keyFile.toPath())) {
+                    throw new IllegalArgumentException("KeyStore file path is unreadable or doesn't exist");
+                }
+                if (!Files.exists(trustCertificateFile.toPath()) || !Files.isReadable(trustCertificateFile.toPath())) {
+                    throw new IllegalArgumentException("TrustStore file path is unreadable or doesn't exist");
+                }
+                PrivateKey privateKey = loadPrivateKey(keyFile, Optional.of(config.getKeyStorePassword()));
+                X509Certificate[] certificateChain = readCertificateChain(keyFile).toArray(new X509Certificate[0]);
+                X509Certificate[] trustChain = readCertificateChain(trustCertificateFile).toArray(new X509Certificate[0]);
+
+                String os = System.getProperty("os.name");
+                if (os.toLowerCase(Locale.ENGLISH).contains("linux")) {
+                    // Make sure Open ssl is available for linux deployments
+                    if (!OpenSsl.isAvailable()) {
+                        throw new UnsupportedOperationException(format("OpenSsl is not unavailable. Stacktrace: %s", Arrays.toString(OpenSsl.unavailabilityCause().getStackTrace()).replace(',', '\n')));
+                    }
+                    // Make sure epoll threads are used for linux deployments
+                    if (!Epoll.isAvailable()) {
+                        throw new UnsupportedOperationException(format("Epoll is not unavailable. Stacktrace: %s", Arrays.toString(Epoll.unavailabilityCause().getStackTrace()).replace(',', '\n')));
+                    }
+                }
+
+                SslProvider provider = isAlpnSupported(OPENSSL) ? OPENSSL : JDK;
+                SslContextBuilder sslContextBuilder = SslContextBuilder.forClient()
+                        .sslProvider(provider)
+                        .protocols(TLS_v1_3, TLS_v1_2)
+                        .keyManager(privateKey, certificateChain)
+                        .trustManager(trustChain)
+                        .applicationProtocolConfig(new ApplicationProtocolConfig(ALPN, NO_ADVERTISE, ACCEPT, HTTP_2, HTTP_1_1));
+                if (config.getCipherSuites().isPresent()) {
+                    sslContextBuilder.ciphers(Splitter
+                            .on(',')
+                            .trimResults()
+                            .omitEmptyStrings()
+                            .splitToList(config.getCipherSuites().get()));
+                }
+
+                sslContext = sslContextBuilder.build();
+            }
+            catch (IOException | GeneralSecurityException e) {
+                throw new RuntimeException("Failed to configure SSL context", e);
+            }
+        }
+
+        /*
+         * This is like wrapper and underlying there is a separate pool of connections for http1 and http2 protocols. Basically different pools for different protocols.
+         * Reactor Netty's HttpConnectionProvider will wrap this connection provider and handle protocol routing in the acquire() call. It examines
+         * the configured protocols and routes requests appropriately. So the http2 allocation strategy defined here will only be used for http2 connections.
+         */
+        ConnectionProvider pool = ConnectionProvider.builder("shared-pool")
+                .maxConnections(config.getMaxConnections())
+                .allocationStrategy((Http2AllocationStrategy.builder()
+                        .maxConnections(config.getMaxConnections())
+                        .maxConcurrentStreams(config.getMaxStreamPerChannel())
+                        .minConnections(config.getMinConnections()).build()))
+                .build();
+
+        LoopResources loopResources = LoopResources.create("event-loop", config.getSelectorThreadCount(), config.getEventLoopThreadCount(), true, false);
+
+        // Add the JMX MeterRegistry to the global Metrics registry
+        JmxMeterRegistry jmxMeterRegistry = new JmxMeterRegistry(DEFAULT, SYSTEM);
+        Metrics.addRegistry(jmxMeterRegistry);
+
+        // Create HTTP/2 client
+        SslContext finalSslContext = sslContext;
+        this.httpClient = HttpClient
+                // The custom pool is wrapped with a HttpConnectionProvider over here
+                .create(pool)
+                .protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
+                .runOn(loopResources, true)
+                .http2Settings(settings -> settings.maxConcurrentStreams(config.getMaxStreamPerChannel()))
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) config.getConnectTimeout().getValue())
+                // Track the metrics for all the tcp connections
+                .metrics(true, () -> new MicrometerChannelMetricsRecorder("reactor.netty.http.client", "tcp", false));
+
+        if (config.isHttpsEnabled()) {
+            if (finalSslContext == null) {
+                throw new IllegalStateException("SSL context must be configured for HTTPS");
+            }
+            httpClient = httpClient.secure(spec -> spec.sslContext(finalSslContext));
+        }
+
+        this.requestTimeout = config.getRequestTimeout();
+    }
+
+    @Override
+    public <T, E extends Exception> T execute(Request request, ResponseHandler<T, E> responseHandler)
+            throws E
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public <T, E extends Exception> HttpResponseFuture<T> executeAsync(Request airliftRequest, ResponseHandler<T, E> responseHandler)
+    {
+        SettableFuture<Object> listenableFuture = SettableFuture.create();
+
+        // Set the request headers
+        HttpClient client = this.httpClient.headers(hdr -> {
+            for (Map.Entry<String, String> entry : airliftRequest.getHeaders().entries()) {
+                hdr.set(entry.getKey(), entry.getValue());
+            }
+        });
+
+        URI uri = airliftRequest.getUri();
+        Disposable disposable;
+        switch (airliftRequest.getMethod()) {
+            case "GET":
+                disposable = client.get()
+                        .uri(uri)
+                        .responseSingle((response, bytes) -> bytes.asInputStream().zipWith(Mono.just(response)))
+                        // Request timeout
+                        .timeout(java.time.Duration.of(requestTimeout.toMillis(), MILLIS))
+                        .subscribe(t -> onSuccess(responseHandler, t.getT1(), t.getT2(), listenableFuture), e -> onError(listenableFuture, e), () -> onComplete(listenableFuture));
+                break;
+            case "POST":
+                byte[] postBytes = ((StaticBodyGenerator) airliftRequest.getBodyGenerator()).getBody();
+                disposable = client.post()
+                        .uri(uri)
+                        .send(ByteBufFlux.fromInbound(Mono.just(postBytes)))
+                        .responseSingle((response, bytes) -> bytes.asInputStream().zipWith(Mono.just(response)))
+                        // Request timeout
+                        .timeout(java.time.Duration.of(requestTimeout.toMillis(), MILLIS))
+                        .subscribe(t -> onSuccess(responseHandler, t.getT1(), t.getT2(), listenableFuture), e -> onError(listenableFuture, e), () -> onComplete(listenableFuture));
+                break;
+            case "DELETE":
+                disposable = client.delete()
+                        .uri(uri)
+                        .responseSingle((response, bytes) -> bytes.asInputStream().zipWith(Mono.just(response)))
+                        // Request timeout
+                        .timeout(java.time.Duration.of(requestTimeout.toMillis(), MILLIS))
+                        .subscribe(t -> onSuccess(responseHandler, t.getT1(), t.getT2(), listenableFuture), e -> onError(listenableFuture, e), () -> onComplete(listenableFuture));
+                break;
+            default:
+                throw new UnsupportedOperationException("Unexpected request: " + airliftRequest);
+        }
+
+        return new HttpResponseFuture()
+        {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning)
+            {
+                disposable.dispose();
+                return listenableFuture.cancel(mayInterruptIfRunning);
+            }
+
+            @Override
+            public boolean isCancelled()
+            {
+                return listenableFuture.isCancelled();
+            }
+
+            @Override
+            public boolean isDone()
+            {
+                return listenableFuture.isDone();
+            }
+
+            @Override
+            public Object get()
+                    throws InterruptedException, ExecutionException
+            {
+                return listenableFuture.get();
+            }
+
+            @Override
+            public Object get(long timeout, TimeUnit unit)
+                    throws InterruptedException, ExecutionException, TimeoutException
+            {
+                return listenableFuture.get(timeout, unit);
+            }
+
+            @Override
+            public void addListener(Runnable listener, Executor executor)
+            {
+                listenableFuture.addListener(listener, executor);
+            }
+
+            @Override
+            public String getState()
+            {
+                return "";
+            }
+        };
+    }
+
+    public void onSuccess(ResponseHandler responseHandler, InputStream inputStream, HttpClientResponse response, SettableFuture<Object> listenableFuture)
+    {
+        ListMultimap<HeaderName, String> responseHeaders = ArrayListMultimap.create();
+        HttpHeaders headers = response.responseHeaders();
+        int status = response.status().code();
+        if (status != 200 && status != 204) {
+            listenableFuture.setException(new RuntimeException("Invalid response status: " + status));
+            return;
+        }
+
+        long contentLength = 0;
+        // Iterate over the headers
+        for (String name : headers.names()) {
+            if (name.equalsIgnoreCase(CONTENT_LENGTH_HEADER_NAME.toString())) {
+                String val = headers.get(name);
+                contentLength = Integer.parseInt(val);
+                responseHeaders.put(CONTENT_LENGTH_HEADER_NAME, val);
+            }
+            else if (name.equalsIgnoreCase(CONTENT_TYPE_HEADER_NAME.toString())) {
+                responseHeaders.put(CONTENT_TYPE_HEADER_NAME, headers.get(name));
+            }
+            else {
+                responseHeaders.put(HeaderName.of(name), headers.get(name));
+            }
+        }
+
+        if (!responseHeaders.containsKey(CONTENT_TYPE_HEADER_NAME) || responseHeaders.get(CONTENT_TYPE_HEADER_NAME).size() != 1) {
+            listenableFuture.setException(new RuntimeException("Expected ContentType header: " + responseHeaders));
+            return;
+        }
+
+        try {
+            long finalContentLength = contentLength;
+            Object a = responseHandler.handle(null, new Response()
+            {
+                @Override
+                public int getStatusCode()
+                {
+                    return status;
+                }
+
+                @Override
+                public ListMultimap<HeaderName, String> getHeaders()
+                {
+                    return responseHeaders;
+                }
+
+                @Override
+                public long getBytesRead()
+                {
+                    return finalContentLength;
+                }
+
+                @Override
+                public InputStream getInputStream()
+                        throws IOException
+                {
+                    return inputStream;
+                }
+            });
+            // closing it here to prevent memory leak of bytebuf
+            inputStream.close();
+            listenableFuture.set(a);
+        }
+        catch (Exception e) {
+            listenableFuture.setException(e);
+        }
+        finally {
+            try {
+                inputStream.close();
+            }
+            catch (IOException e) {
+                log.warn(e, "Failed to close input stream");
+            }
+        }
+    }
+
+    public void onError(SettableFuture<Object> listenableFuture, Throwable t)
+    {
+        listenableFuture.setException(t);
+    }
+
+    public void onComplete(SettableFuture<Object> listenableFuture)
+    {
+        if (!listenableFuture.isDone()) {
+            listenableFuture.setException(new RuntimeException("completed without success or failure"));
+        }
+    }
+
+    @Override
+    public RequestStats getStats()
+    {
+        return null;
+    }
+
+    @Override
+    public long getMaxContentLength()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+    {
+        // void
+    }
+
+    @Override
+    public boolean isClosed()
+    {
+        return false;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClientConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClientConfig.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+
+import javax.validation.constraints.Min;
+
+import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class ReactorNettyHttpClientConfig
+{
+    private boolean reactorNettyHttpClientEnabled;
+    private boolean httpsEnabled;
+    private int minConnections = 50;
+    private int maxConnections = 100;
+    private int maxStreamPerChannel = 100;
+    private int selectorThreadCount = Runtime.getRuntime().availableProcessors();
+    private int eventLoopThreadCount = Runtime.getRuntime().availableProcessors();
+    private Duration connectTimeout = new Duration(10, SECONDS);
+    private Duration requestTimeout = new Duration(10, SECONDS);
+    private String keyStorePath;
+    private String keyStorePassword;
+    private String trustStorePath;
+    private Optional<String> cipherSuites = Optional.empty();
+
+    public boolean isReactorNettyHttpClientEnabled()
+    {
+        return reactorNettyHttpClientEnabled;
+    }
+
+    @Config("reactor.netty-http-client-enabled")
+    @ConfigDescription("Enable reactor netty client for http communication between coordinator and worker")
+    public ReactorNettyHttpClientConfig setReactorNettyHttpClientEnabled(boolean reactorNettyHttpClientEnabled)
+    {
+        this.reactorNettyHttpClientEnabled = reactorNettyHttpClientEnabled;
+        return this;
+    }
+
+    public boolean isHttpsEnabled()
+    {
+        return httpsEnabled;
+    }
+
+    @Config("reactor.https-enabled")
+    public ReactorNettyHttpClientConfig setHttpsEnabled(boolean httpsEnabled)
+    {
+        this.httpsEnabled = httpsEnabled;
+        return this;
+    }
+
+    public int getMinConnections()
+    {
+        return minConnections;
+    }
+
+    @Min(10)
+    @Config("reactor.min-connections")
+    @ConfigDescription("Min number of connections in the pool used by the netty http2 client to talk to the workers")
+    public ReactorNettyHttpClientConfig setMinConnections(int minConnections)
+    {
+        this.minConnections = minConnections;
+        return this;
+    }
+
+    public int getMaxConnections()
+    {
+        return maxConnections;
+    }
+
+    @Min(10)
+    @Config("reactor.max-connections")
+    @ConfigDescription("Max total number of connections in the pool used by the netty client to talk to the workers")
+    public ReactorNettyHttpClientConfig setMaxConnections(int maxConnections)
+    {
+        this.maxConnections = maxConnections;
+        return this;
+    }
+
+    public int getMaxStreamPerChannel()
+    {
+        return maxStreamPerChannel;
+    }
+
+    @Config("reactor.max-stream-per-channel")
+    @ConfigDescription("Max number of streams per single tcp connection between coordinator and worker")
+    public ReactorNettyHttpClientConfig setMaxStreamPerChannel(int maxStreamPerChannel)
+    {
+        this.maxStreamPerChannel = maxStreamPerChannel;
+        return this;
+    }
+
+    public int getSelectorThreadCount()
+    {
+        return selectorThreadCount;
+    }
+
+    @Config("reactor.selector-thread-count")
+    @ConfigDescription("Number of select threads used by netty to handle the http messages")
+    public ReactorNettyHttpClientConfig setSelectorThreadCount(int selectorThreadCount)
+    {
+        this.selectorThreadCount = selectorThreadCount;
+        return this;
+    }
+
+    public int getEventLoopThreadCount()
+    {
+        return eventLoopThreadCount;
+    }
+
+    @Config("reactor.event-loop-thread-count")
+    @ConfigDescription("Number of event loop threads used by netty to handle the http messages")
+    public ReactorNettyHttpClientConfig setEventLoopThreadCount(int eventLoopThreadCount)
+    {
+        this.eventLoopThreadCount = eventLoopThreadCount;
+        return this;
+    }
+
+    public Duration getConnectTimeout()
+    {
+        return connectTimeout;
+    }
+
+    @Config("reactor.connect-timeout")
+    public ReactorNettyHttpClientConfig setConnectTimeout(Duration connectTimeout)
+    {
+        this.connectTimeout = connectTimeout;
+        return this;
+    }
+
+    public Duration getRequestTimeout()
+    {
+        return requestTimeout;
+    }
+
+    @Config("reactor.request-timeout")
+    public ReactorNettyHttpClientConfig setRequestTimeout(Duration requestTimeout)
+    {
+        this.requestTimeout = requestTimeout;
+        return this;
+    }
+
+    public String getKeyStorePath()
+    {
+        return keyStorePath;
+    }
+
+    @Config("reactor.keystore-path")
+    public ReactorNettyHttpClientConfig setKeyStorePath(String keyStorePath)
+    {
+        this.keyStorePath = keyStorePath;
+        return this;
+    }
+
+    public String getKeyStorePassword()
+    {
+        return keyStorePassword;
+    }
+
+    @Config("reactor.keystore-password")
+    public ReactorNettyHttpClientConfig setKeyStorePassword(String keyStorePassword)
+    {
+        this.keyStorePassword = keyStorePassword;
+        return this;
+    }
+
+    public String getTrustStorePath()
+    {
+        return trustStorePath;
+    }
+
+    @Config("reactor.truststore-path")
+    public ReactorNettyHttpClientConfig setTrustStorePath(String trustStorePath)
+    {
+        this.trustStorePath = trustStorePath;
+        return this;
+    }
+
+    public Optional<String> getCipherSuites()
+    {
+        return cipherSuites;
+    }
+
+    @Config("reactor.cipher-suites")
+    public ReactorNettyHttpClientConfig setCipherSuites(String cipherSuites)
+    {
+        this.cipherSuites = Optional.ofNullable(cipherSuites);
+        return this;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/remotetask/TestReactorNettyHttpClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/remotetask/TestReactorNettyHttpClient.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.remotetask;
+
+import com.facebook.airlift.http.client.HttpClient.HttpResponseFuture;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonCodecFactory;
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.execution.TaskStatus;
+import com.facebook.presto.server.remotetask.ReactorNettyHttpClient;
+import com.facebook.presto.server.remotetask.ReactorNettyHttpClientConfig;
+import com.facebook.presto.server.smile.AdaptingJsonResponseHandler;
+import com.facebook.presto.server.smile.JsonResponseWrapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.server.HttpServer;
+
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.presto.execution.TaskState.PLANNED;
+import static com.facebook.presto.server.RequestHelpers.getJsonTransportBuilder;
+import static com.facebook.presto.server.smile.AdaptingJsonResponseHandler.createAdaptingJsonResponseHandler;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+
+public class TestReactorNettyHttpClient
+{
+    private static DisposableServer server;
+    private static ReactorNettyHttpClient reactorNettyHttpClient;
+    private static JsonCodec<TaskStatus> taskStatusCodec;
+
+    private static final TaskStatus TEST_TASK_STATUS_HTTP11 = new TaskStatus(
+            11111L,
+            99999L,
+            123,
+            PLANNED,
+            URI.create("http://localhost:8080/v1/task/1234"),
+            ImmutableSet.of(),
+            ImmutableList.of(),
+            0,
+            0,
+            0.0,
+            false,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0L,
+            0L);
+
+    @BeforeClass
+    public static void setUp()
+    {
+        taskStatusCodec = new JsonCodecFactory(new JsonObjectMapperProvider()).jsonCodec(TaskStatus.class);
+        server = HttpServer.create()
+                .port(8080)
+                .protocol(HttpProtocol.HTTP11)
+                .route(routes ->
+                        routes.get("/v1/task/1234/status", (request, response) ->
+                                response.header("Content-Type", "application/json").sendString(Mono.just(taskStatusCodec.toJson(TEST_TASK_STATUS_HTTP11)))))
+                .bindNow();
+        ReactorNettyHttpClientConfig reactorNettyHttpClientConfig = new ReactorNettyHttpClientConfig()
+                .setRequestTimeout(new Duration(30, TimeUnit.SECONDS))
+                .setConnectTimeout(new Duration(30, TimeUnit.SECONDS));
+        reactorNettyHttpClient = new ReactorNettyHttpClient(reactorNettyHttpClientConfig);
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        server.disposeNow();
+    }
+
+    @Test
+    public void testGetTaskStatus()
+            throws ExecutionException, InterruptedException
+    {
+        AdaptingJsonResponseHandler<TaskStatus> responseHandler = createAdaptingJsonResponseHandler(taskStatusCodec);
+        Request request = getJsonTransportBuilder(prepareGet()).setUri(uriBuilderFrom(TEST_TASK_STATUS_HTTP11.getSelf()).appendPath("status").build()).build();
+
+        HttpResponseFuture response = reactorNettyHttpClient.executeAsync(request, responseHandler);
+        TaskStatus a = (TaskStatus) ((JsonResponseWrapper) response.get()).getValue();
+
+        assertEquals(a.getState(), TEST_TASK_STATUS_HTTP11.getState());
+        assertEquals(a.getTaskInstanceIdLeastSignificantBits(), TEST_TASK_STATUS_HTTP11.getTaskInstanceIdLeastSignificantBits());
+        assertEquals(a.getTaskInstanceIdMostSignificantBits(), TEST_TASK_STATUS_HTTP11.getTaskInstanceIdMostSignificantBits());
+        assertEquals(a.getVersion(), TEST_TASK_STATUS_HTTP11.getVersion());
+        assertEquals(a.getSelf(), TEST_TASK_STATUS_HTTP11.getSelf());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/remotetask/TestReactorNettyHttpClientConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/remotetask/TestReactorNettyHttpClientConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.remotetask;
+
+import com.facebook.presto.server.remotetask.ReactorNettyHttpClientConfig;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestReactorNettyHttpClientConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ReactorNettyHttpClientConfig.class)
+                .setReactorNettyHttpClientEnabled(false)
+                .setHttpsEnabled(false)
+                .setMinConnections(50)
+                .setMaxConnections(100)
+                .setMaxStreamPerChannel(100)
+                .setSelectorThreadCount(Runtime.getRuntime().availableProcessors())
+                .setEventLoopThreadCount(Runtime.getRuntime().availableProcessors())
+                .setConnectTimeout(new Duration(10, SECONDS))
+                .setRequestTimeout(new Duration(10, SECONDS))
+                .setKeyStorePath(null)
+                .setKeyStorePassword(null)
+                .setTrustStorePath(null)
+                .setCipherSuites(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("reactor.netty-http-client-enabled", "true")
+                .put("reactor.https-enabled", "true")
+                .put("reactor.min-connections", "100")
+                .put("reactor.max-connections", "500")
+                .put("reactor.max-stream-per-channel", "300")
+                .put("reactor.selector-thread-count", "50")
+                .put("reactor.event-loop-thread-count", "150")
+                .put("reactor.connect-timeout", "2s")
+                .put("reactor.request-timeout", "1s")
+                .put("reactor.keystore-path", "/var/abc/def/presto.jks")
+                .put("reactor.truststore-path", "/var/abc/def/presto.jks")
+                .put("reactor.keystore-password", "password")
+                .put("reactor.cipher-suites", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
+                .build();
+
+        ReactorNettyHttpClientConfig expected = new ReactorNettyHttpClientConfig()
+                .setReactorNettyHttpClientEnabled(true)
+                .setHttpsEnabled(true)
+                .setMinConnections(100)
+                .setMaxConnections(500)
+                .setMaxStreamPerChannel(300)
+                .setSelectorThreadCount(50)
+                .setEventLoopThreadCount(150)
+                .setConnectTimeout(new Duration(2, SECONDS))
+                .setRequestTimeout(new Duration(1, SECONDS))
+                .setKeyStorePath("/var/abc/def/presto.jks")
+                .setTrustStorePath("/var/abc/def/presto.jks")
+                .setKeyStorePassword("password")
+                .setCipherSuites("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -182,6 +182,13 @@ public class PrestoNativeQueryRunnerUtils
             return this;
         }
 
+        public HiveQueryRunnerBuilder setUseReactorNettyHttpClient(boolean useReactorNettyHttpClient)
+        {
+            this.extraProperties
+                    .put("reactor.netty-http-client-enabled", String.valueOf(useReactorNettyHttpClient));
+            return this;
+        }
+
         public HiveQueryRunnerBuilder setSingleNodeExecutionEnabled(boolean singleNodeExecutionEnabled)
         {
             if (singleNodeExecutionEnabled) {

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeJoinQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeJoinQueries.java
@@ -25,6 +25,7 @@ public class TestPrestoNativeJoinQueries
         return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
                 .setAddStorageFormatToPath(true)
                 .setUseThrift(true)
+                .setUseReactorNettyHttpClient(true)
                 .build();
     }
 


### PR DESCRIPTION
## Description
This new client is based on reactor-netty library. https://github.com/reactor/reactor-netty
It supports both Http1.1 and Http2 communication with the workers and uses netty under the cover.

## Motivation and Context
We observed 10%-15% CPU improvement on coordinator when we enabled HTTP2 via ReactorNettyHttpClient.

## Impact
None

## Test Plan
Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add support for using a netty client to do HTTP communication between coordinator and worker. This new http client can be enabled on the coordinator by setting the config ``reactor.netty-http-client-enabled`` to ``true``
```

