### PR TITLE
Correct session property rules json

### DIFF
--- a/presto-docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/session-property-managers.rst
@@ -79,7 +79,7 @@ These requirements can be expressed with the following rules:
       {
         "group": "global.*",
         "sessionProperties": {
-          "query_max_execution_time": "8h",
+          "query_max_execution_time": "8h"
         }
       },
       {


### PR DESCRIPTION
## Description
Remove problematic comma from session property rules json on https://prestodb.io/docs/current/admin/session-property-managers.html#example.

## Motivation and Context
Existing example json results in server startup failure

## Impact
NA

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

