### PR TITLE
Enhance lineage capture to include column-level details

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/SourceColumn.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/SourceColumn.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class SourceColumn
+{
+    private final QualifiedObjectName tableName;
+    private final String columnName;
+
+    @JsonCreator
+    public SourceColumn(
+            @JsonProperty("tableName") QualifiedObjectName tableName,
+            @JsonProperty("columnName") String columnName)
+    {
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.columnName = requireNonNull(columnName, "columnName is null");
+    }
+
+    @JsonProperty
+    public QualifiedObjectName getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(tableName, columnName);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        SourceColumn entry = (SourceColumn) obj;
+        return Objects.equals(tableName, entry.tableName) &&
+                Objects.equals(columnName, entry.columnName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SourceColumn{" +
+                "tableName=" + tableName +
+                ", columnName='" + columnName + '\'' +
+                '}';
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -50,6 +50,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.eventlistener.Column;
 import com.facebook.presto.spi.eventlistener.OperatorStatistics;
+import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryContext;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
@@ -600,11 +601,12 @@ public class QueryMonitor
                     .map(TableFinishInfo.class::cast)
                     .findFirst();
 
-            Optional<List<Column>> outputColumns = queryInfo.getOutput().get().getColumns()
+            Optional<List<OutputColumnMetadata>> outputColumnsMetadata = queryInfo.getOutput().get().getColumns()
                     .map(columns -> columns.stream()
-                            .map(column -> new Column(
-                                    column.getName(),
-                                    column.getType()))
+                            .map(column -> new OutputColumnMetadata(
+                                    column.getColumnName(),
+                                    column.getColumnType(),
+                                    column.getSourceColumns()))
                             .collect(toImmutableList()));
 
             output = Optional.of(
@@ -615,7 +617,7 @@ public class QueryMonitor
                             tableFinishInfo.map(TableFinishInfo::getSerializedConnectorOutputMetadata),
                             tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded),
                             queryInfo.getOutput().get().getSerializedCommitOutput(),
-                            outputColumns));
+                            outputColumnsMetadata));
         }
 
         return new QueryIOMetadata(inputs.build(), output);

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/Output.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/Output.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -32,7 +33,7 @@ public final class Output
     private final String schema;
     private final String table;
     private final String serializedCommitOutput;
-    private final Optional<List<Column>> columns;
+    private final Optional<List<OutputColumnMetadata>> columns;
 
     @JsonCreator
     public Output(
@@ -40,7 +41,7 @@ public final class Output
             @JsonProperty("schema") String schema,
             @JsonProperty("table") String table,
             @JsonProperty("serializedCommitOutput") String serializedCommitOutput,
-            @JsonProperty("columns") Optional<List<Column>> columns)
+            @JsonProperty("columns") Optional<List<OutputColumnMetadata>> columns)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -74,7 +75,7 @@ public final class Output
     }
 
     @JsonProperty
-    public Optional<List<Column>> getColumns()
+    public Optional<List<OutputColumnMetadata>> getColumns()
     {
         return columns;
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/TemporaryTableUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/TemporaryTableUtil.java
@@ -202,7 +202,7 @@ public class TemporaryTableUtil
             Optional<String> cteId)
     {
         SchemaTableName schemaTableName = metadata.getTableMetadata(session, tableHandle).getTable();
-        TableWriterNode.InsertReference insertReference = new TableWriterNode.InsertReference(tableHandle, schemaTableName);
+        TableWriterNode.InsertReference insertReference = new TableWriterNode.InsertReference(tableHandle, schemaTableName, Optional.empty());
         List<String> outputColumnNames = outputs.stream()
                 .map(variableToColumnMap::get)
                 .map(ColumnMetadata::getName)
@@ -300,7 +300,7 @@ public class TemporaryTableUtil
                 .collect(Collectors.toSet());
 
         SchemaTableName schemaTableName = metadata.getTableMetadata(session, tableHandle).getTable();
-        TableWriterNode.InsertReference insertReference = new TableWriterNode.InsertReference(tableHandle, schemaTableName);
+        TableWriterNode.InsertReference insertReference = new TableWriterNode.InsertReference(tableHandle, schemaTableName, Optional.empty());
 
         PartitioningScheme partitioningScheme = new PartitioningScheme(
                 Partitioning.create(partitioningHandle, partitioningVariables),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.AggregationNode.GroupingSetDescriptor;
@@ -1113,6 +1114,12 @@ public class CanonicalPlanGenerator
         {
             // Just return a sample table name, which is always same
             return new SchemaTableName("schema", "table");
+        }
+
+        @Override
+        public Optional<List<OutputColumnMetadata>> getOutputColumns()
+        {
+            return Optional.empty();
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -286,7 +286,7 @@ public class LogicalPlanner
         return createTableWriterPlan(
                 analysis,
                 plan,
-                new CreateName(new ConnectorId(destination.getCatalogName()), tableMetadata, newTableLayout),
+                new CreateName(new ConnectorId(destination.getCatalogName()), tableMetadata, newTableLayout, analysis.getUpdatedSourceColumns()),
                 columnNames,
                 tableMetadata.getColumns(),
                 newTableLayout,
@@ -310,7 +310,7 @@ public class LogicalPlanner
 
         TableHandle tableHandle = insertAnalysis.getTarget();
         List<ColumnHandle> columnHandles = insertAnalysis.getColumns();
-        TableWriterNode.WriterTarget target = new InsertReference(tableHandle, metadata.getTableMetadata(session, tableHandle).getTable());
+        TableWriterNode.WriterTarget target = new InsertReference(tableHandle, metadata.getTableMetadata(session, tableHandle).getTable(), analysis.getUpdatedSourceColumns());
 
         return buildInternalInsertPlan(tableHandle, columnHandles, insertStatement.getQuery(), analysis, target);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestOutput.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestOutput.java
@@ -14,8 +14,12 @@
 package com.facebook.presto.execution;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.SourceColumn;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -37,7 +41,10 @@ public class TestOutput
                 EMPTY_COMMIT_OUTPUT,
                 Optional.of(
                         ImmutableList.of(
-                                new Column("column", "type"))));
+                                new OutputColumnMetadata(
+                                        "column", "type",
+                                        ImmutableSet.of(
+                                                new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column"))))));
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestingWriterTarget.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestingWriterTarget.java
@@ -14,9 +14,17 @@
 
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.SourceColumn;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
 import com.facebook.presto.spi.plan.TableWriterNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Optional;
 
 public class TestingWriterTarget
         extends TableWriterNode.WriterTarget
@@ -34,6 +42,17 @@ public class TestingWriterTarget
     public SchemaTableName getSchemaTableName()
     {
         return SCHEMA_TABLE_NAME;
+    }
+
+    @Override
+    public Optional<List<OutputColumnMetadata>> getOutputColumns()
+    {
+        return Optional.of(
+                ImmutableList.of(
+                        new OutputColumnMetadata(
+                                "column", "type",
+                                ImmutableSet.of(
+                                        new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column")))));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.eventlistener.Column;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.OperatorStatistics;
+import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
 import com.facebook.presto.spi.eventlistener.PlanOptimizerInformation;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryContext;
@@ -374,10 +375,13 @@ public class TestEventListenerManager
         List<QueryInputMetadata> inputs = new ArrayList<>();
         QueryInputMetadata queryInputMetadata = getQueryInputMetadata();
         inputs.add(queryInputMetadata);
-        Column column1 = new Column("column1", "int");
-        Column column2 = new Column("column2", "varchar");
-        Column column3 = new Column("column3", "varchar");
-        List<Column> columns = Arrays.asList(column1, column2, column3);
+        OutputColumnMetadata column1 = new OutputColumnMetadata("column1", "int", new HashSet<>());
+        OutputColumnMetadata column2 = new OutputColumnMetadata("column2", "varchar", new HashSet<>());
+        OutputColumnMetadata column3 = new OutputColumnMetadata("column3", "varchar", new HashSet<>());
+        List<OutputColumnMetadata> columns = new ArrayList<>();
+        columns.add(column1);
+        columns.add(column2);
+        columns.add(column3);
         QueryOutputMetadata outputMetadata = new QueryOutputMetadata(
                 "dummyCatalog",
                 "dummySchema",

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OutputColumnMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OutputColumnMetadata.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.eventlistener;
+
+import com.facebook.presto.common.SourceColumn;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class OutputColumnMetadata
+{
+    private final String columnName;
+    private final String columnType;
+    private final Set<SourceColumn> sourceColumns;
+
+    @JsonCreator
+    public OutputColumnMetadata(String columnName, String columnType, Set<SourceColumn> sourceColumns)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.columnType = requireNonNull(columnType, "columnType is null");
+        this.sourceColumns = requireNonNull(sourceColumns, "sourceColumns is null");
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public String getColumnType()
+    {
+        return columnType;
+    }
+
+    @JsonProperty
+    public Set<SourceColumn> getSourceColumns()
+    {
+        return sourceColumns;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnName, columnType, sourceColumns);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        OutputColumnMetadata other = (OutputColumnMetadata) obj;
+        return Objects.equals(columnName, other.columnName) &&
+                Objects.equals(columnType, other.columnType) &&
+                Objects.equals(sourceColumns, other.sourceColumns);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
@@ -30,7 +30,7 @@ public class QueryOutputMetadata
     private final Optional<Boolean> jsonLengthLimitExceeded;
 
     private final String serializedCommitOutput;
-    private final Optional<List<Column>> columns;
+    private final Optional<List<OutputColumnMetadata>> columns;
 
     public QueryOutputMetadata(
             String catalogName,
@@ -39,7 +39,7 @@ public class QueryOutputMetadata
             Optional<String> connectorOutputMetadata,
             Optional<Boolean> jsonLengthLimitExceeded,
             String serializedCommitOutput,
-            Optional<List<Column>> columns)
+            Optional<List<OutputColumnMetadata>> columns)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -87,7 +87,7 @@ public class QueryOutputMetadata
     }
 
     @JsonProperty
-    public Optional<List<Column>> getColumns()
+    public Optional<List<OutputColumnMetadata>> getColumns()
     {
         return columns;
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableWriterNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/TableWriterNode.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.NewTableLayout;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.eventlistener.OutputColumnMetadata;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -281,6 +282,8 @@ public final class TableWriterNode
 
         public abstract SchemaTableName getSchemaTableName();
 
+        public abstract Optional<List<OutputColumnMetadata>> getOutputColumns();
+
         @Override
         public abstract String toString();
     }
@@ -291,12 +294,14 @@ public final class TableWriterNode
         private final ConnectorId connectorId;
         private final ConnectorTableMetadata tableMetadata;
         private final Optional<NewTableLayout> layout;
+        private final Optional<List<OutputColumnMetadata>> columns;
 
-        public CreateName(ConnectorId connectorId, ConnectorTableMetadata tableMetadata, Optional<NewTableLayout> layout)
+        public CreateName(ConnectorId connectorId, ConnectorTableMetadata tableMetadata, Optional<NewTableLayout> layout, Optional<List<OutputColumnMetadata>> columns)
         {
             this.connectorId = requireNonNull(connectorId, "connectorId is null");
             this.tableMetadata = requireNonNull(tableMetadata, "tableMetadata is null");
             this.layout = requireNonNull(layout, "layout is null");
+            this.columns = requireNonNull(columns, "columns is null");
         }
 
         @Override
@@ -327,6 +332,12 @@ public final class TableWriterNode
         {
             return connectorId + "." + tableMetadata.getTable();
         }
+
+        @Override
+        public Optional<List<OutputColumnMetadata>> getOutputColumns()
+        {
+            return columns;
+        }
     }
 
     public static class InsertReference
@@ -334,11 +345,13 @@ public final class TableWriterNode
     {
         private final TableHandle handle;
         private final SchemaTableName schemaTableName;
+        private final Optional<List<OutputColumnMetadata>> columns;
 
-        public InsertReference(TableHandle handle, SchemaTableName schemaTableName)
+        public InsertReference(TableHandle handle, SchemaTableName schemaTableName, Optional<List<OutputColumnMetadata>> columns)
         {
             this.handle = requireNonNull(handle, "handle is null");
             this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+            this.columns = requireNonNull(columns, "columns is null");
         }
 
         public TableHandle getHandle()
@@ -356,6 +369,12 @@ public final class TableWriterNode
         public SchemaTableName getSchemaTableName()
         {
             return schemaTableName;
+        }
+
+        @Override
+        public Optional<List<OutputColumnMetadata>> getOutputColumns()
+        {
+            return columns;
         }
 
         @Override
@@ -396,6 +415,12 @@ public final class TableWriterNode
             return schemaTableName;
         }
 
+        @Override
+        public Optional<List<OutputColumnMetadata>> getOutputColumns()
+        {
+            return Optional.empty();
+        }
+
         public String toString()
         {
             return handle.toString();
@@ -429,6 +454,12 @@ public final class TableWriterNode
         public SchemaTableName getSchemaTableName()
         {
             return schemaTableName;
+        }
+
+        @Override
+        public Optional<List<OutputColumnMetadata>> getOutputColumns()
+        {
+            return Optional.empty();
         }
 
         @Override
@@ -472,6 +503,12 @@ public final class TableWriterNode
         public SchemaTableName getSchemaTableName()
         {
             return schemaTableName;
+        }
+
+        @Override
+        public Optional<List<OutputColumnMetadata>> getOutputColumns()
+        {
+            return Optional.empty();
         }
 
         public List<String> getUpdatedColumns()


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This PR adds changes to capture column-level details, which are essential for populating column-level lineage. The enhancements ensure that lineage metadata includes precise mappings between input and output columns, and detailed lineage tracking.

cherry-pick : https://github.com/trinodb/trino/pull/7465
cherry-pick : https://github.com/trinodb/trino/pull/10319

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

