### PR TITLE
Support multiple catalogs for Presto spark native execution

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -29,6 +29,7 @@ import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkBootstrapTimer;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -69,6 +70,7 @@ public class PrestoSparkInjectorFactory
     private final SqlParserOptions sqlParserOptions;
     private final List<Module> additionalModules;
     private final boolean isForTesting;
+    private final PrestoSparkConfiguration prestoSparkConfiguration;
 
     public PrestoSparkInjectorFactory(
             SparkProcessType sparkProcessType,
@@ -81,7 +83,8 @@ public class PrestoSparkInjectorFactory
             Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
             Optional<Map<String, Map<String, String>>> tempStorageProperties,
             SqlParserOptions sqlParserOptions,
-            List<Module> additionalModules)
+            List<Module> additionalModules,
+            PrestoSparkConfiguration prestoSparkConfiguration)
     {
         this(
                 sparkProcessType,
@@ -95,7 +98,8 @@ public class PrestoSparkInjectorFactory
                 tempStorageProperties,
                 sqlParserOptions,
                 additionalModules,
-                false);
+                false,
+                prestoSparkConfiguration);
     }
 
     public PrestoSparkInjectorFactory(
@@ -110,7 +114,8 @@ public class PrestoSparkInjectorFactory
             Optional<Map<String, Map<String, String>>> tempStorageProperties,
             SqlParserOptions sqlParserOptions,
             List<Module> additionalModules,
-            boolean isForTesting)
+            boolean isForTesting,
+            PrestoSparkConfiguration prestoSparkConfiguration)
     {
         this.sparkProcessType = requireNonNull(sparkProcessType, "sparkProcessType is null");
         this.configProperties = ImmutableMap.copyOf(requireNonNull(configProperties, "configProperties is null"));
@@ -129,6 +134,7 @@ public class PrestoSparkInjectorFactory
         this.sqlParserOptions = requireNonNull(sqlParserOptions, "sqlParserOptions is null");
         this.additionalModules = ImmutableList.copyOf(requireNonNull(additionalModules, "additionalModules is null"));
         this.isForTesting = isForTesting;
+        this.prestoSparkConfiguration = requireNonNull(prestoSparkConfiguration, "prestoSparkConfiguration is null");
     }
 
     public Injector create(PrestoSparkBootstrapTimer bootstrapTimer)
@@ -144,7 +150,7 @@ public class PrestoSparkInjectorFactory
                 new JsonModule(),
                 new SmileModule(),
                 new EventListenerModule(),
-                new PrestoSparkModule(sparkProcessType, sqlParserOptions),
+                new PrestoSparkModule(sparkProcessType, sqlParserOptions, prestoSparkConfiguration),
                 new WarningCollectorModule());
 
         if (isForTesting) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -115,6 +115,7 @@ import com.facebook.presto.sessionpropertyproviders.NativeWorkerSessionPropertyP
 import com.facebook.presto.spark.accesscontrol.PrestoSparkAccessControlChecker;
 import com.facebook.presto.spark.accesscontrol.PrestoSparkAuthenticatorProvider;
 import com.facebook.presto.spark.accesscontrol.PrestoSparkCredentialsProvider;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
 import com.facebook.presto.spark.execution.BroadcastFileInfo;
 import com.facebook.presto.spark.execution.PrestoSparkBroadcastTableCacheManager;
@@ -251,11 +252,13 @@ public class PrestoSparkModule
 {
     private final SparkProcessType sparkProcessType;
     private final SqlParserOptions sqlParserOptions;
+    private final PrestoSparkConfiguration prestoSparkConfiguration;
 
-    public PrestoSparkModule(SparkProcessType sparkProcessType, SqlParserOptions sqlParserOptions)
+    public PrestoSparkModule(SparkProcessType sparkProcessType, SqlParserOptions sqlParserOptions, PrestoSparkConfiguration prestoSparkConfiguration)
     {
         this.sparkProcessType = requireNonNull(sparkProcessType, "sparkProcessType is null");
         this.sqlParserOptions = requireNonNull(sqlParserOptions, "sqlParserOptions is null");
+        this.prestoSparkConfiguration = requireNonNull(prestoSparkConfiguration, "prestoSparkConfiguration is null");
     }
 
     @Override
@@ -552,6 +555,7 @@ public class PrestoSparkModule
 
         // spark specific
         binder.bind(SparkProcessType.class).toInstance(sparkProcessType);
+        binder.bind(PrestoSparkConfiguration.class).toInstance(prestoSparkConfiguration);
         binder.bind(PrestoSparkExecutionExceptionFactory.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkSettingsRequirements.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkQueryPlanner.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -55,7 +55,8 @@ public class PrestoSparkServiceFactory
                 configuration.getFunctionNamespaceProperties(),
                 configuration.getTempStorageProperties(),
                 getSqlParserOptions(),
-                getAdditionalModules(configuration));
+                getAdditionalModules(configuration),
+                configuration);
 
         Injector injector = prestoSparkInjectorFactory.create(bootstrapTimer);
         PrestoSparkService prestoSparkService = injector.getInstance(PrestoSparkService.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcess.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import okhttp3.OkHttpClient;
 
@@ -47,7 +48,8 @@ public class DetachedNativeExecutionProcess
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             Duration maxErrorDuration,
-            WorkerProperty<?, ?, ?> workerProperty)
+            WorkerProperty<?, ?, ?> workerProperty,
+            PrestoSparkConfiguration prestoSparkConfiguration)
             throws IOException
     {
         super(executablePath,
@@ -58,7 +60,8 @@ public class DetachedNativeExecutionProcess
                 errorRetryScheduledExecutor,
                 serverInfoCodec,
                 maxErrorDuration,
-                workerProperty);
+                workerProperty,
+                prestoSparkConfiguration);
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/DetachedNativeExecutionProcessFactory.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spark.execution.task.ForNativeExecutionTask;
 import com.facebook.presto.spi.PrestoException;
@@ -41,6 +42,7 @@ public class DetachedNativeExecutionProcessFactory
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final JsonCodec<ServerInfo> serverInfoCodec;
     private final WorkerProperty<?, ?, ?> workerProperty;
+    private final PrestoSparkConfiguration prestoSparkConfiguration;
 
     @Inject
     public DetachedNativeExecutionProcessFactory(
@@ -49,14 +51,16 @@ public class DetachedNativeExecutionProcessFactory
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             WorkerProperty<?, ?, ?> workerProperty,
+            PrestoSparkConfiguration prestoSparkConfiguration,
             FeaturesConfig featuresConfig)
     {
-        super(httpClient, coreExecutor, errorRetryScheduledExecutor, serverInfoCodec, workerProperty, featuresConfig);
+        super(httpClient, coreExecutor, errorRetryScheduledExecutor, serverInfoCodec, workerProperty, prestoSparkConfiguration, featuresConfig);
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
-        this.coreExecutor = requireNonNull(coreExecutor, "ecoreExecutor is null");
+        this.coreExecutor = requireNonNull(coreExecutor, "coreExecutor is null");
         this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
         this.workerProperty = requireNonNull(workerProperty, "workerProperty is null");
+        this.prestoSparkConfiguration = requireNonNull(prestoSparkConfiguration, "prestoSparkConfiguration is null");
     }
 
     @Override
@@ -78,7 +82,8 @@ public class DetachedNativeExecutionProcessFactory
                     errorRetryScheduledExecutor,
                     serverInfoCodec,
                     maxErrorDuration,
-                    workerProperty);
+                    workerProperty,
+                    prestoSparkConfiguration);
         }
         catch (IOException e) {
             throw new PrestoException(NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR, format("Cannot start native process: %s", e.getMessage()), e);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcessFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcessFactory.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spark.execution.task.ForNativeExecutionTask;
 import com.facebook.presto.spi.PrestoException;
@@ -43,7 +44,8 @@ public class NativeExecutionProcessFactory
     private final ExecutorService coreExecutor;
     private final ScheduledExecutorService errorRetryScheduledExecutor;
     private final JsonCodec<ServerInfo> serverInfoCodec;
-    private final WorkerProperty<?, ?, ?> workerProperty;
+    protected final WorkerProperty<?, ?, ?> workerProperty;
+    private final PrestoSparkConfiguration prestoSparkConfiguration;
     private final String executablePath;
     private final String programArguments;
 
@@ -56,6 +58,7 @@ public class NativeExecutionProcessFactory
             ScheduledExecutorService errorRetryScheduledExecutor,
             JsonCodec<ServerInfo> serverInfoCodec,
             WorkerProperty<?, ?, ?> workerProperty,
+            PrestoSparkConfiguration prestoSparkConfiguration,
             FeaturesConfig featuresConfig)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
@@ -63,6 +66,7 @@ public class NativeExecutionProcessFactory
         this.errorRetryScheduledExecutor = requireNonNull(errorRetryScheduledExecutor, "errorRetryScheduledExecutor is null");
         this.serverInfoCodec = requireNonNull(serverInfoCodec, "serverInfoCodec is null");
         this.workerProperty = requireNonNull(workerProperty, "workerProperty is null");
+        this.prestoSparkConfiguration = requireNonNull(prestoSparkConfiguration, "prestoSparkConfiguration is null");
         this.executablePath = featuresConfig.getNativeExecutionExecutablePath();
         this.programArguments = featuresConfig.getNativeExecutionProgramArguments();
     }
@@ -87,7 +91,8 @@ public class NativeExecutionProcessFactory
                     errorRetryScheduledExecutor,
                     serverInfoCodec,
                     maxErrorDuration,
-                    workerProperty);
+                    workerProperty,
+                    prestoSparkConfiguration);
         }
         catch (IOException e) {
             throw new PrestoException(NATIVE_EXECUTION_PROCESS_LAUNCH_ERROR, format("Cannot start native process: %s", e.getMessage()), e);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
@@ -103,6 +103,20 @@ public class WorkerProperty<T1 extends NativeExecutionConnectorConfig, T2 extend
         populateProperty(connectorConfig.getAllProperties(), connectorConfigPath);
     }
 
+    public void populateAllProperties(Path systemConfigPath, Path nodeConfigPath, Path catalogDirectory, Map<String, Map<String, String>> catalogProperties)
+            throws IOException
+    {
+        populateProperty(systemConfig.getAllProperties(), systemConfigPath);
+        populateProperty(nodeConfig.getAllProperties(), nodeConfigPath);
+
+        for (Map.Entry<String, Map<String, String>> catalogEntry : catalogProperties.entrySet()) {
+            String catalogName = catalogEntry.getKey();
+            Map<String, String> properties = catalogEntry.getValue();
+            Path catalogConfigPath = catalogDirectory.resolve(catalogName + ".properties");
+            populateProperty(properties, catalogConfigPath);
+        }
+    }
+
     private void populateProperty(Map<String, String> properties, Path path)
             throws IOException
     {

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -53,6 +53,7 @@ import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecutio
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutorFactory;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkBootstrapTimer;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkConfInitializer;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkFailure;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSession;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
@@ -315,6 +316,19 @@ public class PrestoSparkQueryRunner
         moduleBuilder.add(new PrestoSparkLocalMetadataStorageModule());
         moduleBuilder.addAll(additionalModules);
 
+        // Create a test PrestoSparkConfiguration for the test injector factory
+        PrestoSparkConfiguration testConfiguration = new PrestoSparkConfiguration(
+                configProperties.build(),
+                "", // pluginsDirectoryPath
+                ImmutableMap.<String, Map<String, String>>of(), // catalogProperties
+                ImmutableMap.of("metadata_storage_type", "LOCAL"), // prestoSparkProperties
+                Optional.empty(), // nativeWorkerConfigProperties
+                Optional.empty(), // eventListenerProperties
+                Optional.empty(), // accessControlProperties
+                Optional.empty(), // sessionPropertyConfigurationProperties
+                Optional.empty(), // functionNamespaceProperties
+                Optional.empty()); // tempStorageProperties
+
         PrestoSparkInjectorFactory injectorFactory = new PrestoSparkInjectorFactory(
                 DRIVER,
                 configProperties.build(),
@@ -327,7 +341,8 @@ public class PrestoSparkQueryRunner
                 Optional.empty(),
                 new SqlParserOptions(),
                 moduleBuilder.build(),
-                true);
+                true, // Set isForTesting to true
+                testConfiguration);
 
         Injector injector = injectorFactory.create(new PrestoSparkBootstrapTimer(systemTicker(), false));
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.units.Duration;
 import com.facebook.presto.Session;
 import com.facebook.presto.client.ServerInfo;
 import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkFatalException;
 import com.facebook.presto.spark.execution.http.TestPrestoSparkHttpClient;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcess;
@@ -27,8 +28,11 @@ import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -98,7 +102,23 @@ public class TestNativeExecutionProcess
                 errorScheduler,
                 SERVER_INFO_JSON_CODEC,
                 workerProperty,
+                createTestPrestoSparkConfiguration(),
                 new FeaturesConfig().setNativeExecutionExecutablePath("/bin/echo"));
         return factory;
+    }
+
+    private PrestoSparkConfiguration createTestPrestoSparkConfiguration()
+    {
+        return new PrestoSparkConfiguration(
+                ImmutableMap.of(), // configProperties
+                "", // pluginsDirectoryPath
+                ImmutableMap.<String, Map<String, String>>of(), // catalogProperties - empty for test
+                ImmutableMap.of("metadata_storage_type", "LOCAL"), // prestoSparkProperties
+                Optional.empty(), // nativeWorkerConfigProperties
+                Optional.empty(), // eventListenerProperties
+                Optional.empty(), // accessControlProperties
+                Optional.empty(), // sessionPropertyConfigurationProperties
+                Optional.empty(), // functionNamespaceProperties
+                Optional.empty()); // tempStorageProperties
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -28,6 +28,7 @@ import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.operator.PageBufferClient;
 import com.facebook.presto.operator.PageTransportErrorException;
 import com.facebook.presto.operator.TaskStats;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkConfiguration;
 import com.facebook.presto.spark.execution.http.server.smile.BaseResponse;
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskInfoFetcher;
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskResultFetcher;
@@ -75,6 +76,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -906,6 +908,7 @@ public class TestPrestoSparkHttpClient
                 scheduledExecutorService,
                 SERVER_INFO_JSON_CODEC,
                 workerProperty,
+                createTestPrestoSparkConfiguration(),
                 new FeaturesConfig());
         return factory.createNativeExecutionProcess(testSessionBuilder().build(), maxErrorDuration);
     }
@@ -1417,5 +1420,20 @@ public class TestPrestoSparkHttpClient
             }
             throw new RuntimeException("response handler is not expected to be called more than once");
         }
+    }
+
+    private PrestoSparkConfiguration createTestPrestoSparkConfiguration()
+    {
+        return new PrestoSparkConfiguration(
+                ImmutableMap.of(), // configProperties
+                "", // pluginsDirectoryPath
+                ImmutableMap.<String, Map<String, String>>of(), // catalogProperties - empty for test
+                ImmutableMap.of("metadata_storage_type", "LOCAL"), // prestoSparkProperties
+                Optional.empty(), // nativeWorkerConfigProperties
+                Optional.empty(), // eventListenerProperties
+                Optional.empty(), // accessControlProperties
+                Optional.empty(), // sessionPropertyConfigurationProperties
+                Optional.empty(), // functionNamespaceProperties
+                Optional.empty());
     }
 }


### PR DESCRIPTION
Summary: Enable Presto Spark native execution to support multiple catalogs by  accessing catalog properties from `PrestoSparkConfiguration` instead of relying on a single catalog from session as done currently.

Differential Revision: D80944841


