### PR TITLE
Support for query retry on different cluster via router and plan-checker

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -52,6 +52,7 @@ public final class PrestoHeaders
     public static final String PRESTO_PAGE_NEXT_TOKEN = "X-Presto-Page-End-Sequence-Id";
     public static final String PRESTO_BUFFER_COMPLETE = "X-Presto-Buffer-Complete";
     public static final String PRESTO_PREFIX_URL = "X-Presto-Prefix-Url";
+    public static final String PRESTO_RETRY_QUERY = "X-Presto-Retry-Query";
 
     private PrestoHeaders() {}
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -15,6 +15,7 @@ package com.facebook.presto.client;
 
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.spi.security.SelectedRole;
+import okhttp3.Headers;
 
 import javax.annotation.Nullable;
 
@@ -59,6 +60,8 @@ public interface StatementClient
     Map<String, String> getAddedPreparedStatements();
 
     Set<String> getDeallocatedPreparedStatements();
+
+    Headers getResponseHeaders();
 
     @Nullable
     String getStartedTransactionId();

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
@@ -115,6 +115,7 @@ class StatementClientV1
     private final Map<String, String> addedSessionFunctions = new ConcurrentHashMap<>();
     private final Set<String> removedSessionFunctions = newConcurrentHashSet();
     private final boolean validateNextUriSource;
+    private final Headers responseHeaders;
 
     private final AtomicReference<State> state = new AtomicReference<>(State.RUNNING);
 
@@ -141,6 +142,7 @@ class StatementClientV1
         }
 
         processResponse(response.getHeaders(), response.getValue());
+        this.responseHeaders = response.getHeaders();
     }
 
     private Request buildQueryRequest(ClientSession session, String query)
@@ -215,6 +217,11 @@ class StatementClientV1
         }
 
         return builder.build();
+    }
+
+    public Headers getResponseHeaders()
+    {
+        return responseHeaders;
     }
 
     @Override

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPlanCheckerRouterPlugin.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPlanCheckerRouterPlugin.java
@@ -260,7 +260,8 @@ public class TestPlanCheckerRouterPlugin
         String javaClusterURI = format("router-java-url=%s", planCheckerRouterConfig.getJavaRouterURI());
         String nativeClusterURI = format("router-native-url=%s", planCheckerRouterConfig.getNativeRouterURI());
         String javaClusterFallbackEnabled = format("enable-java-cluster-fallback=%s", planCheckerRouterConfig.isJavaClusterFallbackEnabled());
-        Files.write(tempPluginSchedulerConfigFile, ImmutableList.of(schedulerName, planCheckerClusterURIs, javaClusterURI, nativeClusterURI, javaClusterFallbackEnabled));
+        String javaClusterQueryRetryEnabled = format("enable-java-cluster-query-retry=%s", planCheckerRouterConfig.isJavaClusterQueryRetryEnabled());
+        Files.write(tempPluginSchedulerConfigFile, ImmutableList.of(schedulerName, planCheckerClusterURIs, javaClusterURI, nativeClusterURI, javaClusterFallbackEnabled, javaClusterQueryRetryEnabled));
         return tempPluginSchedulerConfigFile.toFile();
     }
 

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginConfig.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginConfig.java
@@ -34,6 +34,7 @@ public class PlanCheckerRouterPluginConfig
     private URI nativeRouterURI;
     private Duration clientRequestTimeout = new Duration(2, MINUTES);
     private boolean javaClusterFallbackEnabled;
+    private boolean javaClusterQueryRetryEnabled;
 
     @Config("plan-check-clusters-uris")
     public PlanCheckerRouterPluginConfig setPlanCheckClustersURIs(String uris)
@@ -100,6 +101,18 @@ public class PlanCheckerRouterPluginConfig
     public PlanCheckerRouterPluginConfig setJavaClusterFallbackEnabled(boolean javaClusterFallbackEnabled)
     {
         this.javaClusterFallbackEnabled = javaClusterFallbackEnabled;
+        return this;
+    }
+
+    public boolean isJavaClusterQueryRetryEnabled()
+    {
+        return javaClusterQueryRetryEnabled;
+    }
+
+    @Config("enable-java-cluster-query-retry")
+    public PlanCheckerRouterPluginConfig setJavaClusterQueryRetryEnabled(boolean javaClusterQueryRetryEnabled)
+    {
+        this.javaClusterQueryRetryEnabled = javaClusterQueryRetryEnabled;
         return this;
     }
 }

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
@@ -17,10 +17,13 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.client.ClientSession;
 import com.facebook.presto.client.QueryError;
+import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -33,13 +36,18 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_RETRY_QUERY;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_TRANSACTION_ID;
 import static com.facebook.presto.client.StatementClientFactory.newStatementClient;
 import static com.facebook.presto.router.scheduler.HttpRequestSessionContext.getResourceEstimates;
 import static com.facebook.presto.router.scheduler.HttpRequestSessionContext.getSerializedSessionFunctions;
 import static com.google.common.base.Verify.verify;
+import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 public class PlanCheckerRouterPluginPrestoClient
@@ -56,6 +64,7 @@ public class PlanCheckerRouterPluginPrestoClient
     private final URI nativeRouterURI;
     private final Duration clientRequestTimeout;
     private final boolean javaClusterFallbackEnabled;
+    private final boolean javaClusterQueryRetryEnabled;
 
     @Inject
     public PlanCheckerRouterPluginPrestoClient(PlanCheckerRouterPluginConfig planCheckerRouterPluginConfig)
@@ -69,12 +78,13 @@ public class PlanCheckerRouterPluginPrestoClient
                 requireNonNull(planCheckerRouterPluginConfig.getNativeRouterURI(), "nativeRouterURI is null");
         this.clientRequestTimeout = planCheckerRouterPluginConfig.getClientRequestTimeout();
         this.javaClusterFallbackEnabled = planCheckerRouterPluginConfig.isJavaClusterFallbackEnabled();
+        this.javaClusterQueryRetryEnabled = planCheckerRouterPluginConfig.isJavaClusterQueryRetryEnabled();
     }
 
     public Optional<URI> getCompatibleClusterURI(Map<String, List<String>> headers, String statement, Principal principal)
     {
         String newSql = ANALYZE_CALL + statement;
-        ClientSession clientSession = parseHeadersToClientSession(headers, principal);
+        ClientSession clientSession = parseHeadersToClientSession(headers, principal, getPlanCheckerClusterDestination());
         boolean isNativeCompatible = true;
         // submit initial query
         try (StatementClient client = newStatementClient(httpClient, clientSession, newSql)) {
@@ -119,11 +129,86 @@ public class PlanCheckerRouterPluginPrestoClient
         if (isNativeCompatible) {
             log.debug("Native compatible, routing to native-clusters router: [%s]", nativeRouterURI);
             nativeClusterRedirectRequests.update(1L);
+            if (javaClusterQueryRetryEnabled) {
+                return buildNativeRedirectURI(headers, principal, statement);
+            }
             return Optional.of(nativeRouterURI);
         }
         log.debug("Native incompatible, routing to java-clusters router: [%s]", javaRouterURI);
         javaClusterRedirectRequests.update(1L);
         return Optional.of(javaRouterURI);
+    }
+
+    private Optional<URI> buildNativeRedirectURI(Map<String, List<String>> headers, Principal principal, String statement)
+    {
+        ClientSession javaSession = parseHeadersToClientSession(prepareHeadersForJavaCluster(headers), principal, javaRouterURI);
+        try (StatementClient client = newStatementClient(httpClient, javaSession, statement)) {
+            Optional<URI> redirectUri = postQueryOnJavaAndGetRedirectUri(client);
+            return Optional.of(redirectUri.orElse(nativeRouterURI));
+        }
+        catch (Exception e) {
+            log.error("Error submitting query for redirect URI: {%s}", e.getMessage(), e);
+            return Optional.of(nativeRouterURI);
+        }
+    }
+
+    public Optional<URI> postQueryOnJavaAndGetRedirectUri(StatementClient client)
+    {
+        QueryStatusInfo statusInfo = client.currentStatusInfo();
+        if (statusInfo == null || statusInfo.getNextUri() == null) {
+            return Optional.empty();
+        }
+
+        URI retryUri = statusInfo.getNextUri();
+        Headers headers = client.getResponseHeaders();
+        OptionalLong maxAgeSeconds = extractMaxAgeInSeconds(headers);
+
+        HttpUrl.Builder redirectBuilder = HttpUrl.get(nativeRouterURI)
+                .newBuilder()
+                .addQueryParameter("retryUrl", retryUri.toString());
+
+        maxAgeSeconds.ifPresent(expiration ->
+                redirectBuilder.addQueryParameter("retryExpirationInSeconds", Long.toString(expiration)));
+
+        URI redirect = redirectBuilder.build().uri();
+        log.info("Redirecting to combined native URI: {%s}", redirect);
+
+        return Optional.of(redirect);
+    }
+
+    private static OptionalLong extractMaxAgeInSeconds(Headers headers)
+    {
+        if (headers == null) {
+            return OptionalLong.empty();
+        }
+
+        List<String> cacheControlList = headers.values("Cache-Control");
+        if (cacheControlList == null) {
+            return OptionalLong.empty();
+        }
+
+        Pattern maxAgePattern = Pattern.compile("max-age=(\\d+)");
+        for (String headerValue : cacheControlList) {
+            Matcher matcher = maxAgePattern.matcher(headerValue);
+            if (matcher.find()) {
+                return OptionalLong.of(Long.parseLong(matcher.group(1)));
+            }
+        }
+        return OptionalLong.empty();
+    }
+
+    private static Map<String, List<String>> prepareHeadersForJavaCluster(Map<String, List<String>> headers)
+    {
+        ImmutableMap.Builder<String, List<String>> builder = ImmutableMap.builder();
+
+        headers.forEach((key, value) -> {
+            if (!key.equalsIgnoreCase("Host")) {
+                builder.put(key, value);
+            }
+        });
+        builder.put(PRESTO_RETRY_QUERY, singletonList("true"));
+
+        return builder.build();
     }
 
     @Managed
@@ -147,7 +232,7 @@ public class PlanCheckerRouterPluginPrestoClient
         return fallBackToJavaClusterRedirectRequests;
     }
 
-    private ClientSession parseHeadersToClientSession(Map<String, List<String>> headers, Principal principal)
+    private ClientSession parseHeadersToClientSession(Map<String, List<String>> headers, Principal principal, URI destinationOverride)
     {
         HttpRequestSessionContext sessionContext =
                 new HttpRequestSessionContext(
@@ -156,7 +241,7 @@ public class PlanCheckerRouterPluginPrestoClient
                         principal);
 
         return new ClientSession(
-                getPlanCheckerClusterDestination(),
+                destinationOverride,
                 sessionContext.getIdentity().getUser(),
                 sessionContext.getSource(),
                 Optional.empty(),

--- a/presto-plan-checker-router-plugin/src/test/java/com/facebook/presto/router/scheduler/TestPlanCheckerProviderRouterPluginConfig.java
+++ b/presto-plan-checker-router-plugin/src/test/java/com/facebook/presto/router/scheduler/TestPlanCheckerProviderRouterPluginConfig.java
@@ -36,7 +36,8 @@ public class TestPlanCheckerProviderRouterPluginConfig
                 .setNativeRouterURI(null)
                 .setPlanCheckClustersURIs(null)
                 .setClientRequestTimeout(new Duration(2, MINUTES))
-                .setJavaClusterFallbackEnabled(false));
+                .setJavaClusterFallbackEnabled(false)
+                .setJavaClusterQueryRetryEnabled(false));
     }
 
     @Test
@@ -49,13 +50,15 @@ public class TestPlanCheckerProviderRouterPluginConfig
                 .put("plan-check-clusters-uris", "192.168.0.3, 192.168.0.4")
                 .put("client-request-timeout", "5m")
                 .put("enable-java-cluster-fallback", "true")
+                .put("enable-java-cluster-query-retry", "true")
                 .build();
         PlanCheckerRouterPluginConfig expected = new PlanCheckerRouterPluginConfig()
                 .setJavaRouterURI(new URI("192.168.0.1"))
                 .setNativeRouterURI(new URI("192.168.0.2"))
                 .setPlanCheckClustersURIs("192.168.0.3, 192.168.0.4")
                 .setClientRequestTimeout(new Duration(5, MINUTES))
-                .setJavaClusterFallbackEnabled(true);
+                .setJavaClusterFallbackEnabled(true)
+                .setJavaClusterQueryRetryEnabled(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-router/src/main/java/com/facebook/presto/router/RouterResource.java
+++ b/presto-router/src/main/java/com/facebook/presto/router/RouterResource.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.router;
 
+import com.facebook.airlift.http.client.HttpUriBuilder;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.router.cluster.ClusterManager;
@@ -27,6 +28,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -57,12 +59,23 @@ public class RouterResource
     @POST
     @Path("/v1/statement")
     @Produces(APPLICATION_JSON)
-    public Response routeQuery(String statement, @Context HttpServletRequest servletRequest)
+    public Response routeQuery(
+            String statement,
+            @Context HttpServletRequest servletRequest,
+            @QueryParam("retryUrl") String retryUrl,
+            @QueryParam("retryExpirationInSeconds") String retryExpirationInSeconds)
     {
         RequestInfo requestInfo = new RequestInfo(servletRequest, statement);
         URI coordinatorUri = clusterManager.getDestination(requestInfo).orElseThrow(() -> badRequest(BAD_GATEWAY, "No Presto cluster available"));
-        URI statementUri = uriBuilderFrom(coordinatorUri).replacePath("/v1/statement").build();
+        HttpUriBuilder statementUriBuilder = uriBuilderFrom(coordinatorUri).replacePath("/v1/statement");
         successRedirectRequests.update(1);
+        if (retryUrl != null && !retryUrl.isEmpty()) {
+            statementUriBuilder.addParameter("retryUrl", retryUrl);
+        }
+        if (retryExpirationInSeconds != null && !retryExpirationInSeconds.isEmpty()) {
+            statementUriBuilder.addParameter("retryExpirationInSeconds", retryExpirationInSeconds);
+        }
+        URI statementUri = statementUriBuilder.build();
         log.info("route query to %s", statementUri);
         return Response.temporaryRedirect(statementUri).build();
     }


### PR DESCRIPTION
## Description
Support for query retry on a different cluster via the router and plan-checker
This depends on https://github.com/prestodb/presto/pull/25625

## Motivation and Context
When `enable-java-cluster-query-retry` is enabled, 
If presto-plan-checker-router-plugin` schedules query on Native cluster `router-native-url` then if the query fails, the query is retried on a Java cluster `router-java-url`

## Impact
This will allow routing the Query on the Java cluster when the query is failing or not supported on the Native cluster.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Added `enable-java-cluster-query-retry` configuration in `router-scheduler.properties` to retry queries on `router-java-url `when they fail on `router-native-url`.
```
