### PR TITLE
Clean up InternalPlanVisitor

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.sql.planner.plan;
 
-import com.facebook.presto.spi.plan.MetadataDeleteNode;
 import com.facebook.presto.spi.plan.PlanVisitor;
 import com.facebook.presto.sql.planner.CanonicalJoinNode;
 import com.facebook.presto.sql.planner.CanonicalTableScanNode;
@@ -124,11 +123,6 @@ public abstract class InternalPlanVisitor<R, C>
     }
 
     public R visitSequence(SequenceNode node, C context)
-    {
-        return visitPlan(node, context);
-    }
-
-    public R visitMetadataDelete(MetadataDeleteNode node, C context)
     {
         return visitPlan(node, context);
     }


### PR DESCRIPTION
## Description

Clean up visitMetadataDelete() in InternalPlanVisitor as it is not required. 

## Motivation and Context
visitMetadataDelete() exists in PlanVisitor and InternalPlanVisitor.
Both instances were added in https://github.com/prestodb/presto/pull/25745 

It is not needed in InternalPlanVisitor if it is in InternalPlanVisitor

## Impact
Clean up of unnecessary code

## Test Plan
- [x] Github tests
- [x] Meta tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

