### PR TITLE
Convert class to components to function components, pt. 2

### DIFF
--- a/presto-ui/src/components/QueryDetail.jsx
+++ b/presto-ui/src/components/QueryDetail.jsx
@@ -776,43 +776,41 @@ const StageSummary = ({ stage }) => {
     );
 };
 
-class StageList extends React.Component {
-    getStages(stage) {
+const StageList = ({ outputStage }) => {
+    const getStages = (stage) => {
         if (stage === undefined || !stage.hasOwnProperty('subStages')) {
             return []
         }
 
-        return [].concat.apply(stage, stage.subStages.map(this.getStages, this));
-    }
+        return [].concat.apply(stage, stage.subStages.map(getStages));
+    };
 
-    render() {
-        const stages = this.getStages(this.props.outputStage);
+    const stages = getStages(outputStage);
 
-        if (stages === undefined || stages.length === 0) {
-            return (
-                <div className="row">
-                    <div className="col-12">
-                        No stage information available.
-                    </div>
-                </div>
-            );
-        }
-
-        const renderedStages = stages.map(stage => <StageSummary key={stage.stageId} stage={stage}/>);
-
+    if (stages === undefined || stages.length === 0) {
         return (
             <div className="row">
                 <div className="col-12">
-                    <table className="table" id="stage-list">
-                        <tbody>
-                        {renderedStages}
-                        </tbody>
-                    </table>
+                    No stage information available.
                 </div>
             </div>
         );
     }
-}
+
+    const renderedStages = stages.map(stage => <StageSummary key={stage.stageId} stage={stage}/>);
+
+    return (
+        <div className="row">
+            <div className="col-12">
+                <table className="table" id="stage-list">
+                    <tbody>
+                    {renderedStages}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+};
 
 const SMALL_SPARKLINE_PROPERTIES = {
     width: '100%',

--- a/presto-ui/src/components/QueryDetail.jsx
+++ b/presto-ui/src/components/QueryDetail.jsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import DataTable, {createTheme} from 'react-data-table-component';
 
 import {
@@ -845,231 +845,260 @@ const TASK_FILTER = {
     },
 };
 
-export class QueryDetail extends React.Component {
+// Static helper functions moved outside the component
+const formatStackTrace = (info) => {
+    return formatStackTraceHelper(info, [], "", "");
+};
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            query: null,
-            lastSnapshotStages: null,
+const formatStackTraceHelper = (info, parentStack, prefix, linePrefix) => {
+    let s = linePrefix + prefix + failureInfoToString(info) + "\n";
 
-            lastScheduledTime: 0,
-            lastCpuTime: 0,
-            lastRowInput: 0,
-            lastByteInput: 0,
-
-            scheduledTimeRate: [],
-            cpuTimeRate: [],
-            rowInputRate: [],
-            byteInputRate: [],
-
-            reservedMemory: [],
-
-            initialized: false,
-            ended: false,
-
-            lastRefresh: null,
-            lastRender: null,
-
-            stageRefresh: true,
-        };
-
-        this.refreshLoop = this.refreshLoop.bind(this);
-    }
-
-    static formatStackTrace(info) {
-        return QueryDetail.formatStackTraceHelper(info, [], "", "");
-    }
-
-    static formatStackTraceHelper(info, parentStack, prefix, linePrefix) {
-        let s = linePrefix + prefix + QueryDetail.failureInfoToString(info) + "\n";
-
-        if (info.stack) {
-            let sharedStackFrames = 0;
-            if (parentStack !== null) {
-                sharedStackFrames = QueryDetail.countSharedStackFrames(info.stack, parentStack);
-            }
-
-            for (let i = 0; i < info.stack.length - sharedStackFrames; i++) {
-                s += linePrefix + "\tat " + info.stack[i] + "\n";
-            }
-            if (sharedStackFrames !== 0) {
-                s += linePrefix + "\t... " + sharedStackFrames + " more" + "\n";
-            }
+    if (info.stack) {
+        let sharedStackFrames = 0;
+        if (parentStack !== null) {
+            sharedStackFrames = countSharedStackFrames(info.stack, parentStack);
         }
 
-        if (info.suppressed) {
-            for (let i = 0; i < info.suppressed.length; i++) {
-                s += QueryDetail.formatStackTraceHelper(info.suppressed[i], info.stack, "Suppressed: ", linePrefix + "\t");
-            }
+        for (let i = 0; i < info.stack.length - sharedStackFrames; i++) {
+            s += linePrefix + "\tat " + info.stack[i] + "\n";
         }
-
-        if (info.cause) {
-            s += QueryDetail.formatStackTraceHelper(info.cause, info.stack, "Caused by: ", linePrefix);
+        if (sharedStackFrames !== 0) {
+            s += linePrefix + "\t... " + sharedStackFrames + " more" + "\n";
         }
-
-        return s;
     }
 
-    static countSharedStackFrames(stack, parentStack) {
-        let n = 0;
-        const minStackLength = Math.min(stack.length, parentStack.length);
-        while (n < minStackLength && stack[stack.length - 1 - n] === parentStack[parentStack.length - 1 - n]) {
-            n++;
+    if (info.suppressed) {
+        for (let i = 0; i < info.suppressed.length; i++) {
+            s += formatStackTraceHelper(info.suppressed[i], info.stack, "Suppressed: ", linePrefix + "\t");
         }
-        return n;
     }
 
-    static failureInfoToString(t) {
-        return (t.message !== null) ? (t.type + ": " + t.message) : t.type;
+    if (info.cause) {
+        s += formatStackTraceHelper(info.cause, info.stack, "Caused by: ", linePrefix);
     }
 
-    resetTimer() {
-        clearTimeout(this.timeoutId);
+    return s;
+}
+
+const countSharedStackFrames = (stack, parentStack) => {
+    let n = 0;
+    const minStackLength = Math.min(stack.length, parentStack.length);
+    while (n < minStackLength && stack[stack.length - 1 - n] === parentStack[parentStack.length - 1 - n]) {
+        n++;
+    }
+    return n;
+}
+
+const failureInfoToString = (t) => {
+    return (t.message !== null) ? (t.type + ": " + t.message) : t.type;
+}
+
+const getQueryURL = (id) => {
+    if (!id || typeof id !== 'string' || id.length === 0) {
+        return "/v1/query/undefined";
+    }
+    const sanitizedId = id.replace(/[^a-z0-9_]/gi, '');
+    return sanitizedId.length > 0 ? `/v1/query/${encodeURIComponent(sanitizedId)}` : "/v1/query/undefined";
+}
+
+const isSparklineDataLoaded = (data) => {
+    return data.every((d) => d.length > 0);
+}
+
+export const QueryDetail = () => {
+    const [query, setQuery] = useState(null);
+    const [lastSnapshotStages, setLastSnapshotStages] = useState(null);
+    const [lastScheduledTime, setLastScheduledTime] = useState(0);
+    const [lastCpuTime, setLastCpuTime] = useState(0);
+    const [lastRowInput, setLastRowInput] = useState(0);
+    const [lastByteInput, setLastByteInput] = useState(0);
+    const [scheduledTimeRate, setScheduledTimeRate] = useState([]);
+    const [cpuTimeRate, setCpuTimeRate] = useState([]);
+    const [rowInputRate, setRowInputRate] = useState([]);
+    const [byteInputRate, setByteInputRate] = useState([]);
+    const [reservedMemory, setReservedMemory] = useState([]);
+    const [initialized, setInitialized] = useState(false);
+    const [ended, setEnded] = useState(false);
+    const [lastRefresh, setLastRefresh] = useState(null);
+    const [lastRender, setLastRender] = useState(null);
+    const [stageRefresh, setStageRefresh] = useState(true);
+    
+    const timeoutIdRef = useRef(null);
+    const endedRef = useRef(false);
+    const queryRef = useRef(null);
+
+    const resetTimer = () => {
+        clearTimeout(timeoutIdRef.current);
+        // console.log("QUERY", query, "ENDED", ended);
         // stop refreshing when query finishes or fails
-        if (this.state.query === null || !this.state.ended) {
+        if (queryRef.current === null || !endedRef.current || !isSparklineDataLoaded([cpuTimeRate, rowInputRate, byteInputRate, reservedMemory])) {
             // task.info-update-interval is set to 3 seconds by default
-            this.timeoutId = setTimeout(this.refreshLoop, 3000);
+            timeoutIdRef.current = setTimeout(() => {
+                if (queryRef.current === null || !endedRef.current) {
+                    return;
+                }
+                refreshLoop();
+            }, 3000);
         }
-    }
+    };
 
-    static getQueryURL(id) {
-        if (!id || typeof id !== 'string' || id.length === 0) {
-            return "/v1/query/undefined";
-        }
-        const sanitizedId = id.replace(/[^a-z0-9_]/gi, '');
-        return sanitizedId.length > 0 ? `/v1/query/${encodeURIComponent(sanitizedId)}` : "/v1/query/undefined";
-    }
+    // if the query is not ended, keep polling for updates
 
-
-    refreshLoop() {
-        clearTimeout(this.timeoutId); // to stop multiple series of refreshLoop from going on simultaneously
+    const refreshLoop = useCallback(() => {
+        clearTimeout(timeoutIdRef.current); // to stop multiple series of refreshLoop from going on simultaneously
         const queryId = getFirstParameter(window.location.search);
+        if (ended) {
+            return;
+        }
 
-        $.get(QueryDetail.getQueryURL(queryId), function (query) {
-            let lastSnapshotStages = this.state.lastSnapshotStage;
-            if (this.state.stageRefresh) {
-                lastSnapshotStages = query.outputStage;
+        $.get(getQueryURL(queryId), function (queryData) {
+            let currentLastSnapshotStages = lastSnapshotStages;
+            if (stageRefresh) {
+                currentLastSnapshotStages = queryData.outputStage;
             }
 
-            let lastRefresh = this.state.lastRefresh;
-            const lastScheduledTime = this.state.lastScheduledTime;
-            const lastCpuTime = this.state.lastCpuTime;
-            const lastRowInput = this.state.lastRowInput;
-            const lastByteInput = this.state.lastByteInput;
-            const alreadyEnded = this.state.ended;
+            let currentLastRefresh = lastRefresh;
+            const currentLastScheduledTime = lastScheduledTime;
+            const currentLastCpuTime = lastCpuTime;
+            const currentLastRowInput = lastRowInput;
+            const currentLastByteInput = lastByteInput;
             const nowMillis = Date.now();
+            const newEnded = queryData.finalQueryInfo;
+            console.log("refresh loop, checking ended and queryEnded", ended, newEnded);
 
-            this.setState({
-                query: query,
-                lastSnapshotStage: lastSnapshotStages,
-
-                lastScheduledTime: parseDuration(query.queryStats.totalScheduledTime),
-                lastCpuTime: parseDuration(query.queryStats.totalCpuTime),
-                lastRowInput: query.queryStats.processedInputPositions,
-                lastByteInput: parseDataSize(query.queryStats.processedInputDataSize),
-
-                initialized: true,
-                ended: query.finalQueryInfo,
-
-                lastRefresh: nowMillis,
-            });
+            setQuery(queryData);
+            setLastSnapshotStages(currentLastSnapshotStages);
+            setLastScheduledTime(parseDuration(queryData.queryStats.totalScheduledTime));
+            setLastCpuTime(parseDuration(queryData.queryStats.totalCpuTime));
+            setLastRowInput(queryData.queryStats.processedInputPositions);
+            setLastByteInput(parseDataSize(queryData.queryStats.processedInputDataSize));
+            setInitialized(true);
+            setEnded(newEnded);
+            setLastRefresh(nowMillis);
 
             // i.e. don't show sparklines if we've already decided not to update or if we don't have one previous measurement
-            if (alreadyEnded || (lastRefresh === null && query.state === "RUNNING")) {
-                this.resetTimer();
+            if (ended || (currentLastRefresh === null && queryData.state === "RUNNING")) {
+                // Pass the new `queryData` and `newEnded` to `resetTimer` to avoid the stale closure
+                resetTimer();
                 return;
             }
 
-            if (lastRefresh === null) {
-                lastRefresh = nowMillis - parseDuration(query.queryStats.elapsedTime);
+            if (currentLastRefresh === null) {
+                currentLastRefresh = nowMillis - parseDuration(queryData.queryStats.elapsedTime);
             }
 
-            const elapsedSecsSinceLastRefresh = (nowMillis - lastRefresh) / 1000.0;
+            const elapsedSecsSinceLastRefresh = (nowMillis - currentLastRefresh) / 1000.0;
             if (elapsedSecsSinceLastRefresh >= 0) {
-                const currentScheduledTimeRate = (parseDuration(query.queryStats.totalScheduledTime) - lastScheduledTime) / (elapsedSecsSinceLastRefresh * 1000);
-                const currentCpuTimeRate = (parseDuration(query.queryStats.totalCpuTime) - lastCpuTime) / (elapsedSecsSinceLastRefresh * 1000);
-                const currentRowInputRate = (query.queryStats.processedInputPositions - lastRowInput) / elapsedSecsSinceLastRefresh;
-                const currentByteInputRate = (parseDataSize(query.queryStats.processedInputDataSize) - lastByteInput) / elapsedSecsSinceLastRefresh;
-                this.setState({
-                    scheduledTimeRate: addToHistory(currentScheduledTimeRate, this.state.scheduledTimeRate),
-                    cpuTimeRate: addToHistory(currentCpuTimeRate, this.state.cpuTimeRate),
-                    rowInputRate: addToHistory(currentRowInputRate, this.state.rowInputRate),
-                    byteInputRate: addToHistory(currentByteInputRate, this.state.byteInputRate),
-                    reservedMemory: addToHistory(parseDataSize(query.queryStats.userMemoryReservation), this.state.reservedMemory),
-                });
+                const currentScheduledTimeRate = (parseDuration(queryData.queryStats.totalScheduledTime) - currentLastScheduledTime) / (elapsedSecsSinceLastRefresh * 1000);
+                const currentCpuTimeRate = (parseDuration(queryData.queryStats.totalCpuTime) - currentLastCpuTime) / (elapsedSecsSinceLastRefresh * 1000);
+                const currentRowInputRate = (queryData.queryStats.processedInputPositions - currentLastRowInput) / elapsedSecsSinceLastRefresh;
+                const currentByteInputRate = (parseDataSize(queryData.queryStats.processedInputDataSize) - currentLastByteInput) / elapsedSecsSinceLastRefresh;
+                console.log("updating time and input rates", currentScheduledTimeRate, currentCpuTimeRate, currentRowInputRate, currentByteInputRate);
+                
+                setScheduledTimeRate(prev => addToHistory(currentScheduledTimeRate, prev));
+                setCpuTimeRate(prev => addToHistory(currentCpuTimeRate, prev));
+                setRowInputRate(prev => addToHistory(currentRowInputRate, prev));
+                setByteInputRate(prev => addToHistory(currentByteInputRate, prev));
+                setReservedMemory(prev => addToHistory(parseDataSize(queryData.queryStats.userMemoryReservation), prev));
             }
-            this.resetTimer();
-        }.bind(this))
+            // Pass the new `queryData` and `newEnded` to `resetTimer` to avoid the stale closure
+            resetTimer();
+        })
             .fail(() => {
-                this.setState({
-                    initialized: true,
-                });
-                this.resetTimer();
+                setInitialized(true);
+                // Pass the new `query` (null) and the old `ended` value
+                resetTimer();
             });
-    }
+    }, [query, ended, lastSnapshotStages, stageRefresh, lastRefresh, lastScheduledTime, lastCpuTime, lastRowInput, lastByteInput, resetTimer]);
 
-    handleStageRefreshClick() {
-        if (this.state.stageRefresh) {
-            this.setState({
-                stageRefresh: false,
-                lastSnapshotStages: this.state.query.outputStage,
+    useEffect(() => {
+        refreshLoop();
+        
+        return () => {
+            clearTimeout(timeoutIdRef.current);
+        };
+    }, []);
+
+    useEffect(() => {
+        console.log("useEffect for ended", ended);
+    }, [ended]);
+
+    useEffect(() => {
+        endedRef.current = ended;
+        queryRef.current = query;
+    }, [query]);
+
+    // Syntax highlighting effect - runs when query data is available
+    useEffect(() => {
+        if (query && query.query) {
+            $('#query').each((i, block) => {
+                hljs.highlightBlock(block);
             });
         }
-        else {
-            this.setState({
-                stageRefresh: true,
+        
+        if (query && query.preparedQuery) {
+            $('#prepared-query').each((i, block) => {
+                hljs.highlightBlock(block);
             });
         }
-    }
+    }, [query?.query, query?.preparedQuery]);
 
-    renderStageRefreshButton() {
-        if (this.state.stageRefresh) {
-            return <button className="btn btn-info live-button rounded-0" onClick={this.handleStageRefreshClick.bind(this)}>Auto-Refresh: On</button>
-        }
-        else {
-            return <button className="btn btn-info live-button rounded-0" onClick={this.handleStageRefreshClick.bind(this)}>Auto-Refresh: Off</button>
-        }
-    }
+    // ComponentDidUpdate equivalent for sparklines and tooltips
+    useEffect(() => {
 
-    componentDidMount() {
-        this.refreshLoop();
-    }
-
-    componentDidUpdate() {
+        //   console.log("ABOUT TO UPDATE SPARKLINE")
         // prevent multiple calls to componentDidUpdate (resulting from calls to setState or otherwise) within the refresh interval from re-rendering sparklines/charts
-        if (this.state.lastRender === null || (Date.now() - this.state.lastRender) >= 1000) {
-            const renderTimestamp = Date.now();
-            $('#scheduled-time-rate-sparkline').sparkline(this.state.scheduledTimeRate, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {
-                chartRangeMin: 0,
-                numberFormatter: precisionRound
-            }));
-            $('#cpu-time-rate-sparkline').sparkline(this.state.cpuTimeRate, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {chartRangeMin: 0, numberFormatter: precisionRound}));
-            $('#row-input-rate-sparkline').sparkline(this.state.rowInputRate, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {numberFormatter: formatCount}));
-            $('#byte-input-rate-sparkline').sparkline(this.state.byteInputRate, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {numberFormatter: formatDataSize}));
-            $('#reserved-memory-sparkline').sparkline(this.state.reservedMemory, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {numberFormatter: formatDataSize}));
+    //   console.log("LAST RENDER", lastRender)
+    //   console.log("RENDER TIME", Date.now() - lastRender)
+        console.log("trying to update sparkline");
+        // if (lastRender === null || (Date.now() - lastRender) >= 1000) {
+                const renderTimestamp = Date.now();
+                $('#scheduled-time-rate-sparkline').sparkline(scheduledTimeRate, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {
+                    chartRangeMin: 0,
+                    numberFormatter: precisionRound
+                }));
+                console.log("updating sparkline - data", cpuTimeRate, rowInputRate, byteInputRate, reservedMemory)
+                const ids = [
+                '#scheduled-time-rate-sparkline',
+                '#cpu-time-rate-sparkline',
+                '#row-input-rate-sparkline',
+                '#byte-input-rate-sparkline',
+                '#reserved-memory-sparkline',
+                ];
+                console.log(ids.map(sel => document.querySelector(sel)));
+                $('#cpu-time-rate-sparkline').sparkline(cpuTimeRate, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {chartRangeMin: 0, numberFormatter: precisionRound}));
+                $('#row-input-rate-sparkline').sparkline(rowInputRate, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {numberFormatter: formatCount}));
+                $('#byte-input-rate-sparkline').sparkline(byteInputRate, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {numberFormatter: formatDataSize}));
+                $('#reserved-memory-sparkline').sparkline(reservedMemory, $.extend({}, SMALL_SPARKLINE_PROPERTIES, {numberFormatter: formatDataSize}));
 
-            if (this.state.lastRender === null) {
-                $('#query').each((i, block) => {
-                    hljs.highlightBlock(block);
-                });
-
-                $('#prepared-query').each((i, block) => {
-                    hljs.highlightBlock(block);
-                });
-            }
-
-            this.setState({
-                lastRender: renderTimestamp,
-            });
-        }
+                setLastRender(renderTimestamp);
+        // }
 
         $('[data-bs-toggle="tooltip"]')?.tooltip?.();
         new Clipboard('.copy-button');
-    }
+    }, [initialized, scheduledTimeRate, cpuTimeRate, rowInputRate, byteInputRate, reservedMemory, ended]);
 
-    renderStages() {
-        if (this.state.lastSnapshotStage === null) {
+    const handleStageRefreshClick = () => {
+        if (stageRefresh) {
+            setStageRefresh(false);
+            setLastSnapshotStages(query.outputStage);
+        }
+        else {
+            setStageRefresh(true);
+        }
+    };
+
+    const renderStageRefreshButton = () => {
+        if (stageRefresh) {
+            return <button className="btn btn-info live-button rounded-0" onClick={handleStageRefreshClick}>Auto-Refresh: On</button>
+        }
+        else {
+            return <button className="btn btn-info live-button rounded-0" onClick={handleStageRefreshClick}>Auto-Refresh: Off</button>
+        }
+    };
+
+    const renderStages = () => {
+        if (lastSnapshotStages === null) {
             return;
         }
 
@@ -1084,7 +1113,7 @@ export class QueryDetail extends React.Component {
                             <tbody>
                             <tr>
                                 <td>
-                                    {this.renderStageRefreshButton()}
+                                    {renderStageRefreshButton()}
                                 </td>
                             </tr>
                             </tbody>
@@ -1093,15 +1122,14 @@ export class QueryDetail extends React.Component {
                 </div>
                 <div className="row">
                     <div className="col-12">
-                        <StageList key={this.state.query.queryId} outputStage={this.state.lastSnapshotStage}/>
+                        <StageList key={query.queryId} outputStage={lastSnapshotStages}/>
                     </div>
                 </div>
             </div>
         );
-    }
+    };
 
-    renderPreparedQuery() {
-        const query = this.state.query;
+    const renderPreparedQuery = () => {
         if (!query.hasOwnProperty('preparedQuery') || query.preparedQuery === null) {
             return;
         }
@@ -1121,16 +1149,14 @@ export class QueryDetail extends React.Component {
                 </pre>
             </div>
         );
-    }
+    };
 
-    renderSessionProperties() {
-        const query = this.state.query;
-
+    const renderSessionProperties = () => {
         const properties = [];
         for (let property in query.session.systemProperties) {
             if (query.session.systemProperties.hasOwnProperty(property)) {
                 properties.push(
-                    <span>- {property + "=" + query.session.systemProperties[property]} <br/></span>
+                    <span key={property}>- {property + "=" + query.session.systemProperties[property]} <br/></span>
                 );
             }
         }
@@ -1140,7 +1166,7 @@ export class QueryDetail extends React.Component {
                 for (let property in query.session.catalogProperties[catalog]) {
                     if (query.session.catalogProperties[catalog].hasOwnProperty(property)) {
                         properties.push(
-                            <span>- {catalog + "." + property + "=" + query.session.catalogProperties[catalog][property]} <br/></span>
+                            <span key={catalog + "." + property}>- {catalog + "." + property + "=" + query.session.catalogProperties[catalog][property]} <br/></span>
                         );
                     }
                 }
@@ -1148,10 +1174,9 @@ export class QueryDetail extends React.Component {
         }
 
         return properties;
-    }
+    };
 
-    renderResourceEstimates() {
-        const query = this.state.query;
+    const renderResourceEstimates = () => {
         const estimates = query.session.resourceEstimates;
         const renderedEstimates = [];
 
@@ -1164,16 +1189,15 @@ export class QueryDetail extends React.Component {
                 }
 
                 renderedEstimates.push(
-                    <span>- {snakeCased + "=" + query.session.resourceEstimates[resource]} <br/></span>
+                    <span key={resource}>- {snakeCased + "=" + query.session.resourceEstimates[resource]} <br/></span>
                 )
             }
         }
 
         return renderedEstimates;
-    }
+    };
 
-    renderWarningInfo() {
-        const query = this.state.query;
+    const renderWarningInfo = () => {
         if (query.warnings.length > 0) {
             return (
                 <div className="row">
@@ -1181,8 +1205,8 @@ export class QueryDetail extends React.Component {
                         <h3>Warnings</h3>
                         <hr className="h3-hr"/>
                         <table className="table" id="warnings-table">
-                            {query.warnings.map((warning) =>
-                                <tr>
+                            {query.warnings.map((warning, index) =>
+                                <tr key={index}>
                                     <td>
                                         {warning.warningCode.name}
                                     </td>
@@ -1199,10 +1223,9 @@ export class QueryDetail extends React.Component {
         else {
             return null;
         }
-    }
+    };
 
-    renderRuntimeStats() {
-        const query = this.state.query;
+    const renderRuntimeStats = () => {
         if (query.queryStats.runtimeStats === undefined) {
             return null;
         }
@@ -1218,10 +1241,9 @@ export class QueryDetail extends React.Component {
                 </div>
             </div>
         );
-    }
+    };
 
-    renderFailureInfo() {
-        const query = this.state.query;
+    const renderFailureInfo = () => {
         if (query.failureInfo) {
             return (
                 <div className="row">
@@ -1243,7 +1265,7 @@ export class QueryDetail extends React.Component {
                                     Error Code
                                 </td>
                                 <td className="info-text">
-                                    {query.errorCode.name + " (" + this.state.query.errorCode.code + ")"}
+                                    {query.errorCode.name + " (" + query.errorCode.code + ")"}
                                 </td>
                             </tr>
                             <tr>
@@ -1256,7 +1278,7 @@ export class QueryDetail extends React.Component {
                                 </td>
                                 <td className="info-text">
                                         <pre id="stack-trace">
-                                            {QueryDetail.formatStackTrace(query.failureInfo)}
+                                            {formatStackTrace(query.failureInfo)}
                                         </pre>
                                 </td>
                             </tr>
@@ -1269,482 +1291,478 @@ export class QueryDetail extends React.Component {
         else {
             return "";
         }
-    }
+    };
 
-    render() {
-        const query = this.state.query;
-
-        if (query === null || this.state.initialized === false) {
-            let label = (<div className="loader">Loading...</div>);
-            if (this.state.initialized) {
-                label = "Query not found";
-            }
-            return (
-                <div className="row error-message">
-                    <div className="col-12"><h4>{label}</h4></div>
-                </div>
-            );
+    if (query === null || initialized === false) {
+        let label = (<div className="loader">Loading...</div>);
+        if (initialized) {
+            label = "Query not found";
         }
-
         return (
-            <div>
-                <QueryHeader query={query}/>
-                <div className="row mt-3">
-                    <div className="col-6">
-                        <h3>Session</h3>
-                        <hr className="h3-hr"/>
-                        <table className="table">
-                            <tbody>
-                            <tr>
-                                <td className="info-title">
-                                    User
-                                </td>
-                                <td className="info-text wrap-text">
-                                    <span id="query-user">{query.session.user}</span>
-                                    &nbsp;&nbsp;
-                                    <a href="#" className="copy-button" data-clipboard-target="#query-user" data-bs-toggle="tooltip" data-bs-placement="right"
-                                       title="Copy to clipboard">
-                                        <span className="bi bi-copy" aria-hidden="true" alt="Copy to clipboard"/>
-                                    </a>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Principal
-                                </td>
-                                <td className="info-text wrap-text">
-                                    {query.session.principal}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Source
-                                </td>
-                                <td className="info-text wrap-text">
-                                    {query.session.source}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Catalog
-                                </td>
-                                <td className="info-text">
-                                    {query.session.catalog}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Schema
-                                </td>
-                                <td className="info-text">
-                                    {query.session.schema}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Client Address
-                                </td>
-                                <td className="info-text">
-                                    {query.session.remoteUserAddress}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Client Tags
-                                </td>
-                                <td className="info-text">
-                                    {query.session.clientTags.join(", ")}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Session Properties
-                                </td>
-                                <td className="info-text wrap-text">
-                                    {this.renderSessionProperties()}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Resource Estimates
-                                </td>
-                                <td className="info-text wrap-text">
-                                    {this.renderResourceEstimates()}
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div className="col-6">
-                        <h3>Execution</h3>
-                        <hr className="h3-hr"/>
-                        <table className="table">
-                            <tbody>
-                            <tr>
-                                <td className="info-title">
-                                    Resource Group
-                                </td>
-                                <td className="info-text wrap-text">
-                                    {query.resourceGroupId ? query.resourceGroupId.join(".") : "n/a"}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Submission Time
-                                </td>
-                                <td className="info-text">
-                                    {formatShortDateTime(new Date(query.queryStats.createTime))}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Completion Time
-                                </td>
-                                <td className="info-text">
-                                    {new Date(query.queryStats.endTime).getTime() !== 0 ? formatShortDateTime(new Date(query.queryStats.endTime)) : ""}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Elapsed Time
-                                </td>
-                                <td className="info-text">
-                                    {query.queryStats.elapsedTime}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Prerequisites Wait Time
-                                </td>
-                                <td className="info-text">
-                                    {query.queryStats.waitingForPrerequisitesTime}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Queued Time
-                                </td>
-                                <td className="info-text">
-                                    {query.queryStats.queuedTime}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Planning Time
-                                </td>
-                                <td className="info-text">
-                                    {query.queryStats.totalPlanningTime}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Execution Time
-                                </td>
-                                <td className="info-text">
-                                    {query.queryStats.executionTime}
-                                </td>
-                            </tr>
-                            <tr>
-                                <td className="info-title">
-                                    Coordinator
-                                </td>
-                                <td className="info-text">
-                                    {getHostname(query.self)}
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div className="row">
-                    <div className="col-12">
-                        <div className="row">
-                            <div className="col-6">
-                                <h3>Resource Utilization Summary</h3>
-                                <hr className="h3-hr"/>
-                                <table className="table">
-                                    <tbody>
-                                    <tr>
-                                        <td className="info-title">
-                                            CPU Time
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.totalCpuTime}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Scheduled Time
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.totalScheduledTime}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Blocked Time
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.totalBlockedTime}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Input Rows
-                                        </td>
-                                        <td className="info-text">
-                                            {formatCount(query.queryStats.processedInputPositions)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Input Data
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.processedInputDataSize}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Raw Input Rows
-                                        </td>
-                                        <td className="info-text">
-                                            {formatCount(query.queryStats.rawInputPositions)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Raw Input Data
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.rawInputDataSize}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            <span className="text" data-bs-toggle="tooltip" data-bs-placement="right"
-                                                  title="The total number of rows shuffled across all query stages">
-                                                Shuffled Rows
-                                            </span>
-                                        </td>
-                                        <td className="info-text">
-                                            {formatCount(query.queryStats.shuffledPositions)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            <span className="text" data-bs-toggle="tooltip" data-bs-placement="right"
-                                                  title="The total number of bytes shuffled across all query stages">
-                                                Shuffled Data
-                                            </span>
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.shuffledDataSize}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Peak User Memory
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.peakUserMemoryReservation}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Peak Total Memory
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.peakTotalMemoryReservation}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Memory Pool
-                                        </td>
-                                        <td className="info-text">
-                                            {query.memoryPool}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Cumulative User Memory
-                                        </td>
-                                        <td className="info-text">
-                                            {formatDataSize(query.queryStats.cumulativeUserMemory / 1000.0)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Cumulative Total
-                                        </td>
-                                        <td className="info-text">
-                                            {formatDataSize(query.queryStats.cumulativeTotalMemory / 1000.0)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Output Rows
-                                        </td>
-                                        <td className="info-text">
-                                            {formatCount(query.queryStats.outputPositions)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Output Data
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.outputDataSize}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Written Output Rows
-                                        </td>
-                                        <td className="info-text">
-                                            {formatCount(query.queryStats.writtenOutputPositions)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Written Output Logical Data Size
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.writtenOutputLogicalDataSize}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Written Output Physical Data Size
-                                        </td>
-                                        <td className="info-text">
-                                            {query.queryStats.writtenOutputPhysicalDataSize}
-                                        </td>
-                                    </tr>
-                                    {parseDataSize(query.queryStats.spilledDataSize) > 0 &&
-                                        <tr>
-                                            <td className="info-title">
-                                                Spilled Data
-                                            </td>
-                                            <td className="info-text">
-                                                {query.queryStats.spilledDataSize}
-                                            </td>
-                                        </tr>
-                                    }
-                                    </tbody>
-                                </table>
-                            </div>
-                            <div className="col-6">
-                                <h3>Timeline</h3>
-                                <hr className="h3-hr"/>
-                                <table className="table">
-                                    <tbody>
-                                    <tr>
-                                        <td className="info-title">
-                                            Parallelism
-                                        </td>
-                                        <td rowSpan="2">
-                                            <div className="query-stats-sparkline-container">
-                                                <span className="sparkline" id="cpu-time-rate-sparkline"><div className="loader">Loading ...</div></span>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <tr className="tr-noborder">
-                                        <td className="info-sparkline-text">
-                                            {formatCount(this.state.cpuTimeRate[this.state.cpuTimeRate.length - 1])}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Scheduled Time/s
-                                        </td>
-                                        <td rowSpan="2">
-                                            <div className="query-stats-sparkline-container">
-                                                <span className="sparkline" id="scheduled-time-rate-sparkline"><div className="loader">Loading ...</div></span>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <tr className="tr-noborder">
-                                        <td className="info-sparkline-text">
-                                            {formatCount(this.state.scheduledTimeRate[this.state.scheduledTimeRate.length - 1])}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Input Rows/s
-                                        </td>
-                                        <td rowSpan="2">
-                                            <div className="query-stats-sparkline-container">
-                                                <span className="sparkline" id="row-input-rate-sparkline"><div className="loader">Loading ...</div></span>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <tr className="tr-noborder">
-                                        <td className="info-sparkline-text">
-                                            {formatCount(this.state.rowInputRate[this.state.rowInputRate.length - 1])}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Input Bytes/s
-                                        </td>
-                                        <td rowSpan="2">
-                                            <div className="query-stats-sparkline-container">
-                                                <span className="sparkline" id="byte-input-rate-sparkline"><div className="loader">Loading ...</div></span>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <tr className="tr-noborder">
-                                        <td className="info-sparkline-text">
-                                            {formatDataSize(this.state.byteInputRate[this.state.byteInputRate.length - 1])}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="info-title">
-                                            Memory Utilization
-                                        </td>
-                                        <td rowSpan="2">
-                                            <div className="query-stats-sparkline-container">
-                                                <span className="sparkline" id="reserved-memory-sparkline"><div className="loader">Loading ...</div></span>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <tr className="tr-noborder">
-                                        <td className="info-sparkline-text">
-                                            {formatDataSize(this.state.reservedMemory[this.state.reservedMemory.length - 1])}
-                                        </td>
-                                    </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                {this.renderRuntimeStats()}
-                {this.renderWarningInfo()}
-                {this.renderFailureInfo()}
-                <div className="row">
-                    <div className="col-12">
-                        <h3>
-                            Query
-                            <a className="btn copy-button" data-clipboard-target="#query-text" data-bs-toggle="tooltip" data-bs-placement="right" title="Copy to clipboard">
-                                <span className="bi bi-copy" aria-hidden="true" alt="Copy to clipboard"/>
-                            </a>
-                        </h3>
-                        <pre id="query">
-                            <code className="lang-sql" id="query-text">
-                                {query.query}
-                            </code>
-                        </pre>
-                    </div>
-                    {this.renderPreparedQuery()}
-                </div>
-                {this.renderStages()}
+            <div className="row error-message">
+                <div className="col-12"><h4>{label}</h4></div>
             </div>
         );
     }
-}
+
+    return (
+        <div>
+            <QueryHeader query={query}/>
+            <div className="row mt-3">
+                <div className="col-6">
+                    <h3>Session</h3>
+                    <hr className="h3-hr"/>
+                    <table className="table">
+                        <tbody>
+                        <tr>
+                            <td className="info-title">
+                                User
+                            </td>
+                            <td className="info-text wrap-text">
+                                <span id="query-user">{query.session.user}</span>
+                                &nbsp;&nbsp;
+                                <a href="#" className="copy-button" data-clipboard-target="#query-user" data-bs-toggle="tooltip" data-bs-placement="right"
+                                   title="Copy to clipboard">
+                                    <span className="bi bi-copy" aria-hidden="true" alt="Copy to clipboard"/>
+                                </a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Principal
+                            </td>
+                            <td className="info-text wrap-text">
+                                {query.session.principal}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Source
+                            </td>
+                            <td className="info-text wrap-text">
+                                {query.session.source}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Catalog
+                            </td>
+                            <td className="info-text">
+                                {query.session.catalog}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Schema
+                            </td>
+                            <td className="info-text">
+                                {query.session.schema}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Client Address
+                            </td>
+                            <td className="info-text">
+                                {query.session.remoteUserAddress}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Client Tags
+                            </td>
+                            <td className="info-text">
+                                {query.session.clientTags.join(", ")}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Session Properties
+                            </td>
+                            <td className="info-text wrap-text">
+                                {renderSessionProperties()}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Resource Estimates
+                            </td>
+                            <td className="info-text wrap-text">
+                                {renderResourceEstimates()}
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div className="col-6">
+                    <h3>Execution</h3>
+                    <hr className="h3-hr"/>
+                    <table className="table">
+                        <tbody>
+                        <tr>
+                            <td className="info-title">
+                                Resource Group
+                            </td>
+                            <td className="info-text wrap-text">
+                                {query.resourceGroupId ? query.resourceGroupId.join(".") : "n/a"}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Submission Time
+                            </td>
+                            <td className="info-text">
+                                {formatShortDateTime(new Date(query.queryStats.createTime))}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Completion Time
+                            </td>
+                            <td className="info-text">
+                                {new Date(query.queryStats.endTime).getTime() !== 0 ? formatShortDateTime(new Date(query.queryStats.endTime)) : ""}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Elapsed Time
+                            </td>
+                            <td className="info-text">
+                                {query.queryStats.elapsedTime}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Prerequisites Wait Time
+                            </td>
+                            <td className="info-text">
+                                {query.queryStats.waitingForPrerequisitesTime}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Queued Time
+                            </td>
+                            <td className="info-text">
+                                {query.queryStats.queuedTime}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Planning Time
+                            </td>
+                            <td className="info-text">
+                                {query.queryStats.totalPlanningTime}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Execution Time
+                            </td>
+                            <td className="info-text">
+                                {query.queryStats.executionTime}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="info-title">
+                                Coordinator
+                            </td>
+                            <td className="info-text">
+                                {getHostname(query.self)}
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div className="row">
+                <div className="col-12">
+                    <div className="row">
+                        <div className="col-6">
+                            <h3>Resource Utilization Summary</h3>
+                            <hr className="h3-hr"/>
+                            <table className="table">
+                                <tbody>
+                                <tr>
+                                    <td className="info-title">
+                                        CPU Time
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.totalCpuTime}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Scheduled Time
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.totalScheduledTime}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Blocked Time
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.totalBlockedTime}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Input Rows
+                                    </td>
+                                    <td className="info-text">
+                                        {formatCount(query.queryStats.processedInputPositions)}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Input Data
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.processedInputDataSize}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Raw Input Rows
+                                    </td>
+                                    <td className="info-text">
+                                        {formatCount(query.queryStats.rawInputPositions)}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Raw Input Data
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.rawInputDataSize}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        <span className="text" data-bs-toggle="tooltip" data-bs-placement="right"
+                                              title="The total number of rows shuffled across all query stages">
+                                            Shuffled Rows
+                                        </span>
+                                    </td>
+                                    <td className="info-text">
+                                        {formatCount(query.queryStats.shuffledPositions)}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        <span className="text" data-bs-toggle="tooltip" data-bs-placement="right"
+                                              title="The total number of bytes shuffled across all query stages">
+                                            Shuffled Data
+                                        </span>
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.shuffledDataSize}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Peak User Memory
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.peakUserMemoryReservation}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Peak Total Memory
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.peakTotalMemoryReservation}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Memory Pool
+                                    </td>
+                                    <td className="info-text">
+                                        {query.memoryPool}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Cumulative User Memory
+                                    </td>
+                                    <td className="info-text">
+                                        {formatDataSize(query.queryStats.cumulativeUserMemory / 1000.0)}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Cumulative Total
+                                    </td>
+                                    <td className="info-text">
+                                        {formatDataSize(query.queryStats.cumulativeTotalMemory / 1000.0)}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Output Rows
+                                    </td>
+                                    <td className="info-text">
+                                        {formatCount(query.queryStats.outputPositions)}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Output Data
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.outputDataSize}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Written Output Rows
+                                    </td>
+                                    <td className="info-text">
+                                        {formatCount(query.queryStats.writtenOutputPositions)}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Written Output Logical Data Size
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.writtenOutputLogicalDataSize}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Written Output Physical Data Size
+                                    </td>
+                                    <td className="info-text">
+                                        {query.queryStats.writtenOutputPhysicalDataSize}
+                                    </td>
+                                </tr>
+                                {parseDataSize(query.queryStats.spilledDataSize) > 0 &&
+                                    <tr>
+                                        <td className="info-title">
+                                            Spilled Data
+                                        </td>
+                                        <td className="info-text">
+                                            {query.queryStats.spilledDataSize}
+                                        </td>
+                                    </tr>
+                                }
+                                </tbody>
+                            </table>
+                        </div>
+                        <div className="col-6">
+                            <h3>Timeline</h3>
+                            <hr className="h3-hr"/>
+                            <table className="table">
+                                <tbody>
+                                <tr>
+                                    <td className="info-title">
+                                        Parallelism
+                                    </td>
+                                    <td rowSpan="2">
+                                        <div className="query-stats-sparkline-container">
+                                            <span className="sparkline" id="cpu-time-rate-sparkline"><div className="loader">Loading ...</div></span>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr className="tr-noborder">
+                                    <td className="info-sparkline-text">
+                                        {formatCount(cpuTimeRate[cpuTimeRate.length - 1])}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Scheduled Time/s
+                                    </td>
+                                    <td rowSpan="2">
+                                        <div className="query-stats-sparkline-container">
+                                            <span className="sparkline" id="scheduled-time-rate-sparkline"><div className="loader">Loading ...</div></span>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr className="tr-noborder">
+                                    <td className="info-sparkline-text">
+                                        {formatCount(scheduledTimeRate[scheduledTimeRate.length - 1])}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Input Rows/s
+                                    </td>
+                                    <td rowSpan="2">
+                                        <div className="query-stats-sparkline-container">
+                                            <span className="sparkline" id="row-input-rate-sparkline"><div className="loader">Loading ...</div></span>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr className="tr-noborder">
+                                    <td className="info-sparkline-text">
+                                        {formatCount(rowInputRate[rowInputRate.length - 1])}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Input Bytes/s
+                                    </td>
+                                    <td rowSpan="2">
+                                        <div className="query-stats-sparkline-container">
+                                            <span className="sparkline" id="byte-input-rate-sparkline"><div className="loader">Loading ...</div></span>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr className="tr-noborder">
+                                    <td className="info-sparkline-text">
+                                        {formatDataSize(byteInputRate[byteInputRate.length - 1])}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td className="info-title">
+                                        Memory Utilization
+                                    </td>
+                                    <td rowSpan="2">
+                                        <div className="query-stats-sparkline-container">
+                                            <span className="sparkline" id="reserved-memory-sparkline"><div className="loader">Loading ...</div></span>
+                                        </div>
+                                    </td>
+                                </tr>
+                                <tr className="tr-noborder">
+                                    <td className="info-sparkline-text">
+                                        {formatDataSize(reservedMemory[reservedMemory.length - 1])}
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {renderRuntimeStats()}
+            {renderWarningInfo()}
+            {renderFailureInfo()}
+            <div className="row">
+                <div className="col-12">
+                    <h3>
+                        Query
+                        <a className="btn copy-button" data-clipboard-target="#query-text" data-bs-toggle="tooltip" data-bs-placement="right" title="Copy to clipboard">
+                            <span className="bi bi-copy" aria-hidden="true" alt="Copy to clipboard"/>
+                        </a>
+                    </h3>
+                    <pre id="query">
+                        <code className="lang-sql" id="query-text">
+                            {query.query}
+                        </code>
+                    </pre>
+                </div>
+                {renderPreparedQuery()}
+            </div>
+            {renderStages()}
+        </div>
+    );
+};
 
 export default QueryDetail;
 

--- a/presto-ui/src/components/QueryDetail.jsx
+++ b/presto-ui/src/components/QueryDetail.jsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
 import DataTable, {createTheme} from 'react-data-table-component';
 
 import {
@@ -349,29 +349,22 @@ const HISTOGRAM_PROPERTIES = {
     disableHiddenCheck: true,
 };
 
-class RuntimeStatsList extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            expanded: false
-        };
-    }
+const RuntimeStatsList = ({ stats }) => {
+    const [expanded, setExpanded] = React.useState(false);
 
-    getExpandedIcon() {
-        return this.state.expanded ? "bi bi-chevron-up" : "bi bi-chevron-down";
-    }
+    const getExpandedIcon = () => {
+        return expanded ? "bi bi-chevron-up" : "bi bi-chevron-down";
+    };
 
-    getExpandedStyle() {
-        return this.state.expanded ? {} : {display: "none"};
-    }
+    const getExpandedStyle = () => {
+        return expanded ? {} : {display: "none"};
+    };
 
-    toggleExpanded() {
-        this.setState({
-            expanded: !this.state.expanded,
-        })
-    }
+    const toggleExpanded = () => {
+        setExpanded(!expanded);
+    };
 
-    renderMetricValue(unit, value) {
+    const renderMetricValue = (unit, value) => {
         if (unit === "NANO") {
             return formatDuration(parseDuration(value + "ns"));
         }
@@ -379,69 +372,52 @@ class RuntimeStatsList extends React.Component {
             return formatDataSize(value);
         }
         return formatCount(value); // NONE
-    }
+    };
 
-    render() {
-        return (
-            <table className="table" id="runtime-stats-table">
-                <tbody>
-                <tr>
-                    <th className="info-text">Metric Name</th>
-                    <th className="info-text">Sum</th>
-                    <th className="info-text">Count</th>
-                    <th className="info-text">Min</th>
-                    <th className="info-text">Max</th>
-                    <th className="expand-charts-container">
-                        <a onClick={this.toggleExpanded.bind(this)} className="expand-stats-button">
-                            <span className={"bi " + this.getExpandedIcon()} style={GLYPHICON_HIGHLIGHT} data-bs-toggle="tooltip" data-bs-placement="top" title="Show metrics"/>
-                        </a>
-                    </th>
-                </tr>
-                {
-                    Object
-                        .values(this.props.stats)
-                        .sort((m1, m2) => (m1.name.localeCompare(m2.name)))
-                        .map((metric) =>
-                            <tr style={this.getExpandedStyle()}>
-                                <td className="info-text">{metric.name}</td>
-                                <td className="info-text">{this.renderMetricValue(metric.unit, metric.sum)}</td>
-                                <td className="info-text">{formatCount(metric.count)}</td>
-                                <td className="info-text">{this.renderMetricValue(metric.unit, metric.min)}</td>
-                                <td className="info-text">{this.renderMetricValue(metric.unit, metric.max)}</td>
-                            </tr>
-                        )
-                }
-                </tbody>
-            </table>
-        );
-    }
-}
+    return (
+        <table className="table" id="runtime-stats-table">
+            <tbody>
+            <tr>
+                <th className="info-text">Metric Name</th>
+                <th className="info-text">Sum</th>
+                <th className="info-text">Count</th>
+                <th className="info-text">Min</th>
+                <th className="info-text">Max</th>
+                <th className="expand-charts-container">
+                    <a onClick={toggleExpanded} className="expand-stats-button">
+                        <span className={"bi " + getExpandedIcon()} style={GLYPHICON_HIGHLIGHT} data-bs-toggle="tooltip" data-bs-placement="top" title="Show metrics"/>
+                    </a>
+                </th>
+            </tr>
+            {
+                Object
+                    .values(stats)
+                    .sort((m1, m2) => (m1.name.localeCompare(m2.name)))
+                    .map((metric) =>
+                        <tr style={getExpandedStyle()}>
+                            <td className="info-text">{metric.name}</td>
+                            <td className="info-text">{renderMetricValue(metric.unit, metric.sum)}</td>
+                            <td className="info-text">{formatCount(metric.count)}</td>
+                            <td className="info-text">{renderMetricValue(metric.unit, metric.min)}</td>
+                            <td className="info-text">{renderMetricValue(metric.unit, metric.max)}</td>
+                        </tr>
+                    )
+            }
+            </tbody>
+        </table>
+    );
+};
 
-class StageSummary extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            expanded: false,
-            lastRender: null,
-            taskFilter: TASK_FILTER.ALL
-        };
-    }
+const StageSummary = ({ stage }) => {
+    const [expanded, setExpanded] = useState(false);
+    const lastRenderRef = useRef(null);
+    const [taskFilter, setTaskFilter] = useState(TASK_FILTER.ALL);
 
-    getExpandedIcon() {
-        return this.state.expanded ? "bi bi-chevron-up" : "bi bi-chevron-down";
-    }
+    const getExpandedIcon = () => (expanded ? "bi bi-chevron-up" : "bi bi-chevron-down");
+    const getExpandedStyle = () => (expanded ? {} : { display: "none" });
+    const toggleExpanded = () => setExpanded(!expanded);
 
-    getExpandedStyle() {
-        return this.state.expanded ? {} : {display: "none"};
-    }
-
-    toggleExpanded() {
-        this.setState({
-            expanded: !this.state.expanded,
-        })
-    }
-
-    static renderHistogram(histogramId, inputData, numberFormatter) {
+    const renderHistogram = (histogramId, inputData, numberFormatter) => {
         const numBuckets = Math.min(HISTOGRAM_WIDTH, Math.sqrt(inputData.length));
         const dataMin = Math.min.apply(null, inputData);
         const dataMax = Math.max.apply(null, inputData);
@@ -450,12 +426,10 @@ class StageSummary extends React.Component {
         let histogramData = [];
         if (bucketSize === 0) {
             histogramData = [inputData.length];
-        }
-        else {
+        } else {
             for (let i = 0; i < numBuckets + 1; i++) {
                 histogramData.push(0);
             }
-
             for (let i in inputData) {
                 const dataPoint = inputData[i];
                 const bucket = Math.floor((dataPoint - dataMin) / bucketSize);
@@ -463,367 +437,344 @@ class StageSummary extends React.Component {
             }
         }
 
-        const tooltipValueLookups = {'offset': {}};
+        const tooltipValueLookups = { offset: {} };
         for (let i = 0; i < histogramData.length; i++) {
-            tooltipValueLookups['offset'][i] = numberFormatter(dataMin + (i * bucketSize)) + "-" + numberFormatter(dataMin + ((i + 1) * bucketSize));
+            tooltipValueLookups["offset"][i] =
+                numberFormatter(dataMin + i * bucketSize) +
+                "-" +
+                numberFormatter(dataMin + (i + 1) * bucketSize);
         }
 
-        const stageHistogramProperties = $.extend({}, HISTOGRAM_PROPERTIES, {barWidth: (HISTOGRAM_WIDTH / histogramData.length), tooltipValueLookups: tooltipValueLookups});
+        const stageHistogramProperties = $.extend({}, HISTOGRAM_PROPERTIES, {
+            barWidth: HISTOGRAM_WIDTH / histogramData.length,
+            tooltipValueLookups: tooltipValueLookups,
+        });
         $(histogramId).sparkline(histogramData, stageHistogramProperties);
-    }
+    };
 
-    componentDidUpdate() {
-        const stage = this.props.stage;
+    const renderBarChart = (barChartId, inputData, numTasks) => {
+        // this needs to be a string otherwise it will also be passed to numberFormatter
+        const tooltipValueLookups = { offset: {} };
+        const stageId = getStageNumber(stage.stageId);
+        for (let i = 0; i < numTasks; i++) {
+            tooltipValueLookups["offset"][i] = stageId + "." + i;
+        }
+
+        const stageBarChartProperties = $.extend({}, BAR_CHART_PROPERTIES, {
+            barWidth: BAR_CHART_WIDTH / numTasks,
+            tooltipValueLookups: tooltipValueLookups,
+        });
+
+        $(barChartId).sparkline(
+            inputData,
+            $.extend({}, stageBarChartProperties, { numberFormatter: formatDuration })
+        );
+    };
+
+    useEffect(() => {
+        if (!stage || !stage.latestAttemptExecutionInfo) {
+            return;
+        }
+
         const numTasks = stage.latestAttemptExecutionInfo.tasks.length;
+        // sort the x-axis without mutating props
+        const sortedTasks = [...stage.latestAttemptExecutionInfo.tasks].sort(
+            (taskA, taskB) => getTaskNumber(taskA.taskId) - getTaskNumber(taskB.taskId)
+        );
 
-        // sort the x-axis
-        stage.latestAttemptExecutionInfo.tasks.sort((taskA, taskB) => getTaskNumber(taskA.taskId) - getTaskNumber(taskB.taskId));
+        const scheduledTimes = sortedTasks.map((task) =>
+            parseDuration(task.stats.totalScheduledTimeInNanos + "ns")
+        );
+        const cpuTimes = sortedTasks.map((task) =>
+            parseDuration(task.stats.totalCpuTimeInNanos + "ns")
+        );
 
-        const scheduledTimes = stage.latestAttemptExecutionInfo.tasks.map(task => parseDuration(task.stats.totalScheduledTimeInNanos + "ns"));
-        const cpuTimes = stage.latestAttemptExecutionInfo.tasks.map(task => parseDuration(task.stats.totalCpuTimeInNanos + "ns"));
-
-        // prevent multiple calls to componentDidUpdate (resulting from calls to setState or otherwise) within the refresh interval from re-rendering sparklines/charts
-        if (this.state.lastRender === null || (Date.now() - this.state.lastRender) >= 1000) {
+        // prevent multiple re-renders within the refresh interval from re-rendering sparklines/charts
+        if (lastRenderRef.current === null || Date.now() - lastRenderRef.current >= 1000) {
             const renderTimestamp = Date.now();
             const stageId = getStageNumber(stage.stageId);
 
-            StageSummary.renderHistogram('#scheduled-time-histogram-' + stageId, scheduledTimes, formatDuration);
-            StageSummary.renderHistogram('#cpu-time-histogram-' + stageId, cpuTimes, formatDuration);
+            renderHistogram("#scheduled-time-histogram-" + stageId, scheduledTimes, formatDuration);
+            renderHistogram("#cpu-time-histogram-" + stageId, cpuTimes, formatDuration);
 
-            if (this.state.expanded) {
-                // this needs to be a string otherwise it will also be passed to numberFormatter
-                const tooltipValueLookups = {'offset': {}};
-                for (let i = 0; i < numTasks; i++) {
-                    tooltipValueLookups['offset'][i] = getStageNumber(stage.stageId) + "." + i;
-                }
-
-                const stageBarChartProperties = $.extend({}, BAR_CHART_PROPERTIES, {barWidth: BAR_CHART_WIDTH / numTasks, tooltipValueLookups: tooltipValueLookups});
-
-                $('#scheduled-time-bar-chart-' + stageId).sparkline(scheduledTimes, $.extend({}, stageBarChartProperties, {numberFormatter: formatDuration}));
-                $('#cpu-time-bar-chart-' + stageId).sparkline(cpuTimes, $.extend({}, stageBarChartProperties, {numberFormatter: formatDuration}));
+            if (expanded) {
+                renderBarChart("#scheduled-time-bar-chart-" + stageId, scheduledTimes, numTasks);
+                renderBarChart("#cpu-time-bar-chart-" + stageId, cpuTimes, numTasks);
             }
 
-            this.setState({
-                lastRender: renderTimestamp
-            });
+            lastRenderRef.current = renderTimestamp;
         }
-    }
+    }, [stage, expanded]);
 
-    renderStageExecutionAttemptsTasks(attempts) {
-        return attempts.map(attempt => {
-            return this.renderTaskList(attempt.tasks)
-        });
-    }
-
-    renderTaskList(tasks) {
-        tasks = this.state.expanded ? tasks : [];
-        tasks = tasks.filter(task => this.state.taskFilter.predicate(task.taskStatus.state), this);
+    const renderTaskList = (tasks) => {
+        tasks = expanded ? tasks : [];
+        tasks = tasks.filter((task) => taskFilter.predicate(task.taskStatus.state));
         return (
-            <tr style={this.getExpandedStyle()}>
+            <tr style={getExpandedStyle()}>
                 <td colSpan="6">
-                    <TaskList tasks={tasks}/>
+                    <TaskList tasks={tasks} />
                 </td>
             </tr>
         );
-    }
+    };
 
-    renderTaskFilterListItem(taskFilter) {
-        return (
-            <li><a href="#" className={`dropdown-item text-dark ${this.state.taskFilter === taskFilter ? "selected" : ""}`}
-                   onClick={this.handleTaskFilterClick.bind(this, taskFilter)}>{taskFilter.text}</a></li>
-        );
-    }
-
-    handleTaskFilterClick(filter, event) {
-        this.setState({
-            taskFilter: filter
+    const renderStageExecutionAttemptsTasks = (attempts) => {
+        return attempts.map((attempt) => {
+            return renderTaskList(attempt.tasks);
         });
-        event.preventDefault();
-    }
+    };
 
-    renderTaskFilter() {
-        return (<div className="row">
+    const handleTaskFilterClick = (filter, event) => {
+        setTaskFilter(filter);
+        event.preventDefault();
+    };
+
+    const renderTaskFilterListItem = (candidateFilter) => (
+        <li>
+            <a
+                href="#"
+                className={`dropdown-item text-dark ${taskFilter === candidateFilter ? "selected" : ""}`}
+                onClick={(e) => handleTaskFilterClick(candidateFilter, e)}
+            >
+                {candidateFilter.text}
+            </a>
+        </li>
+    );
+
+    const renderTaskFilter = () => (
+        <div className="row">
             <div className="col-6">
                 <h3>Tasks</h3>
             </div>
             <div className="col-6">
                 <table className="header-inline-links">
                     <tbody>
-                    <tr>
-                        <td>
-                            <div className="btn-group text-right">
-                                <button type="button" className="btn dropdown-toggle bg-white text-dark float-end text-right rounded-0"
-                                        data-bs-toggle="dropdown" aria-haspopup="true"
-                                        aria-expanded="false">
-                                    Show: {this.state.taskFilter.text} <span className="caret"/>
-                                </button>
-                                <ul className="dropdown-menu bg-white text-dark rounded-0">
-                                    {this.renderTaskFilterListItem(TASK_FILTER.ALL)}
-                                    {this.renderTaskFilterListItem(TASK_FILTER.PLANNED)}
-                                    {this.renderTaskFilterListItem(TASK_FILTER.RUNNING)}
-                                    {this.renderTaskFilterListItem(TASK_FILTER.FINISHED)}
-                                    {this.renderTaskFilterListItem(TASK_FILTER.FAILED)}
-                                </ul>
-                            </div>
-                        </td>
-                    </tr>
+                        <tr>
+                            <td>
+                                <div className="btn-group text-right">
+                                    <button
+                                        type="button"
+                                        className="btn dropdown-toggle bg-white text-dark float-end text-right rounded-0"
+                                        data-bs-toggle="dropdown"
+                                        aria-haspopup="true"
+                                        aria-expanded="false"
+                                    >
+                                        Show: {taskFilter.text} <span className="caret" />
+                                    </button>
+                                    <ul className="dropdown-menu bg-white text-dark rounded-0">
+                                        {renderTaskFilterListItem(TASK_FILTER.ALL)}
+                                        {renderTaskFilterListItem(TASK_FILTER.PLANNED)}
+                                        {renderTaskFilterListItem(TASK_FILTER.RUNNING)}
+                                        {renderTaskFilterListItem(TASK_FILTER.FINISHED)}
+                                        {renderTaskFilterListItem(TASK_FILTER.FAILED)}
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
-        </div>);
+        </div>
+    );
 
-    }
-
-    render() {
-        const stage = this.props.stage;
-        if (stage === undefined || !stage.hasOwnProperty('plan')) {
-            return (
-                <tr>
-                    <td>Information about this stage is unavailable.</td>
-                </tr>);
-        }
-
-        const totalBufferedBytes = stage.latestAttemptExecutionInfo.tasks
-            .map(task => task.outputBuffers.totalBufferedBytes)
-            .reduce((a, b) => a + b, 0);
-
-        const stageId = getStageNumber(stage.stageId);
-
+    if (stage === undefined || !stage.hasOwnProperty("plan")) {
         return (
             <tr>
-                <td className="stage-id">
-                    <div className="stage-state-color" style={{borderLeftColor: getStageStateColor(stage)}}>{stageId}</div>
-                </td>
-                <td>
-                    <table className="table single-stage-table">
-                        <tbody>
+                <td>Information about this stage is unavailable.</td>
+            </tr>
+        );
+    }
+
+    const totalBufferedBytes = stage.latestAttemptExecutionInfo.tasks
+        .map((task) => task.outputBuffers.totalBufferedBytes)
+        .reduce((a, b) => a + b, 0);
+
+    const stageId = getStageNumber(stage.stageId);
+
+    return (
+        <tr>
+            <td className="stage-id">
+                <div className="stage-state-color" style={{ borderLeftColor: getStageStateColor(stage) }}>{stageId}</div>
+            </td>
+            <td>
+                <table className="table single-stage-table">
+                    <tbody>
                         <tr>
                             <td>
                                 <table className="stage-table stage-table-time">
                                     <thead>
-                                    <tr>
-                                        <th className="stage-table-stat-title stage-table-stat-header">
-                                            Time
-                                        </th>
-                                        <th/>
-                                    </tr>
+                                        <tr>
+                                            <th className="stage-table-stat-title stage-table-stat-header">Time</th>
+                                            <th />
+                                        </tr>
                                     </thead>
                                     <tbody>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Scheduled
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.stats.totalScheduledTime}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Blocked
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.stats.totalBlockedTime}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            CPU
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.stats.totalCpuTime}
-                                        </td>
-                                    </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Scheduled</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.stats.totalScheduledTime}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Blocked</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.stats.totalBlockedTime}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">CPU</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.stats.totalCpuTime}</td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </td>
                             <td>
                                 <table className="stage-table stage-table-memory">
                                     <thead>
-                                    <tr>
-                                        <th className="stage-table-stat-title stage-table-stat-header">
-                                            Memory
-                                        </th>
-                                        <th/>
-                                    </tr>
+                                        <tr>
+                                            <th className="stage-table-stat-title stage-table-stat-header">Memory</th>
+                                            <th />
+                                        </tr>
                                     </thead>
                                     <tbody>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Cumulative
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {formatDataSize(stage.latestAttemptExecutionInfo.stats.cumulativeUserMemory / 1000)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Cumulative Total
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {formatDataSize(stage.latestAttemptExecutionInfo.stats.cumulativeTotalMemory / 1000)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Current
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.stats.userMemoryReservation}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Buffers
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {formatDataSize(totalBufferedBytes)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Peak
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.stats.peakUserMemoryReservation}
-                                        </td>
-                                    </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Cumulative</td>
+                                            <td className="stage-table-stat-text">{formatDataSize(stage.latestAttemptExecutionInfo.stats.cumulativeUserMemory / 1000)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Cumulative Total</td>
+                                            <td className="stage-table-stat-text">{formatDataSize(stage.latestAttemptExecutionInfo.stats.cumulativeTotalMemory / 1000)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Current</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.stats.userMemoryReservation}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Buffers</td>
+                                            <td className="stage-table-stat-text">{formatDataSize(totalBufferedBytes)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Peak</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.stats.peakUserMemoryReservation}</td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </td>
                             <td>
                                 <table className="stage-table stage-table-tasks">
                                     <thead>
-                                    <tr>
-                                        <th className="stage-table-stat-title stage-table-stat-header">
-                                            Tasks
-                                        </th>
-                                        <th/>
-                                    </tr>
+                                        <tr>
+                                            <th className="stage-table-stat-title stage-table-stat-header">Tasks</th>
+                                            <th />
+                                        </tr>
                                     </thead>
                                     <tbody>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Pending
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.tasks.filter(task => task.taskStatus.state === "PLANNED").length}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Running
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.tasks.filter(task => task.taskStatus.state === "RUNNING").length}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Blocked
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.tasks.filter(task => task.stats.fullyBlocked).length}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td className="stage-table-stat-title">
-                                            Total
-                                        </td>
-                                        <td className="stage-table-stat-text">
-                                            {stage.latestAttemptExecutionInfo.tasks.length}
-                                        </td>
-                                    </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Pending</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.tasks.filter((task) => task.taskStatus.state === "PLANNED").length}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Running</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.tasks.filter((task) => task.taskStatus.state === "RUNNING").length}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Blocked</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.tasks.filter((task) => task.stats.fullyBlocked).length}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title">Total</td>
+                                            <td className="stage-table-stat-text">{stage.latestAttemptExecutionInfo.tasks.length}</td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </td>
                             <td>
                                 <table className="stage-table histogram-table">
                                     <thead>
-                                    <tr>
-                                        <th className="stage-table-stat-title stage-table-chart-header">
-                                            Scheduled Time Skew
-                                        </th>
-                                    </tr>
+                                        <tr>
+                                            <th className="stage-table-stat-title stage-table-chart-header">Scheduled Time Skew</th>
+                                        </tr>
                                     </thead>
                                     <tbody>
-                                    <tr>
-                                        <td className="histogram-container">
-                                            <span className="histogram" id={"scheduled-time-histogram-" + stageId}><div className="loader"/></span>
-                                        </td>
-                                    </tr>
+                                        <tr>
+                                            <td className="histogram-container">
+                                                <span className="histogram" id={"scheduled-time-histogram-" + stageId}>
+                                                    <div className="loader" />
+                                                </span>
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </td>
                             <td>
                                 <table className="stage-table histogram-table">
                                     <thead>
-                                    <tr>
-                                        <th className="stage-table-stat-title stage-table-chart-header">
-                                            CPU Time Skew
-                                        </th>
-                                    </tr>
+                                        <tr>
+                                            <th className="stage-table-stat-title stage-table-chart-header">CPU Time Skew</th>
+                                        </tr>
                                     </thead>
                                     <tbody>
-                                    <tr>
-                                        <td className="histogram-container">
-                                            <span className="histogram" id={"cpu-time-histogram-" + stageId}><div className="loader"/></span>
-                                        </td>
-                                    </tr>
+                                        <tr>
+                                            <td className="histogram-container">
+                                                <span className="histogram" id={"cpu-time-histogram-" + stageId}>
+                                                    <div className="loader" />
+                                                </span>
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </td>
                             <td className="expand-charts-container">
-                                <a onClick={this.toggleExpanded.bind(this)} className="expand-charts-button">
-                                    <span className={"bi " + this.getExpandedIcon()} style={GLYPHICON_HIGHLIGHT} data-bs-toggle="tooltip" data-bs-placement="top" title="More"/>
+                                <a onClick={toggleExpanded} className="expand-charts-button">
+                                    <span
+                                        className={"bi " + getExpandedIcon()}
+                                        style={GLYPHICON_HIGHLIGHT}
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="More"
+                                    />
                                 </a>
                             </td>
                         </tr>
-                        <tr style={this.getExpandedStyle()}>
+                        <tr style={getExpandedStyle()}>
                             <td colSpan="6">
                                 <table className="expanded-chart">
                                     <tbody>
-                                    <tr>
-                                        <td className="stage-table-stat-title expanded-chart-title">
-                                            Task Scheduled Time
-                                        </td>
-                                        <td className="bar-chart-container">
-                                            <span className="bar-chart" id={"scheduled-time-bar-chart-" + stageId}><div className="loader"/></span>
-                                        </td>
-                                    </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title expanded-chart-title">Task Scheduled Time</td>
+                                            <td className="bar-chart-container">
+                                                <span className="bar-chart" id={"scheduled-time-bar-chart-" + stageId}>
+                                                    <div className="loader" />
+                                                </span>
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </td>
                         </tr>
-                        <tr style={this.getExpandedStyle()}>
+                        <tr style={getExpandedStyle()}>
                             <td colSpan="6">
                                 <table className="expanded-chart">
                                     <tbody>
-                                    <tr>
-                                        <td className="stage-table-stat-title expanded-chart-title">
-                                            Task CPU Time
-                                        </td>
-                                        <td className="bar-chart-container">
-                                            <span className="bar-chart" id={"cpu-time-bar-chart-" + stageId}><div className="loader"/></span>
-                                        </td>
-                                    </tr>
+                                        <tr>
+                                            <td className="stage-table-stat-title expanded-chart-title">Task CPU Time</td>
+                                            <td className="bar-chart-container">
+                                                <span className="bar-chart" id={"cpu-time-bar-chart-" + stageId}>
+                                                    <div className="loader" />
+                                                </span>
+                                            </td>
+                                        </tr>
                                     </tbody>
                                 </table>
                             </td>
                         </tr>
-                        <tr style={this.getExpandedStyle()}>
-                            <td colSpan="6">
-                                {this.renderTaskFilter()}
-                            </td>
+                        <tr style={getExpandedStyle()}>
+                            <td colSpan="6">{renderTaskFilter()}</td>
                         </tr>
-                        {this.renderStageExecutionAttemptsTasks([stage.latestAttemptExecutionInfo])}
-
-                        {this.renderStageExecutionAttemptsTasks(stage.previousAttemptsExecutionInfos)}
-                        </tbody>
-                    </table>
-                </td>
-            </tr>);
-    }
-}
+                        {renderStageExecutionAttemptsTasks([stage.latestAttemptExecutionInfo])}
+                        {renderStageExecutionAttemptsTasks(stage.previousAttemptsExecutionInfos)}
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    );
+};
 
 class StageList extends React.Component {
     getStages(stage) {

--- a/presto-ui/src/components/QueryHeader.jsx
+++ b/presto-ui/src/components/QueryHeader.jsx
@@ -17,13 +17,8 @@ import { clsx } from 'clsx';
 
 import {getHumanReadableState, getProgressBarPercentage, getProgressBarTitle, getQueryStateColor, isQueryEnded} from "../utils";
 
-export class QueryHeader extends React.Component {
-    constructor(props) {
-        super(props);
-    }
-
-    renderProgressBar() {
-        const query = this.props.query;
+export const QueryHeader = ({ query }) => {
+    const renderProgressBar = () => {
         const queryStateColor = getQueryStateColor(
             query.state,
             query.queryStats && query.queryStats.fullyBlocked,
@@ -82,55 +77,49 @@ export class QueryHeader extends React.Component {
                 </tbody>
             </table>
         );
-    }
+    };
 
-    isActive(path) {
-        if (window.location.pathname.includes(path)) {
-            return  true;
-        }
+    const isActive = (path) => {
+        return window.location.pathname.includes(path);
+    };
 
-        return false;
-    }
-
-    render() {
-        const query = this.props.query;
-        const queryId = this.props.query.queryId;
-        const tabs = [
-            {path: 'query.html', label: 'Overview'},
-            {path: 'plan.html', label: 'Live Plan'},
-            {path: 'stage.html', label: 'Stage Performance'},
-            {path: 'timeline.html', label: 'Splits'},
-        ];
-        return (
-            <div>
-                <div className="row mt-4">
-                    <div className="col-6">
-                        <h3 className="query-id">
-                            <span id="query-id">{query.queryId}</span>
-                            <a className="btn copy-button" data-clipboard-target="#query-id" data-bs-toggle="tooltip" data-bs-placement="right" title="Copy to clipboard">
-                                <span className="bi bi-copy" aria-hidden="true" alt="Copy to clipboard"/>
-                            </a>
-                        </h3>
-                    </div>
-                    <div className="col-6 d-flex justify-content-end">
-                        <nav className="nav nav-tabs">
-                            {tabs.map((page, _) => (
-                                <>
-                                    <a className={clsx('nav-link', 'navbar-btn', this.isActive(page.path) && 'active')} href={page.path + '?' + queryId} >{page.label}</a>
-                                    &nbsp;
-                                </>
-                            ))}
-                            <a className="nav-link navbar-btn" href={"/v1/query/" + query.queryId + "?pretty"} target="_blank">JSON</a>
-                        </nav>
-                    </div>
+    const queryId = query.queryId;
+    const tabs = [
+        {path: 'query.html', label: 'Overview'},
+        {path: 'plan.html', label: 'Live Plan'},
+        {path: 'stage.html', label: 'Stage Performance'},
+        {path: 'timeline.html', label: 'Splits'},
+    ];
+    
+    return (
+        <div>
+            <div className="row mt-4">
+                <div className="col-6">
+                    <h3 className="query-id">
+                        <span id="query-id">{query.queryId}</span>
+                        <a className="btn copy-button" data-clipboard-target="#query-id" data-bs-toggle="tooltip" data-bs-placement="right" title="Copy to clipboard">
+                            <span className="bi bi-copy" aria-hidden="true" alt="Copy to clipboard"/>
+                        </a>
+                    </h3>
                 </div>
-                <hr className="h2-hr"/>
-                <div className="row">
-                    <div className="col-12">
-                        {this.renderProgressBar()}
-                    </div>
+                <div className="col-6 d-flex justify-content-end">
+                    <nav className="nav nav-tabs">
+                        {tabs.map((page, index) => (
+                            <React.Fragment key={index}>
+                                <a className={clsx('nav-link', 'navbar-btn', isActive(page.path) && 'active')} href={page.path + '?' + queryId} >{page.label}</a>
+                                &nbsp;
+                            </React.Fragment>
+                        ))}
+                        <a className="nav-link navbar-btn" href={"/v1/query/" + query.queryId + "?pretty"} target="_blank">JSON</a>
+                    </nav>
                 </div>
             </div>
-        );
-    }
-}
+            <hr className="h2-hr"/>
+            <div className="row">
+                <div className="col-12">
+                    {renderProgressBar()}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/presto-ui/src/components/QueryList.jsx
+++ b/presto-ui/src/components/QueryList.jsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 
 import {
     formatCount,
@@ -79,43 +79,43 @@ const stripQueryTextWhitespace = (queryText, isTruncated) => {
             break;
         }
 
-        if (lines[i].trim().length === 0) {
-            continue;
-        }
-
-        const leadingWhitespace = lines[i].search(/\S/);
-
-        if (leadingWhitespace > -1 && ((leadingWhitespace < minLeadingWhitespace) || minLeadingWhitespace === -1)) {
-            minLeadingWhitespace = leadingWhitespace;
-        }
-    }
-
-    const maxLines = 7;
-    const maxQueryLength = 300;
-    const maxWidthPerLine = 75;
-    let lineCount = 0;
-    let formattedQueryText = "";
-
-    for (let i = 0; i < lines.length; i++) {
-        const trimmedLine = lines[i].substring(minLeadingWhitespace).replace(/\s+$/g, '');
-        lineCount += Math.ceil(trimmedLine.length / maxWidthPerLine);
-
-        if (trimmedLine.length > 0) {
-            formattedQueryText += trimmedLine;
-
-            if (formattedQueryText.length > maxQueryLength) {
-                break;
+            if (lines[i].trim().length === 0) {
+                continue;
             }
 
-            if (lineCount >= maxLines) {
-                return formattedQueryText + "...";
-            }
+            const leadingWhitespace = lines[i].search(/\S/);
 
-            if (i < (lines.length - 1)) {
-                formattedQueryText += "\n";
+            if (leadingWhitespace > -1 && ((leadingWhitespace < minLeadingWhitespace) || minLeadingWhitespace === -1)) {
+                minLeadingWhitespace = leadingWhitespace;
             }
         }
-    }
+
+        const maxLines = 7;
+        const maxQueryLength = 300;
+        const maxWidthPerLine = 75;
+        let lineCount = 0;
+        let formattedQueryText = "";
+
+        for (let i = 0; i < lines.length; i++) {
+            const trimmedLine = lines[i].substring(minLeadingWhitespace).replace(/\s+$/g, '');
+            lineCount += Math.ceil(trimmedLine.length / maxWidthPerLine);
+
+            if (trimmedLine.length > 0) {
+                formattedQueryText += trimmedLine;
+
+                if (formattedQueryText.length > maxQueryLength) {
+                    break;
+                }
+
+                if (lineCount >= maxLines) {
+                    return formattedQueryText + "...";
+                }
+
+                if (i < (lines.length - 1)) {
+                    formattedQueryText += "\n";
+                }
+            }
+        }
 
     return isTruncated ? formattedQueryText + "..." : truncateString(formattedQueryText, maxQueryLength);
 };
@@ -140,92 +140,92 @@ export const QueryListItem = ({ query }) => {
     const humanReadableState = getHumanReadableStateFromInfo(query);
     const progressBarTitle = getProgressBarTitle(query.progress.progressPercentage, query.queryState, humanReadableState);
 
-    const driverDetails = (
-        <div className="col-12 tinystat-row">
-             <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Completed splits">
-                 <span className="bi bi-check-lg" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                 {formatCount(query.progress.completedDrivers)}
-             </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Running splits">
-                 <span className="bi bi-play-circle-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.runningDrivers}
-             </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Queued splits">
-                 <span className="bi bi-pause-btn-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.queuedDrivers}
+        const driverDetails = (
+            <div className="col-12 tinystat-row">
+                 <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Completed splits">
+                     <span className="bi bi-check-lg" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                     {formatCount(query.progress.completedDrivers)}
                  </span>
-        </div>);
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Running splits">
+                     <span className="bi bi-play-circle-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.runningDrivers}
+                 </span>
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Queued splits">
+                     <span className="bi bi-pause-btn-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.queuedDrivers}
+                     </span>
+            </div>);
 
-    const newDriverDetails = (
-        <div className="col-12 tinystat-row">
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Completed drivers">
-                <span className="bi bi-check-circle-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {formatCount(query.progress.completedNewDrivers)}
-            </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Running drivers">
-                <span className="bi bi-play-circle-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.runningNewDrivers}
-            </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Queued drivers">
-                <span className="bi bi-pause-circle-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.queuedNewDrivers}
+        const newDriverDetails = (
+            <div className="col-12 tinystat-row">
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Completed drivers">
+                    <span className="bi bi-check-circle-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {formatCount(query.progress.completedNewDrivers)}
                 </span>
-        </div>);
-
-    const splitDetails = (
-        <div className="col-12 tinystat-row">
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Completed splits">
-                <span className="bi bi-check-circle" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {formatCount(query.progress.completedSplits)}
-            </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Running splits">
-                <span className="bi bi-play-circle" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.runningSplits}
-            </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Queued splits">
-                <span className="bi bi-pause-circle" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.queuedSplits}
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Running drivers">
+                    <span className="bi bi-play-circle-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.runningNewDrivers}
                 </span>
-        </div>);
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Queued drivers">
+                    <span className="bi bi-pause-circle-fill" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.queuedNewDrivers}
+                    </span>
+            </div>);
 
-    const timingDetails = (
-        <div className="col-12 tinystat-row">
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Wall time spent executing the query (not including queued time)">
-                <span className="bi bi-hourglass-split" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {formatDuration(query.progress.executionTimeMillis)}
-            </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Total query wall time">
-                <span className="bi bi-clock" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {formatDuration(query.progress.elapsedTimeMillis)}
-            </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="CPU time spent by this query">
-                <span className="bi bi-speedometer2" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {formatDuration(query.progress.cpuTimeMillis)}
-            </span>
-        </div>);
+        const splitDetails = (
+            <div className="col-12 tinystat-row">
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Completed splits">
+                    <span className="bi bi-check-circle" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {formatCount(query.progress.completedSplits)}
+                </span>
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Running splits">
+                    <span className="bi bi-play-circle" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.runningSplits}
+                </span>
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Queued splits">
+                    <span className="bi bi-pause-circle" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {(query.queryState === "FINISHED" || query.queryState === "FAILED") ? 0 : query.progress.queuedSplits}
+                    </span>
+            </div>);
 
-    const memoryDetails = (
-        <div className="col-12 tinystat-row">
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Current reserved memory">
-                <span className="bi bi-calendar2-event" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {formatDataSize(query.progress.currentMemoryBytes)}
-            </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Peak memory">
-                <span className="bi bi-fire" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {formatDataSize(query.progress.peakMemoryBytes)}
-            </span>
-            <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Cumulative user memory">
-                <span className="bi bi-reception-3" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
-                {formatDataSizeBytes(query.progress.cumulativeUserMemory / 1000.0)}
-            </span>
-        </div>);
+        const timingDetails = (
+            <div className="col-12 tinystat-row">
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Wall time spent executing the query (not including queued time)">
+                    <span className="bi bi-hourglass-split" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {formatDuration(query.progress.executionTimeMillis)}
+                </span>
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Total query wall time">
+                    <span className="bi bi-clock" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {formatDuration(query.progress.elapsedTimeMillis)}
+                </span>
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="CPU time spent by this query">
+                    <span className="bi bi-speedometer2" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {formatDuration(query.progress.cpuTimeMillis)}
+                </span>
+            </div>);
 
-    let user = (<span>{truncateString(query.user, 35)}</span>);
-    if (query.authenticated) {
-        user = (
-            <span>{truncateString(query.user, 35)}</span>
-        );
-    }
+        const memoryDetails = (
+            <div className="col-12 tinystat-row">
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Current reserved memory">
+                    <span className="bi bi-calendar2-event" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {formatDataSize(query.progress.currentMemoryBytes)}
+                </span>
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Peak memory">
+                    <span className="bi bi-fire" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {formatDataSize(query.progress.peakMemoryBytes)}
+                </span>
+                <span className="tinystat" data-bs-toggle="tooltip" data-bs-placement="top" title="Cumulative user memory">
+                    <span className="bi bi-reception-3" style={GLYPHICON_HIGHLIGHT}/>&nbsp;&nbsp;
+                    {formatDataSizeBytes(query.progress.cumulativeUserMemory / 1000.0)}
+                </span>
+            </div>);
+
+        let user = (<span>{truncateString(query.user, 35)}</span>);
+        if (query.authenticated) {
+            user = (
+                <span>{truncateString(query.user, 35)}</span>
+            );
+        }
 
     return (
         <div className="query">
@@ -309,20 +309,17 @@ export const QueryListItem = ({ query }) => {
     );
 };
 
-class DisplayedQueriesList extends React.Component {
-    render() {
-        const queryNodes = this.props.queries.map(function (query) {
-            return (
-                <QueryListItem key={query.queryId} query={query}/>
-            );
-        }.bind(this));
-        return (
-            <div>
-                {queryNodes}
-            </div>
-        );
-    }
-}
+const DisplayedQueriesList = ({ queries }) => {
+    const queryNodes = queries.map((query) => (
+        <QueryListItem key={query.queryId} query={query}/>
+    ));
+    return (
+        <div>
+            {queryNodes}
+        </div>
+    );
+};
+
 
 const FILTER_TYPE = {
     RUNNING: function (query) {
@@ -353,61 +350,65 @@ const SORT_ORDER = {
     DESCENDING: function (value) {return -value}
 };
 
-export class QueryList extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            allQueries: [],
-            displayedQueries: [],
-            reorderInterval: 5000,
-            currentSortType: SORT_TYPE.CREATED,
-            currentSortOrder: SORT_ORDER.DESCENDING,
-            stateFilters: [FILTER_TYPE.RUNNING, FILTER_TYPE.QUEUED],
-            errorTypeFilters: [ERROR_TYPE.INTERNAL_ERROR, ERROR_TYPE.INSUFFICIENT_RESOURCES, ERROR_TYPE.EXTERNAL],
-            searchString: '',
-            maxQueries: 100,
-            lastRefresh: Date.now(),
-            lastReorder: Date.now(),
-            initialized: false
-        };
+export const QueryList = () => {
+    const [allQueries, setAllQueries] = useState([]);
+    const [displayedQueries, setDisplayedQueries] = useState([]);
+    const [reorderInterval, setReorderInterval] = useState(5000);
+    const [currentSortType, setCurrentSortType] = useState(() => SORT_TYPE.CREATED);
+    const [currentSortOrder, setCurrentSortOrder] = useState(() => SORT_ORDER.DESCENDING);
+    const [stateFilters, setStateFilters] = useState([FILTER_TYPE.RUNNING, FILTER_TYPE.QUEUED]);
+    const [errorTypeFilters, setErrorTypeFilters] = useState([ERROR_TYPE.INTERNAL_ERROR, ERROR_TYPE.INSUFFICIENT_RESOURCES, ERROR_TYPE.EXTERNAL]);
+    const [searchString, setSearchString] = useState('');
+    const [maxQueries, setMaxQueries] = useState(100);
+    const [lastRefresh, setLastRefresh] = useState(() => Date.now());
+    const [lastReorder, setLastReorder] = useState(() => Date.now());
+    const [initialized, setInitialized] = useState(false);
 
-        this.refreshLoop = this.refreshLoop.bind(this);
-        this.handleSearchStringChange = this.handleSearchStringChange.bind(this);
-        this.executeSearch = this.executeSearch.bind(this);
-        this.handleSortClick = this.handleSortClick.bind(this);
-    }
+    const timeoutId = useRef(null);
+    const searchTimeoutId = useRef(null);
+    // Refs to avoid stale closures in the polling loop
+    const displayedQueriesRef = useRef(displayedQueries);
+    const stateFiltersRef = useRef(stateFilters);
+    const errorTypeFiltersRef = useRef(errorTypeFilters);
+    const searchStringRef = useRef(searchString);
+    const reorderIntervalRef = useRef(reorderInterval);
+    const lastReorderRef = useRef(lastReorder);
+    const currentSortTypeRef = useRef(currentSortType);
+    const currentSortOrderRef = useRef(currentSortOrder);
+    const maxQueriesRef = useRef(maxQueries);
+    const allQueriesRef = useRef(allQueries);
 
-    sortAndLimitQueries(queries, sortType, sortOrder, maxQueries) {
-        queries.sort(function (queryA, queryB) {
+    const sortAndLimitQueries = (queries, sortType, sortOrder, maxQueriesValue) => {
+        queries.sort((queryA, queryB) => {
             return sortOrder(sortType(queryA) - sortType(queryB));
-        }, this);
+        });
 
-        if (maxQueries !== 0 && queries.length > maxQueries) {
-            queries.splice(maxQueries, (queries.length - maxQueries));
+        if (maxQueriesValue !== 0 && queries.length > maxQueriesValue) {
+            queries.splice(maxQueriesValue, (queries.length - maxQueriesValue));
         }
-    }
+    };
 
-    filterQueries(queries, stateFilters, errorTypeFilters, searchString) {
-        const stateFilteredQueries = queries.filter(function (query) {
-            for (let i = 0; i < stateFilters.length; i++) {
-                if (stateFilters[i](query)) {
+    const filterQueries = (queries, stateFiltersValue, errorTypeFiltersValue, searchStringValue) => {
+        const stateFilteredQueries = queries.filter((query) => {
+            for (let i = 0; i < stateFiltersValue.length; i++) {
+                if (stateFiltersValue[i](query)) {
                     return true;
                 }
             }
-            for (let i = 0; i < errorTypeFilters.length; i++) {
-                if (errorTypeFilters[i](query)) {
+            for (let i = 0; i < errorTypeFiltersValue.length; i++) {
+                if (errorTypeFiltersValue[i](query)) {
                     return true;
                 }
             }
             return false;
         });
 
-        if (searchString === '') {
+        if (searchStringValue === '') {
             return stateFilteredQueries;
         }
         else {
-            return stateFilteredQueries.filter(function (query) {
-                const term = searchString.toLowerCase();
+            return stateFilteredQueries.filter((query) => {
+                const term = searchStringValue.toLowerCase();
                 const humanReadableState = getHumanReadableStateFromInfo(query);
                 if (query.queryId.toLowerCase().indexOf(term) !== -1 ||
                     humanReadableState.toLowerCase().indexOf(term) !== -1 ||
@@ -427,27 +428,17 @@ export class QueryList extends React.Component {
                     return true;
                 }
 
-                return query.warningCodes.some(function (warning) {
+                return query.warningCodes.some((warning) => {
                     if ("warning".indexOf(term) !== -1 || warning.indexOf(term) !== -1) {
                         return true;
                     }
                 });
-
-            }, this);
+            });
         }
-    }
+    };
 
-    resetTimer() {
-        clearTimeout(this.timeoutId);
-        // stop refreshing when query finishes or fails
-        if (this.state.query === null || !this.state.ended) {
-            this.timeoutId = setTimeout(this.refreshLoop, 1000);
-        }
-    }
-
-    refreshLoop() {
-        clearTimeout(this.timeoutId); // to stop multiple series of refreshLoop from going on simultaneously
-        clearTimeout(this.searchTimeoutId);
+    const refreshLoop = useCallback(() => {
+        clearTimeout(timeoutId.current);
 
         $.get('/v1/queryState?includeAllQueries=true&includeAllQueryProgressStats=true&excludeResourceGroupPathInfo=true', function (queryList) {
             const queryMap = queryList.reduce(function (map, query) {
@@ -456,7 +447,7 @@ export class QueryList extends React.Component {
             }, {});
 
             let updatedQueries = [];
-            this.state.displayedQueries.forEach(function (oldQuery) {
+            displayedQueriesRef.current.forEach(function (oldQuery) {
                 if (oldQuery.queryId in queryMap) {
                     updatedQueries.push(queryMap[oldQuery.queryId]);
                     queryMap[oldQuery.queryId] = false;
@@ -469,107 +460,133 @@ export class QueryList extends React.Component {
                     newQueries.push(queryMap[queryId]);
                 }
             }
-            newQueries = this.filterQueries(newQueries, this.state.stateFilters, this.state.errorTypeFilters, this.state.searchString);
+            newQueries = filterQueries(newQueries, stateFiltersRef.current, errorTypeFiltersRef.current, searchStringRef.current);
 
-            const lastRefresh = Date.now();
-            let lastReorder = this.state.lastReorder;
+            const newLastRefresh = Date.now();
+            let newLastReorder = lastReorderRef.current;
 
-            if (this.state.reorderInterval !== 0 && ((lastRefresh - lastReorder) >= this.state.reorderInterval)) {
-                updatedQueries = this.filterQueries(updatedQueries, this.state.stateFilters, this.state.errorTypeFilters, this.state.searchString);
+            if (reorderIntervalRef.current !== 0 && ((newLastRefresh - newLastReorder) >= reorderIntervalRef.current)) {
+                updatedQueries = filterQueries(updatedQueries, stateFiltersRef.current, errorTypeFiltersRef.current, searchStringRef.current);
                 updatedQueries = updatedQueries.concat(newQueries);
-                this.sortAndLimitQueries(updatedQueries, this.state.currentSortType, this.state.currentSortOrder, 0);
-                lastReorder = Date.now();
+                sortAndLimitQueries(updatedQueries, currentSortTypeRef.current, currentSortOrderRef.current, 0);
+                newLastReorder = Date.now();
             }
             else {
-                this.sortAndLimitQueries(newQueries, this.state.currentSortType, this.state.currentSortOrder, 0);
+                sortAndLimitQueries(newQueries, currentSortTypeRef.current, currentSortOrderRef.current, 0);
                 updatedQueries = updatedQueries.concat(newQueries);
             }
 
-            if (this.state.maxQueries !== 0 && (updatedQueries.length > this.state.maxQueries)) {
-                updatedQueries.splice(this.state.maxQueries, (updatedQueries.length - this.state.maxQueries));
+            if (maxQueriesRef.current !== 0 && (updatedQueries.length > maxQueriesRef.current)) {
+                updatedQueries.splice(maxQueriesRef.current, (updatedQueries.length - maxQueriesRef.current));
             }
 
-            this.setState({
-                allQueries: queryList,
-                displayedQueries: updatedQueries,
-                lastRefresh: lastRefresh,
-                lastReorder: lastReorder,
-                initialized: true
-            });
-            this.resetTimer();
-        }.bind(this))
+            setAllQueries(queryList);
+            setDisplayedQueries(updatedQueries);
+            setLastRefresh(newLastRefresh);
+            setLastReorder(newLastReorder);
+            setInitialized(true);
+
+            timeoutId.current = setTimeout(refreshLoop, 1000);
+        })
         .fail(function () {
-                this.setState({
-                    initialized: true,
-                });
-                this.resetTimer();
-            }.bind(this));
-    }
+            setInitialized(true);
+            timeoutId.current = setTimeout(refreshLoop, 1000);
+        });
+    }, []);
 
-    componentDidMount() {
-        this.refreshLoop();
-    }
+    useEffect(() => {
+        refreshLoop();
+        return () => {
+            clearTimeout(timeoutId.current);
+            clearTimeout(searchTimeoutId.current);
+        };
+    }, [refreshLoop]);
 
-    handleSearchStringChange(event) {
+    // Keep refs in sync with state to avoid stale closures in refreshLoop
+    useEffect(() => { displayedQueriesRef.current = displayedQueries; }, [displayedQueries]);
+    useEffect(() => { stateFiltersRef.current = stateFilters; }, [stateFilters]);
+    useEffect(() => { errorTypeFiltersRef.current = errorTypeFilters; }, [errorTypeFilters]);
+    useEffect(() => { searchStringRef.current = searchString; }, [searchString]);
+    useEffect(() => { reorderIntervalRef.current = reorderInterval; }, [reorderInterval]);
+    useEffect(() => { lastReorderRef.current = lastReorder; }, [lastReorder]);
+    useEffect(() => { currentSortTypeRef.current = currentSortType; }, [currentSortType]);
+    useEffect(() => { currentSortOrderRef.current = currentSortOrder; }, [currentSortOrder]);
+    useEffect(() => { maxQueriesRef.current = maxQueries; }, [maxQueries]);
+    useEffect(() => { allQueriesRef.current = allQueries; }, [allQueries]);
+
+    const executeSearch = useCallback(() => {
+        clearTimeout(searchTimeoutId.current);
+
+        // Use latest refs to avoid closure over stale state during debounce window
+        const newDisplayedQueries = filterQueries(allQueriesRef.current, stateFiltersRef.current, errorTypeFiltersRef.current, searchStringRef.current);
+        sortAndLimitQueries(newDisplayedQueries, currentSortTypeRef.current, currentSortOrderRef.current, maxQueriesRef.current);
+
+        setDisplayedQueries(newDisplayedQueries);
+    }, []);
+
+    const handleSearchStringChange = (event) => {
         const newSearchString = event.target.value;
-        clearTimeout(this.searchTimeoutId);
+        clearTimeout(searchTimeoutId.current);
 
-        this.setState({
-            searchString: newSearchString
-        });
+        setSearchString(newSearchString);
+        // keep ref in sync immediately for debounce to read latest
+        searchStringRef.current = newSearchString;
 
-        this.searchTimeoutId = setTimeout(this.executeSearch, 200);
-    }
+        searchTimeoutId.current = setTimeout(executeSearch, 200);
+    };
 
-    executeSearch() {
-        clearTimeout(this.searchTimeoutId);
+    const handleMaxQueriesClick = (newMaxQueries) => {
+        const filteredQueries = filterQueries(allQueriesRef.current, stateFiltersRef.current, errorTypeFiltersRef.current, searchStringRef.current);
+        sortAndLimitQueries(filteredQueries, currentSortTypeRef.current, currentSortOrderRef.current, newMaxQueries);
 
-        const newDisplayedQueries = this.filterQueries(this.state.allQueries, this.state.stateFilters, this.state.errorTypeFilters, this.state.searchString);
-        this.sortAndLimitQueries(newDisplayedQueries, this.state.currentSortType, this.state.currentSortOrder, this.state.maxQueries);
+        setMaxQueries(newMaxQueries);
+        maxQueriesRef.current = newMaxQueries;
+        setDisplayedQueries(filteredQueries);
+    };
 
-        this.setState({
-            displayedQueries: newDisplayedQueries
-        });
-    }
-
-    renderMaxQueriesListItem(maxQueries, maxQueriesText) {
+    const renderMaxQueriesListItem = (maxQueriesValue, maxQueriesText) => {
         return (
-            <li><a href="#" className={`dropdown-item text-dark ${this.state.maxQueries === maxQueries ? "active bg-info text-white" : "text-dark"}`} onClick={this.handleMaxQueriesClick.bind(this, maxQueries)}>{maxQueriesText}</a>
+            <li><a href="#" className={`dropdown-item text-dark ${maxQueries === maxQueriesValue ? "active bg-info text-white" : "text-dark"}`} onClick={() => handleMaxQueriesClick(maxQueriesValue)}>{maxQueriesText}</a>
             </li>
         );
-    }
+    };
 
-    handleMaxQueriesClick(newMaxQueries) {
-        const filteredQueries = this.filterQueries(this.state.allQueries, this.state.stateFilters, this.state.errorTypeFilters, this.state.searchString);
-        this.sortAndLimitQueries(filteredQueries, this.state.currentSortType, this.state.currentSortOrder, newMaxQueries);
-
-        this.setState({
-            maxQueries: newMaxQueries,
-            displayedQueries: filteredQueries
-        });
-    }
-
-    renderReorderListItem(interval, intervalText) {
-        return (
-            <li><a href="#" className={`dropdown-item text-dark ${this.state.reorderInterval === interval ? "active bg-info text-white" : "text-dark"}`} onClick={this.handleReorderClick.bind(this, interval)}>{intervalText}</a></li>
-        );
-    }
-
-    handleReorderClick(interval) {
-        if (this.state.reorderInterval !== interval) {
-            this.setState({
-                reorderInterval: interval,
-            });
+    const handleReorderClick = (interval) => {
+        if (reorderIntervalRef.current !== interval) {
+            setReorderInterval(interval);
+            reorderIntervalRef.current = interval;
         }
-    }
+    };
 
-    renderSortListItem(sortType, sortText) {
-        if (this.state.currentSortType === sortType) {
-            const directionArrow = this.state.currentSortOrder === SORT_ORDER.ASCENDING ? <span className="bi bi-caret-up-fill"/> :
+    const renderReorderListItem = (interval, intervalText) => {
+        return (
+            <li><a href="#" className={`dropdown-item text-dark ${reorderInterval === interval ? "active bg-info text-white" : "text-dark"}`} onClick={() => handleReorderClick(interval)}>{intervalText}</a></li>
+        );
+    };
+
+    const handleSortClick = (sortType) => {
+        const newSortType = sortType;
+        let newSortOrder = SORT_ORDER.DESCENDING;
+
+        if (currentSortType === sortType && currentSortOrder === SORT_ORDER.DESCENDING) {
+            newSortOrder = SORT_ORDER.ASCENDING;
+        }
+
+        const newDisplayedQueries = filterQueries(allQueriesRef.current, stateFiltersRef.current, errorTypeFiltersRef.current, searchStringRef.current);
+        sortAndLimitQueries(newDisplayedQueries, newSortType, newSortOrder, maxQueriesRef.current);
+
+        setDisplayedQueries(newDisplayedQueries);
+        setCurrentSortType(newSortType);
+        setCurrentSortOrder(newSortOrder);
+    };
+
+    const renderSortListItem = (sortType, sortText) => {
+        if (currentSortType === sortType) {
+            const directionArrow = currentSortOrder === SORT_ORDER.ASCENDING ? <span className="bi bi-caret-up-fill"/> :
                 <span className="bi bi-caret-down-fill"/>;
             return (
                 <li>
-                    <a href="#" className="dropdown-item active bg-info text-white" onClick={this.handleSortClick.bind(this, sortType)}>
+                    <a href="#" className="dropdown-item active bg-info text-white" onClick={() => handleSortClick(sortType)}>
                         {sortText} {directionArrow}
                     </a>
                 </li>);
@@ -577,188 +594,164 @@ export class QueryList extends React.Component {
         else {
             return (
                 <li>
-                    <a href="#" className="dropdown-item text-dark" onClick={this.handleSortClick.bind(this, sortType)}>
+                    <a href="#" className="dropdown-item text-dark" onClick={() => handleSortClick(sortType)}>
                         {sortText}
                     </a>
                 </li>);
         }
-    }
+    };
 
-    handleSortClick(sortType) {
-        const newSortType = sortType;
-        let newSortOrder = SORT_ORDER.DESCENDING;
-
-        if (this.state.currentSortType === sortType && this.state.currentSortOrder === SORT_ORDER.DESCENDING) {
-            newSortOrder = SORT_ORDER.ASCENDING;
-        }
-
-        const newDisplayedQueries = this.filterQueries(this.state.allQueries, this.state.stateFilters, this.state.errorTypeFilters, this.state.searchString);
-        this.sortAndLimitQueries(newDisplayedQueries, newSortType, newSortOrder, this.state.maxQueries);
-
-        this.setState({
-            displayedQueries: newDisplayedQueries,
-            currentSortType: newSortType,
-            currentSortOrder: newSortOrder
-        });
-    }
-
-    renderFilterButton(filterType, filterText) {
-        let checkmarkStyle = {color: '#57aac7'};
-        let classNames = "btn btn-sm btn-info style-check rounded-0";
-        if (this.state.stateFilters.indexOf(filterType) > -1) {
-            classNames += " active";
-            checkmarkStyle = {color: '#ffffff'};
-        }
-
-        return (
-            <button type="button" className={classNames} onClick={this.handleStateFilterClick.bind(this, filterType)} style={{height: "30px", fontSize:"12px", color:"white"}}>
-                <span className="bi bi-check-lg" style={checkmarkStyle}/>&nbsp;{filterText}
-            </button>
-        );
-    }
-
-    handleStateFilterClick(filter) {
-        const newFilters = this.state.stateFilters.slice();
-        if (this.state.stateFilters.indexOf(filter) > -1) {
+    const handleStateFilterClick = (filter) => {
+        const newFilters = stateFilters.slice();
+        if (stateFilters.indexOf(filter) > -1) {
             newFilters.splice(newFilters.indexOf(filter), 1);
         }
         else {
             newFilters.push(filter);
         }
 
-        const filteredQueries = this.filterQueries(this.state.allQueries, newFilters, this.state.errorTypeFilters, this.state.searchString);
-        this.sortAndLimitQueries(filteredQueries, this.state.currentSortType, this.state.currentSortOrder);
+        const filteredQueries = filterQueries(allQueriesRef.current, newFilters, errorTypeFiltersRef.current, searchStringRef.current);
+        sortAndLimitQueries(filteredQueries, currentSortTypeRef.current, currentSortOrderRef.current, maxQueriesRef.current);
 
-        this.setState({
-            stateFilters: newFilters,
-            displayedQueries: filteredQueries
-        });
-    }
+        setStateFilters(newFilters);
+        setDisplayedQueries(filteredQueries);
+    };
 
-    renderErrorTypeListItem(errorType, errorTypeText) {
-        let checkmarkStyle = {color: '#ffffff'};
-        if (this.state.errorTypeFilters.indexOf(errorType) > -1) {
-            checkmarkStyle = {color: 'black'};
+    const renderFilterButton = (filterType, filterText) => {
+        let checkmarkStyle = {color: '#57aac7'};
+        let classNames = "btn btn-sm btn-info style-check rounded-0";
+        if (stateFilters.indexOf(filterType) > -1) {
+            classNames += " active";
+            checkmarkStyle = {color: '#ffffff'};
         }
-        return (
-            <li>
-                <a className="dropdown-item text-dark" href="#" onClick={this.handleErrorTypeFilterClick.bind(this, errorType)}>
-                    <span className="bi bi-check-lg" style={checkmarkStyle}/>
-                    &nbsp;{errorTypeText}
-                </a>
-            </li>);
-    }
 
-    handleErrorTypeFilterClick(errorType) {
-        const newFilters = this.state.errorTypeFilters.slice();
-        if (this.state.errorTypeFilters.indexOf(errorType) > -1) {
+        return (
+            <button type="button" className={classNames} onClick={() => handleStateFilterClick(filterType)} style={{height: "30px", fontSize:"12px", color:"white"}}>
+                <span className="bi bi-check-lg" style={checkmarkStyle}/>&nbsp;{filterText}
+            </button>
+        );
+    };
+
+    const handleErrorTypeFilterClick = (errorType) => {
+        const newFilters = errorTypeFilters.slice();
+        if (errorTypeFilters.indexOf(errorType) > -1) {
             newFilters.splice(newFilters.indexOf(errorType), 1);
         }
         else {
             newFilters.push(errorType);
         }
 
-        const filteredQueries = this.filterQueries(this.state.allQueries, this.state.stateFilters, newFilters, this.state.searchString);
-        this.sortAndLimitQueries(filteredQueries, this.state.currentSortType, this.state.currentSortOrder);
+        const filteredQueries = filterQueries(allQueriesRef.current, stateFiltersRef.current, newFilters, searchStringRef.current);
+        sortAndLimitQueries(filteredQueries, currentSortTypeRef.current, currentSortOrderRef.current, maxQueriesRef.current);
 
-        this.setState({
-            errorTypeFilters: newFilters,
-            displayedQueries: filteredQueries
-        });
-    }
+        setErrorTypeFilters(newFilters);
+        setDisplayedQueries(filteredQueries);
+    };
 
-    render() {
-        let queryList = <DisplayedQueriesList queries={this.state.displayedQueries}/>;
-        if (this.state.displayedQueries === null || this.state.displayedQueries.length === 0) {
-            let label = (<div className="loader">Loading...</div>);
-            if (this.state.initialized) {
-                if (this.state.allQueries === null || this.state.allQueries.length === 0) {
-                    label = "No queries";
-                }
-                else {
-                    label = "No queries matched filters";
-                }
-            }
-            queryList = (
-                <div className="row error-message">
-                    <div className="col-12"><h4>{label}</h4></div>
-                </div>
-            );
+    const renderErrorTypeListItem = (errorType, errorTypeText) => {
+        let checkmarkStyle = {color: '#ffffff'};
+        if (errorTypeFilters.indexOf(errorType) > -1) {
+            checkmarkStyle = {color: 'black'};
         }
-
         return (
-            <div>
-                <div className="row toolbar-row">
-                    <div className="col-12 input-group gap-1 toolbar-col d-flex">
-                        <div className="input-group-prepend flex-grow-1">
-                            <input type="text" className="form-control search-bar rounded-0" placeholder="User, source, query ID, resource group, or query text"
-                                onChange={this.handleSearchStringChange} value={this.state.searchString} style={{backgroundColor: "white" ,color: 'black', fontSize: '12px', borderColor:"#CCCCCC"}} />
-                        </div>
+            <li>
+                <a className="dropdown-item text-dark" href="#" onClick={() => handleErrorTypeFilterClick(errorType)}>
+                    <span className="bi bi-check-lg" style={checkmarkStyle}/>
+                    &nbsp;{errorTypeText}
+                </a>
+            </li>);
+    };
 
-                            <div className="input-group-btn d-flex align-items-center ms-auto">
-                                 <span className="input-group-text input-group-prepend rounded-0" style={{backgroundColor: "white", color: 'black', height:"2rem", fontSize:'12px', borderColor:"#454A58" }}>State:</span>
-                                {this.renderFilterButton(FILTER_TYPE.RUNNING, "Running")}
-                                {this.renderFilterButton(FILTER_TYPE.QUEUED, "Queued")}
-                                {this.renderFilterButton(FILTER_TYPE.FINISHED, "Finished")}
-                                <button type="button" id="error-type-dropdown" className="btn btn-info dropdown-toggle rounded-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style={{height: '30px'}}>
-                                    Failed <span className="caret"/>
-                                </button>
-                                <ul className="dropdown-menu bg-white text-dark error-type-dropdown-menu">
-                                    {this.renderErrorTypeListItem(ERROR_TYPE.INTERNAL_ERROR, "Internal Error")}
-                                    {this.renderErrorTypeListItem(ERROR_TYPE.EXTERNAL, "External Error")}
-                                    {this.renderErrorTypeListItem(ERROR_TYPE.INSUFFICIENT_RESOURCES, "Resources Error")}
-                                    {this.renderErrorTypeListItem(ERROR_TYPE.USER_ERROR, "User Error")}
-                                </ul>
-
-                            </div>
-                            &nbsp;
-                            <div className="input-group-btn">
-                                <button type="button" className="btn btn-dark btn-sm dropdown-toggle bg-white text-btn-default .query-detail-buttons rounded-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style={{fontSize:'12px', height: '31px'}}>
-                                    Sort <span className="caret"/>
-                                </button>
-                                <ul className="dropdown-menu bg-white text-dark rounded-0">
-                                    {this.renderSortListItem(SORT_TYPE.CREATED, "Creation Time")}
-                                    {this.renderSortListItem(SORT_TYPE.ELAPSED, "Elapsed Time")}
-                                    {this.renderSortListItem(SORT_TYPE.CPU, "CPU Time")}
-                                    {this.renderSortListItem(SORT_TYPE.EXECUTION, "Execution Time")}
-                                    {this.renderSortListItem(SORT_TYPE.CURRENT_MEMORY, "Current Memory")}
-                                    {this.renderSortListItem(SORT_TYPE.CUMULATIVE_MEMORY, "Cumulative User Memory")}
-                                </ul>
-                            </div>
-                            &nbsp;
-                            <div className="input-group-btn">
-                                <button type="button" className="btn btn-dark btn-sm dropdown-toggle bg-white text-btn-default rounded-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style={{fontSize:'12px', height: '31px'}}>
-                                    Reorder Interval <span className="caret"/>
-                                </button>
-                                <ul className="dropdown-menu bg-white text-dark rounded-0">
-                                    {this.renderReorderListItem(1000, "1s")}
-                                    {this.renderReorderListItem(5000, "5s")}
-                                    {this.renderReorderListItem(10000, "10s")}
-                                    {this.renderReorderListItem(30000, "30s")}
-                                    <hr className="mt-1 mb-1"/>
-                                    {this.renderReorderListItem(0, "Off")}
-                                </ul>
-                            </div>
-                            &nbsp;
-                            <div className="input-group-btn">
-                                <button type="button" className="btn btn-dark btn-sm dropdown-toggle bg-white text-btn-default rounded-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style={{fontSize:'12px', height: '31px'}}>
-                                    Show <span className="caret"/>
-                                </button>
-                                <ul className="dropdown-menu bg-white text-dark rounded-0">
-                                    {this.renderMaxQueriesListItem(20, "20 queries")}
-                                    {this.renderMaxQueriesListItem(50, "50 queries")}
-                                    {this.renderMaxQueriesListItem(100, "100 queries")}
-                                    <hr className="mt-1 mb-1" />
-                                    {this.renderMaxQueriesListItem(0, "All queries")}
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-
-                {queryList}
+    let queryList = <DisplayedQueriesList queries={displayedQueries}/>;
+    if (displayedQueries === null || displayedQueries.length === 0) {
+        let label = (<div className="loader">Loading...</div>);
+        if (initialized) {
+            if (allQueries === null || allQueries.length === 0) {
+                label = "No queries";
+            }
+            else {
+                label = "No queries matched filters";
+            }
+        }
+        queryList = (
+            <div className="row error-message">
+                <div className="col-12"><h4>{label}</h4></div>
             </div>
         );
     }
-}
+
+    return (
+        <div>
+            <div className="row toolbar-row">
+                <div className="col-12 input-group gap-1 toolbar-col d-flex">
+                    <div className="input-group-prepend flex-grow-1">
+                        <input type="text" className="form-control search-bar rounded-0" placeholder="User, source, query ID, resource group, or query text"
+                                onChange={handleSearchStringChange} value={searchString} style={{backgroundColor: "white" ,color: 'black', fontSize: '12px', borderColor:"#CCCCCC"}} />
+                    </div>
+
+                        <div className="input-group-btn d-flex align-items-center ms-auto">
+                             <span className="input-group-text input-group-prepend rounded-0" style={{backgroundColor: "white", color: 'black', height:"2rem", fontSize:'12px', borderColor:"#454A58" }}>State:</span>
+                            {renderFilterButton(FILTER_TYPE.RUNNING, "Running")}
+                            {renderFilterButton(FILTER_TYPE.QUEUED, "Queued")}
+                            {renderFilterButton(FILTER_TYPE.FINISHED, "Finished")}
+                            <button type="button" id="error-type-dropdown" className="btn btn-info dropdown-toggle rounded-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style={{height: '30px'}}>
+                                Failed <span className="caret"/>
+                            </button>
+                            <ul className="dropdown-menu bg-white text-dark error-type-dropdown-menu">
+                                {renderErrorTypeListItem(ERROR_TYPE.INTERNAL_ERROR, "Internal Error")}
+                                {renderErrorTypeListItem(ERROR_TYPE.EXTERNAL, "External Error")}
+                                {renderErrorTypeListItem(ERROR_TYPE.INSUFFICIENT_RESOURCES, "Resources Error")}
+                                {renderErrorTypeListItem(ERROR_TYPE.USER_ERROR, "User Error")}
+                            </ul>
+
+                        </div>
+                        &nbsp;
+                        <div className="input-group-btn">
+                            <button type="button" className="btn btn-dark btn-sm dropdown-toggle bg-white text-btn-default .query-detail-buttons rounded-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style={{fontSize:'12px', height: '31px'}}>
+                                Sort <span className="caret"/>
+                            </button>
+                            <ul className="dropdown-menu bg-white text-dark rounded-0">
+                                {renderSortListItem(SORT_TYPE.CREATED, "Creation Time")}
+                                {renderSortListItem(SORT_TYPE.ELAPSED, "Elapsed Time")}
+                                {renderSortListItem(SORT_TYPE.CPU, "CPU Time")}
+                                {renderSortListItem(SORT_TYPE.EXECUTION, "Execution Time")}
+                                {renderSortListItem(SORT_TYPE.CURRENT_MEMORY, "Current Memory")}
+                                {renderSortListItem(SORT_TYPE.CUMULATIVE_MEMORY, "Cumulative User Memory")}
+                            </ul>
+                        </div>
+                        &nbsp;
+                        <div className="input-group-btn">
+                            <button type="button" className="btn btn-dark btn-sm dropdown-toggle bg-white text-btn-default rounded-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style={{fontSize:'12px', height: '31px'}}>
+                                Reorder Interval <span className="caret"/>
+                            </button>
+                            <ul className="dropdown-menu bg-white text-dark rounded-0">
+                                {renderReorderListItem(1000, "1s")}
+                                {renderReorderListItem(5000, "5s")}
+                                {renderReorderListItem(10000, "10s")}
+                                {renderReorderListItem(30000, "30s")}
+                                <hr className="mt-1 mb-1"/>
+                                {renderReorderListItem(0, "Off")}
+                            </ul>
+                        </div>
+                        &nbsp;
+                        <div className="input-group-btn">
+                            <button type="button" className="btn btn-dark btn-sm dropdown-toggle bg-white text-btn-default rounded-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style={{fontSize:'12px', height: '31px'}}>
+                                Show <span className="caret"/>
+                            </button>
+                            <ul className="dropdown-menu bg-white text-dark rounded-0">
+                                {renderMaxQueriesListItem(20, "20 queries")}
+                                {renderMaxQueriesListItem(50, "50 queries")}
+                                {renderMaxQueriesListItem(100, "100 queries")}
+                                <hr className="mt-1 mb-1" />
+                                {renderMaxQueriesListItem(0, "All queries")}
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+            {queryList}
+        </div>
+    );
+};
 
 export default QueryList;

--- a/presto-ui/src/components/QueryViewer.jsx
+++ b/presto-ui/src/components/QueryViewer.jsx
@@ -34,7 +34,7 @@ const FileForm = ({ onChange }) => (
     </div>
 );
 
-export function QueryViewer() {
+export const QueryViewer = () => {
     const [state, setState] = React.useState({
         initialized: false,
         ended: false,
@@ -88,6 +88,6 @@ export function QueryViewer() {
             <SplitView data={state.query} show={state.tab === 'splits'} />
         </div>
     );
-}
+};
 
 export default QueryViewer;

--- a/presto-ui/src/components/StageDetail.jsx
+++ b/presto-ui/src/components/StageDetail.jsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import ReactDOM from "react-dom";
 import { createRoot } from 'react-dom/client';
 import ReactDOMServer from "react-dom/server";
@@ -38,73 +38,69 @@ function getTotalWallTime(operator) {
     return parseDuration(operator.addInputWall) + parseDuration(operator.getOutputWall) + parseDuration(operator.finishWall) + parseDuration(operator.blockedWall)
 }
 
-class OperatorSummary extends React.Component {
-    render() {
-        const operator = this.props.operator;
+const OperatorSummary = ({ operator }) => {
+    const totalWallTime = parseDuration(operator.addInputWall) + parseDuration(operator.getOutputWall) + parseDuration(operator.finishWall) + parseDuration(operator.blockedWall);
 
-        const totalWallTime = parseDuration(operator.addInputWall) + parseDuration(operator.getOutputWall) + parseDuration(operator.finishWall) + parseDuration(operator.blockedWall);
+    const rowInputRate = totalWallTime === 0 ? 0 : (1.0 * operator.inputPositions) / (totalWallTime / 1000.0);
+    const byteInputRate = totalWallTime === 0 ? 0 : (1.0 * parseDataSize(operator.inputDataSize)) / (totalWallTime / 1000.0);
 
-        const rowInputRate = totalWallTime === 0 ? 0 : (1.0 * operator.inputPositions) / (totalWallTime / 1000.0);
-        const byteInputRate = totalWallTime === 0 ? 0 : (1.0 * parseDataSize(operator.inputDataSize)) / (totalWallTime / 1000.0);
-
-        return (
-            <div className="header-data">
-                <div className="highlight-row">
-                    <div className="header-row">
-                        {operator.operatorType}
-                    </div>
-                    <div>
-                        {formatCount(rowInputRate) + " rows/s (" + formatDataSize(byteInputRate) + "/s)"}
-                    </div>
+    return (
+        <div className="header-data">
+            <div className="highlight-row">
+                <div className="header-row">
+                    {operator.operatorType}
                 </div>
-                <table className="table">
-                    <tbody>
-                    <tr>
-                        <td>
-                            Output
-                        </td>
-                        <td>
-                            {formatCount(operator.outputPositions) + " rows (" + operator.outputDataSize + ")"}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            Drivers
-                        </td>
-                        <td>
-                            {operator.totalDrivers}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            Wall Time
-                        </td>
-                        <td>
-                            {formatDuration(totalWallTime)}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            Blocked
-                        </td>
-                        <td>
-                            {formatDuration(parseDuration(operator.blockedWall))}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            Input
-                        </td>
-                        <td>
-                            {formatCount(operator.inputPositions) + " rows (" + operator.inputDataSize + ")"}
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
+                <div>
+                    {formatCount(rowInputRate) + " rows/s (" + formatDataSize(byteInputRate) + "/s)"}
+                </div>
             </div>
-        );
-    }
-}
+            <table className="table">
+                <tbody>
+                <tr>
+                    <td>
+                        Output
+                    </td>
+                    <td>
+                        {formatCount(operator.outputPositions) + " rows (" + operator.outputDataSize + ")"}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        Drivers
+                    </td>
+                    <td>
+                        {operator.totalDrivers}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        Wall Time
+                    </td>
+                    <td>
+                        {formatDuration(totalWallTime)}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        Blocked
+                    </td>
+                    <td>
+                        {formatDuration(parseDuration(operator.blockedWall))}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        Input
+                    </td>
+                    <td>
+                        {formatCount(operator.inputPositions) + " rows (" + operator.inputDataSize + ")"}
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    );
+};
 
 const BAR_CHART_PROPERTIES = {
     type: 'bar',
@@ -118,9 +114,9 @@ const BAR_CHART_PROPERTIES = {
     disableHiddenCheck: true,
 };
 
-function OperatorStatistic({ id, name, operators, supplier, renderer }) {
+const OperatorStatistic = ({ id, name, operators, supplier, renderer }) => {
 
-    React.useEffect(() => {
+    useEffect(() => {
         const statistic = operators.map(supplier);
         const numTasks = operators.length;
 
@@ -144,9 +140,9 @@ function OperatorStatistic({ id, name, operators, supplier, renderer }) {
             </div>
         </div>
     );
-}
+};
 
-function OperatorDetail({ index, operator, tasks }) {
+const OperatorDetail = ({ index, operator, tasks }) => {
     const selectedStatistics = [
         {
             name: "Total Wall Time",
@@ -332,24 +328,15 @@ function OperatorDetail({ index, operator, tasks }) {
             </div>
         </div>
     );
-}
+};
 
-class StageOperatorGraph extends React.Component {
-    componentDidMount() {
-        this.updateD3Graph();
-    }
-
-    componentDidUpdate() {
-        this.updateD3Graph();
-    }
-
-    handleOperatorClick(event) {
+const StageOperatorGraph = ({ stage }) => {
+    const handleOperatorClick = useCallback((event) => {
         if (event.target.hasOwnProperty("__data__") && event.target.__data__ !== undefined) {
             $('#operator-detail-modal').modal("show")
 
             const pipelineId = (event?.target?.__data__ || "").split('-').length > 0 ? parseInt((event?.target?.__data__ || '').split('-')[1] || '0') : 0;
             const operatorId = (event?.target?.__data__ || "").split('-').length > 0 ? parseInt((event?.target?.__data__ || '').split('-')[2] || '0') : 0;
-            const stage = this.props.stage;
 
             let operatorStageSummary = null;
             const operatorSummaries = stage.latestAttemptExecutionInfo.stats.operatorSummaries;
@@ -361,14 +348,12 @@ class StageOperatorGraph extends React.Component {
             const container = document.getElementById('operator-detail');
             const root = createRoot(container);
             root.render(<OperatorDetail key={event} operator={operatorStageSummary} tasks={stage.latestAttemptExecutionInfo.tasks} />);
-        } else {
-            return;
         }
-    }
+    }, [stage]);
 
-    computeOperatorGraphs() {
+    const computeOperatorGraphs = useCallback(() => {
         const pipelineOperators = new Map();
-        this.props.stage.latestAttemptExecutionInfo.stats.operatorSummaries.forEach(operator => {
+        stage.latestAttemptExecutionInfo.stats.operatorSummaries.forEach(operator => {
             if (!pipelineOperators.has(operator.pipelineId)) {
                 pipelineOperators.set(operator.pipelineId, []);
             }
@@ -393,17 +378,15 @@ class StageOperatorGraph extends React.Component {
         });
 
         return result;
-    }
+    }, [stage]);
 
-    computeD3StageOperatorGraph(graph, operator, sink, pipelineNode) {
+    const computeD3StageOperatorGraph = useCallback((graph, operator, sink, pipelineNode) => {
         const operatorNodeId = "operator-" + operator.pipelineId + "-" + operator.operatorId;
-
-        // this is a non-standard use of ReactDOMServer, but it's the cleanest way to unify DagreD3 with React
         const html = ReactDOMServer.renderToString(<OperatorSummary key={operator.pipelineId + "-" + operator.operatorId} operator={operator}/>);
         graph.setNode(operatorNodeId, {class: "operator-stats", label: html, labelType: "html"});
 
         if (operator.hasOwnProperty("child")) {
-            this.computeD3StageOperatorGraph(graph, operator.child, operatorNodeId, pipelineNode);
+            computeD3StageOperatorGraph(graph, operator.child, operatorNodeId, pipelineNode);
         }
 
         if (sink !== null) {
@@ -411,20 +394,20 @@ class StageOperatorGraph extends React.Component {
         }
 
         graph.setParent(operatorNodeId, pipelineNode);
-    }
+    }, [/* static */]);
 
-    updateD3Graph() {
-        if (!this.props.stage) {
+    const updateD3Graph = useCallback(() => {
+        if (!stage) {
             return;
         }
 
-        const operatorGraphs = this.computeOperatorGraphs();
+        const operatorGraphs = computeOperatorGraphs();
 
         const graph = initializeGraph();
         operatorGraphs.forEach((operator, pipelineId) => {
             const pipelineNodeId = "pipeline-" + pipelineId;
             graph.setNode(pipelineNodeId, {label: "Pipeline " + pipelineId + " ", clusterLabelPos: 'top', style: 'fill: #2b2b2b', labelStyle: 'fill: #fff'});
-            this.computeD3StageOperatorGraph(graph, operator, null, pipelineNodeId)
+            computeD3StageOperatorGraph(graph, operator, null, pipelineNodeId)
         });
 
         $("#operator-canvas").html("");
@@ -435,40 +418,40 @@ class StageOperatorGraph extends React.Component {
             const render = new dagreD3.render();
             render(d3.select("#operator-canvas g"), graph);
 
-            svg.selectAll("g.operator-stats").on("click", this.handleOperatorClick.bind(this));
+            svg.selectAll("g.operator-stats").on("click", handleOperatorClick);
             svg.attr("height", graph.graph().height);
             svg.attr("width", graph.graph().width);
         }
         else {
             $(".graph-container").css("display", "none");
         }
+    }, [stage, computeOperatorGraphs, computeD3StageOperatorGraph, handleOperatorClick]);
+
+    if (!stage.hasOwnProperty('plan')) {
+        return (
+            <div className="row error-message">
+                <div className="col-12"><h4>Stage does not have a plan</h4></div>
+            </div>
+        );
     }
 
-    render() {
-        const stage = this.props.stage;
-
-        if (!stage.hasOwnProperty('plan')) {
-            return (
-                <div className="row error-message">
-                    <div className="col-12"><h4>Stage does not have a plan</h4></div>
+    const latestAttemptExecutionInfo = stage.latestAttemptExecutionInfo;
+    if (!latestAttemptExecutionInfo.hasOwnProperty('stats') || !latestAttemptExecutionInfo.stats.hasOwnProperty("operatorSummaries") || latestAttemptExecutionInfo.stats.operatorSummaries.length === 0) {
+        return (
+            <div className="row error-message">
+                <div className="col-12">
+                    <h4>Operator data not available for {stage.stageId}</h4>
                 </div>
-            );
-        }
-
-        const latestAttemptExecutionInfo = stage.latestAttemptExecutionInfo;
-        if (!latestAttemptExecutionInfo.hasOwnProperty('stats') || !latestAttemptExecutionInfo.stats.hasOwnProperty("operatorSummaries") || latestAttemptExecutionInfo.stats.operatorSummaries.length === 0) {
-            return (
-                <div className="row error-message">
-                    <div className="col-12">
-                        <h4>Operator data not available for {stage.stageId}</h4>
-                    </div>
-                </div>
-            );
-        }
-
-        return null;
+            </div>
+        );
     }
-}
+
+    useEffect(() => {
+        updateD3Graph();
+    }, [updateD3Graph]);
+
+    return null;
+};
 
 const findStage = (stageId, currentStage) => {
     if (stageId === null) {
@@ -518,7 +501,7 @@ export const StageDetail = () => {
     useEffect(() => { endedRef.current = ended; }, [ended]);
     useEffect(() => { selectedStageIdRef.current = selectedStageId; }, [selectedStageId]);
 
-    const refreshLoop = React.useCallback(() => {
+    const refreshLoop = useCallback(() => {
         clearTimeout(timerId.current);
         const queryString = getFirstParameter(window.location.search).split('.');
         const rawQueryId = queryString.length > 0 ? queryString[0] : "";


### PR DESCRIPTION
## Description
Third batch of the component conversion started in https://github.com/prestodb/presto/pull/25666 (please see PR for background details). This finishes converting all the components in the `components/` folder from class components to function components, and with the other two PRs in this series, finishes converting all the class components in the application.

## Motivation and Context
Resolves item 12 in #21062; function components are the new de-facto standard in react, and benefit from ongoing optimizations in current and future react versions. 

## Impact
UI

## Test Plan
Tested the UI interface extensively, checking all refactored components and their interactions.

Components/interactions tested:

- ClusterHUD - including sparkline charts
- LivePlan - including bug fix for finished queries
- PageTitle
- SQLClientView, including running queries and other interactions
- StaticQueryHeader
- WorkerStatus, including sparkline charts
- WorkerThreadList

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

