### PR TITLE
refactor: Rename SpatialJoinNode.Type -> SpatialJoinNode.SpatialJoinType

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/SpatialJoinOperator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/SpatialJoinOperator.java
@@ -28,8 +28,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getDone;
-import static com.facebook.presto.spi.plan.SpatialJoinNode.Type.INNER;
-import static com.facebook.presto.spi.plan.SpatialJoinNode.Type.LEFT;
+import static com.facebook.presto.spi.plan.SpatialJoinNode.SpatialJoinType.INNER;
+import static com.facebook.presto.spi.plan.SpatialJoinNode.SpatialJoinType.LEFT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -44,7 +44,7 @@ public class SpatialJoinOperator
     {
         private final int operatorId;
         private final PlanNodeId planNodeId;
-        private final SpatialJoinNode.Type joinType;
+        private final SpatialJoinNode.SpatialJoinType joinType;
         private final List<Type> probeTypes;
         private final List<Integer> probeOutputChannels;
         private final int probeGeometryChannel;
@@ -56,7 +56,7 @@ public class SpatialJoinOperator
         public SpatialJoinOperatorFactory(
                 int operatorId,
                 PlanNodeId planNodeId,
-                SpatialJoinNode.Type joinType,
+                SpatialJoinNode.SpatialJoinType joinType,
                 List<Type> probeTypes,
                 List<Integer> probeOutputChannels,
                 int probeGeometryChannel,
@@ -114,7 +114,7 @@ public class SpatialJoinOperator
 
     private final OperatorContext operatorContext;
     private final LocalMemoryContext localUserMemoryContext;
-    private final SpatialJoinNode.Type joinType;
+    private final SpatialJoinNode.SpatialJoinType joinType;
     private final List<Type> probeTypes;
     private final List<Integer> probeOutputChannels;
     private final int probeGeometryChannel;
@@ -139,7 +139,7 @@ public class SpatialJoinOperator
 
     public SpatialJoinOperator(
             OperatorContext operatorContext,
-            SpatialJoinNode.Type joinType,
+            SpatialJoinNode.SpatialJoinType joinType,
             List<Type> probeTypes,
             List<Integer> probeOutputChannels,
             int probeGeometryChannel,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -457,7 +457,7 @@ public class ExtractSpatialJoins
         return Result.ofPlanNode(new SpatialJoinNode(
                 joinNode.getSourceLocation(),
                 nodeId,
-                SpatialJoinNode.Type.fromJoinNodeType(joinNode.getType()),
+                SpatialJoinNode.SpatialJoinType.fromJoinNodeType(joinNode.getType()),
                 newLeftNode,
                 newRightNode,
                 outputVariables,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -905,12 +905,12 @@ public class PredicatePushDown
             RowExpression inheritedPredicate = context.get();
 
             // See if we can rewrite left join in terms of a plain inner join
-            if (node.getType() == SpatialJoinNode.Type.LEFT && canConvertOuterToInner(node.getRight().getOutputVariables(), inheritedPredicate)) {
+            if (node.getType() == SpatialJoinNode.SpatialJoinType.LEFT && canConvertOuterToInner(node.getRight().getOutputVariables(), inheritedPredicate)) {
                 planChanged = true;
                 node = new SpatialJoinNode(
                         node.getSourceLocation(),
                         node.getId(),
-                        SpatialJoinNode.Type.INNER,
+                        SpatialJoinNode.SpatialJoinType.INNER,
                         node.getLeft(),
                         node.getRight(),
                         node.getOutputVariables(),

--- a/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestSpatialJoinOperator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestSpatialJoinOperator.java
@@ -32,7 +32,7 @@ import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.ValuesOperator;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.plan.PlanNodeId;
-import com.facebook.presto.spi.plan.SpatialJoinNode.Type;
+import com.facebook.presto.spi.plan.SpatialJoinNode.SpatialJoinType;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.TestingTaskContext;
@@ -64,8 +64,8 @@ import static com.facebook.presto.geospatial.GeoFunctions.stGeometryFromText;
 import static com.facebook.presto.geospatial.GeoFunctions.stPoint;
 import static com.facebook.presto.geospatial.type.GeometryType.GEOMETRY;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEqualsIgnoreOrder;
-import static com.facebook.presto.spi.plan.SpatialJoinNode.Type.INNER;
-import static com.facebook.presto.spi.plan.SpatialJoinNode.Type.LEFT;
+import static com.facebook.presto.spi.plan.SpatialJoinNode.SpatialJoinType.INNER;
+import static com.facebook.presto.spi.plan.SpatialJoinNode.SpatialJoinType.LEFT;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -227,7 +227,7 @@ public class TestSpatialJoinOperator
         assertSpatialJoin(taskContext, LEFT, buildPages, probePages, expected);
     }
 
-    private void assertSpatialJoin(TaskContext taskContext, Type joinType, RowPagesBuilder buildPages, RowPagesBuilder probePages, MaterializedResult expected)
+    private void assertSpatialJoin(TaskContext taskContext, SpatialJoinType joinType, RowPagesBuilder buildPages, RowPagesBuilder probePages, MaterializedResult expected)
     {
         DriverContext driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
         PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.intersects(probe), Optional.empty(), Optional.empty(), buildPages);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -502,13 +502,13 @@ public final class PlanMatchPattern
     public static PlanMatchPattern spatialJoin(String expectedFilter, Optional<String> kdbTree, PlanMatchPattern left, PlanMatchPattern right)
     {
         return node(SpatialJoinNode.class, left, right).with(
-                new SpatialJoinMatcher(SpatialJoinNode.Type.INNER, rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedFilter, new ParsingOptions())), kdbTree));
+                new SpatialJoinMatcher(SpatialJoinNode.SpatialJoinType.INNER, rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedFilter, new ParsingOptions())), kdbTree));
     }
 
     public static PlanMatchPattern spatialLeftJoin(String expectedFilter, PlanMatchPattern left, PlanMatchPattern right)
     {
         return node(SpatialJoinNode.class, left, right).with(
-                new SpatialJoinMatcher(SpatialJoinNode.Type.LEFT, rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedFilter, new ParsingOptions())), Optional.empty()));
+                new SpatialJoinMatcher(SpatialJoinNode.SpatialJoinType.LEFT, rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(expectedFilter, new ParsingOptions())), Optional.empty()));
     }
 
     public static PlanMatchPattern mergeJoin(JoinType joinType, List<ExpectedValueProvider<EquiJoinClause>> expectedEquiCriteria, Optional<Expression> filter, PlanMatchPattern left, PlanMatchPattern right)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/SpatialJoinMatcher.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/SpatialJoinMatcher.java
@@ -18,7 +18,7 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.SpatialJoinNode;
-import com.facebook.presto.spi.plan.SpatialJoinNode.Type;
+import com.facebook.presto.spi.plan.SpatialJoinNode.SpatialJoinType;
 import com.facebook.presto.sql.tree.Expression;
 
 import java.util.Optional;
@@ -32,11 +32,11 @@ import static java.util.Objects.requireNonNull;
 public class SpatialJoinMatcher
         implements Matcher
 {
-    private final Type type;
+    private final SpatialJoinType type;
     private final Expression filter;
     private final Optional<String> kdbTree;
 
-    public SpatialJoinMatcher(Type type, Expression filter, Optional<String> kdbTree)
+    public SpatialJoinMatcher(SpatialJoinType type, Expression filter, Optional<String> kdbTree)
     {
         this.type = type;
         this.filter = requireNonNull(filter, "filter can not be null");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/SpatialJoinNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/SpatialJoinNode.java
@@ -34,14 +34,14 @@ import static java.util.Objects.requireNonNull;
 public class SpatialJoinNode
         extends PlanNode
 {
-    public enum Type
+    public enum SpatialJoinType
     {
         INNER("SpatialInnerJoin"),
         LEFT("SpatialLeftJoin");
 
         private final String joinLabel;
 
-        Type(String joinLabel)
+        SpatialJoinType(String joinLabel)
         {
             this.joinLabel = joinLabel;
         }
@@ -51,20 +51,20 @@ public class SpatialJoinNode
             return joinLabel;
         }
 
-        public static Type fromJoinNodeType(JoinType joinNodeType)
+        public static SpatialJoinType fromJoinNodeType(JoinType joinNodeType)
         {
             switch (joinNodeType) {
                 case INNER:
-                    return Type.INNER;
+                    return SpatialJoinType.INNER;
                 case LEFT:
-                    return Type.LEFT;
+                    return SpatialJoinType.LEFT;
                 default:
                     throw new IllegalArgumentException("Unsupported spatial join type: " + joinNodeType);
             }
         }
     }
 
-    private final Type type;
+    private final SpatialJoinType type;
     private final PlanNode left;
     private final PlanNode right;
     private final List<VariableReferenceExpression> outputVariables;
@@ -84,7 +84,7 @@ public class SpatialJoinNode
     public SpatialJoinNode(
             Optional<SourceLocation> sourceLocation,
             @JsonProperty("id") PlanNodeId id,
-            @JsonProperty("type") Type type,
+            @JsonProperty("type") SpatialJoinType type,
             @JsonProperty("left") PlanNode left,
             @JsonProperty("right") PlanNode right,
             @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables,
@@ -100,7 +100,7 @@ public class SpatialJoinNode
             Optional<SourceLocation> sourceLocation,
             PlanNodeId id,
             Optional<PlanNode> statsEquivalentPlanNode,
-            Type type,
+            SpatialJoinType type,
             PlanNode left,
             PlanNode right,
             List<VariableReferenceExpression> outputVariables,
@@ -140,7 +140,7 @@ public class SpatialJoinNode
     }
 
     @JsonProperty
-    public Type getType()
+    public SpatialJoinType getType()
     {
         return type;
     }


### PR DESCRIPTION
## Description
Rename inner class name SpatialJoinNode.Type to SpatialJoinNode.SpatialJoinType.

## Motivation and Context
The name Type caused an identifier conflict during codegen for the cpp protocol. Renaming it something unique avoids that.


## Impact
This should have no public facing change.

## Test Plan
All unit tests should still pass.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

