### PR TITLE
Upgrade Nessie to version 0.95.0.

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.iceberg.version>1.5.0</dep.iceberg.version>
-        <dep.nessie.version>0.77.1</dep.nessie.version>
+        <dep.nessie.version>0.95.0</dep.nessie.version>
     </properties>
 
     <dependencies>

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
@@ -19,8 +19,8 @@ import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.containers.NessieContainer;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.api.NessieApiV1;
-import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -53,7 +53,7 @@ public class TestNessieMultiBranching
     {
         nessieContainer = NessieContainer.builder().build();
         nessieContainer.start();
-        nessieApiV1 = HttpClientBuilder.builder().withUri(nessieContainer.getRestApiUri()).build(NessieApiV1.class);
+        nessieApiV1 = NessieClientBuilder.createClientBuilder(null, null).withUri(nessieContainer.getRestApiUri()).build(NessieApiV1.class);
         super.init();
     }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Upgrade Nessie to version 0.95.0.
Upgraded to Nessie 0.95.0 (instead of a later version) because starting from 0.96.0, Java 8 support was dropped, including for the client libraries. Since Presto still runs on Java 8, 0.95.0 is the latest compatible version.
[Nessie changelog](https://github.com/projectnessie/nessie/blob/c907bf30fc8feee571def48d17df098d9a980ea0/CHANGELOG.md?plain=1#L340)

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Upgrade Nessie to version 0.95.0.
```


