### PR TITLE
Add back missing WriteMappings for Decimal & Time type

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/mapping/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/mapping/StandardColumnMappings.java
@@ -428,6 +428,9 @@ public final class StandardColumnMappings
         else if (type instanceof CharType || type instanceof VarcharType) {
             return Optional.of(charWriteMapping());
         }
+        else if (type instanceof DecimalType) {
+            return Optional.of(decimalWriteMapping((DecimalType) type));
+        }
         else if (type.equals(DateType.DATE)) {
             return Optional.of(dateWriteMapping());
         }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/mapping/StandardColumnMappings.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/mapping/StandardColumnMappings.java
@@ -396,6 +396,15 @@ public final class StandardColumnMappings
         else if (type instanceof TimestampType) {
             return Optional.of(timestampWriteMapping((TimestampType) type));
         }
+        else if (type.equals(TIME)) {
+            return Optional.of(timeWriteMapping());
+        }
+        else if (type.equals(TIME_WITH_TIME_ZONE)) {
+            return Optional.of(timeWithTimeZoneWriteMapping());
+        }
+        else if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+            return Optional.of(timestampWithTimeZoneWriteMapping());
+        }
         else if (type.equals(UUID)) {
             return Optional.of(uuidWriteMapping());
         }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -234,6 +234,28 @@ public class TestMySqlIntegrationSmokeTest
     }
 
     @Test
+    public void testMysqlTime()
+    {
+        assertUpdate("CREATE TABLE test_time (datatype_time time)");
+
+        assertUpdate("INSERT INTO test_time VALUES (time '01:02:03.456')", 1);
+
+        assertQuery(
+                "SELECT datatype_time FROM test_time",
+                "VALUES " +
+                        "CAST('01:02:03.456' AS time)");
+
+        assertUpdate("DROP TABLE test_time");
+    }
+
+    @Test
+    public void testMysqlUnsupportedTimeTypes()
+    {
+        assertQueryFails("CREATE TABLE test_timestamp_with_timezone (timestamp_with_time_zone timestamp with time zone)", "Unsupported column type: timestamp with time zone");
+        assertQueryFails("CREATE TABLE test_time_with_timezone (time_with_with_time_zone time with time zone)", "Unsupported column type: time with time zone");
+    }
+
+    @Test
     public void testCharTrailingSpace()
             throws Exception
     {

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -216,6 +216,24 @@ public class TestMySqlIntegrationSmokeTest
     }
 
     @Test
+    public void testMysqlDecimal()
+    {
+        assertUpdate("CREATE TABLE test_decimal (d DECIMAL(10, 2))");
+
+        assertUpdate("INSERT INTO test_decimal VALUES (123.45)", 1);
+        assertUpdate("INSERT INTO test_decimal VALUES (67890.12)", 1);
+        assertUpdate("INSERT INTO test_decimal VALUES (0.99)", 1);
+
+        assertQuery(
+                "SELECT d FROM test_decimal WHERE d<200.00 AND d>0.00",
+                "VALUES " +
+                        "CAST('123.45' AS DECIMAL), " +
+                        "CAST('0.99' AS DECIMAL)");
+
+        assertUpdate("DROP TABLE test_decimal");
+    }
+
+    @Test
     public void testCharTrailingSpace()
             throws Exception
     {


### PR DESCRIPTION
## Description
WriteMapping support for decimal type is already present for writing values but is missing from the query builder. This PR adds the write function to the query builder buildSql function


## Motivation and Context
Queries containing decimal type is not supported

## Impact
No impact to existing queries, will just add decimal type support

## Test Plan
UTs

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Base JDBC Connector Changes
* Add decimal type support to query builder.
```

