### PR TITLE
[native][iceberg] Add new cmake flag for native iceberg connector

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -70,6 +70,8 @@ option(PRESTO_ENABLE_JWT "Enable JWT (JSON Web Token) authentication" OFF)
 
 option(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR "Enable Arrow Flight connector" OFF)
 
+option(PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR "Enable native iceberg connector" OFF)
+
 # Set all Velox options below
 # Make sure that if we include folly headers or other dependency headers
 # that include folly headers we turn off the coroutines and turn on int128.

--- a/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
@@ -12,6 +12,11 @@
 add_library(presto_connectors Registration.cpp PrestoToVeloxConnector.cpp
                               SystemConnector.cpp)
 
+if(PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR)
+  target_sources(presto_connectors PRIVATE IcebergPrestoToVeloxConnector.cpp)
+  target_compile_definitions(presto_connectors PUBLIC PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR)
+endif()
+
 if(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR)
   add_subdirectory(arrow_flight)
   target_compile_definitions(presto_connectors

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -1,0 +1,207 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
+
+#include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
+
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/type/fbhive/HiveTypeParser.h"
+
+using namespace facebook::velox;
+
+namespace facebook::presto {
+
+namespace {
+
+velox::connector::hive::iceberg::FileContent toVeloxFileContent(
+    const presto::protocol::iceberg::FileContent content) {
+  if (content == protocol::iceberg::FileContent::DATA) {
+    return velox::connector::hive::iceberg::FileContent::kData;
+  } else if (content == protocol::iceberg::FileContent::POSITION_DELETES) {
+    return velox::connector::hive::iceberg::FileContent::kPositionalDeletes;
+  }
+  VELOX_UNSUPPORTED("Unsupported file content: {}", fmt::underlying(content));
+}
+
+velox::dwio::common::FileFormat toVeloxFileFormat(
+    const presto::protocol::iceberg::FileFormat format) {
+  if (format == protocol::iceberg::FileFormat::ORC) {
+    return velox::dwio::common::FileFormat::ORC;
+  } else if (format == protocol::iceberg::FileFormat::PARQUET) {
+    return velox::dwio::common::FileFormat::PARQUET;
+  }
+  VELOX_UNSUPPORTED("Unsupported file format: {}", fmt::underlying(format));
+}
+
+} // namespace
+
+std::unique_ptr<velox::connector::ConnectorSplit>
+IcebergPrestoToVeloxConnector::toVeloxSplit(
+    const protocol::ConnectorId& catalogId,
+    const protocol::ConnectorSplit* connectorSplit,
+    const protocol::SplitContext* splitContext) const {
+  auto icebergSplit =
+      dynamic_cast<const protocol::iceberg::IcebergSplit*>(connectorSplit);
+  VELOX_CHECK_NOT_NULL(
+      icebergSplit, "Unexpected split type {}", connectorSplit->_type);
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
+  for (const auto& entry : icebergSplit->partitionKeys) {
+    partitionKeys.emplace(
+        entry.second.name,
+        entry.second.value == nullptr
+            ? std::nullopt
+            : std::optional<std::string>{*entry.second.value});
+  }
+
+  std::unordered_map<std::string, std::string> customSplitInfo;
+  customSplitInfo["table_format"] = "hive-iceberg";
+
+  std::vector<velox::connector::hive::iceberg::IcebergDeleteFile> deletes;
+  deletes.reserve(icebergSplit->deletes.size());
+  for (const auto& deleteFile : icebergSplit->deletes) {
+    std::unordered_map<int32_t, std::string> lowerBounds(
+        deleteFile.lowerBounds.begin(), deleteFile.lowerBounds.end());
+
+    std::unordered_map<int32_t, std::string> upperBounds(
+        deleteFile.upperBounds.begin(), deleteFile.upperBounds.end());
+
+    velox::connector::hive::iceberg::IcebergDeleteFile icebergDeleteFile(
+        toVeloxFileContent(deleteFile.content),
+        deleteFile.path,
+        toVeloxFileFormat(deleteFile.format),
+        deleteFile.recordCount,
+        deleteFile.fileSizeInBytes,
+        std::vector(deleteFile.equalityFieldIds),
+        lowerBounds,
+        upperBounds);
+
+    deletes.emplace_back(icebergDeleteFile);
+  }
+
+  std::unordered_map<std::string, std::string> infoColumns = {
+      {"$data_sequence_number",
+       std::to_string(icebergSplit->dataSequenceNumber)},
+      {"$path", icebergSplit->path}};
+
+  return std::make_unique<connector::hive::iceberg::HiveIcebergSplit>(
+      catalogId,
+      icebergSplit->path,
+      toVeloxFileFormat(icebergSplit->fileFormat),
+      icebergSplit->start,
+      icebergSplit->length,
+      partitionKeys,
+      std::nullopt,
+      customSplitInfo,
+      nullptr,
+      splitContext->cacheable,
+      deletes,
+      infoColumns);
+}
+
+std::unique_ptr<velox::connector::ColumnHandle>
+IcebergPrestoToVeloxConnector::toVeloxColumnHandle(
+    const protocol::ColumnHandle* column,
+    const TypeParser& typeParser) const {
+  auto icebergColumn =
+      dynamic_cast<const protocol::iceberg::IcebergColumnHandle*>(column);
+  VELOX_CHECK_NOT_NULL(
+      icebergColumn, "Unexpected column handle type {}", column->_type);
+  // TODO(imjalpreet): Modify 'hiveType' argument of the 'HiveColumnHandle'
+  //  constructor similar to how Hive Connector is handling for bucketing
+  velox::type::fbhive::HiveTypeParser hiveTypeParser;
+  auto type = stringToType(icebergColumn->type, typeParser);
+  connector::hive::HiveColumnHandle::ColumnParseParameters columnParseParameters;
+  if (type->isDate()) {
+    columnParseParameters.partitionDateValueFormat = connector::hive::HiveColumnHandle::ColumnParseParameters::kDaysSinceEpoch;
+  }
+  return std::make_unique<connector::hive::HiveColumnHandle>(
+      icebergColumn->columnIdentity.name,
+      toHiveColumnType(icebergColumn->columnType),
+      type,
+      type,
+      toRequiredSubfields(icebergColumn->requiredSubfields),
+      columnParseParameters);
+}
+
+std::unique_ptr<velox::connector::ConnectorTableHandle>
+IcebergPrestoToVeloxConnector::toVeloxTableHandle(
+    const protocol::TableHandle& tableHandle,
+    const VeloxExprConverter& exprConverter,
+    const TypeParser& typeParser,
+    velox::connector::ColumnHandleMap& assignments) const {
+  auto addSynthesizedColumn = [&](const std::string& name,
+                                  protocol::hive::ColumnType columnType,
+                                  const protocol::ColumnHandle& column) {
+    if (toHiveColumnType(columnType) ==
+        velox::connector::hive::HiveColumnHandle::ColumnType::kSynthesized) {
+      if (assignments.count(name) == 0) {
+        assignments.emplace(name, toVeloxColumnHandle(&column, typeParser));
+      }
+    }
+  };
+
+  auto icebergLayout = std::dynamic_pointer_cast<
+      const protocol::iceberg::IcebergTableLayoutHandle>(
+      tableHandle.connectorTableLayout);
+  VELOX_CHECK_NOT_NULL(
+      icebergLayout,
+      "Unexpected layout type {}",
+      tableHandle.connectorTableLayout->_type);
+
+  for (const auto& entry : icebergLayout->partitionColumns) {
+    assignments.emplace(
+        entry.columnIdentity.name, toVeloxColumnHandle(&entry, typeParser));
+  }
+
+  // Add synthesized columns to the TableScanNode columnHandles as well.
+  for (const auto& entry : icebergLayout->predicateColumns) {
+    addSynthesizedColumn(entry.first, entry.second.columnType, entry.second);
+  }
+
+  auto icebergTableHandle =
+      std::dynamic_pointer_cast<const protocol::iceberg::IcebergTableHandle>(
+          tableHandle.connectorHandle);
+  VELOX_CHECK_NOT_NULL(
+      icebergTableHandle,
+      "Unexpected table handle type {}",
+      tableHandle.connectorHandle->_type);
+
+  // Use fully qualified name if available.
+  std::string tableName = icebergTableHandle->schemaName.empty()
+      ? icebergTableHandle->icebergTableName.tableName
+      : fmt::format(
+            "{}.{}",
+            icebergTableHandle->schemaName,
+            icebergTableHandle->icebergTableName.tableName);
+
+  return toHiveTableHandle(
+      icebergLayout->domainPredicate,
+      icebergLayout->remainingPredicate,
+      icebergLayout->pushdownFilterEnabled,
+      tableName,
+      icebergLayout->dataColumns,
+      tableHandle,
+      {},
+      exprConverter,
+      typeParser);
+}
+
+std::unique_ptr<protocol::ConnectorProtocol>
+IcebergPrestoToVeloxConnector::createConnectorProtocol() const {
+  return std::make_unique<protocol::iceberg::IcebergConnectorProtocol>();
+}
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
@@ -1,0 +1,46 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "presto_cpp/main/connectors/PrestoToVeloxConnector.h"
+
+namespace facebook::presto {
+
+class IcebergPrestoToVeloxConnector final : public PrestoToVeloxConnector {
+public:
+  explicit IcebergPrestoToVeloxConnector(std::string connectorName)
+      : PrestoToVeloxConnector(std::move(connectorName)) {}
+
+  std::unique_ptr<velox::connector::ConnectorSplit> toVeloxSplit(
+      const protocol::ConnectorId& catalogId,
+      const protocol::ConnectorSplit* connectorSplit,
+      const protocol::SplitContext* splitContext) const final;
+
+  std::unique_ptr<velox::connector::ColumnHandle> toVeloxColumnHandle(
+      const protocol::ColumnHandle* column,
+      const TypeParser& typeParser) const final;
+
+  std::unique_ptr<velox::connector::ConnectorTableHandle> toVeloxTableHandle(
+      const protocol::TableHandle& tableHandle,
+      const VeloxExprConverter& exprConverter,
+      const TypeParser& typeParser,
+      velox::connector::ColumnHandleMap& assignments)
+      const final;
+
+  std::unique_ptr<protocol::ConnectorProtocol> createConnectorProtocol()
+      const final;
+};
+
+} // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
@@ -16,7 +16,6 @@
 #include "presto_cpp/main/types/PrestoToVeloxExpr.h"
 #include "presto_cpp/main/types/TypeParser.h"
 #include "presto_cpp/presto_protocol/connector/hive/HiveConnectorProtocol.h"
-#include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
 #include "presto_cpp/presto_protocol/connector/tpch/TpchConnectorProtocol.h"
 
 #include <velox/type/fbhive/HiveTypeParser.h>
@@ -24,8 +23,6 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
-#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
-#include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
 #include "velox/type/Filter.h"
@@ -33,6 +30,8 @@
 namespace facebook::presto {
 
 namespace {
+using namespace facebook::velox;
+
 std::unordered_map<std::string, std::unique_ptr<const PrestoToVeloxConnector>>&
 connectors() {
   static std::
@@ -42,30 +41,6 @@ connectors() {
 }
 } // namespace
 
-void registerPrestoToVeloxConnector(
-    std::unique_ptr<const PrestoToVeloxConnector> connector) {
-  auto connectorName = connector->connectorName();
-  auto connectorProtocol = connector->createConnectorProtocol();
-  VELOX_CHECK(
-      connectors().insert({connectorName, std::move(connector)}).second,
-      "Connector {} is already registered",
-      connectorName);
-  protocol::registerConnectorProtocol(
-      connectorName, std::move(connectorProtocol));
-}
-
-void unregisterPrestoToVeloxConnector(const std::string& connectorName) {
-  connectors().erase(connectorName);
-  protocol::unregisterConnectorProtocol(connectorName);
-}
-
-const PrestoToVeloxConnector& getPrestoToVeloxConnector(
-    const std::string& connectorName) {
-  auto it = connectors().find(connectorName);
-  VELOX_CHECK(
-      it != connectors().end(), "Connector {} not registered", connectorName);
-  return *(it->second);
-}
 
 namespace {
 using namespace velox;
@@ -102,50 +77,9 @@ dwio::common::FileFormat toVeloxFileFormat(
       "Unsupported file format: {} {}", format.inputFormat, format.serDe);
 }
 
-dwio::common::FileFormat toVeloxFileFormat(
-    const presto::protocol::iceberg::FileFormat format) {
-  if (format == protocol::iceberg::FileFormat::ORC) {
-    return dwio::common::FileFormat::ORC;
-  } else if (format == protocol::iceberg::FileFormat::PARQUET) {
-    return dwio::common::FileFormat::PARQUET;
-  }
-  VELOX_UNSUPPORTED("Unsupported file format: {}", fmt::underlying(format));
-}
-
 template <typename T>
 std::string toJsonString(const T& value) {
   return ((json)value).dump();
-}
-
-TypePtr stringToType(
-    const std::string& typeString,
-    const TypeParser& typeParser) {
-  return typeParser.parse(typeString);
-}
-
-connector::hive::HiveColumnHandle::ColumnType toHiveColumnType(
-    protocol::hive::ColumnType type) {
-  switch (type) {
-    case protocol::hive::ColumnType::PARTITION_KEY:
-      return connector::hive::HiveColumnHandle::ColumnType::kPartitionKey;
-    case protocol::hive::ColumnType::REGULAR:
-      return connector::hive::HiveColumnHandle::ColumnType::kRegular;
-    case protocol::hive::ColumnType::SYNTHESIZED:
-      return connector::hive::HiveColumnHandle::ColumnType::kSynthesized;
-    default:
-      VELOX_UNSUPPORTED(
-          "Unsupported Hive column type: {}.", toJsonString(type));
-  }
-}
-
-std::vector<common::Subfield> toRequiredSubfields(
-    const protocol::List<protocol::Subfield>& subfields) {
-  std::vector<common::Subfield> result;
-  result.reserve(subfields.size());
-  for (auto& subfield : subfields) {
-    result.emplace_back(subfield);
-  }
-  return result;
 }
 
 template <TypeKind KIND>
@@ -800,81 +734,6 @@ std::unique_ptr<common::Filter> toFilter(
   VELOX_UNSUPPORTED("Unsupported filter found.");
 }
 
-std::unique_ptr<connector::ConnectorTableHandle> toHiveTableHandle(
-    const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
-    const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
-    bool isPushdownFilterEnabled,
-    const std::string& tableName,
-    const protocol::List<protocol::Column>& dataColumns,
-    const protocol::TableHandle& tableHandle,
-    const protocol::Map<protocol::String, protocol::String>& tableParameters,
-    const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser) {
-  common::SubfieldFilters subfieldFilters;
-  auto domains = domainPredicate.domains;
-  for (const auto& domain : *domains) {
-    auto filter = domain.second;
-    subfieldFilters[common::Subfield(domain.first)] =
-        toFilter(domain.second, exprConverter, typeParser);
-  }
-
-  auto remainingFilter = exprConverter.toVeloxExpr(remainingPredicate);
-  if (auto constant = std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
-          remainingFilter)) {
-    bool value = constant->value().value<bool>();
-    VELOX_CHECK(value, "Unexpected always-false remaining predicate");
-
-    // Use null for always-true filter.
-    remainingFilter = nullptr;
-  }
-
-  RowTypePtr finalDataColumns;
-  if (!dataColumns.empty()) {
-    std::vector<std::string> names;
-    std::vector<TypePtr> types;
-    velox::type::fbhive::HiveTypeParser hiveTypeParser;
-    names.reserve(dataColumns.size());
-    types.reserve(dataColumns.size());
-    for (auto& column : dataColumns) {
-      std::string name = column.name;
-      folly::toLowerAscii(name);
-      names.emplace_back(std::move(name));
-      auto parsedType = hiveTypeParser.parse(column.type);
-      // The type from the metastore may have upper case letters
-      // in field names, convert them all to lower case to be
-      // compatible with Presto.
-      types.push_back(VELOX_DYNAMIC_TYPE_DISPATCH(
-          fieldNamesToLowerCase, parsedType->kind(), parsedType));
-    }
-    finalDataColumns = ROW(std::move(names), std::move(types));
-  }
-
-  if (tableParameters.empty()) {
-    return std::make_unique<connector::hive::HiveTableHandle>(
-        tableHandle.connectorId,
-        tableName,
-        isPushdownFilterEnabled,
-        std::move(subfieldFilters),
-        remainingFilter,
-        finalDataColumns);
-  }
-
-  std::unordered_map<std::string, std::string> finalTableParameters = {};
-  finalTableParameters.reserve(tableParameters.size());
-  for (const auto& [key, value] : tableParameters) {
-    finalTableParameters[key] = value;
-  }
-
-  return std::make_unique<connector::hive::HiveTableHandle>(
-      tableHandle.connectorId,
-      tableName,
-      isPushdownFilterEnabled,
-      std::move(subfieldFilters),
-      remainingFilter,
-      finalDataColumns,
-      finalTableParameters);
-}
-
 connector::hive::LocationHandle::TableType toTableType(
     protocol::hive::TableType tableType) {
   switch (tableType) {
@@ -1088,17 +947,138 @@ velox::connector::hive::HiveBucketConversion toVeloxBucketConversion(
   return veloxBucketConversion;
 }
 
-velox::connector::hive::iceberg::FileContent toVeloxFileContent(
-    const presto::protocol::iceberg::FileContent content) {
-  if (content == protocol::iceberg::FileContent::DATA) {
-    return velox::connector::hive::iceberg::FileContent::kData;
-  } else if (content == protocol::iceberg::FileContent::POSITION_DELETES) {
-    return velox::connector::hive::iceberg::FileContent::kPositionalDeletes;
-  }
-  VELOX_UNSUPPORTED("Unsupported file content: {}", fmt::underlying(content));
+} // namespace
+
+void registerPrestoToVeloxConnector(
+    std::unique_ptr<const PrestoToVeloxConnector> connector) {
+  auto connectorName = connector->connectorName();
+  auto connectorProtocol = connector->createConnectorProtocol();
+  VELOX_CHECK(
+      connectors().insert({connectorName, std::move(connector)}).second,
+      "Connector {} is already registered",
+      connectorName);
+  protocol::registerConnectorProtocol(
+      connectorName, std::move(connectorProtocol));
 }
 
-} // namespace
+void unregisterPrestoToVeloxConnector(const std::string& connectorName) {
+  connectors().erase(connectorName);
+  protocol::unregisterConnectorProtocol(connectorName);
+}
+
+TypePtr stringToType(
+    const std::string& typeString,
+    const TypeParser& typeParser) {
+  return typeParser.parse(typeString);
+}
+
+std::vector<common::Subfield> toRequiredSubfields(
+    const protocol::List<protocol::Subfield>& subfields) {
+  std::vector<common::Subfield> result;
+  result.reserve(subfields.size());
+  for (auto& subfield : subfields) {
+    result.emplace_back(subfield);
+  }
+  return result;
+}
+
+const PrestoToVeloxConnector& getPrestoToVeloxConnector(
+    const std::string& connectorName) {
+  auto it = connectors().find(connectorName);
+  VELOX_CHECK(
+      it != connectors().end(), "Connector {} not registered", connectorName);
+  return *(it->second);
+}
+
+connector::hive::HiveColumnHandle::ColumnType toHiveColumnType(
+    protocol::hive::ColumnType type) {
+  switch (type) {
+    case protocol::hive::ColumnType::PARTITION_KEY:
+      return connector::hive::HiveColumnHandle::ColumnType::kPartitionKey;
+    case protocol::hive::ColumnType::REGULAR:
+      return connector::hive::HiveColumnHandle::ColumnType::kRegular;
+    case protocol::hive::ColumnType::SYNTHESIZED:
+      return connector::hive::HiveColumnHandle::ColumnType::kSynthesized;
+    default:
+      VELOX_UNSUPPORTED(
+          "Unsupported Hive column type: {}.", toJsonString(type));
+  }
+}
+
+std::unique_ptr<connector::ConnectorTableHandle> toHiveTableHandle(
+    const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
+    const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
+    bool isPushdownFilterEnabled,
+    const std::string& tableName,
+    const protocol::List<protocol::Column>& dataColumns,
+    const protocol::TableHandle& tableHandle,
+    const protocol::Map<protocol::String, protocol::String>& tableParameters,
+    const VeloxExprConverter& exprConverter,
+    const TypeParser& typeParser) {
+  common::SubfieldFilters subfieldFilters;
+  auto domains = domainPredicate.domains;
+  for (const auto& domain : *domains) {
+    auto filter = domain.second;
+    subfieldFilters[common::Subfield(domain.first)] =
+        toFilter(domain.second, exprConverter, typeParser);
+  }
+
+  auto remainingFilter = exprConverter.toVeloxExpr(remainingPredicate);
+  if (auto constant = std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
+          remainingFilter)) {
+    bool value = constant->value().value<bool>();
+    VELOX_CHECK(value, "Unexpected always-false remaining predicate");
+
+    // Use null for always-true filter.
+    remainingFilter = nullptr;
+  }
+
+  RowTypePtr finalDataColumns;
+  if (!dataColumns.empty()) {
+    std::vector<std::string> names;
+    std::vector<TypePtr> types;
+    velox::type::fbhive::HiveTypeParser hiveTypeParser;
+    names.reserve(dataColumns.size());
+    types.reserve(dataColumns.size());
+    for (auto& column : dataColumns) {
+      std::string name = column.name;
+      folly::toLowerAscii(name);
+      names.emplace_back(std::move(name));
+      auto parsedType = hiveTypeParser.parse(column.type);
+      // The type from the metastore may have upper case letters
+      // in field names, convert them all to lower case to be
+      // compatible with Presto.
+      types.push_back(VELOX_DYNAMIC_TYPE_DISPATCH(
+          fieldNamesToLowerCase, parsedType->kind(), parsedType));
+    }
+    finalDataColumns = ROW(std::move(names), std::move(types));
+  }
+
+  if (tableParameters.empty()) {
+    return std::make_unique<connector::hive::HiveTableHandle>(
+        tableHandle.connectorId,
+        tableName,
+        isPushdownFilterEnabled,
+        std::move(subfieldFilters),
+        remainingFilter,
+        finalDataColumns);
+  }
+
+  std::unordered_map<std::string, std::string> finalTableParameters = {};
+  finalTableParameters.reserve(tableParameters.size());
+  for (const auto& [key, value] : tableParameters) {
+    finalTableParameters[key] = value;
+  }
+
+  return std::make_unique<connector::hive::HiveTableHandle>(
+      tableHandle.connectorId,
+      tableName,
+      isPushdownFilterEnabled,
+      std::move(subfieldFilters),
+      remainingFilter,
+      finalDataColumns,
+      finalTableParameters);
+}
 
 std::unique_ptr<velox::connector::ConnectorSplit>
 HivePrestoToVeloxConnector::toVeloxSplit(
@@ -1332,163 +1312,6 @@ HivePrestoToVeloxConnector::createVeloxPartitionFunctionSpec(
 std::unique_ptr<protocol::ConnectorProtocol>
 HivePrestoToVeloxConnector::createConnectorProtocol() const {
   return std::make_unique<protocol::hive::HiveConnectorProtocol>();
-}
-
-std::unique_ptr<velox::connector::ConnectorSplit>
-IcebergPrestoToVeloxConnector::toVeloxSplit(
-    const protocol::ConnectorId& catalogId,
-    const protocol::ConnectorSplit* connectorSplit,
-    const protocol::SplitContext* splitContext) const {
-  auto icebergSplit =
-      dynamic_cast<const protocol::iceberg::IcebergSplit*>(connectorSplit);
-  VELOX_CHECK_NOT_NULL(
-      icebergSplit, "Unexpected split type {}", connectorSplit->_type);
-
-  std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
-  for (const auto& entry : icebergSplit->partitionKeys) {
-    partitionKeys.emplace(
-        entry.second.name,
-        entry.second.value == nullptr
-            ? std::nullopt
-            : std::optional<std::string>{*entry.second.value});
-  }
-
-  std::unordered_map<std::string, std::string> customSplitInfo;
-  customSplitInfo["table_format"] = "hive-iceberg";
-
-  std::vector<velox::connector::hive::iceberg::IcebergDeleteFile> deletes;
-  deletes.reserve(icebergSplit->deletes.size());
-  for (const auto& deleteFile : icebergSplit->deletes) {
-    std::unordered_map<int32_t, std::string> lowerBounds(
-        deleteFile.lowerBounds.begin(), deleteFile.lowerBounds.end());
-
-    std::unordered_map<int32_t, std::string> upperBounds(
-        deleteFile.upperBounds.begin(), deleteFile.upperBounds.end());
-
-    velox::connector::hive::iceberg::IcebergDeleteFile icebergDeleteFile(
-        toVeloxFileContent(deleteFile.content),
-        deleteFile.path,
-        toVeloxFileFormat(deleteFile.format),
-        deleteFile.recordCount,
-        deleteFile.fileSizeInBytes,
-        std::vector(deleteFile.equalityFieldIds),
-        lowerBounds,
-        upperBounds);
-
-    deletes.emplace_back(icebergDeleteFile);
-  }
-
-  std::unordered_map<std::string, std::string> infoColumns = {
-      {"$data_sequence_number",
-       std::to_string(icebergSplit->dataSequenceNumber)},
-      {"$path", icebergSplit->path}};
-
-  return std::make_unique<connector::hive::iceberg::HiveIcebergSplit>(
-      catalogId,
-      icebergSplit->path,
-      toVeloxFileFormat(icebergSplit->fileFormat),
-      icebergSplit->start,
-      icebergSplit->length,
-      partitionKeys,
-      std::nullopt,
-      customSplitInfo,
-      nullptr,
-      splitContext->cacheable,
-      deletes,
-      infoColumns);
-}
-
-std::unique_ptr<velox::connector::ColumnHandle>
-IcebergPrestoToVeloxConnector::toVeloxColumnHandle(
-    const protocol::ColumnHandle* column,
-    const TypeParser& typeParser) const {
-  auto icebergColumn =
-      dynamic_cast<const protocol::iceberg::IcebergColumnHandle*>(column);
-  VELOX_CHECK_NOT_NULL(
-      icebergColumn, "Unexpected column handle type {}", column->_type);
-  // TODO(imjalpreet): Modify 'hiveType' argument of the 'HiveColumnHandle'
-  //  constructor similar to how Hive Connector is handling for bucketing
-  velox::type::fbhive::HiveTypeParser hiveTypeParser;
-  auto type = stringToType(icebergColumn->type, typeParser);
-  connector::hive::HiveColumnHandle::ColumnParseParameters columnParseParameters;
-  if (type->isDate()) {
-    columnParseParameters.partitionDateValueFormat = connector::hive::HiveColumnHandle::ColumnParseParameters::kDaysSinceEpoch;
-  }
-  return std::make_unique<connector::hive::HiveColumnHandle>(
-      icebergColumn->columnIdentity.name,
-      toHiveColumnType(icebergColumn->columnType),
-      type,
-      type,
-      toRequiredSubfields(icebergColumn->requiredSubfields),
-      columnParseParameters);
-}
-
-std::unique_ptr<velox::connector::ConnectorTableHandle>
-IcebergPrestoToVeloxConnector::toVeloxTableHandle(
-    const protocol::TableHandle& tableHandle,
-    const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser,
-    velox::connector::ColumnHandleMap& assignments) const {
-  auto addSynthesizedColumn = [&](const std::string& name,
-                                  protocol::hive::ColumnType columnType,
-                                  const protocol::ColumnHandle& column) {
-    if (toHiveColumnType(columnType) ==
-        velox::connector::hive::HiveColumnHandle::ColumnType::kSynthesized) {
-      if (assignments.count(name) == 0) {
-        assignments.emplace(name, toVeloxColumnHandle(&column, typeParser));
-      }
-    }
-  };
-
-  auto icebergLayout = std::dynamic_pointer_cast<
-      const protocol::iceberg::IcebergTableLayoutHandle>(
-      tableHandle.connectorTableLayout);
-  VELOX_CHECK_NOT_NULL(
-      icebergLayout,
-      "Unexpected layout type {}",
-      tableHandle.connectorTableLayout->_type);
-
-  for (const auto& entry : icebergLayout->partitionColumns) {
-    assignments.emplace(
-        entry.columnIdentity.name, toVeloxColumnHandle(&entry, typeParser));
-  }
-
-  // Add synthesized columns to the TableScanNode columnHandles as well.
-  for (const auto& entry : icebergLayout->predicateColumns) {
-    addSynthesizedColumn(entry.first, entry.second.columnType, entry.second);
-  }
-
-  auto icebergTableHandle =
-      std::dynamic_pointer_cast<const protocol::iceberg::IcebergTableHandle>(
-          tableHandle.connectorHandle);
-  VELOX_CHECK_NOT_NULL(
-      icebergTableHandle,
-      "Unexpected table handle type {}",
-      tableHandle.connectorHandle->_type);
-
-  // Use fully qualified name if available.
-  std::string tableName = icebergTableHandle->schemaName.empty()
-      ? icebergTableHandle->icebergTableName.tableName
-      : fmt::format(
-            "{}.{}",
-            icebergTableHandle->schemaName,
-            icebergTableHandle->icebergTableName.tableName);
-
-  return toHiveTableHandle(
-      icebergLayout->domainPredicate,
-      icebergLayout->remainingPredicate,
-      icebergLayout->pushdownFilterEnabled,
-      tableName,
-      icebergLayout->dataColumns,
-      tableHandle,
-      {},
-      exprConverter,
-      typeParser);
-}
-
-std::unique_ptr<protocol::ConnectorProtocol>
-IcebergPrestoToVeloxConnector::createConnectorProtocol() const {
-  return std::make_unique<protocol::iceberg::IcebergConnectorProtocol>();
 }
 
 std::unique_ptr<velox::connector::ConnectorSplit>

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.h
@@ -35,6 +35,27 @@ void unregisterPrestoToVeloxConnector(const std::string& connectorName);
 const PrestoToVeloxConnector& getPrestoToVeloxConnector(
     const std::string& connectorName);
 
+velox::TypePtr stringToType(
+    const std::string& typeString,
+    const TypeParser& typeParser);
+
+std::vector<velox::common::Subfield> toRequiredSubfields(
+    const protocol::List<protocol::Subfield>& subfields);
+
+velox::connector::hive::HiveColumnHandle::ColumnType toHiveColumnType(
+    protocol::hive::ColumnType type);
+
+std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
+    const protocol::TupleDomain<protocol::Subfield>& domainPredicate,
+    const std::shared_ptr<protocol::RowExpression>& remainingPredicate,
+    bool isPushdownFilterEnabled,
+    const std::string& tableName,
+    const protocol::List<protocol::Column>& dataColumns,
+    const protocol::TableHandle& tableHandle,
+    const protocol::Map<protocol::String, protocol::String>& tableParameters,
+    const VeloxExprConverter& exprConverter,
+    const TypeParser& typeParser);
+
 class PrestoToVeloxConnector {
  public:
   virtual ~PrestoToVeloxConnector() = default;
@@ -164,31 +185,6 @@ class HivePrestoToVeloxConnector final : public PrestoToVeloxConnector {
       const protocol::List<protocol::hive::HiveColumnHandle>& inputColumns,
       const TypeParser& typeParser,
       bool& hasPartitionColumn) const;
-};
-
-class IcebergPrestoToVeloxConnector final : public PrestoToVeloxConnector {
- public:
-  explicit IcebergPrestoToVeloxConnector(std::string connectorName)
-      : PrestoToVeloxConnector(std::move(connectorName)) {}
-
-  std::unique_ptr<velox::connector::ConnectorSplit> toVeloxSplit(
-      const protocol::ConnectorId& catalogId,
-      const protocol::ConnectorSplit* connectorSplit,
-      const protocol::SplitContext* splitContext) const final;
-
-  std::unique_ptr<velox::connector::ColumnHandle> toVeloxColumnHandle(
-      const protocol::ColumnHandle* column,
-      const TypeParser& typeParser) const final;
-
-  std::unique_ptr<velox::connector::ConnectorTableHandle> toVeloxTableHandle(
-      const protocol::TableHandle& tableHandle,
-      const VeloxExprConverter& exprConverter,
-      const TypeParser& typeParser,
-      velox::connector::ColumnHandleMap& assignments)
-      const final;
-
-  std::unique_ptr<protocol::ConnectorProtocol> createConnectorProtocol()
-      const final;
 };
 
 class TpchPrestoToVeloxConnector final : public PrestoToVeloxConnector {

--- a/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
@@ -19,6 +19,10 @@
 #include "presto_cpp/main/connectors/arrow_flight/ArrowPrestoToVeloxConnector.h"
 #endif
 
+#ifdef PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR
+#include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
+#endif
+
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 
@@ -47,11 +51,13 @@ void registerConnectorFactories() {
 
   // Register Velox connector factory for iceberg.
   // The iceberg catalog is handled by the hive connector factory.
+#ifdef PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR
   if (!velox::connector::hasConnectorFactory(kIcebergConnectorName)) {
     velox::connector::registerConnectorFactory(
         std::make_shared<velox::connector::hive::HiveConnectorFactory>(
             kIcebergConnectorName));
   }
+#endif
 
 #ifdef PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR
   if (!velox::connector::hasConnectorFactory(
@@ -70,8 +76,12 @@ void registerConnectors() {
       velox::connector::hive::HiveConnectorFactory::kHiveConnectorName));
   registerPrestoToVeloxConnector(
       std::make_unique<HivePrestoToVeloxConnector>(kHiveHadoop2ConnectorName));
+
+#ifdef PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR
   registerPrestoToVeloxConnector(
       std::make_unique<IcebergPrestoToVeloxConnector>(kIcebergConnectorName));
+#endif
+
   registerPrestoToVeloxConnector(std::make_unique<TpchPrestoToVeloxConnector>(
       velox::connector::tpch::TpchConnectorFactory::kTpchConnectorName));
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -41,12 +41,6 @@ namespace facebook::presto {
 
 namespace {
 
-TypePtr stringToType(
-    const std::string& typeString,
-    const TypeParser& typeParser) {
-  return typeParser.parse(typeString);
-}
-
 std::vector<std::string> getNames(const protocol::Assignments& assignments) {
   std::vector<std::string> names;
   names.reserve(assignments.assignments.size());

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -11,6 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#ifdef PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR
+#include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
+#endif
+
 #include "presto_cpp/main/connectors/PrestoToVeloxConnector.h"
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
@@ -29,8 +34,12 @@ TEST_F(PrestoToVeloxConnectorTest, registerVariousConnectors) {
       "hive-hadoop2",
 
       std::make_unique<HivePrestoToVeloxConnector>("hive-hadoop2")));
+
+#ifdef PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR
   connectorList.emplace_back(std::pair(
       "iceberg", std::make_unique<IcebergPrestoToVeloxConnector>("iceberg")));
+#endif
+
   connectorList.emplace_back(
       std::pair("tpch", std::make_unique<HivePrestoToVeloxConnector>("tpch")));
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Refactor prestissimo iceberg connector code. Moving all iceberg connector related code to standalone files.
Add a new cmake flag `PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR` to control the compile of Iceberg connector source code.
Change the corresponding unit test.

With this new cmake flag. To use native iceberg connector, this flag `PRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR` should be set to `ON` when compiling prestissimo source code. For example, 
`make debug EXTRA_CMAKE_FLAGS="-DPRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR=ON"`
or
`make EXTRA_CMAKE_FLAGS="-DPRESTO_ENABLE_NATIVE_ICEBERG_CONNECTOR=ON"`

The default value of this flag is `OFF`.
And when using the default value, querying in native iceberg connector causes following error:
`Query 20250727_185123_00003_epz3j failed: it != protocols().end() Protocol for connector iceberg not registered`


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Currently, the Iceberg native connector is not yet fully functional compared to the Java Iceberg connector. Therefore, it is reasonable to provide an option to disable the native connector entirely when building the binary image.
Additionally, grouping the Iceberg native connector code into standalone source files promotes a cleaner and more modular design, improving maintainability and clarity.
Finally, this isolation allows downstream users to extend or customize the native connector’s functionality without affecting or breaking the main branch build, providing greater flexibility for integration and experimentation.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add new cmake flag for native iceberg connector.
* Update native iceberg connector, by default it will not be enabled.
```

