### PR TITLE
Fix expression queries in unit tests that use TestingConnectorSession

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.testing;
 
+import com.facebook.presto.FullConnectorSession;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.TimeZoneKey;
@@ -39,12 +40,13 @@ import java.util.Set;
 
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class TestingConnectorSession
-        implements ConnectorSession
+        extends FullConnectorSession
 {
     private static final QueryIdGenerator queryIdGenerator = new QueryIdGenerator();
     public static final ConnectorSession SESSION = new TestingConnectorSession(ImmutableList.of());
@@ -105,6 +107,7 @@ public class TestingConnectorSession
             Optional<String> schema,
             Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions)
     {
+        super(testSessionBuilder().build(), identity);
         this.queryId = queryIdGenerator.createNextQueryId().toString();
         this.identity = requireNonNull(identity, "identity is null");
         this.source = requireNonNull(source, "source is null");


### PR DESCRIPTION
## Description
`TestingConnectorSession` needs to extend FullConnectorSession instead of inheriting `ConnectorSession` to run `isSerializable()` function in `RowExpressionInterpreter`.

## Motivation and Context
While the current codebase does not yet break any unit tests, new unit tests that utilize `isSerializable()` function will throw `java.lang.ClassCastException: com.facebook.presto.testing.TestingConnectorSession cannot be cast to com.facebook.presto.FullConnectorSession` error. This PR fixes this issue. 

## Impact
This PR additionally fixes some unit tests in presto-facebook.

## Test Plan
Build and unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

