### PR TITLE
Enable more features for prestissimo image

### DIFF
--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -398,7 +398,17 @@ jobs:
         working-directory: presto-native-execution
         run: |
           df -h
-          docker compose build centos-native-runtime
+          docker compose build --build-arg EXTRA_CMAKE_FLAGS="
+            -DPRESTO_ENABLE_PARQUET=ON \
+            -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
+            -DPRESTO_ENABLE_JWT=ON \
+            -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
+            -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
+            -DPRESTO_ENABLE_SPATIAL=ON \
+            -DPRESTO_ENABLE_TESTING=OFF \
+            -DPRESTO_ENABLE_S3=ON" \
+            --build-arg NUM_THREADS=2 \
+            centos-native-runtime
 
       - name: Add release tag
         working-directory: presto-native-execution

--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -12,9 +12,14 @@
 
 FROM quay.io/centos/centos:stream9
 
-ENV PROMPT_ALWAYS_RESPOND=n
+# Set this when build arm with common flags
+# from https://github.com/facebookincubator/velox/pull/14366
+ARG ARM_BUILD_TARGET
+
+ENV PROMPT_ALWAYS_RESPOND=y
 ENV CC=/opt/rh/gcc-toolset-12/root/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-12/root/bin/g++
+ENV ARM_BUILD_TARGET=${ARM_BUILD_TARGET}
 
 RUN mkdir -p /scripts /velox/scripts
 COPY scripts /scripts

--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -26,8 +26,10 @@ ENV BUILD_DIR=""
 
 RUN mkdir -p /prestissimo /runtime-libraries
 COPY . /prestissimo/
-RUN EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
-    NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR}
+RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
+    EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS} \
+    NUM_THREADS=${NUM_THREADS} make --directory="/prestissimo/" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR} && \
+    ccache -sz -v
 RUN !(LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server  | grep "not found") && \
     LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/lib64 ldd /prestissimo/${BUILD_BASE_DIR}/${BUILD_DIR}/presto_cpp/main/presto_server | awk 'NF == 4 { system("cp " $3 " /runtime-libraries") }'
 

--- a/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/ubuntu-22.04-dependency.dockerfile
@@ -16,12 +16,18 @@ FROM ${base}
 # Set a default timezone, can be overriden via ARG
 ARG tz="America/New_York"
 ARG DEBIAN_FRONTEND="noninteractive"
-ENV PROMPT_ALWAYS_RESPOND=n
+
+# Set this when build arm with common flags
+# from https://github.com/facebookincubator/velox/pull/14366
+ARG ARM_BUILD_TARGET
+
+ENV PROMPT_ALWAYS_RESPOND=y
 ENV SUDO=" "
 # TZ and DEBIAN_FRONTEND="noninteractive"
 # are required to avoid tzdata installation
 # to prompt for region selection.
 ENV TZ=${tz}
+ENV ARM_BUILD_TARGET=${ARM_BUILD_TARGET}
 
 RUN mkdir -p /scripts /velox/scripts
 COPY scripts /scripts

--- a/presto-native-execution/scripts/setup-adapters.sh
+++ b/presto-native-execution/scripts/setup-adapters.sh
@@ -47,7 +47,7 @@ function install_arrow_flight {
   # Arrow Flight enabled. The Velox version of Arrow is used.
   # NOTE: benchmarks are on due to a compilation error with v15.0.0, once updated that can be removed
   # see https://github.com/apache/arrow/issues/41617
-  EXTRA_ARROW_OPTIONS=" -DARROW_FLIGHT=ON -DARROW_BUILD_BENCHMARKS=ON "
+  EXTRA_ARROW_OPTIONS=" -DARROW_FLIGHT=ON -DARROW_BUILD_BENCHMARKS=ON -DgRPC_SOURCE=BUNDLED -DProtobuf_SOURCE=BUNDLED "
   install_arrow
 }
 


### PR DESCRIPTION
## Description

1. Enables features for prestissimo image by default, added flags below when building the image:
```
-DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON
-DPRESTO_ENABLE_JWT=ON
-DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS
-DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER
-DPRESTO_ENABLE_SPATIAL=ON 
```
2. Use cache mount on ccache directory to accelerate local build
3. Added ARM_BUILD_TARGET for arm build
4. Fixed error in centos dependency image when building arrow
 
## Motivation and Context
By default the image is built with 
```
-DPRESTO_ENABLE_TESTING=OFF
-DPRESTO_ENABLE_PARQUET=ON
-DPRESTO_ENABLE_S3=ON
```

Add more features so that user can try without rebuild the image

## Impact
Release

## Test Plan
Build and test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

