### PR TITLE
fix(ui): Handle null bigint values in query results table

### DIFF
--- a/presto-ui/src/components/QueryResults.jsx
+++ b/presto-ui/src/components/QueryResults.jsx
@@ -38,7 +38,7 @@ export function QueryResults({ results }) {
             let column = {
                 name: row.name,
             };
-            column.selector = row.type === 'bigint' ? row => row[index]?.toString() : row => row[index];
+            column.selector = row.type === 'bigint' ? row => row[index]?.toString() ?? 'NULL' : row => row[index];
             return column;
         });
     };

--- a/presto-ui/src/components/QueryResults.jsx
+++ b/presto-ui/src/components/QueryResults.jsx
@@ -38,7 +38,7 @@ export function QueryResults({ results }) {
             let column = {
                 name: row.name,
             };
-            column.selector = row.type === 'bigint' ? row => row[index].toString() : row => row[index];
+            column.selector = row.type === 'bigint' ? row => row[index]?.toString() : row => row[index];
             return column;
         });
     };


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Bug fix for the SQL Client's query results component, now handles null values for bigint columns without throwing errors.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Fixes https://github.com/prestodb/presto/issues/25714

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
UI query results in SQL Client handles null bigint values

## Test Plan
<!---Please fill in how you tested your change-->
1. Create table will a bigint column
2. Insert row with null value for bigint column
3. Open SQL Client in UI
4. Query table, to include the null bigint row
5. Confirm that `NULL` appears in query results table, no UI error

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

