### PR TITLE
migrate to AWS SDK v2 with MinIO compatibility fixes on presto-iceberg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,8 @@
         <air.test.jvmsize>4g</air.test.jvmsize>
         <grpc.version>1.70.0</grpc.version>
         <air.javadoc.lint>-missing</air.javadoc.lint>
+        <dep.commons.codec.version>1.17.1</dep.commons.codec.version>
+        <aws.sdk.version>2.32.4</aws.sdk.version>
     </properties>
 
     <modules>
@@ -220,6 +222,20 @@
 
     <dependencyManagement>
         <dependencies>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${dep.commons.codec.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -1975,12 +1991,6 @@
             </dependency>
 
             <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.17.0</version>
-            </dependency>
-
-            <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>gcs-connector</artifactId>
                 <version>hadoop2-${dep.gcs.version}</version>
@@ -2709,6 +2719,7 @@
                         </ignoredClassPatterns>
                         <ignoredResourcePatterns combine.children="append">
                             <ignoredResourcePattern>git.properties</ignoredResourcePattern>
+                            <ignoredResourcePattern>mime.types</ignoredResourcePattern>
                         </ignoredResourcePatterns>
                     </configuration>
                 </plugin>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -18,6 +18,12 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>concurrent</artifactId>
@@ -262,16 +268,6 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk-core</artifactId>
-        </dependency>
-
-        <dependency>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
 
         <dependency>
@@ -681,7 +677,14 @@
                             <dependency>com.facebook.airlift:node:jar</dependency>
                             <dependency>javax.servlet:javax.servlet-api:jar</dependency>
                             <dependency>org.apache.httpcomponents.core5:httpcore5:jar</dependency>
+                            <dependency>software.amazon.awssdk:regions:jar</dependency>
+                            <dependency>software.amazon.awssdk:sdk-core:jar</dependency>
+                            <dependency>software.amazon.awssdk:auth:jar</dependency>
+                            <dependency>software.amazon.awssdk:aws-core:jar</dependency>
                         </ignoredUsedUndeclaredDependencies>
+                        <ignoredUnusedDeclaredDependencies>
+                            <ignoredUnusedDeclaredDependency>commons-codec:commons-codec</ignoredUnusedDeclaredDependency>
+                        </ignoredUnusedDeclaredDependencies>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -712,6 +715,7 @@
                             <requireUpperBoundDeps>
                                 <excludes combine.children="append">
                                     <exclude>com.google.guava:guava</exclude>
+                                    <exclude>commons-codec:commons-codec</exclude>
                                 </excludes>
                             </requireUpperBoundDeps>
                         </rules>

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/container/IcebergMinIODataLake.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/container/IcebergMinIODataLake.java
@@ -13,18 +13,22 @@
  */
 package com.facebook.presto.iceberg.container;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.facebook.presto.testing.containers.MinIOContainer;
 import com.facebook.presto.util.AutoCloseableCloser;
 import com.google.common.collect.ImmutableMap;
 import org.testcontainers.containers.Network;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.URI;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Objects.requireNonNull;
@@ -39,7 +43,6 @@ public class IcebergMinIODataLake
     private final String bucketName;
     private final String warehouseDir;
     private final MinIOContainer minIOContainer;
-
     private final AtomicBoolean isStarted = new AtomicBoolean(false);
     private final AutoCloseableCloser closer = AutoCloseableCloser.create();
 
@@ -63,19 +66,36 @@ public class IcebergMinIODataLake
         if (isStarted()) {
             return;
         }
+
         try {
             this.minIOContainer.start();
-            AmazonS3 s3Client = AmazonS3ClientBuilder
-                    .standard()
-                    .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
-                            "http://localhost:" + minIOContainer.getMinioApiEndpoint().getPort(),
-                            "us-east-1"))
-                    .withPathStyleAccessEnabled(true)
-                    .withCredentials(new AWSStaticCredentialsProvider(
-                            new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY)))
+
+            S3Client s3Client = S3Client.builder()
+                    .endpointOverride(URI.create("http://localhost:" + minIOContainer.getMinioApiEndpoint().getPort()))
+                    .region(Region.US_EAST_1)
+                    .forcePathStyle(true)
+                    .serviceConfiguration(S3Configuration.builder()
+                            .checksumValidationEnabled(false)
+                            .chunkedEncodingEnabled(false)
+                            .build())
+                    .credentialsProvider(StaticCredentialsProvider.create(
+                            AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
                     .build();
-            s3Client.createBucket(this.bucketName);
-            s3Client.putObject(this.bucketName, this.warehouseDir, "");
+
+            s3Client.createBucket(CreateBucketRequest.builder()
+                    .bucket(this.bucketName)
+                    .build());
+            String keeperKey = this.warehouseDir.endsWith("/")
+                    ? this.warehouseDir + ".keep"
+                    : this.warehouseDir + "/.keep";
+
+            s3Client.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(this.bucketName)
+                            .key(keeperKey)
+                            .build(),
+                    RequestBody.fromString("placeholder"));
+            closer.register(s3Client);
         }
         finally {
             isStarted.set(true);
@@ -107,8 +127,7 @@ public class IcebergMinIODataLake
     }
 
     @Override
-    public void close()
-            throws IOException
+    public void close() throws IOException
     {
         stop();
     }


### PR DESCRIPTION
## Description

Migration to AWS SDK v2
Disable checksum validation and chunked encoding to ensure compatibility with MinIO and newer AWS SDK versions per aws/aws-sdk-java-v2#5836

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

