### PR TITLE
Add support to use pooled byte buffer for thrift serde

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/thrift/ByteBufferPoolManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/thrift/ByteBufferPoolManager.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.thrift;
+
+import com.facebook.drift.buffer.ByteBufferPool;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ByteBufferPoolManager
+{
+    private final ConcurrentHashMap<Thread, ByteBufferPool> threadPools = new ConcurrentHashMap<>();
+    private static final int DEFAULT_BUFFER_SIZE = 1024; // 1KB
+    private static final int DEFAULT_BUFFER_COUNT = 16;
+    private final int bufferSize;
+    private final int maxPoolSize;
+
+    public ByteBufferPoolManager()
+    {
+        this.bufferSize = DEFAULT_BUFFER_SIZE;
+        this.maxPoolSize = DEFAULT_BUFFER_COUNT;
+    }
+
+    public ByteBufferPoolManager(int bufferSize, int maxPoolSize)
+    {
+        this.bufferSize = bufferSize;
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public ByteBufferPool getPool()
+    {
+        return threadPools.computeIfAbsent(Thread.currentThread(), t -> new ByteBufferPool(bufferSize, maxPoolSize));
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorCodecManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/ConnectorCodecManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.connector;
 
 import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorId;
@@ -41,11 +42,11 @@ public class ConnectorCodecManager
     private final Map<String, ConnectorCodecProvider> connectorCodecProviders = new ConcurrentHashMap<>();
 
     @Inject
-    public ConnectorCodecManager(Provider<ThriftCodecManager> thriftCodecManagerProvider)
+    public ConnectorCodecManager(Provider<ThriftCodecManager> thriftCodecManagerProvider, ByteBufferPoolManager byteBufferPoolManager)
     {
         requireNonNull(thriftCodecManagerProvider, "thriftCodecManager is null");
 
-        connectorCodecProviders.put(REMOTE_CONNECTOR_ID.toString(), new RemoteCodecProvider(thriftCodecManagerProvider));
+        connectorCodecProviders.put(REMOTE_CONNECTOR_ID.toString(), new RemoteCodecProvider(thriftCodecManagerProvider, byteBufferPoolManager));
     }
 
     public void addConnectorCodecProvider(ConnectorId connectorId, ConnectorCodecProvider connectorCodecProvider)

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -102,6 +102,35 @@ public class QueryManagerConfig
 
     private int minColumnarEncodingChannelsToPreferRowWiseEncoding = 1000;
 
+    private int byteBufferPoolBufferSize = 4096; // default 4KB
+    private int byteBufferPoolMaxSize = 16;
+
+    @Min(1)
+    public int getByteBufferPoolMaxSize()
+    {
+        return byteBufferPoolMaxSize;
+    }
+
+    @Min(1024)
+    public int getByteBufferPoolBufferSize()
+    {
+        return byteBufferPoolBufferSize;
+    }
+
+    @Config("query.thrift-serde.byte-buffer-size")
+    public QueryManagerConfig setByteBufferPoolBufferSize(int bufferSize)
+    {
+        this.byteBufferPoolBufferSize = bufferSize;
+        return this;
+    }
+
+    @Config("query.thrift-serde.byte-buffer-pool-max-size")
+    public QueryManagerConfig setByteBufferPoolMaxSize(int maxPoolSize)
+    {
+        this.byteBufferPoolMaxSize = maxPoolSize;
+        return this;
+    }
+
     @Min(1)
     public int getScheduleSplitBatchSize()
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/PluginManagerUtil.java
@@ -64,6 +64,7 @@ public class PluginManagerUtil
             .add("org.openjdk.jol.")
             .add("com.facebook.presto.common")
             .add("com.facebook.drift.annotations.")
+            .add("com.facebook.drift.buffer.ByteBufferPool")
             .add("com.facebook.drift.TException")
             .add("com.facebook.drift.TApplicationException")
             .build();

--- a/presto-main-base/src/main/java/com/facebook/presto/server/thrift/ConnectorSplitThriftCodec.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/thrift/ConnectorSplitThriftCodec.java
@@ -18,14 +18,18 @@ import com.facebook.drift.codec.CodecThriftType;
 import com.facebook.drift.codec.metadata.ThriftType;
 import com.facebook.drift.protocol.TProtocolReader;
 import com.facebook.drift.protocol.TProtocolWriter;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.connector.ConnectorCodecManager;
 import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorSplit;
 
 import javax.inject.Inject;
 
-import java.nio.ByteBuffer;
+import java.util.Optional;
 
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.deserialize;
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.serialize;
 import static java.util.Objects.requireNonNull;
 
 public class ConnectorSplitThriftCodec
@@ -33,15 +37,20 @@ public class ConnectorSplitThriftCodec
 {
     private static final ThriftType THRIFT_TYPE = createThriftType(ConnectorSplit.class);
     private final ConnectorCodecManager connectorCodecManager;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
     @Inject
-    public ConnectorSplitThriftCodec(HandleResolver handleResolver, ConnectorCodecManager connectorCodecManager, JsonCodec<ConnectorSplit> jsonCodec)
+    public ConnectorSplitThriftCodec(HandleResolver handleResolver,
+            ConnectorCodecManager connectorCodecManager,
+            JsonCodec<ConnectorSplit> jsonCodec,
+            ByteBufferPoolManager byteBufferPoolManager)
     {
         super(ConnectorSplit.class,
                 requireNonNull(jsonCodec, "jsonCodec is null"),
                 requireNonNull(handleResolver, "handleResolver is null")::getId,
                 handleResolver::getSplitClass);
         this.connectorCodecManager = requireNonNull(connectorCodecManager, "connectorThriftCodecManager is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @CodecThriftType
@@ -60,10 +69,12 @@ public class ConnectorSplitThriftCodec
     public ConnectorSplit readConcreteValue(String connectorId, TProtocolReader reader)
             throws Exception
     {
-        ByteBuffer byteBuffer = reader.readBinary();
-        assert (byteBuffer.position() == 0);
-        byte[] bytes = byteBuffer.array();
-        return connectorCodecManager.getConnectorSplitCodec(connectorId).map(codec -> codec.deserialize(bytes)).orElse(null);
+        Optional<ConnectorCodec<ConnectorSplit>> codec = connectorCodecManager.getConnectorSplitCodec(connectorId);
+        if (!codec.isPresent()) {
+            return null;
+        }
+
+        return deserialize(codec.get(), reader, byteBufferPoolManager);
     }
 
     @Override
@@ -71,7 +82,12 @@ public class ConnectorSplitThriftCodec
             throws Exception
     {
         requireNonNull(value, "value is null");
-        writer.writeBinary(ByteBuffer.wrap(connectorCodecManager.getConnectorSplitCodec(connectorId).map(codec -> codec.serialize(value)).orElseThrow(() -> new IllegalArgumentException("Cannot serialize " + value))));
+        Optional<ConnectorCodec<ConnectorSplit>> codec = connectorCodecManager.getConnectorSplitCodec(connectorId);
+        if (!codec.isPresent()) {
+            return;
+        }
+
+        serialize(codec.get(), value, writer, byteBufferPoolManager);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/server/thrift/InsertTableHandleThriftCodec.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/thrift/InsertTableHandleThriftCodec.java
@@ -18,14 +18,18 @@ import com.facebook.drift.codec.CodecThriftType;
 import com.facebook.drift.codec.metadata.ThriftType;
 import com.facebook.drift.protocol.TProtocolReader;
 import com.facebook.drift.protocol.TProtocolWriter;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.connector.ConnectorCodecManager;
 import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 
 import javax.inject.Inject;
 
-import java.nio.ByteBuffer;
+import java.util.Optional;
 
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.deserialize;
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.serialize;
 import static java.util.Objects.requireNonNull;
 
 public class InsertTableHandleThriftCodec
@@ -33,15 +37,20 @@ public class InsertTableHandleThriftCodec
 {
     private static final ThriftType THRIFT_TYPE = createThriftType(ConnectorInsertTableHandle.class);
     private final ConnectorCodecManager connectorCodecManager;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
     @Inject
-    public InsertTableHandleThriftCodec(HandleResolver handleResolver, ConnectorCodecManager connectorCodecManager, JsonCodec<ConnectorInsertTableHandle> jsonCodec)
+    public InsertTableHandleThriftCodec(HandleResolver handleResolver,
+            ConnectorCodecManager connectorCodecManager,
+            JsonCodec<ConnectorInsertTableHandle> jsonCodec,
+            ByteBufferPoolManager byteBufferPoolManager)
     {
         super(ConnectorInsertTableHandle.class,
                 requireNonNull(jsonCodec, "jsonCodec is null"),
                 requireNonNull(handleResolver, "handleResolver is null")::getId,
                 handleResolver::getInsertTableHandleClass);
         this.connectorCodecManager = requireNonNull(connectorCodecManager, "connectorThriftCodecManager is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @CodecThriftType
@@ -60,10 +69,12 @@ public class InsertTableHandleThriftCodec
     public ConnectorInsertTableHandle readConcreteValue(String connectorId, TProtocolReader reader)
             throws Exception
     {
-        ByteBuffer byteBuffer = reader.readBinary();
-        assert (byteBuffer.position() == 0);
-        byte[] bytes = byteBuffer.array();
-        return connectorCodecManager.getInsertTableHandleCodec(connectorId).map(codec -> codec.deserialize(bytes)).orElse(null);
+        Optional<ConnectorCodec<ConnectorInsertTableHandle>> codec = connectorCodecManager.getInsertTableHandleCodec(connectorId);
+        if (!codec.isPresent()) {
+            return null;
+        }
+
+        return deserialize(codec.get(), reader, byteBufferPoolManager);
     }
 
     @Override
@@ -71,7 +82,12 @@ public class InsertTableHandleThriftCodec
             throws Exception
     {
         requireNonNull(value, "value is null");
-        writer.writeBinary(ByteBuffer.wrap(connectorCodecManager.getInsertTableHandleCodec(connectorId).map(codec -> codec.serialize(value)).orElseThrow(() -> new IllegalArgumentException("Can not serialize " + value))));
+        Optional<ConnectorCodec<ConnectorInsertTableHandle>> codec = connectorCodecManager.getInsertTableHandleCodec(connectorId);
+        if (!codec.isPresent()) {
+            return;
+        }
+
+        serialize(codec.get(), value, writer, byteBufferPoolManager);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/server/thrift/TableHandleThriftCodec.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/thrift/TableHandleThriftCodec.java
@@ -18,14 +18,18 @@ import com.facebook.drift.codec.CodecThriftType;
 import com.facebook.drift.codec.metadata.ThriftType;
 import com.facebook.drift.protocol.TProtocolReader;
 import com.facebook.drift.protocol.TProtocolWriter;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.connector.ConnectorCodecManager;
 import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorTableHandle;
 
 import javax.inject.Inject;
 
-import java.nio.ByteBuffer;
+import java.util.Optional;
 
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.deserialize;
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.serialize;
 import static java.util.Objects.requireNonNull;
 
 public class TableHandleThriftCodec
@@ -33,15 +37,20 @@ public class TableHandleThriftCodec
 {
     private static final ThriftType THRIFT_TYPE = createThriftType(ConnectorTableHandle.class);
     private final ConnectorCodecManager connectorCodecManager;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
     @Inject
-    public TableHandleThriftCodec(HandleResolver handleResolver, ConnectorCodecManager connectorCodecManager, JsonCodec<ConnectorTableHandle> jsonCodec)
+    public TableHandleThriftCodec(HandleResolver handleResolver,
+            ConnectorCodecManager connectorCodecManager,
+            JsonCodec<ConnectorTableHandle> jsonCodec,
+            ByteBufferPoolManager byteBufferPoolManager)
     {
         super(ConnectorTableHandle.class,
                 requireNonNull(jsonCodec, "jsonCodec is null"),
                 requireNonNull(handleResolver, "handleResolver is null")::getId,
                 handleResolver::getTableHandleClass);
         this.connectorCodecManager = requireNonNull(connectorCodecManager, "connectorThriftCodecManager is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @CodecThriftType
@@ -60,10 +69,12 @@ public class TableHandleThriftCodec
     public ConnectorTableHandle readConcreteValue(String connectorId, TProtocolReader reader)
             throws Exception
     {
-        ByteBuffer byteBuffer = reader.readBinary();
-        assert (byteBuffer.position() == 0);
-        byte[] bytes = byteBuffer.array();
-        return connectorCodecManager.getTableHandleCodec(connectorId).map(codec -> codec.deserialize(bytes)).orElse(null);
+        Optional<ConnectorCodec<ConnectorTableHandle>> codec = connectorCodecManager.getTableHandleCodec(connectorId);
+        if (!codec.isPresent()) {
+            return null;
+        }
+
+        return deserialize(codec.get(), reader, byteBufferPoolManager);
     }
 
     @Override
@@ -71,7 +82,12 @@ public class TableHandleThriftCodec
             throws Exception
     {
         requireNonNull(value, "value is null");
-        writer.writeBinary(ByteBuffer.wrap(connectorCodecManager.getTableHandleCodec(connectorId).map(codec -> codec.serialize(value)).orElseThrow(() -> new IllegalArgumentException("Can not serialize " + value))));
+        Optional<ConnectorCodec<ConnectorTableHandle>> codec = connectorCodecManager.getTableHandleCodec(connectorId);
+        if (!codec.isPresent()) {
+            return;
+        }
+
+        serialize(codec.get(), value, writer, byteBufferPoolManager);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/server/thrift/TableLayoutHandleThriftCodec.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/thrift/TableLayoutHandleThriftCodec.java
@@ -18,14 +18,18 @@ import com.facebook.drift.codec.CodecThriftType;
 import com.facebook.drift.codec.metadata.ThriftType;
 import com.facebook.drift.protocol.TProtocolReader;
 import com.facebook.drift.protocol.TProtocolWriter;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.connector.ConnectorCodecManager;
 import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 
 import javax.inject.Inject;
 
-import java.nio.ByteBuffer;
+import java.util.Optional;
 
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.deserialize;
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.serialize;
 import static java.util.Objects.requireNonNull;
 
 public class TableLayoutHandleThriftCodec
@@ -33,15 +37,20 @@ public class TableLayoutHandleThriftCodec
 {
     private static final ThriftType THRIFT_TYPE = createThriftType(ConnectorTableLayoutHandle.class);
     private final ConnectorCodecManager connectorCodecManager;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
     @Inject
-    public TableLayoutHandleThriftCodec(HandleResolver handleResolver, ConnectorCodecManager connectorCodecManager, JsonCodec<ConnectorTableLayoutHandle> jsonCodec)
+    public TableLayoutHandleThriftCodec(HandleResolver handleResolver,
+            ConnectorCodecManager connectorCodecManager,
+            JsonCodec<ConnectorTableLayoutHandle> jsonCodec,
+            ByteBufferPoolManager byteBufferPoolManager)
     {
         super(ConnectorTableLayoutHandle.class,
                 requireNonNull(jsonCodec, "jsonCodec is null"),
                 requireNonNull(handleResolver, "handleResolver is null")::getId,
                 handleResolver::getTableLayoutHandleClass);
         this.connectorCodecManager = requireNonNull(connectorCodecManager, "connectorThriftCodecManager is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @CodecThriftType
@@ -60,10 +69,12 @@ public class TableLayoutHandleThriftCodec
     public ConnectorTableLayoutHandle readConcreteValue(String connectorId, TProtocolReader reader)
             throws Exception
     {
-        ByteBuffer byteBuffer = reader.readBinary();
-        assert (byteBuffer.position() == 0);
-        byte[] bytes = byteBuffer.array();
-        return connectorCodecManager.getTableLayoutHandleCodec(connectorId).map(codec -> codec.deserialize(bytes)).orElse(null);
+        Optional<ConnectorCodec<ConnectorTableLayoutHandle>> codec = connectorCodecManager.getTableLayoutHandleCodec(connectorId);
+        if (!codec.isPresent()) {
+            return null;
+        }
+
+        return deserialize(codec.get(), reader, byteBufferPoolManager);
     }
 
     @Override
@@ -71,7 +82,12 @@ public class TableLayoutHandleThriftCodec
             throws Exception
     {
         requireNonNull(value, "value is null");
-        writer.writeBinary(ByteBuffer.wrap(connectorCodecManager.getTableLayoutHandleCodec(connectorId).map(codec -> codec.serialize(value)).orElseThrow(() -> new IllegalArgumentException("Can not serialize " + value))));
+        Optional<ConnectorCodec<ConnectorTableLayoutHandle>> codec = connectorCodecManager.getTableLayoutHandleCodec(connectorId);
+        if (!codec.isPresent()) {
+            return;
+        }
+
+        serialize(codec.get(), value, writer, byteBufferPoolManager);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/server/thrift/ThriftCodecUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/thrift/ThriftCodecUtils.java
@@ -13,11 +13,25 @@
  */
 package com.facebook.presto.server.thrift;
 
+import com.facebook.drift.TException;
+import com.facebook.drift.buffer.ByteBufferPool;
 import com.facebook.drift.codec.ThriftCodec;
 import com.facebook.drift.protocol.TBinaryProtocol;
 import com.facebook.drift.protocol.TMemoryBuffer;
 import com.facebook.drift.protocol.TMemoryBufferWriteOnly;
+import com.facebook.drift.protocol.TProtocol;
 import com.facebook.drift.protocol.TProtocolException;
+import com.facebook.drift.protocol.TProtocolReader;
+import com.facebook.drift.protocol.TProtocolWriter;
+import com.facebook.drift.protocol.bytebuffer.ByteBufferInputTransport;
+import com.facebook.drift.protocol.bytebuffer.ByteBufferOutputTransport;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
+import com.facebook.presto.spi.ConnectorCodec;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 
 public class ThriftCodecUtils
 {
@@ -49,5 +63,64 @@ public class ThriftCodecUtils
         catch (Exception e) {
             throw new TProtocolException("Can not serialize the data", e);
         }
+    }
+
+    public static <T> T deserializeConcreteValue(
+            List<ByteBuffer> byteBuffers,
+            ThriftCodec<T> codec)
+            throws Exception
+    {
+        ByteBufferInputTransport transport = new ByteBufferInputTransport(byteBuffers);
+        TProtocol protocol = new TBinaryProtocol(transport);
+        return codec.read(protocol);
+    }
+
+    public static <T> void serializeConcreteValue(T value, ThriftCodec<T> codec, ByteBufferPool pool, Consumer<List<ByteBuffer>> consumer)
+            throws Exception
+    {
+        List<ByteBuffer> byteBuffers = new ArrayList<>();
+        ByteBufferOutputTransport transport = new ByteBufferOutputTransport(pool, byteBuffers);
+        TProtocol protocol = new TBinaryProtocol(transport);
+
+        codec.write(value, protocol);
+        transport.finish();
+        consumer.accept(byteBuffers);
+    }
+
+    public static <T> T deserialize(ConnectorCodec<T> codec, TProtocolReader reader, ByteBufferPoolManager byteBufferPoolManager)
+            throws Exception
+    {
+        ByteBufferPool byteBufferPool = byteBufferPoolManager.getPool();
+        List<ByteBuffer> byteBuffers = reader.readBinaryToBuffers(byteBufferPool);
+        if (byteBuffers.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return codec.deserialize(byteBuffers);
+        }
+        finally {
+            for (ByteBuffer byteBuffer : byteBuffers) {
+                byteBufferPool.release(byteBuffer);
+            }
+        }
+    }
+
+    public static <T> void serialize(ConnectorCodec<T> codec, T value, TProtocolWriter writer, ByteBufferPoolManager byteBufferPoolManager)
+            throws Exception
+    {
+        codec.serialize(value, byteBuffers -> {
+            try {
+                writer.writeBinaryFromBuffers(byteBuffers);
+            }
+            catch (TException e) {
+                throw new IllegalStateException("Failed to serialize value", e);
+            }
+            finally {
+                for (ByteBuffer byteBuffer : byteBuffers) {
+                    byteBufferPoolManager.getPool().release(byteBuffer);
+                }
+            }
+        });
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/thrift/TransactionHandleThriftCodec.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/thrift/TransactionHandleThriftCodec.java
@@ -18,14 +18,18 @@ import com.facebook.drift.codec.CodecThriftType;
 import com.facebook.drift.codec.metadata.ThriftType;
 import com.facebook.drift.protocol.TProtocolReader;
 import com.facebook.drift.protocol.TProtocolWriter;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.connector.ConnectorCodecManager;
 import com.facebook.presto.metadata.HandleResolver;
+import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 
 import javax.inject.Inject;
 
-import java.nio.ByteBuffer;
+import java.util.Optional;
 
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.deserialize;
+import static com.facebook.presto.server.thrift.ThriftCodecUtils.serialize;
 import static java.util.Objects.requireNonNull;
 
 public class TransactionHandleThriftCodec
@@ -33,15 +37,20 @@ public class TransactionHandleThriftCodec
 {
     private static final ThriftType THRIFT_TYPE = createThriftType(ConnectorTransactionHandle.class);
     private final ConnectorCodecManager connectorCodecManager;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
     @Inject
-    public TransactionHandleThriftCodec(HandleResolver handleResolver, ConnectorCodecManager connectorCodecManager, JsonCodec<ConnectorTransactionHandle> jsonCodec)
+    public TransactionHandleThriftCodec(HandleResolver handleResolver,
+            ConnectorCodecManager connectorCodecManager,
+            JsonCodec<ConnectorTransactionHandle> jsonCodec,
+            ByteBufferPoolManager byteBufferPoolManager)
     {
         super(ConnectorTransactionHandle.class,
                 requireNonNull(jsonCodec, "jsonCodec is null"),
                 requireNonNull(handleResolver, "handleResolver is null")::getId,
                 handleResolver::getTransactionHandleClass);
         this.connectorCodecManager = requireNonNull(connectorCodecManager, "connectorThriftCodecManager is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @CodecThriftType
@@ -60,10 +69,11 @@ public class TransactionHandleThriftCodec
     public ConnectorTransactionHandle readConcreteValue(String connectorId, TProtocolReader reader)
             throws Exception
     {
-        ByteBuffer byteBuffer = reader.readBinary();
-        assert (byteBuffer.position() == 0);
-        byte[] bytes = byteBuffer.array();
-        return connectorCodecManager.getTransactionHandleCodec(connectorId).map(codec -> codec.deserialize(bytes)).orElse(null);
+        Optional<ConnectorCodec<ConnectorTransactionHandle>> codec = connectorCodecManager.getTransactionHandleCodec(connectorId);
+        if (!codec.isPresent()) {
+            return null;
+        }
+        return deserialize(codec.get(), reader, byteBufferPoolManager);
     }
 
     @Override
@@ -71,7 +81,12 @@ public class TransactionHandleThriftCodec
             throws Exception
     {
         requireNonNull(value, "value is null");
-        writer.writeBinary(ByteBuffer.wrap(connectorCodecManager.getTransactionHandleCodec(connectorId).map(codec -> codec.serialize(value)).orElseThrow(() -> new IllegalArgumentException("Can not serialize " + value))));
+        Optional<ConnectorCodec<ConnectorTransactionHandle>> codec = connectorCodecManager.getTransactionHandleCodec(connectorId);
+        if (!codec.isPresent()) {
+            return;
+        }
+
+        serialize(codec.get(), value, writer, byteBufferPoolManager);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -26,6 +26,7 @@ import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.analyzer.PreparedQuery;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.connector.ConnectorCodecManager;
@@ -509,7 +510,7 @@ public class LocalQueryRunner
                 new FilterStatsCalculator(metadata, scalarStatsCalculator, statsNormalizer),
                 blockEncodingManager,
                 featuresConfig,
-                new ConnectorCodecManager(ThriftCodecManager::new));
+                new ConnectorCodecManager(ThriftCodecManager::new, new ByteBufferPoolManager()));
 
         GlobalSystemConnectorFactory globalSystemConnectorFactory = new GlobalSystemConnectorFactory(ImmutableSet.of(
                 new NodeSystemTable(nodeManager),

--- a/presto-main-base/src/main/java/com/facebook/presto/thrift/RemoteCodecProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/thrift/RemoteCodecProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.thrift;
 
 import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
@@ -28,21 +29,23 @@ public class RemoteCodecProvider
         implements ConnectorCodecProvider
 {
     private final Provider<ThriftCodecManager> thriftCodecManagerProvider;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
-    public RemoteCodecProvider(Provider<ThriftCodecManager> thriftCodecManagerProvider)
+    public RemoteCodecProvider(Provider<ThriftCodecManager> thriftCodecManagerProvider, ByteBufferPoolManager byteBufferPoolManager)
     {
         this.thriftCodecManagerProvider = requireNonNull(thriftCodecManagerProvider, "thriftCodecManagerProvider is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @Override
     public Optional<ConnectorCodec<ConnectorSplit>> getConnectorSplitCodec()
     {
-        return Optional.of(new RemoteSplitCodec(thriftCodecManagerProvider));
+        return Optional.of(new RemoteSplitCodec(thriftCodecManagerProvider, byteBufferPoolManager));
     }
 
     @Override
     public Optional<ConnectorCodec<ConnectorTransactionHandle>> getConnectorTransactionHandleCodec()
     {
-        return Optional.of(new RemoteTransactionHandleCodec(thriftCodecManagerProvider));
+        return Optional.of(new RemoteTransactionHandleCodec(thriftCodecManagerProvider, byteBufferPoolManager));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -41,6 +41,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockEncoding;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.connector.ConnectorCodecManager;
@@ -840,6 +841,10 @@ public class ServerMainModule
         // Node manager binding
         binder.bind(PluginNodeManager.class).in(Scopes.SINGLETON);
         binder.bind(NodeManager.class).to(PluginNodeManager.class).in(Scopes.SINGLETON);
+
+        QueryManagerConfig config = buildConfigObject(QueryManagerConfig.class);
+        ByteBufferPoolManager poolManager = new ByteBufferPoolManager(config.getByteBufferPoolBufferSize(), config.getByteBufferPoolMaxSize());
+        binder.bind(ByteBufferPoolManager.class).toInstance(poolManager);
     }
 
     @Provides

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorCodec.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorCodec.java
@@ -15,10 +15,16 @@ package com.facebook.presto.spi;
 
 import com.facebook.presto.spi.api.Experimental;
 
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Consumer;
+
 @Experimental
 public interface ConnectorCodec<T>
 {
-    byte[] serialize(T value);
+    void serialize(T value, Consumer<List<ByteBuffer>> consumer)
+            throws Exception;
 
-    T deserialize(byte[] bytes);
+    T deserialize(List<ByteBuffer> byteBufferList)
+            throws Exception;
 }

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>drift-protocol</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -131,7 +136,6 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-
 
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsConnectorFactory.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsConnectorFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.tpcds;
 
 import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.connector.Connector;
@@ -110,7 +111,7 @@ public class TpcdsConnectorFactory
             @Override
             public ConnectorCodecProvider getConnectorCodecProvider()
             {
-                return new TpcdsCodecProvider(new ThriftCodecManager());
+                return new TpcdsCodecProvider(ThriftCodecManager::new, new ByteBufferPoolManager());
             }
         };
     }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/thrift/TpcdsCodecProvider.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/thrift/TpcdsCodecProvider.java
@@ -14,12 +14,14 @@
 package com.facebook.presto.tpcds.thrift;
 
 import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.inject.Provider;
 
 import java.util.Optional;
 
@@ -28,34 +30,36 @@ import static java.util.Objects.requireNonNull;
 public class TpcdsCodecProvider
         implements ConnectorCodecProvider
 {
-    private final ThriftCodecManager thriftCodecManager;
+    private final Provider<ThriftCodecManager> thriftCodecManagerProvider;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
-    public TpcdsCodecProvider(ThriftCodecManager thriftCodecManager)
+    public TpcdsCodecProvider(Provider<ThriftCodecManager> thriftCodecManagerProvider, ByteBufferPoolManager byteBufferPoolManager)
     {
-        this.thriftCodecManager = requireNonNull(thriftCodecManager, "thriftCodecManager is null");
+        this.thriftCodecManagerProvider = requireNonNull(thriftCodecManagerProvider, "thriftCodecManagerProvider is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @Override
     public Optional<ConnectorCodec<ConnectorSplit>> getConnectorSplitCodec()
     {
-        return Optional.of(new TpcdsSplitCodec(thriftCodecManager));
+        return Optional.of(new TpcdsSplitCodec(thriftCodecManagerProvider, byteBufferPoolManager));
     }
 
     @Override
     public Optional<ConnectorCodec<ConnectorTransactionHandle>> getConnectorTransactionHandleCodec()
     {
-        return Optional.of(new TpcdsTransactionHandleCodec(thriftCodecManager));
+        return Optional.of(new TpcdsTransactionHandleCodec(thriftCodecManagerProvider, byteBufferPoolManager));
     }
 
     @Override
     public Optional<ConnectorCodec<ConnectorTableLayoutHandle>> getConnectorTableLayoutHandleCodec()
     {
-        return Optional.of(new TpcdsTableLayoutHandleCodec(thriftCodecManager));
+        return Optional.of(new TpcdsTableLayoutHandleCodec(thriftCodecManagerProvider, byteBufferPoolManager));
     }
 
     @Override
     public Optional<ConnectorCodec<ConnectorTableHandle>> getConnectorTableHandleCodec()
     {
-        return Optional.of(new TpcdsTableHandleCodec(thriftCodecManager));
+        return Optional.of(new TpcdsTableHandleCodec(thriftCodecManagerProvider, byteBufferPoolManager));
     }
 }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/thrift/TpcdsTableLayoutHandleCodec.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/thrift/TpcdsTableLayoutHandleCodec.java
@@ -13,48 +13,51 @@
  */
 package com.facebook.presto.tpcds.thrift;
 
-import com.facebook.drift.codec.ThriftCodec;
 import com.facebook.drift.codec.ThriftCodecManager;
-import com.facebook.drift.protocol.TProtocolException;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.tpcds.TpcdsTableLayoutHandle;
+import com.google.inject.Provider;
 
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
-import static com.facebook.presto.tpcds.thrift.ThriftCodecUtils.fromThrift;
-import static com.facebook.presto.tpcds.thrift.ThriftCodecUtils.toThrift;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.tpcds.thrift.ThriftCodecUtils.deserializeConcreteValue;
+import static com.facebook.presto.tpcds.thrift.ThriftCodecUtils.serializeConcreteValue;
 import static java.util.Objects.requireNonNull;
 
 public class TpcdsTableLayoutHandleCodec
         implements ConnectorCodec<ConnectorTableLayoutHandle>
 {
-    private final ThriftCodec<TpcdsTableLayoutHandle> thriftCodec;
+    private final Provider<ThriftCodecManager> thriftCodecManagerProvider;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
-    public TpcdsTableLayoutHandleCodec(ThriftCodecManager thriftCodecManager)
+    public TpcdsTableLayoutHandleCodec(Provider<ThriftCodecManager> thriftCodecManagerProvider, ByteBufferPoolManager byteBufferPoolManager)
     {
-        this.thriftCodec = requireNonNull(thriftCodecManager, "thriftCodecManager is null").getCodec(TpcdsTableLayoutHandle.class);
+        this.thriftCodecManagerProvider = requireNonNull(thriftCodecManagerProvider, "thriftCodecManagerProvider is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @Override
-    public byte[] serialize(ConnectorTableLayoutHandle handle)
+    public void serialize(ConnectorTableLayoutHandle handle, Consumer<List<ByteBuffer>> consumer)
+            throws Exception
     {
-        try {
-            return toThrift((TpcdsTableLayoutHandle) handle, thriftCodec);
-        }
-        catch (TProtocolException e) {
-            throw new PrestoException(INVALID_ARGUMENTS, "Can not serialize tpcds table Layout handle", e);
-        }
+        requireNonNull(handle, "handle is null");
+        requireNonNull(consumer, "consumer is null");
+
+        TpcdsTableLayoutHandle layoutHandle = (TpcdsTableLayoutHandle) handle;
+
+        serializeConcreteValue(layoutHandle, thriftCodecManagerProvider.get().getCodec(TpcdsTableLayoutHandle.class), byteBufferPoolManager.getPool(), consumer);
     }
 
     @Override
-    public ConnectorTableLayoutHandle deserialize(byte[] bytes)
+    public ConnectorTableLayoutHandle deserialize(List<ByteBuffer> byteBuffers)
+            throws Exception
     {
-        try {
-            return fromThrift(bytes, thriftCodec);
-        }
-        catch (TProtocolException e) {
-            throw new PrestoException(INVALID_ARGUMENTS, "Can not deserialize tpcds table Layout handle", e);
-        }
+        requireNonNull(byteBuffers, "byteBuffers is null");
+
+        return deserializeConcreteValue(byteBuffers, thriftCodecManagerProvider.get().getCodec(TpcdsTableLayoutHandle.class));
     }
 }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/thrift/TpcdsTransactionHandleCodec.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/thrift/TpcdsTransactionHandleCodec.java
@@ -13,48 +13,51 @@
  */
 package com.facebook.presto.tpcds.thrift;
 
-import com.facebook.drift.codec.ThriftCodec;
 import com.facebook.drift.codec.ThriftCodecManager;
-import com.facebook.drift.protocol.TProtocolException;
+import com.facebook.presto.common.thrift.ByteBufferPoolManager;
 import com.facebook.presto.spi.ConnectorCodec;
-import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.tpcds.TpcdsTransactionHandle;
+import com.google.inject.Provider;
 
-import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
-import static com.facebook.presto.tpcds.thrift.ThriftCodecUtils.fromThrift;
-import static com.facebook.presto.tpcds.thrift.ThriftCodecUtils.toThrift;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static com.facebook.presto.tpcds.thrift.ThriftCodecUtils.deserializeConcreteValue;
+import static com.facebook.presto.tpcds.thrift.ThriftCodecUtils.serializeConcreteValue;
 import static java.util.Objects.requireNonNull;
 
 public class TpcdsTransactionHandleCodec
         implements ConnectorCodec<ConnectorTransactionHandle>
 {
-    private final ThriftCodec<TpcdsTransactionHandle> thriftCodec;
+    private final Provider<ThriftCodecManager> thriftCodecManagerProvider;
+    private final ByteBufferPoolManager byteBufferPoolManager;
 
-    public TpcdsTransactionHandleCodec(ThriftCodecManager thriftCodecManager)
+    public TpcdsTransactionHandleCodec(Provider<ThriftCodecManager> thriftCodecManagerProvider, ByteBufferPoolManager byteBufferPoolManager)
     {
-        this.thriftCodec = requireNonNull(thriftCodecManager, "thriftCodecManager is null").getCodec(TpcdsTransactionHandle.class);
+        this.thriftCodecManagerProvider = requireNonNull(thriftCodecManagerProvider, "thriftCodecManagerProvider is null");
+        this.byteBufferPoolManager = requireNonNull(byteBufferPoolManager, "byteBufferPoolManager is null");
     }
 
     @Override
-    public byte[] serialize(ConnectorTransactionHandle handle)
+    public void serialize(ConnectorTransactionHandle handle, Consumer<List<ByteBuffer>> consumer)
+            throws Exception
     {
-        try {
-            return toThrift((TpcdsTransactionHandle) handle, thriftCodec);
-        }
-        catch (TProtocolException e) {
-            throw new PrestoException(INVALID_ARGUMENTS, "Can not serialize tpcds transaction handle", e);
-        }
+        requireNonNull(handle, "handle is null");
+        requireNonNull(consumer, "consumer is null");
+
+        TpcdsTransactionHandle transactionHandle = (TpcdsTransactionHandle) handle;
+
+        serializeConcreteValue(transactionHandle, thriftCodecManagerProvider.get().getCodec(TpcdsTransactionHandle.class), byteBufferPoolManager.getPool(), consumer);
     }
 
     @Override
-    public ConnectorTransactionHandle deserialize(byte[] bytes)
+    public ConnectorTransactionHandle deserialize(List<ByteBuffer> byteBuffers)
+            throws Exception
     {
-        try {
-            return fromThrift(bytes, thriftCodec);
-        }
-        catch (TProtocolException e) {
-            throw new PrestoException(INVALID_ARGUMENTS, "Can not deserialize tpcds transaction handle", e);
-        }
+        requireNonNull(byteBuffers, "byteBuffers is null");
+
+        return deserializeConcreteValue(byteBuffers, thriftCodecManagerProvider.get().getCodec(TpcdsTransactionHandle.class));
     }
 }


### PR DESCRIPTION
## Description
1. add support to use byte buffer pool for thrift serde to avoid intermediate byte array allocation and reduce gc overhead
2. each event loop will have its own pool so that no contention from other threads
3. Will need https://github.com/prestodb/airlift/pull/123 to compile
4. We saw about **12%** gc time reduction compared to non-pooled thrift serde


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. verifier passed
2. ensure the pool is being used
<img width="1452" height="597" alt="Screenshot 2025-08-17 at 20 28 29" src="https://github.com/user-attachments/assets/8b0568fe-16a0-4e4d-9837-61680500c172" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support to use byte buffer pool for thrift serde to reduce intermediate allocation thus reduce gc overhead
```


