### PR TITLE
[Coordinator throttling] Scheduling Policies for Admission Control based on worker load 

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/ClusterOverloadConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/ClusterOverloadConfig.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.configuration.Config;
+
+public class ClusterOverloadConfig
+{
+    public static final String OVERLOAD_POLICY_CNT_BASED = "overload_worker_cnt_based_throttling";
+    public static final String OVERLOAD_POLICY_PCT_BASED = "overload_worker_pct_based_throttling";
+    private boolean clusterOverloadThrottlingEnabled;
+    private double allowedOverloadWorkersPct = 0.01;
+    private int allowedOverloadWorkersCnt;
+    private String overloadPolicyType = OVERLOAD_POLICY_CNT_BASED;
+    private int overloadCheckCacheTtlInSecs = 5;
+
+    /**
+     * Gets the time-to-live for the cached cluster overload state.
+     * This determines how frequently the system will re-evaluate whether the cluster is overloaded.
+     *
+     * @return the cache TTL duration
+     */
+    public int getOverloadCheckCacheTtlInSecs()
+    {
+        return overloadCheckCacheTtlInSecs;
+    }
+
+    /**
+     * Gets the time-to-live for the cached cluster overload state.
+     * This determines how frequently the system will re-evaluate whether the cluster is overloaded.
+     *
+     * @return the cache TTL duration
+     */
+    public int getOverloadCheckCacheTtlMillis()
+    {
+        return overloadCheckCacheTtlInSecs * 1000;
+    }
+
+    /**
+     * Sets the time-to-live for the cached cluster overload state.
+     *
+     * @param overloadCheckCacheTtlInSecs the cache TTL duration
+     * @return this for chaining
+     */
+    @Config("cluster.overload-check-cache-ttl-secs")
+    public ClusterOverloadConfig setOverloadCheckCacheTtlInSecs(int overloadCheckCacheTtlInSecs)
+    {
+        this.overloadCheckCacheTtlInSecs = overloadCheckCacheTtlInSecs;
+        return this;
+    }
+
+    @Config("cluster-overload.enable-throttling")
+    public ClusterOverloadConfig setClusterOverloadThrottlingEnabled(boolean clusterOverloadThrottlingEnabled)
+    {
+        this.clusterOverloadThrottlingEnabled = clusterOverloadThrottlingEnabled;
+        return this;
+    }
+
+    public boolean isClusterOverloadThrottlingEnabled()
+    {
+        return this.clusterOverloadThrottlingEnabled;
+    }
+
+    @Config("cluster-overload.allowed-overload-workers-pct")
+    public ClusterOverloadConfig setAllowedOverloadWorkersPct(Double allowedOverloadWorkersPct)
+    {
+        this.allowedOverloadWorkersPct = allowedOverloadWorkersPct;
+        return this;
+    }
+
+    public double getAllowedOverloadWorkersPct()
+    {
+        return this.allowedOverloadWorkersPct;
+    }
+
+    @Config("cluster-overload.allowed-overload-workers-cnt")
+    public ClusterOverloadConfig setAllowedOverloadWorkersCnt(int allowedOverloadWorkersCnt)
+    {
+        this.allowedOverloadWorkersCnt = allowedOverloadWorkersCnt;
+        return this;
+    }
+
+    public double getAllowedOverloadWorkersCnt()
+    {
+        return this.allowedOverloadWorkersCnt;
+    }
+
+    @Config("cluster-overload.overload-policy-type")
+    public ClusterOverloadConfig setOverloadPolicyType(String overloadPolicyType)
+    {
+        // validate
+        this.overloadPolicyType = overloadPolicyType;
+        return this;
+    }
+
+    public String getOverloadPolicyType()
+    {
+        return this.overloadPolicyType;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -19,6 +19,8 @@ import com.facebook.airlift.units.Duration;
 import com.facebook.presto.execution.ManagedQueryExecution;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroup.RootInternalResourceGroup;
+import com.facebook.presto.execution.scheduler.clusterOverload.ClusterOverloadStateListener;
+import com.facebook.presto.execution.scheduler.clusterOverload.ClusterResourceChecker;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.resourcemanager.ResourceGroupService;
 import com.facebook.presto.server.ResourceGroupInfo;
@@ -81,7 +83,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @ThreadSafe
 public final class InternalResourceGroupManager<C>
-        implements ResourceGroupManager<C>
+        implements ResourceGroupManager<C>, ClusterOverloadStateListener
 {
     private static final Logger log = Logger.get(InternalResourceGroupManager.class);
     private static final File RESOURCE_GROUPS_CONFIGURATION = new File("etc/resource-groups.properties");
@@ -112,6 +114,7 @@ public final class InternalResourceGroupManager<C>
     private final QueryManagerConfig queryManagerConfig;
     private final InternalNodeManager nodeManager;
     private AtomicBoolean isConfigurationManagerLoaded;
+    private final ClusterResourceChecker clusterResourceChecker;
 
     @Inject
     public InternalResourceGroupManager(
@@ -121,7 +124,8 @@ public final class InternalResourceGroupManager<C>
             MBeanExporter exporter,
             ResourceGroupService resourceGroupService,
             ServerConfig serverConfig,
-            InternalNodeManager nodeManager)
+            InternalNodeManager nodeManager,
+            ClusterResourceChecker clusterResourceChecker)
     {
         this.queryManagerConfig = requireNonNull(queryManagerConfig, "queryManagerConfig is null");
         this.exporter = requireNonNull(exporter, "exporter is null");
@@ -137,6 +141,7 @@ public final class InternalResourceGroupManager<C>
         this.resourceGroupRuntimeExecutor = new PeriodicTaskExecutor(resourceGroupRuntimeInfoRefreshInterval.toMillis(), refreshExecutor, this::refreshResourceGroupRuntimeInfo);
         configurationManagerFactories.putIfAbsent(LegacyResourceGroupConfigurationManager.NAME, new LegacyResourceGroupConfigurationManager.Factory());
         this.isConfigurationManagerLoaded = new AtomicBoolean(false);
+        this.clusterResourceChecker = clusterResourceChecker;
     }
 
     @Override
@@ -254,6 +259,8 @@ public final class InternalResourceGroupManager<C>
     @PreDestroy
     public void destroy()
     {
+        // Unregister from cluster overload state changes
+        clusterResourceChecker.removeListener(this);
         refreshExecutor.shutdownNow();
         resourceGroupRuntimeExecutor.stop();
     }
@@ -275,6 +282,9 @@ public final class InternalResourceGroupManager<C>
             if (isResourceManagerEnabled) {
                 resourceGroupRuntimeExecutor.start();
             }
+
+            // Register as listener for cluster overload state changes
+            clusterResourceChecker.addListener(this);
         }
     }
 
@@ -396,7 +406,7 @@ public final class InternalResourceGroupManager<C>
             else {
                 RootInternalResourceGroup root;
                 if (!isResourceManagerEnabled) {
-                    root = new RootInternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor, ignored -> Optional.empty(), rg -> false, nodeManager);
+                    root = new RootInternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor, ignored -> Optional.empty(), rg -> false, nodeManager, clusterResourceChecker);
                 }
                 else {
                     root = new RootInternalResourceGroup(
@@ -409,7 +419,8 @@ public final class InternalResourceGroupManager<C>
                                     resourceGroupRuntimeInfosSnapshot::get,
                                     lastUpdatedResourceGroupRuntimeInfo::get,
                                     concurrencyThreshold),
-                            nodeManager);
+                            nodeManager,
+                            clusterResourceChecker);
                 }
                 group = root;
                 rootGroups.add(root);
@@ -461,6 +472,24 @@ public final class InternalResourceGroupManager<C>
         }
 
         return queriesQueuedInternal;
+    }
+
+    @Override
+    public void onClusterEnteredOverloadedState()
+    {
+        // Resource groups will handle overload state through their existing admission control logic
+        // No additional action needed here as queries will be queued automatically
+    }
+
+    @Override
+    public void onClusterExitedOverloadedState()
+    {
+        log.info("Cluster exited overloaded state, updating eligibility for all resource groups");
+        for (RootInternalResourceGroup rootGroup : rootGroups) {
+            synchronized (rootGroup) {
+                rootGroup.updateEligibilityRecursively(rootGroup);
+            }
+        }
     }
 
     @Managed

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterOverloadPolicy.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterOverloadPolicy.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.execution.scheduler.clusterOverload;
+
+import com.facebook.presto.metadata.InternalNodeManager;
+
+/**
+ * Interface for policies that determine if cluster is overloaded.
+ * Implementations can check various metrics from NodeStats to determine
+ * if a worker is overloaded and queries should be throttled.
+ */
+public interface ClusterOverloadPolicy
+{
+    /**
+     * Checks if cluster is overloaded.
+     *
+     * @param nodeManager The node manager to get node information
+     * @return true if cluster is overloaded, false otherwise
+     */
+    boolean isClusterOverloaded(InternalNodeManager nodeManager);
+
+    /**
+     * Gets the name of the policy.
+     *
+     * @return The name of the policy
+     */
+    String getName();
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterOverloadPolicyFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterOverloadPolicyFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.clusterOverload;
+
+import com.google.common.collect.ImmutableMap;
+import jakarta.inject.Inject;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Factory for creating ClusterOverloadPolicy instances.
+ * This allows for extensible policy creation based on configuration.
+ */
+public class ClusterOverloadPolicyFactory
+{
+    private final Map<String, ClusterOverloadPolicy> policies;
+
+    @Inject
+    public ClusterOverloadPolicyFactory(ClusterOverloadPolicy clusterOverloadPolicy)
+    {
+        requireNonNull(clusterOverloadPolicy, "clusterOverloadPolicy is null");
+
+        // Register available policies
+        ImmutableMap.Builder<String, ClusterOverloadPolicy> policiesBuilder = ImmutableMap.builder();
+
+        // Add the default overload policy - use the injected instance
+        policiesBuilder.put(clusterOverloadPolicy.getName(), clusterOverloadPolicy);
+
+        // Add more policies here as they are implemented
+        this.policies = policiesBuilder.build();
+    }
+
+    /**
+     * Get a policy by name.
+     *
+     * @param name The name of the policy to get
+     * @return The policy, or empty if no policy with that name exists
+     */
+    public Optional<ClusterOverloadPolicy> getPolicy(String name)
+    {
+        return Optional.ofNullable(policies.get(name));
+    }
+
+    /**
+     * Get the default policy.
+     *
+     * @return The default policy
+     */
+    public ClusterOverloadPolicy getDefaultPolicy()
+    {
+        // Default to CPU/Memory policy
+        return policies.get("cpu-memory-overload");
+    }
+
+    /**
+     * Get all available policies.
+     *
+     * @return Map of policy name to policy
+     */
+    public Map<String, ClusterOverloadPolicy> getPolicies()
+    {
+        return policies;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterOverloadPolicyModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterOverloadPolicyModule.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.clusterOverload;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.execution.ClusterOverloadConfig;
+import com.google.inject.Binder;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.inject.Scopes.SINGLETON;
+
+/**
+ * Provides bindings for the node overload policy and cluster resource checker.
+ */
+public class ClusterOverloadPolicyModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        // Bind the default node overload policy
+        binder.bind(ClusterOverloadPolicy.class).to(CpuMemoryOverloadPolicy.class).in(SINGLETON);
+
+        // Bind the node overload policy factory
+        binder.bind(ClusterOverloadPolicyFactory.class).in(SINGLETON);
+
+        // Bind the cluster resource checker
+        binder.bind(ClusterResourceChecker.class).in(SINGLETON);
+
+        // Bind the cluster overload config
+        configBinder(binder).bindConfig(ClusterOverloadConfig.class);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterOverloadStateListener.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterOverloadStateListener.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.clusterOverload;
+
+/**
+ * Listener interface for receiving notifications about cluster overload state changes.
+ * This interface allows components to react to changes in cluster capacity and
+ * resource availability, particularly when the cluster transitions from an overloaded
+ * state back to a normal state.
+ */
+public interface ClusterOverloadStateListener
+{
+    /**
+     * Called when the cluster enters an overloaded state.
+     * This indicates that the cluster resources are under stress and
+     * new query admissions should be restricted.
+     */
+    void onClusterEnteredOverloadedState();
+
+    /**
+     * Called when the cluster exits the overloaded state.
+     * This indicates that cluster resources have recovered and
+     * normal query processing can resume.
+     */
+    void onClusterExitedOverloadedState();
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterResourceChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/ClusterResourceChecker.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.clusterOverload;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.CounterStat;
+import com.facebook.airlift.stats.TimeStat;
+import com.facebook.presto.execution.ClusterOverloadConfig;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.google.errorprone.annotations.ThreadSafe;
+import com.google.inject.Singleton;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+/**
+ * Provides methods to check if more queries can be run on the cluster
+ * based on various resource constraints.
+ */
+@Singleton
+@ThreadSafe
+public class ClusterResourceChecker
+{
+    private static final Logger log = Logger.get(ClusterResourceChecker.class);
+
+    private final ClusterOverloadPolicy clusterOverloadPolicy;
+    private final ClusterOverloadConfig config;
+    private final AtomicBoolean cachedOverloadState = new AtomicBoolean(false);
+    private final AtomicLong lastCheckTimeMillis = new AtomicLong(0);
+    private final CounterStat overloadDetectionCount = new CounterStat();
+    private final TimeStat timeSinceLastCheck = new TimeStat();
+    private final AtomicLong overloadStartTimeMillis = new AtomicLong(0);
+    private final CopyOnWriteArrayList<ClusterOverloadStateListener> listeners = new CopyOnWriteArrayList<>();
+
+    private final ScheduledExecutorService overloadCheckerExecutor;
+    private final InternalNodeManager nodeManager;
+
+    @Inject
+    public ClusterResourceChecker(ClusterOverloadPolicy clusterOverloadPolicy, ClusterOverloadConfig config, InternalNodeManager nodeManager)
+    {
+        this.clusterOverloadPolicy = requireNonNull(clusterOverloadPolicy, "clusterOverloadPolicy is null");
+        this.config = requireNonNull(config, "config is null");
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.overloadCheckerExecutor = newSingleThreadScheduledExecutor(threadsNamed("cluster-overload-checker-%s"));
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        if (config.isClusterOverloadThrottlingEnabled()) {
+            long checkIntervalMillis = Math.max(1000, config.getOverloadCheckCacheTtlInSecs() * 1000L);
+            overloadCheckerExecutor.scheduleWithFixedDelay(() -> {
+                try {
+                    performPeriodicOverloadCheck();
+                }
+                catch (Exception e) {
+                    log.error(e, "Error polling cluster overload state");
+                }
+            }, checkIntervalMillis, checkIntervalMillis, TimeUnit.MILLISECONDS);
+            log.info("Started periodic cluster overload checker with interval: %d milliseconds", checkIntervalMillis);
+            // Perform initial check
+            performPeriodicOverloadCheck();
+        }
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        overloadCheckerExecutor.shutdownNow();
+    }
+
+    /**
+     * Registers a listener to be notified when the cluster exits the overloaded state.
+     *
+     * @param listener the listener to register
+     */
+    public void addListener(ClusterOverloadStateListener listener)
+    {
+        requireNonNull(listener, "listener is null");
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes a previously registered listener.
+     *
+     * @param listener the listener to remove
+     */
+    public void removeListener(ClusterOverloadStateListener listener)
+    {
+        listeners.remove(listener);
+    }
+
+    /**
+     * Performs a periodic check of cluster overload state.
+     * This method is called by the periodic task when throttling is enabled.
+     * Updates JMX metrics and notifies listeners when cluster exits overloaded state.
+     */
+    private void performPeriodicOverloadCheck()
+    {
+        try {
+            long currentTimeMillis = System.currentTimeMillis();
+            long lastCheckTime = lastCheckTimeMillis.get();
+
+            if (lastCheckTime > 0) {
+                timeSinceLastCheck.add(currentTimeMillis - lastCheckTime, TimeUnit.MILLISECONDS);
+            }
+
+            boolean isOverloaded = clusterOverloadPolicy.isClusterOverloaded(nodeManager);
+            synchronized (this) {
+                boolean wasOverloaded = cachedOverloadState.getAndSet(isOverloaded);
+                lastCheckTimeMillis.set(currentTimeMillis);
+
+                if (isOverloaded && !wasOverloaded) {
+                    overloadDetectionCount.update(1);
+                    overloadStartTimeMillis.set(currentTimeMillis);
+                    log.info("Cluster entered overloaded state via periodic check");
+                }
+                else if (!isOverloaded && wasOverloaded) {
+                    long overloadDuration = currentTimeMillis - overloadStartTimeMillis.get();
+                    log.info("Cluster exited overloaded state after %d ms via periodic check", overloadDuration);
+                    overloadStartTimeMillis.set(0);
+                    // Notify listeners that cluster exited overload state
+                    notifyClusterExitedOverloadedState();
+                }
+            }
+
+            log.debug("Periodic overload check completed: %s", isOverloaded ? "OVERLOADED" : "NOT OVERLOADED");
+        }
+        catch (Exception e) {
+            log.error(e, "Error during periodic cluster overload check");
+        }
+    }
+
+    /**
+     * Returns the current overload state of the cluster.
+     * @return true if cluster is overloaded, false otherwise
+     */
+    public boolean isClusterCurrentlyOverloaded()
+    {
+        if (!config.isClusterOverloadThrottlingEnabled()) {
+            return false;
+        }
+
+        return cachedOverloadState.get();
+    }
+
+    /**
+     * Notifies all registered listeners that the cluster has exited the overloaded state.
+     */
+    private void notifyClusterExitedOverloadedState()
+    {
+        for (ClusterOverloadStateListener listener : listeners) {
+            listener.onClusterExitedOverloadedState();
+        }
+    }
+
+    /**
+     * Returns whether cluster overload throttling is enabled.
+     * When disabled, the cluster overload check will be bypassed.
+     *
+     * @return true if throttling is enabled, false otherwise
+     */
+    @Managed
+    public boolean isClusterOverloadThrottlingEnabled()
+    {
+        return config.isClusterOverloadThrottlingEnabled();
+    }
+
+    /**
+     * Returns whether the cluster is currently in an overloaded state.
+     * This is exposed as a JMX metric for monitoring.
+     *
+     * @return true if the cluster is overloaded, false otherwise
+     */
+    @Managed
+    public boolean isClusterOverloaded()
+    {
+        return cachedOverloadState.get();
+    }
+
+    /**
+     * Returns the number of times the cluster has entered an overloaded state.
+     *
+     * @return counter of overload detections
+     */
+    @Managed
+    @Nested
+    public CounterStat getOverloadDetectionCount()
+    {
+        return overloadDetectionCount;
+    }
+
+    /**
+     * Returns statistics about the time between overload checks.
+     *
+     * @return time statistics for overload checks
+     */
+    @Managed
+    @Nested
+    public TimeStat getTimeSinceLastCheck()
+    {
+        return timeSinceLastCheck;
+    }
+
+    /**
+     * Returns the duration in milliseconds that the cluster has been in an overloaded state.
+     * Returns 0 if the cluster is not currently overloaded.
+     *
+     * Note: This method reads two atomic fields but doesn't need synchronization because:
+     * 1. Single writer (periodic task) ensures consistent updates
+     * 2. Atomic fields provide memory visibility guarantees
+     * 3. Slight inconsistency in edge cases is acceptable for monitoring metrics
+     *
+     * @return duration in milliseconds of current overload state
+     */
+    @Managed
+    public long getOverloadDurationMillis()
+    {
+        long startTime = overloadStartTimeMillis.get();
+        if (startTime == 0 || !cachedOverloadState.get()) {
+            return 0;
+        }
+        return System.currentTimeMillis() - startTime;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/CpuMemoryOverloadPolicy.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/clusterOverload/CpuMemoryOverloadPolicy.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.execution.scheduler.clusterOverload;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.execution.ClusterOverloadConfig;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.spi.NodeLoadMetrics;
+import jakarta.inject.Inject;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.spi.NodeState.ACTIVE;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A policy that checks if cluster is overloaded based on CPU or memory metrics.
+ * Supports two modes of operation:
+ * - Percentage-based: Checks if the percentage of overloaded workers exceeds a threshold
+ * - Count-based: Checks if the absolute count of overloaded workers exceeds a threshold
+ */
+public class CpuMemoryOverloadPolicy
+        implements ClusterOverloadPolicy
+{
+    private static final Logger log = Logger.get(CpuMemoryOverloadPolicy.class);
+
+    private final double allowedOverloadWorkersPct;
+    private final double allowedOverloadWorkersCnt;
+    private final String policyType;
+
+    @Inject
+    public CpuMemoryOverloadPolicy(ClusterOverloadConfig config)
+    {
+        this.allowedOverloadWorkersPct = config.getAllowedOverloadWorkersPct();
+        this.allowedOverloadWorkersCnt = config.getAllowedOverloadWorkersCnt();
+        this.policyType = requireNonNull(config.getOverloadPolicyType(), "policyType is null");
+    }
+
+    @Override
+    public boolean isClusterOverloaded(InternalNodeManager nodeManager)
+    {
+        Set<InternalNode> activeNodes = nodeManager.getNodes(ACTIVE);
+        if (activeNodes.isEmpty()) {
+            return false;
+        }
+
+        OverloadStats stats = collectOverloadStats(activeNodes, nodeManager);
+        return evaluateOverload(stats, activeNodes.size());
+    }
+
+    private OverloadStats collectOverloadStats(Set<InternalNode> activeNodes, InternalNodeManager nodeManager)
+    {
+        Set<String> overloadedNodeIds = new HashSet<>();
+        int overloadedWorkersCnt = 0;
+
+        for (InternalNode node : activeNodes) {
+            Optional<NodeLoadMetrics> metricsOptional = nodeManager.getNodeLoadMetrics(node.getNodeIdentifier());
+            String nodeId = node.getNodeIdentifier();
+
+            if (!metricsOptional.isPresent()) {
+                continue;
+            }
+
+            NodeLoadMetrics metrics = metricsOptional.get();
+
+            // Check for CPU overload
+            if (metrics.getCpuOverload()) {
+                overloadedNodeIds.add(String.format("%s (CPU overloaded)", nodeId));
+                overloadedWorkersCnt++;
+                continue;
+            }
+
+            // Check for memory overload
+            if (metrics.getMemoryOverload()) {
+                overloadedNodeIds.add(String.format("%s (Memory overloaded)", nodeId));
+                overloadedWorkersCnt++;
+            }
+        }
+
+        return new OverloadStats(overloadedNodeIds, overloadedWorkersCnt);
+    }
+
+    private boolean evaluateOverload(OverloadStats stats, int totalNodes)
+    {
+        boolean isOverloaded;
+
+        if (ClusterOverloadConfig.OVERLOAD_POLICY_PCT_BASED.equals(policyType)) {
+            double overloadedWorkersPct = (double) stats.getOverloadedWorkersCnt() / totalNodes;
+            isOverloaded = overloadedWorkersPct > allowedOverloadWorkersPct;
+
+            if (isOverloaded) {
+                logOverload(
+                        String.format("%s%% of workers are overloaded (threshold: %s%%)",
+                                format("%.2f", overloadedWorkersPct * 100),
+                                format("%.2f", allowedOverloadWorkersPct * 100)),
+                        stats.getOverloadedNodeIds());
+            }
+        }
+        else if (ClusterOverloadConfig.OVERLOAD_POLICY_CNT_BASED.equals(policyType)) {
+            isOverloaded = stats.getOverloadedWorkersCnt() > allowedOverloadWorkersCnt;
+
+            if (isOverloaded) {
+                logOverload(
+                        String.format("%s workers are overloaded (threshold: %s workers)",
+                                stats.getOverloadedWorkersCnt(), allowedOverloadWorkersCnt),
+                        stats.getOverloadedNodeIds());
+            }
+        }
+        else {
+            throw new IllegalStateException("Unknown cluster overload policy type: " + policyType);
+        }
+
+        return isOverloaded;
+    }
+
+    private void logOverload(String message, Set<String> overloadedNodeIds)
+    {
+        log.warn("Cluster is overloaded: " + message);
+        if (!overloadedNodeIds.isEmpty()) {
+            log.warn("Overloaded nodes: %s", String.join(", ", overloadedNodeIds));
+        }
+    }
+
+    @Override
+    public String getName()
+    {
+        return "cpu-memory-overload-" +
+                (ClusterOverloadConfig.OVERLOAD_POLICY_PCT_BASED.equals(policyType) ? "pct" : "cnt");
+    }
+
+    // Helper class to encapsulate overload statistics
+    private static class OverloadStats
+    {
+        private final Set<String> overloadedNodeIds;
+        private final int overloadedWorkersCnt;
+
+        public OverloadStats(Set<String> overloadedNodeIds, int overloadedWorkersCnt)
+        {
+            this.overloadedNodeIds = overloadedNodeIds;
+            this.overloadedWorkersCnt = overloadedWorkersCnt;
+        }
+
+        public Set<String> getOverloadedNodeIds()
+        {
+            return overloadedNodeIds;
+        }
+
+        public int getOverloadedWorkersCnt()
+        {
+            return overloadedWorkersCnt;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/InMemoryNodeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/InMemoryNodeManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.NodeLoadMetrics;
 import com.facebook.presto.spi.NodeState;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -27,6 +28,7 @@ import jakarta.inject.Inject;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -178,5 +180,11 @@ public class InMemoryNodeManager
     public synchronized void removeNodeChangeListener(Consumer<AllNodes> listener)
     {
         listeners.remove(requireNonNull(listener, "listener is null"));
+    }
+
+    @Override
+    public Optional<NodeLoadMetrics> getNodeLoadMetrics(String nodeIdentifier)
+    {
+        return Optional.empty();
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/InternalNodeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/InternalNodeManager.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.NodeLoadMetrics;
 import com.facebook.presto.spi.NodeState;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -46,4 +48,6 @@ public interface InternalNodeManager
     void addNodeChangeListener(Consumer<AllNodes> listener);
 
     void removeNodeChangeListener(Consumer<AllNodes> listener);
+
+    Optional<NodeLoadMetrics> getNodeLoadMetrics(String nodeIdentifier);
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/RemoteNodeStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/RemoteNodeStats.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.NodeStats;
+
+import java.util.Optional;
+
+/**
+ * Interface for retrieving statistics from remote nodes in a Presto cluster.
+ * <p>
+ * This interface provides a mechanism to asynchronously fetch and cache node statistics
+ * from remote Presto worker nodes. Implementations handle the communication protocol
+ * details (HTTP, Thrift, etc.) and provide a unified way to access node health and
+ * performance metrics.
+ * <p>
+ * The interface supports lazy loading and caching of node statistics to minimize
+ * network overhead while ensuring that cluster management components have access
+ * to current node state information for scheduling and health monitoring decisions.
+ */
+public interface RemoteNodeStats
+{
+    /**
+     * Returns the cached node statistics if available.
+     * <p>
+     * This method returns the most recently fetched statistics for the remote node.
+     * If no statistics have been fetched yet or if the last fetch failed, this
+     * method returns an empty Optional.
+     *
+     * @return an Optional containing the node statistics if available, empty otherwise
+     */
+    Optional<NodeStats> getNodeStats();
+
+    /**
+     * Triggers an asynchronous refresh of the node statistics.
+     * <p>
+     * This method initiates a background request to fetch the latest statistics
+     * from the remote node. The operation is non-blocking and the results will
+     * be available through subsequent calls to {@link #getNodeStats()}.
+     * <p>
+     * Implementations should handle network failures gracefully and avoid
+     * overwhelming the remote node with excessive requests.
+     */
+    void asyncRefresh();
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/ThriftRemoteNodeStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/ThriftRemoteNodeStats.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.units.Duration;
+import com.facebook.drift.client.DriftClient;
+import com.facebook.presto.server.thrift.ThriftServerInfoClient;
+import com.facebook.presto.spi.NodeState;
+import com.facebook.presto.spi.NodeStats;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.errorprone.annotations.ThreadSafe;
+import jakarta.annotation.Nullable;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.airlift.units.Duration.nanosSince;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@ThreadSafe
+public class ThriftRemoteNodeStats
+        implements RemoteNodeStats
+{
+    private static final Logger log = Logger.get(ThriftRemoteNodeStats.class);
+
+    private final ThriftServerInfoClient thriftClient;
+    private final long refreshIntervalMillis;
+    private final AtomicReference<Optional<NodeStats>> nodeStats = new AtomicReference<>(Optional.empty());
+    private final AtomicBoolean requestInflight = new AtomicBoolean();
+    private final AtomicLong lastUpdateNanos = new AtomicLong();
+    private final URI stateInfoUri;
+    private final AtomicLong lastWarningLogged = new AtomicLong();
+
+    public ThriftRemoteNodeStats(DriftClient<ThriftServerInfoClient> thriftClient, URI stateInfoUri, long refreshIntervalMillis)
+    {
+        requireNonNull(stateInfoUri, "stateInfoUri is null");
+        checkArgument(stateInfoUri.getScheme().equals("thrift"), "unexpected scheme %s", stateInfoUri.getScheme());
+
+        this.stateInfoUri = stateInfoUri;
+        this.refreshIntervalMillis = refreshIntervalMillis;
+        this.thriftClient = requireNonNull(thriftClient, "thriftClient is null").get(Optional.of(stateInfoUri.getAuthority()));
+    }
+
+    @Override
+    public Optional<NodeStats> getNodeStats()
+    {
+        return nodeStats.get();
+    }
+
+    @Override
+    public void asyncRefresh()
+    {
+        Duration sinceUpdate = nanosSince(lastUpdateNanos.get());
+        if (nanosSince(lastWarningLogged.get()).toMillis() > 1_000 &&
+                sinceUpdate.toMillis() > 10_000 &&
+                requestInflight.get()) {
+            log.warn("Node state update request to %s has not returned in %s", stateInfoUri, sinceUpdate.toString(SECONDS));
+            lastWarningLogged.set(System.nanoTime());
+        }
+
+        if (sinceUpdate.toMillis() > refreshIntervalMillis && requestInflight.compareAndSet(false, true)) {
+            ListenableFuture<Integer> responseFuture = thriftClient.getServerState();
+
+            Futures.addCallback(responseFuture, new FutureCallback<Integer>()
+            {
+                @Override
+                public void onSuccess(@Nullable Integer result)
+                {
+                    lastUpdateNanos.set(System.nanoTime());
+                    requestInflight.compareAndSet(true, false);
+                    if (result != null) {
+                        NodeStats nodeStats1 = new NodeStats(NodeState.valueOf(result), null);
+                        nodeStats.set(Optional.of(nodeStats1));
+                    }
+                    else {
+                        log.warn("Node statistics endpoint %s returned null response, using cached statistics", stateInfoUri);
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    log.error("Error fetching node stats from %s: %s", stateInfoUri, t.getMessage());
+                    lastUpdateNanos.set(System.nanoTime());
+                    requestInflight.compareAndSet(true, false);
+                }
+            }, directExecutor());
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/InternalCommunicationConfig.java
@@ -49,6 +49,8 @@ public class InternalCommunicationConfig
     private CommunicationProtocol serverInfoCommunicationProtocol = CommunicationProtocol.HTTP;
     private boolean memoizeDeadNodesEnabled;
     private String sharedSecret;
+    private long nodeStatsRefreshIntervalMillis = 1_000;
+    private long nodeDiscoveryPollingIntervalMillis = 5_000;
 
     private boolean internalJwtEnabled;
 
@@ -309,6 +311,32 @@ public class InternalCommunicationConfig
     public InternalCommunicationConfig setSharedSecret(String sharedSecret)
     {
         this.sharedSecret = sharedSecret;
+        return this;
+    }
+
+    public long getNodeStatsRefreshIntervalMillis()
+    {
+        return nodeStatsRefreshIntervalMillis;
+    }
+
+    @Config("internal-communication.node-stats-refresh-interval-millis")
+    @ConfigDescription("Interval in milliseconds for refreshing node statistics")
+    public InternalCommunicationConfig setNodeStatsRefreshIntervalMillis(long nodeStatsRefreshIntervalMillis)
+    {
+        this.nodeStatsRefreshIntervalMillis = nodeStatsRefreshIntervalMillis;
+        return this;
+    }
+
+    public long getNodeDiscoveryPollingIntervalMillis()
+    {
+        return nodeDiscoveryPollingIntervalMillis;
+    }
+
+    @Config("internal-communication.node-discovery-polling-interval-millis")
+    @ConfigDescription("Interval in milliseconds for polling node discovery and refreshing node states")
+    public InternalCommunicationConfig setNodeDiscoveryPollingIntervalMillis(long nodeDiscoveryPollingIntervalMillis)
+    {
+        this.nodeDiscoveryPollingIntervalMillis = nodeDiscoveryPollingIntervalMillis;
         return this;
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestClusterOverloadConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestClusterOverloadConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.execution.ClusterOverloadConfig.OVERLOAD_POLICY_CNT_BASED;
+
+public class TestClusterOverloadConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(ClusterOverloadConfig.class)
+                .setClusterOverloadThrottlingEnabled(false)
+                .setAllowedOverloadWorkersPct(0.01)
+                .setAllowedOverloadWorkersCnt(0)
+                .setOverloadPolicyType(OVERLOAD_POLICY_CNT_BASED)
+                .setOverloadCheckCacheTtlInSecs(5));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("cluster-overload.enable-throttling", "true")
+                .put("cluster-overload.allowed-overload-workers-pct", "0.05")
+                .put("cluster-overload.allowed-overload-workers-cnt", "5")
+                .put("cluster-overload.overload-policy-type", "overload_worker_pct_based_throttling")
+                .put("cluster.overload-check-cache-ttl-secs", "10")
+                .build();
+
+        ClusterOverloadConfig expected = new ClusterOverloadConfig()
+                .setClusterOverloadThrottlingEnabled(true)
+                .setAllowedOverloadWorkersPct(0.05)
+                .setAllowedOverloadWorkersCnt(5)
+                .setOverloadPolicyType("overload_worker_pct_based_throttling")
+                .setOverloadCheckCacheTtlInSecs(10);
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/resourceGroups/TestInternalResourceGroupManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/resourceGroups/TestInternalResourceGroupManager.java
@@ -15,8 +15,11 @@
 package com.facebook.presto.execution.resourceGroups;
 
 import com.facebook.airlift.node.NodeInfo;
+import com.facebook.presto.execution.ClusterOverloadConfig;
 import com.facebook.presto.execution.MockManagedQueryExecution;
 import com.facebook.presto.execution.QueryManagerConfig;
+import com.facebook.presto.execution.scheduler.clusterOverload.ClusterResourceChecker;
+import com.facebook.presto.execution.scheduler.clusterOverload.CpuMemoryOverloadPolicy;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.spi.PrestoException;
@@ -32,8 +35,7 @@ public class TestInternalResourceGroupManager
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = ".*Presto server is still initializing.*")
     public void testQueryFailsWithInitializingConfigurationManager()
     {
-        InternalResourceGroupManager<ImmutableMap<Object, Object>> internalResourceGroupManager = new InternalResourceGroupManager<>((poolId, listener) -> {},
-                new QueryManagerConfig(), new NodeInfo("test"), new MBeanExporter(new TestingMBeanServer()), () -> null, new ServerConfig(), new InMemoryNodeManager());
+        InternalResourceGroupManager<ImmutableMap<Object, Object>> internalResourceGroupManager = new InternalResourceGroupManager<>((poolId, listener) -> {}, new QueryManagerConfig(), new NodeInfo("test"), new MBeanExporter(new TestingMBeanServer()), () -> null, new ServerConfig(), new InMemoryNodeManager(), new ClusterResourceChecker(new CpuMemoryOverloadPolicy(new ClusterOverloadConfig()), new ClusterOverloadConfig(), new InMemoryNodeManager()));
         internalResourceGroupManager.submit(new MockManagedQueryExecution(0), new SelectionContext<>(new ResourceGroupId("global"), ImmutableMap.of()), command -> {});
     }
 
@@ -42,7 +44,7 @@ public class TestInternalResourceGroupManager
             throws Exception
     {
         InternalResourceGroupManager<ImmutableMap<Object, Object>> internalResourceGroupManager = new InternalResourceGroupManager<>((poolId, listener) -> {},
-                new QueryManagerConfig(), new NodeInfo("test"), new MBeanExporter(new TestingMBeanServer()), () -> null, new ServerConfig(), new InMemoryNodeManager());
+                new QueryManagerConfig(), new NodeInfo("test"), new MBeanExporter(new TestingMBeanServer()), () -> null, new ServerConfig(), new InMemoryNodeManager(), new ClusterResourceChecker(new CpuMemoryOverloadPolicy(new ClusterOverloadConfig()), new ClusterOverloadConfig(), new InMemoryNodeManager()));
         internalResourceGroupManager.loadConfigurationManager();
         internalResourceGroupManager.submit(new MockManagedQueryExecution(0), new SelectionContext<>(new ResourceGroupId("global"), ImmutableMap.of()), command -> {});
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -15,8 +15,11 @@ package com.facebook.presto.execution.resourceGroups;
 
 import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
+import com.facebook.presto.execution.ClusterOverloadConfig;
 import com.facebook.presto.execution.MockManagedQueryExecution;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroup.RootInternalResourceGroup;
+import com.facebook.presto.execution.scheduler.clusterOverload.ClusterOverloadPolicy;
+import com.facebook.presto.execution.scheduler.clusterOverload.ClusterResourceChecker;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
@@ -69,7 +72,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testQueueFull()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(1);
         root.setHardConcurrencyLimit(1);
@@ -91,7 +94,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testFairEligibility()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
@@ -151,7 +154,7 @@ public class TestResourceGroups
     @Test
     public void testSetSchedulingPolicy()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
@@ -197,7 +200,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testFairQueuing()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
@@ -243,7 +246,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testMemoryLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
@@ -271,7 +274,7 @@ public class TestResourceGroups
     @Test
     public void testSubgroupMemoryLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(10, BYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
@@ -304,7 +307,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testSoftCpuLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setSoftCpuLimit(new Duration(1, SECONDS));
         root.setHardCpuLimit(new Duration(2, SECONDS));
@@ -341,7 +344,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testPerWorkerQueryLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setWorkersPerQueryLimit(5);
         root.setMaxQueuedQueries(2);
         root.setHardConcurrencyLimit(2);
@@ -374,7 +377,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testPerWorkerQueryLimitMultipleGroups()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setWorkersPerQueryLimit(5);
         root.setMaxQueuedQueries(5);
         root.setHardConcurrencyLimit(2);
@@ -417,7 +420,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testHardCpuLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setHardCpuLimit(new Duration(1, SECONDS));
         root.setCpuQuotaGenerationMillisPerSecond(2000);
@@ -444,7 +447,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testPriorityScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(100);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -494,7 +497,7 @@ public class TestResourceGroups
     @Test(timeOut = 20_000)
     public void testWeightedScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -543,7 +546,7 @@ public class TestResourceGroups
     @Test(timeOut = 30_000)
     public void testWeightedFairScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -586,7 +589,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedFairSchedulingEqualWeights()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -645,7 +648,7 @@ public class TestResourceGroups
     @Test(timeOut = 20_000)
     public void testWeightedFairSchedulingNoStarvation()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -686,7 +689,7 @@ public class TestResourceGroups
     @Test
     public void testGetInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(40);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -776,7 +779,7 @@ public class TestResourceGroups
     @Test
     public void testGetResourceGroupStateInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, GIGABYTE));
         root.setMaxQueuedQueries(40);
         root.setHardConcurrencyLimit(10);
@@ -844,7 +847,7 @@ public class TestResourceGroups
     @Test
     public void testGetStaticResourceGroupInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, GIGABYTE));
         root.setMaxQueuedQueries(100);
         root.setHardConcurrencyLimit(10);
@@ -921,7 +924,7 @@ public class TestResourceGroups
     @Test
     public void testGetBlockedQueuedQueries()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), ignored -> Optional.empty(), rg -> false, createNodeManager(), createClusterResourceChecker());
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(40);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -1071,5 +1074,28 @@ public class TestResourceGroups
                         false,
                         false));
         return internalNodeManager;
+    }
+
+    private ClusterResourceChecker createClusterResourceChecker()
+    {
+        ClusterOverloadPolicy mockPolicy = new ClusterOverloadPolicy()
+        {
+            @Override
+            public boolean isClusterOverloaded(InternalNodeManager nodeManager)
+            {
+                return false;
+            }
+
+            @Override
+            public String getName()
+            {
+                return "test-policy";
+            }
+        };
+
+        ClusterOverloadConfig config = new ClusterOverloadConfig()
+                .setClusterOverloadThrottlingEnabled(false);
+
+        return new ClusterResourceChecker(mockPolicy, config, createNodeManager());
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/clusterOverload/TestClusterResourceChecker.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/clusterOverload/TestClusterResourceChecker.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.clusterOverload;
+
+import com.facebook.presto.execution.ClusterOverloadConfig;
+import com.facebook.presto.metadata.AllNodes;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.NodeLoadMetrics;
+import com.facebook.presto.spi.NodeState;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestClusterResourceChecker
+{
+    private static final int CACHE_TTL_SECS = 1;
+    private static final int SLEEP_BUFFER_MILLIS = 200;
+
+    private ClusterOverloadConfig config;
+    private TestingClusterOverloadPolicy clusterOverloadPolicy;
+    private ClusterResourceChecker clusterResourceChecker;
+    private TestingInternalNodeManager nodeManager;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        config = new ClusterOverloadConfig()
+                .setOverloadCheckCacheTtlInSecs(CACHE_TTL_SECS)
+                .setClusterOverloadThrottlingEnabled(true);
+
+        clusterOverloadPolicy = new TestingClusterOverloadPolicy();
+        nodeManager = new TestingInternalNodeManager();
+
+        clusterResourceChecker = new ClusterResourceChecker(clusterOverloadPolicy, config, nodeManager);
+    }
+
+    public void testInitialState()
+    {
+        assertFalse(clusterResourceChecker.isClusterOverloaded());
+        assertEquals(clusterResourceChecker.getOverloadDetectionCount().getTotalCount(), 0);
+        assertEquals(clusterResourceChecker.getOverloadDurationMillis(), 0);
+        assertTrue(clusterResourceChecker.isClusterOverloadThrottlingEnabled());
+    }
+
+    @Test
+    public void testIsClusterCurrentlyOverloaded()
+    {
+        // Start the periodic task
+        clusterResourceChecker.start();
+
+        // Initially not overloaded
+        clusterOverloadPolicy.setOverloaded(false);
+        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded());
+
+        // Wait for periodic check to update state
+        clusterOverloadPolicy.setOverloaded(true);
+        sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertTrue(clusterResourceChecker.isClusterOverloaded());
+        assertEquals(clusterResourceChecker.getOverloadDetectionCount().getTotalCount(), 1);
+
+        // Set back to not overloaded
+        clusterOverloadPolicy.setOverloaded(false);
+        sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertFalse(clusterResourceChecker.isClusterOverloaded());
+
+        // Stop the periodic task
+        clusterResourceChecker.stop();
+    }
+
+    @Test
+    public void testOverloadDurationMetric()
+    {
+        // Start the periodic task
+        clusterResourceChecker.start();
+
+        // Set to overloaded and wait for periodic check
+        clusterOverloadPolicy.setOverloaded(true);
+        sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertTrue(clusterResourceChecker.isClusterOverloaded());
+
+        // Duration should be greater than 0
+        sleep(100);
+        assertTrue(clusterResourceChecker.getOverloadDurationMillis() > 0);
+
+        // Set back to not overloaded
+        clusterOverloadPolicy.setOverloaded(false);
+        sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded());
+
+        // Duration should be 0 again
+        assertEquals(clusterResourceChecker.getOverloadDurationMillis(), 0);
+
+        // Stop the periodic task
+        clusterResourceChecker.stop();
+    }
+
+    @Test
+    public void testMultipleOverloadTransitions()
+    {
+        // Start the periodic task
+        clusterResourceChecker.start();
+
+        // First transition to overloaded
+        clusterOverloadPolicy.setOverloaded(true);
+        sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertEquals(clusterResourceChecker.getOverloadDetectionCount().getTotalCount(), 1);
+
+        // Wait and transition back to not overloaded
+        clusterOverloadPolicy.setOverloaded(false);
+        sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+        assertFalse(clusterResourceChecker.isClusterCurrentlyOverloaded());
+
+        // Second transition to overloaded
+        clusterOverloadPolicy.setOverloaded(true);
+        sleep((CACHE_TTL_SECS * 1000) + SLEEP_BUFFER_MILLIS);
+        assertTrue(clusterResourceChecker.isClusterCurrentlyOverloaded());
+        assertEquals(clusterResourceChecker.getOverloadDetectionCount().getTotalCount(), 2);
+
+        // Stop the periodic task
+        clusterResourceChecker.stop();
+    }
+
+    @Test
+    public void testClusterOverloadThrottlingEnabled()
+    {
+        // Default is enabled (set in setUp)
+        assertTrue(clusterResourceChecker.isClusterOverloadThrottlingEnabled());
+
+        // Create a new config with throttling disabled
+        ClusterOverloadConfig disabledConfig = new ClusterOverloadConfig()
+                .setOverloadCheckCacheTtlInSecs(CACHE_TTL_SECS)
+                .setClusterOverloadThrottlingEnabled(false);
+
+        // Create a new checker with throttling disabled
+        ClusterResourceChecker disabledChecker = new ClusterResourceChecker(clusterOverloadPolicy, disabledConfig, nodeManager);
+        assertFalse(disabledChecker.isClusterOverloadThrottlingEnabled());
+
+        // Even when cluster is overloaded, isClusterCurrentlyOverloaded should return false if throttling is disabled
+        clusterOverloadPolicy.setOverloaded(true);
+        assertFalse(disabledChecker.isClusterCurrentlyOverloaded());
+    }
+
+    private void sleep(long millis)
+    {
+        try {
+            Thread.sleep(millis);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class TestingClusterOverloadPolicy
+            implements ClusterOverloadPolicy
+    {
+        private boolean overloaded;
+        private final AtomicInteger checkCount = new AtomicInteger();
+
+        @Override
+        public boolean isClusterOverloaded(InternalNodeManager nodeManager)
+        {
+            checkCount.incrementAndGet();
+            return overloaded;
+        }
+
+        @Override
+        public String getName()
+        {
+            return "test-policy";
+        }
+
+        public void setOverloaded(boolean overloaded)
+        {
+            this.overloaded = overloaded;
+        }
+
+        public int getCheckCount()
+        {
+            return checkCount.get();
+        }
+    }
+
+    private static class TestingInternalNodeManager
+            implements InternalNodeManager
+    {
+        @Override
+        public Set<InternalNode> getNodes(NodeState state)
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<InternalNode> getActiveConnectorNodes(ConnectorId connectorId)
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<InternalNode> getAllConnectorNodes(ConnectorId connectorId)
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public InternalNode getCurrentNode()
+        {
+            return null;
+        }
+
+        @Override
+        public Set<InternalNode> getCoordinators()
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<InternalNode> getShuttingDownCoordinator()
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<InternalNode> getResourceManagers()
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<InternalNode> getCatalogServers()
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<InternalNode> getCoordinatorSidecars()
+        {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public AllNodes getAllNodes()
+        {
+            return new AllNodes(
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet(),
+                    Collections.emptySet());
+        }
+
+        @Override
+        public void refreshNodes()
+        {
+            // No-op for testing
+        }
+
+        @Override
+        public void addNodeChangeListener(Consumer<AllNodes> listener)
+        {
+            // No-op for testing
+        }
+
+        @Override
+        public void removeNodeChangeListener(Consumer<AllNodes> listener)
+        {
+            // No-op for testing
+        }
+
+        @Override
+        public Optional<NodeLoadMetrics> getNodeLoadMetrics(String nodeIdentifier)
+        {
+            return Optional.empty();
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/clusterOverload/TestCpuMemoryOverloadPolicy.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/clusterOverload/TestCpuMemoryOverloadPolicy.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.clusterOverload;
+
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.execution.ClusterOverloadConfig;
+import com.facebook.presto.metadata.AllNodes;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.NodeLoadMetrics;
+import com.facebook.presto.spi.NodeState;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.execution.ClusterOverloadConfig.OVERLOAD_POLICY_CNT_BASED;
+import static com.facebook.presto.execution.ClusterOverloadConfig.OVERLOAD_POLICY_PCT_BASED;
+import static com.facebook.presto.metadata.InternalNode.NodeStatus.ALIVE;
+import static com.facebook.presto.spi.NodePoolType.DEFAULT;
+import static com.facebook.presto.spi.NodeState.ACTIVE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestCpuMemoryOverloadPolicy
+{
+    private static final NodeVersion TEST_VERSION = new NodeVersion("test");
+    private static final URI TEST_URI = URI.create("http://test.example.com");
+
+    @Test
+    public void testIsClusterOverloadedCountBasedNoOverload()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig()
+                .setAllowedOverloadWorkersCnt(1)
+                .setOverloadPolicyType(OVERLOAD_POLICY_CNT_BASED);
+        CpuMemoryOverloadPolicy policy = new CpuMemoryOverloadPolicy(config);
+
+        // One node is overloaded, but allowed count is 1, so not overloaded
+        InternalNodeManager nodeManager = createNodeManager(ImmutableSet.of(createNode("node1", true, false), createNode("node2", false, false), createNode("node3", false, false)));
+        assertFalse(policy.isClusterOverloaded(nodeManager));
+    }
+
+    @Test
+    public void testIsClusterOverloadedCountBasedOverload()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig()
+                .setAllowedOverloadWorkersCnt(1)
+                .setOverloadPolicyType(OVERLOAD_POLICY_CNT_BASED);
+        CpuMemoryOverloadPolicy policy = new CpuMemoryOverloadPolicy(config);
+
+        // Two nodes are overloaded, but allowed count is 1, so overloaded
+        InternalNodeManager nodeManager = createNodeManager(ImmutableSet.of(createNode("node1", true, false), createNode("node2", false, true), createNode("node3", false, false)));
+        assertTrue(policy.isClusterOverloaded(nodeManager));
+    }
+
+    @Test
+    public void testIsClusterOverloadedPctBasedNoOverload()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig().setAllowedOverloadWorkersPct(0.4).setOverloadPolicyType(OVERLOAD_POLICY_PCT_BASED);
+        CpuMemoryOverloadPolicy policy = new CpuMemoryOverloadPolicy(config);
+
+        // 1 out of 3 nodes (33%) are overloaded, allowed is 40%, so not overloaded
+        InternalNodeManager nodeManager = createNodeManager(ImmutableSet.of(createNode("node1", true, false), createNode("node2", false, false), createNode("node3", false, false)));
+        assertFalse(policy.isClusterOverloaded(nodeManager));
+    }
+
+    @Test
+    public void testIsClusterOverloadedPctBasedOverload()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig().setAllowedOverloadWorkersPct(0.3).setOverloadPolicyType(OVERLOAD_POLICY_PCT_BASED);
+        CpuMemoryOverloadPolicy policy = new CpuMemoryOverloadPolicy(config);
+
+        // 2 out of 5 nodes (40%) are overloaded, allowed is 30%, so overloaded
+        InternalNodeManager nodeManager = createNodeManager(ImmutableSet.of(createNode("node1", true, false), createNode("node2", false, true), createNode("node3", false, false), createNode("node4", false, false), createNode("node5", false, false)));
+        assertTrue(policy.isClusterOverloaded(nodeManager));
+    }
+
+    @Test
+    public void testIsClusterOverloadedBothMetricsOverloaded()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig()
+                .setAllowedOverloadWorkersCnt(0)
+                .setOverloadPolicyType(OVERLOAD_POLICY_CNT_BASED);
+        CpuMemoryOverloadPolicy policy = new CpuMemoryOverloadPolicy(config);
+
+        // Node has both CPU and memory overloaded, should only count as one overloaded node
+        InternalNodeManager nodeManager = createNodeManager(ImmutableSet.of(createNode("node1", true, true)));
+        assertTrue(policy.isClusterOverloaded(nodeManager));
+    }
+
+    @Test
+    public void testIsClusterOverloadedNoNodes()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig()
+                .setAllowedOverloadWorkersCnt(0)
+                .setOverloadPolicyType(OVERLOAD_POLICY_CNT_BASED);
+        CpuMemoryOverloadPolicy policy = new CpuMemoryOverloadPolicy(config);
+
+        // No nodes, should not be overloaded
+        InternalNodeManager nodeManager = createNodeManager(ImmutableSet.of());
+        assertFalse(policy.isClusterOverloaded(nodeManager));
+    }
+
+    @Test
+    public void testGetNameCountBased()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig()
+                .setOverloadPolicyType(OVERLOAD_POLICY_CNT_BASED);
+        CpuMemoryOverloadPolicy policy = new CpuMemoryOverloadPolicy(config);
+
+        assertEquals(policy.getName(), "cpu-memory-overload-cnt");
+    }
+
+    @Test
+    public void testGetNamePctBased()
+    {
+        ClusterOverloadConfig config = new ClusterOverloadConfig()
+                .setOverloadPolicyType(OVERLOAD_POLICY_PCT_BASED);
+        CpuMemoryOverloadPolicy policy = new CpuMemoryOverloadPolicy(config);
+        assertEquals(policy.getName(), "cpu-memory-overload-pct");
+    }
+
+    // Store metrics separately since they're no longer part of InternalNode
+    private static final Map<String, NodeLoadMetrics> NODE_METRICS = new HashMap<>();
+
+    private static InternalNode createNode(String nodeId, boolean cpuOverload, boolean memoryOverload)
+    {
+        // Store metrics in the map for later retrieval
+        NODE_METRICS.put(nodeId, new NodeLoadMetrics(0.0, 0.0, 0, cpuOverload, memoryOverload));
+        return new InternalNode(
+                nodeId,
+                TEST_URI,
+                OptionalInt.empty(),
+                TEST_VERSION,
+                false,
+                false,
+                false,
+                false,
+                ALIVE,
+                OptionalInt.empty(),
+                DEFAULT);
+    }
+
+    private static InternalNodeManager createNodeManager(Set<InternalNode> nodes)
+    {
+        return new InternalNodeManager()
+        {
+            @Override
+            public Set<InternalNode> getNodes(NodeState state)
+            {
+                if (state == ACTIVE) {
+                    return nodes;
+                }
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public Set<InternalNode> getActiveConnectorNodes(ConnectorId connectorId)
+            {
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public Set<InternalNode> getAllConnectorNodes(ConnectorId connectorId)
+            {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public InternalNode getCurrentNode()
+            {
+                return null;
+            }
+
+            @Override
+            public Set<InternalNode> getCoordinators()
+            {
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public Set<InternalNode> getShuttingDownCoordinator()
+            {
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public Set<InternalNode> getResourceManagers()
+            {
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public Set<InternalNode> getCatalogServers()
+            {
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public Set<InternalNode> getCoordinatorSidecars()
+            {
+                return ImmutableSet.of();
+            }
+
+            @Override
+            public AllNodes getAllNodes()
+            {
+                return new AllNodes(nodes, ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of());
+            }
+
+            @Override
+            public void refreshNodes()
+            {
+            }
+
+            @Override
+            public void addNodeChangeListener(Consumer<AllNodes> listener)
+            {
+            }
+
+            @Override
+            public void removeNodeChangeListener(Consumer<AllNodes> listener)
+            {
+            }
+
+            @Override
+            public Optional<NodeLoadMetrics> getNodeLoadMetrics(String nodeIdentifier)
+            {
+                NodeLoadMetrics metrics = NODE_METRICS.get(nodeIdentifier);
+                return metrics != null ? Optional.of(metrics) : Optional.empty();
+            }
+        };
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestInternalCommunicationConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestInternalCommunicationConfig.java
@@ -52,7 +52,9 @@ public class TestInternalCommunicationConfig
                 .setSharedSecret(null)
                 .setTaskUpdateRequestThriftSerdeEnabled(false)
                 .setTaskInfoResponseThriftSerdeEnabled(false)
-                .setInternalJwtEnabled(false));
+                .setInternalJwtEnabled(false)
+                .setNodeStatsRefreshIntervalMillis(1_000)
+                .setNodeDiscoveryPollingIntervalMillis(5_000));
     }
 
     @Test
@@ -80,6 +82,8 @@ public class TestInternalCommunicationConfig
                 .put("internal-communication.jwt.enabled", "true")
                 .put("experimental.internal-communication.task-update-request-thrift-serde-enabled", "true")
                 .put("experimental.internal-communication.task-info-response-thrift-serde-enabled", "true")
+                .put("internal-communication.node-stats-refresh-interval-millis", "2000")
+                .put("internal-communication.node-discovery-polling-interval-millis", "3000")
                 .build();
 
         InternalCommunicationConfig expected = new InternalCommunicationConfig()
@@ -103,7 +107,9 @@ public class TestInternalCommunicationConfig
                 .setSharedSecret("secret")
                 .setInternalJwtEnabled(true)
                 .setTaskUpdateRequestThriftSerdeEnabled(true)
-                .setTaskInfoResponseThriftSerdeEnabled(true);
+                .setTaskInfoResponseThriftSerdeEnabled(true)
+                .setNodeStatsRefreshIntervalMillis(2000)
+                .setNodeDiscoveryPollingIntervalMillis(3000);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -27,6 +27,7 @@ import com.facebook.presto.server.InternalCommunicationConfig;
 import com.facebook.presto.server.InternalCommunicationConfig.CommunicationProtocol;
 import com.facebook.presto.server.thrift.ThriftServerInfoClient;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.NodeLoadMetrics;
 import com.facebook.presto.spi.NodePoolType;
 import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.spi.NodeStats;
@@ -446,6 +447,15 @@ public final class DiscoveryNodeManager
                 ? nodeStats.get(nodeId).getNodeStats()
                 : Optional.empty();
         return remoteNodeStats.isPresent() && remoteNodeStats.get().getNodeState() == SHUTTING_DOWN;
+    }
+
+    @Override
+    public Optional<NodeLoadMetrics> getNodeLoadMetrics(String nodeId)
+    {
+        Optional<NodeStats> remoteNodeStats = nodeStats.containsKey(nodeId)
+                ? nodeStats.get(nodeId).getNodeStats()
+                : Optional.empty();
+        return remoteNodeStats.flatMap(NodeStats::getLoadMetrics);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -29,6 +29,7 @@ import com.facebook.presto.server.thrift.ThriftServerInfoClient;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.NodePoolType;
 import com.facebook.presto.spi.NodeState;
+import com.facebook.presto.spi.NodeStats;
 import com.facebook.presto.statusservice.NodeStatusService;
 import com.google.common.base.Splitter;
 import com.google.common.collect.HashMultimap;
@@ -93,7 +94,7 @@ public final class DiscoveryNodeManager
     private final FailureDetector failureDetector;
     private final Optional<NodeStatusService> nodeStatusService;
     private final NodeVersion expectedNodeVersion;
-    private final ConcurrentHashMap<String, RemoteNodeState> nodeStates = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, RemoteNodeStats> nodeStats = new ConcurrentHashMap<>();
     private final HttpClient httpClient;
     private final DriftClient<ThriftServerInfoClient> driftClient;
     private final ScheduledExecutorService nodeStateUpdateExecutor;
@@ -102,6 +103,7 @@ public final class DiscoveryNodeManager
     private final InternalNode currentNode;
     private final CommunicationProtocol protocol;
     private final boolean isMemoizeDeadNodesEnabled;
+    private final InternalCommunicationConfig internalCommunicationConfig;
 
     @GuardedBy("this")
     private SetMultimap<ConnectorId, InternalNode> activeNodesByConnectorId;
@@ -153,6 +155,7 @@ public final class DiscoveryNodeManager
         this.nodeStateUpdateExecutor = newSingleThreadScheduledExecutor(threadsNamed("node-state-poller-%s"));
         this.nodeStateEventExecutor = newCachedThreadPool(threadsNamed("node-state-events-%s"));
         this.httpsRequired = internalCommunicationConfig.isHttpsRequired();
+        this.internalCommunicationConfig = requireNonNull(internalCommunicationConfig, "internalCommunicationConfig is null");
 
         this.currentNode = findCurrentNode(
                 serviceSelector.selectAllServices(),
@@ -211,6 +214,7 @@ public final class DiscoveryNodeManager
     @PostConstruct
     public void startPollingNodeStates()
     {
+        long pollingIntervalMillis = internalCommunicationConfig.getNodeDiscoveryPollingIntervalMillis();
         nodeStateUpdateExecutor.scheduleWithFixedDelay(() -> {
             try {
                 pollWorkers();
@@ -218,7 +222,7 @@ public final class DiscoveryNodeManager
             catch (Exception e) {
                 log.error(e, "Error polling state of nodes");
             }
-        }, 5, 5, TimeUnit.SECONDS);
+        }, pollingIntervalMillis, pollingIntervalMillis, TimeUnit.MILLISECONDS);
         pollWorkers();
     }
 
@@ -236,20 +240,20 @@ public final class DiscoveryNodeManager
 
         // Remove nodes that don't exist anymore
         // Make a copy to materialize the set difference
-        Set<String> deadNodes = difference(nodeStates.keySet(), aliveNodeIds).immutableCopy();
-        nodeStates.keySet().removeAll(deadNodes);
+        Set<String> deadNodes = difference(nodeStats.keySet(), aliveNodeIds).immutableCopy();
+        nodeStats.keySet().removeAll(deadNodes);
 
         // Add new nodes
         for (InternalNode node : aliveNodes) {
             switch (protocol) {
                 case HTTP:
-                    nodeStates.putIfAbsent(node.getNodeIdentifier(),
-                            new HttpRemoteNodeState(httpClient, uriBuilderFrom(node.getInternalUri()).appendPath("/v1/info/state").build()));
+                    nodeStats.putIfAbsent(node.getNodeIdentifier(),
+                            new HttpRemoteNodeStats(httpClient, uriBuilderFrom(node.getInternalUri()).appendPath("/v1/info/stats").build(), internalCommunicationConfig.getNodeStatsRefreshIntervalMillis()));
                     break;
                 case THRIFT:
                     if (node.getThriftPort().isPresent()) {
-                        nodeStates.put(node.getNodeIdentifier(),
-                                new ThriftRemoteNodeState(driftClient, uriBuilderFrom(node.getInternalUri()).scheme("thrift").port(node.getThriftPort().getAsInt()).build()));
+                        nodeStats.put(node.getNodeIdentifier(),
+                                new ThriftRemoteNodeStats(driftClient, uriBuilderFrom(node.getInternalUri()).scheme("thrift").port(node.getThriftPort().getAsInt()).build(), internalCommunicationConfig.getNodeStatsRefreshIntervalMillis()));
                     }
                     else {
                         // thrift port has not yet been populated; ignore the node for now
@@ -259,7 +263,7 @@ public final class DiscoveryNodeManager
         }
 
         // Schedule refresh
-        nodeStates.values().forEach(RemoteNodeState::asyncRefresh);
+        nodeStats.values().forEach(RemoteNodeStats::asyncRefresh);
 
         // update indexes
         refreshNodesInternal();
@@ -438,10 +442,10 @@ public final class DiscoveryNodeManager
 
     private boolean isNodeShuttingDown(String nodeId)
     {
-        Optional<NodeState> remoteNodeState = nodeStates.containsKey(nodeId)
-                ? nodeStates.get(nodeId).getNodeState()
+        Optional<NodeStats> remoteNodeStats = nodeStats.containsKey(nodeId)
+                ? nodeStats.get(nodeId).getNodeStats()
                 : Optional.empty();
-        return remoteNodeState.isPresent() && remoteNodeState.get() == SHUTTING_DOWN;
+        return remoteNodeStats.isPresent() && remoteNodeStats.get().getNodeState() == SHUTTING_DOWN;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/HttpRemoteNodeStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/HttpRemoteNodeStats.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpClient.HttpResponseFuture;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.spi.NodeStats;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.errorprone.annotations.ThreadSafe;
+import jakarta.annotation.Nullable;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static com.facebook.airlift.http.client.HttpStatus.OK;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.units.Duration.nanosSince;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@ThreadSafe
+public class HttpRemoteNodeStats
+        implements RemoteNodeStats
+{
+    private static final Logger log = Logger.get(HttpRemoteNodeStats.class);
+
+    private final HttpClient httpClient;
+    private final URI stateInfoUri;
+    private final long refreshIntervalMillis;
+    private final AtomicReference<Optional<NodeStats>> nodeStats = new AtomicReference<>(Optional.empty());
+    private final AtomicReference<Future<?>> future = new AtomicReference<>();
+    private final AtomicLong lastUpdateNanos = new AtomicLong();
+    private final AtomicLong lastWarningLogged = new AtomicLong();
+
+    public HttpRemoteNodeStats(HttpClient httpClient, URI stateInfoUri, long refreshIntervalMillis)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.stateInfoUri = requireNonNull(stateInfoUri, "stateInfoUri is null");
+        this.refreshIntervalMillis = refreshIntervalMillis;
+    }
+
+    @Override
+    public Optional<NodeStats> getNodeStats()
+    {
+        return nodeStats.get();
+    }
+
+    @Override
+    public synchronized void asyncRefresh()
+    {
+        Duration sinceUpdate = nanosSince(lastUpdateNanos.get());
+        if (nanosSince(lastWarningLogged.get()).toMillis() > 1_000 &&
+                sinceUpdate.toMillis() > 10_000 &&
+                future.get() != null) {
+            log.warn("Node state update request to %s has not returned in %s", stateInfoUri, sinceUpdate.toString(SECONDS));
+            lastWarningLogged.set(System.nanoTime());
+        }
+        if (sinceUpdate.toMillis() > refreshIntervalMillis && future.get() == null) {
+            Request request = prepareGet()
+                    .setUri(stateInfoUri)
+                    .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .build();
+            HttpResponseFuture<JsonResponse<NodeStats>> responseFuture = httpClient.executeAsync(request, createFullJsonResponseHandler(jsonCodec(NodeStats.class)));
+            future.compareAndSet(null, responseFuture);
+
+            Futures.addCallback(responseFuture, new FutureCallback<JsonResponse<NodeStats>>()
+            {
+                @Override
+                public void onSuccess(@Nullable JsonResponse<NodeStats> result)
+                {
+                    lastUpdateNanos.set(System.nanoTime());
+                    future.compareAndSet(responseFuture, null);
+                    if (result != null) {
+                        if (result.hasValue()) {
+                            nodeStats.set(Optional.ofNullable(result.getValue()));
+                        }
+                        if (result.getStatusCode() != OK.code()) {
+                            log.warn("Error fetching node stats from %s returned status %d", stateInfoUri, result.getStatusCode());
+                            return;
+                        }
+                    }
+                    else {
+                        log.warn("Node statistics endpoint %s returned null response, using cached statistics", stateInfoUri);
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t)
+                {
+                    log.error("Error fetching node stats from %s: %s", stateInfoUri, t.getMessage());
+                    lastUpdateNanos.set(System.nanoTime());
+                    future.compareAndSet(responseFuture, null);
+                }
+            }, directExecutor());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -84,6 +84,8 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.NodeSchedulerExporter;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.execution.scheduler.clusterOverload.ClusterOverloadPolicyModule;
+import com.facebook.presto.execution.scheduler.clusterOverload.ClusterResourceChecker;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.functionNamespace.JsonBasedUdfFunctionMetadata;
@@ -708,6 +710,10 @@ public class ServerMainModule
 
         // system connector
         binder.install(new SystemConnectorModule());
+
+        // ClusterOverload policy module
+        binder.install(new ClusterOverloadPolicyModule());
+        newExporter(binder).export(ClusterResourceChecker.class).withGeneratedName();
 
         // splits
         jsonCodecBinder(binder).bindJsonCodec(TaskUpdateRequest.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -61,6 +61,7 @@ import com.facebook.presto.execution.executor.TaskExecutor;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.execution.scheduler.clusterOverload.ClusterOverloadPolicyModule;
 import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.index.IndexManager;
@@ -329,6 +330,9 @@ public class PrestoSparkModule
 
         // handle resolver
         binder.install(new HandleJsonModule());
+
+        // ClusterOverload policy module
+        binder.install(new ClusterOverloadPolicyModule());
 
         // plugin manager
         configBinder(binder).bindConfig(PluginManagerConfig.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkInternalNodeManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkInternalNodeManager.java
@@ -18,10 +18,12 @@ import com.facebook.presto.metadata.AllNodes;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.NodeLoadMetrics;
 import com.facebook.presto.spi.NodeState;
 import com.google.common.collect.ImmutableSet;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -124,5 +126,11 @@ public class PrestoSparkInternalNodeManager
     public void removeNodeChangeListener(Consumer<AllNodes> listener)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<NodeLoadMetrics> getNodeLoadMetrics(String nodeIdentifier)
+    {
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
**Admission control scheduling policy**

**Logic**
Gather worker overload data from the added end point in PR - [https://github.com/prestodb/presto/pull/25687](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Fprestodb%2Fpresto%2Fpull%2F25687&h=AT20QdO6Ld9h4KN4cMS_xFUtKTtNuKLc-glQIqSWbPgMh0KxW_3-UYhiBxO2gl-I8P_i8wG5gixSBWcGmglCWFShRKtOUlWnYZ5RqgBNHhmkGYrK2XJfKIjqXNj4Ltd4oWghm0eSCgnKL0UGvLr9mXLyJyA)
Based on configured policies (cnt of overloaded workers or pct of overloaded workers) and cluster overload, queue the queries

**Background**
RFC PR: [https://github.com/prestodb/rfcs/pull/42](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Fprestodb%2Frfcs%2Fpull%2F42&h=AT20QdO6Ld9h4KN4cMS_xFUtKTtNuKLc-glQIqSWbPgMh0KxW_3-UYhiBxO2gl-I8P_i8wG5gixSBWcGmglCWFShRKtOUlWnYZ5RqgBNHhmkGYrK2XJfKIjqXNj4Ltd4oWghm0eSCgnKL0UGvLr9mXLyJyA)

**Metrics on queuing due to this feature:**
Added following metrics
- ClusterOverloadDuration
- ClusterOverloadCount

**Feature flag:** 
Right now feature is disabled. We can use coordinator configs to enable / add thresholds

## Summary by Sourcery

Add cluster overload-based admission control scheduling policy and supporting infrastructure to throttle queries based on worker load.

New Features:
- Introduce ClusterResourceChecker for periodic cluster overload detection and query throttling based on worker load metrics
- Implement CpuMemoryOverloadPolicy with count- and percentage-based overload thresholds and expose overload detection count and duration metrics
- Add AdmissionControlBypassConfig to allow certain queries (e.g., DDL) to bypass admission control

Enhancements:
- Refactor DiscoveryNodeManager and SPI to use RemoteNodeStats for asynchronous fetching of node load metrics
- Integrate cluster overload checks into InternalResourceGroup scheduling logic and update eligibility propagation on overload state changes
- Introduce ClusterOverloadPolicyModule and DI bindings for policy selection and checker

Tests:
- Add unit tests for ClusterResourceChecker, CpuMemoryOverloadPolicy, and AdmissionControlBypassConfig
- Update existing resource group and node manager tests to support clustering resource checker mocks

Chores:
- Add new configuration properties for cluster-overload throttling and internal-communication stats polling intervals