### PR TITLE
refactor(OSS Presto): Support passing RuntimeStats to ConnectorSession via PageSinkManager

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/Session.java
@@ -495,17 +495,26 @@ public final class Session
                 .build();
     }
 
-    public ConnectorSession toConnectorSession(ConnectorId connectorId)
+    public ConnectorSession toConnectorSession(ConnectorId connectorId, RuntimeStats runtimeStats)
     {
         requireNonNull(connectorId, "connectorId is null");
 
-        return new FullConnectorSession(
-                this,
-                identity.toConnectorIdentity(connectorId.getCatalogName()),
-                connectorProperties.getOrDefault(connectorId, ImmutableMap.of()),
-                connectorId,
-                connectorId.getCatalogName(),
-                sessionPropertyManager);
+        FullConnectorSession.Builder connectorSessionBuilder = FullConnectorSession
+                .builder(
+                        this,
+                        identity.toConnectorIdentity(connectorId.getCatalogName()),
+                        connectorProperties.getOrDefault(connectorId, ImmutableMap.of()),
+                        connectorId,
+                        connectorId.getCatalogName(),
+                        sessionPropertyManager)
+                .setRuntimeStats(runtimeStats);
+
+        return connectorSessionBuilder.build();
+    }
+
+    public ConnectorSession toConnectorSession(ConnectorId connectorId)
+    {
+        return toConnectorSession(connectorId, runtimeStats);
     }
 
     public SessionRepresentation toSessionRepresentation()

--- a/presto-main-base/src/main/java/com/facebook/presto/split/PageSinkManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/split/PageSinkManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.split;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.metadata.InsertTableHandle;
 import com.facebook.presto.metadata.OutputTableHandle;
 import com.facebook.presto.spi.ConnectorId;
@@ -46,20 +47,30 @@ public class PageSinkManager
         pageSinkProviders.remove(connectorId);
     }
 
+    public ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle, PageSinkContext pageSinkContext, RuntimeStats runtimeStats)
+    {
+        // assumes connectorId and catalog are the same
+        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId(), runtimeStats);
+        return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+    }
+
+    public ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle, PageSinkContext pageSinkContext, RuntimeStats runtimeStats)
+    {
+        // assumes connectorId and catalog are the same
+        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId(), runtimeStats);
+        return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+    }
+
     @Override
     public ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle, PageSinkContext pageSinkContext)
     {
-        // assumes connectorId and catalog are the same
-        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId());
-        return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+        return createPageSink(session, tableHandle, pageSinkContext, null);
     }
 
     @Override
     public ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle, PageSinkContext pageSinkContext)
     {
-        // assumes connectorId and catalog are the same
-        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId());
-        return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+        return createPageSink(session, tableHandle, pageSinkContext, null);
     }
 
     private ConnectorPageSinkProvider providerFor(ConnectorId connectorId)


### PR DESCRIPTION
Summary: Overload `PageSinkManger`'s `createPageSink` to suport passing `RuntimeStats` down to the `ConnectorSession`

Differential Revision: D80503086

```
== NO RELEASE NOTE ==
```


