### PR TITLE
Add support for retrying on a different cluster

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -42,6 +42,7 @@ public final class PrestoHeaders
     public static final String PRESTO_SESSION_FUNCTION = "X-Presto-Session-Function";
     public static final String PRESTO_ADDED_SESSION_FUNCTION = "X-Presto-Added-Session-Functions";
     public static final String PRESTO_REMOVED_SESSION_FUNCTION = "X-Presto-Removed-Session-Function";
+    public static final String PRESTO_RETRY_QUERY = "X-Presto-Retry-Query";
 
     public static final String PRESTO_CURRENT_STATE = "X-Presto-Current-State";
     public static final String PRESTO_MAX_WAIT = "X-Presto-Max-Wait";

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1157,3 +1157,47 @@ The corresponding session property is :ref:`admin/properties-session:\`\`query_c
 Use to configure how long a query can be queued before it is terminated.
 
 The corresponding session property is :ref:`admin/properties-session:\`\`query_max_queued_time\`\``.
+
+Query Retry Properties
+----------------------
+
+``retry.enabled``
+^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Enable cross-cluster retry functionality. When enabled, queries that fail with
+specific error codes can be automatically retried on a backup cluster if a
+retry URL is provided.
+
+``retry.allowed-domains``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** (empty, signifying current second-level domain allowed only)
+
+Comma-separated list of allowed domains for retry URLs. Supports wildcards
+like ``*.example.com``. For example: ``cluster1.example.com,*.backup.example.net``.
+When empty (default), only retry URLs from the same domain as the current server
+are allowed.
+
+``retry.require-https``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Require HTTPS for retry URLs. When enabled, only HTTPS URLs will be accepted
+for cross-cluster retry operations.
+
+``retry.cross-cluster-error-codes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``REMOTE_TASK_ERROR``
+
+Comma-separated list of error codes that allow cross-cluster retry. When a query
+fails with one of these error codes, it can be automatically retried on a backup
+cluster if a retry URL is provided. Available error codes include standard Presto
+error codes such as ``REMOTE_TASK_ERROR``, ``CLUSTER_OUT_OF_MEMORY``, etc.

--- a/presto-main-base/src/main/java/com/facebook/presto/server/RetryConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/RetryConfig.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.presto.common.ErrorCode;
+import com.facebook.presto.spi.StandardErrorCode;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Set;
+
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class RetryConfig
+{
+    private boolean retryEnabled = true;
+    private Set<String> allowedRetryDomains = ImmutableSet.of();
+    private boolean requireHttps;
+    private Set<Integer> crossClusterRetryErrorCodes = ImmutableSet.of(
+            REMOTE_TASK_ERROR.toErrorCode().getCode());
+
+    public boolean isRetryEnabled()
+    {
+        return retryEnabled;
+    }
+
+    @Config("retry.enabled")
+    @ConfigDescription("Enable cross-cluster retry functionality")
+    public RetryConfig setRetryEnabled(boolean retryEnabled)
+    {
+        this.retryEnabled = retryEnabled;
+        return this;
+    }
+
+    @NotNull
+    public Set<String> getAllowedRetryDomains()
+    {
+        return allowedRetryDomains;
+    }
+
+    @Config("retry.allowed-domains")
+    @ConfigDescription("Comma-separated list of allowed domains for retry URLs " +
+            "(supports wildcards like *.example.com)")
+    public RetryConfig setAllowedRetryDomains(String domains)
+    {
+        if (domains == null || domains.trim().isEmpty()) {
+            this.allowedRetryDomains = ImmutableSet.of();
+        }
+        else {
+            this.allowedRetryDomains = Splitter.on(',')
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .splitToList(domains)
+                    .stream()
+                    .map(String::toLowerCase)
+                    .collect(toImmutableSet());
+        }
+        return this;
+    }
+
+    public boolean isRequireHttps()
+    {
+        return requireHttps;
+    }
+
+    @Config("retry.require-https")
+    @ConfigDescription("Require HTTPS for retry URLs")
+    public RetryConfig setRequireHttps(boolean requireHttps)
+    {
+        this.requireHttps = requireHttps;
+        return this;
+    }
+
+    @NotNull
+    public Set<Integer> getCrossClusterRetryErrorCodes()
+    {
+        return crossClusterRetryErrorCodes;
+    }
+
+    @Config("retry.cross-cluster-error-codes")
+    @ConfigDescription("Comma-separated list of error codes that allow cross-cluster retry")
+    public RetryConfig setCrossClusterRetryErrorCodes(String errorCodes)
+    {
+        if (errorCodes == null || errorCodes.trim().isEmpty()) {
+            // Keep the default error codes
+            return this;
+        }
+        else {
+            this.crossClusterRetryErrorCodes = Splitter.on(',')
+                    .trimResults()
+                    .omitEmptyStrings()
+                    .splitToList(errorCodes)
+                    .stream()
+                    .map(StandardErrorCode::valueOf)
+                    .map(StandardErrorCode::toErrorCode)
+                    .map(ErrorCode::getCode)
+                    .collect(toImmutableSet());
+        }
+        return this;
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestRetryConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestRetryConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+
+public class TestRetryConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(ConfigAssertions.recordDefaults(RetryConfig.class)
+                .setRetryEnabled(true)
+                .setRequireHttps(false)
+                .setAllowedRetryDomains(null)
+                .setCrossClusterRetryErrorCodes("REMOTE_TASK_ERROR"));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("retry.enabled", "false")
+                .put("retry.allowed-domains", "*.foo.bar,*.baz.qux")
+                .put("retry.require-https", "true")
+                .put("retry.cross-cluster-error-codes", "QUERY_QUEUE_FULL")
+                .build();
+
+        RetryConfig expected = new RetryConfig()
+                .setRetryEnabled(false)
+                .setRequireHttps(true)
+                .setAllowedRetryDomains("*.foo.bar,*.baz.qux")
+                .setCrossClusterRetryErrorCodes("QUERY_QUEUE_FULL");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -210,6 +210,10 @@ public class CoordinatorModule
         binder.bind(QueryBlockingRateLimiter.class).in(Scopes.SINGLETON);
         newExporter(binder).export(QueryBlockingRateLimiter.class).withGeneratedName();
 
+        // retry configuration
+        configBinder(binder).bindConfig(RetryConfig.class);
+        binder.bind(RetryUrlValidator.class).in(Scopes.SINGLETON);
+
         binder.bind(LocalQueryProvider.class).in(Scopes.SINGLETON);
         binder.bind(ExecutingQueryResponseProvider.class).to(LocalExecutingQueryResponseProvider.class).in(Scopes.SINGLETON);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/RetryUrlValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/RetryUrlValidator.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.log.Logger;
+
+import javax.inject.Inject;
+
+import java.net.URI;
+import java.util.Set;
+
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class RetryUrlValidator
+{
+    private static final Logger log = Logger.get(RetryUrlValidator.class);
+    public static final String RETRY_PATH = "/v1/statement/queued/retry";
+
+    private final RetryConfig retryConfig;
+
+    @Inject
+    public RetryUrlValidator(RetryConfig retryConfig)
+    {
+        this.retryConfig = requireNonNull(retryConfig, "retryConfig is null");
+    }
+
+    public boolean isValidRetryUrl(URI retryUrl, String currentServerHost)
+    {
+        requireNonNull(retryUrl, "retryUrl is null");
+        if (!retryConfig.isRetryEnabled()) {
+            return false;
+        }
+
+        try {
+            // Check protocol
+            if (retryConfig.isRequireHttps() && !"https".equalsIgnoreCase(retryUrl.getScheme())) {
+                log.debug("Retry URL rejected - not HTTPS: %s", retryUrl);
+                return false;
+            }
+
+            // Check path
+            if (!retryUrl.getPath().startsWith(RETRY_PATH)) {
+                log.debug("Retry URL rejected - invalid path: %s", retryUrl);
+                return false;
+            }
+
+            if (retryUrl.getRawQuery() != null) {
+                log.debug("Retry URL rejected - parameters present: %s", retryUrl);
+                return false;
+            }
+
+            // Check domain allowlist
+            if (!isDomainAllowed(retryUrl.getHost(), currentServerHost)) {
+                log.debug("Retry URL rejected - domain not allowed: %s", retryUrl.getHost());
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception e) {
+            log.debug(e, "Invalid retry URL: %s", retryUrl);
+            return false;
+        }
+    }
+
+    private boolean isDomainAllowed(String host, String currentServerHost)
+    {
+        Set<String> allowedDomains = retryConfig.getAllowedRetryDomains();
+        String lowerHost = host.toLowerCase(ENGLISH);
+
+        // If no domains are configured, only allow same domain as current server
+        if (allowedDomains.isEmpty()) {
+            if (currentServerHost == null) {
+                // Fallback to original behavior if current host not provided
+                log.warn("Current server host not provided, cannot restrict to same domain");
+                return false;
+            }
+            return lowerHost.equals(currentServerHost.toLowerCase(ENGLISH));
+        }
+
+        for (String allowedDomain : allowedDomains) {
+            if (allowedDomain.startsWith("*.")) {
+                // Wildcard domain
+                String suffix = allowedDomain.substring(1);
+                if (lowerHost.endsWith(suffix)) {
+                    return true;
+                }
+            }
+            else if (lowerHost.equals(allowedDomain)) {
+                // Exact match
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingQueryResponseProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/ExecutingQueryResponseProvider.java
@@ -21,7 +21,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import java.net.URI;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 public interface ExecutingQueryResponseProvider
 {
@@ -46,6 +48,9 @@ public interface ExecutingQueryResponseProvider
      * @param compressionEnabled enable compression
      * @param nestedDataSerializationEnabled enable nested data serialization
      * @param binaryResults generate results in binary format, rather than JSON
+     * @param retryUrl optional retry URL for cross-cluster retry
+     * @param retryExpirationEpochTime optional retry expiration time
+     * @param isRetryQuery true if this query is already a retry query
      * @return the ExecutingStatement's Response, if available
      */
     Optional<ListenableFuture<Response>> waitForExecutingResponse(
@@ -60,5 +65,8 @@ public interface ExecutingQueryResponseProvider
             boolean compressionEnabled,
             boolean nestedDataSerializationEnabled,
             boolean binaryResults,
-            long durationUntilExpirationMs);
+            long durationUntilExpirationMs,
+            Optional<URI> retryUrl,
+            OptionalLong retryExpirationEpochTime,
+            boolean isRetryQuery);
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/LocalExecutingQueryResponseProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/LocalExecutingQueryResponseProvider.java
@@ -23,7 +23,9 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import java.net.URI;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static com.facebook.presto.server.protocol.QueryResourceUtil.toResponse;
 import static com.google.common.util.concurrent.Futures.transform;
@@ -54,11 +56,14 @@ public class LocalExecutingQueryResponseProvider
             boolean compressionEnabled,
             boolean nestedDataSerializationEnabled,
             boolean binaryResults,
-            long durationUntilExpirationMs)
+            long durationUntilExpirationMs,
+            Optional<URI> retryUrl,
+            OptionalLong retryExpirationEpochTime,
+            boolean isRetryQuery)
     {
         Query query;
         try {
-            query = queryProvider.getQuery(queryId, slug);
+            query = queryProvider.getQuery(queryId, slug, retryUrl, retryExpirationEpochTime, isRetryQuery);
         }
         catch (WebApplicationException e) {
             return Optional.empty();


### PR DESCRIPTION
## Description
Support cross-cluster query retry by passing retry information through the query endpoints.

## Motivation and Context
This change implements the cross-cluster retry functionality described in issue #25396. When a query fails on one cluster, it can be automatically retried on a backup cluster. The implementation uses query parameters (`retryUrl` and [retryExpirationInSeconds](url)) to pass retry information, ensuring this data is preserved through HTTP 307 redirects. A separate header (`X-Presto-Retry-Query`) marks queries as retries to prevent retry chains.

## Impact
  - Modified `/v1/statement` endpoint to accept retryUrl and retryExpirationInSeconds as query parameters
  - Added `X-Presto-Retry-Query` header to identify retry queries
  - This is a structural change that doesn't affect query execution performance

Fixes #25396.

## Test Plan
Unit tests are included in this change.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for cross-cluster query retry. Failed queries can now be automatically retried on a backup cluster by providing retry URL and expiration time as query parameters.
* Add `X-Presto-Retry-Query` header to identify queries that are being retried on a backup cluster.
```

