### PR TITLE
Remove duplicate binding

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -429,7 +429,7 @@ public class PrestoSparkModule
         binder.bind(PageSourceProvider.class).to(PageSourceManager.class).in(Scopes.SINGLETON);
 
         // for thrift serde
-        binder.bind(ThriftCodecManager.class).toInstance(new ThriftCodecManager());
+        newOptionalBinder(binder, ThriftCodecManager.class).setDefault().toInstance(new ThriftCodecManager());
         binder.bind(ConnectorCodecManager.class).in(Scopes.SINGLETON);
 
         // page sink provider


### PR DESCRIPTION
## Description
1. See the following error:
```
com.google.inject.CreationException: Unable to create injector, see the following errors:

1) [Guice/BindingAlreadySet]: ThriftCodecManager was bound multiple times.

Bound at:
1  : PrestoSparkModule.setup(PrestoSparkModule.java:432)
2  : ThriftCodecModule.configure(ThriftCodecModule.java:54)
      \_ installed by: PrestoFacebookSparkManifoldMetadataStorageModule -> BlobStoreServiceModule -> SmcClientModule -> ThriftCodecModule
```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

```
== NO RELEASE NOTE ==
```

