### PR TITLE
[native] Fix testRemoveRedundantCastToVarcharInJoinClause

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -282,7 +282,7 @@ public class NativeQueryRunnerUtils
     {
         if (!queryRunner.tableExists(session, "customer")) {
             queryRunner.execute(session, "CREATE TABLE customer AS " +
-                    "SELECT custkey, name, address, nationkey, phone, acctbal, comment, mktsegment " +
+                    "SELECT custkey, name, address, nationkey, phone, acctbal, mktsegment, comment " +
                     "FROM tpch.tiny.customer");
         }
     }


### PR DESCRIPTION
## Description
testRemoveRedundantCastToVarcharInJoinClause test case fails in native worker, the results do not match for actualQueryRunner( PrestoNativeRunner) and expectedQueryRunner(i.e. H2).
Addresses : https://github.com/prestodb/presto/issues/24900
## Error
```
java.lang.AssertionError: For query: 
 select *, cast(o.custkey as varchar), cast(c.custkey as varchar) from orders o join customer c on cast(o.custkey as varchar) = cast(c.custkey as varchar)
 actual column types:
 [bigint, bigint, varchar(1), double, date, varchar(15), varchar(15), integer, varchar(79), bigint, varchar(25), varchar(40), bigint, varchar(15), double, varchar(117), varchar(10), varchar, varchar]
expected column types:
[bigint, bigint, varchar(1), double, date, varchar(15), varchar(15), integer, varchar(79), bigint, varchar(25), varchar(40), bigint, varchar(15), double, varchar(117), varchar(10), varchar, varchar]

not equal
Actual rows (100 of 15000 extra rows shown, 15000 rows in total):
    [3747, 1492, O, 258977.08, 1996-08-20, 1-URGENT, Clerk#000000226, 0, refully across the final theodolites. carefully bold accounts cajol, 1492, Customer#000001492, 2QNz4Zy0UjjI, 1, 11-527-949-4092, -875.17,  blithely even accounts. furiously final instructions across the decoys cajo, HOUSEHOLD, 1492, 1492]..........................
Expected rows (100 of 15000 missing rows shown, 15000 rows in total):
    [1, 370, O, 172799.49, 1996-01-02, 5-LOW, Clerk#000000951, 0, nstructio ........................................
```
