### PR TITLE
Improve metastore headers

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -222,22 +222,30 @@ public final class HttpRequestSessionContext
         Map<String, String> requestHeaders = getRequestHeaders(servletRequest);
         TracerHandle tracerHandle = tracerProvider.getHandleGenerator().apply(requestHeaders);
 
-        if (isTracingEnabled()) {
+        TraceTokenFactory traceTokenFactory = new PrestoTraceTokenFactory();
+
+        if (traceTokenFactory.getTraceToken(clientInfo).isPresent()) {
             this.tracer = Optional.of(requireNonNull(tracerProvider.getNewTracer(tracerHandle), "tracer is null"));
-            traceToken = Optional.ofNullable(this.tracer.get().getTracerId());
+            traceToken = (traceTokenFactory.getTraceToken(clientInfo));
         }
         else {
-            this.tracer = Optional.of(NoopTracerProvider.NOOP_TRACER);
-
-            // If tunnel trace token is null, we expose the Presto tracing id.
-            // Otherwise we preserve the ability of trace token tunneling but
-            // still trace Presto internally for aggregation purposes.
-            String tunnelTraceId = trimEmptyToNull(servletRequest.getHeader(PRESTO_TRACE_TOKEN));
-            if (tunnelTraceId != null) {
-                traceToken = Optional.of(tunnelTraceId);
+            if (isTracingEnabled()) {
+                this.tracer = Optional.of(requireNonNull(tracerProvider.getNewTracer(tracerHandle), "tracer is null"));
+                traceToken = Optional.ofNullable(this.tracer.get().getTracerId());
             }
             else {
-                traceToken = Optional.ofNullable(tracerHandle.getTraceToken());
+                this.tracer = Optional.of(NoopTracerProvider.NOOP_TRACER);
+
+                // If tunnel trace token is null, we expose the Presto tracing id.
+                // Otherwise we preserve the ability of trace token tunneling but
+                // still trace Presto internally for aggregation purposes.
+                String tunnelTraceId = trimEmptyToNull(servletRequest.getHeader(PRESTO_TRACE_TOKEN));
+                if (tunnelTraceId != null) {
+                    traceToken = Optional.of(tunnelTraceId);
+                }
+                else {
+                    traceToken = Optional.ofNullable(tracerHandle.getTraceToken());
+                }
             }
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoTraceTokenFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoTraceTokenFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import java.util.Optional;
+public class PrestoTraceTokenFactory
+        implements TraceTokenFactory
+{
+    @Override
+    public Optional<String> getTraceToken(String clientInfo)
+    {
+        // No factory tracing token in open source Presto
+        return Optional.empty();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/TraceTokenFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TraceTokenFactory.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import java.util.Optional;
+
+public interface TraceTokenFactory
+{
+    Optional<String> getTraceToken(String clientInfo);
+}


### PR DESCRIPTION
## Description
Presto should propagate task context from dataswarm to metastore to improve discoverability of dataswarm generated data

## Motivation and Context
SEV Followup

## Impact
Metastore headers will have correct info now

## Test Plan
e2e tested

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

