### PR TITLE
Add proper checks for SchemaTablePrefix when table or schema is null

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
@@ -192,7 +192,7 @@ public class DruidMetadata
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
     {
         if (prefix.getTableName() == null) {
-            return listTables(session, Optional.of(prefix.getSchemaName()));
+            return listTables(session, Optional.ofNullable(prefix.getSchemaName()));
         }
         return ImmutableList.of(prefix.toSchemaTableName());
     }

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsMetadata.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsMetadata.java
@@ -159,7 +159,7 @@ public class SheetsMetadata
     {
         requireNonNull(prefix, "prefix is null");
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
-        for (SchemaTableName tableName : listTables(session, Optional.of(prefix.getSchemaName()))) {
+        for (SchemaTableName tableName : listTables(session, Optional.ofNullable(prefix.getSchemaName()))) {
             Optional<ConnectorTableMetadata> tableMetadata = getTableMetadata(session, tableName);
             // table can disappear during listing operation
             if (tableMetadata.isPresent()) {

--- a/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiMetadata.java
+++ b/presto-hudi/src/main/java/com/facebook/presto/hudi/HudiMetadata.java
@@ -170,7 +170,7 @@ public class HudiMetadata
     @Override
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        List<SchemaTableName> tables = prefix.getTableName() != null ? singletonList(prefix.toSchemaTableName()) : listTables(session, Optional.of(prefix.getSchemaName()));
+        List<SchemaTableName> tables = prefix.getTableName() != null ? singletonList(prefix.toSchemaTableName()) : listTables(session, Optional.ofNullable(prefix.getSchemaName()));
 
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
         for (SchemaTableName table : tables) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -472,7 +472,7 @@ public class IcebergHiveMetadata
     {
         ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
         List<SchemaTableName> tableNames;
-        if (prefix.getTableName() != null) {
+        if (prefix.getSchemaName() != null && prefix.getTableName() != null) {
             tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
         }
         else {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -270,11 +270,11 @@ public class IcebergNativeMetadata
         Catalog catalog = catalogFactory.getCatalog(session);
         if (catalog instanceof ViewCatalog) {
             List<SchemaTableName> tableNames;
-            if (prefix.getTableName() != null) {
+            if (prefix.getSchemaName() != null && prefix.getTableName() != null) {
                 tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
             }
             else {
-                tableNames = listViews(session, Optional.of(prefix.getSchemaName()));
+                tableNames = listViews(session, Optional.ofNullable(prefix.getSchemaName()));
             }
 
             for (SchemaTableName schemaTableName : tableNames) {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
`SchemaTablePrefix` allows for `schemaName` and `tableName` to be nullable, this change adds proper checks for null values to prevent a NPE. This follows the fix from https://github.com/prestodb/presto/pull/25695 to ensure remaining usage handles null correctly.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Preemptively add checks to prevent errors for cases where  `SchemaTablePrefix` contains null values. `SchemaTablePrefix` should probably be returning `Optional.ofNullable()`, but since it is an SPI defined class, we should not change the signature and instead make sure these cases are handled correctly.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

