### PR TITLE
Add max_serializable_object_size system property

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -125,6 +125,16 @@ To avoid these problems:
 
 The corresponding configuration property is :ref:`admin/properties:\`\`check-access-control-on-utilized-columns-only\`\``.
 
+``max_serializable_object_size``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``long``
+* **Default value:** ``1000``
+
+Maximum object size in bytes that can be considered serializable in a function call by the coordinator.
+
+The corresponding configuration property is :ref:`admin/properties:\`\`max-serializable-object-size\`\``.
+
 Spilling Properties
 -------------------
 

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -149,6 +149,16 @@ To enable the ``OFFSET`` clause in SQL query expressions, set this property to `
 
 The corresponding session property is :ref:`admin/properties-session:\`\`offset_clause_enabled\`\``. 
 
+``max-serializable-object-size``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``long``
+* **Default value:** ``1000``
+
+Maximum object size in bytes that can be considered serializable in a function call by the coordinator.
+
+The corresponding session property is :ref:`admin/properties-session:\`\`max_serializable_object_size\`\``. 
+
 Memory Management Properties
 ----------------------------
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -339,6 +339,7 @@ public final class SystemSessionProperties
     public static final String ADD_DISTINCT_BELOW_SEMI_JOIN_BUILD = "add_distinct_below_semi_join_build";
     public static final String PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET = "pushdown_subfields_for_map_subset";
     public static final String PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS = "pushdown_subfields_for_map_functions";
+    public static final String MAX_SERIALIZABLE_OBJECT_SIZE = "max_serializable_object_size";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -1936,6 +1937,10 @@ public final class SystemSessionProperties
                         "Enable subfield pruning for map functions, currently include map_subset and map_filter",
                         featuresConfig.isPushdownSubfieldForMapFunctions(),
                         false),
+                longProperty(MAX_SERIALIZABLE_OBJECT_SIZE,
+                        "Configure the maximum byte size of a serializable object in expression interpreters",
+                        featuresConfig.getMaxSerializableObjectSize(),
+                        false),
                 new PropertyMetadata<>(
                         QUERY_CLIENT_TIMEOUT,
                         "Configures how long the query runs without contact from the client application, such as the CLI, before it's abandoned",
@@ -3323,5 +3328,10 @@ public final class SystemSessionProperties
     public static boolean isOptimizeConditionalApproxDistinctEnabled(Session session)
     {
         return session.getSystemProperty(OPTIMIZE_CONDITIONAL_CONSTANT_APPROXIMATE_DISTINCT, Boolean.class);
+    }
+
+    public static long getMaxSerializableObjectSize(Session session)
+    {
+        return session.getSystemProperty(MAX_SERIALIZABLE_OBJECT_SIZE, Long.class);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -308,6 +308,7 @@ public class FeaturesConfig
     private boolean addExchangeBelowPartialAggregationOverGroupId;
     private boolean addDistinctBelowSemiJoinBuild;
     private boolean pushdownSubfieldForMapFunctions = true;
+    private long maxSerializableObjectSize = 1000;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -3082,5 +3083,18 @@ public class FeaturesConfig
     public boolean isPushdownSubfieldForMapFunctions()
     {
         return pushdownSubfieldForMapFunctions;
+    }
+
+    @Config("max_serializable_object_size")
+    @ConfigDescription("Configure the maximum byte size of a serializable object in expression interpreters")
+    public FeaturesConfig setMaxSerializableObjectSize(long maxSerializableObjectSize)
+    {
+        this.maxSerializableObjectSize = maxSerializableObjectSize;
+        return this;
+    }
+
+    public long getMaxSerializableObjectSize()
+    {
+        return maxSerializableObjectSize;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -116,6 +116,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.SystemSessionProperties.getMaxSerializableObjectSize;
 import static com.facebook.presto.SystemSessionProperties.isLegacyRowFieldOrdinalAccessEnabled;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
@@ -160,7 +161,6 @@ import static java.util.stream.Collectors.toList;
 @Deprecated
 public class ExpressionInterpreter
 {
-    private static final long MAX_SERIALIZABLE_OBJECT_SIZE = 1000;
     private final Expression expression;
     private final Metadata metadata;
     private final LiteralEncoder literalEncoder;
@@ -1318,7 +1318,7 @@ public class ExpressionInterpreter
         {
             requireNonNull(type, "type is null");
             // If value is already Expression, literal values contained inside should already have been made serializable. Otherwise, we make sure the object is small and serializable.
-            return value instanceof Expression || (isSupportedLiteralType(type) && estimatedSizeInBytes(value) <= MAX_SERIALIZABLE_OBJECT_SIZE);
+            return value instanceof Expression || (isSupportedLiteralType(type) && estimatedSizeInBytes(value) <= getMaxSerializableObjectSize(session));
         }
 
         private List<Expression> toExpressions(List<Object> values, List<Type> types)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.FullConnectorSession;
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.BlockBuilder;
@@ -60,6 +61,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.SystemSessionProperties.getMaxSerializableObjectSize;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
@@ -122,7 +124,6 @@ import static java.util.stream.Collectors.toList;
 
 public class RowExpressionInterpreter
 {
-    private static final long MAX_SERIALIZABLE_OBJECT_SIZE = 1000;
     private final RowExpression expression;
     private final ConnectorSession session;
     private final Level optimizationLevel;
@@ -779,7 +780,7 @@ public class RowExpressionInterpreter
         private boolean isSerializable(Object value, Type type)
         {
             // If value is already RowExpression, constant values contained inside should already have been made serializable. Otherwise, we make sure the object is small and serializable.
-            return value instanceof RowExpression || (isSupportedLiteralType(type) && estimatedSizeInBytes(value) <= MAX_SERIALIZABLE_OBJECT_SIZE);
+            return value instanceof RowExpression || (isSupportedLiteralType(type) && estimatedSizeInBytes(value) <= getMaxSerializableObjectSize(((FullConnectorSession) session).getSession()));
         }
 
         private SpecialCallResult tryHandleArrayConstructor(CallExpression callExpression, List<Object> argumentValues)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -265,7 +265,8 @@ public class TestFeaturesConfig
                 .setBroadcastSemiJoinForDelete(true)
                 .setInEqualityJoinPushdownEnabled(false)
                 .setRewriteMinMaxByToTopNEnabled(false)
-                .setPrestoSparkExecutionEnvironment(false));
+                .setPrestoSparkExecutionEnvironment(false)
+                .setMaxSerializableObjectSize(1000));
     }
 
     @Test
@@ -478,6 +479,7 @@ public class TestFeaturesConfig
                 .put("optimizer.add-distinct-below-semi-join-build", "true")
                 .put("optimizer.pushdown-subfield-for-map-functions", "false")
                 .put("optimizer.add-exchange-below-partial-aggregation-over-group-id", "true")
+                .put("max_serializable_object_size", "50")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -688,7 +690,8 @@ public class TestFeaturesConfig
                 .setBroadcastSemiJoinForDelete(false)
                 .setRewriteMinMaxByToTopNEnabled(true)
                 .setInnerJoinPushdownEnabled(true)
-                .setPrestoSparkExecutionEnvironment(true);
+                .setPrestoSparkExecutionEnvironment(true)
+                .setMaxSerializableObjectSize(50);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
## Description
Introducing a session property `max_serializable_object_size` to update the maximum byte size of an object that can possibly be considered serializable by the expression interpreters.

## Motivation and Context
For certain functions that only have Java worker implementations but no CPP worker implementations, there is a logic in place to only attempt the function in the coordinator. This existing logic does an additional check on the serializability of the returned object to forward the call to worker (even CPP worker).

Currently there is a hard coded limit of 1000 bytes to consider an object as serializable, which limits the execution on the coordinator by the unintended limit. This PR adds the intention by making the object size customizable through a session property and not hard coded to 1000 bytes (it is instead the default value now).

## Impact
This adds the option to execute more functions (functions that have more than 1000 bytes in their computed response)  in the coordinator. 

## Test Plan
Unit Test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add a session property to change the maximum serializable object size at the coordinator.
```
