### PR TITLE
Exclude ValidationMessages.properties from shaded presto-jdbc

### DIFF
--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -433,6 +433,7 @@
                                         <exclude>META-INF/services/com.fasterxml.**</exclude>
                                         <exclude>META-INF.versions.9.module-info</exclude>
                                         <exclude>LICENSE</exclude>
+                                        <exclude>ValidationMessages.properties</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
## Description
Exclude ValidationMessages.properties from shaded presto-jdbc. This is brought in by com.facebook.airlift.units, and can cause duplicate resources errors when both com.facebook.airlift.units and presto-jdbc are used as dependencies. It's not needed in the shaded jar.

## Motivation and Context

Prevent errors like the following in some circumstances when units and presto-jdbc are both included as dependencies
```
[WARNING] Found duplicate (but equal) resources in [com.facebook.airlift:units:0.221, com.facebook.presto:presto-jdbc:0.295-SNAPSHOT]:
[WARNING]   ValidationMessages.properties
[WARNING] Found duplicate classes/resources in compile classpath.
[WARNING] Found duplicate (but equal) resources in [com.facebook.airlift:units:0.221, com.facebook.presto:presto-jdbc:0.295-SNAPSHOT]:
[WARNING]   ValidationMessages.properties
[WARNING] Found duplicate classes/resources in runtime classpath.
[WARNING] Found duplicate (but equal) resources in [com.facebook.airlift:units:0.221, com.facebook.presto:presto-jdbc:0.295-SNAPSHOT]:
[WARNING]   ValidationMessages.properties
[WARNING] Found duplicate classes/resources in test classpath.
```

## Impact
No duplicate resource when using com.facebook.airlift.units and presto-jdbc

## Test Plan
Tried building with some custom exclusions removed

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

