### PR TITLE
security(csp): fix ZAP findings — form-action, img-src

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -144,7 +144,7 @@ public class CoordinatorModule
 {
     private static final String DEFAULT_WEBUI_CSP =
             "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-                    "font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'; img-src http: https: data:";
+                    "font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'; img-src 'self' http: https: data:; form-action 'self'";
 
     public static HttpResourceBinding webUIBinder(Binder binder, String path, String classPathResourceBase)
     {


### PR DESCRIPTION
## Description
Medium Dynamic scan CSV's issues flagged by ZAP.

1. CSP: Failure to Define Directive with No Fallback
2. CSP: Wildcard Directive

- [CWE-693](https://cwe.mitre.org/data/definitions/693.html)
- [OWASP_2021_A05](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/)
- [OWASP_2017_A06](https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html)

## Motivation and Context

(1) CSP: Failure to Define Directive with No Fallback

**Issue**:
CSP header does not define `form-action`


(2) CSP: Wildcard Directive

**Issue**: CSP has a very broad `img-src:`


## Impact

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Fix CSP by adding `form-action 'self'` and setting `img-src 'self'` in response to `CWE-693 <https://cwe.mitre.org/data/definitions/693.html>`_. :pr:`25910`

```

