### PR TITLE
Fix NPE in IcebergHiveMetadata.getViews when the provided schema is null

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -475,9 +475,8 @@ public class IcebergHiveMetadata
             tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
         }
         else {
-            tableNames = listViews(session, Optional.of(prefix.getSchemaName()));
+            tableNames = listViews(session, Optional.ofNullable(prefix.getSchemaName()));
         }
-        MetastoreContext metastoreContext = getMetastoreContext(session);
         for (SchemaTableName schemaTableName : tableNames) {
             Optional<Table> table = getHiveTable(session, schemaTableName);
             if (table.isPresent() && isPrestoView(table.get())) {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Fix NPE for HiveIcebergMetadata.getViews if the provided schema is null. With an empty schema, it will proceed to list table names from the session.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

We have encountered the following error:
```
java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:209)
        at java.base/java.util.Optional.of(Optional.java:113)
        at com.facebook.presto.iceberg.IcebergHiveMetadata.getViews(IcebergHiveMetadata.java:478)
        at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.getViews(ClassLoaderSafeConnectorMetadata.java:539)
        at com.facebook.presto.metadata.MetadataManager.listTableColumns(MetadataManager.java:611)
        at com.facebook.presto.metadata.MetadataListing.listTableColumns(MetadataListing.java:96)
        at com.facebook.presto.connector.system.jdbc.ColumnJdbcTable.cursor(ColumnJdbcTable.java:125)
```

This is because the schema provided is null and it is not put into an `Optional.ofNullable`.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix NPE error in getViews when a schema is not provided. 
```

