### PR TITLE
Upgrade helix-core to 1.4.3 to address CVE-2023-38647

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <dep.commons.lang3.version>3.18.0</dep.commons.lang3.version>
         <dep.guice.version>6.0.0</dep.guice.version>
         <dep.arrow.version>17.0.0</dep.arrow.version>
+        <dep.helix.version>1.4.3</dep.helix.version>
 
         <dep.pos.classloader.module-name.suffix>2</dep.pos.classloader.module-name.suffix>
 
@@ -2243,6 +2244,13 @@
                 <groupId>org.apache.pinot</groupId>
                 <artifactId>presto-pinot-driver</artifactId>
                 <version>${dep.pinot.version}</version>
+            </dependency>
+
+            <!-- Upgrades the transitive helix-core version used by the Presto Pinot driver to address CVE-2023-38647 -->
+            <dependency>
+                <groupId>org.apache.helix</groupId>
+                <artifactId>helix-core</artifactId>
+                <version>${dep.helix.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
Upgraded helix-core to version 1.4.3 to address CVE-2023-38647, as the vulnerable version (helix-core:1.0.4) was introduced as a transitive dependency through the presto-pinot-driver.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade helix-core to 1.4.3 to address `CVE-2023-38647  <https://github.com/advisories/GHSA-jhcr-hph9-g7wm>`_.

```