### PR TITLE
[Iceberg] Migrate ApplyChangeLog to connector function

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -15,6 +15,7 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.presto.hive.HiveTransactionHandle;
+import com.facebook.presto.iceberg.function.changelog.ApplyChangelogFunction;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
@@ -217,5 +218,13 @@ public class IcebergConnector
     public ConnectorPlanOptimizerProvider getConnectorPlanOptimizerProvider()
     {
         return planOptimizerProvider;
+    }
+
+    @Override
+    public Set<Class<?>> getSystemFunctions()
+    {
+        return ImmutableSet.<Class<?>>builder()
+                .add(ApplyChangelogFunction.class)
+                .build();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPlugin.java
@@ -13,16 +13,13 @@
  */
 package com.facebook.presto.iceberg;
 
-import com.facebook.presto.iceberg.function.changelog.ApplyChangelogFunction;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 import javax.management.MBeanServer;
 
 import java.lang.management.ManagementFactory;
-import java.util.Set;
 
 public class IcebergPlugin
         implements Plugin
@@ -43,13 +40,5 @@ public class IcebergPlugin
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
         return ImmutableList.of(new IcebergConnectorFactory(mBeanServer));
-    }
-
-    @Override
-    public Set<Class<?>> getFunctions()
-    {
-        return ImmutableSet.<Class<?>>builder()
-                .add(ApplyChangelogFunction.class)
-                .build();
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableChangelog.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableChangelog.java
@@ -308,4 +308,28 @@ public class TestIcebergTableChangelog
                 .mapToLong(Long.class::cast)
                 .skip(idx).findFirst().getAsLong();
     }
+
+    @Test
+    public void testApplyChangelogFunctionInSystemNamespace()
+    {
+        assertQuery(
+                "SELECT iceberg.system.apply_changelog(1, 'INSERT', 'test_value') IS NOT NULL",
+                "SELECT true");
+    }
+
+    @Test
+    public void testApplyChangelogFunctionNotInGlobalNamespace()
+    {
+        assertQueryFails(
+                "SELECT apply_changelog(1, 'INSERT', 'test_value')",
+                "line 1:8: Function apply_changelog not registered");
+    }
+
+    @Test
+    public void testApplyChangelogFunctionNotInPrestoDefaultNamespace()
+    {
+        assertQueryFails(
+                "SELECT presto.default.apply_changelog(1, 'INSERT', 'test_value')",
+                "line 1:8: Function apply_changelog not registered");
+    }
 }


### PR DESCRIPTION
# Migrate Iceberg ApplyChangeLog to a connector function

Moves the `ApplyChangelogFunction` from `IcebergPlugin.getFunctions()` to `IcebergConnector.getSystemFunctions()`. This makes the function available in the `iceberg.system` namespace instead of the global `presto.default` namespace.

This change follows the connector-level function pattern introduced in PR \#25594 and improves function organization by keeping connector-specific functions within their appropriate namespaces. The function's behavior remains unchanged.

Fixes \#25849

-----

##  Motivation and Context

This migration improves function organization by ensuring connector-specific functions are available in their appropriate namespaces rather than being in the global namespace. It aligns the `ApplyChangelogFunction` with the established pattern for connector-level system functions.

-----

##  Impact

  * **API Change**: Users will now need to call `iceberg.system.apply_changelog()` instead of `apply_changelog()`.
  * **No Performance Impact**: The function's behavior and performance remain identical.
  * **Improved Organization**: Provides better separation of connector-specific functionality.

-----

##  Test Plan

  * Verified existing unit tests in `TestApplyChangelogFunction` continue to pass.
  * Verified connector tests in `TestIcebergConnectorFactory` continue to pass.
  * Confirmed that the `presto-iceberg` module compiles successfully.
  * Validated that the function registers and works correctly in the new `iceberg.system` namespace.

-----

## Contributor Checklist

* [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).

* [ ] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.

* [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.

* [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).

* [ ] Adequate tests were added if applicable.

* [ ] CI passed.

-----

##  Release Notes

```
== RELEASE NOTES ==

General Changes
* Improve Iceberg's `apply_changelog` function by migrating it from the global namespace to the connector-specific namespace. The function is now available as `iceberg.system.apply_changelog()` instead of `apply_changelog()`.

Iceberg Connector Changes
* Improve `ApplyChangelogFunction` by moving it to connector-level functions following the pattern introduced in PR #25594.
