### PR TITLE
[native] Build for gcc14

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -33,6 +33,12 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
 set(DISABLED_WARNINGS
     "-Wno-nullability-completeness -Wno-deprecated-declarations")
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
+    string(APPEND DISABLED_WARNINGS " -Wno-error=template-id-cdtor")
+  endif()
+endif()
+
 # Important warnings that must be explicitly enabled.
 set(ENABLE_WARNINGS "-Wreorder")
 
@@ -221,7 +227,7 @@ include_directories(SYSTEM ${FBTHRIFT_INCLUDE_DIR})
 set(PROXYGEN_LIBRARIES ${PROXYGEN_HTTP_SERVER} ${PROXYGEN} ${WANGLE} ${FIZZ}
                        ${MVFST_EXCEPTION})
 find_path(PROXYGEN_DIR NAMES include/proxygen)
-set(PROXYGEN_INCLUDE_DIR "${PROXYGEN_DIR}/include/proxygen")
+set(PROXYGEN_INCLUDE_DIR "${PROXYGEN_DIR}/include/")
 
 include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR} ${PROXYGEN_INCLUDE_DIR})
 include_directories(.)

--- a/presto-native-execution/presto_cpp/main/operators/tests/BinarySortableSerializerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BinarySortableSerializerTest.cpp
@@ -1045,7 +1045,7 @@ TEST_F(BinarySortableSerializerTest, ArrayTypeSingleFieldTests) {
   // null < []
   EXPECT_TRUE(
       singleArrayFieldCompare<int64_t>(
-          {std::nullopt, {{}}}, velox::core::kAscNullsFirst) < 0);
+          {std::nullopt, {std::vector<std::optional<int64_t>>{}}}, velox::core::kAscNullsFirst) < 0);
 }
 
 TEST_F(BinarySortableSerializerTest, RowTypeSingleFieldTests) {

--- a/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
@@ -272,7 +272,7 @@ TEST_F(BroadcastTest, endToEndSerdeLayout) {
   runBroadcastTest({data}, {{"c1", "c1", "c2"}});
 
   // Skip all.
-  runBroadcastTest({data}, {{}});
+  runBroadcastTest({data}, {std::vector<std::string>{}});
 }
 
 TEST_F(BroadcastTest, endToEndWithNoRows) {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/Duration.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/Duration.h
@@ -13,6 +13,7 @@
  */
 #pragma once
 #include <re2/re2.h>
+#include <chrono>
 
 namespace facebook::presto::protocol {
 


### PR DESCRIPTION
Summary:
Fix to support GCC14 build

- Replace `{}` with explicit empty container to avoid the following error within optionals.

          error: converting to 'std::in_place_t' from list would use explicit contructor
     `{}` leads to copy initialization which is not allowed since in_place_t is marked explicit

- Add Import `chrono` in `Duration.h` as gcc14 mandates having it

- Correct include directory path for proxygen

- Ignore errors associated with template-id-cdtor as gcc14 fails build for constructors having template support

Rollback Plan:

Differential Revision: D80762196

```
== NO RELEASE NOTE ==
```