### PR TITLE
fix: rename column failed if the column is used as source column of non-identity transform

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -83,7 +83,6 @@ import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes.None;
-import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
@@ -904,9 +903,12 @@ public abstract class IcebergAbstractMetadata
         Table icebergTable = getIcebergTable(session, icebergTableHandle.getSchemaTableName());
         Transaction transaction = icebergTable.newTransaction();
         transaction.updateSchema().renameColumn(columnHandle.getName(), target).commit();
-        if (icebergTable.spec().fields().stream().map(PartitionField::sourceId).anyMatch(sourceId -> sourceId == columnHandle.getId())) {
-            transaction.updateSpec().renameField(columnHandle.getName(), target).commit();
-        }
+        icebergTable.spec().fields().stream()
+                .filter(field -> field.sourceId() == columnHandle.getId())
+                .forEach(field -> {
+                    String transform = field.transform().toString();
+                    transaction.updateSpec().renameField(field.name(), getPartitionColumnName(target, transform)).commit();
+                });
         transaction.commitTransaction();
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
@@ -213,7 +213,17 @@ public final class PartitionFields
             return columnName + "_bucket";
         }
 
+        matcher = ICEBERG_BUCKET_PATTERN.matcher(transform);
+        if (matcher.matches()) {
+            return columnName + "_bucket";
+        }
+
         matcher = COLUMN_TRUNCATE_PATTERN.matcher(transform);
+        if (matcher.matches()) {
+            return columnName + "_trunc";
+        }
+
+        matcher = ICEBERG_TRUNCATE_PATTERN.matcher(transform);
         if (matcher.matches()) {
             return columnName + "_trunc";
         }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Fix https://github.com/prestodb/presto/issues/25692.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix iceberg connector rename column failed if the column is used as source column of non-identity transform.
```

