### PR TITLE
Add plan support for using uniqueness of row_id

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -185,6 +185,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.FILE_MODIFIED_TIME_COLUM
 import static com.facebook.presto.hive.HiveColumnHandle.FILE_SIZE_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveColumnHandle.PATH_COLUMN_NAME;
 import static com.facebook.presto.hive.HiveColumnHandle.ROW_ID_COLUMN_NAME;
+import static com.facebook.presto.hive.HiveColumnHandle.rowIdColumnHandle;
 import static com.facebook.presto.hive.HiveColumnHandle.updateRowIdHandle;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_COLUMN_ORDER_MISMATCH;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CONCURRENT_MODIFICATION_DETECTED;
@@ -2924,7 +2925,8 @@ public class HiveMetadata
                 streamPartitionColumns,
                 discretePredicates,
                 localPropertyBuilder.build(),
-                Optional.of(combinedRemainingPredicate));
+                Optional.of(combinedRemainingPredicate),
+                Optional.of(rowIdColumnHandle()));
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketedTablesWithRowId.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveBucketedTablesWithRowId.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
+import static io.airlift.tpch.TpchTable.ORDERS;
+
+@Test(singleThreaded = true)
+public class TestHiveBucketedTablesWithRowId
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, CUSTOMER),
+                ImmutableMap.of(),
+                Optional.empty());
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        // Create bucketed customer table
+        assertUpdate("CREATE TABLE customer_bucketed WITH " +
+                "(bucketed_by = ARRAY['custkey'], bucket_count = 13) " +
+                "AS SELECT * FROM customer", 1500);
+
+        // Create bucketed orders table
+        assertUpdate("CREATE TABLE orders_bucketed WITH " +
+                "(bucketed_by = ARRAY['orderkey'], bucket_count = 11) " +
+                "AS SELECT * FROM orders", 15000);
+
+        // Verify tables are created
+        assertQuery("SELECT count(*) FROM customer_bucketed", "SELECT count(*) FROM customer");
+        assertQuery("SELECT count(*) FROM orders_bucketed", "SELECT count(*) FROM orders");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        try {
+            assertUpdate("DROP TABLE IF EXISTS customer_bucketed");
+            assertUpdate("DROP TABLE IF EXISTS orders_bucketed");
+        }
+        catch (Exception e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    @Test
+    public void testRowIdWithBucketColumn()
+    {
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING, "true")
+                .build();
+
+        // Test basic query with both $row_id and $bucket
+        String sql = "SELECT \"$row_id\", \"$bucket\", custkey, name " +
+                "FROM customer_bucketed " +
+                "WHERE \"$bucket\" = 5";
+
+        assertPlan(session, sql, anyTree(
+                project(filter(tableScan("customer_bucketed")))));
+
+        // Test aggregation grouping by both $row_id and $bucket
+        sql = "SELECT \"$row_id\", \"$bucket\", COUNT(*) " +
+                "FROM customer_bucketed " +
+                "GROUP BY \"$row_id\", \"$bucket\"";
+
+        assertPlan(session, sql, anyTree(
+                aggregation(ImmutableMap.of(),
+                        project(tableScan("customer_bucketed")))));
+
+        // Test join between bucketed tables using both $row_id and $bucket
+        sql = "SELECT c.\"$row_id\" AS customer_row_id, " +
+                "c.\"$bucket\" AS customer_bucket, " +
+                "o.\"$row_id\" AS order_row_id, " +
+                "o.\"$bucket\" AS order_bucket, " +
+                "c.name, o.orderkey " +
+                "FROM customer_bucketed c " +
+                "JOIN orders_bucketed o " +
+                "ON c.custkey = o.custkey " +
+                "WHERE c.\"$bucket\" IN (1, 3, 5) " +
+                "AND o.\"$bucket\" IN (2, 4, 6)";
+
+        assertPlan(session, sql, anyTree(
+                join(
+                        project(filter(tableScan("customer_bucketed"))),
+                        exchange(anyTree(tableScan("orders_bucketed"))))));
+    }
+
+    @Test
+    public void testRowIdUniquePropertyWithBucketing()
+    {
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING, "true")
+                .build();
+
+        // Test unique grouping by $row_id with bucket filtering
+        String sql = "SELECT " +
+                "customer_row_id, " +
+                "ARBITRARY(name) AS customer_name, " +
+                "ARBITRARY(bucket_num) AS customer_bucket, " +
+                "ARRAY_AGG(orderkey) AS orders_info " +
+                "FROM (" +
+                "    SELECT " +
+                "        c.\"$row_id\" AS customer_row_id, " +
+                "        c.\"$bucket\" AS bucket_num, " +
+                "        c.name, " +
+                "        o.orderkey " +
+                "    FROM customer_bucketed c " +
+                "    LEFT JOIN orders_bucketed o " +
+                "        ON c.custkey = o.custkey " +
+                "        AND o.orderstatus IN ('O', 'F') " +
+                "    WHERE c.\"$bucket\" < 5 " +
+                "        AND c.nationkey IN (1, 2, 3) " +
+                ") " +
+                "GROUP BY customer_row_id";
+
+        assertPlan(session, sql, anyTree(
+                aggregation(ImmutableMap.of(),
+                        join(
+                                anyTree(tableScan("customer_bucketed")),
+                                anyTree(tableScan("orders_bucketed"))))));
+    }
+
+    @Test
+    public void testRowIdAndBucketInComplexQuery()
+    {
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING, "true")
+                .build();
+
+        // Complex query with both row_id and bucket columns
+        String sql = "SELECT " +
+                "    unique_id, " +
+                "    bucket_group, " +
+                "    COUNT(*) AS order_count, " +
+                "    AVG(totalprice) AS avg_price " +
+                "FROM (" +
+                "    SELECT " +
+                "        c.\"$row_id\" AS unique_id, " +
+                "        CASE " +
+                "            WHEN c.\"$bucket\" < 5 THEN 'low' " +
+                "            WHEN c.\"$bucket\" < 10 THEN 'medium' " +
+                "            ELSE 'high' " +
+                "        END AS bucket_group, " +
+                "        o.totalprice " +
+                "    FROM customer_bucketed c " +
+                "    JOIN orders_bucketed o " +
+                "        ON c.custkey = o.custkey " +
+                "    WHERE o.\"$bucket\" % 2 = 0 " +
+                ") t " +
+                "GROUP BY unique_id, bucket_group";
+
+        assertPlan(session, sql, anyTree(
+                aggregation(ImmutableMap.of(),
+                        project(project(join(
+                                project(tableScan("customer_bucketed")),
+                                anyTree(tableScan("orders_bucketed"))))))));
+    }
+
+    @Test
+    public void testDistinctRowIdWithBucketFilter()
+    {
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING, "true")
+                .build();
+
+        // Test DISTINCT with row_id and bucket filtering
+        String sql = "SELECT " +
+                "    DISTINCT c.\"$row_id\" AS unique_id, " +
+                "    c.\"$bucket\" AS bucket_num, " +
+                "    c.name " +
+                "FROM customer_bucketed c " +
+                "WHERE c.\"$bucket\" BETWEEN 3 AND 8 " +
+                "    AND c.nationkey = 1";
+
+        assertPlan(session, sql, anyTree(
+                aggregation(ImmutableMap.of(),
+                        project(filter(tableScan("customer_bucketed"))))));
+    }
+
+    @Test
+    public void testRowIdJoinOnBucketColumn()
+    {
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING, "true")
+                .build();
+
+        // Test joining on bucket column while selecting row_id
+        String sql = "SELECT " +
+                "    c.\"$row_id\" AS customer_row_id, " +
+                "    o.\"$row_id\" AS order_row_id, " +
+                "    c.\"$bucket\" AS shared_bucket, " +
+                "    c.name, " +
+                "    o.orderkey " +
+                "FROM customer_bucketed c " +
+                "JOIN orders_bucketed o " +
+                "    ON c.\"$bucket\" = o.\"$bucket\" " +
+                "WHERE c.\"$bucket\" < 5";
+
+        assertPlan(session, sql, anyTree(
+                join(
+                        exchange(anyTree(tableScan("customer_bucketed"))),
+                        exchange(anyTree(tableScan("orders_bucketed"))))));
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -337,6 +337,7 @@ public final class SystemSessionProperties
     public static final String QUERY_CLIENT_TIMEOUT = "query_client_timeout";
     public static final String REWRITE_MIN_MAX_BY_TO_TOP_N = "rewrite_min_max_by_to_top_n";
     public static final String ADD_DISTINCT_BELOW_SEMI_JOIN_BUILD = "add_distinct_below_semi_join_build";
+    public static final String UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING = "utilize_unique_property_in_query_planning";
     public static final String PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS = "pushdown_subfields_for_map_functions";
     public static final String MAX_SERIALIZABLE_OBJECT_SIZE = "max_serializable_object_size";
 
@@ -1950,6 +1951,10 @@ public final class SystemSessionProperties
                         false,
                         value -> Duration.valueOf((String) value),
                         Duration::toString),
+                booleanProperty(UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING,
+                        "Utilize the unique property of input columns in query planning",
+                        featuresConfig.isUtilizeUniquePropertyInQueryPlanning(),
+                        false),
                 booleanProperty(ADD_DISTINCT_BELOW_SEMI_JOIN_BUILD,
                         "Add distinct aggregation below semi join build",
                         featuresConfig.isAddDistinctBelowSemiJoinBuild(),
@@ -3308,6 +3313,11 @@ public final class SystemSessionProperties
     public static boolean isPushSubfieldsForMapFunctionsEnabled(Session session)
     {
         return session.getSystemProperty(PUSHDOWN_SUBFIELDS_FOR_MAP_FUNCTIONS, Boolean.class);
+    }
+
+    public static boolean isUtilizeUniquePropertyInQueryPlanningEnabled(Session session)
+    {
+        return session.getSystemProperty(UTILIZE_UNIQUE_PROPERTY_IN_QUERY_PLANNING, Boolean.class);
     }
 
     public static boolean isAddDistinctBelowSemiJoinBuildEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/TableLayout.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/TableLayout.java
@@ -78,6 +78,11 @@ public class TableLayout
         return layout.getLocalProperties();
     }
 
+    public Optional<ColumnHandle> getUniqueColumn()
+    {
+        return layout.getUniqueColumn();
+    }
+
     public ConnectorTableLayoutHandle getLayoutHandle()
     {
         return layout.getHandle();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -309,6 +309,7 @@ public class FeaturesConfig
     private boolean addDistinctBelowSemiJoinBuild;
     private boolean pushdownSubfieldForMapFunctions = true;
     private long maxSerializableObjectSize = 1000;
+    private boolean utilizeUniquePropertyInQueryPlanning = true;
 
     private boolean builtInSidecarFunctionsEnabled;
 
@@ -3099,6 +3100,19 @@ public class FeaturesConfig
     public boolean isPushdownSubfieldForMapFunctions()
     {
         return pushdownSubfieldForMapFunctions;
+    }
+
+    @Config("optimizer.utilize-unique-property-in-query-planning")
+    @ConfigDescription("Utilize the unique property of input columns in query planning")
+    public FeaturesConfig setUtilizeUniquePropertyInQueryPlanning(boolean utilizeUniquePropertyInQueryPlanning)
+    {
+        this.utilizeUniquePropertyInQueryPlanning = utilizeUniquePropertyInQueryPlanning;
+        return this;
+    }
+
+    public boolean isUtilizeUniquePropertyInQueryPlanning()
+    {
+        return utilizeUniquePropertyInQueryPlanning;
     }
 
     @Config("max_serializable_object_size")

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -311,7 +311,8 @@ public class AddExchanges
                         child.getProperties());
             }
             else if (hasMixedGroupingSets
-                    || !isStreamPartitionedOn(child.getProperties(), partitioningRequirement) && !isNodePartitionedOn(child.getProperties(), partitioningRequirement)) {
+                    || !isStreamPartitionedOn(child.getProperties(), partitioningRequirement) && !isNodePartitionedOn(child.getProperties(), partitioningRequirement)
+                    && !isNodePartitionedOnAdditionalProperty(child.getProperties(), partitioningRequirement) && !isStreamPartitionedOnAdditionalProperty(child.getProperties(), partitioningRequirement)) {
                 child = withDerivedProperties(
                         partitionedExchange(
                                 idAllocator.getNextId(),
@@ -1624,9 +1625,19 @@ public class AddExchanges
             return properties.isNodePartitionedOn(columns, isExactPartitioningPreferred(session));
         }
 
+        private boolean isNodePartitionedOnAdditionalProperty(ActualProperties properties, Collection<VariableReferenceExpression> columns)
+        {
+            return properties.isNodePartitionedOnAdditionalProperty(columns, isExactPartitioningPreferred(session));
+        }
+
         private boolean isStreamPartitionedOn(ActualProperties properties, Collection<VariableReferenceExpression> columns)
         {
             return properties.isStreamPartitionedOn(columns, isExactPartitioningPreferred(session));
+        }
+
+        private boolean isStreamPartitionedOnAdditionalProperty(ActualProperties properties, Collection<VariableReferenceExpression> columns)
+        {
+            return properties.isStreamPartitionedOnAdditionalProperty(columns, isExactPartitioningPreferred(session));
         }
 
         private boolean shouldAggregationMergePartitionPreferences(AggregationPartitioningMergingStrategy aggregationPartitioningMergingStrategy)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -399,7 +399,8 @@ public class AddLocalExchanges
             // [A, B] [(A, C)]     ->   List.of(Optional.of(GroupingProperty(C)))
             // [A, B] [(D, A, C)]  ->   List.of(Optional.of(GroupingProperty(D, C)))
             List<Optional<LocalProperty<VariableReferenceExpression>>> matchResult = LocalProperties.match(child.getProperties().getLocalProperties(), LocalProperties.grouped(groupingKeys));
-            if (!matchResult.get(0).isPresent()) {
+            List<Optional<LocalProperty<VariableReferenceExpression>>> matchResultForAdditional = LocalProperties.match(child.getProperties().getAdditionalLocalProperties(), LocalProperties.grouped(groupingKeys));
+            if (!matchResult.get(0).isPresent() || !matchResultForAdditional.get(0).isPresent()) {
                 // !isPresent() indicates the property was satisfied completely
                 preGroupedSymbols = groupingKeys;
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LocalProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/LocalProperties.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ConstantProperty;
 import com.facebook.presto.spi.GroupingProperty;
 import com.facebook.presto.spi.LocalProperty;
 import com.facebook.presto.spi.SortingProperty;
+import com.facebook.presto.spi.UniqueProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.PeekingIterator;
@@ -53,6 +54,11 @@ public final class LocalProperties
     public static <T> List<LocalProperty<T>> sorted(Collection<T> columns, SortOrder order)
     {
         return columns.stream().map(column -> new SortingProperty<>(column, order)).collect(toImmutableList());
+    }
+
+    public static <T> List<LocalProperty<T>> unique(T column)
+    {
+        return ImmutableList.of(new UniqueProperty<>(column));
     }
 
     public static <T> List<LocalProperty<T>> stripLeadingConstants(List<? extends LocalProperty<T>> properties)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPreferredProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPreferredProperties.java
@@ -188,9 +188,11 @@ public class StreamPreferredProperties
         // is there a preference for a specific partitioning scheme?
         if (partitioningColumns.isPresent()) {
             if (exactColumnOrder) {
-                return actualProperties.isExactlyPartitionedOn(partitioningColumns.get());
+                return actualProperties.isExactlyPartitionedOn(partitioningColumns.get())
+                        || actualProperties.getStreamPropertiesFromUniqueColumn().isPresent() && actualProperties.getStreamPropertiesFromUniqueColumn().get().isExactlyPartitionedOn(partitioningColumns.get());
             }
-            return actualProperties.isPartitionedOn(partitioningColumns.get());
+            return actualProperties.isPartitionedOn(partitioningColumns.get())
+                    || actualProperties.getStreamPropertiesFromUniqueColumn().isPresent() && actualProperties.getStreamPropertiesFromUniqueColumn().get().isPartitionedOn(partitioningColumns.get());
         }
 
         return true;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingAggregations.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingAggregations.java
@@ -86,8 +86,10 @@ public class ValidateStreamingAggregations
 
             List<LocalProperty<VariableReferenceExpression>> desiredProperties = ImmutableList.of(new GroupingProperty<>(node.getPreGroupedVariables()));
             Iterator<Optional<LocalProperty<VariableReferenceExpression>>> matchIterator = LocalProperties.match(properties.getLocalProperties(), desiredProperties).iterator();
+            Iterator<Optional<LocalProperty<VariableReferenceExpression>>> additionalMatchIterator = LocalProperties.match(properties.getAdditionalLocalProperties(), desiredProperties).iterator();
             Optional<LocalProperty<VariableReferenceExpression>> unsatisfiedRequirement = Iterators.getOnlyElement(matchIterator);
-            checkArgument(!unsatisfiedRequirement.isPresent(), "Streaming aggregation with input not grouped on the grouping keys");
+            Optional<LocalProperty<VariableReferenceExpression>> additionalUnsatisfiedRequirement = Iterators.getOnlyElement(additionalMatchIterator);
+            checkArgument(!unsatisfiedRequirement.isPresent() || !additionalUnsatisfiedRequirement.isPresent(), "Streaming aggregation with input not grouped on the grouping keys");
             return null;
         }
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -263,6 +263,7 @@ public class TestFeaturesConfig
                 .setAddExchangeBelowPartialAggregationOverGroupId(false)
                 .setAddDistinctBelowSemiJoinBuild(false)
                 .setPushdownSubfieldForMapFunctions(true)
+                .setUtilizeUniquePropertyInQueryPlanning(true)
                 .setInnerJoinPushdownEnabled(false)
                 .setBroadcastSemiJoinForDelete(true)
                 .setInEqualityJoinPushdownEnabled(false)
@@ -482,6 +483,7 @@ public class TestFeaturesConfig
                 .put("exclude-invalid-worker-session-properties", "true")
                 .put("optimizer.add-distinct-below-semi-join-build", "true")
                 .put("optimizer.pushdown-subfield-for-map-functions", "false")
+                .put("optimizer.utilize-unique-property-in-query-planning", "false")
                 .put("optimizer.add-exchange-below-partial-aggregation-over-group-id", "true")
                 .put("max_serializable_object_size", "50")
                 .build();
@@ -692,6 +694,7 @@ public class TestFeaturesConfig
                 .setAddExchangeBelowPartialAggregationOverGroupId(true)
                 .setAddDistinctBelowSemiJoinBuild(true)
                 .setPushdownSubfieldForMapFunctions(false)
+                .setUtilizeUniquePropertyInQueryPlanning(false)
                 .setInEqualityJoinPushdownEnabled(true)
                 .setBroadcastSemiJoinForDelete(false)
                 .setRewriteMinMaxByToTopNEnabled(true)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -412,6 +412,11 @@ public final class PlanMatchPattern
                 .withExactAssignments(assignments.values());
     }
 
+    public static PlanMatchPattern semiJoin(PlanMatchPattern source, PlanMatchPattern filtering)
+    {
+        return node(SemiJoinNode.class, source, filtering);
+    }
+
     public static PlanMatchPattern semiJoin(String sourceSymbolAlias, String filteringSymbolAlias, String outputAlias, PlanMatchPattern source, PlanMatchPattern filtering)
     {
         return semiJoin(sourceSymbolAlias, filteringSymbolAlias, outputAlias, Optional.empty(), source, filtering);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableLayout.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableLayout.java
@@ -34,6 +34,7 @@ public class ConnectorTableLayout
     private final Optional<DiscretePredicates> discretePredicates;
     private final List<LocalProperty<ColumnHandle>> localProperties;
     private final Optional<RowExpression> remainingPredicate;
+    private final Optional<ColumnHandle> uniqueColumn;
 
     public ConnectorTableLayout(ConnectorTableLayoutHandle handle)
     {
@@ -69,6 +70,20 @@ public class ConnectorTableLayout
             List<LocalProperty<ColumnHandle>> localProperties,
             Optional<RowExpression> remainingPredicate)
     {
+        this(handle, columns, predicate, tablePartitioning, streamPartitioningColumns, discretePredicates, localProperties, remainingPredicate, Optional.empty());
+    }
+
+    public ConnectorTableLayout(
+            ConnectorTableLayoutHandle handle,
+            Optional<List<ColumnHandle>> columns,
+            TupleDomain<ColumnHandle> predicate,
+            Optional<ConnectorTablePartitioning> tablePartitioning,
+            Optional<Set<ColumnHandle>> streamPartitioningColumns,
+            Optional<DiscretePredicates> discretePredicates,
+            List<LocalProperty<ColumnHandle>> localProperties,
+            Optional<RowExpression> remainingPredicate,
+            Optional<ColumnHandle> uniqueColumn)
+    {
         requireNonNull(handle, "handle is null");
         requireNonNull(columns, "columns is null");
         requireNonNull(streamPartitioningColumns, "partitioningColumns is null");
@@ -86,6 +101,7 @@ public class ConnectorTableLayout
         this.discretePredicates = discretePredicates;
         this.localProperties = localProperties;
         this.remainingPredicate = remainingPredicate;
+        this.uniqueColumn = uniqueColumn;
     }
 
     public ConnectorTableLayoutHandle getHandle()
@@ -121,6 +137,11 @@ public class ConnectorTableLayout
     public Optional<RowExpression> getRemainingPredicate()
     {
         return remainingPredicate;
+    }
+
+    public Optional<ColumnHandle> getUniqueColumn()
+    {
+        return uniqueColumn;
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/UniqueProperty.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/UniqueProperty.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public final class UniqueProperty<E>
+        implements LocalProperty<E>
+{
+    private final E column;
+
+    @JsonCreator
+    public UniqueProperty(@JsonProperty("column") E column)
+    {
+        this.column = requireNonNull(column, "column is null");
+    }
+
+    @Override
+    public boolean isOrderSensitive()
+    {
+        return false;
+    }
+
+    @JsonProperty
+    public E getColumn()
+    {
+        return column;
+    }
+
+    public Set<E> getColumns()
+    {
+        return Collections.singleton(column);
+    }
+
+    @Override
+    public <T> Optional<LocalProperty<T>> translate(Function<E, Optional<T>> translator)
+    {
+        return translator.apply(column)
+                .map(UniqueProperty::new);
+    }
+
+    @Override
+    public boolean isSimplifiedBy(LocalProperty<E> known)
+    {
+        return known instanceof UniqueProperty && known.equals(this);
+    }
+
+    @Override
+    public Optional<LocalProperty<E>> withConstants(Set<E> constants)
+    {
+        return Optional.of(this);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "U(" + column + ")";
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UniqueProperty<?> that = (UniqueProperty<?>) o;
+        return Objects.equals(column, that.column);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(column);
+    }
+}


### PR DESCRIPTION
## Description
Hive table now offers a special column which is the row_id column. However, this special attribute is not used in query plan. Take an example query:

```
set session join_distribution_type='BROADCAST';
explain (type distributed)
SELECT
    unique_id AS unique_id,
    ARBITRARY(name) AS customer_name,
    ARBITRARY(nationkey) AS customer_nation,
    ARBITRARY(acctbal) AS customer_acctbal,
    ARBITRARY(mktsegment) AS customer_mktsegment,
    ARRAY_AGG(ROW(orderkey, orderstatus, orderdate, totalprice)) AS orders_info
FROM (
    SELECT
        customer.name,
        customer.nationkey,
        customer.acctbal,
        customer.mktsegment,
        orders.orderkey,
        orders.orderstatus,
        orders.orderdate,
        orders.totalprice,
        customer."$row_id" AS unique_id
    FROM customer
    LEFT JOIN orders
        ON customer.custkey = orders.custkey
        AND orders.orderstatus IN ('O', 'F')
        AND orders.orderdate BETWEEN DATE '1995-01-01' AND DATE '1995-12-31'
    WHERE
        customer.nationkey IN (1, 2, 3, 4, 5)
)
GROUP BY
    unique_id;
```

Without using the unique properties of $row_id, the plan 1) has an exchange between aggregation and join 2) aggregation is a hash aggregation.
```
---------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                          >
     Output layout: [$row_id, arbitrary, arbitrary_48, arbitrary_49, arbitrary_50, array_agg]                                                 >
     Output partitioning: SINGLE []                                                                                                           >
     Output encoding: COLUMNAR                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                            >
     - Output[PlanNodeId 18][unique_id, customer_name, customer_nation, customer_acctbal, customer_mktsegment, orders_info] => [$row_id:varbin>
             unique_id := $row_id (1:35)                                                                                                      >
             customer_name := arbitrary (1:59)                                                                                                >
             customer_nation := arbitrary_48 (1:93)                                                                                           >
             customer_acctbal := arbitrary_49 (1:134)                                                                                         >
             customer_mktsegment := arbitrary_50 (1:174)                                                                                      >
             orders_info := array_agg (1:220)                                                                                                 >
         - RemoteSource[1] => [$row_id:varbinary, arbitrary:varchar(25), arbitrary_48:bigint, arbitrary_49:double, arbitrary_50:varchar(10), a>
                                                                                                                                              >
 Fragment 1 [HASH]                                                                                                                            >
     Output layout: [$row_id, arbitrary, arbitrary_48, arbitrary_49, arbitrary_50, array_agg]                                                 >
     Output partitioning: SINGLE []                                                                                                           >
     Output encoding: COLUMNAR                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                            >
     - Project[PlanNodeId 754][projectLocality = LOCAL] => [$row_id:varbinary, arbitrary:varchar(25), array_agg:array(row(bigint, varchar(1), >
         - Aggregate(FINAL)[$row_id][$hashvalue][PlanNodeId 13] => [$row_id:varbinary, $hashvalue:bigint, arbitrary:varchar(25), array_agg:arr>
                 arbitrary := "presto.default.arbitrary"((arbitrary_75)) (1:59)                                                               >
                 array_agg := "presto.default.array_agg"((array_agg_79)) (1:220)                                                              >
                 arbitrary_49 := "presto.default.arbitrary"((arbitrary_77)) (1:134)                                                           >
                 arbitrary_48 := "presto.default.arbitrary"((arbitrary_76)) (1:93)                                                            >
                 arbitrary_50 := "presto.default.arbitrary"((arbitrary_78)) (1:174)                                                           >
             - LocalExchange[PlanNodeId 684][HASH][$hashvalue] ($row_id) => [$row_id:varbinary, arbitrary_76:bigint, arbitrary_75:varchar(25),>
                 - RemoteSource[2] => [$row_id:varbinary, arbitrary_76:bigint, arbitrary_75:varchar(25), arbitrary_77:double, arbitrary_78:var>
                                                                                                                                              >
 Fragment 2 [SOURCE]                                                                                                                          >
     Output layout: [$row_id, arbitrary_76, arbitrary_75, arbitrary_77, arbitrary_78, array_agg_79, $hashvalue_85]                            >
     Output partitioning: HASH [$row_id][$hashvalue_85]                                                                                       >
     Output encoding: COLUMNAR                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                            >
     - Aggregate(PARTIAL)[$row_id][$hashvalue_85][PlanNodeId 688] => [$row_id:varbinary, $hashvalue_85:bigint, arbitrary_76:bigint, arbitrary_>
             arbitrary_76 := "presto.default.arbitrary"((nationkey)) (1:93)                                                                   >
             arbitrary_75 := "presto.default.arbitrary"((name)) (1:59)                                                                        >
             arbitrary_77 := "presto.default.arbitrary"((acctbal)) (1:134)                                                                    >
             arbitrary_78 := "presto.default.arbitrary"((mktsegment)) (1:174)                                                                 >
             array_agg_79 := "presto.default.array_agg"((expr_47)) (1:220)                                                                    >
         - Project[PlanNodeId 11][projectLocality = LOCAL] => [$row_id:varbinary, name:varchar(25), nationkey:bigint, acctbal:double, mktsegme>
                 Estimates: {source: CostBasedSourceInfo, rows: 459 (108.84kB), cpu: 2,355,630.71, memory: 284,540.54, network: 284,540.54}   >
                 expr_47 := ROW_CONSTRUCTOR(orderkey, orderstatus, orderdate, totalprice) (1:385)                                             >
                 $hashvalue_85 := combine_hash(BIGINT'0', COALESCE($operator$hash_code($row_id), BIGINT'0')) (1:459)                          >
             - LeftJoin[PlanNodeId 5][("custkey" = "custkey_0")][$hashvalue_81, $hashvalue_82] => [name:varchar(25), nationkey:bigint, acctbal>
                     Estimates: {source: CostBasedSourceInfo, rows: 459 (108.84kB), cpu: 2,277,672.54, memory: 284,540.54, network: 284,540.54>
                     Distribution: REPLICATED                                                                                                 >
                 - ScanFilterProject[PlanNodeId 0,607,752][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaNam>
                         Estimates: {source: CostBasedSourceInfo, rows: 1,500 (355.96kB), cpu: 178,465.00, memory: 0.00, network: 0.00}/{sourc>
                         $hashvalue_81 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:524)                  >
                         LAYOUT: tpch.customer{domains={nationkey=[ [["1"], ["2"], ["3"], ["4"], ["5"]] ]}}                                   >
                         custkey := custkey:bigint:0:REGULAR (1:495)                                                                          >
                         acctbal := acctbal:double:5:REGULAR (1:495)                                                                          >
                         name := name:varchar(25):1:REGULAR (1:495)                                                                           >
                         nationkey := nationkey:bigint:3:REGULAR (1:495)                                                                      >
                         $row_id := $row_id:binary:-10:SYNTHESIZED (1:495)                                                                    >
                         mktsegment := mktsegment:varchar(10):6:REGULAR (1:495)                                                               >
                 - LocalExchange[PlanNodeId 664][HASH][$hashvalue_82] (custkey_0) => [orderkey:bigint, custkey_0:bigint, orderstatus:varchar(1>
                         Estimates: {source: CostBasedSourceInfo, rows: 1,514 (359.16kB), cpu: 1,282,270.27, memory: 0.00, network: 284,540.54>
                     - RemoteSource[3] => [orderkey:bigint, custkey_0:bigint, orderstatus:varchar(1), totalprice:double, orderdate:date, $hash>
                                                                                                                                              >
 Fragment 3 [SOURCE]                                                                                                                          >
     Output layout: [orderkey, custkey_0, orderstatus, totalprice, orderdate, $hashvalue_84]                                                  >
     Output partitioning: BROADCAST []                                                                                                        >
     Output encoding: COLUMNAR                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                            >
     - ScanFilterProject[PlanNodeId 1,608,753][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tabl>
             Estimates: {source: CostBasedSourceInfo, rows: 15,000 (688.48kB), cpu: 570,000.00, memory: 0.00, network: 0.00}/{source: CostBase>
             $hashvalue_84 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_0), BIGINT'0')) (1:514)                            >
             LAYOUT: tpch.orders{domains={orderstatus=[ [["F"], ["O"]] ], orderdate=[ [["1995-01-01", "1995-12-31"]] ]}}                      >
             orderdate := orderdate:date:4:REGULAR (1:514)                                                                                    >
             orderstatus := orderstatus:varchar(1):2:REGULAR (1:514)                                                                          >
             totalprice := totalprice:double:3:REGULAR (1:514)                                                                                >
             custkey_0 := custkey:bigint:1:REGULAR (1:514)                                                                                    >
             orderkey := orderkey:bigint:0:REGULAR (1:514)                                                                                    >
                                                                                                                                              >
                                                                                                                                              >
(1 row)
```
However, this is not necessary. 1) since the $row_id has unique values for each row, we can consider it's partitioned on $row_id, whose partitioned property propagates to the corresponding join output, i.e. unique_id, hence the exchange between join and aggregation is not needed 2) the input data can also be considered as pre-grouped by $row_id, whose attributes also propagates to the join output, i.e. unique_id, hence streaming aggregation can be used instead of hash aggregation.

With the changes in this PR, the unique properties of $row_id used. Plan now has nod exchange between join and aggregation, and streaming aggregation is used.
```
---------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                          >
     Output layout: [$row_id, arbitrary, arbitrary_48, arbitrary_49, arbitrary_50, array_agg]                                                 >
     Output partitioning: SINGLE []                                                                                                           >
     Output encoding: COLUMNAR                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                            >
     - Output[PlanNodeId 18][unique_id, customer_name, customer_nation, customer_acctbal, customer_mktsegment, orders_info] => [$row_id:varbin>
             Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: 2,425,333.36, memory: ?, network: ?}                                  >
             unique_id := $row_id (1:35)                                                                                                      >
             customer_name := arbitrary (1:59)                                                                                                >
             customer_nation := arbitrary_48 (1:93)                                                                                           >
             customer_acctbal := arbitrary_49 (1:134)                                                                                         >
             customer_mktsegment := arbitrary_50 (1:174)                                                                                      >
             orders_info := array_agg (1:220)                                                                                                 >
         - RemoteSource[1] => [$row_id:varbinary, arbitrary:varchar(25), arbitrary_48:bigint, arbitrary_49:double, arbitrary_50:varchar(10), a>
                                                                                                                                              >
 Fragment 1 [SOURCE]                                                                                                                          >
     Output layout: [$row_id, arbitrary, arbitrary_48, arbitrary_49, arbitrary_50, array_agg]                                                 >
     Output partitioning: SINGLE []                                                                                                           >
     Output encoding: COLUMNAR                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                            >
     - Aggregate(STREAMING)[$row_id][PlanNodeId 13] => [$row_id:varbinary, arbitrary:varchar(25), arbitrary_48:bigint, arbitrary_49:double, ar>
             Estimates: {source: CostBasedSourceInfo, rows: ? (?), cpu: 2,425,333.36, memory: ?, network: 284,540.54}                         >
             arbitrary := "presto.default.arbitrary"((name)) (1:59)                                                                           >
             arbitrary_48 := "presto.default.arbitrary"((nationkey)) (1:93)                                                                   >
             arbitrary_49 := "presto.default.arbitrary"((acctbal)) (1:134)                                                                    >
             arbitrary_50 := "presto.default.arbitrary"((mktsegment)) (1:174)                                                                 >
             array_agg := "presto.default.array_agg"((expr_47)) (1:220)                                                                       >
         - Project[PlanNodeId 11][projectLocality = LOCAL] => [$row_id:varbinary, name:varchar(25), nationkey:bigint, acctbal:double, mktsegme>
                 Estimates: {source: CostBasedSourceInfo, rows: 459 (104.81kB), cpu: 2,351,502.95, memory: 284,540.54, network: 284,540.54}   >
                 expr_47 := ROW_CONSTRUCTOR(orderkey, orderstatus, orderdate, totalprice) (1:385)                                             >
             - LeftJoin[PlanNodeId 5][("custkey" = "custkey_0")][$hashvalue, $hashvalue_75] => [name:varchar(25), nationkey:bigint, acctbal:do>
                     Estimates: {source: CostBasedSourceInfo, rows: 459 (104.81kB), cpu: 2,277,672.54, memory: 284,540.54, network: 284,540.54>
                     Distribution: REPLICATED                                                                                                 >
                 - ScanFilterProject[PlanNodeId 0,607,709][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaNam>
                         Estimates: {source: CostBasedSourceInfo, rows: 1,500 (342.77kB), cpu: 178,465.00, memory: 0.00, network: 0.00}/{sourc>
                         $hashvalue := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey), BIGINT'0')) (1:524)                     >
                         LAYOUT: tpch.customer{domains={nationkey=[ [["1"], ["2"], ["3"], ["4"], ["5"]] ]}}                                   >
                         custkey := custkey:bigint:0:REGULAR (1:495)                                                                          >
                         acctbal := acctbal:double:5:REGULAR (1:495)                                                                          >
                         name := name:varchar(25):1:REGULAR (1:495)                                                                           >
                         nationkey := nationkey:bigint:3:REGULAR (1:495)                                                                      >
                         $row_id := $row_id:binary:-10:SYNTHESIZED (1:495)                                                                    >
                         mktsegment := mktsegment:varchar(10):6:REGULAR (1:495)                                                               >
                 - LocalExchange[PlanNodeId 658][HASH][$hashvalue_75] (custkey_0) => [orderkey:bigint, custkey_0:bigint, orderstatus:varchar(1>
                         Estimates: {source: CostBasedSourceInfo, rows: 1,514 (345.86kB), cpu: 1,282,270.27, memory: 0.00, network: 284,540.54>
                     - RemoteSource[2] => [orderkey:bigint, custkey_0:bigint, orderstatus:varchar(1), totalprice:double, orderdate:date, $hash>
                                                                                                                                              >
 Fragment 2 [SOURCE]                                                                                                                          >
     Output layout: [orderkey, custkey_0, orderstatus, totalprice, orderdate, $hashvalue_77]                                                  >
     Output partitioning: BROADCAST []                                                                                                        >
     Output encoding: COLUMNAR                                                                                                                >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                            >
     - ScanFilterProject[PlanNodeId 1,608,710][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tabl>
             Estimates: {source: CostBasedSourceInfo, rows: 15,000 (688.48kB), cpu: 570,000.00, memory: 0.00, network: 0.00}/{source: CostBase>
             $hashvalue_77 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(custkey_0), BIGINT'0')) (1:514)                            >
             LAYOUT: tpch.orders{domains={orderdate=[ [["1995-01-01", "1995-12-31"]] ], orderstatus=[ [["F"], ["O"]] ]}}                      >
             orderdate := orderdate:date:4:REGULAR (1:514)                                                                                    >
             orderstatus := orderstatus:varchar(1):2:REGULAR (1:514)                                                                          >
             totalprice := totalprice:double:3:REGULAR (1:514)                                                                                >
             custkey_0 := custkey:bigint:1:REGULAR (1:514)                                                                                    >
             orderkey := orderkey:bigint:0:REGULAR (1:514)                                                                                    >
                                                                                                                                              >
                                                                                                                                              >
(1 row)

```

In order to achieve using the uniqueness of $row_id, following changes are included:
1) Add a new field, additionalProperties into ActualProperties. This is because that current ActualProperties only supports preserving and using one property, however when there are two concurrent properties existing in the data, we have to drop one property. For example, it's possible that the input of a operator is pre-grouped by orderstatus, but at the same time it surely also pre-grouped by $row_id. Since the representation of local properties (which contains the grouping properties) does not support representing properties which are independent of each other. In order to keep supporting of existing support of properties, I adde a new field for the unique $row_id, and it will not be tracked if $row_id is not used.

2) Similar to 1, add a new field additionalStreamProperties to StreamProperties, which is used to track the properties brought by unique row_id.

2) Add a new UniqueProperty. The UniqueProperty is kind of similar to GroupingProperty, with the biggest difference that UniqueProperty has ordered to be false, while GroupingProperty has ordered to be true, i.e. when output is reordered, the GroupingProperty may not hold, but UniqueProperty still hold. For example, after exchange node, we will lost almost all stream property and local properties, but the unique property will still hold.

3) Change code to propagate the unique properties and use it in query planning. Mainly in StreamPropertyDerivations and  PropertyDerivations, which is used in AddLocalExchange and AddExchange, so as to avoid unnecessary exchange nodes.

## Motivation and Context
Add support to utilize $row_id in query plan

## Impact
Improve performance for queries using $row_id

## Test Plan
Unit tests.
Also tested with [verifier suite](https://www.internalfb.com/intern/presto/verifier/results/?test_id=242050&build&user&limit=200&error_regex&error_code&suite) and [verifier suite](https://www.internalfb.com/intern/presto/verifier/results/?test_id=243022)

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix add exchange and add local exchange optimizers to simplify query plans using the unique $row_id  
```

