### PR TITLE
Fix channel mapping in createColumnValueAndRowIdChannels

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2440,6 +2440,18 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
+    public void testUpdateWithDuplicateValues()
+    {
+        String tableName = "test_update_duplicate_values_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + "(id int, column1 varchar(10), column2 varchar(10), column3 int)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a', 'a', 1), (2, 'b', 'b', 1), (3, 'c', 'c', 1)", 3);
+
+        // update single row with duplicate values
+        assertUpdate("UPDATE " + tableName + " SET column1 = CAST(1 as varchar), column2 = CAST(1 as varchar), column3 = 11 WHERE id = 1", 1);
+        assertQuery("SELECT id, column1, column2, column3 FROM " + tableName, "VALUES (1, '1', '1', 11), (2, 'b', 'b', 1), (3, 'c', 'c', 1)");
+    }
+
+    @Test
     public void testUpdateWithPredicates()
     {
         String tableName = "test_update_predicates_" + randomTableSuffix();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -3008,16 +3008,15 @@ public class LocalExecutionPlanner
         {
             Integer[] columnValueAndRowIdChannels = new Integer[columnValueAndRowIdSymbols.size()];
             int symbolCounter = 0;
-            // This depends on the outputSymbols being ordered as the blocks of the
-            // resulting page are ordered.
-            for (VariableReferenceExpression variableReferenceExpression : variableReferenceExpressions) {
-                int index = columnValueAndRowIdSymbols.indexOf(variableReferenceExpression);
-                if (index >= 0) {
-                    columnValueAndRowIdChannels[index] = symbolCounter;
-                }
+            for (VariableReferenceExpression columnValueAndRowIdSymbol : columnValueAndRowIdSymbols) {
+                int index = variableReferenceExpressions.indexOf(columnValueAndRowIdSymbol);
+
+                verify(index >= 0, "Could not find columnValueAndRowIdSymbol %s in the variableReferenceExpressions %s", columnValueAndRowIdSymbol, variableReferenceExpressions);
+                columnValueAndRowIdChannels[symbolCounter] = index;
+
                 symbolCounter++;
             }
-            checkArgument(symbolCounter == columnValueAndRowIdSymbols.size(), "symbolCounter %s should be columnValueAndRowIdChannels.size() %s", symbolCounter);
+
             return Arrays.asList(columnValueAndRowIdChannels);
         }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Previously, createColumnValueAndRowIdChannels() iterated over all variableReferenceExpressions and attempted to locate them in columnValueAndRowIdSymbols, relying on the output order and performing an incorrect size check.

This commit fixes the logic by iterating directly over columnValueAndRowIdSymbols and verifying each one’s position in variableReferenceExpressions. This removes the incorrect ordering assumption and ensures accurate channel mapping when multiple identical values or updates are involved.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fixes #25345 

```
presto:imjalpreet_iceberg> create table test_update (id int, column1 varchar(10), column2 varchar(10), column3 int);
CREATE TABLE

presto:imjalpreet_iceberg> insert into test_update values(1, 'a', 'a', 1);
INSERT: 1 row

Query 20250721_103400_00005_yzsks, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:19, server-side: 0:18] [0 rows, 0B] [0 rows/s, 0B/s]

presto:imjalpreet_iceberg> select * from test_update;
 id | c1 | c2 | c3 
----+----+----+----
  1 | a  | a  | 1
(1 row)

presto:imjalpreet_iceberg> update test_update SET column1 = cast(1 as varchar), column2 = cast(1 as varchar), column3 = 11 where id=1;

Query 20250722_235500_00001_xh3ec, FAILED, 1 node
Splits: 1 total, 0 done (0.00%)
[Latency: client-side: 0:11, server-side: 0:10] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20250722_235500_00001_xh3ec failed: symbolCounter 3 should be columnValueAndRowIdChannels.size() %s

```

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

```
presto:imjalpreet_iceberg> update test_update SET column1 = cast(1 as varchar), column2 = cast(1 as varchar), column3 = 11 where id=1;
UPDATE: 1 row

Query 20250722_235536_00002_xh3ec, FINISHED, 1 node
Splits: 5 total, 5 done (100.00%)
[Latency: client-side: 0:19, server-side: 0:19] [4 rows, 1.97KB] [0 rows/s, 105B/s]

presto:imjalpreet_iceberg> select * from test_update;
 id | c1 | c2 | c3 
----+----+----+----
  1 | 1  | 1  | 11 
(1 row)

Query 20250722_235600_00003_xh3ec, FINISHED, 1 node
Splits: 21 total, 21 done (100.00%)
[Latency: client-side: 0:08, server-side: 0:08] [5 rows, 3.14KB] [0 rows/s, 396B/s]

```

## Test Plan
<!---Please fill in how you tested your change-->

Added a test case similar to the one in the issue

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix for UPDATE statements involving multiple identical target column values.

```

