### PR TITLE
[Coordinator throttling] Endpoint on Java worker reporting nodestats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerInfoResource.java
@@ -19,6 +19,7 @@ import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.spi.NodeState;
+import com.facebook.presto.spi.NodeStats;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -126,6 +127,16 @@ public class ServerInfoResource
         else {
             return nodeState;
         }
+    }
+
+    @GET
+    @Path("stats")
+    @Produces({APPLICATION_JSON, APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
+    @RolesAllowed(ADMIN)
+    public NodeStats getServerStats()
+    {
+        NodeStats stats = new NodeStats(getServerState(), null);
+        return stats;
     }
 
     @GET

--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -208,6 +208,8 @@ class PrestoServer {
 
   void reportNodeStatus(proxygen::ResponseHandler* downstream);
 
+  void reportNodeStats(proxygen::ResponseHandler* downstream);
+
   void handleGracefulShutdown(
       const std::vector<std::unique_ptr<folly::IOBuf>>& body,
       proxygen::ResponseHandler* downstream);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -7034,6 +7034,148 @@ void from_json(const json& j, MergeJoinNode& p) {
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
+void to_json(json& j, const NodeLoadMetrics& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "cpuUsedPercent",
+      p.cpuUsedPercent,
+      "NodeLoadMetrics",
+      "double",
+      "cpuUsedPercent");
+  to_json_key(
+      j,
+      "memoryUsedInBytes",
+      p.memoryUsedInBytes,
+      "NodeLoadMetrics",
+      "double",
+      "memoryUsedInBytes");
+  to_json_key(
+      j,
+      "numQueuedDrivers",
+      p.numQueuedDrivers,
+      "NodeLoadMetrics",
+      "int",
+      "numQueuedDrivers");
+  to_json_key(
+      j,
+      "cpuOverload",
+      p.cpuOverload,
+      "NodeLoadMetrics",
+      "bool",
+      "cpuOverload");
+  to_json_key(
+      j,
+      "memoryOverload",
+      p.memoryOverload,
+      "NodeLoadMetrics",
+      "bool",
+      "memoryOverload");
+}
+
+void from_json(const json& j, NodeLoadMetrics& p) {
+  from_json_key(
+      j,
+      "cpuUsedPercent",
+      p.cpuUsedPercent,
+      "NodeLoadMetrics",
+      "double",
+      "cpuUsedPercent");
+  from_json_key(
+      j,
+      "memoryUsedInBytes",
+      p.memoryUsedInBytes,
+      "NodeLoadMetrics",
+      "double",
+      "memoryUsedInBytes");
+  from_json_key(
+      j,
+      "numQueuedDrivers",
+      p.numQueuedDrivers,
+      "NodeLoadMetrics",
+      "int",
+      "numQueuedDrivers");
+  from_json_key(
+      j,
+      "cpuOverload",
+      p.cpuOverload,
+      "NodeLoadMetrics",
+      "bool",
+      "cpuOverload");
+  from_json_key(
+      j,
+      "memoryOverload",
+      p.memoryOverload,
+      "NodeLoadMetrics",
+      "bool",
+      "memoryOverload");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+
+// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
+static const std::pair<NodeState, json> NodeState_enum_table[] =
+    { // NOLINT: cert-err58-cpp
+        {NodeState::ACTIVE, "ACTIVE"},
+        {NodeState::INACTIVE, "INACTIVE"},
+        {NodeState::SHUTTING_DOWN, "SHUTTING_DOWN"}};
+void to_json(json& j, const NodeState& e) {
+  static_assert(std::is_enum<NodeState>::value, "NodeState must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(NodeState_enum_table),
+      std::end(NodeState_enum_table),
+      [e](const std::pair<NodeState, json>& ej_pair) -> bool {
+        return ej_pair.first == e;
+      });
+  j = ((it != std::end(NodeState_enum_table))
+           ? it
+           : std::begin(NodeState_enum_table))
+          ->second;
+}
+void from_json(const json& j, NodeState& e) {
+  static_assert(std::is_enum<NodeState>::value, "NodeState must be an enum!");
+  const auto* it = std::find_if(
+      std::begin(NodeState_enum_table),
+      std::end(NodeState_enum_table),
+      [&j](const std::pair<NodeState, json>& ej_pair) -> bool {
+        return ej_pair.second == j;
+      });
+  e = ((it != std::end(NodeState_enum_table))
+           ? it
+           : std::begin(NodeState_enum_table))
+          ->first;
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const NodeStats& p) {
+  j = json::object();
+  to_json_key(
+      j, "nodeState", p.nodeState, "NodeStats", "NodeState", "nodeState");
+  to_json_key(
+      j,
+      "loadMetrics",
+      p.loadMetrics,
+      "NodeStats",
+      "NodeLoadMetrics",
+      "loadMetrics");
+}
+
+void from_json(const json& j, NodeStats& p) {
+  from_json_key(
+      j, "nodeState", p.nodeState, "NodeStats", "NodeState", "nodeState");
+  from_json_key(
+      j,
+      "loadMetrics",
+      p.loadMetrics,
+      "NodeStats",
+      "NodeLoadMetrics",
+      "loadMetrics");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
 void to_json(json& j, const NodeVersion& p) {
   j = json::object();
   to_json_key(j, "version", p.version, "NodeVersion", "String", "version");
@@ -11567,41 +11709,5 @@ void from_json(const json& j, WindowNode& p) {
       "WindowNode",
       "int",
       "preSortedOrderPrefix");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
-
-// NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
-static const std::pair<NodeState, json> NodeState_enum_table[] =
-    { // NOLINT: cert-err58-cpp
-        {NodeState::ACTIVE, "ACTIVE"},
-        {NodeState::INACTIVE, "INACTIVE"},
-        {NodeState::SHUTTING_DOWN, "SHUTTING_DOWN"}};
-void to_json(json& j, const NodeState& e) {
-  static_assert(std::is_enum<NodeState>::value, "NodeState must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(NodeState_enum_table),
-      std::end(NodeState_enum_table),
-      [e](const std::pair<NodeState, json>& ej_pair) -> bool {
-        return ej_pair.first == e;
-      });
-  j = ((it != std::end(NodeState_enum_table))
-           ? it
-           : std::begin(NodeState_enum_table))
-          ->second;
-}
-void from_json(const json& j, NodeState& e) {
-  static_assert(std::is_enum<NodeState>::value, "NodeState must be an enum!");
-  const auto* it = std::find_if(
-      std::begin(NodeState_enum_table),
-      std::end(NodeState_enum_table),
-      [&j](const std::pair<NodeState, json>& ej_pair) -> bool {
-        return ej_pair.second == j;
-      });
-  e = ((it != std::end(NodeState_enum_table))
-           ? it
-           : std::begin(NodeState_enum_table))
-          ->first;
 }
 } // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1761,6 +1761,30 @@ void to_json(json& j, const MergeJoinNode& p);
 void from_json(const json& j, MergeJoinNode& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+struct NodeLoadMetrics {
+  double cpuUsedPercent = {};
+  double memoryUsedInBytes = {};
+  int numQueuedDrivers = {};
+  bool cpuOverload = {};
+  bool memoryOverload = {};
+};
+void to_json(json& j, const NodeLoadMetrics& p);
+void from_json(const json& j, NodeLoadMetrics& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+enum class NodeState { ACTIVE, INACTIVE, SHUTTING_DOWN };
+extern void to_json(json& j, const NodeState& e);
+extern void from_json(const json& j, NodeState& e);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct NodeStats {
+  NodeState nodeState = {};
+  std::shared_ptr<NodeLoadMetrics> loadMetrics = {};
+};
+void to_json(json& j, const NodeStats& p);
+void from_json(const json& j, NodeStats& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct NodeVersion {
   String version = {};
 };
@@ -2526,9 +2550,4 @@ struct WindowNode : public PlanNode {
 };
 void to_json(json& j, const WindowNode& p);
 void from_json(const json& j, WindowNode& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-enum class NodeState { ACTIVE, INACTIVE, SHUTTING_DOWN };
-extern void to_json(json& j, const NodeState& e);
-extern void from_json(const json& j, NodeState& e);
 } // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -42,9 +42,6 @@ ExtraFields:
   RemoteTransactionHandle:
     Optional<String>: dummy
 
-AddToOutput:
-  - NodeState
-
 AbstractClasses:
   ColumnHandle:
     super: JsonEncodedSubclass
@@ -345,3 +342,5 @@ JavaClasses:
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/BaseInputDistribution.java
   - presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInFunctionKind.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/NodeStats.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/NodeLoadMetrics.java

--- a/presto-spi/src/main/java/com/facebook/presto/spi/NodeLoadMetrics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/NodeLoadMetrics.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Load Statistics for a worker node in the Presto cluster along with the state.
+ */
+@ThriftStruct
+public class NodeLoadMetrics
+{
+    private final double cpuUsedPercent;
+    private final double memoryUsedInBytes;
+    private final int numQueuedDrivers;
+    private final boolean cpuOverload;
+    private final boolean memoryOverload;
+
+    @JsonCreator
+    @ThriftConstructor
+    public NodeLoadMetrics(
+            @JsonProperty("cpuUsedPercent") double cpuUsedPercent,
+            @JsonProperty("memoryUsedInBytes") double memoryUsedInBytes,
+            @JsonProperty("numQueuedDrivers") int numQueuedDrivers,
+            @JsonProperty("cpuOverload") boolean cpuOverload,
+            @JsonProperty("memoryOverload") boolean memoryOverload)
+    {
+        this.cpuUsedPercent = cpuUsedPercent;
+        this.memoryUsedInBytes = memoryUsedInBytes;
+        this.numQueuedDrivers = numQueuedDrivers;
+        this.cpuOverload = cpuOverload;
+        this.memoryOverload = memoryOverload;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public double getCpuUsedPercent()
+    {
+        return cpuUsedPercent;
+    }
+
+    @JsonProperty
+    @ThriftField(2)
+    public double getMemoryUsedInBytes()
+    {
+        return memoryUsedInBytes;
+    }
+
+    @JsonProperty
+    @ThriftField(3)
+    public int getNumQueuedDrivers()
+    {
+        return numQueuedDrivers;
+    }
+
+    @JsonProperty
+    @ThriftField(4)
+    public boolean getCpuOverload()
+    {
+        return cpuOverload;
+    }
+
+    @JsonProperty
+    @ThriftField(5)
+    public boolean getMemoryOverload()
+    {
+        return memoryOverload;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NodeLoadMetrics that = (NodeLoadMetrics) o;
+        return Double.compare(cpuUsedPercent, that.cpuUsedPercent) == 0 &&
+                Double.compare(memoryUsedInBytes, that.memoryUsedInBytes) == 0 &&
+                numQueuedDrivers == that.numQueuedDrivers &&
+                cpuOverload == that.cpuOverload &&
+                memoryOverload == that.memoryOverload;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(cpuUsedPercent, memoryUsedInBytes, numQueuedDrivers, cpuOverload, memoryOverload);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("NodeLoadMetrics{");
+        sb.append("cpuUsedPercent=").append(cpuUsedPercent);
+        sb.append(", memoryUsedInBytes=").append(memoryUsedInBytes);
+        sb.append(", numQueuedDrivers=").append(numQueuedDrivers);
+        sb.append(", cpuOverload=").append(cpuOverload);
+        sb.append(", memoryOverload=").append(memoryOverload);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/NodeStats.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/NodeStats.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Load Statistics for a node in the Presto cluster along with the state.
+ */
+@ThriftStruct
+public class NodeStats
+{
+    private final NodeState nodeState;
+    private final Optional<NodeLoadMetrics> loadMetrics;
+
+    @JsonCreator
+    @ThriftConstructor
+    public NodeStats(
+            @JsonProperty("nodeState") NodeState nodeState,
+            @JsonProperty("loadMetrics") Optional<NodeLoadMetrics> loadMetrics)
+    {
+        this.nodeState = requireNonNull(nodeState, "nodeState is null");
+        this.loadMetrics = loadMetrics;
+    }
+
+    @JsonProperty
+    @ThriftField(1)
+    public NodeState getNodeState()
+    {
+        return nodeState;
+    }
+
+    @JsonProperty
+    @ThriftField(2)
+    public Optional<NodeLoadMetrics> getLoadMetrics()
+    {
+        return loadMetrics;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NodeStats nodeStats = (NodeStats) o;
+        return Objects.equals(nodeState, nodeStats.nodeState) &&
+                Objects.equals(loadMetrics, nodeStats.loadMetrics);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(nodeState, loadMetrics);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("NodeStats{");
+        sb.append("nodeState=").append(nodeState);
+        sb.append(", loadMetrics=").append(loadMetrics);
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Summary:
Similar to cpp worker added the endpoint for java.
We won't be using the worker-load as going forward we will be focussing on cpp worker only

Differential Revision: D79471792


