### PR TITLE
feat(connector): Add is_deprecated column to table_properties table

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -4620,7 +4620,7 @@ public class TestHiveIntegrationSmokeTest
     public void testAnalyzePropertiesSystemTable()
     {
         assertQuery("SELECT * FROM system.metadata.analyze_properties WHERE catalog_name = 'hive'",
-                "SELECT 'hive', 'partitions', '', 'array(array(varchar))', 'Partitions to be analyzed'");
+                "SELECT 'hive', 'partitions', '', 'array(array(varchar))', 'Partitions to be analyzed', 'false'");
     }
 
     @Test

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -65,6 +65,7 @@ public class IcebergConnector
     private final List<PropertyMetadata<?>> schemaProperties;
     private final List<PropertyMetadata<?>> tableProperties;
     private final List<PropertyMetadata<?>> materializedViewProperties;
+    private final List<PropertyMetadata<?>> deprecatedTableProperties;
     private final List<PropertyMetadata<?>> columnProperties;
     private final ConnectorAccessControl accessControl;
     private final Set<BaseProcedure<?>> procedures;
@@ -83,6 +84,7 @@ public class IcebergConnector
             List<PropertyMetadata<?>> schemaProperties,
             List<PropertyMetadata<?>> tableProperties,
             List<PropertyMetadata<?>> materializedViewProperties,
+            List<PropertyMetadata<?>> deprecatedTableProperties,
             List<PropertyMetadata<?>> columnProperties,
             ConnectorAccessControl accessControl,
             Set<BaseProcedure<?>> procedures,
@@ -100,6 +102,7 @@ public class IcebergConnector
         this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null"));
         this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
         this.materializedViewProperties = ImmutableList.copyOf(requireNonNull(materializedViewProperties, "materializedViewProperties is null"));
+        this.deprecatedTableProperties = ImmutableList.copyOf(requireNonNull(deprecatedTableProperties, "deprecatedTableProperties is null"));
         this.columnProperties = ImmutableList.copyOf(requireNonNull(columnProperties, "columnProperties is null"));
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.procedures = requireNonNull(procedures, "procedures is null");
@@ -183,6 +186,11 @@ public class IcebergConnector
     public List<PropertyMetadata<?>> getTableProperties()
     {
         return tableProperties;
+    }
+
+    public List<PropertyMetadata<?>> getDeprecatedTableProperties()
+    {
+        return deprecatedTableProperties;
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -123,6 +123,7 @@ public class IcebergTableProperties
     private static final String DEFAULT_FORMAT_VERSION = "2";
 
     private final List<PropertyMetadata<?>> tableProperties;
+    private final List<PropertyMetadata<?>> deprecatedTableProperties;
     private final List<PropertyMetadata<?>> columnProperties;
     private final Map<String, PropertyMetadata<?>> deprecatedPropertyMetadata;
 
@@ -264,11 +265,20 @@ public class IcebergTableProperties
                                 .collect(toImmutableList()),
                         value -> value)
                         .withAdditionalTypeHandler(VARCHAR, ImmutableList::of));
+
+        deprecatedTableProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .addAll(deprecatedPropertyMetadata.values())
+                .build();
     }
 
     public List<PropertyMetadata<?>> getTableProperties()
     {
         return tableProperties;
+    }
+
+    public List<PropertyMetadata<?>> getDeprecatedTableProperties()
+    {
+        return deprecatedTableProperties;
     }
 
     public List<PropertyMetadata<?>> getColumnProperties()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
@@ -145,6 +145,7 @@ public final class InternalIcebergConnectorFactory
                     SchemaProperties.SCHEMA_PROPERTIES,
                     icebergTableProperties.getTableProperties(),
                     icebergMaterializedViewProperties.getMaterializedViewProperties(),
+                    icebergTableProperties.getDeprecatedTableProperties(),
                     icebergTableProperties.getColumnProperties(),
                     accessControl,
                     procedures,

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableProperties.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableProperties.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+public class TestIcebergTableProperties
+        extends AbstractTestQueryFramework
+{
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder().build().getQueryRunner();
+    }
+
+    @Test
+    public void testDeprecatedProperties()
+    {
+        assertQuery("select property_name from system.metadata.table_properties where catalog_name = 'iceberg' and is_deprecated = true",
+                "VALUES 'commit_retries', 'delete_mode', 'format', 'metadata_delete_after_commit', 'metadata_previous_versions_max', 'metrics_max_inferred_column', 'format_version'");
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorManager.java
@@ -339,6 +339,7 @@ public class ConnectorManager
 
         metadataManager.getTablePropertyManager().addProperties(connectorId, connector.getTableProperties());
         metadataManager.getMaterializedViewPropertyManager().addProperties(connectorId, connector.getMaterializedViewProperties());
+        metadataManager.getTableDeprecatedPropertyManager().ifPresent(manager -> manager.addProperties(connectorId, connector.getDeprecatedTableProperties()));
         metadataManager.getColumnPropertyManager().addProperties(connectorId, connector.getColumnProperties());
         metadataManager.getSchemaPropertyManager().addProperties(connectorId, connector.getSchemaProperties());
         metadataManager.getAnalyzePropertyManager().addProperties(connectorId, connector.getAnalyzeProperties());
@@ -446,6 +447,7 @@ public class ConnectorManager
         private final List<PropertyMetadata<?>> sessionProperties;
         private final List<PropertyMetadata<?>> tableProperties;
         private final List<PropertyMetadata<?>> materializedViewProperties;
+        private final List<PropertyMetadata<?>> deprecatedTableProperties;
         private final List<PropertyMetadata<?>> schemaProperties;
         private final List<PropertyMetadata<?>> columnProperties;
         private final List<PropertyMetadata<?>> analyzeProperties;
@@ -562,6 +564,10 @@ public class ConnectorManager
             requireNonNull(materializedViewProperties, "Connector %s returned a null materialized view properties set");
             this.materializedViewProperties = ImmutableList.copyOf(materializedViewProperties);
 
+            List<PropertyMetadata<?>> deprecatedTableProperties = connector.getDeprecatedTableProperties();
+            requireNonNull(deprecatedTableProperties, "Connector %s returned a null deprecated table properties set");
+            this.deprecatedTableProperties = ImmutableList.copyOf(deprecatedTableProperties);
+
             List<PropertyMetadata<?>> schemaProperties = connector.getSchemaProperties();
             requireNonNull(schemaProperties, "Connector %s returned a null schema properties set");
             this.schemaProperties = ImmutableList.copyOf(schemaProperties);
@@ -659,6 +665,10 @@ public class ConnectorManager
         public List<PropertyMetadata<?>> getMaterializedViewProperties()
         {
             return materializedViewProperties;
+        }
+        public List<PropertyMetadata<?>> getDeprecatedTableProperties()
+        {
+            return deprecatedTableProperties;
         }
 
         public List<PropertyMetadata<?>> getColumnProperties()

--- a/presto-main-base/src/main/java/com/facebook/presto/connector/system/AbstractPropertiesSystemTable.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/system/AbstractPropertiesSystemTable.java
@@ -15,6 +15,7 @@ package com.facebook.presto.connector.system;
 
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
@@ -28,10 +29,12 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static com.facebook.presto.spi.SystemTable.Distribution.SINGLE_COORDINATOR;
@@ -53,6 +56,7 @@ abstract class AbstractPropertiesSystemTable
                 .column("default_value", createUnboundedVarcharType())
                 .column("type", createUnboundedVarcharType())
                 .column("description", createUnboundedVarcharType())
+                .column("is_deprecated", BOOLEAN)
                 .build();
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.propertySupplier = requireNonNull(propertySupplier, "propertySupplier is null");
@@ -75,20 +79,38 @@ abstract class AbstractPropertiesSystemTable
     {
         TransactionId transactionId = ((GlobalSystemTransactionHandle) transactionHandle).getTransactionId();
 
+        /*
+        Get the list of catalogs. Catalog object will have CatalogContext which can help in retrieving the iceberg connector.
+        Catalog object has the Connector object as well.
+        Once you have the connector, get the deprecatedTableProperties and populate is_deprecated column.
+         */
         InMemoryRecordSet.Builder table = InMemoryRecordSet.builder(tableMetadata);
         Map<ConnectorId, Map<String, PropertyMetadata<?>>> connectorProperties = propertySupplier.get();
-        for (Entry<String, ConnectorId> entry : new TreeMap<>(transactionManager.getCatalogNames(transactionId)).entrySet()) {
-            String catalog = entry.getKey();
-            Map<String, PropertyMetadata<?>> properties = new TreeMap<>(connectorProperties.getOrDefault(entry.getValue(), ImmutableMap.of()));
+        for (Catalog catalog : transactionManager.getCatalogs(transactionId)) {
+            String catalogName = catalog.getCatalogName();
+            ConnectorId connectorId = catalog.getConnectorId();
+            Map<String, PropertyMetadata<?>> properties = new TreeMap<>(connectorProperties.getOrDefault(connectorId, ImmutableMap.of()));
+            boolean isDeprecated;
+            Set<String> deprecatedPropertyNames = catalog.getConnector(connectorId).getDeprecatedTableProperties().stream().map(PropertyMetadata::getName).collect(Collectors.toSet());
             for (PropertyMetadata<?> propertyMetadata : properties.values()) {
-                table.addRow(
-                        catalog,
-                        propertyMetadata.getName(),
-                        firstNonNull(propertyMetadata.getDefaultValue(), "").toString(),
-                        propertyMetadata.getSqlType().toString(),
-                        propertyMetadata.getDescription());
+                isDeprecated = deprecatedPropertyNames.contains(propertyMetadata.getName());
+                addTableRow(table, catalogName, isDeprecated, propertyMetadata);
             }
         }
         return table.build().cursor();
+    }
+
+    private void addTableRow(InMemoryRecordSet.Builder table,
+                             String catalogName,
+                             boolean isDeprecated,
+                             PropertyMetadata<?> propertyMetadata)
+    {
+        table.addRow(
+                catalogName,
+                propertyMetadata.getName(),
+                firstNonNull(propertyMetadata.getDefaultValue(), "").toString(),
+                propertyMetadata.getSqlType().toString(),
+                propertyMetadata.getDescription(),
+                isDeprecated);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Catalog.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Catalog.java
@@ -121,7 +121,7 @@ public class Catalog
                 .toString();
     }
 
-    public class CatalogContext
+    public static class CatalogContext
     {
         private final String catalogName;
         private final String connectorName;

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DeprecatedTablePropertyManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DeprecatedTablePropertyManager.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
+
+/*
+The class manages table properties which are deprecated at connector level. This is basically getting used
+for displaying deprecated table properties as deprecated in system.metadata.table_properties table.
+ */
+public class DeprecatedTablePropertyManager
+        extends AbstractPropertyManager
+{
+    public DeprecatedTablePropertyManager()
+    {
+        super("table deprecated", INVALID_TABLE_PROPERTY);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -573,6 +573,11 @@ public interface Metadata
 
     MaterializedViewPropertyManager getMaterializedViewPropertyManager();
 
+    default Optional<DeprecatedTablePropertyManager> getTableDeprecatedPropertyManager()
+    {
+        return Optional.empty();
+    }
+
     ColumnPropertyManager getColumnPropertyManager();
 
     AnalyzePropertyManager getAnalyzePropertyManager();

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -162,6 +162,7 @@ public class MetadataManager
     private final SchemaPropertyManager schemaPropertyManager;
     private final TablePropertyManager tablePropertyManager;
     private final MaterializedViewPropertyManager materializedViewPropertyManager;
+    private final DeprecatedTablePropertyManager deprecatedTablePropertyManager;
     private final ColumnPropertyManager columnPropertyManager;
     private final AnalyzePropertyManager analyzePropertyManager;
     private final TransactionManager transactionManager;
@@ -177,6 +178,7 @@ public class MetadataManager
             SchemaPropertyManager schemaPropertyManager,
             TablePropertyManager tablePropertyManager,
             MaterializedViewPropertyManager materializedViewPropertyManager,
+            DeprecatedTablePropertyManager deprecatedTablePropertyManager,
             ColumnPropertyManager columnPropertyManager,
             AnalyzePropertyManager analyzePropertyManager,
             TransactionManager transactionManager)
@@ -188,6 +190,7 @@ public class MetadataManager
                 schemaPropertyManager,
                 tablePropertyManager,
                 materializedViewPropertyManager,
+                deprecatedTablePropertyManager,
                 columnPropertyManager,
                 analyzePropertyManager,
                 transactionManager,
@@ -202,6 +205,7 @@ public class MetadataManager
             SchemaPropertyManager schemaPropertyManager,
             TablePropertyManager tablePropertyManager,
             MaterializedViewPropertyManager materializedViewPropertyManager,
+            DeprecatedTablePropertyManager deprecatedTablePropertyManager,
             ColumnPropertyManager columnPropertyManager,
             AnalyzePropertyManager analyzePropertyManager,
             TransactionManager transactionManager,
@@ -214,6 +218,7 @@ public class MetadataManager
                 schemaPropertyManager,
                 tablePropertyManager,
                 materializedViewPropertyManager,
+                deprecatedTablePropertyManager,
                 columnPropertyManager,
                 analyzePropertyManager,
                 transactionManager,
@@ -229,6 +234,7 @@ public class MetadataManager
             SchemaPropertyManager schemaPropertyManager,
             TablePropertyManager tablePropertyManager,
             MaterializedViewPropertyManager materializedViewPropertyManager,
+            DeprecatedTablePropertyManager deprecatedTablePropertyManager,
             ColumnPropertyManager columnPropertyManager,
             AnalyzePropertyManager analyzePropertyManager,
             TransactionManager transactionManager,
@@ -241,6 +247,7 @@ public class MetadataManager
         this.schemaPropertyManager = requireNonNull(schemaPropertyManager, "schemaPropertyManager is null");
         this.tablePropertyManager = requireNonNull(tablePropertyManager, "tablePropertyManager is null");
         this.materializedViewPropertyManager = requireNonNull(materializedViewPropertyManager, "materializedViewPropertyManager is null");
+        this.deprecatedTablePropertyManager = requireNonNull(deprecatedTablePropertyManager, "tableDeprecatedPropertyManager is null");
         this.columnPropertyManager = requireNonNull(columnPropertyManager, "columnPropertyManager is null");
         this.analyzePropertyManager = requireNonNull(analyzePropertyManager, "analyzePropertyManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -290,6 +297,7 @@ public class MetadataManager
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 new MaterializedViewPropertyManager(),
+                new DeprecatedTablePropertyManager(),
                 new ColumnPropertyManager(),
                 new AnalyzePropertyManager(),
                 transactionManager);
@@ -305,6 +313,7 @@ public class MetadataManager
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 new MaterializedViewPropertyManager(),
+                new DeprecatedTablePropertyManager(),
                 new ColumnPropertyManager(),
                 new AnalyzePropertyManager(),
                 transactionManager,
@@ -321,6 +330,7 @@ public class MetadataManager
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 new MaterializedViewPropertyManager(),
+                new DeprecatedTablePropertyManager(),
                 new ColumnPropertyManager(),
                 new AnalyzePropertyManager(),
                 functionAndTypeManager.getTransactionManager(),
@@ -1602,6 +1612,11 @@ public class MetadataManager
     public TablePropertyManager getTablePropertyManager()
     {
         return tablePropertyManager;
+    }
+
+    public Optional<DeprecatedTablePropertyManager> getTableDeprecatedPropertyManager()
+    {
+        return Optional.of(deprecatedTablePropertyManager);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -101,6 +101,7 @@ import com.facebook.presto.metadata.AnalyzePropertyManager;
 import com.facebook.presto.metadata.BuiltInProcedureRegistry;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.ColumnPropertyManager;
+import com.facebook.presto.metadata.DeprecatedTablePropertyManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.metadata.InMemoryNodeManager;
@@ -464,6 +465,7 @@ public class LocalQueryRunner
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 new MaterializedViewPropertyManager(),
+                new DeprecatedTablePropertyManager(),
                 new ColumnPropertyManager(),
                 new AnalyzePropertyManager(),
                 transactionManager,

--- a/presto-main-base/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
@@ -215,6 +215,11 @@ public class InMemoryTransactionManager
         return getTransactionMetadata(transactionId).getCatalogNames();
     }
 
+    public List<Catalog> getCatalogs(TransactionId transactionId)
+    {
+        return getTransactionMetadata(transactionId).getCatalogs();
+    }
+
     @Override
     public Map<String, CatalogContext> getCatalogNamesWithConnectorContext(TransactionId transactionId)
     {
@@ -481,6 +486,11 @@ public class InMemoryTransactionManager
                     .forEach(catalog -> catalogNamesWithConnectorContext.putIfAbsent(catalog.getCatalogName(), catalog.getCatalogContext()));
 
             return ImmutableMap.copyOf(catalogNamesWithConnectorContext);
+        }
+
+        private synchronized List<Catalog> getCatalogs()
+        {
+            return catalogManager.getCatalogs();
         }
 
         private synchronized Optional<ConnectorId> getConnectorId(String catalogName)

--- a/presto-main-base/src/main/java/com/facebook/presto/transaction/TransactionManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/transaction/TransactionManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.transaction;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.transaction.TransactionId;
+import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.metadata.Catalog.CatalogContext;
 import com.facebook.presto.metadata.CatalogMetadata;
 import com.facebook.presto.spi.ConnectorId;
@@ -23,6 +24,7 @@ import com.facebook.presto.spi.function.FunctionNamespaceManager;
 import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -52,6 +54,11 @@ public interface TransactionManager
     default Map<String, CatalogContext> getCatalogNamesWithConnectorContext(TransactionId transactionId)
     {
         return ImmutableMap.of();
+    }
+
+    default List<Catalog> getCatalogs(TransactionId transactionId)
+    {
+        return ImmutableList.of();
     }
 
     Optional<CatalogMetadata> getOptionalCatalogMetadata(TransactionId transactionId, String catalogName);

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -102,6 +102,7 @@ import com.facebook.presto.metadata.AnalyzePropertyManager;
 import com.facebook.presto.metadata.BuiltInProcedureRegistry;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.ColumnPropertyManager;
+import com.facebook.presto.metadata.DeprecatedTablePropertyManager;
 import com.facebook.presto.metadata.DiscoveryNodeManager;
 import com.facebook.presto.metadata.ForNodeManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -398,6 +399,9 @@ public class ServerMainModule
 
         // materialized view properties
         binder.bind(MaterializedViewPropertyManager.class).in(Scopes.SINGLETON);
+
+        // deprecated table properties
+        binder.bind(DeprecatedTablePropertyManager.class).in(Scopes.SINGLETON);
 
         // column properties
         binder.bind(ColumnPropertyManager.class).in(Scopes.SINGLETON);

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -54,6 +54,7 @@ system| metadata| analyze_properties| property_name| varchar| YES| null| null|
 system| metadata| analyze_properties| default_value| varchar| YES| null| null|
 system| metadata| analyze_properties| type| varchar| YES| null| null|
 system| metadata| analyze_properties| description| varchar| YES| null| null|
+system| metadata| analyze_properties| is_deprecated| boolean| YES| null| null|
 system| metadata| catalogs| catalog_name| varchar| YES| null| null|
 system| metadata| catalogs| connector_id| varchar| YES| null| null|
 system| metadata| catalogs| connector_name| varchar| YES| null| null|
@@ -62,16 +63,19 @@ system| metadata| column_properties| property_name| varchar| YES| null| null|
 system| metadata| column_properties| default_value| varchar| YES| null| null|
 system| metadata| column_properties| type| varchar| YES| null| null|
 system| metadata| column_properties| description| varchar| YES| null| null|
+system| metadata| column_properties| is_deprecated| boolean| YES| null| null|
 system| metadata| schema_properties| catalog_name| varchar| YES| null| null|
 system| metadata| schema_properties| property_name| varchar| YES| null| null|
 system| metadata| schema_properties| default_value| varchar| YES| null| null|
 system| metadata| schema_properties| type| varchar| YES| null| null|
 system| metadata| schema_properties| description| varchar| YES| null| null|
+system| metadata| schema_properties| is_deprecated| boolean| YES| null| null|
 system| metadata| table_properties| catalog_name| varchar| YES| null| null|
 system| metadata| table_properties| property_name| varchar| YES| null| null|
 system| metadata| table_properties| default_value| varchar| YES| null| null|
 system| metadata| table_properties| type| varchar| YES| null| null|
 system| metadata| table_properties| description| varchar| YES| null| null|
+system| metadata| table_properties| is_deprecated| boolean| YES| null| null|
 system| runtime| nodes| node_id| varchar| YES| null| null|
 system| runtime| nodes| http_uri| varchar| YES| null| null|
 system| runtime| nodes| node_version| varchar| YES| null| null|

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -71,6 +71,7 @@ import com.facebook.presto.metadata.AnalyzePropertyManager;
 import com.facebook.presto.metadata.BuiltInProcedureRegistry;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.ColumnPropertyManager;
+import com.facebook.presto.metadata.DeprecatedTablePropertyManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.HandleJsonModule;
 import com.facebook.presto.metadata.InternalNodeManager;
@@ -359,6 +360,7 @@ public class PrestoSparkModule
         binder.bind(SchemaPropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(TablePropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(MaterializedViewPropertyManager.class).in(Scopes.SINGLETON);
+        binder.bind(DeprecatedTablePropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(ColumnPropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(AnalyzePropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(QuerySessionSupplier.class).in(Scopes.SINGLETON);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
@@ -180,6 +180,11 @@ public interface Connector
         return emptyList();
     }
 
+    default List<PropertyMetadata<?>> getDeprecatedTableProperties()
+    {
+        return emptyList();
+    }
+
     /**
      * @return the column properties for this connector
      */


### PR DESCRIPTION
## Description
Few table properties from iceberg connector are deprecated. Hence, `system.metadata.table_properties` is showing 2 entries for them (deprecated and their current replacement) and we need a way to mark them as deprecated for showing correct information to users.

**NOTE**: Not sure if the approach I took is the best one for making this change. Any feedbacks are welcome.

## Motivation and Context
Clearly show deprecated table properties as deprecated to maintain transparency for end users.

<img width="1482" height="573" alt="Screenshot 2025-07-23 at 6 21 46 PM" src="https://github.com/user-attachments/assets/28449171-f3d6-45eb-b914-ddf3a1bd0134" />


## Impact
`system.metadata.table_properties` now has an additional column `is_deprecated`. Due to implementational requirements, this new column is also added to below tables from `system.metadata` - 

```
analyze_properties
column_properties
schema_properties
```

## Test Plan
Manual testing. Product tests modified.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

