### PR TITLE
[native] Pass Presto build options to Velox build options directly

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -77,58 +77,46 @@ option(PRESTO_ENABLE_SPATIAL "Enable spatial support" ON)
 # and turn on int128.
 add_compile_definitions(FOLLY_HAVE_INT128_T=1 FOLLY_CFG_NO_COROUTINES)
 
-if(PRESTO_ENABLE_S3)
-  set(VELOX_ENABLE_S3
-      ON
-      CACHE BOOL "Build S3 support")
-endif()
+set(VELOX_ENABLE_S3
+    ${PRESTO_ENABLE_S3}
+    CACHE BOOL "Build S3 support")
 
-if(PRESTO_ENABLE_HDFS)
-  set(VELOX_ENABLE_HDFS
-      ON
-      CACHE BOOL "Build HDFS support")
-endif()
+set(VELOX_ENABLE_HDFS
+    ${PRESTO_ENABLE_HDFS}
+    CACHE BOOL "Build HDFS support")
 
-if(PRESTO_ENABLE_GCS)
-  set(VELOX_ENABLE_GCS
-      ON
-      CACHE BOOL "Build GCS support")
-endif()
+set(VELOX_ENABLE_GCS
+    ${PRESTO_ENABLE_GCS}
+    CACHE BOOL "Build GCS support")
 
-if(PRESTO_ENABLE_ABFS)
-  set(VELOX_ENABLE_ABFS
-      ON
-      CACHE BOOL "Build ABFS support")
-endif()
+set(VELOX_ENABLE_ABFS
+    ${PRESTO_ENABLE_ABFS}
+    CACHE BOOL "Build ABFS support")
 
-if(PRESTO_ENABLE_PARQUET)
-  set(VELOX_ENABLE_PARQUET
-      ON
-      CACHE BOOL "Enable Parquet support")
-endif()
+set(VELOX_ENABLE_PARQUET
+    ${PRESTO_ENABLE_PARQUET}
+    CACHE BOOL "Enable Parquet support")
 
+set(VELOX_ENABLE_REMOTE_FUNCTIONS
+    ${PRESTO_ENABLE_REMOTE_FUNCTIONS}
+    CACHE BOOL "Enable remote function support in Velox")
 if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
-  set(VELOX_ENABLE_REMOTE_FUNCTIONS
-      ON
-      CACHE BOOL "Enable remote function support in Velox")
   add_compile_definitions(PRESTO_ENABLE_REMOTE_FUNCTIONS)
 endif()
 
+set(VELOX_ENABLE_CUDF
+    ${PRESTO_ENABLE_CUDF}
+    CACHE BOOL "Enable cuDF support")
 if(PRESTO_ENABLE_CUDF)
-  set(VELOX_ENABLE_CUDF
-      ON
-      CACHE BOOL "Enable cuDF support")
   add_compile_definitions(PRESTO_ENABLE_CUDF)
   enable_language(CUDA)
   # Determine CUDA_ARCHITECTURES automatically.
   cmake_policy(SET CMP0104 NEW)
 endif()
 
-if(PRESTO_ENABLE_SPATIAL)
-  set(VELOX_ENABLE_GEO
-      ON
-      CACHE BOOL "Enable Velox Geometry (aka spatial) support")
-endif()
+set(VELOX_ENABLE_GEO
+    ${PRESTO_ENABLE_SPATIAL}
+    CACHE BOOL "Enable Velox Geometry (aka spatial) support")
 
 set(VELOX_BUILD_TESTING
     OFF


### PR DESCRIPTION
Some Presto build options directly set Velox build option to enable certain features.
Previously, configuration values that do not match Velox defaults might not set the Velox config appropriatly. For example, turning off parquet support would not actually disable it at the build level because the Velox config would be left to the default value which is ON.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

