### PR TITLE
Upgrade Iceberg version to 1.6.1

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>17</project.build.targetJdk>
-        <dep.iceberg.version>1.5.0</dep.iceberg.version>
+        <dep.iceberg.version>1.6.1</dep.iceberg.version>
         <dep.nessie.version>0.95.0</dep.nessie.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergDistributedRest.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergDistributedRest.java
@@ -36,7 +36,6 @@ import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnector
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Test
 public class TestIcebergDistributedRest
@@ -96,15 +95,6 @@ public class TestIcebergDistributedRest
                 .setDataDirectory(Optional.of(warehouseLocation.toPath()))
                 .build()
                 .getQueryRunner();
-    }
-
-    @Test
-    public void testDeleteOnV1Table()
-    {
-        // v1 table create fails due to Iceberg REST catalog bug (see: https://github.com/apache/iceberg/issues/8756)
-        assertThatThrownBy(super::testDeleteOnV1Table)
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageMatching("Cannot downgrade v2 table to v1");
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRest.java
@@ -47,7 +47,6 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.lang.String.format;
 import static org.apache.iceberg.rest.auth.OAuth2Properties.OAUTH2_SERVER_URI;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
 @Test
@@ -126,69 +125,6 @@ public class TestIcebergSmokeRest
         return getNativeIcebergTable(getCatalogFactory(restConfig),
                 session,
                 SchemaTableName.valueOf(schema + "." + tableName));
-    }
-
-    @Test
-    public void testDeleteOnPartitionedV1Table()
-    {
-        // v1 table create fails due to Iceberg REST catalog bug (see: https://github.com/apache/iceberg/issues/8756)
-        assertThatThrownBy(super::testDeleteOnPartitionedV1Table)
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageMatching("Cannot downgrade v2 table to v1");
-    }
-
-    @Test
-    public void testCreateTableWithFormatVersion()
-    {
-        // v1 table create fails due to Iceberg REST catalog bug (see: https://github.com/apache/iceberg/issues/8756)
-        assertThatThrownBy(() -> super.testMetadataDeleteOnNonIdentityPartitionColumn("1", "copy-on-write"))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageMatching("Cannot downgrade v2 table to v1");
-
-        // v2 succeeds
-        super.testCreateTableWithFormatVersion("2", "merge-on-read");
-    }
-
-    @Test(dataProvider = "version_and_mode")
-    public void testMetadataDeleteOnNonIdentityPartitionColumn(String version, String mode)
-    {
-        if (version.equals("1")) {
-            // v1 table create fails due to Iceberg REST catalog bug (see: https://github.com/apache/iceberg/issues/8756)
-            assertThatThrownBy(() -> super.testMetadataDeleteOnNonIdentityPartitionColumn(version, mode))
-                    .isInstanceOf(RuntimeException.class);
-        }
-        else {
-            // v2 succeeds
-            super.testMetadataDeleteOnNonIdentityPartitionColumn(version, mode);
-        }
-    }
-
-    @Test(dataProvider = "version_and_mode")
-    public void testMetadataDeleteOnTableWithUnsupportedSpecsIncludingNoData(String version, String mode)
-    {
-        if (version.equals("1")) {
-            // v1 table create fails due to Iceberg REST catalog bug (see: https://github.com/apache/iceberg/issues/8756)
-            assertThatThrownBy(() -> super.testMetadataDeleteOnTableWithUnsupportedSpecsIncludingNoData(version, mode))
-                    .isInstanceOf(RuntimeException.class);
-        }
-        else {
-            // v2 succeeds
-            super.testMetadataDeleteOnTableWithUnsupportedSpecsIncludingNoData(version, mode);
-        }
-    }
-
-    @Test(dataProvider = "version_and_mode")
-    public void testMetadataDeleteOnTableWithUnsupportedSpecsWhoseDataAllDeleted(String version, String mode)
-    {
-        if (version.equals("1")) {
-            // v1 table create fails due to Iceberg REST catalog bug (see: https://github.com/apache/iceberg/issues/8756)
-            assertThatThrownBy(() -> super.testMetadataDeleteOnTableWithUnsupportedSpecsWhoseDataAllDeleted(version, mode))
-                    .isInstanceOf(RuntimeException.class);
-        }
-        else {
-            // v2 succeeds
-            super.testMetadataDeleteOnTableWithUnsupportedSpecsWhoseDataAllDeleted(version, mode);
-        }
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergSmokeRestNestedNamespace.java
@@ -53,7 +53,6 @@ import static java.lang.String.format;
 import static java.nio.file.Files.createTempDirectory;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Test
 public class TestIcebergSmokeRestNestedNamespace
@@ -261,19 +260,6 @@ public class TestIcebergSmokeRestNestedNamespace
                 "SELECT orderkey, shippriority, orderstatus FROM orders");
 
         dropTable(session, "test_create_partitioned_table_as_" + fileFormatString);
-    }
-
-    @Test
-    @Override
-    public void testCreateTableWithFormatVersion()
-    {
-        // v1 table create fails due to Iceberg REST catalog bug (see: https://github.com/apache/iceberg/issues/8756)
-        assertThatThrownBy(() -> testCreateTableWithFormatVersion("1", "copy-on-write"))
-                .hasCauseInstanceOf(RuntimeException.class)
-                .hasStackTraceContaining("Cannot downgrade v2 table to v1");
-
-        // v2 succeeds
-        testCreateTableWithFormatVersion("2", "merge-on-read");
     }
 
     @Override // override due to double quotes around nested namespace


### PR DESCRIPTION
## Description

This PR upgrade Iceberg to 1.6.1. Since Iceberg1.6 addressed the issue that v1 tables couldn't be created in `RestCatalog` (see [here](https://github.com/apache/iceberg/issues/8756)), we adjusted the corresponding test cases in Iceberg connector as well.

## Motivation and Context

Upgrade Iceberg to 1.6.1.

## Impact

N/A

## Test Plan

 - Adjust test cases to enable the test cases involving V1 tables in `RestCatalog`
 - Make sure this upgrade do not affect existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Upgrade Iceberg version from 1.5.0 to 1.6.1.
```

