### PR TITLE
refactor: Use std::optional compatible members

### DIFF
--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -70,7 +70,7 @@ void updateFromSystemConfigs(
     const auto& systemConfigName = configNameEntry.second;
     if (queryConfigs.count(veloxConfigName) == 0) {
       const auto propertyOpt = systemConfig->optionalProperty(systemConfigName);
-      if (propertyOpt.hasValue()) {
+      if (propertyOpt.has_value()) {
         queryConfigs[veloxConfigName] = propertyOpt.value();
       }
     }

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -110,7 +110,7 @@ folly::Optional<std::string> ConfigBase::setValue(
       propertyName);
   auto oldValue = config_->get<std::string>(propertyName);
   config_->set(propertyName, value);
-  if (oldValue.hasValue()) {
+  if (oldValue.has_value()) {
     return oldValue;
   }
   return registeredProps_[propertyName];
@@ -372,7 +372,7 @@ SystemConfig::remoteFunctionServerLocation() const {
   // First check if there is a UDS path registered. If there's one, use it.
   auto remoteServerUdsPath =
       optionalProperty(kRemoteFunctionServerThriftUdsPath);
-  if (remoteServerUdsPath.hasValue()) {
+  if (remoteServerUdsPath.has_value()) {
     return folly::SocketAddress::makeFromPath(remoteServerUdsPath.value());
   }
 
@@ -382,13 +382,13 @@ SystemConfig::remoteFunctionServerLocation() const {
   auto remoteServerPort =
       optionalProperty<uint16_t>(kRemoteFunctionServerThriftPort);
 
-  if (remoteServerPort.hasValue()) {
+  if (remoteServerPort.has_value()) {
     // Fallback to localhost if address is not specified.
-    return remoteServerAddress.hasValue()
+    return remoteServerAddress.has_value()
         ? folly::
               SocketAddress{remoteServerAddress.value(), remoteServerPort.value()}
         : folly::SocketAddress{"::1", remoteServerPort.value()};
-  } else if (remoteServerAddress.hasValue()) {
+  } else if (remoteServerAddress.has_value()) {
     VELOX_FAIL(
         "Remote function server port not provided using '{}'.",
         kRemoteFunctionServerThriftPort);
@@ -959,7 +959,7 @@ int NodeConfig::prometheusExecutorThreads() const {
   static constexpr int
       kNodePrometheusExecutorThreadsDefault = 2;
   auto resultOpt = optionalProperty<int>(kNodePrometheusExecutorThreads);
-  if (resultOpt.hasValue()) {
+  if (resultOpt.has_value()) {
     return resultOpt.value();
   }
   return kNodePrometheusExecutorThreadsDefault;
@@ -967,7 +967,7 @@ int NodeConfig::prometheusExecutorThreads() const {
 
 std::string NodeConfig::nodeId() const {
   auto resultOpt = optionalProperty(kNodeId);
-  if (resultOpt.hasValue()) {
+  if (resultOpt.has_value()) {
     return resultOpt.value();
   }
   // Generate the nodeId which must be a UUID. nodeId must be a singleton.
@@ -985,7 +985,7 @@ std::string NodeConfig::nodeInternalAddress(
   auto resultOpt = optionalProperty(kNodeInternalAddress);
   /// node.ip(kNodeIp) is legacy config replaced with node.internal-address, but
   /// still valid config in Presto, so handling both.
-  if (!resultOpt.hasValue()) {
+  if (!resultOpt.has_value()) {
     resultOpt = optionalProperty(kNodeIp);
   }
   if (resultOpt.has_value()) {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -95,7 +95,7 @@ class ConfigBase {
   template <typename T>
   folly::Optional<T> optionalProperty(const std::string& propertyName) const {
     auto valOpt = config_->get<T>(propertyName);
-    if (valOpt.hasValue()) {
+    if (valOpt.has_value()) {
       return valOpt.value();
     }
     const auto it = registeredProps_.find(propertyName);


### PR DESCRIPTION
## Description

folly::Optional have two same member functions, one is std::optional compatible name, another is not.
Let's use first instead of second 

## Motivation and Context

Allow to use std::optional in velox instead of folly::Optional
Details: https://github.com/facebookincubator/velox/pull/14455

## Impact

No, same member function, just different name

## Test Plan

Not needed

## Contributor checklist

Done

## Release Notes

```
== NO RELEASE NOTE ==
```

