### PR TITLE
 refactor: Replace folly::Optional with std::optional

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -111,7 +111,7 @@ folly::Optional<std::string> ConfigBase::setValue(
   auto oldValue = config_->get<std::string>(propertyName);
   config_->set(propertyName, value);
   if (oldValue.has_value()) {
-    return oldValue;
+    return oldValue.value();
   }
   return registeredProps_[propertyName];
 }

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -116,7 +116,7 @@ class ConfigBase {
       const std::string& propertyName) const {
     auto val = config_->get<std::string>(propertyName);
     if (val.has_value()) {
-      return val;
+      return val.value();
     }
     const auto it = registeredProps_.find(propertyName);
     if (it != registeredProps_.end()) {


### PR DESCRIPTION
Summary:
It follows style guide and also avoids extra "velox depends on folly".

https://github.com/facebookincubator/velox/blob/09bc52ac56a4876385686cd26e6891fd7c2ca871/CODING_STYLE.md#L323-L324

X-link: https://github.com/facebookincubator/velox/pull/14455

Differential Revision: D80160509

Pulled By: mbasmanova


