### PR TITLE
docs: update README with Java 17 run flags for running Presto in IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ After opening the project in IntelliJ, double check that the Java SDK is properl
 Presto comes with sample configuration that should work out-of-the-box for development. Use the following options to create a run configuration:
 
 * Main Class: `com.facebook.presto.server.PrestoServer`
-* VM Options: `-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties`
+* VM Options: `-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties -Djdk.attach.allowAttachSelf=true`
 * Working directory: `$MODULE_WORKING_DIR$` or `$MODULE_DIR$`(Depends your version of IntelliJ)
 * Use classpath of module: `presto-main`
 
@@ -58,6 +58,32 @@ The working directory should be the `presto-main` subdirectory. In IntelliJ, usi
 Additionally, the Hive plugin must be configured with location of your Hive metastore Thrift service. Add the following to the list of VM options, replacing `localhost:9083` with the correct host and port (or use the below value if you do not have a Hive metastore):
 
     -Dhive.metastore.uri=thrift://localhost:9083
+
+### Additional configuration for Java 17
+
+When running with Java 17, additional `--add-opens` flags are required to allow reflective access used by certain catalogs based on which catalogs are configured.  
+For the default set of catalogs loaded when starting the Presto server in IntelliJ without changes, add the following flags to the **VM Options**:
+
+    --add-opens=java.base/java.io=ALL-UNNAMED
+    --add-opens=java.base/java.lang=ALL-UNNAMED
+    --add-opens=java.base/java.lang.ref=ALL-UNNAMED
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+    --add-opens=java.base/java.net=ALL-UNNAMED
+    --add-opens=java.base/java.nio=ALL-UNNAMED
+    --add-opens=java.base/java.security=ALL-UNNAMED
+    --add-opens=java.base/javax.security.auth=ALL-UNNAMED
+    --add-opens=java.base/javax.security.auth.login=ALL-UNNAMED
+    --add-opens=java.base/java.text=ALL-UNNAMED
+    --add-opens=java.base/java.util=ALL-UNNAMED
+    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+    --add-opens=java.base/java.util.regex=ALL-UNNAMED
+    --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED
+    --add-opens=java.base/sun.security.action=ALL-UNNAMED
+    --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+
+These flags ensure that internal JDK modules are accessible at runtime for components used by Presto’s default configuration.
+It is not a comprehensive list. Additional flags may need to be added, depending on the catalogs configured on the server.
 
 ### Using SOCKS for Hive or HDFS
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Add `-Djdk.attach.allowAttachSelf=true` to enable self-attach in Java 17, which is required for certain debugging and monitoring tools during local Presto development.

Also include the necessary `--add-opens` flags to allow access to internal JDK APIs that Presto depends on.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

If the above flags are not added, developers might see below errors:

```
Caused by: java.io.IOException: java.io.IOException: Can not attach to current VM (try adding '-Djdk.attach.allowAttachSelf=true' to the JVM config)
	at com.facebook.airlift.jmx.JmxAgent9.startJmxAgent(JmxAgent9.java:127)
	at com.facebook.airlift.jmx.JmxAgent9.<init>(JmxAgent9.java:88)
	at com.facebook.airlift.jmx.JmxAgent9$$FastClassByGuice$$1e98d76.GUICE$TRAMPOLINE(<generated>)
	at com.facebook.airlift.jmx.JmxAgent9$$FastClassByGuice$$1e98d76.apply(<generated>)
```

```
Caused by: ExceptionInInitializerError: Exception InaccessibleObjectException: Unable to make private native Field[] Class.getDeclaredFields0(boolean) accessible: module java.base does not "opens java.lang" to unnamed module @f89fc49 [in thread "main"]
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

