### PR TITLE
[native] Update to use C++20

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -24,7 +24,7 @@ execute_process(
   OUTPUT_VARIABLE SCRIPT_CXX_FLAGS
   RESULT_VARIABLE COMMAND_STATUS)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 message("Appending CMAKE_CXX_FLAGS with ${SCRIPT_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
@@ -70,9 +70,9 @@ option(PRESTO_ENABLE_JWT "Enable JWT (JSON Web Token) authentication" OFF)
 
 option(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR "Enable Arrow Flight connector" OFF)
 
-# Set all Velox options below
-# Make sure that if we include folly headers or other dependency headers
-# that include folly headers we turn off the coroutines and turn on int128.
+# Set all Velox options below and make sure that if we include folly headers or
+# other dependency headers that include folly headers we turn off the coroutines
+# and turn on int128.
 add_compile_definitions(FOLLY_HAVE_INT128_T=1 FOLLY_CFG_NO_COROUTINES)
 
 if(PRESTO_ENABLE_S3)
@@ -210,7 +210,8 @@ find_package(wangle CONFIG)
 find_package(FBThrift)
 include_directories(SYSTEM ${FBTHRIFT_INCLUDE_DIR})
 
-set(PROXYGEN_LIBRARIES ${PROXYGEN_HTTP_SERVER} ${PROXYGEN} ${WANGLE} ${FIZZ} ${MVFST_EXCEPTION})
+set(PROXYGEN_LIBRARIES ${PROXYGEN_HTTP_SERVER} ${PROXYGEN} ${WANGLE} ${FIZZ}
+                       ${MVFST_EXCEPTION})
 find_path(PROXYGEN_DIR NAMES include/proxygen)
 set(PROXYGEN_INCLUDE_DIR "${PROXYGEN_DIR}/include/proxygen")
 

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -65,18 +65,19 @@ The supported architectures are `x86_64 (avx, sse)`, and `AArch64 (apple-m1+crc,
 Prestissimo can be built by a variety of compilers (and versions) but not all.
 Compilers (and versions) not mentioned are known to not work or have not been tried.
 
+#### Minimum required
+| OS | compiler |
+| -- | -------- |
+| Ubuntu 22.04 | `gcc11` |
+| macOS | `clang15` |
+| CentOS 9/RHEL 9 | `gcc11` |
+
 #### Recommended
 | OS | compiler |
 | -- | -------- |
 | CentOS 9/RHEL 9 | `gcc12` |
 | Ubuntu 22.04 | `gcc11` |
-| macOS | `clang15` |
-
-#### Older alternatives
-| OS | compiler |
-| -- | -------- |
-| Ubuntu 20.04 | `gcc9` |
-| macOS | `clang14` |
+| macOS | `clang15 (or later)` |
 
 ### Build Prestissimo
 #### Parquet and S3 Support

--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -542,7 +542,7 @@ folly::SemiFuture<std::unique_ptr<HttpResponse>> HttpClient::sendRequest(
   if (eventBase_ != nullptr) {
     if (delayMs > 0) {
       // schedule() is expected to be run in the event base thread
-      eventBase_->runInEventBaseThread([=]() {
+      eventBase_->runInEventBaseThread([=, this]() {
         eventBase_->schedule(sendCb, std::chrono::milliseconds(delayMs));
       });
     } else {

--- a/presto-native-execution/presto_cpp/main/types/tests/FunctionMetadataTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/FunctionMetadataTest.cpp
@@ -48,12 +48,15 @@ class FunctionMetadataTest : public ::testing::Test {
     EXPECT_EQ(metadataList.size(), expectedSize);
     std::string expectedStr = slurp(test::utils::getDataPath(expectedFile));
     auto expected = json::parse(expectedStr);
+    auto comparator = [](const json& a, const json& b) {
+      return (a["outputType"] < b["outputType"]);
+    };
 
     json::array_t expectedList = expected[name];
-    std::sort(expectedList.begin(), expectedList.end());
-    std::sort(metadataList.begin(), metadataList.end());
+    std::sort(expectedList.begin(), expectedList.end(), comparator);
+    std::sort(metadataList.begin(), metadataList.end(), comparator);
     for (auto i = 0; i < expectedSize; i++) {
-      EXPECT_EQ(expectedList[i], metadataList[i]);
+      EXPECT_EQ(expectedList[i], metadataList[i]) << "Position: " << i;
     }
   }
 


### PR DESCRIPTION
This updates the C++ standard to C++20 to match
the Velox C++ standard.

Resolves https://github.com/prestodb/presto/issues/25634

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

