### PR TITLE
Remove unused session property `pushdown_subfields_for_map_subset`

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -336,7 +336,6 @@ public final class SystemSessionProperties
     public static final String QUERY_CLIENT_TIMEOUT = "query_client_timeout";
     public static final String REWRITE_MIN_MAX_BY_TO_TOP_N = "rewrite_min_max_by_to_top_n";
     public static final String ADD_DISTINCT_BELOW_SEMI_JOIN_BUILD = "add_distinct_below_semi_join_build";
-    public static final String PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET = "pushdown_subfields_for_map_subset";
     public static final String PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS = "pushdown_subfields_for_map_functions";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
@@ -1918,10 +1917,6 @@ public final class SystemSessionProperties
                         "Optimize out APPROX_DISTINCT operations over constant conditionals",
                         featuresConfig.isOptimizeConditionalApproxDistinct(),
                         false),
-                booleanProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET,
-                        "Enable subfield pruning for map_subset function",
-                        featuresConfig.isPushdownSubfieldForMapFunctions(),
-                        false),
                 booleanProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS,
                         "Enable subfield pruning for map functions, currently include map_subset and map_filter",
                         featuresConfig.isPushdownSubfieldForMapFunctions(),
@@ -3278,11 +3273,6 @@ public final class SystemSessionProperties
     public static boolean isEnabledAddExchangeBelowGroupId(Session session)
     {
         return session.getSystemProperty(ADD_EXCHANGE_BELOW_PARTIAL_AGGREGATION_OVER_GROUP_ID, Boolean.class);
-    }
-
-    public static boolean isPushSubfieldsForMapSubsetEnabled(Session session)
-    {
-        return session.getSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_SUBSET, Boolean.class);
     }
 
     public static boolean isPushSubfieldsForMapFunctionsEnabled(Session session)


### PR DESCRIPTION
## Description

PR #25451 introduced a new session property `pushdown_subfields_for_map_functions`, which extends the role of the original session property `pushdown_subfields_for_map_subset`. After the change is merged, the original `pushdown_subfields_for_map_subset` is no longer used.

This PR removed the unused session property `pushdown_subfields_for_map_subset`.

## Motivation and Context

Remove unused session property.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

