### PR TITLE
[native] Ensure calling 'no more splits' after the task started.

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_set>
 #include "presto_cpp/main/http/HttpServer.h"
 #include "presto_cpp/main/types/PrestoTaskId.h"
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
@@ -142,6 +143,10 @@ struct PrestoTask {
 
   /// Info request. May arrive before there is a Task.
   PromiseHolderWeakPtr<std::unique_ptr<protocol::TaskInfo>> infoRequest;
+
+  /// If the task has not been started yet, we collect all plan node IDs that
+  /// had 'no more splits' message to process them after the task starts.
+  std::unordered_set<velox::core::PlanNodeId> delayedNoMoreSplitsPlanNodes_;
 
   /// @param taskId Task ID.
   /// @param nodeId Node ID.

--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -639,7 +639,13 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTaskImpl(
       if (source.noMoreSplits) {
         LOG(INFO) << "No more splits for " << taskId << " for node "
                   << source.planNodeId;
-        execTask->noMoreSplits(source.planNodeId);
+        // If the task has not been started yet, we collect the plan node to
+        // call 'no more splits' after the start.
+        if (prestoTask->taskStarted) {
+          execTask->noMoreSplits(source.planNodeId);
+        } else {
+          prestoTask->delayedNoMoreSplitsPlanNodes_.emplace(source.planNodeId);
+        }
       }
     }
 
@@ -803,6 +809,16 @@ void TaskManager::maybeStartNextQueuedTask() {
     LOG(INFO) << "TASK QUEUE: Picking task to start from the queue: "
               << taskToStart->info.taskId;
     startTaskLocked(taskToStart);
+    // Make sure we call 'no more splits' we might have received before the task
+    // started.
+    auto execTask = taskToStart->task;
+    if (execTask != nullptr) {
+      for (const auto& planNodeId :
+           taskToStart->delayedNoMoreSplitsPlanNodes_) {
+        execTask->noMoreSplits(planNodeId);
+      }
+      taskToStart->delayedNoMoreSplitsPlanNodes_.clear();
+    }
   }
   const auto queuedTasksLeft = numQueuedTasks();
   if (queuedTasksLeft > 0) {

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -24,25 +24,17 @@
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
-#include "velox/common/memory/SharedArbitrator.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/WriterFactory.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
-#include "velox/exec/Exchange.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
-#include "velox/exec/tests/utils/TempFilePath.h"
-#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
-#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/parse/TypeResolver.h"
-#include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/Type.h"
 
 DECLARE_int32(old_task_ms);
@@ -892,6 +884,54 @@ TEST_P(TaskManagerTest, taskCleanupWithPendingResultData) {
       break;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}
+
+// Tests a grouped execution task with no splits and task queuing enabled.
+TEST_P(TaskManagerTest, queuedEmptyGroupedExecutionTask) {
+  SystemConfig::instance()->setValue(
+      std::string(SystemConfig::kWorkerOverloadedTaskQueuingEnabled), "true");
+
+  core::PlanNodeId scanNodeId;
+  auto planFragment = exec::test::PlanBuilder()
+                          .tableScan(rowType_)
+                          .capturePlanNodeId(scanNodeId)
+                          .filter("c0 % 5 = 1")
+                          .partitionedOutput({}, 1, {"c0", "c1"}, GetParam())
+                          .planFragment();
+  planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
+  planFragment.groupedExecutionLeafNodeIds.emplace(scanNodeId);
+  planFragment.numSplitGroups = 2;
+
+  // Tell task manager that server is overloaded and create a task with no
+  // splits and 'no more splits' message.
+  taskManager_->setServerOverloaded(true);
+
+  const protocol::TaskId taskId = "scanQueuedTask.0.0.1.0";
+  protocol::TaskUpdateRequest updateRequest;
+  long splitSequenceId{0};
+  updateRequest.sources.push_back(
+      makeSource(scanNodeId, {}, true, splitSequenceId));
+
+  createOrUpdateTask(taskId, updateRequest, planFragment);
+
+  // Check that the task is not started.
+  auto prestoTask = taskManager_->tasks().at(taskId);
+  ASSERT_FALSE(prestoTask->taskStarted);
+
+  // Mark server no longer overloaded and trigger the task start.
+  taskManager_->setServerOverloaded(false);
+  taskManager_->maybeStartNextQueuedTask();
+
+  // Check that the task is started.
+  ASSERT_TRUE(prestoTask->taskStarted);
+
+  // Fetch the results and see that we have finished the task.
+  auto results = fetchAllResults(taskId, rowType_, {taskId});
+  ASSERT_EQ(results.results.size(), 0);
+  auto execTask = prestoTask->task;
+  if (execTask) {
+    ASSERT_EQ(execTask->state(), TaskState::kFinished);
   }
 }
 


### PR DESCRIPTION
## Description
We have discovered a rare bug when running with worker overloaded pushback enabled.

If in grouped execution 'noMoreSplits' arrived before the task started, then the task won't be finished with terminate(TaskState::kFinished).
This situation is possible with the worker pushback enabled when worker is overloaded. In that case we skip starting the task, but process splits and split messages, such as 'noMoreSplits'. During that we don't register the task completion as we don't have the vital 'numDriversPerSplitGroup_' initialized.

At the time the task starts (later, when the worker stops being overloaded), we never run Task::checkNoMoreSplitGroupsLocked() and no more split messages ever arrive from the Coordinator, thus leaving the task hanging in the incomplete (running) state until the query times out.

## Test Plan
Ran the hanging query in the overloaded cluster and observed it completes.
Added new unit test which hangs (times out) with the old code.

```
== NO RELEASE NOTE ==
```

