### PR TITLE
Add LDAP authentication support for environments without anonymous bind

### DIFF
--- a/presto-password-authenticators/src/main/java/com/facebook/presto/password/ldap/LdapAuthenticator.java
+++ b/presto-password-authenticators/src/main/java/com/facebook/presto/password/ldap/LdapAuthenticator.java
@@ -76,7 +76,6 @@ public class LdapAuthenticator
                 .put(INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
                 .put(PROVIDER_URL, ldapUrl)
                 .build();
-        checkEnvironment(environment);
         this.basicEnvironment = environment;
         this.authenticationCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(serverConfig.getLdapCacheTtl().toMillis(), MILLISECONDS)
@@ -173,16 +172,6 @@ public class LdapAuthenticator
     private static String replaceUser(String pattern, String user)
     {
         return pattern.replaceAll("\\$\\{USER}", user);
-    }
-
-    private static void checkEnvironment(Map<String, String> environment)
-    {
-        try {
-            closeContext(createDirContext(environment));
-        }
-        catch (NamingException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private static void closeContext(DirContext context)

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   presto-master:
-    image: 'prestodb/centos6-oj8-openldap:${DOCKER_IMAGES_VERSION}'
+    image: 'prestodb/centos7-oj8-openldap:11'
     command: /docker/volumes/conf/docker/files/presto-launcher-wrapper.sh singlenode-ldap run
     extra_hosts:
        - "${LDAP_SERVER_HOST}:${LDAP_SERVER_IP}"
@@ -12,10 +12,10 @@ services:
       - ${OVERRIDE_JDK_DIR}:/docker/volumes/overridejdk
 
   application-runner:
-    image: 'prestodb/centos6-oj8-openldap:${DOCKER_IMAGES_VERSION}'
+    image: 'prestodb/centos7-oj8-openldap:11'
     environment:
       - TEMPTO_PROFILE_CONFIG_FILE=/docker/volumes/conf/tempto/tempto-configuration-for-docker-ldap.yaml
       - CLI_ARGUMENTS=--server https://presto-master:8443 --keystore-path /etc/openldap/certs/coordinator.jks --keystore-password testldap
 
   ldapserver:
-    image: 'prestodb/centos6-oj8-openldap:${DOCKER_IMAGES_VERSION}'
+    image: 'prestodb/centos7-oj8-openldap:11'

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoLdapCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoLdapCliTests.java
@@ -228,7 +228,7 @@ public class PrestoLdapCliTests
         ldapTruststorePassword = "wrong_password";
         launchPrestoCliWithServerArgument("--execute", "select * from hive.default.nation;");
         assertThat(trimLines(presto.readRemainingErrorLines())).anySatisfy(line ->
-                assertThat(line).contains("Keystore was tampered with, or password was incorrect"));
+                assertThat(line).contains("Error setting up SSL: keystore password was incorrect"));
         skipAfterTestWithContext();
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/LdapPrestoJdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/LdapPrestoJdbcTests.java
@@ -119,7 +119,7 @@ public class LdapPrestoJdbcTests
             fail();
         }
         catch (SQLException exception) {
-            assertEquals(exception.getMessage(), "Error setting up SSL: Keystore was tampered with, or password was incorrect");
+            assertEquals(exception.getMessage(), "Error setting up SSL: keystore password was incorrect");
         }
     }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

In certain environments, LDAP servers are configured to disallow anonymous binds for security reasons. This change enables Presto to authenticate against such LDAP servers where anonymous bind is disabled.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Error message observed when trying to authenticate with LDAP servers with anonymous bind disabled

```
presto-master-1  | 1 error
presto-master-1  | 
presto-master-1  | ======================
presto-master-1  | Full classname legend:
presto-master-1  | ======================
presto-master-1  | AuthenticationNotSupportedException: "javax.naming.AuthenticationNotSupportedException"
presto-master-1  | LdapAuthenticator:                   "com.facebook.presto.password.ldap.LdapAuthenticator"
presto-master-1  | LdapAuthenticatorFactory:            "com.facebook.presto.password.ldap.LdapAuthenticatorFactory"
presto-master-1  | ========================
presto-master-1  | End of classname legend:
presto-master-1  | ========================
presto-master-1  | 
presto-master-1  | 	at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:576)
presto-master-1  | 	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:190)
presto-master-1  | 	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:113)
presto-master-1  | 	at com.google.inject.Guice.createInjector(Guice.java:87)
presto-master-1  | 	at com.facebook.airlift.bootstrap.Bootstrap.initialize(Bootstrap.java:263)
presto-master-1  | 	at com.facebook.presto.password.ldap.LdapAuthenticatorFactory.create(LdapAuthenticatorFactory.java:49)
presto-master-1  | 	at com.facebook.presto.server.security.PasswordAuthenticatorManager.loadPasswordAuthenticator(PasswordAuthenticatorManager.java:75)
presto-master-1  | 	at com.facebook.presto.server.PrestoServer.run(PrestoServer.java:183)
presto-master-1  | 	at com.facebook.presto.server.PrestoServer.main(PrestoServer.java:96)
presto-master-1  | Caused by: java.lang.RuntimeException: javax.naming.AuthenticationNotSupportedException: [LDAP: error code 48 - anonymous bind disallowed]
presto-master-1  | 	at com.facebook.presto.password.ldap.LdapAuthenticator.checkEnvironment(LdapAuthenticator.java:184)
presto-master-1  | 	at com.facebook.presto.password.ldap.LdapAuthenticator.<init>(LdapAuthenticator.java:79)
presto-master-1  | 	at com.facebook.presto.password.ldap.LdapAuthenticator$$FastClassByGuice$$1807621.GUICE$TRAMPOLINE(<generated>)
presto-master-1  | 	at com.facebook.presto.password.ldap.LdapAuthenticator$$FastClassByGuice$$1807621.apply(<generated>)
presto-master-1  | 	at com.google.inject.internal.DefaultConstructionProxyFactory$FastClassProxy.newInstance(DefaultConstructionProxyFactory.java:82)
presto-master-1  | 	at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:114)
presto-master-1  | 	at com.google.inject.internal.ConstructorInjector.access$000(ConstructorInjector.java:33)
presto-master-1  | 	at com.google.inject.internal.ConstructorInjector$1.call(ConstructorInjector.java:98)
presto-master-1  | 	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
presto-master-1  | 	at com.facebook.airlift.bootstrap.LifeCycleModule.provision(LifeCycleModule.java:54)
presto-master-1  | 	at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:117)
presto-master-1  | 	at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:66)
presto-master-1  | 	at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:93)
presto-master-1  | 	at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:300)
presto-master-1  | 	at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
presto-master-1  | 	at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:169)
presto-master-1  | 	at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:45)
presto-master-1  | 	at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:213)
presto-master-1  | 	at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:186)
presto-master-1  | 	... 7 more
presto-master-1  | Caused by: javax.naming.AuthenticationNotSupportedException: [LDAP: error code 48 - anonymous bind disallowed]
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtx.mapErrorCode(LdapCtx.java:3252)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:3207)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtx.processReturnCode(LdapCtx.java:2993)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtx.connect(LdapCtx.java:2907)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtx.<init>(LdapCtx.java:347)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxFromUrl(LdapCtxFactory.java:229)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtxFactory.getUsingURL(LdapCtxFactory.java:189)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtxFactory.getUsingURLs(LdapCtxFactory.java:247)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxInstance(LdapCtxFactory.java:154)
presto-master-1  | 	at com.sun.jndi.ldap.LdapCtxFactory.getInitialContext(LdapCtxFactory.java:84)
presto-master-1  | 	at javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:695)
presto-master-1  | 	at javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:313)
presto-master-1  | 	at javax.naming.InitialContext.init(InitialContext.java:244)
presto-master-1  | 	at javax.naming.InitialContext.<init>(InitialContext.java:216)
presto-master-1  | 	at javax.naming.directory.InitialDirContext.<init>(InitialDirContext.java:101)
presto-master-1  | 	at com.facebook.presto.password.jndi.JndiUtils.createDirContext(JndiUtils.java:30)
presto-master-1  | 	at com.facebook.presto.password.ldap.LdapAuthenticator.checkEnvironment(LdapAuthenticator.java:181)
presto-master-1  | 	... 25 more
```

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Presto allows to authenticate against LDAP servers with anonymous bind disabled

## Test Plan
<!---Please fill in how you tested your change-->

Included test coverage by configuring the LDAP server in product tests to disallow anonymous bind.

Also upgraded the Docker image for the singlenode-ldap test suite and updated expected error messages to align with the new image.

The Docker image used for tests has also been upgraded from CentOS 6 to CentOS 7. This has been done as part of the new Hadoop docker images.

New Docker image with anonymous bind disabled added as part of the following PR: https://github.com/prestodb/docker-images/pull/57

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Add support for LDAP with anonymous bind disabled.

```

