### PR TITLE
[native][presto-on-spark] Free form native config rework

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -121,7 +121,6 @@ import com.facebook.presto.spark.execution.PrestoSparkExecutionExceptionFactory;
 import com.facebook.presto.spark.execution.http.BatchTaskUpdateRequest;
 import com.facebook.presto.spark.execution.property.NativeExecutionConnectorConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
-import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleReadInfo;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleWriteInfo;
 import com.facebook.presto.spark.execution.task.PrestoSparkNativeTaskExecutorFactory;
@@ -283,7 +282,6 @@ public class PrestoSparkModule
         configBinder(binder).bindConfig(SessionPropertyProviderConfig.class);
         configBinder(binder).bindConfig(PrestoSparkConfig.class);
         configBinder(binder).bindConfig(TracingConfig.class);
-        configBinder(binder).bindConfig(NativeExecutionSystemConfig.class);
         configBinder(binder).bindConfig(NativeExecutionNodeConfig.class);
         configBinder(binder).bindConfig(NativeExecutionConnectorConfig.class);
         configBinder(binder).bindConfig(PlanCheckerProviderManagerConfig.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionModule.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleInfoTransla
 import com.facebook.presto.spark.execution.task.ForNativeExecutionTask;
 import com.facebook.presto.spark.execution.task.NativeExecutionTaskFactory;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -73,9 +74,13 @@ public class NativeExecutionModule
 
     protected void bindWorkerProperties(Binder binder)
     {
-        newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?>>() {}).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?>>() {
+        }).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);
         if (connectorConfig.isPresent()) {
-            binder.bind(PrestoSparkWorkerProperty.class).toInstance(new PrestoSparkWorkerProperty(connectorConfig.get(), new NativeExecutionNodeConfig(), new NativeExecutionSystemConfig()));
+            binder.bind(PrestoSparkWorkerProperty.class).toInstance(
+                    new PrestoSparkWorkerProperty(connectorConfig.get(),
+                            new NativeExecutionNodeConfig(), new NativeExecutionSystemConfig(
+                            ImmutableMap.of())));
         }
         else {
             binder.bind(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkFatalException
 import com.facebook.presto.spark.execution.http.PrestoSparkHttpServerClient;
 import com.facebook.presto.spark.execution.http.server.RequestErrorTracker;
 import com.facebook.presto.spark.execution.http.server.smile.BaseResponse;
+import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
@@ -337,11 +338,13 @@ public class NativeExecutionProcess
         // there is no port isolation among all the containers running on the same host, so we have
         // to pick unique port per worker to avoid port collision. This config will be passed down to
         // the native execution process eventually for process initialization.
-        workerProperty.getSystemConfig().setHttpServerPort(port);
+        workerProperty.getSystemConfig()
+                .update(NativeExecutionSystemConfig.HTTP_SERVER_HTTP_PORT, String.valueOf(port));
         workerProperty.populateAllProperties(
                 Paths.get(configBasePath, WORKER_CONFIG_FILE),
                 Paths.get(configBasePath, WORKER_NODE_CONFIG_FILE),
-                Paths.get(configBasePath, format("%s%s.properties", WORKER_CONNECTOR_CONFIG_FILE, getNativeExecutionCatalogName(session))));
+                Paths.get(configBasePath, format("%s%s.properties", WORKER_CONNECTOR_CONFIG_FILE,
+                    getNativeExecutionCatalogName(session))));
     }
 
     private void doGetServerInfo(SettableFuture<ServerInfo> future)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConfigModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConfigModule.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution.property;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Native configuration module that allows the population of config properties without config
+ * annotation checks.
+ */
+public class NativeExecutionConfigModule
+        extends AbstractModule
+{
+    private final Map<String, String> systemConfigs;
+
+    public NativeExecutionConfigModule(Map<String, String> systemConfigs)
+    {
+        this.systemConfigs = ImmutableMap.copyOf(
+                requireNonNull(systemConfigs, "systemConfigs is null"));
+    }
+
+    @Override
+    protected void configure()
+    {
+        bind(new TypeLiteral<Map<String, String>>() {})
+                .annotatedWith(
+                        Names.named(NativeExecutionSystemConfig.NATIVE_EXECUTION_SYSTEM_CONFIG))
+                .toInstance(systemConfigs);
+
+        bind(NativeExecutionSystemConfig.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -13,740 +13,209 @@
  */
 package com.facebook.presto.spark.execution.property;
 
-import com.facebook.airlift.configuration.Config;
-import com.facebook.airlift.units.DataSize;
-import com.facebook.airlift.units.Duration;
 import com.google.common.collect.ImmutableMap;
+import org.apache.spark.SparkEnv$;
+import org.apache.spark.SparkFiles;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
- * This config class corresponds to config.properties for native execution process. Properties inside will be used in Configs::SystemConfig in Configs.h/cpp
+ * This config class corresponds to config.properties for native execution process. Properties
+ * inside will be used in Configs::SystemConfig in Configs.h/cpp
  */
 public class NativeExecutionSystemConfig
 {
-    private static final String CONCURRENT_LIFESPANS_PER_TASK = "concurrent-lifespans-per-task";
-    private static final String ENABLE_SERIALIZED_PAGE_CHECKSUM = "enable-serialized-page-checksum";
-    private static final String ENABLE_VELOX_EXPRESSION_LOGGING = "enable_velox_expression_logging";
-    private static final String ENABLE_VELOX_TASK_LOGGING = "enable_velox_task_logging";
-    // Port on which presto-native http server should run
-    private static final String HTTP_SERVER_HTTP_PORT = "http-server.http.port";
-    private static final String HTTP_SERVER_REUSE_PORT = "http-server.reuse-port";
-    private static final String HTTP_SERVER_BIND_TO_NODE_INTERNAL_ADDRESS_ONLY_ENABLED = "http-server.bind-to-node-internal-address-only-enabled";
-    // Number of I/O thread to use for serving http request on presto-native (proxygen server)
-    // this excludes worker thread used by velox
-    private static final String HTTP_SERVER_HTTPS_PORT = "http-server.https.port";
-    private static final String HTTP_SERVER_HTTPS_ENABLED = "http-server.https.enabled";
+    public static final String NATIVE_EXECUTION_SYSTEM_CONFIG = "native-execution-system-config";
 
-    // This config control what cipher suites are supported by Native workers for server and client.
-    // Note Java and folly::SSLContext use different names to refer to the same cipher.
-    // (guess for different name, Java specific authentication,key exchange and cipher together and folly just cipher).
-    // For e.g. TLS_RSA_WITH_AES_256_GCM_SHA384 in Java and AES256-GCM-SHA384 in folly::SSLContext.
-    // The ciphers need to enable worker to worker, worker to coordinator and coordinator to worker communication.
-    // Have at least one cipher suite that is shared for the above 3, otherwise weird failures will result.
-    private static final String HTTPS_CIPHERS = "https-supported-ciphers";
+    public static final String CONCURRENT_LIFESPANS_PER_TASK = "concurrent-lifespans-per-task";
+    public static final String ENABLE_SERIALIZED_PAGE_CHECKSUM = "enable-serialized-page-checksum";
+    public static final String ENABLE_VELOX_EXPRESSION_LOGGING = "enable_velox_expression_logging";
+    public static final String ENABLE_VELOX_TASK_LOGGING = "enable_velox_task_logging";
+    public static final String HTTP_SERVER_HTTP_PORT = "http-server.http.port";
+    public static final String HTTP_SERVER_REUSE_PORT = "http-server.reuse-port";
+    public static final String HTTP_SERVER_BIND_TO_NODE_INTERNAL_ADDRESS_ONLY_ENABLED = "http-server.bind-to-node-internal-address-only-enabled";
+    public static final String HTTP_SERVER_HTTPS_PORT = "http-server.https.port";
+    public static final String HTTP_SERVER_HTTPS_ENABLED = "http-server.https.enabled";
+    public static final String HTTPS_SUPPORTED_CIPHERS = "https-supported-ciphers";
+    public static final String HTTPS_CERT_PATH = "https-cert-path";
+    public static final String HTTPS_KEY_PATH = "https-key-path";
+    public static final String HTTP_SERVER_NUM_IO_THREADS_HW_MULTIPLIER = "http-server.num-io-threads-hw-multiplier";
+    public static final String EXCHANGE_HTTP_CLIENT_NUM_IO_THREADS_HW_MULTIPLIER = "exchange.http-client.num-io-threads-hw-multiplier";
+    public static final String ASYNC_DATA_CACHE_ENABLED = "async-data-cache-enabled";
+    public static final String ASYNC_CACHE_SSD_GB = "async-cache-ssd-gb";
+    public static final String CONNECTOR_NUM_IO_THREADS_HW_MULTIPLIER = "connector.num-io-threads-hw-multiplier";
+    public static final String PRESTO_VERSION = "presto.version";
+    public static final String SHUTDOWN_ONSET_SEC = "shutdown-onset-sec";
+    public static final String SYSTEM_MEMORY_GB = "system-memory-gb";
+    public static final String QUERY_MEMORY_GB = "query-memory-gb";
+    public static final String QUERY_MAX_MEMORY_PER_NODE = "query.max-memory-per-node";
+    public static final String USE_MMAP_ALLOCATOR = "use-mmap-allocator";
+    public static final String MEMORY_ARBITRATOR_KIND = "memory-arbitrator-kind";
+    public static final String SHARED_ARBITRATOR_RESERVED_CAPACITY = "shared-arbitrator.reserved-capacity";
+    public static final String SHARED_ARBITRATOR_MEMORY_POOL_INITIAL_CAPACITY = "shared-arbitrator.memory-pool-initial-capacity";
+    public static final String SHARED_ARBITRATOR_MAX_MEMORY_ARBITRATION_TIME = "shared-arbitrator.max-memory-arbitration-time";
+    public static final String EXPERIMENTAL_SPILLER_SPILL_PATH = "experimental.spiller-spill-path";
+    public static final String TASK_MAX_DRIVERS_PER_TASK = "task.max-drivers-per-task";
+    public static final String ENABLE_OLD_TASK_CLEANUP = "enable-old-task-cleanup";
+    public static final String SHUFFLE_NAME = "shuffle.name";
+    public static final String HTTP_SERVER_ENABLE_ACCESS_LOG = "http-server.enable-access-log";
+    public static final String CORE_ON_ALLOCATION_FAILURE_ENABLED = "core-on-allocation-failure-enabled";
+    public static final String SPILL_ENABLED = "spill-enabled";
+    public static final String AGGREGATION_SPILL_ENABLED = "aggregation-spill-enabled";
+    public static final String JOIN_SPILL_ENABLED = "join-spill-enabled";
+    public static final String ORDER_BY_SPILL_ENABLED = "order-by-spill-enabled";
+    public static final String MAX_SPILL_BYTES = "max-spill-bytes";
+    public static final String REMOTE_FUNCTION_SERVER_THRIFT_UDS_PATH = "remote-function-server.thrift.uds-path";
+    public static final String REMOTE_FUNCTION_SERVER_SIGNATURE_FILES_DIRECTORY_PATH = "remote-function-server.signature.files.directory.path";
+    public static final String REMOTE_FUNCTION_SERVER_SERDE = "remote-function-server.serde";
+    public static final String REMOTE_FUNCTION_SERVER_CATALOG_NAME = "remote-function-server.catalog-name";
 
-    // Note: Java packages cert and key in combined JKS file. But CPP requires them separately.
-    // The HTTPS provides integrity and not security(authentication/authorization).
-    // But the HTTPS will protect against data corruption by bad router and man in middle attacks.
+    private final String remoteFunctionServerSignatureFilesDirectoryPathDefault = "./functions/spark/";
+    private final String remoteFunctionServerSerdeDefault = "presto_page";
+    private final String remoteFunctionServerCatalogNameDefault = "";
+    private final String concurrentLifespansPerTaskDefault = "5";
+    private final String enableSerializedPageChecksumDefault = "true";
+    private final String enableVeloxExpressionLoggingDefault = "false";
+    private final String enableVeloxTaskLoggingDefault = "true";
+    private final String httpServerHttpPortDefault = "7777";
+    private final String httpServerReusePortDefault = "true";
+    private final String httpServerBindToNodeInternalAddressOnlyEnabledDefault = "true";
+    private final String httpServerHttpsPortDefault = "7778";
+    private final String httpServerHttpsEnabledDefault = "false";
+    private final String httpsSupportedCiphersDefault = "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384";
+    private final String httpsCertPathDefault = "";
+    private final String httpsKeyPathDefault = "";
+    private final String httpServerNumIoThreadsHwMultiplierDefault = "1.0";
+    private final String exchangeHttpClientNumIoThreadsHwMultiplierDefault = "1.0";
+    private final String asyncDataCacheEnabledDefault = "false";
+    private final String asyncCacheSsdGbDefault = "0";
+    private final String connectorNumIoThreadsHwMultiplierDefault = "0";
+    private final String prestoVersionDefault = "dummy.presto.version";
+    private final String shutdownOnsetSecDefault = "10";
+    private final String systemMemoryGbDefault = "10";
+    private final String queryMemoryGbDefault = "8";
+    private final String queryMaxMemoryPerNodeDefault = "8GB";
+    private final String useMmapAllocatorDefault = "true";
+    private final String memoryArbitratorKindDefault = "SHARED";
+    private final String sharedArbitratorReservedCapacityDefault = "0GB";
+    private final String sharedArbitratorMemoryPoolInitialCapacityDefault = "4GB";
+    private final String sharedArbitratorMaxMemoryArbitrationTimeDefault = "5m";
+    private final String experimentalSpillerSpillPathDefault = "";
+    private final String taskMaxDriversPerTaskDefault = "15";
+    private final String enableOldTaskCleanupDefault = "false";
+    private final String shuffleNameDefault = "local";
+    private final String httpServerEnableAccessLogDefault = "true";
+    private final String coreOnAllocationFailureEnabledDefault = "false";
+    private final String spillEnabledDefault = "true";
+    private final String aggregationSpillEnabledDefault = "true";
+    private final String joinSpillEnabledDefault = "true";
+    private final String orderBySpillEnabledDefault = "true";
+    private final String maxSpillBytesDefault = String.valueOf(600L << 30);
 
-    // The cert path for the https server
-    private static final String HTTPS_CERT_PATH = "https-cert-path";
-    // The key path for the https server
-    private static final String HTTPS_KEY_PATH = "https-key-path";
+    private final Map<String, String> systemConfigs;
+    private final Map<String, String> defaultSystemConfigs;
 
-    // TODO: others use "-" separator and this property use _ separator. Fix them.
-    private static final String HTTP_SERVER_NUM_IO_THREADS_HW_MULTIPLIER = "http-server.num-io-threads-hw-multiplier";
-    private static final String EXCHANGE_HTTP_CLIENT_NUM_IO_THREADS_HW_MULTIPLIER = "exchange.http-client.num-io-threads-hw-multiplier";
-    private static final String ASYNC_DATA_CACHE_ENABLED = "async-data-cache-enabled";
-    private static final String ASYNC_CACHE_SSD_GB = "async-cache-ssd-gb";
-    private static final String CONNECTOR_NUM_IO_THREADS_HW_MULTIPLIER = "connector.num-io-threads-hw-multiplier";
-    private static final String PRESTO_VERSION = "presto.version";
-    private static final String SHUTDOWN_ONSET_SEC = "shutdown-onset-sec";
-    // Memory related configurations.
-    private static final String SYSTEM_MEMORY_GB = "system-memory-gb";
-    private static final String QUERY_MEMORY_GB = "query.max-memory-per-node";
-    private static final String USE_MMAP_ALLOCATOR = "use-mmap-allocator";
-    // Memory arbitration related configurations.
-    // Set the memory arbitrator kind. If it is empty, then there is no memory
-    // arbitration, when a query runs out of its capacity, the query will fail.
-    // If it set to "SHARED" (default), the shared memory arbitrator will be
-    // used to conduct arbitration and try to trigger disk spilling to reclaim
-    // memory so the query can run through completion.
-    private static final String MEMORY_ARBITRATOR_KIND = "memory-arbitrator-kind";
-    // Set memory arbitrator capacity to the same as per-query memory capacity
-    // as there is only one query running at Presto-on-Spark at a time.
-    private static final String MEMORY_ARBITRATOR_CAPACITY_GB = "query-memory-gb";
-    // Set memory arbitrator reserved capacity. Since there is only one query
-    // running at Presto-on-Spark at a time, then we shall set this to zero.
-    private static final String SHARED_ARBITRATOR_RESERVED_CAPACITY = "shared-arbitrator.reserved-capacity";
-    // Set the initial memory capacity when we create a query memory pool. For
-    // Presto-on-Spark, we set it to 'query-memory-gb' to allocate all the
-    // memory arbitrator capacity to the query memory pool on its creation as
-    // there is only one query running at a time.
-    private static final String SHARED_ARBITRATOR_MEMORY_POOL_INITIAL_CAPACITY = "shared-arbitrator.memory-pool-initial-capacity";
-    // Set the reserved memory capacity when we create a query memory pool. For
-    // Presto-on-Spark, we set this to zero as there is only one query running
-    // at a time.
-    private static final String SHARED_ARBITRATOR_MEMORY_POOL_RESERVED_CAPACITY = "shared-arbitrator.memory-pool-reserved-capacity";
-    private static final String SHARED_ARBITRATOR_MAX_MEMORY_ARBITRATION_TIME = "shared-arbitrator.max-memory-arbitration-time";
-    // Spilling related configs.
-    private static final String SPILLER_SPILL_PATH = "experimental.spiller-spill-path";
-    private static final String TASK_MAX_DRIVERS_PER_TASK = "task.max-drivers-per-task";
-    // Tasks are considered old, when they are in not-running state and it ended more than
-    // OLD_TASK_CLEANUP_MS ago or last heartbeat was more than OLD_TASK_CLEANUP_MS ago.
-    // For Presto-On-Spark, this is not relevant as it runs tasks serially, and spark's speculative
-    // execution takes care of zombie tasks.
-    private static final String ENABLE_OLD_TASK_CLEANUP = "enable-old-task-cleanup";
-    // Name of exchange client to use
-    private static final String SHUFFLE_NAME = "shuffle.name";
-    // Feature flag for access log on presto-native http server
-    private static final String HTTP_SERVER_ACCESS_LOGS = "http-server.enable-access-log";
-    // Terminates the native process and generates a core file on an allocation failure
-    private static final String CORE_ON_ALLOCATION_FAILURE_ENABLED = "core-on-allocation-failure-enabled";
-    // Spill related properties
-    private static final String SPILL_ENABLED = "spill-enabled";
-    private static final String AGGREGATION_SPILL_ENABLED = "aggregation-spill-enabled";
-    private static final String JOIN_SPILL_ENABLED = "join-spill-enabled";
-    private static final String ORDER_BY_SPILL_ENABLED = "order-by-spill-enabled";
-    private static final String MAX_SPILL_BYTES = "max-spill-bytes";
+    @Inject
+    public NativeExecutionSystemConfig(
+            @Named(NATIVE_EXECUTION_SYSTEM_CONFIG) Map<String, String> systemConfigs)
+    {
+        this.systemConfigs = new HashMap<>(
+                requireNonNull(systemConfigs, "systemConfigs is null"));
 
-    private boolean enableSerializedPageChecksum = true;
-    private boolean enableVeloxExpressionLogging;
-    private boolean enableVeloxTaskLogging = true;
-    private boolean httpServerReusePort = true;
-    private boolean httpServerBindToNodeInternalAddressOnlyEnabled = true;
-    private int httpServerPort = 7777;
-    private double httpServerNumIoThreadsHwMultiplier = 1.0;
-    private int httpsServerPort = 7778;
-    private boolean enableHttpsCommunication;
-    private String httpsCiphers = "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384";
-    private String httpsCertPath = "";
-    private String httpsKeyPath = "";
-    private double exchangeHttpClientNumIoThreadsHwMultiplier = 1.0;
-    private boolean asyncDataCacheEnabled; // false
-    private int asyncCacheSsdGb; // 0
-    private double connectorNumIoThreadsHwMultiplier; // 0.0
-    private int shutdownOnsetSec = 10;
-    private int systemMemoryGb = 10;
-    // Reserve 2GB from system memory for system operations such as disk
-    // spilling and cache prefetch.
-    private DataSize queryMemoryGb = new DataSize(8, DataSize.Unit.GIGABYTE);
+        ImmutableMap.Builder<String, String> defaultSystemConfigsBuilder = ImmutableMap.builder();
 
-    private boolean useMmapAllocator = true;
-    private String memoryArbitratorKind = "SHARED";
-    private int memoryArbitratorCapacityGb = 8;
-    private DataSize sharedArbitratorReservedCapacity = new DataSize(0, DataSize.Unit.GIGABYTE);
-    private DataSize sharedArbitratorMemoryPoolInitialCapacity = new DataSize(4, DataSize.Unit.GIGABYTE);
-    private DataSize sharedArbitratorMemoryPoolReservedCapacity = new DataSize(32, DataSize.Unit.MEGABYTE);
-    private Duration sharedArbitratorMaxMemoryArbitrationTime = new Duration(5, TimeUnit.MINUTES);
-    private String spillerSpillPath = "";
-    private int concurrentLifespansPerTask = 5;
-    private int maxDriversPerTask = 15;
-    private boolean enableOldTaskCleanUp; // false;
-    private String prestoVersion = "dummy.presto.version";
-    private String shuffleName = "local";
-    private boolean enableHttpServerAccessLog = true;
-    private boolean coreOnAllocationFailureEnabled;
-    private boolean spillEnabled = true;
-    private boolean aggregationSpillEnabled = true;
-    private boolean joinSpillEnabled = true;
-    private boolean orderBySpillEnabled = true;
-    private Long maxSpillBytes = 600L << 30;
+        String remoteFunctionServerThriftUdsPath = System.getProperty(REMOTE_FUNCTION_SERVER_THRIFT_UDS_PATH);
+        if (remoteFunctionServerThriftUdsPath != null) {
+            defaultSystemConfigsBuilder.put(REMOTE_FUNCTION_SERVER_THRIFT_UDS_PATH, remoteFunctionServerThriftUdsPath);
+            defaultSystemConfigsBuilder.put(REMOTE_FUNCTION_SERVER_SIGNATURE_FILES_DIRECTORY_PATH, getAbsolutePath(remoteFunctionServerSignatureFilesDirectoryPathDefault));
+            defaultSystemConfigsBuilder.put(REMOTE_FUNCTION_SERVER_SERDE, remoteFunctionServerSerdeDefault);
+            defaultSystemConfigsBuilder.put(REMOTE_FUNCTION_SERVER_CATALOG_NAME, remoteFunctionServerCatalogNameDefault);
+        }
 
-    // TODO: Deprecate following configs
-    private static final String REGISTER_TEST_FUNCTIONS = "register-test-functions";
-    private static final String MEMORY_POOL_INIT_CAPACITY = "memory-pool-init-capacity";
-    private static final String MEMORY_POOL_RESERVED_CAPACITY = "memory-pool-reserved-capacity";
-    private static final String MEMORY_POOL_TRANSFER_CAPACITY = "memory-pool-transfer-capacity";
-    private static final String MEMORY_RECLAIM_WAIT_MS = "memory-reclaim-wait-ms";
-    private boolean registerTestFunctions;
-    private long memoryPoolInitCapacity;
-    private long memoryPoolReservedCapacity;
-    private long memoryPoolTransferCapacity;
-    private long memoryReclaimWaitMs;
+        defaultSystemConfigs = defaultSystemConfigsBuilder
+                .put(CONCURRENT_LIFESPANS_PER_TASK, concurrentLifespansPerTaskDefault)
+                .put(ENABLE_SERIALIZED_PAGE_CHECKSUM, enableSerializedPageChecksumDefault)
+                .put(ENABLE_VELOX_EXPRESSION_LOGGING, enableVeloxExpressionLoggingDefault)
+                .put(ENABLE_VELOX_TASK_LOGGING, enableVeloxTaskLoggingDefault)
+                .put(HTTP_SERVER_HTTP_PORT, httpServerHttpPortDefault)
+                .put(HTTP_SERVER_REUSE_PORT, httpServerReusePortDefault)
+                .put(HTTP_SERVER_BIND_TO_NODE_INTERNAL_ADDRESS_ONLY_ENABLED,
+                    httpServerBindToNodeInternalAddressOnlyEnabledDefault)
+                .put(HTTP_SERVER_HTTPS_PORT, httpServerHttpsPortDefault)
+                .put(HTTP_SERVER_HTTPS_ENABLED, httpServerHttpsEnabledDefault)
+                .put(HTTPS_SUPPORTED_CIPHERS, httpsSupportedCiphersDefault)
+                .put(HTTPS_CERT_PATH, httpsCertPathDefault)
+                .put(HTTPS_KEY_PATH, httpsKeyPathDefault)
+                .put(HTTP_SERVER_NUM_IO_THREADS_HW_MULTIPLIER,
+                    httpServerNumIoThreadsHwMultiplierDefault)
+                .put(EXCHANGE_HTTP_CLIENT_NUM_IO_THREADS_HW_MULTIPLIER,
+                    exchangeHttpClientNumIoThreadsHwMultiplierDefault)
+                .put(ASYNC_DATA_CACHE_ENABLED, asyncDataCacheEnabledDefault)
+                .put(ASYNC_CACHE_SSD_GB, asyncCacheSsdGbDefault)
+                .put(CONNECTOR_NUM_IO_THREADS_HW_MULTIPLIER, connectorNumIoThreadsHwMultiplierDefault)
+                .put(PRESTO_VERSION, prestoVersionDefault)
+                .put(SHUTDOWN_ONSET_SEC, shutdownOnsetSecDefault)
+                .put(SYSTEM_MEMORY_GB, systemMemoryGbDefault)
+                .put(QUERY_MEMORY_GB, queryMemoryGbDefault)
+                .put(QUERY_MAX_MEMORY_PER_NODE, queryMaxMemoryPerNodeDefault)
+                .put(USE_MMAP_ALLOCATOR, useMmapAllocatorDefault)
+                .put(MEMORY_ARBITRATOR_KIND, memoryArbitratorKindDefault)
+                .put(SHARED_ARBITRATOR_RESERVED_CAPACITY, sharedArbitratorReservedCapacityDefault)
+                .put(SHARED_ARBITRATOR_MEMORY_POOL_INITIAL_CAPACITY,
+                    sharedArbitratorMemoryPoolInitialCapacityDefault)
+                .put(SHARED_ARBITRATOR_MAX_MEMORY_ARBITRATION_TIME,
+                    sharedArbitratorMaxMemoryArbitrationTimeDefault)
+                .put(EXPERIMENTAL_SPILLER_SPILL_PATH, experimentalSpillerSpillPathDefault)
+                .put(TASK_MAX_DRIVERS_PER_TASK, taskMaxDriversPerTaskDefault)
+                .put(ENABLE_OLD_TASK_CLEANUP, enableOldTaskCleanupDefault)
+                .put(SHUFFLE_NAME, shuffleNameDefault)
+                .put(HTTP_SERVER_ENABLE_ACCESS_LOG, httpServerEnableAccessLogDefault)
+                .put(CORE_ON_ALLOCATION_FAILURE_ENABLED, coreOnAllocationFailureEnabledDefault)
+                .put(SPILL_ENABLED, spillEnabledDefault)
+                .put(AGGREGATION_SPILL_ENABLED, aggregationSpillEnabledDefault)
+                .put(JOIN_SPILL_ENABLED, joinSpillEnabledDefault)
+                .put(ORDER_BY_SPILL_ENABLED, orderBySpillEnabledDefault)
+                .put(MAX_SPILL_BYTES, maxSpillBytesDefault)
+                .build();
+    }
 
     public Map<String, String> getAllProperties()
     {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        return builder.put(CONCURRENT_LIFESPANS_PER_TASK, String.valueOf(getConcurrentLifespansPerTask()))
-                .put(ENABLE_SERIALIZED_PAGE_CHECKSUM, String.valueOf(isEnableSerializedPageChecksum()))
-                .put(ENABLE_VELOX_EXPRESSION_LOGGING, String.valueOf(isEnableVeloxExpressionLogging()))
-                .put(ENABLE_VELOX_TASK_LOGGING, String.valueOf(isEnableVeloxTaskLogging()))
-                .put(HTTP_SERVER_HTTP_PORT, String.valueOf(getHttpServerPort()))
-                .put(HTTP_SERVER_REUSE_PORT, String.valueOf(isHttpServerReusePort()))
-                .put(HTTP_SERVER_BIND_TO_NODE_INTERNAL_ADDRESS_ONLY_ENABLED, String.valueOf(isHttpServerBindToNodeInternalAddressOnlyEnabled()))
-                .put(HTTP_SERVER_HTTPS_PORT, String.valueOf(getHttpsServerPort()))
-                .put(HTTP_SERVER_HTTPS_ENABLED, String.valueOf(isEnableHttpsCommunication()))
-                .put(HTTPS_CIPHERS, String.valueOf(getHttpsCiphers()))
-                .put(HTTPS_CERT_PATH, String.valueOf(getHttpsCertPath()))
-                .put(HTTPS_KEY_PATH, String.valueOf(getHttpsKeyPath()))
-                .put(HTTP_SERVER_NUM_IO_THREADS_HW_MULTIPLIER, String.valueOf(getHttpServerNumIoThreadsHwMultiplier()))
-                .put(EXCHANGE_HTTP_CLIENT_NUM_IO_THREADS_HW_MULTIPLIER, String.valueOf(getExchangeHttpClientNumIoThreadsHwMultiplier()))
-                .put(ASYNC_DATA_CACHE_ENABLED, String.valueOf(getAsyncDataCacheEnabled()))
-                .put(ASYNC_CACHE_SSD_GB, String.valueOf(getAsyncCacheSsdGb()))
-                .put(CONNECTOR_NUM_IO_THREADS_HW_MULTIPLIER, String.valueOf(getConnectorNumIoThreadsHwMultiplier()))
-                .put(PRESTO_VERSION, getPrestoVersion())
-                .put(SHUTDOWN_ONSET_SEC, String.valueOf(getShutdownOnsetSec()))
-                .put(SYSTEM_MEMORY_GB, String.valueOf(getSystemMemoryGb()))
-                .put(QUERY_MEMORY_GB, String.valueOf(getQueryMemoryGb()))
-                .put(USE_MMAP_ALLOCATOR, String.valueOf(getUseMmapAllocator()))
-                .put(MEMORY_ARBITRATOR_KIND, String.valueOf(getMemoryArbitratorKind()))
-                .put(MEMORY_ARBITRATOR_CAPACITY_GB, String.valueOf(getMemoryArbitratorCapacityGb()))
-                .put(SHARED_ARBITRATOR_RESERVED_CAPACITY, String.valueOf(getSharedArbitratorReservedCapacity()))
-                .put(SHARED_ARBITRATOR_MEMORY_POOL_INITIAL_CAPACITY, String.valueOf(getSharedArbitratorMemoryPoolInitialCapacity()))
-                .put(SHARED_ARBITRATOR_MEMORY_POOL_RESERVED_CAPACITY, String.valueOf(getSharedArbitratorMemoryPoolReservedCapacity()))
-                .put(SHARED_ARBITRATOR_MAX_MEMORY_ARBITRATION_TIME, String.valueOf(getSharedArbitratorMaxMemoryArbitrationTime()))
-                .put(SPILLER_SPILL_PATH, String.valueOf(getSpillerSpillPath()))
-                .put(TASK_MAX_DRIVERS_PER_TASK, String.valueOf(getMaxDriversPerTask()))
-                .put(ENABLE_OLD_TASK_CLEANUP, String.valueOf(getOldTaskCleanupMs()))
-                .put(SHUFFLE_NAME, getShuffleName())
-                .put(HTTP_SERVER_ACCESS_LOGS, String.valueOf(isEnableHttpServerAccessLog()))
-                .put(CORE_ON_ALLOCATION_FAILURE_ENABLED, String.valueOf(isCoreOnAllocationFailureEnabled()))
-                .put(SPILL_ENABLED, String.valueOf(getSpillEnabled()))
-                .put(AGGREGATION_SPILL_ENABLED, String.valueOf(getAggregationSpillEnabled()))
-                .put(JOIN_SPILL_ENABLED, String.valueOf(getJoinSpillEnabled()))
-                .put(ORDER_BY_SPILL_ENABLED, String.valueOf(getOrderBySpillEnabled()))
-                .put(MAX_SPILL_BYTES, String.valueOf(getMaxSpillBytes()))
-                .put(REGISTER_TEST_FUNCTIONS, String.valueOf(registerTestFunctions))
-                .put(MEMORY_POOL_INIT_CAPACITY, String.valueOf(memoryPoolInitCapacity))
-                .put(MEMORY_POOL_RESERVED_CAPACITY, String.valueOf(memoryPoolReservedCapacity))
-                .put(MEMORY_POOL_TRANSFER_CAPACITY, String.valueOf(memoryPoolTransferCapacity))
-                .put(MEMORY_RECLAIM_WAIT_MS, String.valueOf(memoryReclaimWaitMs))
-                .build();
+        builder.putAll(systemConfigs);
+        defaultSystemConfigs.entrySet().stream()
+                .filter(entry -> !systemConfigs.containsKey(entry.getKey()))
+                .forEach(entry -> builder.put(entry.getKey(), entry.getValue()));
+        return builder.build();
     }
 
-    @Config(SHUFFLE_NAME)
-    public NativeExecutionSystemConfig setShuffleName(String shuffleName)
+    public NativeExecutionSystemConfig update(String key, String value)
     {
-        this.shuffleName = requireNonNull(shuffleName);
+        systemConfigs.put(key, value);
         return this;
     }
 
-    public String getShuffleName()
-    {
-        return shuffleName;
-    }
-
-    @Config(ENABLE_SERIALIZED_PAGE_CHECKSUM)
-    public NativeExecutionSystemConfig setEnableSerializedPageChecksum(boolean enableSerializedPageChecksum)
-    {
-        this.enableSerializedPageChecksum = enableSerializedPageChecksum;
-        return this;
-    }
-
-    public boolean isEnableSerializedPageChecksum()
-    {
-        return enableSerializedPageChecksum;
-    }
-
-    @Config(ENABLE_VELOX_EXPRESSION_LOGGING)
-    public NativeExecutionSystemConfig setEnableVeloxExpressionLogging(boolean enableVeloxExpressionLogging)
-    {
-        this.enableVeloxExpressionLogging = enableVeloxExpressionLogging;
-        return this;
-    }
-
-    public boolean isEnableVeloxExpressionLogging()
-    {
-        return enableVeloxExpressionLogging;
-    }
-
-    @Config(ENABLE_VELOX_TASK_LOGGING)
-    public NativeExecutionSystemConfig setEnableVeloxTaskLogging(boolean enableVeloxTaskLogging)
-    {
-        this.enableVeloxTaskLogging = enableVeloxTaskLogging;
-        return this;
-    }
-
-    public boolean isEnableVeloxTaskLogging()
-    {
-        return enableVeloxTaskLogging;
-    }
-
-    @Config(HTTP_SERVER_HTTP_PORT)
-    public NativeExecutionSystemConfig setHttpServerPort(int httpServerPort)
-    {
-        this.httpServerPort = httpServerPort;
-        return this;
-    }
-
-    public int getHttpServerPort()
-    {
-        return httpServerPort;
-    }
-
-    @Config(HTTP_SERVER_REUSE_PORT)
-    public NativeExecutionSystemConfig setHttpServerReusePort(boolean httpServerReusePort)
-    {
-        this.httpServerReusePort = httpServerReusePort;
-        return this;
-    }
-
-    public boolean isHttpServerReusePort()
-    {
-        return httpServerReusePort;
-    }
-
-    public boolean isHttpServerBindToNodeInternalAddressOnlyEnabled()
-    {
-        return httpServerBindToNodeInternalAddressOnlyEnabled;
-    }
-
-    @Config(HTTP_SERVER_BIND_TO_NODE_INTERNAL_ADDRESS_ONLY_ENABLED)
-    public NativeExecutionSystemConfig setHttpServerBindToNodeInternalAddressOnlyEnabled(boolean httpServerBindToNodeInternalAddressOnlyEnabled)
-    {
-        this.httpServerBindToNodeInternalAddressOnlyEnabled = httpServerBindToNodeInternalAddressOnlyEnabled;
-        return this;
-    }
-
-    @Config(HTTP_SERVER_NUM_IO_THREADS_HW_MULTIPLIER)
-    public NativeExecutionSystemConfig setHttpServerNumIoThreadsHwMultiplier(double httpServerNumIoThreadsHwMultiplier)
-    {
-        this.httpServerNumIoThreadsHwMultiplier = httpServerNumIoThreadsHwMultiplier;
-        return this;
-    }
-
-    public double getHttpServerNumIoThreadsHwMultiplier()
-    {
-        return httpServerNumIoThreadsHwMultiplier;
-    }
-
-    public int getHttpsServerPort()
-    {
-        return httpsServerPort;
-    }
-
-    @Config(HTTP_SERVER_HTTPS_PORT)
-    public NativeExecutionSystemConfig setHttpsServerPort(int httpsServerPort)
-    {
-        this.httpsServerPort = httpsServerPort;
-        return this;
-    }
-
-    public boolean isEnableHttpsCommunication()
-    {
-        return enableHttpsCommunication;
-    }
-
-    @Config(HTTP_SERVER_HTTPS_ENABLED)
-    public NativeExecutionSystemConfig setEnableHttpsCommunication(boolean enableHttpsCommunication)
-    {
-        this.enableHttpsCommunication = enableHttpsCommunication;
-        return this;
-    }
-
-    public String getHttpsCiphers()
-    {
-        return httpsCiphers;
-    }
-
-    @Config(HTTPS_CIPHERS)
-    public NativeExecutionSystemConfig setHttpsCiphers(String httpsCiphers)
-    {
-        this.httpsCiphers = httpsCiphers;
-        return this;
-    }
-
-    public String getHttpsCertPath()
-    {
-        return httpsCertPath;
-    }
-
-    @Config(HTTPS_CERT_PATH)
-    public NativeExecutionSystemConfig setHttpsCertPath(String httpsCertPath)
-    {
-        this.httpsCertPath = httpsCertPath;
-        return this;
-    }
-
-    public String getHttpsKeyPath()
-    {
-        return httpsKeyPath;
-    }
-
-    @Config(HTTPS_KEY_PATH)
-    public NativeExecutionSystemConfig setHttpsKeyPath(String httpsKeyPath)
-    {
-        this.httpsKeyPath = httpsKeyPath;
-        return this;
-    }
-
-    @Config(EXCHANGE_HTTP_CLIENT_NUM_IO_THREADS_HW_MULTIPLIER)
-    public NativeExecutionSystemConfig setExchangeHttpClientNumIoThreadsHwMultiplier(double exchangeHttpClientNumIoThreadsHwMultiplier)
-    {
-        this.exchangeHttpClientNumIoThreadsHwMultiplier = exchangeHttpClientNumIoThreadsHwMultiplier;
-        return this;
-    }
-
-    public double getExchangeHttpClientNumIoThreadsHwMultiplier()
-    {
-        return exchangeHttpClientNumIoThreadsHwMultiplier;
-    }
-
-    @Config(ASYNC_DATA_CACHE_ENABLED)
-    public NativeExecutionSystemConfig setAsyncDataCacheEnabled(boolean asyncDataCacheEnabled)
-    {
-        this.asyncDataCacheEnabled = asyncDataCacheEnabled;
-        return this;
-    }
-
-    public boolean getAsyncDataCacheEnabled()
-    {
-        return asyncDataCacheEnabled;
-    }
-
-    @Config(ASYNC_CACHE_SSD_GB)
-    public NativeExecutionSystemConfig setAsyncCacheSsdGb(int asyncCacheSsdGb)
-    {
-        this.asyncCacheSsdGb = asyncCacheSsdGb;
-        return this;
-    }
-
-    public int getAsyncCacheSsdGb()
-    {
-        return asyncCacheSsdGb;
-    }
-
-    @Config(CONNECTOR_NUM_IO_THREADS_HW_MULTIPLIER)
-    public NativeExecutionSystemConfig setConnectorNumIoThreadsHwMultiplier(double connectorNumIoThreadsHwMultiplier)
-    {
-        this.connectorNumIoThreadsHwMultiplier = connectorNumIoThreadsHwMultiplier;
-        return this;
-    }
-
-    public double getConnectorNumIoThreadsHwMultiplier()
-    {
-        return connectorNumIoThreadsHwMultiplier;
-    }
-
-    @Config(SHUTDOWN_ONSET_SEC)
-    public NativeExecutionSystemConfig setShutdownOnsetSec(int shutdownOnsetSec)
-    {
-        this.shutdownOnsetSec = shutdownOnsetSec;
-        return this;
-    }
-
-    public int getShutdownOnsetSec()
-    {
-        return shutdownOnsetSec;
-    }
-
-    @Config(SYSTEM_MEMORY_GB)
-    public NativeExecutionSystemConfig setSystemMemoryGb(int systemMemoryGb)
-    {
-        this.systemMemoryGb = systemMemoryGb;
-        return this;
-    }
-
-    public int getSystemMemoryGb()
-    {
-        return systemMemoryGb;
-    }
-
-    @Config(QUERY_MEMORY_GB)
-    public NativeExecutionSystemConfig setQueryMemoryGb(DataSize queryMemoryGb)
-    {
-        this.queryMemoryGb = queryMemoryGb;
-        return this;
-    }
-
-    public DataSize getQueryMemoryGb()
-    {
-        return queryMemoryGb;
-    }
-
-    @Config(USE_MMAP_ALLOCATOR)
-    public NativeExecutionSystemConfig setUseMmapAllocator(boolean useMmapAllocator)
-    {
-        this.useMmapAllocator = useMmapAllocator;
-        return this;
-    }
-
-    public boolean getUseMmapAllocator()
-    {
-        return useMmapAllocator;
-    }
-
-    @Config(MEMORY_ARBITRATOR_KIND)
-    public NativeExecutionSystemConfig setMemoryArbitratorKind(String memoryArbitratorKind)
-    {
-        this.memoryArbitratorKind = memoryArbitratorKind;
-        return this;
-    }
-
-    public String getMemoryArbitratorKind()
-    {
-        return memoryArbitratorKind;
-    }
-
-    @Config(MEMORY_ARBITRATOR_CAPACITY_GB)
-    public NativeExecutionSystemConfig setMemoryArbitratorCapacityGb(int memoryArbitratorCapacityGb)
-    {
-        this.memoryArbitratorCapacityGb = memoryArbitratorCapacityGb;
-        return this;
-    }
-
-    public int getMemoryArbitratorCapacityGb()
-    {
-        return memoryArbitratorCapacityGb;
-    }
-
-    @Config(SHARED_ARBITRATOR_RESERVED_CAPACITY)
-    public NativeExecutionSystemConfig setSharedArbitratorReservedCapacity(DataSize sharedArbitratorReservedCapacity)
-    {
-        this.sharedArbitratorReservedCapacity = sharedArbitratorReservedCapacity;
-        return this;
-    }
-
-    public DataSize getSharedArbitratorReservedCapacity()
-    {
-        return sharedArbitratorReservedCapacity;
-    }
-
-    @Config(SHARED_ARBITRATOR_MEMORY_POOL_INITIAL_CAPACITY)
-    public NativeExecutionSystemConfig setSharedArbitratorMemoryPoolInitialCapacity(DataSize sharedArbitratorMemoryPoolInitialCapacity)
-    {
-        this.sharedArbitratorMemoryPoolInitialCapacity = sharedArbitratorMemoryPoolInitialCapacity;
-        return this;
-    }
-
-    public DataSize getSharedArbitratorMemoryPoolInitialCapacity()
-    {
-        return sharedArbitratorMemoryPoolInitialCapacity;
-    }
-
-    @Config(SHARED_ARBITRATOR_MEMORY_POOL_RESERVED_CAPACITY)
-    public NativeExecutionSystemConfig setSharedArbitratorMemoryPoolReservedCapacity(DataSize sharedArbitratorMemoryPoolReservedCapacity)
-    {
-        this.sharedArbitratorMemoryPoolReservedCapacity = sharedArbitratorMemoryPoolReservedCapacity;
-        return this;
-    }
-
-    public DataSize getSharedArbitratorMemoryPoolReservedCapacity()
-    {
-        return sharedArbitratorMemoryPoolReservedCapacity;
-    }
-
-    @Config(SHARED_ARBITRATOR_MAX_MEMORY_ARBITRATION_TIME)
-    public NativeExecutionSystemConfig setSharedArbitratorMaxMemoryArbitrationTime(Duration sharedArbitratorMaxMemoryArbitrationTime)
-    {
-        this.sharedArbitratorMaxMemoryArbitrationTime = sharedArbitratorMaxMemoryArbitrationTime;
-        return this;
-    }
-
-    public Duration getSharedArbitratorMaxMemoryArbitrationTime()
-    {
-        return sharedArbitratorMaxMemoryArbitrationTime;
-    }
-
-    @Config(SPILLER_SPILL_PATH)
-    public NativeExecutionSystemConfig setSpillerSpillPath(String spillerSpillPath)
-    {
-        this.spillerSpillPath = spillerSpillPath;
-        return this;
-    }
-
-    public String getSpillerSpillPath()
-    {
-        return spillerSpillPath;
-    }
-
-    @Config(CONCURRENT_LIFESPANS_PER_TASK)
-    public NativeExecutionSystemConfig setConcurrentLifespansPerTask(int concurrentLifespansPerTask)
-    {
-        this.concurrentLifespansPerTask = concurrentLifespansPerTask;
-        return this;
-    }
-
-    public int getConcurrentLifespansPerTask()
-    {
-        return concurrentLifespansPerTask;
-    }
-
-    @Config(TASK_MAX_DRIVERS_PER_TASK)
-    public NativeExecutionSystemConfig setMaxDriversPerTask(int maxDriversPerTask)
-    {
-        this.maxDriversPerTask = maxDriversPerTask;
-        return this;
-    }
-
-    public int getMaxDriversPerTask()
-    {
-        return maxDriversPerTask;
-    }
-
-    public boolean getOldTaskCleanupMs()
-    {
-        return enableOldTaskCleanUp;
-    }
-
-    @Config(ENABLE_OLD_TASK_CLEANUP)
-    public NativeExecutionSystemConfig setOldTaskCleanupMs(boolean enableOldTaskCleanUp)
-    {
-        this.enableOldTaskCleanUp = enableOldTaskCleanUp;
-        return this;
-    }
-
-    @Config(PRESTO_VERSION)
-    public NativeExecutionSystemConfig setPrestoVersion(String prestoVersion)
-    {
-        this.prestoVersion = prestoVersion;
-        return this;
-    }
-
-    public String getPrestoVersion()
-    {
-        return prestoVersion;
-    }
-
-    @Config(HTTP_SERVER_ACCESS_LOGS)
-    public NativeExecutionSystemConfig setEnableHttpServerAccessLog(boolean enableHttpServerAccessLog)
-    {
-        this.enableHttpServerAccessLog = enableHttpServerAccessLog;
-        return this;
-    }
-
-    public boolean isEnableHttpServerAccessLog()
-    {
-        return enableHttpServerAccessLog;
-    }
-
-    public boolean isCoreOnAllocationFailureEnabled()
-    {
-        return coreOnAllocationFailureEnabled;
-    }
-
-    @Config(CORE_ON_ALLOCATION_FAILURE_ENABLED)
-    public NativeExecutionSystemConfig setCoreOnAllocationFailureEnabled(boolean coreOnAllocationFailureEnabled)
-    {
-        this.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled;
-        return this;
-    }
-
-    public boolean getSpillEnabled()
-    {
-        return spillEnabled;
-    }
-
-    @Config(SPILL_ENABLED)
-    public NativeExecutionSystemConfig setSpillEnabled(boolean spillEnabled)
-    {
-        this.spillEnabled = spillEnabled;
-        return this;
-    }
-
-    public boolean getAggregationSpillEnabled()
-    {
-        return aggregationSpillEnabled;
-    }
-
-    @Config(AGGREGATION_SPILL_ENABLED)
-    public NativeExecutionSystemConfig setAggregationSpillEnabled(boolean aggregationSpillEnabled)
-    {
-        this.aggregationSpillEnabled = aggregationSpillEnabled;
-        return this;
-    }
-
-    public boolean getJoinSpillEnabled()
-    {
-        return joinSpillEnabled;
-    }
-
-    @Config(JOIN_SPILL_ENABLED)
-    public NativeExecutionSystemConfig setJoinSpillEnabled(boolean joinSpillEnabled)
-    {
-        this.joinSpillEnabled = joinSpillEnabled;
-        return this;
-    }
-
-    public boolean getOrderBySpillEnabled()
-    {
-        return orderBySpillEnabled;
-    }
-
-    @Config(ORDER_BY_SPILL_ENABLED)
-    public NativeExecutionSystemConfig setOrderBySpillEnabled(boolean orderBySpillEnabled)
-    {
-        this.orderBySpillEnabled = orderBySpillEnabled;
-        return this;
-    }
-
-    public Long getMaxSpillBytes()
-    {
-        return maxSpillBytes;
-    }
-
-    @Config(MAX_SPILL_BYTES)
-    public NativeExecutionSystemConfig setMaxSpillBytes(Long maxSpillBytes)
-    {
-        this.maxSpillBytes = maxSpillBytes;
-        return this;
-    }
-
-    // TODO: All following configs are deprecated and will be removed after references from all
-    //  other systems are cleared.
-
-    @Config(REGISTER_TEST_FUNCTIONS)
-    public NativeExecutionSystemConfig setRegisterTestFunctions(boolean registerTestFunctions)
-    {
-        this.registerTestFunctions = registerTestFunctions;
-        return this;
-    }
-
-    public boolean isRegisterTestFunctions()
-    {
-        return registerTestFunctions;
-    }
-
-    @Config(MEMORY_POOL_INIT_CAPACITY)
-    public NativeExecutionSystemConfig setMemoryPoolInitCapacity(long memoryPoolInitCapacity)
-    {
-        this.memoryPoolInitCapacity = memoryPoolInitCapacity;
-        return this;
-    }
-
-    public long getMemoryPoolInitCapacity()
-    {
-        return memoryPoolInitCapacity;
-    }
-
-    @Config(MEMORY_POOL_RESERVED_CAPACITY)
-    public NativeExecutionSystemConfig setMemoryPoolReservedCapacity(long memoryPoolReservedCapacity)
-    {
-        this.memoryPoolReservedCapacity = memoryPoolReservedCapacity;
-        return this;
-    }
-
-    public long getMemoryPoolReservedCapacity()
-    {
-        return memoryPoolReservedCapacity;
-    }
-
-    @Config(MEMORY_POOL_TRANSFER_CAPACITY)
-    public NativeExecutionSystemConfig setMemoryPoolTransferCapacity(long memoryPoolTransferCapacity)
-    {
-        this.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
-        return this;
-    }
-
-    public long getMemoryPoolTransferCapacity()
-    {
-        return memoryPoolTransferCapacity;
-    }
-
-    @Config(MEMORY_RECLAIM_WAIT_MS)
-    public NativeExecutionSystemConfig setMemoryReclaimWaitMs(long memoryReclaimWaitMs)
-    {
-        this.memoryReclaimWaitMs = memoryReclaimWaitMs;
-        return this;
-    }
-
-    public long getMemoryReclaimWaitMs()
-    {
-        return memoryReclaimWaitMs;
+    private String getAbsolutePath(String path)
+    {
+        File absolutePath = new File(path);
+        if (!absolutePath.isAbsolute()) {
+            // In the case of SparkEnv is not initialed (e.g. unit test), we just use current location instead of calling SparkFiles.getRootDirectory() to avoid error.
+            String rootDirectory = SparkEnv$.MODULE$.get() != null ? SparkFiles.getRootDirectory() : ".";
+            absolutePath = new File(rootDirectory, path);
+        }
+
+        if (!absolutePath.exists()) {
+            throw new IllegalArgumentException(format("File doesn't exist %s", absolutePath.getAbsolutePath()));
+        }
+
+        return absolutePath.getAbsolutePath();
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.ScheduledExecutorService;
@@ -89,7 +90,7 @@ public class TestNativeExecutionProcess
         PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
                 new NativeExecutionConnectorConfig(),
                 new NativeExecutionNodeConfig(),
-                new NativeExecutionSystemConfig());
+                new NativeExecutionSystemConfig(ImmutableMap.of()));
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(
                 new TestPrestoSparkHttpClient.TestingOkHttpClient(
                         errorScheduler,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -899,7 +899,7 @@ public class TestPrestoSparkHttpClient
         PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
                 new NativeExecutionConnectorConfig(),
                 new NativeExecutionNodeConfig(),
-                new NativeExecutionSystemConfig());
+                new NativeExecutionSystemConfig(ImmutableMap.of()));
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(
                 new TestingOkHttpClient(scheduledExecutorService, responseManager),
                 scheduledExecutorService,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -15,8 +15,7 @@ package com.facebook.presto.spark.execution.property;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
 import com.facebook.airlift.units.DataSize;
-import com.facebook.airlift.units.DataSize.Unit;
-import com.facebook.airlift.units.Duration;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -27,7 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
@@ -40,100 +38,145 @@ public class TestNativeExecutionSystemConfig
     public void testNativeExecutionSystemConfig()
     {
         // Test defaults
-        assertRecordedDefaults(ConfigAssertions.recordDefaults(NativeExecutionSystemConfig.class)
-                .setEnableSerializedPageChecksum(true)
-                .setEnableVeloxExpressionLogging(false)
-                .setEnableVeloxTaskLogging(true)
-                .setHttpServerReusePort(true)
-                .setHttpServerBindToNodeInternalAddressOnlyEnabled(true)
-                .setHttpServerPort(7777)
-                .setHttpServerNumIoThreadsHwMultiplier(1.0)
-                .setHttpsServerPort(7778)
-                .setEnableHttpsCommunication(false)
-                .setHttpsCiphers("AES128-SHA,AES128-SHA256,AES256-GCM-SHA384")
-                .setHttpsCertPath("")
-                .setHttpsKeyPath("")
-                .setExchangeHttpClientNumIoThreadsHwMultiplier(1.0)
-                .setAsyncDataCacheEnabled(false)
-                .setAsyncCacheSsdGb(0)
-                .setConnectorNumIoThreadsHwMultiplier(0.0)
-                .setShutdownOnsetSec(10)
-                .setSystemMemoryGb(10)
-                .setQueryMemoryGb(new DataSize(8, DataSize.Unit.GIGABYTE))
-                .setUseMmapAllocator(true)
-                .setMemoryArbitratorKind("SHARED")
-                .setMemoryArbitratorCapacityGb(8)
-                .setSharedArbitratorReservedCapacity(new DataSize(0, Unit.GIGABYTE))
-                .setSharedArbitratorMemoryPoolInitialCapacity(new DataSize(4, Unit.GIGABYTE))
-                .setSharedArbitratorMemoryPoolReservedCapacity(new DataSize(32, Unit.MEGABYTE))
-                .setSharedArbitratorMaxMemoryArbitrationTime(new Duration(5, TimeUnit.MINUTES))
-                .setSpillerSpillPath("")
-                .setConcurrentLifespansPerTask(5)
-                .setMaxDriversPerTask(15)
-                .setOldTaskCleanupMs(false)
-                .setPrestoVersion("dummy.presto.version")
-                .setShuffleName("local")
-                .setEnableHttpServerAccessLog(true)
-                .setCoreOnAllocationFailureEnabled(false)
-                .setSpillEnabled(true)
-                .setAggregationSpillEnabled(true)
-                .setJoinSpillEnabled(true)
-                .setOrderBySpillEnabled(true)
-                .setMaxSpillBytes(600L << 30)
-                .setRegisterTestFunctions(false)
-                .setMemoryPoolInitCapacity(0)
-                .setMemoryPoolReservedCapacity(0)
-                .setMemoryPoolTransferCapacity(0)
-                .setMemoryReclaimWaitMs(0));
+        NativeExecutionSystemConfig nativeExecutionSystemConfig = new NativeExecutionSystemConfig(
+                ImmutableMap.of());
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        ImmutableMap<String, String> expectedConfigs = builder
+                .put("concurrent-lifespans-per-task", "5")
+                .put("enable-serialized-page-checksum", "true")
+                .put("enable_velox_expression_logging", "false")
+                .put("enable_velox_task_logging", "true")
+                .put("http-server.http.port", "7777")
+                .put("http-server.reuse-port", "true")
+                .put("http-server.bind-to-node-internal-address-only-enabled", "true")
+                .put("http-server.https.port", "7778")
+                .put("http-server.https.enabled", "false")
+                .put("https-supported-ciphers", "AES128-SHA,AES128-SHA256,AES256-GCM-SHA384")
+                .put("https-cert-path", "")
+                .put("https-key-path", "")
+                .put("http-server.num-io-threads-hw-multiplier", "1.0")
+                .put("exchange.http-client.num-io-threads-hw-multiplier", "1.0")
+                .put("async-data-cache-enabled", "false")
+                .put("async-cache-ssd-gb", "0")
+                .put("connector.num-io-threads-hw-multiplier", "0")
+                .put("presto.version", "dummy.presto.version")
+                .put("shutdown-onset-sec", "10")
+                .put("system-memory-gb", "10")
+                .put("query-memory-gb", "8")
+                .put("query.max-memory-per-node", "8GB")
+                .put("use-mmap-allocator", "true")
+                .put("memory-arbitrator-kind", "SHARED")
+                .put("shared-arbitrator.reserved-capacity", "0GB")
+                .put("shared-arbitrator.memory-pool-initial-capacity", "4GB")
+                .put("shared-arbitrator.max-memory-arbitration-time", "5m")
+                .put("experimental.spiller-spill-path", "")
+                .put("task.max-drivers-per-task", "15")
+                .put("enable-old-task-cleanup", "false")
+                .put("shuffle.name", "local")
+                .put("http-server.enable-access-log", "true")
+                .put("core-on-allocation-failure-enabled", "false")
+                .put("spill-enabled", "true")
+                .put("aggregation-spill-enabled", "true")
+                .put("join-spill-enabled", "true")
+                .put("order-by-spill-enabled", "true")
+                .put("max-spill-bytes", String.valueOf(600L << 30))
+                .build();
+        assertEquals(nativeExecutionSystemConfig.getAllProperties(), expectedConfigs);
 
         // Test explicit property mapping. Also makes sure properties returned by getAllProperties() covers full property list.
-        NativeExecutionSystemConfig expected = new NativeExecutionSystemConfig()
-                .setConcurrentLifespansPerTask(15)
-                .setEnableSerializedPageChecksum(false)
-                .setEnableVeloxExpressionLogging(true)
-                .setEnableVeloxTaskLogging(false)
-                .setHttpServerReusePort(false)
-                .setHttpServerBindToNodeInternalAddressOnlyEnabled(false)
-                .setHttpServerPort(8080)
-                .setHttpServerNumIoThreadsHwMultiplier(3.0)
-                .setHttpsServerPort(8081)
-                .setEnableHttpsCommunication(true)
-                .setHttpsCiphers("AES128-SHA")
-                .setHttpsCertPath("/tmp/non_existent.cert")
-                .setHttpsKeyPath("/tmp/non_existent.key")
-                .setExchangeHttpClientNumIoThreadsHwMultiplier(0.5)
-                .setAsyncDataCacheEnabled(true)
-                .setAsyncCacheSsdGb(1000)
-                .setConnectorNumIoThreadsHwMultiplier(1.0)
-                .setPrestoVersion("presto-version")
-                .setShutdownOnsetSec(30)
-                .setSystemMemoryGb(40)
-                .setQueryMemoryGb(new DataSize(20, Unit.GIGABYTE))
-                .setUseMmapAllocator(false)
-                .setMemoryArbitratorKind("")
-                .setMemoryArbitratorCapacityGb(10)
-                .setSharedArbitratorReservedCapacity(new DataSize(8, Unit.GIGABYTE))
-                .setSharedArbitratorMemoryPoolInitialCapacity(new DataSize(7, Unit.GIGABYTE))
-                .setSharedArbitratorMemoryPoolReservedCapacity(new DataSize(6, Unit.GIGABYTE))
-                .setSharedArbitratorMaxMemoryArbitrationTime(new Duration(123123123, TimeUnit.MILLISECONDS))
-                .setSpillerSpillPath("dummy.spill.path")
-                .setMaxDriversPerTask(30)
-                .setOldTaskCleanupMs(true)
-                .setShuffleName("custom")
-                .setEnableHttpServerAccessLog(false)
-                .setCoreOnAllocationFailureEnabled(true)
-                .setSpillEnabled(false)
-                .setAggregationSpillEnabled(false)
-                .setJoinSpillEnabled(false)
-                .setOrderBySpillEnabled(false)
-                .setMaxSpillBytes(1L)
-                .setRegisterTestFunctions(true)
-                .setMemoryPoolInitCapacity(10)
-                .setMemoryPoolReservedCapacity(10)
-                .setMemoryPoolTransferCapacity(10)
-                .setMemoryReclaimWaitMs(10);
-        Map<String, String> properties = expected.getAllProperties();
-        assertFullMapping(properties, expected);
+        builder = ImmutableMap.builder();
+        ImmutableMap<String, String> systemConfig = builder
+                .put("concurrent-lifespans-per-task", "15")
+                .put("enable-serialized-page-checksum", "false")
+                .put("enable_velox_expression_logging", "true")
+                .put("enable_velox_task_logging", "false")
+                .put("http-server.http.port", "8777")
+                .put("http-server.reuse-port", "false")
+                .put("http-server.bind-to-node-internal-address-only-enabled", "false")
+                .put("http-server.https.port", "8778")
+                .put("http-server.https.enabled", "true")
+                .put("https-supported-ciphers", "override-cipher")
+                .put("https-cert-path", "/override/path/cert")
+                .put("https-key-path", "/override/path/key")
+                .put("http-server.num-io-threads-hw-multiplier", "1.5")
+                .put("exchange.http-client.num-io-threads-hw-multiplier", "1.5")
+                .put("async-data-cache-enabled", "true")
+                .put("async-cache-ssd-gb", "1")
+                .put("connector.num-io-threads-hw-multiplier", "0.1")
+                .put("presto.version", "override.presto.version")
+                .put("shutdown-onset-sec", "15")
+                .put("system-memory-gb", "5")
+                .put("query-memory-gb", "4")
+                .put("query.max-memory-per-node", "4GB")
+                .put("use-mmap-allocator", "false")
+                .put("memory-arbitrator-kind", "NOOP")
+                .put("shared-arbitrator.reserved-capacity", "1GB")
+                .put("shared-arbitrator.memory-pool-initial-capacity", "1GB")
+                .put("shared-arbitrator.max-memory-arbitration-time", "1s")
+                .put("experimental.spiller-spill-path", "/abc")
+                .put("task.max-drivers-per-task", "25")
+                .put("enable-old-task-cleanup", "true")
+                .put("shuffle.name", "remote")
+                .put("http-server.enable-access-log", "false")
+                .put("core-on-allocation-failure-enabled", "true")
+                .put("spill-enabled", "false")
+                .put("aggregation-spill-enabled", "false")
+                .put("join-spill-enabled", "false")
+                .put("order-by-spill-enabled", "false")
+                .put("non-defined-property-key-0", "non-defined-property-value-0")
+                .put("non-defined-property-key-1", "non-defined-property-value-1")
+                .put("non-defined-property-key-2", "non-defined-property-value-2")
+                .put("non-defined-property-key-3", "non-defined-property-value-3")
+                .build();
+        nativeExecutionSystemConfig = new NativeExecutionSystemConfig(systemConfig);
+
+        builder = ImmutableMap.builder();
+        expectedConfigs = builder
+                .put("concurrent-lifespans-per-task", "15")
+                .put("enable-serialized-page-checksum", "false")
+                .put("enable_velox_expression_logging", "true")
+                .put("enable_velox_task_logging", "false")
+                .put("http-server.http.port", "8777")
+                .put("http-server.reuse-port", "false")
+                .put("http-server.bind-to-node-internal-address-only-enabled", "false")
+                .put("http-server.https.port", "8778")
+                .put("http-server.https.enabled", "true")
+                .put("https-supported-ciphers", "override-cipher")
+                .put("https-cert-path", "/override/path/cert")
+                .put("https-key-path", "/override/path/key")
+                .put("http-server.num-io-threads-hw-multiplier", "1.5")
+                .put("exchange.http-client.num-io-threads-hw-multiplier", "1.5")
+                .put("async-data-cache-enabled", "true")
+                .put("async-cache-ssd-gb", "1")
+                .put("connector.num-io-threads-hw-multiplier", "0.1")
+                .put("presto.version", "override.presto.version")
+                .put("shutdown-onset-sec", "15")
+                .put("system-memory-gb", "5")
+                .put("query-memory-gb", "4")
+                .put("query.max-memory-per-node", "4GB")
+                .put("use-mmap-allocator", "false")
+                .put("memory-arbitrator-kind", "NOOP")
+                .put("shared-arbitrator.reserved-capacity", "1GB")
+                .put("shared-arbitrator.memory-pool-initial-capacity", "1GB")
+                .put("shared-arbitrator.max-memory-arbitration-time", "1s")
+                .put("experimental.spiller-spill-path", "/abc")
+                .put("task.max-drivers-per-task", "25")
+                .put("enable-old-task-cleanup", "true")
+                .put("shuffle.name", "remote")
+                .put("http-server.enable-access-log", "false")
+                .put("core-on-allocation-failure-enabled", "true")
+                .put("spill-enabled", "false")
+                .put("aggregation-spill-enabled", "false")
+                .put("join-spill-enabled", "false")
+                .put("order-by-spill-enabled", "false")
+                .put("non-defined-property-key-0", "non-defined-property-value-0")
+                .put("non-defined-property-key-1", "non-defined-property-value-1")
+                .put("non-defined-property-key-2", "non-defined-property-value-2")
+                .put("non-defined-property-key-3", "non-defined-property-value-3")
+                .put("max-spill-bytes", String.valueOf(600L << 30)) // default spill bytes
+                .build();
+
+        assertEquals(nativeExecutionSystemConfig.getAllProperties(), expectedConfigs);
     }
 
     @Test
@@ -182,7 +225,9 @@ public class TestNativeExecutionSystemConfig
     @Test
     public void testFilePropertiesPopulator()
     {
-        PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(new NativeExecutionConnectorConfig(), new NativeExecutionNodeConfig(), new NativeExecutionSystemConfig());
+        PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
+                new NativeExecutionConnectorConfig(), new NativeExecutionNodeConfig(),
+                new NativeExecutionSystemConfig(ImmutableMap.of()));
         testPropertiesPopulate(workerProperty);
     }
 


### PR DESCRIPTION
## Description
This change makes presto-on-spark native mode to adopt free form native worker config.properties population. With the previous preparation changes landed, this one adds a module called NativeExecutionConfigModule that takes in a free form map configs and feed it to modified NativeExecutionSystemConfig. NativeExecutionSystemConfig is modified such that no Config annotated configs are used anymore, but instead a free form map. And the populator populates the map as is, combining with the default values.
This module could be further modified to adopt other configs such as catalog configs. Following the framework it should be fairly easy going forward to add additional configs.

```
== NO RELEASE NOTE ==
```

