### PR TITLE
Fix CentOS Dependencies Container Build

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -25,9 +25,9 @@ COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /vel
 ENV VELOX_ARROW_CMAKE_PATCH=/velox/cmake-compatibility.patch
 RUN bash -c "mkdir build && \
     (cd build && ../scripts/setup-centos.sh && \
-                 ../velox/scripts/setup-centos9.sh install_adapters && \
-                 ../scripts/setup-adapters.sh && \
                  source ../velox/scripts/setup-centos9.sh && \
+                 source ../velox/scripts/setup-centos-adapters.sh && \
+                 install_adapters && \
                  install_clang15 && \
                  install_cuda 12.8) && \
     rm -rf build"


### PR DESCRIPTION
## Description

Changed the `RUN` command in `centos-dependency.dockerfile` to match changes in Velox @ 730534112

Specifically, the `install_adapters` and `install_cuda` functions are now in `setup-centos-adapters.sh` and the `setup-adapters.sh` script no longer exists.

## Motivation and Context

The CentOS dependencies container build was broken, failing in the Docker image construction due to the above.

## Impact

No public facing changes.

## Test Plan

N/A

## Contributor checklist

- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```