### PR TITLE
Make http2 communication configurable

### DIFF
--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -85,6 +85,7 @@ Property                                                Description
                                                         Should be set to ``true``. Default value is
                                                         ``false``.
 ``http-server.https.port``                              HTTPS server port.
+``http-server.http2.enabled``                           Enables HTTP2 server on the worker.
 ``http-server.https.keystore.path``                     The location of the Java Keystore file that will be
                                                         used to secure TLS.
 ``http-server.https.keystore.key``                      The password for the keystore. This must match the

--- a/presto-docs/src/main/sphinx/security/server.rst
+++ b/presto-docs/src/main/sphinx/security/server.rst
@@ -115,6 +115,7 @@ Property                                                Description
 ``http-server.https.enabled``                           Enables HTTPS access for the Presto coordinator.
                                                         Should be set to ``true``.
 ``http-server.https.port``                              HTTPS server port.
+``http-server.http2.enabled``                           Enables HTTP2 server on the worker.
 ``http-server.https.keystore.path``                     The location of the Java Keystore file that will be
                                                         used to secure TLS.
 ``http-server.https.keystore.key``                      The password for the keystore. This must match the

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -319,8 +319,9 @@ void PrestoServer::run() {
       httpsSocketAddress.setFromLocalPort(httpsPort.value());
     }
 
+    const bool http2Enabled = SystemConfig::instance()->httpServerHttp2Enabled();
     httpsConfig = std::make_unique<http::HttpsConfig>(
-        httpsSocketAddress, certPath, keyPath, ciphers, reusePort);
+        httpsSocketAddress, certPath, keyPath, ciphers, reusePort, http2Enabled);
   }
 
   httpServer_ = std::make_unique<http::HttpServer>(

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -157,6 +157,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kHttpServerNumCpuThreadsHwMultiplier, 1.0),
           NONE_PROP(kHttpServerHttpsPort),
           BOOL_PROP(kHttpServerHttpsEnabled, false),
+          BOOL_PROP(kHttpServerHttp2Enabled, true),
           STR_PROP(
               kHttpsSupportedCiphers,
               "ECDHE-ECDSA-AES256-GCM-SHA384,AES256-GCM-SHA384"),
@@ -295,6 +296,10 @@ int SystemConfig::httpServerHttpsPort() const {
 
 bool SystemConfig::httpServerHttpsEnabled() const {
   return optionalProperty<bool>(kHttpServerHttpsEnabled).value();
+}
+
+bool SystemConfig::httpServerHttp2Enabled() const {
+  return optionalProperty<bool>(kHttpServerHttp2Enabled).value();
 }
 
 std::string SystemConfig::httpsSupportedCiphers() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -202,6 +202,8 @@ class SystemConfig : public ConfigBase {
       "http-server.https.port"};
   static constexpr std::string_view kHttpServerHttpsEnabled{
       "http-server.https.enabled"};
+  static constexpr std::string_view kHttpServerHttp2Enabled{
+      "http-server.http2.enabled"};
   /// List of comma separated ciphers the client can use.
   ///
   /// NOTE: the client needs to have at least one cipher shared with server
@@ -784,6 +786,8 @@ class SystemConfig : public ConfigBase {
   bool httpServerHttpsEnabled() const;
 
   int httpServerHttpsPort() const;
+
+  bool httpServerHttp2Enabled() const;
 
   /// A list of ciphers (comma separated) that are supported by
   /// server and client. Note Java and folly::SSLContext use different names to

--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -37,6 +37,7 @@ std::shared_ptr<folly::SSLContext> createSSLContext(
     sslContext->loadCertKeyPairFromFiles(
         clientCertAndKeyPath.c_str(), clientCertAndKeyPath.c_str());
     sslContext->setCiphersOrThrow(ciphers);
+    sslContext->setAdvertisedNextProtocols({"http/1.1"});
     return sslContext;
   } catch (const std::exception& ex) {
     LOG(FATAL) << fmt::format(

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -106,12 +106,14 @@ HttpsConfig::HttpsConfig(
     const std::string& certPath,
     const std::string& keyPath,
     const std::string& supportedCiphers,
-    bool reusePort)
+    bool reusePort,
+    bool http2Enabled)
     : address_(address),
       certPath_(certPath),
       keyPath_(keyPath),
       supportedCiphers_(supportedCiphers),
-      reusePort_(reusePort) {
+      reusePort_(reusePort),
+      http2Enabled_(http2Enabled) {
   // Wangle separates ciphers by ":" where in the config it's separated with ","
   std::replace(supportedCiphers_.begin(), supportedCiphers_.end(), ',', ':');
 }
@@ -126,6 +128,9 @@ proxygen::HTTPServer::IPConfig HttpsConfig::ipConfig() const {
       folly::SSLContext::VerifyClientCertificate::DO_NOT_REQUEST;
   sslCfg.setCertificate(certPath_, keyPath_, "");
   sslCfg.sslCiphers = supportedCiphers_;
+  if (http2Enabled_) {
+    sslCfg.setNextProtocols({"h2", "http/1.1"});
+  }
 
   ipConfig.sslConfigs.push_back(sslCfg);
 

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -259,7 +259,8 @@ class HttpsConfig {
       const std::string& certPath,
       const std::string& keyPath,
       const std::string& supportedCiphers,
-      bool reusePort = false);
+      bool reusePort = false,
+      bool http2Enabled = true);
 
   proxygen::HTTPServer::IPConfig ipConfig() const;
 
@@ -269,6 +270,7 @@ class HttpsConfig {
   const std::string keyPath_;
   std::string supportedCiphers_;
   const bool reusePort_;
+  const bool http2Enabled_;
 };
 
 class HttpServer {


### PR DESCRIPTION
## Description
Add configuration parameter to enable http2 server on workers

## Motivation and Context
We want to use HTTP2 communication between coordinator and worker . This PR makes the http2 protocol configurable via property.

## Impact
None. Unless http2 is also enabled on the coordinator.

## Test Plan
Unit Tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for configuring http2 server on worker for communication between coordinator and workers. This can be enabled by setting the property ``http-server.http2.enabled`` to  ``true``

```

