### PR TITLE
#25651 [docs] Add doc for pushdown_subfields_for_map_functions sessio…

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -425,6 +425,15 @@ Run the following command to use ``optimizers_to_enable_verbose_runtime_stats``:
 
 ``SET SESSION optimizers_to_enable_verbose_runtime_stats=ALL;``
 
+``pushdown_subfields_for_map_functions``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Use this to optimize the ``map_filter()`` function.
+
+It controls if subfields access is executed at the data source or not.
+
 JDBC Properties
 ---------------
 


### PR DESCRIPTION
…n property

Fix #25651
Added description to docs for session property pushdown_subfields_for_map_functions

## Description
Changed the descriptions in session properties doc for the pushdown_subfields_for_map_functions with the type and default value too.

## Motivation and Context
Fixes this issue [https://github.com/prestodb/presto/issues/25651]  

## Impact
This change would add to the public facing docs helping this merged fix too https://github.com/prestodb/presto/pull/25451

## Test Plan
Not needed for docs

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

