### PR TITLE
Fix for bigquery select not working

### DIFF
--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -244,9 +244,11 @@
             </exclusions>
         </dependency>
 
+        <!-- Pin protobuf-java to 3.25.8 because BigQuery v1beta1 relies on makeExtensionsImmutable(), removed in 4.x -->
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
+            <version>3.25.8</version>
         </dependency>
 
         <dependency>
@@ -400,6 +402,8 @@
                                 <exclude>jakarta.annotation:jakarta.annotation-api</exclude>
                                 <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
                                 <exclude>com.google.api.grpc:proto-google-common-protos</exclude>
+                                <!-- Exclude protobuf-java so enforcer doesn’t force upgrade to 4.x -->
+                                <exclude>com.google.protobuf:protobuf-java</exclude>
                             </excludes>
                         </requireUpperBoundDeps>
                     </rules>


### PR DESCRIPTION
## Description
The following error is shown when trying to select from bigquery:

`io.grpc.StatusRuntimeException: CANCELLED: Failed to read message.
`
## Motivation and Context
This is happening because the `proto-google-cloud-bigquerystorage-v1beta1` library we are using was generated with protobuf-java 3.x, where the `makeExtensionsImmutable()` method existed in the GeneratedMessageV3 base class. However, our runtime is using protobuf-java 4.x, where that method has been removed.

Although the method isn’t explicitly declared in Storage$ReadSession, the generated class makes an inherited call to `makeExtensionsImmutable()` from GeneratedMessageV3, which now results in a NoSuchMethodError.

Since v1beta1 is an older proto version, it still assumes the presence of this method.

we are using the latest 4.x version of `protobuf-java` in presto.
The latest version of `proto-google-cloud-bigquerystorage-v1beta1` library still uses the 3.x version of `protobuf-java`

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

BigQuery Connector Changes
* Fixed query failures on SELECT operations by aligning BigQuery v1beta1 with protobuf-java 3.25.8, preventing runtime incompatibility with protobuf 4.x.
```

