### PR TITLE
Feature Enhancement: Case-Sensitive Support For Bigquery

### DIFF
--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryConfig.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryConfig.java
@@ -35,6 +35,7 @@ public class BigQueryConfig
     private Optional<String> parentProjectId = Optional.empty();
     private OptionalInt parallelism = OptionalInt.empty();
     private boolean viewsEnabled;
+    private boolean caseSensitiveNameMatching;
     private Optional<String> viewMaterializationProject = Optional.empty();
     private Optional<String> viewMaterializationDataset = Optional.empty();
     private int maxReadRowsRetries = DEFAULT_MAX_READ_ROWS_RETRIES;
@@ -178,6 +179,22 @@ public class BigQueryConfig
     public BigQueryConfig setMaxReadRowsRetries(int maxReadRowsRetries)
     {
         this.maxReadRowsRetries = maxReadRowsRetries;
+        return this;
+    }
+
+    public boolean isCaseSensitiveNameMatching()
+    {
+        return caseSensitiveNameMatching;
+    }
+
+    @Config("case-sensitive-name-matching")
+    @ConfigDescription(
+            "Case sensitivity for schema and table name matching. " +
+             "true = preserve case and require exact matches; " +
+             "false (default) = normalize to lower case and match case-insensitively.")
+    public BigQueryConfig setCaseSensitiveNameMatching(boolean caseSensitiveNameMatching)
+    {
+        this.caseSensitiveNameMatching = caseSensitiveNameMatching;
         return this;
     }
 

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryMetadata.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryMetadata.java
@@ -51,6 +51,7 @@ import static com.facebook.presto.plugin.bigquery.Conversions.toColumnMetadata;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 
@@ -63,12 +64,14 @@ public class BigQueryMetadata
     private static final Logger log = Logger.get(BigQueryMetadata.class);
     private final BigQueryClient bigQueryClient;
     private final String projectId;
+    private final boolean caseSensitiveNameMatching;
 
     @Inject
     public BigQueryMetadata(BigQueryClient bigQueryClient, BigQueryConfig config)
     {
         this.bigQueryClient = bigQueryClient;
         this.projectId = config.getProjectId().orElse(bigQueryClient.getProjectId());
+        this.caseSensitiveNameMatching = config.isCaseSensitiveNameMatching();
     }
 
     @Override
@@ -232,5 +235,11 @@ public class BigQueryMetadata
         return tableInfo.isPresent() ?
                 ImmutableList.of(tableName) :
                 ImmutableList.of(); // table does not exist
+    }
+
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier)
+    {
+        return caseSensitiveNameMatching ? identifier : identifier.toLowerCase(ENGLISH);
     }
 }

--- a/presto-bigquery/src/test/java/com/facebook/presto/plugin/bigquery/TestBigQueryConfig.java
+++ b/presto-bigquery/src/test/java/com/facebook/presto/plugin/bigquery/TestBigQueryConfig.java
@@ -36,7 +36,8 @@ public class TestBigQueryConfig
                 .setParallelism(20)
                 .setViewMaterializationProject("vmproject")
                 .setViewMaterializationDataset("vmdataset")
-                .setMaxReadRowsRetries(10);
+                .setMaxReadRowsRetries(10)
+                .setCaseSensitiveNameMatching(false);
 
         assertEquals(config.getCredentialsKey(), Optional.of("ckey"));
         assertEquals(config.getCredentialsFile(), Optional.of("cfile"));
@@ -46,6 +47,7 @@ public class TestBigQueryConfig
         assertEquals(config.getViewMaterializationProject(), Optional.of("vmproject"));
         assertEquals(config.getViewMaterializationDataset(), Optional.of("vmdataset"));
         assertEquals(config.getMaxReadRowsRetries(), 10);
+        assertEquals(config.isCaseSensitiveNameMatching(), false);
     }
 
     @Test
@@ -59,6 +61,7 @@ public class TestBigQueryConfig
                 .put("bigquery.view-materialization-project", "vmproject")
                 .put("bigquery.view-materialization-dataset", "vmdataset")
                 .put("bigquery.max-read-rows-retries", "10")
+                .put("case-sensitive-name-matching", "true")
                 .build();
 
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
@@ -71,6 +74,7 @@ public class TestBigQueryConfig
         assertEquals(config.getViewMaterializationProject(), Optional.of("vmproject"));
         assertEquals(config.getViewMaterializationDataset(), Optional.of("vmdataset"));
         assertEquals(config.getMaxReadRowsRetries(), 10);
+        assertEquals(config.isCaseSensitiveNameMatching(), true);
     }
 
     @Test

--- a/presto-docs/src/main/sphinx/connector/bigquery.rst
+++ b/presto-docs/src/main/sphinx/connector/bigquery.rst
@@ -137,6 +137,9 @@ Property                                  Description                           
 ``bigquery.max-read-rows-retries``        The number of retries in case of retryable server issues       ``3``
 ``bigquery.credentials-key``              credentials key (base64 encoded)                               None. See `authentication <#authentication>`_
 ``bigquery.credentials-file``             JSON credentials file path                                     None. See `authentication <#authentication>`_
+``case-sensitive-name-matching``          Enable case sensitive identifier support for schema and table  ``false``
+                                          names for the connector. When disabled, names are matched
+                                          case-insensitively using lowercase normalization.          
 ========================================= ============================================================== ==============================================
 
 Data Types


### PR DESCRIPTION
## Description

Added catalog level config to support - `case-sensitive-name-matching`

This PR implements case sensitivity handling for BigQuery schema and table names:

1. Added case-sensitive name matching support controlled by the `case-sensitive-name-matching` configuration property
2. Implemented [normalizeIdentifier](cci:1://file:///Users/ajay/ibm/ibminternal/presto/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryMetadata.java:245:4-249:5) in BigQueryMetadata to respect case sensitivity settings
3. Modified BigQueryClient to preserve case when case-sensitive matching is enabled

When `case-sensitive-name-matching` is set to true:
- Schema and table names will preserve their original case
- Queries must use the exact case as defined in BigQuery
- Both `TestSchema` and `testschema` can exist as separate schemas

When `case-sensitive-name-matching` is set to false (default for backward compatibility):
- All names are normalized to lowercase
- Queries are case-insensitive

## Motivation and Context
Feature/Enhancement Item- Mixed-case support for BigQuery

## Impact
**Comparing SHOW SCHEMAS when case-sensitive-name-matching is TRUE Vs. FALSE**
<img width="1700" height="676" alt="image" src="https://github.com/user-attachments/assets/27bcc329-cd96-446e-a7d5-bfe0403cb78c" />

**Comparing SELECT when case-sensitive-name-matching is TRUE Vs. FALSE**
<img width="1448" height="771" alt="image" src="https://github.com/user-attachments/assets/81082be2-e0e0-49d5-8d58-5612cb5a9ff8" />

**Comparing COLUMN Name when case-sensitive-name-matching is TRUE Vs. FALSE**
<img width="1657" height="311" alt="Screenshot 2025-08-18 at 3 16 59 PM" src="https://github.com/user-attachments/assets/6ddb4a87-30c2-42d4-9624-8c63243fff03" />


## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

BigQuery Connector Changes
* Add support for case-sensitive identifiers in BigQuery. Set the configuration property in the catalog file as follows to enable: ``case-sensitive-name-matching=true``.
```
