### PR TITLE
Add performance warning for MAP_FILTER

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -153,6 +153,35 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testMapFilterWarnings()
+    {
+        assertHasWarning(
+                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> v > 1) FROM (VALUES (map(ARRAY[1,2], ARRAY[2,3]))) AS t(x)"),
+                PERFORMANCE_WARNING,
+                "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
+
+        assertHasWarning(
+                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> k = 2) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"),
+                PERFORMANCE_WARNING,
+                "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
+
+        assertHasWarning(
+                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> k IN (1, 3)) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"),
+                PERFORMANCE_WARNING,
+                "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
+
+        assertHasWarning(
+                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> v IN (20, 30)) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"),
+                PERFORMANCE_WARNING,
+                "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
+
+        assertHasWarning(
+                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> k + v > 25) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"),
+                PERFORMANCE_WARNING,
+                "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
+    }
+
+    @Test
     public void testIgnoreNullWarning()
     {
         List<String> valueFunctions = ImmutableList.of(

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestWarnings.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestWarnings.java
@@ -180,7 +180,7 @@ public class TestWarnings
         assertWarnings(queryRunner, TEST_SESSION, query, ImmutableSet.of(SEMANTIC_WARNING.toWarningCode()));
 
         query = "select transform_keys(map(ARRAY [25.5E0, 26.5E0, 27.5E0], ARRAY [25.5E0, 26.5E0, 27.5E0]), (k, v) -> k + v)";
-        assertWarnings(queryRunner, TEST_SESSION, query, ImmutableSet.of(SEMANTIC_WARNING.toWarningCode()));
+        assertWarnings(queryRunner, TEST_SESSION, query, ImmutableSet.of(SEMANTIC_WARNING.toWarningCode(), PERFORMANCE_WARNING.toWarningCode()));
 
         query = "SELECT histogram(RETAILPRICE) FROM tpch.tiny.part";
         assertWarnings(queryRunner, TEST_SESSION, query, ImmutableSet.of(SEMANTIC_WARNING.toWarningCode()));

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
@@ -148,9 +148,6 @@ public class TestEnums
                 "cast(map(array[test.enum.country.FRANCE], array[array[test.enum.mood.HAPPY]]) as JSON)",
                 "{\"France\":[0]}");
         assertSingleValue(
-                "map_filter(MAP(ARRAY[test.enum.country.FRANCE, test.enum.country.US], ARRAY[test.enum.mood.HAPPY, test.enum.mood.SAD]), (k,v) -> CAST(v AS BIGINT) > 0)",
-                ImmutableMap.of("United States", 1L));
-        assertSingleValue(
                 "cast(JSON '{\"France\": [0]}' as MAP<test.enum.country,ARRAY<test.enum.mood>>)",
                 ImmutableMap.of("France", singletonList(0L)));
     }


### PR DESCRIPTION
## Description
Add performance warning for MAP_FILTER

## Motivation and Context
Partly due to the lack of builtins and partly due to not being familiar, users use lambdas on training tables. We should add a performance warning in the presto analyzer things like MAP_FILTER.

## Impact
This will help improve user understanding, as well as prevent issues with performance

## Test Plan
Units tests, looking for warnings. Amended tests ensuring new behavior is updated. Removed one obsolete test case

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.


```
== NO RELEASE NOTE ==
```

