### PR TITLE
Remove duplicated `isEqualFunction` in FunctionResolution

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/properties/EquivalenceClassProperty.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/properties/EquivalenceClassProperty.java
@@ -196,7 +196,7 @@ public final class EquivalenceClassProperty
     private static boolean isVariableEqualVariableOrConstant(FunctionResolution functionResolution, RowExpression expression)
     {
         if (expression instanceof CallExpression
-                && functionResolution.isEqualFunction(((CallExpression) expression).getFunctionHandle())
+                && functionResolution.isEqualsFunction(((CallExpression) expression).getFunctionHandle())
                 && ((CallExpression) expression).getArguments().size() == 2) {
             RowExpression e1 = ((CallExpression) expression).getArguments().get(0);
             RowExpression e2 = ((CallExpression) expression).getArguments().get(1);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -443,7 +443,7 @@ public class ReorderJoins
 
             for (RowExpression predicate : joinPredicates) {
                 if (predicate instanceof CallExpression
-                        && functionResolution.isEqualFunction(((CallExpression) predicate).getFunctionHandle())
+                        && functionResolution.isEqualsFunction(((CallExpression) predicate).getFunctionHandle())
                         && ((CallExpression) predicate).getArguments().size() == 2) {
                     RowExpression argument0 = ((CallExpression) predicate).getArguments().get(0);
                     RowExpression argument1 = ((CallExpression) predicate).getArguments().get(1);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -686,7 +686,7 @@ public class PushdownSubfields
                         if (functionResolution.isArrayContainsFunction(callExpression.getFunctionHandle())) {
                             return extractSubfieldsFromArray((ConstantExpression) callExpression.getArguments().get(0), mapVariable);
                         }
-                        else if (functionResolution.isEqualFunction(callExpression.getFunctionHandle())) {
+                        else if (functionResolution.isEqualsFunction(callExpression.getFunctionHandle())) {
                             ConstantExpression mapKey;
                             if (callExpression.getArguments().get(0) instanceof ConstantExpression) {
                                 mapKey = (ConstantExpression) callExpression.getArguments().get(0);
@@ -1091,7 +1091,7 @@ public class PushdownSubfields
                     return callExpression.getArguments().get(0) instanceof ConstantExpression && callExpression.getArguments().get(1) instanceof VariableReferenceExpression
                             && ((VariableReferenceExpression) callExpression.getArguments().get(1)).getName().equals(lambdaDefinitionExpression.getArguments().get(0));
                 }
-                else if (functionResolution.isEqualFunction(callExpression.getFunctionHandle())) {
+                else if (functionResolution.isEqualsFunction(callExpression.getFunctionHandle())) {
                     return (callExpression.getArguments().get(0) instanceof VariableReferenceExpression
                             && ((VariableReferenceExpression) callExpression.getArguments().get(0)).getName().equals(lambdaDefinitionExpression.getArguments().get(0))
                             && callExpression.getArguments().get(1) instanceof ConstantExpression)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -275,8 +275,7 @@ public final class FunctionResolution
 
     public boolean isEqualsFunction(FunctionHandle functionHandle)
     {
-        Optional<OperatorType> operatorType = functionAndTypeResolver.getFunctionMetadata(functionHandle).getOperatorType();
-        return operatorType.isPresent() && operatorType.get().getOperator().equals(EQUAL.getOperator());
+        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getOperatorType().map(EQUAL::equals).orElse(false);
     }
 
     @Override
@@ -404,11 +403,6 @@ public final class FunctionResolution
     public FunctionHandle approximateSetFunction(Type valueType)
     {
         return functionAndTypeResolver.lookupFunction("approx_set", fromTypes(valueType));
-    }
-
-    public boolean isEqualFunction(FunctionHandle functionHandle)
-    {
-        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getOperatorType().map(EQUAL::equals).orElse(false);
     }
 
     public boolean isArrayContainsFunction(FunctionHandle functionHandle)


### PR DESCRIPTION
## Description

Since `FunctionResolution` already implements the `isEqualsFunction` method from `StandardFunctionResolution`, defining a functionally identical method `isEqualFunction` is redundant.

This PR remove the redundant function `isEqualFunction` in `FunctionResolution`, and make all invocations point to `isEqualsFunction`.

## Motivation and Context

Remove functionally identical method to eliminate duplication.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

