### PR TITLE
[native] Fix CentOS adapter install in dependency image

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -25,9 +25,10 @@ COPY velox/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /vel
 ENV VELOX_ARROW_CMAKE_PATCH=/velox/cmake-compatibility.patch
 RUN bash -c "mkdir build && \
     (cd build && ../scripts/setup-centos.sh && \
-                 ../velox/scripts/setup-centos9.sh install_adapters && \
                  ../scripts/setup-adapters.sh && \
                  source ../velox/scripts/setup-centos9.sh && \
+                 source ../velox/scripts/setup-centos-adapters.sh && \
+                 install_adapters && \
                  install_clang15 && \
                  install_cuda 12.8) && \
     rm -rf build"


### PR DESCRIPTION
Velox PR 14046 moved the adapter installation to a new file. This needs to be referred to for the dependency image build.

Replaces: https://github.com/prestodb/presto/pull/25718

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

