### PR TITLE
[native] Make SessionProperties global singleton

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -20,6 +20,7 @@
 #include "presto_cpp/main/CoordinatorDiscoverer.h"
 #include "presto_cpp/main/PeriodicMemoryChecker.h"
 #include "presto_cpp/main/PeriodicTaskManager.h"
+#include "presto_cpp/main/SessionProperties.h"
 #include "presto_cpp/main/SignalHandler.h"
 #include "presto_cpp/main/TaskResource.h"
 #include "presto_cpp/main/common/ConfigReader.h"
@@ -1651,9 +1652,8 @@ void PrestoServer::registerSidecarEndpoints() {
           proxygen::HTTPMessage* /*message*/,
           const std::vector<std::unique_ptr<folly::IOBuf>>& /*body*/,
           proxygen::ResponseHandler* downstream) {
-        auto sessionProperties =
-            taskManager_->getQueryContextManager()->getSessionProperties();
-        http::sendOkResponse(downstream, sessionProperties.serialize());
+        const auto* sessionProperties = SessionProperties::instance();
+        http::sendOkResponse(downstream, sessionProperties->serialize());
       });
   httpServer_->registerGet(
       "/v1/functions",

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "presto_cpp/main/QueryContextManager.h"
+#include "presto_cpp/main/SessionProperties.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include "presto_cpp/main/common/Configs.h"
 #include "velox/connectors/hive/HiveConfig.h"
@@ -126,8 +127,7 @@ QueryContextManager::QueryContextManager(
     folly::Executor* driverExecutor,
     folly::Executor* spillerExecutor)
     : driverExecutor_(driverExecutor),
-      spillerExecutor_(spillerExecutor),
-      sessionProperties_(SessionProperties()) {}
+      spillerExecutor_(spillerExecutor) {}
 
 std::shared_ptr<velox::core::QueryCtx>
 QueryContextManager::findOrCreateQueryCtx(
@@ -250,7 +250,7 @@ QueryContextManager::toVeloxConfigs(
       configs[core::QueryConfig::kShuffleCompressionKind] =
           velox::common::compressionKindToString(compressionKind);
     } else {
-      configs[sessionProperties_.toVeloxConfig(it.first)] = it.second;
+      configs[SessionProperties::instance()->toVeloxConfig(it.first)] = it.second;
     }
   }
 

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.h
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.h
@@ -19,7 +19,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "presto_cpp/main/SessionProperties.h"
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 #include "velox/core/QueryCtx.h"
 
@@ -142,10 +141,6 @@ class QueryContextManager {
   /// Test method to clear the query context cache.
   void testingClearCache();
 
-  const SessionProperties& getSessionProperties() const {
-    return sessionProperties_;
-  }
-
  private:
   std::shared_ptr<velox::core::QueryCtx> findOrCreateQueryCtx(
       const protocol::TaskId& taskId,
@@ -162,7 +157,6 @@ class QueryContextManager {
   folly::Executor* const spillerExecutor_{nullptr};
 
   folly::Synchronized<QueryContextCache> queryContextCache_;
-  SessionProperties sessionProperties_;
 };
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -34,6 +34,12 @@ json SessionProperty::serialize() {
   return j;
 }
 
+SessionProperties* SessionProperties::instance() {
+  static std::unique_ptr<SessionProperties> instance =
+      std::make_unique<SessionProperties>();
+  return instance.get();
+}
+
 void SessionProperties::addSessionProperty(
     const std::string& name,
     const std::string& description,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -322,8 +322,10 @@ class SessionProperties {
   static constexpr const char* kMaxNumSplitsListenedTo =
       "native_max_num_splits_listened_to";
 
-  SessionProperties();
+  static SessionProperties* instance();
 
+  SessionProperties();
+  
   /// Utility function to translate a config name in Presto to its equivalent in
   /// Velox. Returns 'name' as is if there is no mapping.
   const std::string toVeloxConfig(const std::string& name) const;

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -15,7 +15,6 @@
 
 #include "presto_cpp/main/SessionProperties.h"
 #include "velox/core/QueryConfig.h"
-#include "velox/type/Type.h"
 
 using namespace facebook::presto;
 using namespace facebook::velox;
@@ -23,52 +22,123 @@ using namespace facebook::velox;
 class SessionPropertiesTest : public testing::Test {};
 
 TEST_F(SessionPropertiesTest, validateMapping) {
-  const std::vector<std::string> names = {
-      SessionProperties::kLegacyTimestamp,
-      SessionProperties::kDriverCpuTimeSliceLimitMs,
-      SessionProperties::kSpillCompressionCodec,
-      SessionProperties::kScaleWriterRebalanceMaxMemoryUsageRatio,
-      SessionProperties::kScaleWriterMaxPartitionsPerWriter,
-      SessionProperties::
-          kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
-      SessionProperties::kScaleWriterMinProcessedBytesRebalanceThreshold,
-      SessionProperties::kTableScanScaledProcessingEnabled,
-      SessionProperties::kTableScanScaleUpMemoryUsageRatio,
-      SessionProperties::kStreamingAggregationMinOutputBatchRows,
-      SessionProperties::kRequestDataSizesMaxWaitSec,
-      SessionProperties::kNativeQueryMemoryReclaimerPriority,
-      SessionProperties::kMaxNumSplitsListenedTo};
-  const std::vector<std::string> veloxConfigNames = {
-      core::QueryConfig::kAdjustTimestampToTimezone,
-      core::QueryConfig::kDriverCpuTimeSliceLimitMs,
-      core::QueryConfig::kSpillCompressionKind,
-      core::QueryConfig::kScaleWriterRebalanceMaxMemoryUsageRatio,
-      core::QueryConfig::kScaleWriterMaxPartitionsPerWriter,
-      core::QueryConfig::
-          kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
-      core::QueryConfig::kScaleWriterMinProcessedBytesRebalanceThreshold,
-      core::QueryConfig::kTableScanScaledProcessingEnabled,
-      core::QueryConfig::kTableScanScaleUpMemoryUsageRatio,
-      core::QueryConfig::kStreamingAggregationMinOutputBatchRows,
-      core::QueryConfig::kRequestDataSizesMaxWaitSec,
-      core::QueryConfig::kQueryMemoryReclaimerPriority,
-      core::QueryConfig::kMaxNumSplitsListenedTo};
-  auto sessionProperties = SessionProperties().testingSessionProperties();
-  const auto len = names.size();
-  for (auto i = 0; i < len; i++) {
-    EXPECT_EQ(
-        veloxConfigNames[i],
-        sessionProperties.at(names[i])->getVeloxConfigName());
+  const std::unordered_map<std::string, std::string> expectedMappings = {
+      {SessionProperties::kExprEvalSimplified,
+       core::QueryConfig::kExprEvalSimplified},
+      {SessionProperties::kExprMaxArraySizeInReduce,
+       core::QueryConfig::kExprMaxArraySizeInReduce},
+      {SessionProperties::kExprMaxCompiledRegexes,
+       core::QueryConfig::kExprMaxCompiledRegexes},
+      {SessionProperties::kMaxPartialAggregationMemory,
+       core::QueryConfig::kMaxPartialAggregationMemory},
+      {SessionProperties::kMaxExtendedPartialAggregationMemory,
+       core::QueryConfig::kMaxExtendedPartialAggregationMemory},
+      {SessionProperties::kMaxSpillLevel, core::QueryConfig::kMaxSpillLevel},
+      {SessionProperties::kMaxSpillFileSize,
+       core::QueryConfig::kMaxSpillFileSize},
+      {SessionProperties::kMaxSpillBytes, core::QueryConfig::kMaxSpillBytes},
+      {SessionProperties::kSpillCompressionCodec,
+       core::QueryConfig::kSpillCompressionKind},
+      {SessionProperties::kSpillWriteBufferSize,
+       core::QueryConfig::kSpillWriteBufferSize},
+      {SessionProperties::kSpillFileCreateConfig,
+       core::QueryConfig::kSpillFileCreateConfig},
+      {SessionProperties::kJoinSpillEnabled,
+       core::QueryConfig::kJoinSpillEnabled},
+      {SessionProperties::kWindowSpillEnabled,
+       core::QueryConfig::kWindowSpillEnabled},
+      {SessionProperties::kWriterSpillEnabled,
+       core::QueryConfig::kWriterSpillEnabled},
+      {SessionProperties::kWriterFlushThresholdBytes,
+       core::QueryConfig::kWriterFlushThresholdBytes},
+      {SessionProperties::kRowNumberSpillEnabled,
+       core::QueryConfig::kRowNumberSpillEnabled},
+      {SessionProperties::kSpillerNumPartitionBits,
+       core::QueryConfig::kSpillNumPartitionBits},
+      {SessionProperties::kTopNRowNumberSpillEnabled,
+       core::QueryConfig::kTopNRowNumberSpillEnabled},
+      {SessionProperties::kValidateOutputFromOperators,
+       core::QueryConfig::kValidateOutputFromOperators},
+      {SessionProperties::kDebugDisableExpressionWithPeeling,
+       core::QueryConfig::kDebugDisableExpressionWithPeeling},
+      {SessionProperties::kDebugDisableCommonSubExpressions,
+       core::QueryConfig::kDebugDisableCommonSubExpressions},
+      {SessionProperties::kDebugDisableExpressionWithMemoization,
+       core::QueryConfig::kDebugDisableExpressionWithMemoization},
+      {SessionProperties::kDebugDisableExpressionWithLazyInputs,
+       core::QueryConfig::kDebugDisableExpressionWithLazyInputs},
+      {SessionProperties::kDebugMemoryPoolNameRegex,
+       core::QueryConfig::kDebugMemoryPoolNameRegex},
+      {SessionProperties::kSelectiveNimbleReaderEnabled,
+       core::QueryConfig::kSelectiveNimbleReaderEnabled},
+      {SessionProperties::kQueryTraceEnabled,
+       core::QueryConfig::kQueryTraceEnabled},
+      {SessionProperties::kQueryTraceDir, core::QueryConfig::kQueryTraceDir},
+      {SessionProperties::kQueryTraceNodeId,
+       core::QueryConfig::kQueryTraceNodeId},
+      {SessionProperties::kQueryTraceMaxBytes,
+       core::QueryConfig::kQueryTraceMaxBytes},
+      {SessionProperties::kOpTraceDirectoryCreateConfig,
+       core::QueryConfig::kOpTraceDirectoryCreateConfig},
+      {SessionProperties::kMaxOutputBufferSize,
+       core::QueryConfig::kMaxOutputBufferSize},
+      {SessionProperties::kMaxPartitionedOutputBufferSize,
+       core::QueryConfig::kMaxPartitionedOutputBufferSize},
+      {SessionProperties::kLegacyTimestamp,
+       core::QueryConfig::kAdjustTimestampToTimezone},
+      {SessionProperties::kDriverCpuTimeSliceLimitMs,
+       core::QueryConfig::kDriverCpuTimeSliceLimitMs},
+      {SessionProperties::kMaxLocalExchangePartitionCount,
+       core::QueryConfig::kMaxLocalExchangePartitionCount},
+      {SessionProperties::kSpillPrefixSortEnabled,
+       core::QueryConfig::kSpillPrefixSortEnabled},
+      {SessionProperties::kPrefixSortNormalizedKeyMaxBytes,
+       core::QueryConfig::kPrefixSortNormalizedKeyMaxBytes},
+      {SessionProperties::kPrefixSortMinRows,
+       core::QueryConfig::kPrefixSortMinRows},
+      {SessionProperties::kScaleWriterRebalanceMaxMemoryUsageRatio,
+       core::QueryConfig::kScaleWriterRebalanceMaxMemoryUsageRatio},
+      {SessionProperties::kScaleWriterMaxPartitionsPerWriter,
+       core::QueryConfig::kScaleWriterMaxPartitionsPerWriter},
+      {SessionProperties::
+           kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
+       core::QueryConfig::
+           kScaleWriterMinPartitionProcessedBytesRebalanceThreshold},
+      {SessionProperties::kScaleWriterMinProcessedBytesRebalanceThreshold,
+       core::QueryConfig::kScaleWriterMinProcessedBytesRebalanceThreshold},
+      {SessionProperties::kTableScanScaledProcessingEnabled,
+       core::QueryConfig::kTableScanScaledProcessingEnabled},
+      {SessionProperties::kTableScanScaleUpMemoryUsageRatio,
+       core::QueryConfig::kTableScanScaleUpMemoryUsageRatio},
+      {SessionProperties::kStreamingAggregationMinOutputBatchRows,
+       core::QueryConfig::kStreamingAggregationMinOutputBatchRows},
+      {SessionProperties::kRequestDataSizesMaxWaitSec,
+       core::QueryConfig::kRequestDataSizesMaxWaitSec},
+      {SessionProperties::kNativeQueryMemoryReclaimerPriority,
+       core::QueryConfig::kQueryMemoryReclaimerPriority},
+      {SessionProperties::kMaxNumSplitsListenedTo,
+       core::QueryConfig::kMaxNumSplitsListenedTo}};
+
+  const auto& sessionProperties =
+      SessionProperties::instance()->testingSessionProperties();
+
+  ASSERT_EQ(expectedMappings.size(), sessionProperties.size());
+
+  for (const auto& [sessionPropertyName, expectedVeloxConfigName] :
+       expectedMappings) {
+    ASSERT_EQ(
+        expectedVeloxConfigName,
+        sessionProperties.at(sessionPropertyName)->getVeloxConfigName());
   }
 }
 
 TEST_F(SessionPropertiesTest, serializeProperty) {
-  auto properties = SessionProperties();
-  auto j = properties.serialize();
+  auto* sessionProperties = SessionProperties::instance();
+  auto j = sessionProperties->serialize();
   for (const auto& property : j) {
     auto name = property["name"];
     json expectedProperty =
-        properties.testingSessionProperties().at(name)->serialize();
+        sessionProperties->testingSessionProperties().at(name)->serialize();
     EXPECT_EQ(property, expectedProperty);
   }
 }


### PR DESCRIPTION
Summary: SessionProperties provides static session mapping and defaults, not holding any state. It makes more sense to treat it as global singleton same as other config classes.

Differential Revision: D79916443

== NO RELEASE NOTE ==
