### PR TITLE
[presto] Move out M2Y from RegressionState for regr_slope and regr_intercept functions (#25475)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -68,6 +68,7 @@ import com.facebook.presto.operator.aggregation.DoubleCorrelationAggregation;
 import com.facebook.presto.operator.aggregation.DoubleCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.DoubleHistogramAggregation;
 import com.facebook.presto.operator.aggregation.DoubleRegressionAggregation;
+import com.facebook.presto.operator.aggregation.DoubleRegressionExtendedAggregation;
 import com.facebook.presto.operator.aggregation.DoubleSumAggregation;
 import com.facebook.presto.operator.aggregation.EntropyAggregation;
 import com.facebook.presto.operator.aggregation.GeometricMeanAggregations;
@@ -85,6 +86,7 @@ import com.facebook.presto.operator.aggregation.RealCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.RealGeometricMeanAggregations;
 import com.facebook.presto.operator.aggregation.RealHistogramAggregation;
 import com.facebook.presto.operator.aggregation.RealRegressionAggregation;
+import com.facebook.presto.operator.aggregation.RealRegressionExtendedAggregation;
 import com.facebook.presto.operator.aggregation.RealSumAggregation;
 import com.facebook.presto.operator.aggregation.ReduceAggregationFunction;
 import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
@@ -742,7 +744,9 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregates(DoubleCovarianceAggregation.class)
                 .aggregates(RealCovarianceAggregation.class)
                 .aggregates(DoubleRegressionAggregation.class)
+                .aggregates(DoubleRegressionExtendedAggregation.class)
                 .aggregates(RealRegressionAggregation.class)
+                .aggregates(RealRegressionExtendedAggregation.class)
                 .aggregates(DoubleCorrelationAggregation.class)
                 .aggregates(RealCorrelationAggregation.class)
                 .aggregates(BitwiseOrAggregation.class)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionAggregation.java
@@ -24,15 +24,8 @@ import com.facebook.presto.spi.function.OutputFunction;
 import com.facebook.presto.spi.function.SqlType;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionAvgx;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionAvgy;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionCount;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionIntercept;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionR2;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSlope;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSxx;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSxy;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSyy;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.mergeRegressionState;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.updateRegressionState;
 
@@ -72,102 +65,6 @@ public class DoubleRegressionAggregation
     {
         double result = getRegressionIntercept(state);
         if (Double.isFinite(result)) {
-            DOUBLE.writeDouble(out, result);
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_sxy")
-    @OutputFunction(StandardTypes.DOUBLE)
-    public static void regrSxy(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionSxy(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
-            DOUBLE.writeDouble(out, result);
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_sxx")
-    @OutputFunction(StandardTypes.DOUBLE)
-    public static void regrSxx(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionSxx(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
-            DOUBLE.writeDouble(out, result);
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_syy")
-    @OutputFunction(StandardTypes.DOUBLE)
-    public static void regrSyy(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionSyy(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
-            DOUBLE.writeDouble(out, result);
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_r2")
-    @OutputFunction(StandardTypes.DOUBLE)
-    public static void regrR2(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionR2(state);
-        if (Double.isFinite(result)) {
-            DOUBLE.writeDouble(out, result);
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_count")
-    @OutputFunction(StandardTypes.DOUBLE)
-    public static void regrCount(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionCount(state);
-        if (Double.isFinite(result) && result > 0) {
-            DOUBLE.writeDouble(out, result);
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_avgy")
-    @OutputFunction(StandardTypes.DOUBLE)
-    public static void regrAvgy(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionAvgy(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
-            DOUBLE.writeDouble(out, result);
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_avgx")
-    @OutputFunction(StandardTypes.DOUBLE)
-    public static void regrAvgx(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionAvgx(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             DOUBLE.writeDouble(out, result);
         }
         else {

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionExtendedAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/DoubleRegressionExtendedAggregation.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.operator.aggregation.state.ExtendedRegressionState;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionAvgx;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionAvgy;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionCount;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionR2;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSxx;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSxy;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSyy;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.mergeExtendedRegressionState;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.updateExtendedRegressionState;
+
+@AggregationFunction
+public class DoubleRegressionExtendedAggregation
+{
+    private DoubleRegressionExtendedAggregation() {}
+
+    @InputFunction
+    public static void input(@AggregationState ExtendedRegressionState state, @SqlType(StandardTypes.DOUBLE) double dependentValue, @SqlType(StandardTypes.DOUBLE) double independentValue)
+    {
+        updateExtendedRegressionState(state, independentValue, dependentValue);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState ExtendedRegressionState state, @AggregationState ExtendedRegressionState otherState)
+    {
+        mergeExtendedRegressionState(state, otherState);
+    }
+
+    @AggregationFunction("regr_sxy")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void regrSxy(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionSxy(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            DOUBLE.writeDouble(out, result);
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_sxx")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void regrSxx(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionSxx(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            DOUBLE.writeDouble(out, result);
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_syy")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void regrSyy(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionSyy(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            DOUBLE.writeDouble(out, result);
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_r2")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void regrR2(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionR2(state);
+        if (Double.isFinite(result)) {
+            DOUBLE.writeDouble(out, result);
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_count")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void regrCount(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionCount(state);
+        if (Double.isFinite(result) && result > 0) {
+            DOUBLE.writeDouble(out, result);
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_avgy")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void regrAvgy(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionAvgy(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            DOUBLE.writeDouble(out, result);
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_avgx")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void regrAvgx(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionAvgx(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            DOUBLE.writeDouble(out, result);
+        }
+        else {
+            out.appendNull();
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/RealRegressionAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/RealRegressionAggregation.java
@@ -24,15 +24,8 @@ import com.facebook.presto.spi.function.OutputFunction;
 import com.facebook.presto.spi.function.SqlType;
 
 import static com.facebook.presto.common.type.RealType.REAL;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionAvgx;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionAvgy;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionCount;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionIntercept;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionR2;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSlope;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSxx;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSxy;
-import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSyy;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 
@@ -72,102 +65,6 @@ public class RealRegressionAggregation
     {
         double result = getRegressionIntercept(state);
         if (Double.isFinite(result)) {
-            REAL.writeLong(out, floatToRawIntBits((float) result));
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_sxy")
-    @OutputFunction(StandardTypes.REAL)
-    public static void regrSxy(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionSxy(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
-            REAL.writeLong(out, floatToRawIntBits((float) result));
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_sxx")
-    @OutputFunction(StandardTypes.REAL)
-    public static void regrSxx(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionSxx(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
-            REAL.writeLong(out, floatToRawIntBits((float) result));
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_syy")
-    @OutputFunction(StandardTypes.REAL)
-    public static void regrSyy(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionSyy(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
-            REAL.writeLong(out, floatToRawIntBits((float) result));
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_r2")
-    @OutputFunction(StandardTypes.REAL)
-    public static void regrR2(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionR2(state);
-        if (Double.isFinite(result)) {
-            REAL.writeLong(out, floatToRawIntBits((float) result));
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_count")
-    @OutputFunction(StandardTypes.REAL)
-    public static void regrCount(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionCount(state);
-        if (Double.isFinite(result) && result > 0) {
-            REAL.writeLong(out, floatToRawIntBits((float) result));
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_avgy")
-    @OutputFunction(StandardTypes.REAL)
-    public static void regrAvgy(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionAvgy(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
-            REAL.writeLong(out, floatToRawIntBits((float) result));
-        }
-        else {
-            out.appendNull();
-        }
-    }
-
-    @AggregationFunction("regr_avgx")
-    @OutputFunction(StandardTypes.REAL)
-    public static void regrAvgx(@AggregationState RegressionState state, BlockBuilder out)
-    {
-        double result = getRegressionAvgx(state);
-        double count = getRegressionCount(state);
-        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
             REAL.writeLong(out, floatToRawIntBits((float) result));
         }
         else {

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/RealRegressionExtendedAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/RealRegressionExtendedAggregation.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.operator.aggregation.state.ExtendedRegressionState;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionAvgx;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionAvgy;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionCount;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionR2;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSxx;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSxy;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.getRegressionSyy;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+
+@AggregationFunction
+public class RealRegressionExtendedAggregation
+{
+    private RealRegressionExtendedAggregation() {}
+
+    @InputFunction
+    public static void input(@AggregationState ExtendedRegressionState state, @SqlType(StandardTypes.REAL) long dependentValue, @SqlType(StandardTypes.REAL) long independentValue)
+    {
+        DoubleRegressionExtendedAggregation.input(state, intBitsToFloat((int) dependentValue), intBitsToFloat((int) independentValue));
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState ExtendedRegressionState state, @AggregationState ExtendedRegressionState otherState)
+    {
+        DoubleRegressionExtendedAggregation.combine(state, otherState);
+    }
+
+    @AggregationFunction("regr_sxy")
+    @OutputFunction(StandardTypes.REAL)
+    public static void regrSxy(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionSxy(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            REAL.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_sxx")
+    @OutputFunction(StandardTypes.REAL)
+    public static void regrSxx(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionSxx(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            REAL.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_syy")
+    @OutputFunction(StandardTypes.REAL)
+    public static void regrSyy(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionSyy(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            REAL.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_r2")
+    @OutputFunction(StandardTypes.REAL)
+    public static void regrR2(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionR2(state);
+        if (Double.isFinite(result)) {
+            REAL.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_count")
+    @OutputFunction(StandardTypes.REAL)
+    public static void regrCount(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionCount(state);
+        if (Double.isFinite(result) && result > 0) {
+            REAL.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_avgy")
+    @OutputFunction(StandardTypes.REAL)
+    public static void regrAvgy(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionAvgy(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            REAL.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+
+    @AggregationFunction("regr_avgx")
+    @OutputFunction(StandardTypes.REAL)
+    public static void regrAvgx(@AggregationState ExtendedRegressionState state, BlockBuilder out)
+    {
+        double result = getRegressionAvgx(state);
+        double count = getRegressionCount(state);
+        if (Double.isFinite(result) && Double.isFinite(count) && count > 0) {
+            REAL.writeLong(out, floatToRawIntBits((float) result));
+        }
+        else {
+            out.appendNull();
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/state/ExtendedRegressionState.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/state/ExtendedRegressionState.java
@@ -13,10 +13,10 @@
  */
 package com.facebook.presto.operator.aggregation.state;
 
-public interface RegressionState
-        extends CovarianceState
+public interface ExtendedRegressionState
+        extends RegressionState
 {
-    double getM2X();
+    double getM2Y();
 
-    void setM2X(double value);
+    void setM2Y(double value);
 }


### PR DESCRIPTION
Summary:

## Context
Currently we don't enforce intermediate/return type are the same in Coordinator and Prestissimo Worker.
Velox creates vectors for intermediate/return results based on a plan that comes from Coordinator. Then Prestissimo tries to use those vector and not crash.

In practise we had a crash some time ago due to such a mismatch (D74199165).
And I added validation to Velox to catch such kind of mismatches early: https://github.com/facebookincubator/velox/pull/13322
But we wasn't able to enable it in prod, because the validation failed for "regr_slope" and "regr_intercept" functions.

## What's changed?
In this diff I'm fixing "regr_slope" and "regr_intercept" intermediate types. Basically in Java `AggregationState` for all these functions is the same:
```
    AggregationFunction("regr_slope")
    AggregationFunction("regr_intercept")
    AggregationFunction("regr_sxy")
    AggregationFunction("regr_sxx")
    AggregationFunction("regr_syy")
    AggregationFunction("regr_r2")
    AggregationFunction("regr_count")
    AggregationFunction("regr_avgy")
    AggregationFunction("regr_avgx")
```
But in Prestissimo the state storage is more optimal:
```
    AggregationFunction("regr_slope")
    AggregationFunction("regr_intercept")
```
These 2 aggregation functions don't have M2Y field. And this is more efficient, because we don't waste memory and CPU on the field, that aren't needed.

So I moved M2Y to extended class, the same as it works in Velox: https://github.com/facebookincubator/velox/blob/main/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp?fbclid=IwY2xjawLRTetleHRuA2FlbQIxMQBicmlkETFiT0N3UFR0M2VKOHl6MHRhAR6KRQ1VUQdCkZXzwj14sMQrVZ-R9QBH1utuGJb5U_lyGzDwt8PwV317QRVNJg_aem_-ePxZ-fHO5MNgfUmayVJFA#L326-L337

No major changes, mostly just reorganized the code.

## Test plan
I tested `REGR_SLOPE`, `REGR_INTERCEPT` and `REGR_R2` functions since they are heavily used in prod and cover both cases: with and without M2Y field. 

What my test looked like. For all 3 `REGR_*` functions I found some prod queries, then:
1. Ran them on prev Java build
2. Ran them on new (with this PR) Java build
3. Ran them on prev Prestissimo build
4. Ran them on new (with this PR) Prestissimo build

And compared the output results. They all were identical.
With this manual test we covered `Coordinator -> Java Worker` and `Coordinator -> Prestissimo Worker` integrations.

## Next steps
In this diff I'm trying to apply the same optimization to Java. With this fix, the signatures will become the same in Java and Prestissimo and we will be able to enable the validation

Differential Revision: D77625566

== NO RELEASE NOTES ==
