### PR TITLE
[native] Make stuck driver detach worker threshold hardware based

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -37,13 +37,13 @@ std::string bool2String(bool value) {
   return value ? "true" : "false";
 }
 
-int getThreadCount() {
-  auto numThreads = std::thread::hardware_concurrency();
+uint32_t hardwareConcurrency() {
+  const auto numLogicalCores = std::thread::hardware_concurrency();
   // The spec says std::thread::hardware_concurrency() might return 0.
   // But we depend on std::thread::hardware_concurrency() to create executors.
   // Check to ensure numThreads is > 0.
-  VELOX_CHECK_GT(numThreads, 0);
-  return numThreads;
+  VELOX_CHECK_GT(numLogicalCores, 0);
+  return numLogicalCores;
 }
 
 #define STR_PROP(_key_, _val_) \
@@ -140,7 +140,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kHttpServerReusePort, false),
           BOOL_PROP(kHttpServerBindToNodeInternalAddressOnlyEnabled, false),
           NONE_PROP(kDiscoveryUri),
-          NUM_PROP(kMaxDriversPerTask, getThreadCount()),
+          NUM_PROP(kMaxDriversPerTask, hardwareConcurrency()),
           NONE_PROP(kTaskWriterCount),
           NONE_PROP(kTaskPartitionedWriterCount),
           NUM_PROP(kConcurrentLifespansPerTask, 1),
@@ -166,7 +166,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kDriverStuckOperatorThresholdMs, 30 * 60 * 1000),
           NUM_PROP(
               kDriverCancelTasksWithStuckOperatorsThresholdMs, 40 * 60 * 1000),
-          NUM_PROP(kDriverNumStuckOperatorsToDetachWorker, 8),
+          NUM_PROP(kDriverNumStuckOperatorsToDetachWorker, 0.5 * hardwareConcurrency()),
           NUM_PROP(kSpillerNumCpuThreadsHwMultiplier, 1.0),
           STR_PROP(kSpillerFileCreateConfig, ""),
           STR_PROP(kSpillerDirectoryCreateConfig, ""),

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -260,6 +260,7 @@ class SystemConfig : public ConfigBase {
   /// The number of stuck operators (effectively stuck driver threads) when we
   /// detach the worker from the cluster in an attempt to keep the cluster
   /// operational.
+  /// 1/2 of the hardware concurrency is the default.
   static constexpr std::string_view kDriverNumStuckOperatorsToDetachWorker{
       "driver.num-stuck-operators-to-detach-worker"};
 


### PR DESCRIPTION
Summary: Currently this is hard coded and workers got detached at very early stage when there is still large amount of resources that could be used. This PR changes the default value of 'driver.num-stuck-operators-to-detach-worker' to be 1/2 of the number of logical cores of the hardware.

Differential Revision: D80715227

== NO RELEASE NOTE ==
