### PR TITLE
chore(connector): Migrates the Elasticsearch connector's AWS integration from AWS SDK v1 to v2

### DIFF
--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -94,20 +94,20 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!-- org.elasticsearch:elasticsearch brings in version 2.8.6 (vs 2.6.7) -->
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-cbor</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/AwsRequestSigner.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/AwsRequestSigner.java
@@ -13,10 +13,6 @@
  */
 package com.facebook.presto.elasticsearch.client;
 
-import com.amazonaws.DefaultRequest;
-import com.amazonaws.auth.AWS4Signer;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.http.HttpMethodName;
 import com.facebook.presto.spi.PrestoException;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.EntityDetails;
@@ -31,7 +27,16 @@ import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.http.HttpEntityEnclosingRequest;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.utils.IoUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -44,7 +49,6 @@ import java.util.TreeMap;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
 
@@ -52,16 +56,18 @@ class AwsRequestSigner
         implements HttpRequestInterceptor
 {
     private static final String SERVICE_NAME = "es";
-    private final AWSCredentialsProvider credentialsProvider;
-    private final AWS4Signer signer;
+    private final AwsCredentialsProvider credentialsProvider;
+    private final Aws4Signer signer;
+    private final Region region;
 
-    public AwsRequestSigner(String region, AWSCredentialsProvider credentialsProvider)
+    public AwsRequestSigner(String region, AwsCredentialsProvider credentialsProvider)
     {
         this.credentialsProvider = credentialsProvider;
-        this.signer = new AWS4Signer();
-
-        signer.setServiceName(SERVICE_NAME);
-        signer.setRegionName(region);
+        this.region = Region.of(region);
+        // Note: Aws4Signer is deprecated but we continue using it due to missing features
+        // in AwsV4HttpSigner as documented in AWS SDK issue #5401
+        // https://github.com/aws/aws-sdk-java-v2/issues/5401
+        this.signer = Aws4Signer.create();
     }
 
     @Override
@@ -86,8 +92,9 @@ class AwsRequestSigner
                     .add(parameter.getValue());
         }
 
-        Map<String, String> headers = Arrays.stream(request.getHeaders())
-                .collect(toImmutableMap(Header::getName, Header::getValue));
+        Map<String, List<String>> headers = new TreeMap<>(CASE_INSENSITIVE_ORDER);
+        Arrays.stream(request.getHeaders()).forEach(header ->
+                headers.put(header.getName(), List.of(header.getValue())));
 
         InputStream content = null;
         if (request instanceof HttpEntityEnclosingRequest) {
@@ -97,31 +104,59 @@ class AwsRequestSigner
             }
         }
 
-        DefaultRequest<?> awsRequest = new DefaultRequest<>(SERVICE_NAME);
-
         HttpHost host = (HttpHost) context.getAttribute(HTTP_TARGET_HOST);
         if (host != null) {
-            awsRequest.setEndpoint(URI.create(host.toURI()));
-        }
-        awsRequest.setHttpMethod(HttpMethodName.fromValue(method));
-        awsRequest.setResourcePath(uri.getRawPath());
-        awsRequest.setContent(content);
-        awsRequest.setParameters(parameters);
-        awsRequest.setHeaders(headers);
+            URI endpoint = URI.create(host.toURI());
+            SdkHttpFullRequest.Builder requestBuilder = SdkHttpFullRequest.builder()
+                    .method(SdkHttpMethod.fromValue(method))
+                    .uri(endpoint.resolve(uri.getRawPath()))
+                    .headers(headers);
 
-        signer.sign(awsRequest, credentialsProvider.getCredentials());
+            parameters.forEach((key, values) -> {
+                for (String value : values) {
+                    requestBuilder.putRawQueryParameter(key, value);
+                }
+            });
 
-        Header[] newHeaders = awsRequest.getHeaders().entrySet().stream()
-                .map(entry -> new BasicHeader(entry.getKey(), entry.getValue()))
-                .toArray(Header[]::new);
+            // Using contentStreamProvider as per AWS SDK v2 API
+            if (content != null) {
+                try {
+                    byte[] contentBytes = IoUtils.toByteArray(content);
+                    ContentStreamProvider contentStreamProvider = () -> new ByteArrayInputStream(contentBytes);
+                    requestBuilder.contentStreamProvider(contentStreamProvider);
+                }
+                catch (IOException e) {
+                    throw new IOException("Failed to read request content", e);
+                }
+            }
 
-        request.setHeaders(newHeaders);
+            SdkHttpFullRequest sdkRequest = requestBuilder.build();
 
-        InputStream newContent = awsRequest.getContent();
-        checkState(newContent == null || request instanceof HttpEntityContainer);
-        if (newContent != null) {
-            BasicHttpEntity entity = new BasicHttpEntity(newContent, ContentType.APPLICATION_OCTET_STREAM);
-            ((HttpEntityContainer) request).setEntity(entity);
+            Aws4SignerParams signerParams = Aws4SignerParams.builder()
+                    .awsCredentials(credentialsProvider.resolveCredentials())
+                    .signingName(SERVICE_NAME)
+                    .signingRegion(region)
+                    .build();
+
+            SdkHttpFullRequest signedRequest = signer.sign(sdkRequest, signerParams);
+
+            Header[] newHeaders = signedRequest.headers().entrySet().stream()
+                    .flatMap(entry -> entry.getValue().stream()
+                            .map(value -> new BasicHeader(entry.getKey(), value)))
+                    .toArray(Header[]::new);
+
+            request.setHeaders(newHeaders);
+
+            if (signedRequest.contentStreamProvider().isPresent() && request instanceof HttpEntityContainer) {
+                try {
+                    InputStream signedContent = signedRequest.contentStreamProvider().get().newStream();
+                    BasicHttpEntity entity = new BasicHttpEntity(signedContent, ContentType.APPLICATION_OCTET_STREAM);
+                    ((HttpEntityContainer) request).setEntity(entity);
+                }
+                catch (Exception e) {
+                    throw new IOException("Failed to update request content after signing", e);
+                }
+            }
         }
     }
 }

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
@@ -31,11 +31,6 @@ import co.elastic.clients.transport.rest5_client.low_level.Response;
 import co.elastic.clients.transport.rest5_client.low_level.ResponseException;
 import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 import co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.airlift.log.Logger;
@@ -75,6 +70,11 @@ import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.util.Timeout;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
@@ -267,17 +267,18 @@ public class ElasticsearchClient
         return builder.build();
     }
 
-    private static AWSCredentialsProvider getAwsCredentialsProvider(AwsSecurityConfig config)
+    private static AwsCredentialsProvider getAwsCredentialsProvider(AwsSecurityConfig config)
     {
         if (config.getAccessKey().isPresent() && config.getSecretKey().isPresent()) {
-            return new AWSStaticCredentialsProvider(new BasicAWSCredentials(
-                    config.getAccessKey().get(),
-                    config.getSecretKey().get()));
+            return StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(
+                            config.getAccessKey().get(),
+                            config.getSecretKey().get()));
         }
         if (config.isUseInstanceCredentials()) {
-            return InstanceProfileCredentialsProvider.getInstance();
+            return InstanceProfileCredentialsProvider.create();
         }
-        return DefaultAWSCredentialsProviderChain.getInstance();
+        return DefaultCredentialsProvider.create();
     }
 
     private static Optional<SSLContext> buildSslContext(

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestPasswordAuthentication.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestPasswordAuthentication.java
@@ -16,7 +16,6 @@ package com.facebook.presto.elasticsearch;
 import co.elastic.clients.transport.rest5_client.low_level.Request;
 import co.elastic.clients.transport.rest5_client.low_level.RequestOptions;
 import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
-import com.amazonaws.util.Base64;
 import com.facebook.presto.sql.query.QueryAssertions;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 
 import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
@@ -92,7 +92,7 @@ public class TestPasswordAuthentication
         request.setJsonEntity(json);
         request.addParameter("refresh", "true");
 
-        String auth = Base64.encodeAsString((USER + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
+        String auth = Base64.getEncoder().encodeToString((USER + ":" + PASSWORD).getBytes(StandardCharsets.UTF_8));
         request.setOptions(RequestOptions.DEFAULT.toBuilder()
                 .addHeader("Authorization", "Basic " + auth)
                 .build());

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/client/TestAwsIamAuthentication.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/client/TestAwsIamAuthentication.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch.client;
+
+import co.elastic.clients.transport.rest5_client.low_level.Response;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import com.facebook.presto.elasticsearch.ElasticsearchServer;
+import com.facebook.presto.sql.query.QueryAssertions;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.message.BasicHttpRequest;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+import java.io.IOException;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static com.facebook.presto.elasticsearch.client.ElasticSearchClientUtils.performRequest;
+import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Integration test to validate AWS IAM authentication with OpenSearch/Elasticsearch
+ * using AWS SDK v2.
+ */
+public class TestAwsIamAuthentication
+{
+    private static final String AWS_REGION = "us-east-1";
+    private static final String ACCESS_KEY = "test-access-key";
+    private static final String SECRET_KEY = "test-secret-key";
+
+    private final String elasticsearchImage = "docker.elastic.co/elasticsearch/elasticsearch:9.1.0";
+    private ElasticsearchServer elasticsearch;
+    private Rest5Client client;
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        elasticsearch = new ElasticsearchServer(elasticsearchImage,
+                ImmutableMap.<String, String>builder()
+                        .put("elasticsearch.yml", getElasticsearchConfig())
+                        .build(),
+                ImmutableMap.of());
+
+        HostAndPort address = elasticsearch.getAddress();
+        client = Rest5Client.builder(new HttpHost(address.getHost(), address.getPort())).build();
+
+        DistributedQueryRunner runner = createElasticsearchQueryRunner(
+                elasticsearch.getAddress(),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("elasticsearch.security", "AWS")
+                        .put("elasticsearch.aws.region", AWS_REGION)
+                        .put("elasticsearch.aws.access-key", ACCESS_KEY)
+                        .put("elasticsearch.aws.secret-key", SECRET_KEY)
+                        .build());
+
+        assertions = new QueryAssertions(runner);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+            throws IOException
+    {
+        if (assertions != null) {
+            assertions.close();
+        }
+        if (client != null) {
+            client.close();
+        }
+        if (elasticsearch != null) {
+            elasticsearch.stop();
+        }
+    }
+
+    @Test
+    public void testAwsRequestSigning()
+            throws Exception
+    {
+        AwsRequestSigner signer = new AwsRequestSigner(
+                AWS_REGION,
+                StaticCredentialsProvider.create(AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)));
+
+        HttpRequest request = new BasicHttpRequest("GET", "/_cluster/health");
+        HttpContext context = new BasicHttpContext();
+        HostAndPort address = elasticsearch.getAddress();
+        context.setAttribute(HTTP_TARGET_HOST, new HttpHost(address.getHost(), address.getPort()));
+
+        signer.process(request, null, context);
+
+        assertNotNull(request.getFirstHeader("Authorization"), "Authorization header should be present");
+        assertNotNull(request.getFirstHeader("X-Amz-Date"), "X-Amz-Date header should be present");
+
+        String authHeader = request.getFirstHeader("Authorization").getValue();
+        assertTrue(authHeader.startsWith("AWS4-HMAC-SHA256"), "Authorization header should use AWS4-HMAC-SHA256");
+        assertTrue(authHeader.contains("Credential=" + ACCESS_KEY), "Authorization header should contain access key");
+        assertTrue(authHeader.contains("SignedHeaders="), "Authorization header should contain signed headers");
+        assertTrue(authHeader.contains("Signature="), "Authorization header should contain signature");
+    }
+
+    @Test
+    public void testIamAuthenticatedQuery()
+            throws IOException
+    {
+        String json = new ObjectMapper().writeValueAsString(ImmutableMap.<String, Object>builder()
+                .put("id", 1L)
+                .put("name", "test-document")
+                .put("value", 100L)
+                .build());
+
+        performRequest(
+                "POST",
+                "/test-iam/_doc/1?refresh",
+                ImmutableMap.of(),
+                new ByteArrayEntity(json.getBytes(), ContentType.APPLICATION_JSON),
+                client);
+
+        assertions.assertQuery("SELECT * FROM \"test-iam\"",
+                "VALUES (BIGINT '1', CAST('test-document' AS varchar), BIGINT '100')");
+    }
+
+    @Test
+    public void testIamClusterAccess()
+            throws IOException
+    {
+        Response response = performRequest(
+                "GET",
+                "/_cluster/health",
+                ImmutableMap.of(),
+                null,
+                client);
+
+        assertEquals(response.getStatusCode(), 200, "Cluster health check should return 200 OK");
+        assertNotNull(response.getEntity(), "Response should contain cluster health data");
+    }
+
+    @Test
+    public void testIamIndexOperations()
+            throws IOException
+    {
+        String indexName = "test-iam-operations";
+
+        Response createResponse = performRequest(
+                "PUT",
+                "/" + indexName,
+                ImmutableMap.of(),
+                new ByteArrayEntity("{\"settings\":{\"number_of_shards\":1}}".getBytes(), ContentType.APPLICATION_JSON),
+                client);
+        assertEquals(createResponse.getStatusCode(), 200, "Index creation should return 200 OK");
+
+        Response getResponse = performRequest(
+                "GET",
+                "/" + indexName,
+                ImmutableMap.of(),
+                null,
+                client);
+        assertEquals(getResponse.getStatusCode(), 200, "Index retrieval should return 200 OK");
+
+        Response deleteResponse = performRequest(
+                "DELETE",
+                "/" + indexName,
+                ImmutableMap.of(),
+                null,
+                client);
+        assertEquals(deleteResponse.getStatusCode(), 200, "Index deletion should return 200 OK");
+    }
+
+    private String getElasticsearchConfig()
+    {
+        return "# Basic cluster identification\n" +
+                "cluster.name: test-cluster\n" +
+                "node.name: test-node\n" +
+                "# Allow external connections for testing (binds to all network interfaces)\n" +
+                "network.host: 0.0.0.0\n" +
+                "# Single node setup for testing - no cluster discovery needed\n" +
+                "discovery.type: single-node\n" +
+                "# Disable X-Pack security features for simplified testing environment\n" +
+                "xpack.security.enabled: false\n" +
+                "# Disable monitoring to reduce overhead in test environment\n" +
+                "xpack.monitoring.enabled: false\n" +
+                "# Disable watcher (alerting) as it's not needed for tests\n" +
+                "xpack.watcher.enabled: false\n" +
+                "# Disable machine learning features to reduce resource usage\n" +
+                "xpack.ml.enabled: false";
+    }
+}

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/client/TestAwsIamAuthentication.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/client/TestAwsIamAuthentication.java
@@ -64,10 +64,8 @@ public class TestAwsIamAuthentication
             throws Exception
     {
         elasticsearch = new ElasticsearchServer(elasticsearchImage,
-                ImmutableMap.<String, String>builder()
-                        .put("elasticsearch.yml", getElasticsearchConfig())
-                        .build(),
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                ImmutableMap.of("xpack.security.enabled", "false"));
 
         HostAndPort address = elasticsearch.getAddress();
         client = Rest5Client.builder(new HttpHost(address.getHost(), address.getPort())).build();
@@ -191,24 +189,5 @@ public class TestAwsIamAuthentication
                 null,
                 client);
         assertEquals(deleteResponse.getStatusCode(), 200, "Index deletion should return 200 OK");
-    }
-
-    private String getElasticsearchConfig()
-    {
-        return "# Basic cluster identification\n" +
-                "cluster.name: test-cluster\n" +
-                "node.name: test-node\n" +
-                "# Allow external connections for testing (binds to all network interfaces)\n" +
-                "network.host: 0.0.0.0\n" +
-                "# Single node setup for testing - no cluster discovery needed\n" +
-                "discovery.type: single-node\n" +
-                "# Disable X-Pack security features for simplified testing environment\n" +
-                "xpack.security.enabled: false\n" +
-                "# Disable monitoring to reduce overhead in test environment\n" +
-                "xpack.monitoring.enabled: false\n" +
-                "# Disable watcher (alerting) as it's not needed for tests\n" +
-                "xpack.watcher.enabled: false\n" +
-                "# Disable machine learning features to reduce resource usage\n" +
-                "xpack.ml.enabled: false";
     }
 }


### PR DESCRIPTION
## Description
This change updates the underlying AWS SDK libraries used for signing requests to Elasticsearch, leveraging the modern features and improved performance of SDK v2.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Elasticsearch Connector Changes
* Upgrade AWS integration from SDK v1 to SDK v2 for the Elasticsearch connector.

```

