### PR TITLE
[docs] Add doc for Type Mapping to connector/deltalake.rst #25357

### DIFF
--- a/presto-docs/src/main/sphinx/connector/deltalake.rst
+++ b/presto-docs/src/main/sphinx/connector/deltalake.rst
@@ -133,3 +133,47 @@ in the table ``sales.apac.sales_data``.
 
 Above query drops the external table ``sales.apac.sales_data_new``. This only drops the
 metadata for the table. The referenced data directory is not deleted.
+
+Delta Lake to PrestoDB type mapping
+-----------------------------------
+
+Map of Delta Lake types to the relevant PrestoDB types:
+
+.. list-table:: Delta Lake to PrestoDB type mapping
+  :widths: 50, 50
+  :header-rows: 1
+
+  * - Delta Lake type
+    - PrestoDB type
+  * - ``BOOLEAN``
+    - ``BOOLEAN``
+  * - ``SMALLINT``
+    - ``SMALLINT`` 
+  * - ``TINYINT``
+    - ``TINYINT``
+  * - ``INT``
+    - ``INTEGER``
+  * - ``LONG``
+    - ``BIGINT``
+  * - ``FLOAT``
+    - ``REAL``
+  * - ``DOUBLE``
+    - ``DOUBLE``
+  * - ``DECIMAL``
+    - ``DECIMAL``
+  * - ``STRING``
+    - ``VARCHAR``
+  * - ``BINARY``
+    - ``VARBINARY``
+  * - ``DATE``
+    - ``DATE``
+  * - ``TIMESTAMP_NTZ``
+    - ``TIMESTAMP``
+  * - ``TIMESTAMP``
+    - ``TIMESTAMP WITH TIME ZONE``
+  * - ``ARRAY``
+    - ``ARRAY``
+  * - ``MAP``
+    - ``MAP``
+  * - ``STRUCT``
+    - ``ROW``


### PR DESCRIPTION
Fix #25357
Added type mapping table for Delta Lake to PrestoDB

## Description
Added a table for the Delta Lake to PrestoDB type mapping

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/25357

## Impact
Changes to docs

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

```
== NO RELEASE NOTE ==
```

