### PR TITLE
refactor: Use std::optional compatible members

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
+++ b/presto-native-execution/presto_cpp/main/common/ConfigReader.cpp
@@ -87,7 +87,7 @@ std::string requiredProperty(
     const velox::config::ConfigBase& properties,
     const std::string& name) {
   auto value = properties.get<std::string>(name);
-  if (!value.hasValue()) {
+  if (!value.has_value()) {
     VELOX_USER_FAIL("Missing configuration property {}", name);
   }
   return value.value();
@@ -120,7 +120,7 @@ std::string getOptionalProperty(
     const std::string& name,
     const std::string& defaultValue) {
   auto value = properties.get<std::string>(name);
-  if (!value.hasValue()) {
+  if (!value.has_value()) {
     return defaultValue;
   }
   return value.value();


### PR DESCRIPTION
## Description

folly::Optional have two same member functions, one is std::optional compatible name, another is not.
Let's use first instead of second 

## Motivation and Context

Allow to use std::optional in velox instead of folly::Optional
Details: https://github.com/facebookincubator/velox/pull/14455

## Impact

No, same member function, just different name

## Test Plan

Not needed

## Contributor checklist

Done

## Release Notes

```
== NO RELEASE NOTE ==
```

