### PR TITLE
[native] Add max-spill-bytes system config

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -43,7 +43,7 @@ void updateFromSystemConfigs(
     std::unordered_map<std::string, std::string>& queryConfigs) {
   const auto& systemConfig = SystemConfig::instance();
   static const std::unordered_map<std::string, std::string>
-      sessionSystemConfigMapping{
+      veloxToSystemConfigMapping{
           {core::QueryConfig::kQueryMaxMemoryPerNode,
            std::string(SystemConfig::kQueryMaxMemoryPerNode)},
           {core::QueryConfig::kSpillFileCreateConfig,
@@ -56,19 +56,21 @@ void updateFromSystemConfigs(
           std::string(SystemConfig::kOrderBySpillEnabled)},
           {core::QueryConfig::kAggregationSpillEnabled,
           std::string(SystemConfig::kAggregationSpillEnabled)},
+          {core::QueryConfig::kMaxSpillBytes,
+          std::string(SystemConfig::kMaxSpillBytes)},
           {core::QueryConfig::kRequestDataSizesMaxWaitSec,
           std::string(SystemConfig::kRequestDataSizesMaxWaitSec)},
           {core::QueryConfig::kMaxSplitPreloadPerDriver,
           std::string(SystemConfig::kDriverMaxSplitPreload)},
           {core::QueryConfig::kMaxLocalExchangePartitionBufferSize,
           std::string(SystemConfig::kMaxLocalExchangePartitionBufferSize)}};
-  for (const auto& configNameEntry : sessionSystemConfigMapping) {
-    const auto& sessionName = configNameEntry.first;
+  for (const auto& configNameEntry : veloxToSystemConfigMapping) {
+    const auto& veloxConfigName = configNameEntry.first;
     const auto& systemConfigName = configNameEntry.second;
-    if (queryConfigs.count(sessionName) == 0) {
+    if (queryConfigs.count(veloxConfigName) == 0) {
       const auto propertyOpt = systemConfig->optionalProperty(systemConfigName);
       if (propertyOpt.hasValue()) {
-        queryConfigs[sessionName] = propertyOpt.value();
+        queryConfigs[veloxConfigName] = propertyOpt.value();
       }
     }
   }

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -260,6 +260,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kJoinSpillEnabled, true),
           BOOL_PROP(kAggregationSpillEnabled, true),
           BOOL_PROP(kOrderBySpillEnabled, true),
+          NUM_PROP(kMaxSpillBytes, 100UL << 30), // 100GB
           NUM_PROP(kRequestDataSizesMaxWaitSec, 10),
           STR_PROP(kPluginDir, ""),
           NUM_PROP(kExchangeIoEvbViolationThresholdMs, 1000),
@@ -343,6 +344,10 @@ bool SystemConfig::aggregationSpillEnabled() const {
 
 bool SystemConfig::orderBySpillEnabled() const {
   return optionalProperty<bool>(kOrderBySpillEnabled).value();
+}
+
+uint64_t SystemConfig::maxSpillBytes() const {
+  return optionalProperty<uint64_t>(kMaxSpillBytes).value();
 }
 
 int SystemConfig::requestDataSizesMaxWaitSec() const {
@@ -1042,6 +1047,7 @@ BaseVeloxQueryConfig::BaseVeloxQueryConfig() {
               c.aggregationSpillEnabled()),
           BOOL_PROP(QueryConfig::kJoinSpillEnabled, c.joinSpillEnabled()),
           BOOL_PROP(QueryConfig::kOrderBySpillEnabled, c.orderBySpillEnabled()),
+          NUM_PROP(QueryConfig::kMaxSpillBytes, c.maxSpillBytes()),
           NUM_PROP(QueryConfig::kMaxSpillLevel, c.maxSpillLevel()),
           NUM_PROP(QueryConfig::kMaxSpillFileSize, c.maxSpillFileSize()),
           NUM_PROP(

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -750,6 +750,7 @@ class SystemConfig : public ConfigBase {
       "aggregation-spill-enabled"};
   static constexpr std::string_view kOrderBySpillEnabled{
       "order-by-spill-enabled"};
+  static constexpr std::string_view kMaxSpillBytes{"max-spill-bytes"};
 
   // Max wait time for exchange request in seconds.
   static constexpr std::string_view kRequestDataSizesMaxWaitSec{
@@ -1042,6 +1043,8 @@ class SystemConfig : public ConfigBase {
   bool aggregationSpillEnabled() const;
 
   bool orderBySpillEnabled() const;
+
+  uint64_t maxSpillBytes() const;
 
   int requestDataSizesMaxWaitSec() const;
 


### PR DESCRIPTION
Summary: There is no corresponding system config properties for max-spill-bytes. Add it and apply to native queries.

Differential Revision: D79781954

== NO RELEASE NOTE ==
