### PR TITLE
[Iceberg]Support specifying multiple transforms when adding a column

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1480,6 +1480,12 @@ The table is partitioned by the transformed value of the column::
 
      ALTER TABLE iceberg.web.page_views ADD COLUMN ts timestamp WITH (partitioning = 'hour');
 
+Use ``ARRAY[...]`` instead of a string to specify multiple partition transforms when adding a column. For example::
+
+    ALTER TABLE iceberg.web.page_views ADD COLUMN location VARCHAR WITH (partitioning = ARRAY['truncate(2)', 'bucket(8)', 'identity']);
+
+    ALTER TABLE iceberg.web.page_views ADD COLUMN dt date WITH (partitioning = ARRAY['year', 'bucket(16)', 'identity']);
+
 Table properties can be modified for an Iceberg table using an ALTER TABLE SET PROPERTIES statement. Only `commit_retries` can be modified at present.
 For example, to set `commit_retries` to 6 for the table `iceberg.web.page_views_v2`, use::
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -119,6 +119,9 @@ import static com.facebook.presto.iceberg.HiveTableOperations.STORAGE_FORMAT;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getHiveStatisticsMergeStrategy;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getSortOrder;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getTableLocation;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
 import static com.facebook.presto.iceberg.IcebergUtil.createIcebergViewProperties;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
@@ -344,14 +347,14 @@ public class IcebergHiveMetadata
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
 
-        PartitionSpec partitionSpec = parsePartitionFields(schema, tableProperties.getPartitioning(tableMetadata.getProperties()));
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
 
         MetastoreContext metastoreContext = getMetastoreContext(session);
         Database database = metastore.getDatabase(metastoreContext, schemaName)
                 .orElseThrow(() -> new SchemaNotFoundException(schemaName));
 
         HdfsContext hdfsContext = new HdfsContext(session, schemaName, tableName);
-        String targetPath = tableProperties.getTableLocation(tableMetadata.getProperties());
+        String targetPath = getTableLocation(tableMetadata.getProperties());
         if (targetPath == null) {
             Optional<String> location = database.getLocation();
             if (!location.isPresent() || location.get().isEmpty()) {
@@ -377,7 +380,7 @@ public class IcebergHiveMetadata
         if (operations.current() != null) {
             throw new TableAlreadyExistsException(schemaTableName);
         }
-        SortOrder sortOrder = parseSortFields(schema, tableProperties.getSortOrder(tableMetadata.getProperties()));
+        SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
         FileFormat fileFormat = tableProperties.getFileFormat(session, tableMetadata.getProperties());
         TableMetadata metadata = newTableMetadata(schema, partitionSpec, sortOrder, targetPath, populateTableProperties(this, tableMetadata, tableProperties, fileFormat, session));
         transaction = createTableTransaction(tableName, operations, metadata);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -61,6 +61,9 @@ import java.util.stream.Stream;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getSortOrder;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getTableLocation;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
 import static com.facebook.presto.iceberg.IcebergUtil.VIEW_OWNER;
 import static com.facebook.presto.iceberg.IcebergUtil.createIcebergViewProperties;
@@ -332,12 +335,12 @@ public class IcebergNativeMetadata
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
 
-        PartitionSpec partitionSpec = parsePartitionFields(schema, tableProperties.getPartitioning(tableMetadata.getProperties()));
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
         FileFormat fileFormat = tableProperties.getFileFormat(session, tableMetadata.getProperties());
 
         try {
             TableIdentifier tableIdentifier = toIcebergTableIdentifier(schemaTableName, catalogFactory.isNestedNamespaceEnabled());
-            String targetPath = tableProperties.getTableLocation(tableMetadata.getProperties());
+            String targetPath = getTableLocation(tableMetadata.getProperties());
             if (!isNullOrEmpty(targetPath)) {
                 transaction = catalogFactory.getCatalog(session).newCreateTableTransaction(
                         tableIdentifier,
@@ -360,7 +363,7 @@ public class IcebergNativeMetadata
 
         Table icebergTable = transaction.table();
         ReplaceSortOrder replaceSortOrder = transaction.replaceSortOrder();
-        SortOrder sortOrder = parseSortFields(schema, tableProperties.getSortOrder(tableMetadata.getProperties()));
+        SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
         List<SortField> sortFields = getSupportedSortFields(icebergTable.schema(), sortOrder);
         for (SortField sortField : sortFields) {
             if (sortField.getSortOrder().isAscending()) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -225,11 +225,19 @@ public class IcebergTableProperties
                 .addAll(deprecatedPropertyMetadata.values().iterator())
                 .build();
 
-        columnProperties = ImmutableList.of(stringProperty(
-                PARTITIONING_PROPERTY,
-                "This column's partition transform",
-                null,
-                false));
+        columnProperties = ImmutableList.of(
+                new PropertyMetadata<>(
+                        PARTITIONING_PROPERTY,
+                        "This column's partition transforms, supports both string expressions (e.g., 'bucket(4)') and array expressions (e.g. ARRAY['bucket(4)', 'identity'])",
+                        new ArrayType(VARCHAR),
+                        List.class,
+                        ImmutableList.of(),
+                        false,
+                        value -> ((Collection<?>) value).stream()
+                                .map(name -> ((String) name).toLowerCase(ENGLISH))
+                                .collect(toImmutableList()),
+                        value -> value)
+                        .withAdditionalTypeHandler(VARCHAR, ImmutableList::of));
     }
 
     public List<PropertyMetadata<?>> getTableProperties()
@@ -242,7 +250,7 @@ public class IcebergTableProperties
         return columnProperties;
     }
 
-    public Set<String> getUpdatableProperties()
+    public static Set<String> getUpdatableProperties()
     {
         return UPDATABLE_PROPERTIES;
     }
@@ -251,7 +259,7 @@ public class IcebergTableProperties
      * @return a map of deprecated property name to new property name, or null if the property is
      * removed entirely.
      */
-    public Map<String, String> getDeprecatedProperties()
+    public static Map<String, String> getDeprecatedProperties()
     {
         return DEPRECATED_PROPERTIES;
     }
@@ -262,20 +270,20 @@ public class IcebergTableProperties
     }
 
     @SuppressWarnings("unchecked")
-    public List<String> getPartitioning(Map<String, Object> tableProperties)
+    public static List<String> getPartitioning(Map<String, Object> tableProperties)
     {
         List<String> partitioning = (List<String>) tableProperties.get(PARTITIONING_PROPERTY);
         return partitioning == null ? ImmutableList.of() : ImmutableList.copyOf(partitioning);
     }
 
     @SuppressWarnings("unchecked")
-    public List<String> getSortOrder(Map<String, Object> tableProperties)
+    public static List<String> getSortOrder(Map<String, Object> tableProperties)
     {
         List<String> sortedBy = (List<String>) tableProperties.get(SORTED_BY_PROPERTY);
         return sortedBy == null ? ImmutableList.of() : ImmutableList.copyOf(sortedBy);
     }
 
-    public String getTableLocation(Map<String, Object> tableProperties)
+    public static String getTableLocation(Map<String, Object> tableProperties)
     {
         return (String) tableProperties.get(LOCATION_PROPERTY);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -756,6 +756,107 @@ public abstract class IcebergDistributedSmokeTestBase
     }
 
     @Test
+    public void testAddColumnWithMultiplePartitionTransforms()
+    {
+        Session session = getSession();
+        String catalog = session.getCatalog().get();
+        String schema = format("\"%s\"", session.getSchema().get());
+
+        assertQuerySucceeds("create table add_multiple_partition_column(a int)");
+        assertUpdate("insert into add_multiple_partition_column values 1", 1);
+
+        validateShowCreateTable(catalog, schema, "add_multiple_partition_column",
+                ImmutableList.of(columnDefinition("a", "integer")),
+                null,
+                getCustomizedTableProperties(ImmutableMap.of(
+                        "location", "'" + getLocation(session.getSchema().get(), "add_multiple_partition_column") + "'")));
+
+        // Add a varchar column with partition transforms `ARRAY['bucket(4)', 'truncate(2)', 'identity']`
+        assertQuerySucceeds("alter table add_multiple_partition_column add column b varchar with(partitioning = ARRAY['bucket(4)', 'truncate(2)', 'identity'])");
+        assertUpdate("insert into add_multiple_partition_column values(2, '1002')", 1);
+
+        validateShowCreateTable(catalog, schema, "add_multiple_partition_column",
+                ImmutableList.of(
+                        columnDefinition("a", "integer"),
+                        columnDefinition("b", "varchar")),
+                null,
+                getCustomizedTableProperties(ImmutableMap.of(
+                        "location", "'" + getLocation(session.getSchema().get(), "add_multiple_partition_column") + "'",
+                        "partitioning", "ARRAY['bucket(b, 4)','truncate(b, 2)','b']")));
+
+        // Add a date column with partition transforms `ARRAY['year', 'bucket(8)', 'identity']`
+        assertQuerySucceeds("alter table add_multiple_partition_column add column c date with(partitioning = ARRAY['year', 'bucket(8)', 'identity'])");
+        assertUpdate("insert into add_multiple_partition_column values(3, '1003', date '1984-12-08')", 1);
+
+        validateShowCreateTable(catalog, schema, "add_multiple_partition_column",
+                ImmutableList.of(
+                        columnDefinition("a", "integer"),
+                        columnDefinition("b", "varchar"),
+                        columnDefinition("c", "date")),
+                null,
+                getCustomizedTableProperties(ImmutableMap.of(
+                        "location", "'" + getLocation(session.getSchema().get(), "add_multiple_partition_column") + "'",
+                        "partitioning", "ARRAY['bucket(b, 4)','truncate(b, 2)','b','year(c)','bucket(c, 8)','c']")));
+
+        assertQuery("select * from add_multiple_partition_column",
+                "values(1, null, null), (2, '1002', null), (3, '1003', date '1984-12-08')");
+        dropTable(getSession(), "add_multiple_partition_column");
+    }
+
+    @Test
+    public void testAddColumnWithRedundantOrDuplicatedPartitionTransforms()
+    {
+        Session session = getSession();
+        String catalog = session.getCatalog().get();
+        String schema = format("\"%s\"", session.getSchema().get());
+
+        assertQuerySucceeds("create table add_redundant_partition_column(a int)");
+
+        // Specify duplicated transforms would fail
+        assertQueryFails("alter table add_redundant_partition_column add column b varchar with(partitioning = ARRAY['bucket(4)', 'truncate(2)', 'bucket(4)'])",
+                "Cannot add duplicate partition field: .*");
+        assertQueryFails("alter table add_redundant_partition_column add column b varchar with(partitioning = ARRAY['identity', 'identity'])",
+                "Cannot add duplicate partition field: .*");
+
+        // Specify redundant transforms would fail
+        assertQueryFails("alter table add_redundant_partition_column add column c date with(partitioning = ARRAY['year', 'month'])",
+                "Cannot add redundant partition field: .*");
+        assertQueryFails("alter table add_redundant_partition_column add column c timestamp with(partitioning = ARRAY['day', 'hour'])",
+                "Cannot add redundant partition field: .*");
+
+        validateShowCreateTable(catalog, schema, "add_redundant_partition_column",
+                ImmutableList.of(columnDefinition("a", "integer")),
+                null,
+                getCustomizedTableProperties(ImmutableMap.of(
+                        "location", "'" + getLocation(session.getSchema().get(), "add_redundant_partition_column") + "'")));
+
+        dropTable(getSession(), "add_redundant_partition_column");
+    }
+
+    @Test
+    public void testAddColumnWithUnsupportedPropertyValueTypes()
+    {
+        Session session = getSession();
+        String catalog = session.getCatalog().get();
+        String schema = format("\"%s\"", session.getSchema().get());
+
+        assertQuerySucceeds("create table add_invalid_partition_column(a int)");
+
+        assertQueryFails("alter table add_invalid_partition_column add column b varchar with(partitioning = 123)",
+                "Invalid value for column property 'partitioning': Cannot convert '123' to array\\(varchar\\) or any of \\[varchar]");
+        assertQueryFails("alter table add_invalid_partition_column add column b varchar with(partitioning = ARRAY[123, 234])",
+                "Invalid value for column property 'partitioning': Cannot convert 'ARRAY\\[123,234]' to array\\(varchar\\) or any of \\[varchar]");
+
+        validateShowCreateTable(catalog, schema, "add_invalid_partition_column",
+                ImmutableList.of(columnDefinition("a", "integer")),
+                null,
+                getCustomizedTableProperties(ImmutableMap.of(
+                        "location", "'" + getLocation(session.getSchema().get(), "add_invalid_partition_column") + "'")));
+
+        dropTable(getSession(), "add_invalid_partition_column");
+    }
+
+    @Test
     public void testSchemaEvolution()
     {
         // TODO: Support schema evolution for PARQUET. Schema evolution should be id based.


### PR DESCRIPTION
## Description

This PR supports the feature described in #25854, enables to specify multiple partition transforms when executing `ALTER TABLE ADD COLUMN` to add a column.

In order to maintain backward compatibility, when adding columns we need to support specifying the partition transform(s) in both manner as follows:

```
alter table test_table add column c varchar with(partitioning = 'truncate(2)');
alter table test_table add column c varchar with(partitioning = ARRAY['bucket(4)', 'truncate(2)', 'identity']);
```

One specifies a partitioning property value of type `string`, while the other specifies a value of type `array(tring)`. To enable this feature, we enhanced the property mechanism to enable a property to accept and process property values of multiple types, declared as follows:

```
        new PropertyMetadata<>(
                        PARTITIONING_PROPERTY,
                        ......
                        new ArrayType(VARCHAR),
                        List.class,
                        ......)
                        .withAdditionalTypeHandler(VARCHAR, ImmutableList::of));
```

In this way, Iceberg's column property `partitioning` can now be declared to support both values of type `array(varchar)` and values of type `varchar`, thereby supports both of the aforementioned partition specifying manners.


## Motivation and Context

#25854 

## Impact

 - Now users can specify multiple partition transforms when adding a column.
 - Backward compatibility is maintained as the original syntax for a single partition transform is still fully supported, leaving existing use cases unaffected.

## Test Plan

 - New test cases have been added to demonstrate the behavior and constraints of specifying multiple partition transforms during column creation.
 - Make sure this change do not affect existing test cases


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes


```
== RELEASE NOTES ==

General Changes
* Improve the property mechanism to enable a property to accept and process property values of multiple types.

Iceberg Connector Changes
 * Add supporting for specifying multiple transforms when adding a column.
```

