### PR TITLE
Support enforcement of NOT NULL column declarations

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -718,6 +718,7 @@ public abstract class IcebergAbstractMetadata
                 .map(column -> ColumnMetadata.builder()
                         .setName(normalizeIdentifier(session, column.name()))
                         .setType(toPrestoType(column.type(), typeManager))
+                        .setNullable(column.isOptional())
                         .setComment(column.doc())
                         .setHidden(false)
                         .setExtraInfo(partitionFields.containsKey(column.name()) ?

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -741,7 +741,17 @@ public abstract class IcebergDistributedSmokeTestBase
     @Test
     public void testInsertIntoNotNullColumn()
     {
-        // TODO: To support non-null column. (NOT_NULL_COLUMN_CONSTRAINT)
+        assertUpdate("CREATE TABLE test_not_null_table (c1 INTEGER, c2 INTEGER NOT NULL)");
+        assertUpdate("INSERT INTO test_not_null_table (c2) VALUES (2)", 1);
+        assertQuery("SELECT * FROM test_not_null_table", "VALUES (NULL, 2)");
+        assertQueryFails("INSERT INTO test_not_null_table (c1) VALUES (1)", "NULL value not allowed for NOT NULL column: c2");
+        assertUpdate("DROP TABLE IF EXISTS test_not_null_table");
+
+        assertUpdate("CREATE TABLE test_commuted_not_null_table (a BIGINT, b BIGINT NOT NULL)");
+        assertUpdate("INSERT INTO test_commuted_not_null_table (b) VALUES (2)", 1);
+        assertQuery("SELECT * FROM test_commuted_not_null_table", "VALUES (NULL, 2)");
+        assertQueryFails("INSERT INTO test_commuted_not_null_table (b, a) VALUES (NULL, 3),(4, NULL),(NULL, NULL)", "NULL value not allowed for NOT NULL column: b");
+        assertUpdate("DROP TABLE IF EXISTS test_commuted_not_null_table");
     }
 
     @Test


### PR DESCRIPTION
Original support was added via [#2ad67dcf,](https://github.com/prestodb/presto/commit/2ad67dcf000be86ebc5ff7732bbb9994c8e324a8)
but missed adding it for Iceberg tables

Cherry-pick of trinodb/trino#4144

## Impact
Inserting into Iceberg tables will honor NOT NULL constraints on columns

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

