### PR TITLE
Fix flaky test in `TestHiveCommitHandleOutput`

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCommitHandleOutput.java
@@ -206,7 +206,31 @@ public class TestHiveCommitHandleOutput
         assertEquals(handle.getSerializedCommitOutputForRead(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)), serializedCommitOutput);
         assertTrue(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)).isEmpty());
 
+        // Add the same partition with the same location, the metastore will generate same commit output.
+        hiveMeta = getHiveMetadata(metastore, hiveClientConfig, listeningExecutor);
+        hiveMeta.getMetastore().addPartition(
+                connectorSession,
+                TEST_SCHEMA,
+                TEST_TABLE,
+                "random_table_path",
+                false,
+                createPartition(partitionName, "location1"),
+                new Path("/" + TEST_TABLE),
+                PartitionStatistics.empty());
+        handle = hiveMeta.commit();
+
+        assertEquals(handle.getSerializedCommitOutputForRead(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)), "");
+        assertFalse(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)).isEmpty());
+        assertEquals(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)), serializedCommitOutput);
+
         // Add the same partition with different location, it should trigger the metastore to generate different commit output.
+        // Wait for 1000ms to make sure the commit time changes
+        try {
+            Thread.sleep(1000);
+        }
+        catch (InterruptedException e) {
+            // ignored
+        }
         hiveMeta = getHiveMetadata(metastore, hiveClientConfig, listeningExecutor);
         hiveMeta.getMetastore().addPartition(
                 connectorSession,
@@ -221,7 +245,7 @@ public class TestHiveCommitHandleOutput
 
         assertEquals(handle.getSerializedCommitOutputForRead(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)), "");
         assertFalse(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)).isEmpty());
-        assertEquals(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE)), serializedCommitOutput);
+        assertTrue(Long.parseLong(handle.getSerializedCommitOutputForWrite(new SchemaTableName(TEST_SCHEMA, TEST_TABLE))) > Long.parseLong(serializedCommitOutput));
     }
 
     private HiveMetadata getHiveMetadata(TestingExtendedHiveMetastore metastore, HiveClientConfig hiveClientConfig, ListeningExecutorService listeningExecutor)


### PR DESCRIPTION
## Description

Fix #22668 

## Motivation and Context

Fix flaky test in `TestHiveCommitHandleOutput`

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

