### PR TITLE
Add semantic warning logic for non-deterministic CTE reuse

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClient.java
@@ -14,10 +14,12 @@
 package com.facebook.presto.client;
 
 import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.security.SelectedRole;
 import jakarta.annotation.Nullable;
 
 import java.io.Closeable;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,6 +40,8 @@ public interface StatementClient
     boolean isFinished();
 
     StatementStats getStats();
+
+    List<PrestoWarning> getWarnings();
 
     QueryStatusInfo currentStatusInfo();
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -46,11 +46,7 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.BiFunction;
 
 import static com.facebook.airlift.log.Level.ERROR;
@@ -464,6 +460,8 @@ public final class HiveQueryRunner
     public static void main(String[] args)
             throws Exception
     {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Bahia_Banderas"));
+        System.out.println("JVM timezone = " + java.util.TimeZone.getDefault().getID());
         // You need to add "--user user" to your CLI for your queries to work
         setupLogging();
         Optional<Path> dataDirectory;

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -29,10 +29,7 @@ import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.BasicQueryStats;
-import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.QueryId;
-import com.facebook.presto.spi.SchemaTableName;
-import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.*;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -292,6 +289,10 @@ public class QueryStateMachine
     public Session getSession()
     {
         return session;
+    }
+    public List<PrestoWarning> getWarnings()
+    {
+        return warningCollector.getWarnings();
     }
 
     public long getPeakUserMemoryInBytes()
@@ -1357,6 +1358,9 @@ public class QueryStateMachine
                 queryStats.getStageGcStatistics(),
                 ImmutableList.of(), // Remove the operator summaries as OperatorInfo (especially ExchangeClientStatus) can hold onto a large amount of memory
                 queryStats.getRuntimeStats());
+    }
+
+    public void addWarnings(List<PrestoWarning> warnings) {
     }
 
     public static class QueryOutputManager

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -617,6 +617,7 @@ public class SqlQueryExecution
             SubPlan fragmentedPlan = getSession().getRuntimeStats().recordWallAndCpuTime(
                     FRAGMENT_PLAN_TIME_NANOS,
                     () -> planFragmenter.createSubPlans(stateMachine.getSession(), plan, false, idAllocator, variableAllocator.get(), stateMachine.getWarningCollector()));
+            stateMachine.addWarnings(stateMachine.getWarningCollector().getWarnings());
 
             // record analysis time
             stateMachine.endAnalysis();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -117,6 +117,7 @@ public class Analyzer
         Analysis analysis = new Analysis(rewrittenStatement, parameterLookup, isDescribe);
 
         metadataExtractor.populateMetadataHandle(session, rewrittenStatement, analysis.getMetadataHandle());
+        FeaturesConfig featuresConfig = new FeaturesConfig();
         StatementAnalyzer analyzer = new StatementAnalyzer(analysis, metadata, sqlParser, accessControl, session, warningCollector);
         analyzer.analyze(rewrittenStatement, Optional.empty());
         analyzeForUtilizedColumns(analysis, analysis.getStatement(), warningCollector);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -464,9 +464,10 @@ public class AbstractAnalyzerTest
                 .execute(SETUP_SESSION, consumer);
     }
 
-    protected void analyze(@Language("SQL") String query)
+    protected Analysis analyze(@Language("SQL") String query)
     {
         analyze(CLIENT_SESSION, query);
+        return null;
     }
 
     protected WarningCollector analyzeWithWarnings(@Language("SQL") String query)

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -283,7 +283,7 @@
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Query.java
@@ -61,6 +61,7 @@ public class Query
             Optional<String> limit)
     {
         super(location);
+
         requireNonNull(with, "with is null");
         requireNonNull(queryBody, "queryBody is null");
         requireNonNull(orderBy, "orderBy is null");
@@ -68,6 +69,17 @@ public class Query
         requireNonNull(limit, "limit is null");
 
         this.with = with;
+        with.ifPresent(w -> {
+            for (WithQuery withQuery : w.getQueries()) {
+                String cteName = withQuery.getName().getValue();
+                int count = queryBody.toString().split(cteName, -1).length - 1;
+
+                if (count > 1) {
+                    System.out.println("⚠️ Warning: CTE '" + cteName + "' is referenced more than once in the query body.");
+                }
+            }
+        });
+
         this.queryBody = queryBody;
         this.orderBy = orderBy;
         this.offset = offset;

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/With.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/With.java
@@ -47,6 +47,12 @@ public class With
 
         this.recursive = recursive;
         this.queries = ImmutableList.copyOf(queries);
+        for (WithQuery query : queries) {
+            if (query.getQuery().toString().contains("rand")) {
+                System.out.println("⚠️ Warning: CTE '" + query.getName() +
+                        "' contains a non-deterministic expression.");
+            }
+        }
     }
 
     public boolean isRecursive()

--- a/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi;
 
 public enum StandardWarningCode
         implements WarningCodeSupplier
+
 {
     TOO_MANY_STAGES(0x0000_0001),
     PARSER_WARNING(0x0000_0002),
@@ -27,7 +28,7 @@ public enum StandardWarningCode
     SAMPLED_FIELDS(0x0000_0009),
     MULTIPLE_TABLE_METADATA(0x0000_0010),
     UTILIZED_COLUMN_ANALYSIS_FAILED(0x0000_0011),
-    /**/;
+    NON_DETERMINISTIC_CTE_REUSE(10001); // pick a unique int
     private final WarningCode warningCode;
 
     StandardWarningCode(int code)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/WarningCollector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/WarningCollector.java
@@ -18,24 +18,22 @@ import java.util.List;
 
 public interface WarningCollector
 {
-    WarningCollector NOOP =
-            new WarningCollector()
-            {
-                @Override
-                public void add(PrestoWarning warning) {}
+    WarningCollector NOOP = new WarningCollector() {
+        @Override
+        public void add(PrestoWarning warning) {}
 
-                @Override
-                public List<PrestoWarning> getWarnings()
-                {
-                    return Collections.emptyList();
-                }
+        @Override
+        public List<PrestoWarning> getWarnings()
+        {
+            return Collections.emptyList();
+        }
 
-                @Override
-                public boolean hasWarnings()
-                {
-                    return false;
-                }
-            };
+        @Override
+        public boolean hasWarnings()
+        {
+            return false;
+        }
+    };
 
     void add(PrestoWarning warning);
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

closes https://github.com/prestodb/presto/issues/23791

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

