### PR TITLE
[native] Fix incorrect exclusion of PrestoC++ unit tests

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -117,7 +117,7 @@ jobs:
           # Ensure transitive dependency libboost-iostreams is found.
           ldconfig /usr/local/lib
           cd presto-native-execution/_build/release
-          ctest -j 4 -VV --output-on-failure --exclude-regex velox.*
+          ctest -j 4 -VV --output-on-failure --exclude-regex ^velox.*
 
       - name: Upload artifacts
         if: |

--- a/presto-native-execution/Makefile
+++ b/presto-native-execution/Makefile
@@ -119,7 +119,7 @@ cmake-and-build:			#: cmake and build without updating submodules which requires
 	cmake --build $(BUILD_BASE_DIR)/$(BUILD_DIR) -j $(NUM_THREADS)
 
 unittest: debug			#: Build with debugging and run unit tests
-	cd $(BUILD_BASE_DIR)/debug && ctest -j $(NUM_THREADS) -VV --output-on-failure --exclude-regex velox.*
+	cd $(BUILD_BASE_DIR)/debug && ctest -j $(NUM_THREADS) -VV --output-on-failure --exclude-regex ^velox.*
 
 presto_protocol:		#: Build the presto_protocol serde library
 	cd presto_cpp/presto_protocol; $(MAKE) presto_protocol


### PR DESCRIPTION
The regex used int he CTest command to run tests excludes tests with “velox” in the name leading to skipped tests such as presto_to_velox_query_plan_test and others.
This results in missing coverage and non-detection of introduced issues.

Question is if we actually need the regex. The build doesn't enable velox tests and if we do have velox tests running it would indicate a problem in velox where tests are not guarded properly with VELOX_ENABLE_TESTS.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

