### PR TITLE
Fix iceberg commit atomicity & add `iceberg.engine.hive.lock-enabled` configuration

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -93,6 +93,10 @@ Property Name                                            Description            
 
 ``iceberg.hive.table-refresh.backoff-scale-factor``      The multiple used to scale subsequent wait time between       4.0
                                                          retries.
+
+``iceberg.engine.hive.lock-enabled``                     Whether to use locks to ensure atomicity of commits.          true
+                                                         This will turn off locks but is overridden at a table level
+                                                         with the table configuration ``engine.hive.lock-enabled``.
 ======================================================== ============================================================= ============
 
 Nessie catalog

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public interface ExtendedHiveMetastore
 {
@@ -88,6 +89,8 @@ public interface ExtendedHiveMetastore
      * probably not what you want.
      */
     MetastoreOperationResult replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges);
+
+    MetastoreOperationResult persistTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Supplier<PartitionStatistics> update, Map<String, String> additionalParameters);
 
     MetastoreOperationResult renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName);
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryCachingHiveMetastore.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CORRUPTED_PARTITION_CACHE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
@@ -448,6 +449,18 @@ public class InMemoryCachingHiveMetastore
             }
         });
         return result.build();
+    }
+
+    @Override
+    public MetastoreOperationResult persistTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Supplier<PartitionStatistics> update, Map<String, String> additionalParameters)
+    {
+        try {
+            return getDelegate().persistTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges, update, additionalParameters);
+        }
+        finally {
+            invalidateTableCache(databaseName, tableName);
+            invalidateTableCache(newTable.getDatabaseName(), newTable.getTableName());
+        }
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
@@ -316,6 +316,13 @@ public class RecordingHiveMetastore
     }
 
     @Override
+    public MetastoreOperationResult persistTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Supplier<PartitionStatistics> update, Map<String, String> additionalParameters)
+    {
+        verifyRecordingMode();
+        return delegate.persistTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges, update, additionalParameters);
+    }
+
+    @Override
     public MetastoreOperationResult renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         verifyRecordingMode();

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -61,6 +62,8 @@ public interface HiveMetastore
     void dropTable(MetastoreContext metastoreContext, String databaseName, String tableName, boolean deleteData);
 
     MetastoreOperationResult alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table table);
+
+    MetastoreOperationResult alterTableWithEnvironmentContext(MetastoreContext metastoreContext, String databaseName, String tableName, Table table, EnvironmentContext environmentContext);
 
     default List<String> getDatabases(MetastoreContext metastoreContext, String pattern)
     {

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive.metastore.thrift;
 import org.apache.hadoop.hive.metastore.api.CheckLockRequest;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
@@ -84,6 +85,9 @@ public interface HiveMetastoreClient
             throws TException;
 
     void alterTable(String databaseName, String tableName, Table newTable)
+            throws TException;
+
+    void alterTableWithEnvironmentContext(String databaseName, String tableName, Table newTable, EnvironmentContext context)
             throws TException;
 
     Table getTable(String databaseName, String tableName)

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.CheckLockRequest;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
@@ -1145,6 +1146,35 @@ public class ThriftHiveMetastore
                                     throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
                                 }
                                 client.alterTable(databaseName, tableName, table);
+                                return null;
+                            })));
+            return EMPTY_RESULT;
+        }
+        catch (NoSuchObjectException e) {
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+        }
+        catch (TException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+        catch (Exception e) {
+            throw propagate(e);
+        }
+    }
+
+    @Override
+    public MetastoreOperationResult alterTableWithEnvironmentContext(MetastoreContext metastoreContext, String databaseName, String tableName, Table table, EnvironmentContext environmentContext)
+    {
+        try {
+            retry()
+                    .stopOn(InvalidOperationException.class, MetaException.class)
+                    .stopOnIllegalExceptions()
+                    .run("alterTableWithEnvironmentContext", stats.getAlterTableWithEnvironmentContext().wrap(() ->
+                            getMetastoreClientThenCall(metastoreContext, client -> {
+                                Optional<Table> source = getTable(metastoreContext, databaseName, tableName);
+                                if (!source.isPresent()) {
+                                    throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+                                }
+                                client.alterTableWithEnvironmentContext(databaseName, tableName, table, environmentContext);
                                 return null;
                             })));
             return EMPTY_RESULT;

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.DropConstraintRequest;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalRequest;
 import org.apache.hadoop.hive.metastore.api.GetRoleGrantsForPrincipalResponse;
@@ -197,6 +198,13 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         client.alter_table(constructSchemaName(catalogName, databaseName), tableName, newTable);
+    }
+
+    @Override
+    public void alterTableWithEnvironmentContext(String databaseName, String tableName, Table newTable, EnvironmentContext context)
+            throws TException
+    {
+        client.alter_table_with_environment_context(constructSchemaName(catalogName, databaseName), tableName, newTable, context);
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreStats.java
@@ -40,6 +40,7 @@ public class ThriftHiveMetastoreStats
     private final HiveMetastoreApiStats createTableWithConstraints = new HiveMetastoreApiStats();
     private final HiveMetastoreApiStats dropTable = new HiveMetastoreApiStats();
     private final HiveMetastoreApiStats alterTable = new HiveMetastoreApiStats();
+    private final HiveMetastoreApiStats alterTableWithEnvironmentContext = new HiveMetastoreApiStats();
     private final HiveMetastoreApiStats addPartitions = new HiveMetastoreApiStats();
     private final HiveMetastoreApiStats dropPartition = new HiveMetastoreApiStats();
     private final HiveMetastoreApiStats alterPartition = new HiveMetastoreApiStats();
@@ -214,6 +215,13 @@ public class ThriftHiveMetastoreStats
     public HiveMetastoreApiStats getAlterTable()
     {
         return alterTable;
+    }
+
+    @Managed
+    @Nested
+    public HiveMetastoreApiStats getAlterTableWithEnvironmentContext()
+    {
+        return alterTableWithEnvironmentContext;
     }
 
     @Managed

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class UnimplementedHiveMetastore
         implements ExtendedHiveMetastore
@@ -124,6 +125,12 @@ public class UnimplementedHiveMetastore
 
     @Override
     public MetastoreOperationResult replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MetastoreOperationResult persistTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges, Supplier<PartitionStatistics> update, Map<String, String> additionalParameters)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
@@ -40,6 +40,7 @@ import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
@@ -281,6 +282,12 @@ public class InMemoryHiveMetastore
         relations.remove(oldName);
 
         return EMPTY_RESULT;
+    }
+
+    @Override
+    public synchronized MetastoreOperationResult alterTableWithEnvironmentContext(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, EnvironmentContext environmentContext)
+    {
+        return alterTable(metastoreContext, databaseName, tableName, newTable);
     }
 
     @Override

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.CheckLockRequest;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
@@ -361,6 +362,13 @@ public class MockHiveMetastoreClient
 
     @Override
     public void alterTable(String databaseName, String tableName, Table newTable)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void alterTableWithEnvironmentContext(String databaseName, String tableName, Table newTable, EnvironmentContext context)
+            throws TException
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveTableOperationsConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveTableOperationsConfig.java
@@ -31,6 +31,7 @@ public class IcebergHiveTableOperationsConfig
     private Duration tableRefreshMaxRetryTime = succinctDuration(1, MINUTES);
     private double tableRefreshBackoffScaleFactor = 4.0;
     private int tableRefreshRetries = 20;
+    private boolean lockingEnabled = true;
 
     @MinDuration("1ms")
     public Duration getTableRefreshBackoffMinSleepTime()
@@ -100,5 +101,18 @@ public class IcebergHiveTableOperationsConfig
     public int getTableRefreshRetries()
     {
         return tableRefreshRetries;
+    }
+
+    @Config("iceberg.engine.hive.lock-enabled")
+    @ConfigDescription("Whether to use HMS locks to ensure atomicity of commits")
+    public IcebergHiveTableOperationsConfig setLockingEnabled(boolean lockingEnabled)
+    {
+        this.lockingEnabled = lockingEnabled;
+        return this;
+    }
+
+    public boolean getLockingEnabled()
+    {
+        return lockingEnabled;
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestHiveTableOperationsConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestHiveTableOperationsConfig.java
@@ -37,7 +37,8 @@ public class TestHiveTableOperationsConfig
                 .setTableRefreshBackoffMaxSleepTime(succinctDuration(5, SECONDS))
                 .setTableRefreshMaxRetryTime(succinctDuration(1, MINUTES))
                 .setTableRefreshBackoffScaleFactor(4.0)
-                .setTableRefreshRetries(20));
+                .setTableRefreshRetries(20)
+                .setLockingEnabled(true));
     }
 
     @Test
@@ -49,6 +50,7 @@ public class TestHiveTableOperationsConfig
                 .put("iceberg.hive.table-refresh.max-retry-time", "30s")
                 .put("iceberg.hive.table-refresh.retries", "42")
                 .put("iceberg.hive.table-refresh.backoff-scale-factor", "2.0")
+                .put("iceberg.engine.hive.lock-enabled", "false")
                 .build();
 
         IcebergHiveTableOperationsConfig expected = new IcebergHiveTableOperationsConfig()
@@ -56,7 +58,8 @@ public class TestHiveTableOperationsConfig
                 .setTableRefreshBackoffMaxSleepTime(succinctDuration(20, SECONDS))
                 .setTableRefreshMaxRetryTime(succinctDuration(30, SECONDS))
                 .setTableRefreshBackoffScaleFactor(2.0)
-                .setTableRefreshRetries(42);
+                .setTableRefreshRetries(42)
+                .setLockingEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Currently, in the iceberg connector, HiveTableOperations performs two operations when committing. 
The first is `replaceTable`, the second is `updateTableStatistics`. 
This is unlike the [Iceberg implementation](https://github.com/apache/iceberg/blob/main/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L210) where only `persistTable` is called.


This may cause several issues:

- If we turn off locks we it can cause an inconsistent state.
- If replaceTable is performed and updateTableStatistics is not, an inconsistent state occurs.

The reason for the previous implementation was probably due to the fact thrift hive metastore API for alterTable without modifying the statistics.  I have implemented the following:

- Added a new alterTable function to the thrift hive metastore which will reset statistics while altering. This function specs can be [found here](https://github.com/apache/hive/blob/ac1f60ab4d21f9d19b4759b3f248a5dea7c7d26d/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift#L2296)
- Combined the replaceTable & updateTableStatistics functions for file based and glue based metastores to perform one transaction
- Added the `iceberg.engine.hive.lock-enabled` to enable or disable table locks when iceberg accesses a hive table. This can be overridden with the table property `engine.hive.lock-enabled`. This implementation is based on the iceberg implementation which can be [found here](https://github.com/apache/iceberg/blob/main/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L210)


## Motivation and Context
Resolves https://github.com/prestodb/presto/issues/25607

## Impact
No impact by default, `iceberg.engine.hive.lock-enabled` as an option is added to disable locks. This is only relevant for file based & thrift based metastores. Glue does not have metastore locks by default.

Only HMS

## Test Plan
UTs and local testing with several concurrent queries.
Used the concurrent iceberg smoke test that was removed in this PR:
https://github.com/prestodb/presto/pull/21250/files
I didn't add it back due to concerns about the flakiness of the test in that PR.
Tested thrift based metastore locally

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix implementation of commit to do one operation as opposed to two.
* Add ``iceberg.engine.hive.lock-enabled`` configuration to disable Hive locks. 
```
