### PR TITLE
[native] Make initializeThreadPools() virtual

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -126,6 +126,8 @@ class PrestoServer {
 
   virtual void initializeCoordinatorDiscoverer();
 
+  virtual void initializeThreadPools();
+
   virtual std::shared_ptr<velox::exec::TaskListener> getTaskListener();
 
   virtual std::shared_ptr<velox::exec::ExprSetListener> getExprSetListener();
@@ -193,8 +195,6 @@ class PrestoServer {
   getHttpServerFilters() const;
 
   void initializeVeloxMemory();
-
-  void initializeThreadPools();
 
   void registerStatsCounters();
 


### PR DESCRIPTION
Summary: Make this method virtual such that we allow additional thread pool customizations (such as thread pool monitoring) for implementing servers.

Differential Revision: D79104048

== NO RELEASE NOTE ==
