### PR TITLE
Fix presto query config kQueryTraceTaskRegExp

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -264,10 +264,12 @@ QueryContextManager::toVeloxConfigs(
 
   // Construct query tracing regex and pass to Velox config.
   // It replaces the given native_query_trace_task_reg_exp if also set.
+  // Normal format is {queryId}.{fragmentId}.{stageExecutionId}.{shardId}.{attemptId}
+  // Implementation details is in PrestoTaskId.h
   if (traceFragmentId.has_value() || traceShardId.has_value()) {
     configs.emplace(
         velox::core::QueryConfig::kQueryTraceTaskRegExp,
-        ".*\\." + traceFragmentId.value_or(".*") + "\\..*\\." +
+        ".*\\." + traceFragmentId.value_or(".*") + "\\.[^.]*\\." +
             traceShardId.value_or(".*") + "\\..*");
   }
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
@@ -66,8 +66,10 @@ class PrestoTaskId {
 
  private:
   std::string queryId_;
+  // Also known as fregment id.
   int32_t stageId_{0};
   int32_t stageExecutionId_{0};
+  // Also known as shard id.
   int32_t id_{0};
   int32_t attemptNumber_{0};
 };


### PR DESCRIPTION
Summary:
Current implemntation could match x.fregmentId.y.z.a.b.c.shardId.other

The fix would restrict there is no y.z.a.b.c in between but only y

```
== NO RELEASE NOTE ==
```


