### PR TITLE
[G/W routing] ClusterCategory selector take queue weight

### DIFF
--- a/presto-server/src/main/provisio/presto.xml
+++ b/presto-server/src/main/provisio/presto.xml
@@ -1,6 +1,6 @@
 <runtime>
     <!-- Target -->
-    <archive name="${project.artifactId}-${project.version}.tar.gz" hardLinkIncludes="**/*.jar" />
+    <archive name="${project.artifactId}-${project.version}.tar.gz" hardLinkIncludes="" />
 
     <!-- Notices -->
     <fileSet to="/">


### PR DESCRIPTION
Summary:
**Background**: Add queue weight to the interactive cluster similar to batch routing

**Why we need this change?**
With this change -  D79753350  to completely route native eligible to cpp (it was done mostly for interactive use case but it applies to batch as well, batch clusters are seeing high queuing on regions like NHA(Related post: https://fb.workplace.com/groups/presto.users/posts/29167796109508960)). With this change, we want to introduce queue weight on interactive cluster, but still let all queries go to cpp for interactive i.e. the original intention of D79753350. This way we can revert D79753350 and control batch routing via queue weight.

Also this may be useful if we want to control routing via queue weight  on java for any unexpected scenarios for interactive.

**__Changes__**

**Introduce slotWeight**: Consider queue weight from the cluster properties. Given the interactive routing is based on slot, I have mapped  slot weight = 1 / queue_weight (to keep the meaning of queue weight same across batch and interactive). 

**Using slotWeight**: In the new approach i am just multiplying effective concurrency to higher number based on slot weight of the cluster which we need to change in environment_config - https://www.internalfb.com/code/configerator/source/presto/gateway_routing/environment_config.cconf?lines=19%2C21. Right now all are 1.0

Idea is that for cpp cluster, we will set queue weight to sth like 0.00001 so that slot weight = 10000.  This way we will multiple 10000 with effective concurrency so total available slots for cpp will always be higher than java.

Also, change in **coordinator selector to pick cluster with most free slots**. Earlier it was picking any random cluster > 0 slots. This will ensure we will always pick cpp cluster in all scenarios

Differential Revision: D79839151


