### PR TITLE
Add return in deleteTask

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -415,6 +415,7 @@ proxygen::RequestHandler* TaskResource::deleteTask(
               if (!handlerState->requestExpired()) {
                 if (taskInfo == nullptr) {
                   sendTaskNotFound(downstream, taskId);
+                  return;
                 }
                 if (sendThrift) {
                   thrift::TaskInfo thriftTaskInfo;


### PR DESCRIPTION
Summary:
If taskInfo is null , we should do return after sending the response.
Else we will get exception when trying to read the null taskinfo

Differential Revision: D80284931
```
== NO RELEASE NOTES ==
```


