### PR TITLE
Add support for the MariaDb driver to the function namespace manager

### DIFF
--- a/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/function-namespace-managers.rst
@@ -55,6 +55,12 @@ following contents::
     function-namespaces-table-name=example_function_namespaces
     functions-table-name=example_sql_functions
 
+To use the MariaDB Java driver instead of the MySQL Connector Java
+driver, use the following properties for the ``database-`` fields::
+
+    database-driver-name=org.mariadb.jdbc.Driver
+    database-url=jdbc:mariadb://example.net:3306/database?user=root&password=password
+
 When Presto first starts with the above MySQL function namespace
 manager configuration, two MySQL tables will be created if they do
 not exist.
@@ -86,7 +92,11 @@ The following table lists all configuration properties supported by the MySQL fu
 =========================================== ==================================================================================================
 Name                                        Description
 =========================================== ==================================================================================================
-``database-url``                            The URL of the MySQL database used by the MySQL function namespace manager.
+``database-url``                            The JDBC URL of the MySQL database used by the MySQL function namespace manager. If using the MariaDB Java driver, ensure the URL uses the MariaDB connection string format where the string starts with ``jdbc:mariadb:``
+``database-driver-name``                    (optional) The name of the JDBC driver class to use for connecting to the MySQL database. For the MariaDb Java client use ``org.mariadb.jdbc.Driver``. Defaults to ``com.mysql.jdbc.Driver``.
+``database-connection-timeout``             (optional) The timeout in milliseconds for establishing a connection to the database. Defaults to 30 seconds.
+``database-connection-max-lifetime``        (optional) The maximum lifetime of a connection in milliseconds. Defaults to 30 minutes.
+``function-namespace-manager.name``         The name of the function namespace manager to instantiate. Currently, only ``mysql`` is supported.
 ``function-namespaces-table-name``          The name of the table that stores all the function namespaces managed by this manager.
 ``functions-table-name``                    The name of the table that stores all the functions managed by this manager.
 =========================================== ==================================================================================================

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -146,6 +146,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.5.4</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
         </dependency>

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionConfig.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionConfig.java
@@ -18,6 +18,8 @@ import jakarta.validation.constraints.NotNull;
 
 public class MySqlConnectionConfig
 {
+    private String jdbcDriverName = "com.mysql.jdbc.Driver";
+
     private String databaseUrl;
 
     @NotNull
@@ -30,6 +32,18 @@ public class MySqlConnectionConfig
     public MySqlConnectionConfig setDatabaseUrl(String databaseUrl)
     {
         this.databaseUrl = databaseUrl;
+        return this;
+    }
+
+    public String getJdbcDriverName()
+    {
+        return jdbcDriverName;
+    }
+
+    @Config("database-driver-name")
+    public MySqlConnectionConfig setJdbcDriverName(String jdbcDriverName)
+    {
+        this.jdbcDriverName = jdbcDriverName;
         return this;
     }
 }

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionModule.java
@@ -36,9 +36,11 @@ public class MySqlConnectionModule
     {
         configBinder(binder).bindConfig(MySqlConnectionConfig.class);
 
-        String databaseUrl = buildConfigObject(MySqlConnectionConfig.class).getDatabaseUrl();
+        MySqlConnectionConfig mySqlConnectionConfig = buildConfigObject(MySqlConnectionConfig.class);
+        String databaseUrl = mySqlConnectionConfig.getDatabaseUrl();
+        String jdbcDriverName = mySqlConnectionConfig.getJdbcDriverName();
         try {
-            Class.forName("com.mysql.jdbc.Driver");
+            Class.forName(jdbcDriverName);
         }
         catch (ClassNotFoundException e) {
             throw new RuntimeException(e);

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlConnectionConfig.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlConnectionConfig.java
@@ -28,7 +28,8 @@ public class TestMySqlConnectionConfig
     public void testDefault()
     {
         assertRecordedDefaults(recordDefaults(MySqlConnectionConfig.class)
-                .setDatabaseUrl(null));
+                .setDatabaseUrl(null)
+                .setJdbcDriverName("com.mysql.jdbc.Driver"));
     }
 
     @Test
@@ -36,9 +37,11 @@ public class TestMySqlConnectionConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("database-url", "localhost:1080")
+                .put("database-driver-name", "org.mariadb.jdbc.Driver")
                 .build();
         MySqlConnectionConfig expected = new MySqlConnectionConfig()
-                .setDatabaseUrl("localhost:1080");
+                .setDatabaseUrl("localhost:1080")
+                .setJdbcDriverName("org.mariadb.jdbc.Driver");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
@@ -79,9 +79,9 @@ import static org.testng.Assert.fail;
 @Test(singleThreaded = true)
 public class TestMySqlFunctionNamespaceManager
 {
-    private static final String DB = "presto";
+    protected static final String DB = "presto";
 
-    private TestingMySqlServer mySqlServer;
+    protected TestingMySqlServer mySqlServer;
     private Jdbi jdbi;
     private Injector injector;
     private MySqlFunctionNamespaceManager functionNamespaceManager;
@@ -102,16 +102,10 @@ public class TestMySqlFunctionNamespaceManager
                 new DriftNettyClientModule(),
                 new MySqlConnectionModule());
 
-        Map<String, String> config = ImmutableMap.<String, String>builder()
-                .put("function-cache-expiration", "0s")
-                .put("function-instance-cache-expiration", "0s")
-                .put("database-url", mySqlServer.getJdbcUrl(DB))
-                .build();
-
         try {
             this.injector = app
                     .doNotInitializeLogging()
-                    .setRequiredConfigurationProperties(config)
+                    .setRequiredConfigurationProperties(getConfig())
                     .initialize();
             this.functionNamespaceManager = injector.getInstance(MySqlFunctionNamespaceManager.class);
             this.jdbi = injector.getInstance(Jdbi.class);
@@ -120,6 +114,15 @@ public class TestMySqlFunctionNamespaceManager
             throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
+    }
+
+    protected Map<String, String> getConfig()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("function-cache-expiration", "0s")
+                .put("function-instance-cache-expiration", "0s")
+                .put("database-url", mySqlServer.getJdbcUrl(DB))
+                .build();
     }
 
     @BeforeMethod

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManagerWithMariaDbDriver.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManagerWithMariaDbDriver.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.mysql;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+@Test(singleThreaded = true)
+public class TestMySqlFunctionNamespaceManagerWithMariaDbDriver
+        extends TestMySqlFunctionNamespaceManager
+{
+    @Override
+    protected Map<String, String> getConfig()
+    {
+        String jdbcUrl = mySqlServer.getJdbcUrl(DB).replaceFirst("jdbc:mysql:", "jdbc:mariadb:");
+
+        return ImmutableMap.<String, String>builder()
+                .put("function-cache-expiration", "0s")
+                .put("function-instance-cache-expiration", "0s")
+                .put("database-url", jdbcUrl)
+                .put("database-driver-name", "org.mariadb.jdbc.Driver")
+                .build();
+    }
+}

--- a/presto-singlestore/pom.xml
+++ b/presto-singlestore/pom.xml
@@ -167,6 +167,13 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- Exclude MariaDB client to avoid conflict with SingleStore JDBC Driver-->
+                    <groupId>org.mariadb.jdbc</groupId>
+                    <artifactId>mariadb-java-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This can be used in place of MySQL Connector J driver.
This should help users who cannot use the MySQL
Connector J driver due to its license

## Impact
None

## Test Plan
New `TestMySqlFunctionNamespaceManagerWithMariaDbDriver` test added 

Additionally, manually tested by  -
```
$ cat etc/function-namespace/tpcds.properties 
function-namespace-manager.name=mysql
database-url=jdbc:mariadb://0.0.0.0:3306/db?user=user&password=pass
database-driver-name=org.mariadb.jdbc.Driver
function-namespaces-table-name=example_function_namespaces
functions-table-name=example_sql_functions
```
The actual server at `0.0.0.0:3306` was a MySQL container using `quay.io/fedora/mysql-80`

I could test the following commands -
```sql

presto> CREATE OR REPLACE FUNCTION tpcds.sf1.mariadbtan(x double)
     -> RETURNS double
     -> COMMENT 'tangent trigonometric function'
     -> LANGUAGE SQL
     -> DETERMINISTIC
     -> RETURNS NULL ON NULL INPUT
     -> RETURN sin(x) / cos(x);
CREATE FUNCTION


presto> select tpcds.sf1.mariadbtan(10);
       _col0        
--------------------
 0.6483608274590866 
(1 row)

presto> DROP FUNCTION tpcds.sf1.mariadbtan;
DROP FUNCTION

presto> select tpcds.sf1.mariadbtan(10);
Query 20250806_084504_00009_m7qek failed: line 1:8: Function tpcds.sf1.mariadbtan not registered
select tpcds.sf1.mariadbtan(10)

presto> CREATE OR REPLACE FUNCTION tpcds.sf1.mariadbtan(x double)
     -> RETURNS double
     -> COMMENT 'tangent trigonometric function'
     -> LANGUAGE SQL
     -> DETERMINISTIC
     -> RETURNS NULL ON NULL INPUT
     -> RETURN sin(x) / cos(x)
     -> ;
CREATE FUNCTION
presto> select tpcds.sf1.mariadbtan(10);
       _col0        
--------------------
 0.6483608274590866 
(1 row)
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Added support to use the MariaDb Java client with a MySQL based function server
```

