### PR TITLE
Add @pdabre12 as module committer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -111,9 +111,9 @@ CODEOWNERS @prestodb/team-tsc
 
 #####################################################################
 # Prestissimo module
-/presto-native-execution @prestodb/team-velox
-/presto-native-sidecar-plugin @prestodb/team-velox
-/presto-native-tests @prestodb/team-velox
+/presto-native-execution @prestodb/team-velox @prestodb/committers
+/presto-native-sidecar-plugin @pdabre12 @prestodb/team-velox @prestodb/committers
+/presto-native-tests @prestodb/team-velox @prestodb/committers
 /.github/workflows/prestocpp-* @prestodb/team-velox @prestodb/committers
 
 #####################################################################


### PR DESCRIPTION
## Description
@pdabre12 has been voted as module committer for the Presto sidecar module.

Also, I fixed a bug that project committers could not approve some C++ code.  Per our contributing guide, project committers must be capable of approving all code (although C++ module committers are preferred for approving and merging C++ code).

## Motivation and Context
More committers.

## Impact
@pdabre12 will be able to approve code in the sidecar module.

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

