### PR TITLE
[native] Enable the use of the cuDF parquet reader

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/CMakeLists.txt
@@ -19,5 +19,10 @@ if(PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR)
   target_link_libraries(presto_connectors presto_flight_connector)
 endif()
 
+if(PRESTO_ENABLE_CUDF)
+  target_link_libraries(presto_connectors velox_cudf_hive_connector
+                        cudf::cudf)
+endif()
+
 target_link_libraries(presto_connectors presto_velox_expr_conversion
                       velox_type_fbhive)

--- a/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
@@ -19,6 +19,10 @@
 #include "presto_cpp/main/connectors/arrow_flight/ArrowPrestoToVeloxConnector.h"
 #endif
 
+#ifdef PRESTO_ENABLE_CUDF
+#include "velox/experimental/cudf/connectors/hive/CudfHiveConnector.h"
+#endif
+
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 
@@ -31,6 +35,16 @@ constexpr char const* kIcebergConnectorName = "iceberg";
 void registerConnectorFactories() {
   // These checks for connector factories can be removed after we remove the
   // registrations from the Velox library.
+#ifdef PRESTO_ENABLE_CUDF
+  if (!velox::connector::hasConnectorFactory(
+          velox::connector::hive::HiveConnectorFactory::kHiveConnectorName)) {
+    velox::connector::registerConnectorFactory(
+        std::make_shared<facebook::velox::cudf_velox::connector::hive::CudfHiveConnectorFactory>());
+    velox::connector::registerConnectorFactory(
+        std::make_shared<facebook::velox::cudf_velox::connector::hive::CudfHiveConnectorFactory>(
+            kHiveHadoop2ConnectorName));
+  }
+#else
   if (!velox::connector::hasConnectorFactory(
           velox::connector::hive::HiveConnectorFactory::kHiveConnectorName)) {
     velox::connector::registerConnectorFactory(
@@ -39,6 +53,8 @@ void registerConnectorFactories() {
         std::make_shared<velox::connector::hive::HiveConnectorFactory>(
             kHiveHadoop2ConnectorName));
   }
+#endif
+
   if (!velox::connector::hasConnectorFactory(
           velox::connector::tpch::TpchConnectorFactory::kTpchConnectorName)) {
     velox::connector::registerConnectorFactory(

--- a/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(presto_velox_expr_conversion velox_presto_types
 
 add_library(presto_types PrestoToVeloxQueryPlan.cpp VeloxPlanValidator.cpp
                          PrestoToVeloxSplit.cpp)
+target_compile_definitions(presto_types PUBLIC VELOX_ENABLE_BACKWARD_COMPATIBILITY)
 target_link_libraries(
   presto_types
   presto_velox_expr_conversion


### PR DESCRIPTION
## Description
Supersedes #25376 

This PR lets the native worker use the cuDF parquet reader by using a `CudfHiveConnector` that makes a datasource that produces `CudfVector` batches when cudf integration is enabled in velox.
`CudfHiveConnector` extends the `HiveConnector` which allows fallback to the CPU for any unsupported features.

## Motivation and Context
By default the Velox readers produce a RowVector which needs to be both converted and copied into a CudfVector. This conversion can be very expensive and we'd like to avoid this. By leveraging the GPU side Parquet code in cuDF, plus leveraging GPUDirect RDMA, we can skip the CPU path entirely.

## Impact
No impact when presto is compiled with cmake flag `PRESTO_ENABLE_CUDF=OFF`. 
When this flag is turned on, we register a `CudfHiveConnectorFactory` instead of `HiveConnectorFactory`. This `CudfHiveConnectorFactory` only creates `CudfVector` producing datasource if `facebook::velox::cudf_velox::cudfIsRegistered()` returns true.
It defaults to the HiveConnector behavior otherwise.

## Test Plan
I've run TPC-H queries both with, and without the cuDF tablescan enabled.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Improve GPU TableScan performance: if Presto C++ is built with cuDF integration and cuDF operator replacement is enabled, Hive splits can be read by cuDF's parquet library instead of Velox's parquet library
```

