### PR TITLE
[docs] Update doc about sort order transforms in connector/iceberg.rst

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2208,7 +2208,7 @@ Sorting can be combined with partitioning on the same column. For example::
         sorted_by = ARRAY['join_date']
     )
 
-The Iceberg connector does not support sort order transforms. The following sort order transformations are not supported:
+Sort order does not support transforms. The following transforms are not supported:
 
 .. code-block:: text
 


### PR DESCRIPTION
Update doc describing sort order transform support in [connector/iceberg.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/connector/iceberg.rst). 

## Motivation and Context

Fixes #25483. 

## Impact
Documentation. 

## Test Plan
Local doc build. Screenshot: 

<img width="711" height="316" alt="Screenshot 2025-08-13 at 2 50 45 PM" src="https://github.com/user-attachments/assets/3f3f5aba-b7b6-4882-a88f-06a9cb9e554a" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

