### PR TITLE
chore(deps): Upgrade org.glassfish.jersey:jersey-bom version

### DIFF
--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>
-                <version>2.22.2</version>
+                <version>2.41</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -378,6 +378,10 @@
                     <groupId>javax.inject</groupId>
                     <artifactId>javax.inject</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>jakarta.inject</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -392,7 +396,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.glassfish.hk2.external</groupId>
-                    <artifactId>javax.inject</artifactId>
+                    <artifactId>jakarta.inject</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## Description

Upgrade org.glassfish.jersey:jersey-bom  version from 2.22.2 to 2.41

## Motivation and Context

Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade jersey-bom version  to 2.41  in response to the use of an outdated version.
```

