### PR TITLE
[native] Fix broken unit test due to IndexJoinNode change

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxQueryPlanTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxQueryPlanTest.cpp
@@ -235,7 +235,8 @@ TEST_F(PrestoToVeloxQueryPlanTest, parseIndexJoinNode) {
         "form": "AND",
         "returnType": "boolean"
       },
-      "type": "INNER"
+      "type": "INNER",
+      "lookupVariables": []
     }
   )";
 


### PR DESCRIPTION
## Description
Fix broken unit test due to https://github.com/prestodb/presto/pull/25668

## Motivation and Context
Note: Google Test filter = PrestoToVeloxQueryPlanTest.parseIndexJoinNode
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from PrestoToVeloxQueryPlanTest
[ RUN      ] PrestoToVeloxQueryPlanTest.parseIndexJoinNode

terminate called after throwing an instance of 'facebook::presto::protocol::OutOfRange'
  what():  [json.exception.out_of_range.403] key 'lookupVariables' not found IndexJoinNode List<VariableReferenceExpression> lookupVariables

## Impact
No Impact.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```


