### PR TITLE
Fix incorrect session property names

### DIFF
--- a/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
+++ b/presto-docs/src/main/sphinx/optimizer/history-based-optimization.rst
@@ -67,11 +67,11 @@ Session property Name                                       Description         
 ``restrict_history_based_optimization_to_complex_query``    Enable history based optimization only for complex queries, i.e. queries with join and aggregation.  ``True``
 ``history_input_table_statistics_matching_threshold``       Overrides the behavior of the configuration property                                                 ``hbo.history-matching-threshold``
                                                             ``hbo.history-matching-threshold`` in the current session.
-``treat-low-confidence-zero-estimation-as-unknown``         Overrides the behavior of the configuration property
+``treat_low_confidence_zero_estimation_unknown_enabled``    Overrides the behavior of the configuration property
                                                             ``optimizer.treat-low-confidence-zero-estimation-as-unknown`` in the current session.                ``optimizer.treat-low-confidence-zero-estimation-as-unknown``
-``confidence-based-broadcast``                              Overrides the behavior of the configuration property
+``confidence_based_broadcast_enabled``                      Overrides the behavior of the configuration property
                                                             ``optimizer.confidence-based-broadcast`` in the current session.                                     ``optimizer.confidence-based-broadcast``
-``retry-query-with-history-based-optimization``             Overrides the behavior of the configuration property
+``retry_query_with_history_based_optimization``             Overrides the behavior of the configuration property
                                                             ``optimizer.retry-query-with-history-based-optimization`` in the current session.                    ``optimizer.retry-query-with-history-based-optimization``
 =========================================================== ==================================================================================================== ==============================================================
 


### PR DESCRIPTION
Fix documentation to match properties from [SystemSessionProperties](https://github.com/prestodb/presto/blob/9b19f4a02ab1b1c13667dbac30f7891fd98757ee/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java)  

```
== NO RELEASE NOTE ==
```

