### PR TITLE
[native] Remove out-of-line definition of constexpr in nlohmann json.

### DIFF
--- a/presto-native-execution/presto_cpp/external/json/nlohmann/json.hpp
+++ b/presto-native-execution/presto_cpp/external/json/nlohmann/json.hpp
@@ -2235,8 +2235,6 @@ struct static_const
     static constexpr T value{};
 };
 
-template<typename T>
-constexpr T static_const<T>::value;
 }  // namespace detail
 }  // namespace nlohmann
 


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wdeprecated-redundant-constexpr-static-def` which raises the warning:

> warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated

Since we are now on C++20, we can remove the out-of-line definition of constexpr static data members. 
