### PR TITLE
Normalize tables and views list in MetadataManager

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -571,9 +571,11 @@ public class MetadataManager
                 ConnectorSession connectorSession = session.toConnectorSession(connectorId);
                 metadata.listTables(connectorSession, prefix.getSchemaName()).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
-                        .filter(name -> prefix.matches(new QualifiedObjectName(name.getCatalogName(),
+                        .map(name -> new QualifiedObjectName(
+                                name.getCatalogName(),
                                 normalizeIdentifier(session, connectorId.getCatalogName(), name.getSchemaName()),
-                                normalizeIdentifier(session, connectorId.getCatalogName(), name.getObjectName()))))
+                                normalizeIdentifier(session, connectorId.getCatalogName(), name.getObjectName())))
+                        .filter(prefix::matches)
                         .forEach(tables::add);
             }
         }
@@ -996,9 +998,11 @@ public class MetadataManager
                 ConnectorSession connectorSession = session.toConnectorSession(connectorId);
                 metadata.listViews(connectorSession, prefix.getSchemaName()).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
-                        .filter(name -> prefix.matches(new QualifiedObjectName(name.getCatalogName(),
+                        .map(name -> new QualifiedObjectName(
+                                name.getCatalogName(),
                                 normalizeIdentifier(session, connectorId.getCatalogName(), name.getSchemaName()),
-                                normalizeIdentifier(session, connectorId.getCatalogName(), name.getObjectName()))))
+                                normalizeIdentifier(session, connectorId.getCatalogName(), name.getObjectName())))
+                        .filter(prefix::matches)
                         .forEach(views::add);
             }
         }


### PR DESCRIPTION
## Description
Normalize tables and views list in MetadataManager

## Motivation and Context
Normalize tables and views list in MetadataManager

## Impact
Earlier [QualifiedObjectName](https://github.com/prestodb/presto/blob/0.293/presto-common/src/main/java/com/facebook/presto/common/QualifiedObjectName.java#L65) had a check for lowercase. Now, based on the connector, we can normalize based on the connector, until specified in the connector, it would by default normalized to lowercase.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

