### PR TITLE
docs: add IntelliJ JDK 17 workaround to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ After opening the project in IntelliJ, double check that the Java SDK is properl
 * Open the File menu and select Project Structure
 * In the SDKs section, ensure that a distribution of JDK 17 is selected (create one if none exist)
 * In the Project section, ensure the Project language level is set to at least 8.0.
+* When using JDK 17, an [IntelliJ bug](https://youtrack.jetbrains.com/issue/IDEA-201168) requires you
+  to disable the `Use '--release' option for cross-compilation (Java 9 and later)` setting in
+  `Settings > Build, Execution, Deployment > Compiler > Java Compiler`. If this option remains enabled,
+  you may encounter errors such as: `package sun.misc does not exist` because IntelliJ fails to resolve
+  certain internal JDK classes.
 
 Presto comes with sample configuration that should work out-of-the-box for development. Use the following options to create a run configuration:
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Document IDEA-201168 and the need to disable “Use --release option for cross-compilation” in IntelliJ to avoid JDK 17 build errors.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

If the option is enabled, the following errors may be seen

<img width="1610" height="464" alt="Screenshot 2025-08-13 at 11 02 55 PM" src="https://github.com/user-attachments/assets/153be505-1bf7-4646-809a-f884d51e31e5" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

```
== NO RELEASE NOTE ==
```

