### PR TITLE
Fix spill config plumbing for pos cpp

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -111,6 +111,13 @@ public class NativeExecutionSystemConfig
     private static final String HTTP_SERVER_ACCESS_LOGS = "http-server.enable-access-log";
     // Terminates the native process and generates a core file on an allocation failure
     private static final String CORE_ON_ALLOCATION_FAILURE_ENABLED = "core-on-allocation-failure-enabled";
+    // Spill related properties
+    private static final String SPILL_ENABLED = "spill-enabled";
+    private static final String AGGREGATION_SPILL_ENABLED = "aggregation-spill-enabled";
+    private static final String JOIN_SPILL_ENABLED = "join-spill-enabled";
+    private static final String ORDER_BY_SPILL_ENABLED = "order-by-spill-enabled";
+    private static final String MAX_SPILL_BYTES = "max-spill-bytes";
+
     private boolean enableSerializedPageChecksum = true;
     private boolean enableVeloxExpressionLogging;
     private boolean enableVeloxTaskLogging = true;
@@ -151,6 +158,11 @@ public class NativeExecutionSystemConfig
     private boolean registerTestFunctions;
     private boolean enableHttpServerAccessLog = true;
     private boolean coreOnAllocationFailureEnabled;
+    private boolean spillEnabled = true;
+    private boolean aggregationSpillEnabled = true;
+    private boolean joinSpillEnabled = true;
+    private boolean orderBySpillEnabled = true;
+    private Long maxSpillBytes = 600L << 30;
 
     public Map<String, String> getAllProperties()
     {
@@ -191,6 +203,11 @@ public class NativeExecutionSystemConfig
                 .put(SHUFFLE_NAME, getShuffleName())
                 .put(HTTP_SERVER_ACCESS_LOGS, String.valueOf(isEnableHttpServerAccessLog()))
                 .put(CORE_ON_ALLOCATION_FAILURE_ENABLED, String.valueOf(isCoreOnAllocationFailureEnabled()))
+                .put(SPILL_ENABLED, String.valueOf(getSpillEnabled()))
+                .put(AGGREGATION_SPILL_ENABLED, String.valueOf(getAggregationSpillEnabled()))
+                .put(JOIN_SPILL_ENABLED, String.valueOf(getJoinSpillEnabled()))
+                .put(ORDER_BY_SPILL_ENABLED, String.valueOf(getOrderBySpillEnabled()))
+                .put(MAX_SPILL_BYTES, String.valueOf(getMaxSpillBytes()))
                 .build();
     }
 
@@ -623,6 +640,66 @@ public class NativeExecutionSystemConfig
     public NativeExecutionSystemConfig setCoreOnAllocationFailureEnabled(boolean coreOnAllocationFailureEnabled)
     {
         this.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled;
+        return this;
+    }
+
+    public boolean getSpillEnabled()
+    {
+        return spillEnabled;
+    }
+
+    @Config(SPILL_ENABLED)
+    public NativeExecutionSystemConfig setSpillEnabled(boolean spillEnabled)
+    {
+        this.spillEnabled = spillEnabled;
+        return this;
+    }
+
+    public boolean getAggregationSpillEnabled()
+    {
+        return aggregationSpillEnabled;
+    }
+
+    @Config(AGGREGATION_SPILL_ENABLED)
+    public NativeExecutionSystemConfig setAggregationSpillEnabled(boolean aggregationSpillEnabled)
+    {
+        this.aggregationSpillEnabled = aggregationSpillEnabled;
+        return this;
+    }
+
+    public boolean getJoinSpillEnabled()
+    {
+        return joinSpillEnabled;
+    }
+
+    @Config(JOIN_SPILL_ENABLED)
+    public NativeExecutionSystemConfig setJoinSpillEnabled(boolean joinSpillEnabled)
+    {
+        this.joinSpillEnabled = joinSpillEnabled;
+        return this;
+    }
+
+    public boolean getOrderBySpillEnabled()
+    {
+        return orderBySpillEnabled;
+    }
+
+    @Config(ORDER_BY_SPILL_ENABLED)
+    public NativeExecutionSystemConfig setOrderBySpillEnabled(boolean orderBySpillEnabled)
+    {
+        this.orderBySpillEnabled = orderBySpillEnabled;
+        return this;
+    }
+
+    public Long getMaxSpillBytes()
+    {
+        return maxSpillBytes;
+    }
+
+    @Config(MAX_SPILL_BYTES)
+    public NativeExecutionSystemConfig setMaxSpillBytes(Long maxSpillBytes)
+    {
+        this.maxSpillBytes = maxSpillBytes;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionVeloxConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionVeloxConfig.java
@@ -24,31 +24,13 @@ import java.util.Map;
 public class NativeExecutionVeloxConfig
 {
     private static final String CODEGEN_ENABLED = "codegen.enabled";
-    // Spilling related configs.
-    private static final String SPILL_ENABLED = "spill_enabled";
-    private static final String AGGREGATION_SPILL_ENABLED = "aggregation_spill_enabled";
-    private static final String JOIN_SPILL_ENABLED = "join_spill_enabled";
-    private static final String ORDER_BY_SPILL_ENABLED = "order_by_spill_enabled";
-    private static final String MAX_SPILL_BYTES = "max_spill_bytes";
 
     private boolean codegenEnabled;
-    private boolean spillEnabled = true;
-    private boolean aggregationSpillEnabled = true;
-    private boolean joinSpillEnabled = true;
-    private boolean orderBySpillEnabled = true;
-    // Velox default value is 100GB, as it is designed for Presto cluster
-    // use-case. But for presto-on-spark, 500GB is a reasonable default
-    private Long maxSpillBytes = 500L << 30;
 
     public Map<String, String> getAllProperties()
     {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
         return builder.put(CODEGEN_ENABLED, String.valueOf(getCodegenEnabled()))
-                .put(SPILL_ENABLED, String.valueOf(getSpillEnabled()))
-                .put(AGGREGATION_SPILL_ENABLED, String.valueOf(getAggregationSpillEnabled()))
-                .put(JOIN_SPILL_ENABLED, String.valueOf(getJoinSpillEnabled()))
-                .put(ORDER_BY_SPILL_ENABLED, String.valueOf(getOrderBySpillEnabled()))
-                .put(MAX_SPILL_BYTES, String.valueOf(getMaxSpillBytes()))
                 .build();
     }
 
@@ -61,66 +43,6 @@ public class NativeExecutionVeloxConfig
     public NativeExecutionVeloxConfig setCodegenEnabled(boolean codegenEnabled)
     {
         this.codegenEnabled = codegenEnabled;
-        return this;
-    }
-
-    public boolean getSpillEnabled()
-    {
-        return spillEnabled;
-    }
-
-    @Config(SPILL_ENABLED)
-    public NativeExecutionVeloxConfig setSpillEnabled(boolean spillEnabled)
-    {
-        this.spillEnabled = spillEnabled;
-        return this;
-    }
-
-    public boolean getAggregationSpillEnabled()
-    {
-        return aggregationSpillEnabled;
-    }
-
-    @Config(AGGREGATION_SPILL_ENABLED)
-    public NativeExecutionVeloxConfig setAggregationSpillEnabled(boolean aggregationSpillEnabled)
-    {
-        this.aggregationSpillEnabled = aggregationSpillEnabled;
-        return this;
-    }
-
-    public boolean getJoinSpillEnabled()
-    {
-        return joinSpillEnabled;
-    }
-
-    @Config(JOIN_SPILL_ENABLED)
-    public NativeExecutionVeloxConfig setJoinSpillEnabled(boolean joinSpillEnabled)
-    {
-        this.joinSpillEnabled = joinSpillEnabled;
-        return this;
-    }
-
-    public boolean getOrderBySpillEnabled()
-    {
-        return orderBySpillEnabled;
-    }
-
-    @Config(ORDER_BY_SPILL_ENABLED)
-    public NativeExecutionVeloxConfig setOrderBySpillEnabled(boolean orderBySpillEnabled)
-    {
-        this.orderBySpillEnabled = orderBySpillEnabled;
-        return this;
-    }
-
-    public Long getMaxSpillBytes()
-    {
-        return maxSpillBytes;
-    }
-
-    @Config(MAX_SPILL_BYTES)
-    public NativeExecutionVeloxConfig setMaxSpillBytes(Long maxSpillBytes)
-    {
-        this.maxSpillBytes = maxSpillBytes;
         return this;
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -39,21 +39,11 @@ public class TestNativeExecutionSystemConfig
     {
         // Test defaults
         assertRecordedDefaults(ConfigAssertions.recordDefaults(NativeExecutionVeloxConfig.class)
-                .setCodegenEnabled(false)
-                .setSpillEnabled(true)
-                .setAggregationSpillEnabled(true)
-                .setJoinSpillEnabled(true)
-                .setOrderBySpillEnabled(true)
-                .setMaxSpillBytes(500L << 30));
+                .setCodegenEnabled(false));
 
         // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
         NativeExecutionVeloxConfig expected = new NativeExecutionVeloxConfig()
-                .setCodegenEnabled(true)
-                .setSpillEnabled(false)
-                .setAggregationSpillEnabled(false)
-                .setJoinSpillEnabled(false)
-                .setOrderBySpillEnabled(false)
-                .setMaxSpillBytes(1L);
+                .setCodegenEnabled(true);
         Map<String, String> properties = expected.getAllProperties();
         assertFullMapping(properties, expected);
     }
@@ -98,7 +88,12 @@ public class TestNativeExecutionSystemConfig
                 .setShuffleName("local")
                 .setRegisterTestFunctions(false)
                 .setEnableHttpServerAccessLog(true)
-                .setCoreOnAllocationFailureEnabled(false));
+                .setCoreOnAllocationFailureEnabled(false)
+                .setSpillEnabled(true)
+                .setAggregationSpillEnabled(true)
+                .setJoinSpillEnabled(true)
+                .setOrderBySpillEnabled(true)
+                .setMaxSpillBytes(600L << 30));
 
         // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
         NativeExecutionSystemConfig expected = new NativeExecutionSystemConfig()
@@ -137,7 +132,12 @@ public class TestNativeExecutionSystemConfig
                 .setShuffleName("custom")
                 .setRegisterTestFunctions(true)
                 .setEnableHttpServerAccessLog(false)
-                .setCoreOnAllocationFailureEnabled(true);
+                .setCoreOnAllocationFailureEnabled(true)
+                .setSpillEnabled(false)
+                .setAggregationSpillEnabled(false)
+                .setJoinSpillEnabled(false)
+                .setOrderBySpillEnabled(false)
+                .setMaxSpillBytes(1L);
         Map<String, String> properties = expected.getAllProperties();
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
Spill related configs have updated in both names and locations in presto cpp and made queries not able to spill. We need to keep pos cpp up-to-date.

```
== NO RELEASE NOTE ==
```

