### PR TITLE
Fix static scan issue by updating AES cipher mode

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/spiller/AesSpillCipher.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/spiller/AesSpillCipher.java
@@ -33,8 +33,8 @@ import static java.lang.String.format;
 final class AesSpillCipher
         implements SpillCipher
 {
-    //  256-bit AES CBC mode
-    private static final String CIPHER_NAME = "AES/CBC/PKCS5Padding";
+    //  256-bit AES CTR mode
+    private static final String CIPHER_NAME = "AES/CTR/NoPadding";
     private static final int KEY_BITS = 256;
 
     private SecretKey key;


### PR DESCRIPTION
## Description
A static scan flagged the use of padding as a potential security risk and recommended switching to a safer encryption approach. I evaluated whether AES/CBC supports NoPadding, but it doesn't offer that option.
So, I’ve updated the implementation to use AES/CTR, which supports NoPadding and avoids padding-related vulnerabilities. It also maintains strong encryption guarantees and is generally considered safer than CBC mode for most use cases.
Reference: [AES-CBC vs AES-CTR - Crypto StackExchange](https://crypto.stackexchange.com/questions/6029/aes-cbc-mode-or-aes-ctr-mode-recommended)

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
*  Fix static scan issue by updating AES cipher mode.
```

