### PR TITLE
Enable copy button feature explicitly

### DIFF
--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -135,6 +135,7 @@ html_theme_options = {
     'features': [
         'toc.follow',
         'toc.sticky',
+        'content.code.copy',
     ],
     'palette': [
         {


### PR DESCRIPTION
## Description
The PR explicitly enables copy button for code blocks.

## Motivation and Context
The PR fixes the issue (missing copy button) introduced earlier by `sphinx-immaterial` upgrade from `0.11.11` to `0.13.0`

## Impact
_None_

## Test Plan
Build the documentation and check that the page is correct:
```shell
presto-docs/build
open presto-docs/target/html/admin/tuning.html
```
<img width="1081" height="841" alt="Screenshot 2025-08-31 at 19 05 38" src="https://github.com/user-attachments/assets/a2338547-4929-42eb-93bd-4fd37525ba7e" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

