### PR TITLE
feat: Support tracking Page Sink Runtime Stats in TableWriterOperator

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/Session.java
@@ -495,17 +495,26 @@ public final class Session
                 .build();
     }
 
-    public ConnectorSession toConnectorSession(ConnectorId connectorId)
+    public ConnectorSession toConnectorSession(ConnectorId connectorId, RuntimeStats runtimeStats)
     {
         requireNonNull(connectorId, "connectorId is null");
 
-        return new FullConnectorSession(
-                this,
-                identity.toConnectorIdentity(connectorId.getCatalogName()),
-                connectorProperties.getOrDefault(connectorId, ImmutableMap.of()),
-                connectorId,
-                connectorId.getCatalogName(),
-                sessionPropertyManager);
+        FullConnectorSession.Builder connectorSessionBuilder = FullConnectorSession
+                .builder(
+                        this,
+                        identity.toConnectorIdentity(connectorId.getCatalogName()),
+                        connectorProperties.getOrDefault(connectorId, ImmutableMap.of()),
+                        connectorId,
+                        connectorId.getCatalogName(),
+                        sessionPropertyManager)
+                .setRuntimeStats(runtimeStats);
+
+        return connectorSessionBuilder.build();
+    }
+
+    public ConnectorSession toConnectorSession(ConnectorId connectorId)
+    {
+        return toConnectorSession(connectorId, runtimeStats);
     }
 
     public SessionRepresentation toSessionRepresentation()

--- a/presto-main-base/src/main/java/com/facebook/presto/split/PageSinkManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/split/PageSinkManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.split;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.metadata.InsertTableHandle;
 import com.facebook.presto.metadata.OutputTableHandle;
 import com.facebook.presto.spi.ConnectorId;
@@ -46,20 +47,30 @@ public class PageSinkManager
         pageSinkProviders.remove(connectorId);
     }
 
+    public ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle, PageSinkContext pageSinkContext, RuntimeStats runtimeStats)
+    {
+        // assumes connectorId and catalog are the same
+        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId(), runtimeStats);
+        return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+    }
+
+    public ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle, PageSinkContext pageSinkContext, RuntimeStats runtimeStats)
+    {
+        // assumes connectorId and catalog are the same
+        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId(), runtimeStats);
+        return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+    }
+
     @Override
     public ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle, PageSinkContext pageSinkContext)
     {
-        // assumes connectorId and catalog are the same
-        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId());
-        return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+        return createPageSink(session, tableHandle, pageSinkContext, null);
     }
 
     @Override
     public ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle, PageSinkContext pageSinkContext)
     {
-        // assumes connectorId and catalog are the same
-        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId());
-        return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+        return createPageSink(session, tableHandle, pageSinkContext, null);
     }
 
     private ConnectorPageSinkProvider providerFor(ConnectorId connectorId)


### PR DESCRIPTION
Summary:
Pass the Operator Context's Runtime Stats down into the `TableWriteOperator`'s Page Sink.

Specifically this diff makes the following changes:

a) `TableWriteOperator` passes its `RuntimeStats` into the Page Sink it creates via `PageSinkManager.createPageSink`
b) When the `PageSinkManager.createPageSink` is provided `RuntimeStats`, these `RuntimeStats` are passed into the `Session.toConnectorSession` call, which creates a `FullConnectorSession` instance
c) When `Session.toConnectorSession` is provided `RuntimeStats`, it passes this into the `FullConnectorSession` instance it constructs
d) Add a `Builder` to `FullConnectorSession`, which allows providing a `RuntimeStats` instance to `FullConnectorSession` at construction-time. `FullConnectorSession.getRuntimeStats()` now returns the `RuntimeStats` which was set at construction-time. If no `RuntimeStats` were provided at construction-time, then `FullConnectorSession.getRuntimeStats()` defaults to return the `Session` object's `RuntimeStats`—this preserves backwards compatibility.

All changes preserve forward-compatibility.

## Context

Without this change, the `FullConnectorSession`'s `RuntimeStats` points to the `Session`'s `RuntimeStat`s. All metrics added to the `Session`'s `RuntimeStats` within an Operator Worker-side are discarded. That is, all Runtime Metrics added to the Connector Session's RuntimeStats when executing `TableWriterOperator` were being completely discarded.

Specifically, in Meta, the stats from our internal filesystem implementation were missing.

Passing the Operator Context's `RuntimeStats` instance down into Connector Session is the simplest way to fix this.

Additionally, since the previous `RuntimeStat`s for `TableWriteOperator`'s `FullConnectorSession` were always discarded, we can be confident that replacing them with the `OperatorContext` `RuntimeStat`s will not break anyone else's code.

Differential Revision: D80675849

## Release Notes

```
== RELEASE NOTES ==
General Changes
* Update TableWriterOperator to set the Connector Session Runtime Stats to the Operator Context Runtime Stats. Previously, this was set to the Session object's Runtime Stats. This change ensures any metrics added to the Connector Session's Runtime Stats while executing a TableWriterOperator will be available as Operator Stats.
```
