### PR TITLE
Improve DELETE Statement on columns with special characters in their names

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/SubfieldTokenizer.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/SubfieldTokenizer.java
@@ -153,7 +153,7 @@ class SubfieldTokenizer
 
     private static boolean isUnquotedPathCharacter(char c)
     {
-        return c == ':' || c == '$' || c == '-' || c == '/' || c == '@' || c == '|' || c == '#' || c == ' ' || isUnquotedSubscriptCharacter(c);
+        return c == ':' || c == '$' || c == '-' || c == '/' || c == '@' || c == '|' || c == '#' || c == ' ' || c == '<' || c == '>' || isUnquotedSubscriptCharacter(c);
     }
 
     private Subfield.PathElement matchUnquotedSubscript()

--- a/presto-common/src/test/java/com/facebook/presto/common/TestSubfieldTokenizer.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestSubfieldTokenizer.java
@@ -83,6 +83,19 @@ public class TestSubfieldTokenizer
     }
 
     @Test
+    public void testAngleBracketsInColumnNames()
+    {
+        assertPath(new Subfield("<>col", ImmutableList.of()));
+        assertPath(new Subfield("col<with>brackets", ImmutableList.of()));
+        assertPath(new Subfield("<>col", ImmutableList.of(new NestedField("<>field"))));
+        assertPath(new Subfield("table", ImmutableList.of(new NestedField("<>field"))));
+        assertPath(new Subfield("table", ImmutableList.of(new Subfield.StringSubscript("<>value>"))));
+        assertPath(new Subfield("<table>", ImmutableList.of(
+                new NestedField("<field>"),
+                new Subfield.StringSubscript("<value>"))));
+    }
+
+    @Test
     public void testInvalidPaths()
     {
         assertInvalidPath("a[b]");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2052,6 +2052,15 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
+    public void testDeleteWithSpecialCharacterColumnName()
+    {
+        assertUpdate("CREATE TABLE test_special_character_column_name (\"<age>\" int, name varchar)");
+        assertUpdate("INSERT INTO test_special_character_column_name VALUES (1, 'abc'), (2, 'def'), (3, 'ghi')", 3);
+        assertUpdate("DELETE FROM test_special_character_column_name where \"<age>\" = 2", 1);
+        assertUpdate("DROP TABLE IF EXISTS test_special_character_column_name");
+    }
+
+    @Test
     public void testDeletedHiddenColumn()
     {
         assertUpdate("DROP TABLE IF EXISTS test_deleted");


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
https://github.com/prestodb/presto/issues/24584

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve ``DELETE`` on columns with special characters in their names.
```

