### PR TITLE
Introduce `getSqlInvokedFunctions` SPI and `BuiltInPluginFunctionNamespaceManager` for registering sql invoked functions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInFunctionHandle.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInFunctionHandle.java
@@ -24,18 +24,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Objects;
 
+import static com.facebook.presto.metadata.BuiltInFunctionKind.ENGINE;
 import static java.util.Objects.requireNonNull;
 
 public class BuiltInFunctionHandle
         implements FunctionHandle
 {
     private final Signature signature;
+    private final BuiltInFunctionKind builtInFunctionKind;
 
     @JsonCreator
     public BuiltInFunctionHandle(@JsonProperty("signature") Signature signature)
     {
+        this(signature, ENGINE);
+    }
+
+    public BuiltInFunctionHandle(Signature signature, BuiltInFunctionKind builtInFunctionKind)
+    {
         this.signature = requireNonNull(signature, "signature is null");
         checkArgument(signature.getTypeVariableConstraints().isEmpty(), "%s has unbound type parameters", signature);
+        this.builtInFunctionKind = requireNonNull(builtInFunctionKind, "builtInFunctionKind is null");
     }
 
     @JsonProperty
@@ -68,6 +76,12 @@ public class BuiltInFunctionHandle
         return signature.getName().getCatalogSchemaName();
     }
 
+    @JsonProperty
+    public BuiltInFunctionKind getBuiltInFunctionKind()
+    {
+        return builtInFunctionKind;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -78,13 +92,14 @@ public class BuiltInFunctionHandle
             return false;
         }
         BuiltInFunctionHandle that = (BuiltInFunctionHandle) o;
-        return Objects.equals(signature, that.signature);
+        return Objects.equals(signature, that.signature)
+                && Objects.equals(builtInFunctionKind, that.builtInFunctionKind);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(signature);
+        return Objects.hash(signature, builtInFunctionKind);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInFunctionKind.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInFunctionKind.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+
+@ThriftEnum
+public enum BuiltInFunctionKind
+{
+    ENGINE(0),
+    PLUGIN(1);
+
+    private final int value;
+
+    BuiltInFunctionKind(int value)
+    {
+        this.value = value;
+    }
+
+    @ThriftEnumValue
+    public int getValue()
+    {
+        return value;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInPluginFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInPluginFunctionNamespaceManager.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.function.SqlFunctionResult;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.UserDefinedType;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.spi.function.Parameter;
+import com.facebook.presto.spi.function.ScalarFunctionImplementation;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunctionImplementation;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static com.facebook.presto.metadata.BuiltInFunctionKind.PLUGIN;
+import static com.facebook.presto.spi.function.FunctionImplementationType.SQL;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.HOURS;
+
+public class BuiltInPluginFunctionNamespaceManager
+        implements FunctionNamespaceManager<SqlFunction>
+{
+    private volatile FunctionMap functions = new FunctionMap();
+    private final FunctionAndTypeManager functionAndTypeManager;
+    private final Supplier<FunctionMap> cachedFunctions =
+            Suppliers.memoize(this::checkForNamingConflicts);
+    private final LoadingCache<Signature, SpecializedFunctionKey> specializedFunctionKeyCache;
+    private final LoadingCache<SpecializedFunctionKey, ScalarFunctionImplementation> specializedScalarCache;
+
+    public BuiltInPluginFunctionNamespaceManager(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        specializedFunctionKeyCache = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(1, HOURS)
+                .build(CacheLoader.from(this::doGetSpecializedFunctionKey));
+        specializedScalarCache = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(1, HOURS)
+                .build(CacheLoader.from(key -> {
+                    checkArgument(
+                            key.getFunction() instanceof SqlInvokedFunction,
+                            "Unsupported scalar function class: %s",
+                            key.getFunction().getClass());
+                    return new SqlInvokedScalarFunctionImplementation(((SqlInvokedFunction) key.getFunction()).getBody());
+                }));
+    }
+
+    public synchronized void registerPluginFunctions(List<? extends SqlFunction> functions)
+    {
+        checkForNamingConflicts(functions);
+        this.functions = new FunctionMap(this.functions, functions);
+    }
+
+    @Override
+    public FunctionHandle getFunctionHandle(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, Signature signature)
+    {
+        return new BuiltInFunctionHandle(signature, PLUGIN);
+    }
+
+    @Override
+    public Collection<SqlFunction> getFunctions(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, QualifiedObjectName functionName)
+    {
+        if (functions.list().isEmpty() ||
+                (!functionName.getCatalogSchemaName().equals(functionAndTypeManager.getDefaultNamespace()))) {
+            return emptyList();
+        }
+        return cachedFunctions.get().get(functionName);
+    }
+
+    /**
+     * likePattern / escape is not used for optimization, returning all functions.
+     */
+    @Override
+    public Collection<SqlFunction> listFunctions(Optional<String> likePattern, Optional<String> escape)
+    {
+        return cachedFunctions.get().list();
+    }
+
+    public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
+    {
+        checkArgument(functionHandle instanceof BuiltInFunctionHandle, "Expect BuiltInFunctionHandle");
+        Signature signature = ((BuiltInFunctionHandle) functionHandle).getSignature();
+        SpecializedFunctionKey functionKey;
+        try {
+            functionKey = specializedFunctionKeyCache.getUnchecked(signature);
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
+        }
+        SqlFunction function = functionKey.getFunction();
+        checkArgument(function instanceof SqlInvokedFunction, "BuiltInPluginFunctionNamespaceManager only support SqlInvokedFunctions");
+        SqlInvokedFunction sqlFunction = (SqlInvokedFunction) function;
+        List<String> argumentNames = sqlFunction.getParameters().stream().map(Parameter::getName).collect(toImmutableList());
+        return new FunctionMetadata(
+                signature.getName(),
+                signature.getArgumentTypes(),
+                argumentNames,
+                signature.getReturnType(),
+                signature.getKind(),
+                sqlFunction.getRoutineCharacteristics().getLanguage(),
+                SQL,
+                function.isDeterministic(),
+                function.isCalledOnNullInput(),
+                sqlFunction.getVersion(),
+                sqlFunction.getComplexTypeFunctionDescriptor());
+    }
+
+    public ScalarFunctionImplementation getScalarFunctionImplementation(FunctionHandle functionHandle)
+    {
+        checkArgument(functionHandle instanceof BuiltInFunctionHandle, "Expect BuiltInFunctionHandle");
+        return getScalarFunctionImplementation(((BuiltInFunctionHandle) functionHandle).getSignature());
+    }
+
+    @Override
+    public void setBlockEncodingSerde(BlockEncodingSerde blockEncodingSerde)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not support setting block encoding");
+    }
+
+    @Override
+    public FunctionNamespaceTransactionHandle beginTransaction()
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not support setting block encoding");
+    }
+
+    @Override
+    public void commit(FunctionNamespaceTransactionHandle transactionHandle)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not support setting block encoding");
+    }
+
+    @Override
+    public void abort(FunctionNamespaceTransactionHandle transactionHandle)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not support setting block encoding");
+    }
+
+    @Override
+    public void createFunction(SqlInvokedFunction function, boolean replace)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not support setting block encoding");
+    }
+
+    @Override
+    public void dropFunction(QualifiedObjectName functionName, Optional parameterTypes, boolean exists)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not support drop function");
+    }
+
+    @Override
+    public void alterFunction(QualifiedObjectName functionName, Optional parameterTypes, AlterRoutineCharacteristics alterRoutineCharacteristics)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not alter function");
+    }
+
+    @Override
+    public void addUserDefinedType(UserDefinedType userDefinedType)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not support adding user defined types");
+    }
+
+    @Override
+    public Optional<UserDefinedType> getUserDefinedType(QualifiedObjectName typeName)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not support getting user defined types");
+    }
+
+    @Override
+    public CompletableFuture<SqlFunctionResult> executeFunction(String source, FunctionHandle functionHandle, Page input, List channels, TypeManager typeManager)
+    {
+        throw new UnsupportedOperationException("BuiltInPluginFunctionNamespaceManager does not execute function");
+    }
+
+    private ScalarFunctionImplementation getScalarFunctionImplementation(Signature signature)
+    {
+        checkArgument(signature.getKind() == SCALAR, "%s is not a scalar function", signature);
+        checkArgument(signature.getTypeVariableConstraints().isEmpty(), "%s has unbound type parameters", signature);
+
+        try {
+            return specializedScalarCache.getUnchecked(getSpecializedFunctionKey(signature));
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
+        }
+    }
+
+    private synchronized FunctionMap checkForNamingConflicts()
+    {
+        Optional<FunctionNamespaceManager<?>> functionNamespaceManager =
+                functionAndTypeManager.getServingFunctionNamespaceManager(functionAndTypeManager.getDefaultNamespace());
+        checkArgument(functionNamespaceManager.isPresent(), "Cannot find function namespace for catalog '%s'", functionAndTypeManager.getDefaultNamespace().getCatalogName());
+        checkForNamingConflicts(functionNamespaceManager.get().listFunctions(Optional.empty(), Optional.empty()));
+        return functions;
+    }
+
+    private synchronized void checkForNamingConflicts(Collection<? extends SqlFunction> functions)
+    {
+        for (SqlFunction function : functions) {
+            for (SqlFunction existingFunction : this.functions.list()) {
+                checkArgument(!function.getSignature().equals(existingFunction.getSignature()), "Function already registered: %s", function.getSignature());
+            }
+        }
+    }
+
+    private SpecializedFunctionKey doGetSpecializedFunctionKey(Signature signature)
+    {
+        return functionAndTypeManager.getSpecializedFunctionKey(signature, getFunctions(Optional.empty(), signature.getName()));
+    }
+
+    private SpecializedFunctionKey getSpecializedFunctionKey(Signature signature)
+    {
+        try {
+            return specializedFunctionKeyCache.getUnchecked(signature);
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw e;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionListBuilder.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
 import static java.util.Objects.requireNonNull;
 
 public class FunctionListBuilder
@@ -62,13 +63,13 @@ public class FunctionListBuilder
 
     public FunctionListBuilder sqlInvokedScalar(Class<?> clazz)
     {
-        functions.addAll(SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinition(clazz));
+        functions.addAll(SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinition(clazz, JAVA_BUILTIN_NAMESPACE));
         return this;
     }
 
     public FunctionListBuilder sqlInvokedScalars(Class<?> clazz)
     {
-        functions.addAll(SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(clazz));
+        functions.addAll(SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(clazz, JAVA_BUILTIN_NAMESPACE));
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionMap.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionMap.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class FunctionMap
+{
+    private final Multimap<QualifiedObjectName, SqlFunction> functions;
+
+    public FunctionMap()
+    {
+        functions = ImmutableListMultimap.of();
+    }
+
+    public FunctionMap(FunctionMap map, Iterable<? extends SqlFunction> functions)
+    {
+        requireNonNull(map, "map is null");
+        requireNonNull(functions, "functions is null");
+        this.functions = ImmutableListMultimap.<QualifiedObjectName, SqlFunction>builder()
+                .putAll(map.functions)
+                .putAll(Multimaps.index(functions, function -> function.getSignature().getName()))
+                .build();
+
+        // Make sure all functions with the same name are aggregations or none of them are
+        for (Map.Entry<QualifiedObjectName, Collection<SqlFunction>> entry : this.functions.asMap().entrySet()) {
+            Collection<SqlFunction> values = entry.getValue();
+            long aggregations = values.stream()
+                    .map(function -> function.getSignature().getKind())
+                    .filter(kind -> kind == AGGREGATE)
+                    .count();
+            checkState(aggregations == 0 || aggregations == values.size(), "'%s' is both an aggregation and a scalar function", entry.getKey());
+        }
+    }
+
+    public List<SqlFunction> list()
+    {
+        return ImmutableList.copyOf(functions.values());
+    }
+
+    public Collection<SqlFunction> get(QualifiedObjectName name)
+    {
+        return functions.get(name);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -306,6 +306,12 @@ public class PluginManager
             log.info("Registering client request filter factory");
             clientRequestFilterManager.registerClientRequestFilterFactory(clientRequestFilterFactory);
         }
+
+        for (Class<?> functionClass : plugin.getSqlInvokedFunctions()) {
+            log.info("Registering functions from %s", functionClass.getName());
+            metadata.getFunctionAndTypeManager().registerPluginFunctions(
+                    extractFunctions(functionClass, metadata.getFunctionAndTypeManager().getDefaultNamespace()));
+        }
     }
 
     public void installCoordinatorPlugin(CoordinatorPlugin plugin)

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForSqlInvokedScalars.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForSqlInvokedScalars.java
@@ -51,7 +51,7 @@ public class TestAnnotationEngineForSqlInvokedScalars
                 new ArrayType(BIGINT).getTypeSignature(),
                 ImmutableList.of(INTEGER.getTypeSignature()));
 
-        List<SqlInvokedFunction> functions = SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(SingleImplementationSQLInvokedScalarFunction.class);
+        List<SqlInvokedFunction> functions = SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(SingleImplementationSQLInvokedScalarFunction.class, JAVA_BUILTIN_NAMESPACE);
         assertEquals(functions.size(), 1);
         SqlInvokedFunction f = functions.get(0);
 
@@ -75,7 +75,7 @@ public class TestAnnotationEngineForSqlInvokedScalars
                 ImmutableList.of(new TypeSignature("T")),
                 false);
 
-        List<SqlInvokedFunction> functions = SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(SingleImplementationSQLInvokedScalarFunctionWithTypeParameter.class);
+        List<SqlInvokedFunction> functions = SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(SingleImplementationSQLInvokedScalarFunctionWithTypeParameter.class, JAVA_BUILTIN_NAMESPACE);
         assertEquals(functions.size(), 1);
         SqlInvokedFunction f = functions.get(0);
 

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestCustomFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestCustomFunctions.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
 
 public class TestCustomFunctions
         extends AbstractTestFunctions
@@ -41,7 +42,7 @@ public class TestCustomFunctions
     public void setupClass()
     {
         registerScalar(CustomFunctions.class);
-        List<SqlInvokedFunction> functions = SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(CustomFunctions.class);
+        List<SqlInvokedFunction> functions = SqlInvokedScalarFromAnnotationsParser.parseFunctionDefinitions(CustomFunctions.class, JAVA_BUILTIN_NAMESPACE);
         this.functionAssertions.addFunctions(functions);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -153,4 +153,9 @@ public interface Plugin
     {
         return emptyList();
     }
+
+    default Set<Class<?>> getSqlInvokedFunctions()
+    {
+        return emptySet();
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/functions/TestDuplicateSqlInvokedFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/functions/TestDuplicateSqlInvokedFunctions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functions;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+
+public final class TestDuplicateSqlInvokedFunctions
+{
+    private TestDuplicateSqlInvokedFunctions() {}
+
+    @SqlInvokedScalarFunction(value = "array_intersect", deterministic = true, calledOnNullInput = false)
+    @Description("Intersects elements of all arrays in the given array")
+    @TypeParameter("T")
+    @SqlParameter(name = "input", type = "array<array<T>>")
+    @SqlType("array<T>")
+    public static String arrayIntersectArray()
+    {
+        return "RETURN reduce(input, IF((cardinality(input) = 0), ARRAY[], input[1]), (s, x) -> array_intersect(s, x), (s) -> s)";
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/functions/TestFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/functions/TestFunctions.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functions;
+
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.Slice;
+
+public final class TestFunctions
+{
+    private TestFunctions()
+    {}
+
+    @Description("Returns modulo of value by numberOfBuckets")
+    @ScalarFunction
+    @SqlType(StandardTypes.BIGINT)
+    public static long modulo(
+            @SqlType(StandardTypes.BIGINT) long value,
+            @SqlType(StandardTypes.BIGINT) long numberOfBuckets)
+    {
+        return value % numberOfBuckets;
+    }
+
+    @Description(("Return the input string"))
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice identity(@SqlType(StandardTypes.VARCHAR) Slice slice)
+    {
+        return slice;
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/functions/TestPluginLoadedDuplicateSqlInvokedFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/functions/TestPluginLoadedDuplicateSqlInvokedFunctions.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functions;
+
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.tests.TestingPrestoClient;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.testng.Assert.fail;
+
+public class TestPluginLoadedDuplicateSqlInvokedFunctions
+{
+    protected TestingPrestoServer server;
+    protected TestingPrestoClient client;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        server = new TestingPrestoServer();
+        server.installPlugin(new TestDuplicateFunctionsPlugin());
+        client = new TestingPrestoClient(server, testSessionBuilder()
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey("America/Bahia_Banderas"))
+                .build());
+    }
+
+    public void assertInvalidFunction(String expr, String exceptionPattern)
+    {
+        try {
+            client.execute("SELECT " + expr);
+            fail("Function expected to fail but not");
+        }
+        catch (Exception e) {
+            if (!(e.getMessage().matches(exceptionPattern))) {
+                fail(format("Expected exception message '%s' to match '%s' but not",
+                        e.getMessage(), exceptionPattern));
+            }
+        }
+    }
+
+    private static class TestDuplicateFunctionsPlugin
+            implements Plugin
+    {
+        @Override
+        public Set<Class<?>> getSqlInvokedFunctions()
+        {
+            return ImmutableSet.<Class<?>>builder()
+                    .add(TestDuplicateSqlInvokedFunctions.class)
+                    .build();
+        }
+    }
+
+    @Test
+    public void testDuplicateFunctionsLoaded()
+    {
+        assertInvalidFunction(JAVA_BUILTIN_NAMESPACE + ".modulo(10,3)",
+                Pattern.quote(format("java.lang.IllegalArgumentException: Function already registered: %s.array_intersect<T>(array(array(T))):array(T)", JAVA_BUILTIN_NAMESPACE)));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/functions/TestPluginLoadedSqlInvokedFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/functions/TestPluginLoadedSqlInvokedFunctions.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functions;
+
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.TestingPrestoClient;
+import com.google.common.collect.ImmutableSet;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.fail;
+
+public class TestPluginLoadedSqlInvokedFunctions
+{
+    protected TestingPrestoServer server;
+    protected TestingPrestoClient client;
+
+    private static final String CATALOG_NAME = JAVA_BUILTIN_NAMESPACE.getCatalogName();
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        server = new TestingPrestoServer();
+        server.installPlugin(new TestFunctionsPlugin());
+        client = new TestingPrestoClient(server, testSessionBuilder()
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey("America/Bahia_Banderas"))
+                .build());
+    }
+
+    public void assertInvalidFunction(String expr, String exceptionPattern)
+    {
+        try {
+            client.execute("SELECT " + expr);
+            fail("Function expected to fail but not");
+        }
+        catch (Exception e) {
+            if (!(e.getMessage().matches(exceptionPattern))) {
+                fail(format("Expected exception message '%s' to match '%s' but not",
+                        e.getMessage(), exceptionPattern));
+            }
+        }
+    }
+
+    private static class TestFunctionsPlugin
+            implements Plugin
+    {
+        @Override
+        public Set<Class<?>> getSqlInvokedFunctions()
+        {
+            return ImmutableSet.<Class<?>>builder()
+                    .add(TestSqlInvokedFunctionsPlugin.class)
+                    .build();
+        }
+
+        @Override
+        public Set<Class<?>> getFunctions()
+        {
+            return ImmutableSet.<Class<?>>builder()
+                    .add(TestFunctions.class)
+                    .build();
+        }
+    }
+
+    public void check(@Language("SQL") String query, Type expectedType, Object expectedValue)
+    {
+        MaterializedResult result = client.execute(query).getResult();
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getTypes().get(0), expectedType);
+        Object actual = result.getMaterializedRows().get(0).getField(0);
+        assertEquals(actual, expectedValue);
+    }
+
+    @Test
+    public void testNewFunctionNamespaceFunction()
+    {
+        check("SELECT " + JAVA_BUILTIN_NAMESPACE + ".modulo(10,3)", BIGINT, 1L);
+        check("SELECT " + JAVA_BUILTIN_NAMESPACE + ".identity('test-functions')", VARCHAR, "test-functions");
+        check("SELECT " + JAVA_BUILTIN_NAMESPACE + ".custom_square(2, 3)", INTEGER, 4);
+        check("SELECT " + JAVA_BUILTIN_NAMESPACE + ".custom_square(null, 3)", INTEGER, 9);
+    }
+
+    @Test
+    public void testInvalidFunctionAndNamespace()
+    {
+        assertInvalidFunction(CATALOG_NAME + ".namespace.modulo(10,3)", format("line 1:8: Function %s.namespace.modulo not registered", CATALOG_NAME));
+        assertInvalidFunction(CATALOG_NAME + ".system.some_func(10)", format("line 1:8: Function %s.system.some_func not registered", CATALOG_NAME));
+    }
+
+    @Test(dependsOnMethods =
+            {"testNewFunctionNamespaceFunction",
+                    "testInvalidFunctionAndNamespace"})
+    public void testDuplicateFunctionsLoaded()
+    {
+        // Because we trigger the conflict check as soon as the plugins are loaded,
+        // this will throw an Exception: Function already registered: presto.default.modulo(bigint,bigint):bigint while installing the plugin itself
+        assertThrows(IllegalArgumentException.class, () -> server.installPlugin(new TestFunctionsPlugin()));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/functions/TestSqlInvokedFunctionsPlugin.java
+++ b/presto-tests/src/test/java/com/facebook/presto/functions/TestSqlInvokedFunctionsPlugin.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functions;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlParameters;
+import com.facebook.presto.spi.function.SqlType;
+
+public final class TestSqlInvokedFunctionsPlugin
+{
+    private TestSqlInvokedFunctionsPlugin()
+    {}
+
+    @SqlInvokedScalarFunction(value = "custom_square", deterministic = true, calledOnNullInput = false)
+    @Description("Custom SQL to test NULLIF in Functions")
+    @SqlParameters({@SqlParameter(name = "x", type = "integer"), @SqlParameter(name = "y", type = "integer")})
+    @SqlType("integer")
+    public static String customSquare()
+    {
+        return "RETURN IF(NULLIF(x, y) IS NOT NULL, x * x, y * y)";
+    }
+}


### PR DESCRIPTION
## Description
Introduces a new  `getSqlInvokedFunctions` SPI  in Presto, which only supports SQL invoked functions. This SPI enables plugins to register SQL invoked functions via a new built-in plugin function namespace manager interface: `BuiltInPluginFunctionNamespaceManager`.

## Motivation and Context
This change is motivated by the need to safely support SQL invoked functions that may overlap with native C++ functions
pulled from the sidecar. By registering inlined SQL invoked functions through a dedicated SPI and validating them against the functions residing in the default function namespace manager, we ensure clear separate and prevent conflicts in function resolution.

## Impact
No impact for now, but after this change the inlined SQL invoked functions would no longer be registered as built in functions under the `BuiltInTypeAndFunctionNamespaceManager` but instead be provided via a plugin.

## Test Plan
CI and Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

SPI changes
* Add a new  ``getSqlInvokedFunctions`` SPI  in Presto, which only supports SQL invoked functions.

General Changes
* Add a new built-in plugin function namespace manager interface: ``BuiltInPluginFunctionNamespaceManager``.

```

