### PR TITLE
Fix Query ID tooltip position in Web UI

### DIFF
--- a/presto-ui/src/components/QueryList.jsx
+++ b/presto-ui/src/components/QueryList.jsx
@@ -511,6 +511,7 @@ export class QueryList extends React.Component {
 
     componentDidMount() {
         this.refreshLoop();
+        $('[data-bs-toggle="tooltip"]')?.tooltip?.();
     }
 
     handleSearchStringChange(event) {


### PR DESCRIPTION
Added Bootstrap tooltip initialization in QueryList component's componentDidMount method to ensure tooltips display at correct position instead of top-left corner.

This fix addresses the issue where Query ID tooltips were appearing at the top-left corner of the page instead of near the element they were meant to describe.

**Changes:**
- Added `$('[data-bs-toggle="tooltip"]')?.tooltip?.();` to the `componentDidMount` method in `QueryList.jsx`
- This ensures Bootstrap tooltips are properly initialized when the component mounts
- Aligns with the tooltip initialization pattern used in other components

**Testing:**
- Verified that tooltips now appear at the correct position relative to the Query ID elements
- Confirmed that the Web UI loads and functions correctly with this change

Fixes #24727