### PR TITLE
Fix minor documentation issues

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -229,6 +229,7 @@ Property Name                                            Description            
                                                          metadata, instead of their ordinal position. Also toggleable 
                                                          through the ``hive.orc_use_column_names`` session property.
 ======================================================== ============================================================ ============
+
 .. _constructor: https://github.com/apache/hadoop/blob/02a9190af5f8264e25966a80c8f9ea9bb6677899/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java#L844-L875
 
 Avro Configuration Properties

--- a/presto-docs/src/main/sphinx/connector/postgresql.rst
+++ b/presto-docs/src/main/sphinx/connector/postgresql.rst
@@ -149,6 +149,7 @@ The connector maps PostgreSQL types to the corresponding PrestoDB types:
     - ``VARCHAR``
   * - ``GEOGRAPHY``
     - ``VARCHAR``
+
 No other types are supported.
 
 PrestoDB to PostgreSQL type mapping

--- a/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst
+++ b/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst
@@ -29,6 +29,7 @@ Property Name                                Description                        
 ============================================ ===================================================================== ==============================
 
 .. _sidecar-worker-properties:
+
 Sidecar worker properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 Enable sidecar functionality with:
@@ -68,7 +69,7 @@ Property Name                                Description                        
 ============================================ ===================================================================== ==============================
 
 Session properties
------------------
+------------------
 
 These properties must be configured in ``etc/session-property-providers/native-worker.properties`` to use the session property provider of the ``NativeSidecarPlugin``.
 

--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -75,6 +75,7 @@ alphabetical order.
     - Custom type names are peeled in the coordinator. Only the actual base type is preserved.
     - ``CAST(col AS EnumType<T>)`` is rewritten as ``CAST(col AS <T>)``.
     - ``ENUM_KEY(EnumType<T>)`` is rewritten as ``ELEMENT_AT(MAP(<T>, VARCHAR))``.
+
   This property can only be enabled with native execution.
 
 ``optimizer.optimize-hash-generation``


### PR DESCRIPTION
## Description
The PR fixes minor issues in the documentation.

## Motivation and Context
The following warnings have been fixed:
```
./presto/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst:32: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
./presto/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst:71: WARNING: Title underline too short.
./presto/presto-docs/src/main/sphinx/connector/postgresql.rst:152: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
./presto/presto-docs/src/main/sphinx/presto_cpp/properties.rst:78: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
./presto/presto-docs/src/main/sphinx/connector/hive.rst:232: WARNING: Blank line required after table. [docutils]
```

## Impact
_None_

## Test Plan
Build documentation and check there are no related warning mentioned in the description:
```shell
presto-docs/build
```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

