### PR TITLE
Add Prestissimo committers as codeowners to NativeWorkerSessionPropertyProvider

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -114,6 +114,7 @@ CODEOWNERS @prestodb/team-tsc
 /presto-native-execution @prestodb/team-velox @prestodb/committers
 /presto-native-sidecar-plugin @pdabre12 @prestodb/team-velox @prestodb/committers
 /presto-native-tests @prestodb/team-velox @prestodb/committers
+/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java  @prestodb/team-velox @prestodb/committers
 /.github/workflows/prestocpp-* @prestodb/team-velox @prestodb/committers
 
 #####################################################################

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -50,6 +50,7 @@
 /presto-lark-sheets @prestodb/committers
 /presto-local-file @prestodb/committers
 /presto-main @prestodb/committers
+/presto-main-base @prestodb/committers
 /presto-matching @prestodb/committers
 /presto-memory @prestodb/committers
 /presto-memory-context @prestodb/committers
@@ -100,10 +101,10 @@ CODEOWNERS @prestodb/team-tsc
 # Presto core
 
 # Presto analyzer and optimizer
-/presto-main/src/*/java/com/facebook/presto/sql @jaystarshot @feilong-liu @ClarenceThreepwood @prestodb/committers
+/presto-main-base/src/*/java/com/facebook/presto/sql @jaystarshot @feilong-liu @ClarenceThreepwood @prestodb/committers
 
 # Presto cost based optimizer framework
-/presto-main/src/*/java/com/facebook/presto/cost @jaystarshot @feilong-liu @ClarenceThreepwood @prestodb/committers
+/presto-main-base/src/*/java/com/facebook/presto/cost @jaystarshot @feilong-liu @ClarenceThreepwood @prestodb/committers
 
 # Testing module
 # Note: all code owners in Presto core should be included here as well


### PR DESCRIPTION
## Description
1. Add prestissimo commiters as codeowners to NativeWorkerSessionPropertyProvider. 
2. Fix paths to reflect presto-main/presto-main-base split


## Motivation and Context
Make simple changes to add Prestissimo session properties (which doesn't need expertise outside of prestissimo) lower friction.

## Impact
Prestissimo committers will be able to approve changes to NativeWorkerSessionPropertyProvider

## Test Plan
none 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

