### PR TITLE
[docs] Fix formatting in admin/properties.rst

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -150,7 +150,7 @@ To enable the ``OFFSET`` clause in SQL query expressions, set this property to `
 The corresponding session property is :ref:`admin/properties-session:\`\`offset_clause_enabled\`\``. 
 
 ``max-serializable-object-size``
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``long``
 * **Default value:** ``1000``


### PR DESCRIPTION
## Description
Fix formatting in [admin/properties.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/admin/properties.rst). 

## Motivation and Context
A formatting error was causing the following warnings during doc builds: 

```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/properties.rst:153: WARNING: Title underline too short.

``max-serializable-object-size``
^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/properties.rst:153: WARNING: Title underline too short.

``max-serializable-object-size``
^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
[...]
build succeeded, 55 warnings.
```

## Impact
Doc builds. 

## Test Plan
Local doc builds.

Before: 
```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/properties.rst:153: WARNING: Title underline too short.

``max-serializable-object-size``
^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/properties.rst:153: WARNING: Title underline too short.

``max-serializable-object-size``
^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
[...]
build succeeded, 55 warnings.
```

After:
The two warnings were not displayed.
Summary changed to:
```
build succeeded, 53 warnings.
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

