### PR TITLE
Allow duplicate function signatures when matching with generic candidates

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionSignatureMatcher.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionSignatureMatcher.java
@@ -71,7 +71,7 @@ public final class FunctionSignatureMatcher
                 .filter(function -> !function.getSignature().getTypeVariableConstraints().isEmpty())
                 .collect(Collectors.toList());
 
-        match = matchFunctionExact(genericCandidates, parameterTypes);
+        match = matchFunctionGeneric(genericCandidates, parameterTypes);
         if (match.isPresent()) {
             return match;
         }
@@ -89,6 +89,28 @@ public final class FunctionSignatureMatcher
     private Optional<Signature> matchFunctionExact(List<SqlFunction> candidates, List<TypeSignatureProvider> actualParameters)
     {
         return matchFunction(candidates, actualParameters, false);
+    }
+
+    private Optional<Signature> matchFunctionGeneric(List<SqlFunction> candidates, List<TypeSignatureProvider> actualParameters)
+    {
+        List<ApplicableFunction> applicableFunctions = identifyApplicableFunctions(candidates, actualParameters, false);
+        if (applicableFunctions.isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (applicableFunctions.size() == 1) {
+            return Optional.of(getOnlyElement(applicableFunctions).getBoundSignature());
+        }
+
+        List<Signature> deduplicatedSignatures = applicableFunctions.stream()
+                .map(applicableFunction -> applicableFunction.boundSignature)
+                .distinct()
+                .collect(toImmutableList());
+        if (deduplicatedSignatures.size() == 1) {
+            return Optional.of(getOnlyElement(deduplicatedSignatures));
+        }
+
+        throw new PrestoException(AMBIGUOUS_FUNCTION_CALL, getErrorMessage(applicableFunctions));
     }
 
     private Optional<Signature> matchFunctionWithCoercion(Collection<? extends SqlFunction> candidates, List<TypeSignatureProvider> actualParameters)
@@ -112,6 +134,11 @@ public final class FunctionSignatureMatcher
             return Optional.of(getOnlyElement(applicableFunctions).getBoundSignature());
         }
 
+        throw new PrestoException(AMBIGUOUS_FUNCTION_CALL, getErrorMessage(applicableFunctions));
+    }
+
+    private String getErrorMessage(List<ApplicableFunction> applicableFunctions)
+    {
         StringBuilder errorMessageBuilder = new StringBuilder();
         errorMessageBuilder.append("Could not choose a best candidate operator. Explicit type casts must be added.\n");
         errorMessageBuilder.append("Candidates are:\n");
@@ -120,7 +147,8 @@ public final class FunctionSignatureMatcher
             errorMessageBuilder.append(function.getBoundSignature().toString());
             errorMessageBuilder.append("\n");
         }
-        throw new PrestoException(AMBIGUOUS_FUNCTION_CALL, errorMessageBuilder.toString());
+
+        return errorMessageBuilder.toString();
     }
 
     private List<ApplicableFunction> identifyApplicableFunctions(Collection<? extends SqlFunction> candidates, List<TypeSignatureProvider> actualParameters, boolean allowCoercion)

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -318,6 +318,20 @@ public class TestNativeSidecarPlugin
     }
 
     @Test
+    public void testMapSubset()
+    {
+        assertQuery("select m[1], m[3] from (select map_subset(map(array[1,2,3,4], array['a', 'b', 'c', 'd']), array[1,3,10]) m)", "select 'a', 'c'");
+        assertQuery("select m['p'], m['r'] from (select map_subset(map(array['p', 'q', 'r', 's'], array['a', 'b', 'c', 'd']), array['p', 'r', 'z']) m)", "select 'a', 'c'");
+        assertQuery("select m[true], m[false] from (select map_subset(map(array[false, true], array['a', 'z']), array[true, false]) m)", "select 'z', 'a'");
+        assertQuery("select m[DATE '2015-01-01'], m[DATE '2015-01-13'] from (select map_subset(" +
+                "map(array[DATE '2015-01-01', DATE '2015-02-13', DATE '2015-01-13', DATE '2015-05-15'], array['a', 'b', 'c', 'd']), " +
+                "array[DATE '2015-01-01', DATE '2015-01-13', DATE '2015-06-15']) m)", "select 'a', 'c'");
+        assertQuery("select m[TIMESTAMP '2021-01-02 09:04:05.321'] from (select map_subset(" +
+                "map(array[TIMESTAMP '2021-01-02 09:04:05.321', TIMESTAMP '2022-12-22 10:07:08.456'], array['a', 'b']), " +
+                "array[TIMESTAMP '2021-01-02 09:04:05.321', TIMESTAMP '2022-12-22 10:07:09.246']) m)", "select 'a'");
+    }
+
+    @Test
     public void testInformationSchemaTables()
     {
         assertQuery("select lower(table_name) from information_schema.tables "


### PR DESCRIPTION
## Description
Presto C++ sidecar can return function signatures with type variables, or generic function signatures, which can be resolved on the coordinator to the same signature after input type binding. This is because Velox scalar functions can provide an optimized implementation, or fast-path, to optimize for certain cases and a generic implementation for other cases. The function signatures corresponding to these two implementations can be the same after input type resolution. 
In order to account for this, `FunctionSignatureMatcher` should allow for multiple matching function signatures for a given list of parameter types when resolving a function with generic signatures.

## Motivation and Context

`map_subset` implementation in Velox has a fast-path for constant search keys that are of primitive types and a generic implementation for cases where the keys are non-constant, such as a column. When matching function signatures for `map_subset` function calls like:
```
map_subset(map(array[1,2,3,4], array['a', 'b', 'c', 'd']), array[1,3,10])
```
there will be duplicate function signatures after signature matching, resulting from the following Velox function signatures that will be returned by the Presto C++ sidecar:
```
registerFunction<
      ParameterBinder<MapSubsetPrimitiveFunction, int32_t>,
      Map<int32_t, Generic<T1>>,
      Map<int32_t, Generic<T1>>,
      Array<int32_t>>({prefix + "map_subset"});
registerFunction<
      MapSubsetFunction,
      Map<Generic<T1>, Generic<T2>>,
      Map<Generic<T1>, Generic<T2>>,
      Array<Generic<T1>>>({prefix + "map_subset"});
```
This results in the following error during function signature matching on the coordinator:
```
Caused by: java.lang.RuntimeException: line 1:32: Could not choose a best candidate operator. Explicit type casts must be added.
Candidates are:
	 * native.default.map_subset(map(integer,varchar),array(integer)):map(integer,varchar)
	 * native.default.map_subset(map(integer,varchar),array(integer)):map(integer,varchar)
```

## Impact
Enables use of `map_subset` function in Presto C++ (with sidecar).

## Test Plan
Added e2e testcase.

## Release Notes

```
== NO RELEASE NOTE ==
```

