### PR TITLE
[Feat][presto-hive][s3]support specify region

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.facebook.presto</groupId>
     <artifactId>presto-root</artifactId>
-    <version>0.270</version>
+    <version>0.270.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>presto-root</name>
@@ -30,7 +30,7 @@
     <scm>
         <connection>scm:git:git://github.com/prestodb/presto.git</connection>
         <url>https://github.com/prestodb/presto</url>
-        <tag>0.270</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.facebook.presto</groupId>
     <artifactId>presto-root</artifactId>
-    <version>0.270-SNAPSHOT</version>
+    <version>0.270</version>
     <packaging>pom</packaging>
 
     <name>presto-root</name>
@@ -30,7 +30,7 @@
     <scm>
         <connection>scm:git:git://github.com/prestodb/presto.git</connection>
         <url>https://github.com/prestodb/presto</url>
-        <tag>HEAD</tag>
+        <tag>0.270</tag>
     </scm>
 
     <properties>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-accumulo</artifactId>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-accumulo</artifactId>

--- a/presto-atop/pom.xml
+++ b/presto-atop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-atop</artifactId>

--- a/presto-atop/pom.xml
+++ b/presto-atop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-atop</artifactId>

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-base-jdbc</artifactId>

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-base-jdbc</artifactId>

--- a/presto-benchmark-driver/pom.xml
+++ b/presto-benchmark-driver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-benchmark-driver</artifactId>

--- a/presto-benchmark-driver/pom.xml
+++ b/presto-benchmark-driver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-benchmark-driver</artifactId>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-benchmark-runner</artifactId>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-benchmark-runner</artifactId>

--- a/presto-benchmark/pom.xml
+++ b/presto-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-benchmark</artifactId>

--- a/presto-benchmark/pom.xml
+++ b/presto-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-benchmark</artifactId>

--- a/presto-benchto-benchmarks/pom.xml
+++ b/presto-benchto-benchmarks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-benchto-benchmarks</artifactId>

--- a/presto-benchto-benchmarks/pom.xml
+++ b/presto-benchto-benchmarks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-benchto-benchmarks</artifactId>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-bigquery</artifactId>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-bigquery</artifactId>

--- a/presto-blackhole/pom.xml
+++ b/presto-blackhole/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-blackhole</artifactId>

--- a/presto-blackhole/pom.xml
+++ b/presto-blackhole/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-blackhole</artifactId>

--- a/presto-bytecode/pom.xml
+++ b/presto-bytecode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-bytecode</artifactId>

--- a/presto-bytecode/pom.xml
+++ b/presto-bytecode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-bytecode</artifactId>

--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-cache</artifactId>

--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-cache</artifactId>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-cassandra</artifactId>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-cassandra</artifactId>

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-cli</artifactId>

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-cli</artifactId>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-client</artifactId>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-client</artifactId>

--- a/presto-cluster-ttl-providers/pom.xml
+++ b/presto-cluster-ttl-providers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-cluster-ttl-providers/pom.xml
+++ b/presto-cluster-ttl-providers/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-common/pom.xml
+++ b/presto-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-common</artifactId>

--- a/presto-common/pom.xml
+++ b/presto-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-common</artifactId>

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-delta</artifactId>

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-delta</artifactId>

--- a/presto-docs/pom.xml
+++ b/presto-docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-docs</artifactId>

--- a/presto-docs/pom.xml
+++ b/presto-docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-docs</artifactId>

--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.270
     release/release-0.269
     release/release-0.268
     release/release-0.267

--- a/presto-docs/src/main/sphinx/release/release-0.270.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.270.rst
@@ -1,0 +1,36 @@
+=============
+Release 0.270
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix error classification when an invalid timezone is passed as a parameter to :func:`from_unixtime`.
+* Improve performance of ``DISTINCT LIMIT N`` queries for N <= 10000. This can be enabled with the session property ``hash_based_distinct_limit_enabled``
+  or the configuration property ``hash-based-distinct-limit-enabled`` and the limit can be adjusted by using the session property ``hash_based_distinct_limit_threshold``
+  or the configuration property ``hash-based-distinct-limit-threshold``.
+* Add :func:`last_day_of_month` UDF to return the last day of the month.
+* Add dynamic filtering support for right join.
+* Add support for any expression for dynamic filtering probe side.
+* Add new optimizer rule to simplify expressions like ``cardinality(map_keys(m))`` into ``cardinality((m))``. Same for :func:`map_values` function.
+* Add support for the following primitive types to Avro decoder: ``TINYINT``, ``SMALLINT``, ``INTEGER`` and ``REAL``.
+
+Hive Connector Changes
+____________
+* Remove the configuration property ``hive.parquet.fail-on-corrupted-statistics`` and the session property ``parquet_fail_with_corrupted_statistics``.
+
+Iceberg Connector Changes
+_______________
+* Remove the configuration property ``iceberg.native-mode``. Use ``iceberg.catalog.type`` instead.
+
+Pinot Connector Changes
+_____________
+* Add support for Pinot ``TIMESTAMP`` and ``JSON`` types.
+* Add support for Pinot version 0.9.3.
+
+**Credits**
+===========
+
+Amit Dutta, Arunachalam Thirupathi, Beinan, Chunxu Tang, James Petty, James Sun, Nikolay Laptev, Pedro Sereno, Pranjal Shankhdhar, Rongrong Zhong, Sreeni Viswanadha, Timothy Meehan, Xiang Fu, Yang Yang, Zhenxiao Luo, chuxiao, ericyuliu, wangjingdong, zhangyanbing

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-druid</artifactId>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-druid</artifactId>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <artifactId>presto-elasticsearch</artifactId>
     <description>Presto - Elasticsearch Connector</description>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <artifactId>presto-elasticsearch</artifactId>
     <description>Presto - Elasticsearch Connector</description>

--- a/presto-example-http/pom.xml
+++ b/presto-example-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-example-http</artifactId>

--- a/presto-example-http/pom.xml
+++ b/presto-example-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-example-http</artifactId>

--- a/presto-expressions/pom.xml
+++ b/presto-expressions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-expressions</artifactId>

--- a/presto-expressions/pom.xml
+++ b/presto-expressions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-expressions</artifactId>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-geospatial-toolkit</artifactId>

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-geospatial-toolkit</artifactId>

--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-geospatial</artifactId>

--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-geospatial</artifactId>

--- a/presto-google-sheets/pom.xml
+++ b/presto-google-sheets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-google-sheets</artifactId>

--- a/presto-google-sheets/pom.xml
+++ b/presto-google-sheets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-google-sheets</artifactId>

--- a/presto-grpc-api/pom.xml
+++ b/presto-grpc-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-grpc-api/pom.xml
+++ b/presto-grpc-api/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-grpc-testing-udf-server/pom.xml
+++ b/presto-grpc-testing-udf-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-grpc-testing-udf-server/pom.xml
+++ b/presto-grpc-testing-udf-server/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-hive-common/pom.xml
+++ b/presto-hive-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <properties>

--- a/presto-hive-common/pom.xml
+++ b/presto-hive-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/presto-hive-function-namespace/pom.xml
+++ b/presto-hive-function-namespace/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-hive-function-namespace</artifactId>

--- a/presto-hive-function-namespace/pom.xml
+++ b/presto-hive-function-namespace/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hive-function-namespace</artifactId>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hive-hadoop2</artifactId>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-hive-hadoop2</artifactId>

--- a/presto-hive-metastore/pom.xml
+++ b/presto-hive-metastore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hive-metastore</artifactId>

--- a/presto-hive-metastore/pom.xml
+++ b/presto-hive-metastore/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-hive-metastore</artifactId>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hive</artifactId>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-hive</artifactId>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -92,6 +92,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -764,6 +765,17 @@ public class PrestoS3FileSystem
             if (region != null) {
                 clientBuilder = clientBuilder.withRegion(region.getName());
                 regionOrEndpointSet = true;
+            }
+        }
+        String specifiedRegion = hadoopConfig.get(S3ConfigurationUpdater.S3_REGION);
+        if (Objects.nonNull(specifiedRegion)) {
+            Regions regions = Regions.fromName(specifiedRegion);
+            if (Objects.nonNull(regions)) {
+                clientBuilder = clientBuilder.withRegion(regions);
+                regionOrEndpointSet = true;
+            }
+            else {
+                throw new IllegalArgumentException("Invalid S3 region: " + specifiedRegion);
             }
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -92,7 +92,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -768,15 +767,9 @@ public class PrestoS3FileSystem
             }
         }
         String specifiedRegion = hadoopConfig.get(S3ConfigurationUpdater.S3_REGION);
-        if (Objects.nonNull(specifiedRegion)) {
-            Regions regions = Regions.fromName(specifiedRegion);
-            if (Objects.nonNull(regions)) {
-                clientBuilder = clientBuilder.withRegion(regions);
-                regionOrEndpointSet = true;
-            }
-            else {
-                throw new IllegalArgumentException("Invalid S3 region: " + specifiedRegion);
-            }
+        if (specifiedRegion != null) {
+            clientBuilder = clientBuilder.withRegion(Regions.fromName(specifiedRegion));
+            regionOrEndpointSet = true;
         }
 
         String endpoint = hadoopConfig.get(S3_ENDPOINT);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/S3ConfigurationUpdater.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/S3ConfigurationUpdater.java
@@ -43,6 +43,7 @@ public interface S3ConfigurationUpdater
     String S3_PATH_STYLE_ACCESS = "presto.s3.path-style-access";
     String S3_SIGNER_TYPE = "presto.s3.signer-type";
     String S3_ENDPOINT = "presto.s3.endpoint";
+    String S3_REGION = "presto.s3.region";
     String S3_SECRET_KEY = "presto.s3.secret-key";
     String S3_ACCESS_KEY = "presto.s3.access-key";
     String S3_ACL_TYPE = "presto.s3.upload-acl-type";

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -186,6 +186,18 @@ public class TestPrestoS3FileSystem
     }
 
     @Test
+    public void testRegionSpecified() throws Exception
+    {
+        Configuration config = new Configuration();
+        config.set(S3ConfigurationUpdater.S3_REGION, "us-iso-west-1");
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            fs.initialize(new URI("s3p://test-bucket/"), config);
+            String region = getFieldValue(fs.getS3Client(), AmazonS3Client.class, "clientRegion", String.class);
+            assertEquals(region, config.get(S3ConfigurationUpdater.S3_REGION));
+        }
+    }
+
+    @Test
     public void testPathStyleAccess()
             throws Exception
     {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -198,6 +198,18 @@ public class TestPrestoS3FileSystem
     }
 
     @Test
+    public void testInvalidRegionSpecified()
+    {
+        Configuration config = new Configuration();
+        config.set(S3ConfigurationUpdater.S3_REGION, "invalid-region");
+        expectThrows(IllegalArgumentException.class, () -> {
+            try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+                fs.initialize(new URI("s3p://test-bucket/"), config);
+            }
+        });
+    }
+
+    @Test
     public void testPathStyleAccess()
             throws Exception
     {

--- a/presto-i18n-functions/pom.xml
+++ b/presto-i18n-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-i18n-functions</artifactId>

--- a/presto-i18n-functions/pom.xml
+++ b/presto-i18n-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-i18n-functions</artifactId>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <artifactId>presto-iceberg</artifactId>
     <description>Presto - Iceberg Connector</description>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <artifactId>presto-iceberg</artifactId>
     <description>Presto - Iceberg Connector</description>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-jdbc</artifactId>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-jdbc</artifactId>

--- a/presto-jmx/pom.xml
+++ b/presto-jmx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-jmx</artifactId>

--- a/presto-jmx/pom.xml
+++ b/presto-jmx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-jmx</artifactId>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-kafka</artifactId>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-kafka</artifactId>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-kudu</artifactId>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-kudu</artifactId>

--- a/presto-local-file/pom.xml
+++ b/presto-local-file/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-local-file</artifactId>

--- a/presto-local-file/pom.xml
+++ b/presto-local-file/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-local-file</artifactId>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-main</artifactId>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-main</artifactId>

--- a/presto-matching/pom.xml
+++ b/presto-matching/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-matching</artifactId>

--- a/presto-matching/pom.xml
+++ b/presto-matching/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-matching</artifactId>

--- a/presto-memory-context/pom.xml
+++ b/presto-memory-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-memory-context</artifactId>

--- a/presto-memory-context/pom.xml
+++ b/presto-memory-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-memory-context</artifactId>

--- a/presto-memory/pom.xml
+++ b/presto-memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-memory</artifactId>

--- a/presto-memory/pom.xml
+++ b/presto-memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-memory</artifactId>

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-ml</artifactId>

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-ml</artifactId>

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-mongodb</artifactId>

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-mongodb</artifactId>

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-mysql</artifactId>

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-mysql</artifactId>

--- a/presto-node-ttl-fetchers/pom.xml
+++ b/presto-node-ttl-fetchers/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-node-ttl-fetchers</artifactId>

--- a/presto-node-ttl-fetchers/pom.xml
+++ b/presto-node-ttl-fetchers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-node-ttl-fetchers</artifactId>

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-oracle</artifactId>

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-oracle</artifactId>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-orc</artifactId>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-orc</artifactId>

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-parquet</artifactId>

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-parquet</artifactId>

--- a/presto-parser/pom.xml
+++ b/presto-parser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-parser</artifactId>

--- a/presto-parser/pom.xml
+++ b/presto-parser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-parser</artifactId>

--- a/presto-password-authenticators/pom.xml
+++ b/presto-password-authenticators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-password-authenticators</artifactId>

--- a/presto-password-authenticators/pom.xml
+++ b/presto-password-authenticators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-password-authenticators</artifactId>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-pinot-toolkit</artifactId>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-pinot-toolkit</artifactId>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-pinot</artifactId>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-pinot</artifactId>

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-plugin-toolkit</artifactId>

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-plugin-toolkit</artifactId>

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-postgresql</artifactId>

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-postgresql</artifactId>

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-product-tests</artifactId>

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-product-tests</artifactId>

--- a/presto-prometheus/pom.xml
+++ b/presto-prometheus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-prometheus</artifactId>

--- a/presto-prometheus/pom.xml
+++ b/presto-prometheus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-prometheus</artifactId>

--- a/presto-proxy/pom.xml
+++ b/presto-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-proxy</artifactId>

--- a/presto-proxy/pom.xml
+++ b/presto-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-proxy</artifactId>

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-raptor</artifactId>

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-raptor</artifactId>

--- a/presto-rcfile/pom.xml
+++ b/presto-rcfile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-rcfile</artifactId>

--- a/presto-rcfile/pom.xml
+++ b/presto-rcfile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-rcfile</artifactId>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-record-decoder</artifactId>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-record-decoder</artifactId>

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-redis</artifactId>

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-redis</artifactId>

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-redshift</artifactId>

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-redshift</artifactId>

--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-resource-group-managers</artifactId>

--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-resource-group-managers</artifactId>

--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-server-rpm</artifactId>

--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-server-rpm</artifactId>

--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-server</artifactId>

--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-server</artifactId>

--- a/presto-session-property-managers/pom.xml
+++ b/presto-session-property-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-session-property-managers</artifactId>

--- a/presto-session-property-managers/pom.xml
+++ b/presto-session-property-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-session-property-managers</artifactId>

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-common/pom.xml
+++ b/presto-spark-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-spark-common</artifactId>

--- a/presto-spark-common/pom.xml
+++ b/presto-spark-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-spark-common</artifactId>

--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-package/pom.xml
+++ b/presto-spark-package/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-spark-package</artifactId>

--- a/presto-spark-package/pom.xml
+++ b/presto-spark-package/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-spark-package</artifactId>

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark/pom.xml
+++ b/presto-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark/pom.xml
+++ b/presto-spark/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-spi</artifactId>

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-spi</artifactId>

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-teradata-functions</artifactId>

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-teradata-functions</artifactId>

--- a/presto-testing-docker/pom.xml
+++ b/presto-testing-docker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-testing-docker</artifactId>

--- a/presto-testing-docker/pom.xml
+++ b/presto-testing-docker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-testing-docker</artifactId>

--- a/presto-testing-server-launcher/pom.xml
+++ b/presto-testing-server-launcher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-testing-server-launcher</artifactId>

--- a/presto-testing-server-launcher/pom.xml
+++ b/presto-testing-server-launcher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-testing-server-launcher</artifactId>

--- a/presto-testng-services/pom.xml
+++ b/presto-testng-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-testng-services</artifactId>

--- a/presto-testng-services/pom.xml
+++ b/presto-testng-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-testng-services</artifactId>

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-tests</artifactId>

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-tests</artifactId>

--- a/presto-thrift-api/pom.xml
+++ b/presto-thrift-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-thrift-api</artifactId>

--- a/presto-thrift-api/pom.xml
+++ b/presto-thrift-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-api</artifactId>

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-connector</artifactId>

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-thrift-connector</artifactId>

--- a/presto-thrift-spec/pom.xml
+++ b/presto-thrift-spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-thrift-spec</artifactId>

--- a/presto-thrift-spec/pom.xml
+++ b/presto-thrift-spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-spec</artifactId>

--- a/presto-thrift-testing-server/pom.xml
+++ b/presto-thrift-testing-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-testing-server</artifactId>

--- a/presto-thrift-testing-server/pom.xml
+++ b/presto-thrift-testing-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-thrift-testing-server</artifactId>

--- a/presto-thrift-testing-udf-server/pom.xml
+++ b/presto-thrift-testing-udf-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-thrift-testing-udf-server</artifactId>

--- a/presto-thrift-testing-udf-server/pom.xml
+++ b/presto-thrift-testing-udf-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-testing-udf-server</artifactId>

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-tpcds</artifactId>

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-tpcds</artifactId>

--- a/presto-tpch/pom.xml
+++ b/presto-tpch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-tpch</artifactId>

--- a/presto-tpch/pom.xml
+++ b/presto-tpch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-tpch</artifactId>

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270-SNAPSHOT</version>
+        <version>0.270</version>
     </parent>
 
     <artifactId>presto-verifier</artifactId>

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.270</version>
+        <version>0.270.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-verifier</artifactId>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
add a property named presto.s3.region, then build the s3 client use this region when this property is not blank.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
close #25929
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
added UT case
## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support to specify the region of AWS S3 client in Presto-hive
* ... 

Hive Connector Changes
* ... 
* ... 
```



