### PR TITLE
split Exchange and Result compression session properties

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -160,6 +160,8 @@ public final class SystemSessionProperties
     public static final String ITERATIVE_OPTIMIZER_TIMEOUT = "iterative_optimizer_timeout";
     public static final String QUERY_ANALYZER_TIMEOUT = "query_analyzer_timeout";
     public static final String RUNTIME_OPTIMIZER_ENABLED = "runtime_optimizer_enabled";
+    public static final String RESULT_COMPRESSION_CODEC = "result_compression_codec";
+    public static final String RESULT_CHECKSUM = "result_checksum";
     public static final String EXCHANGE_COMPRESSION_CODEC = "exchange_compression_codec";
     public static final String EXCHANGE_CHECKSUM = "exchange_checksum";
     public static final String LEGACY_TIMESTAMP = "legacy_timestamp";
@@ -860,6 +862,20 @@ public final class SystemSessionProperties
                         RUNTIME_OPTIMIZER_ENABLED,
                         "Experimental: enable runtime optimizer",
                         featuresConfig.isRuntimeOptimizerEnabled(),
+                        false),
+                new PropertyMetadata<>(
+                        RESULT_COMPRESSION_CODEC,
+                        "Serialized result compression codec",
+                        VARCHAR,
+                        CompressionCodec.class,
+                        featuresConfig.getResultCompressionCodec(),
+                        false,
+                        value -> CompressionCodec.valueOf(((String) value).toUpperCase()),
+                        CompressionCodec::name),
+                booleanProperty(
+                        RESULT_CHECKSUM,
+                        "Enable checksum in serialized results",
+                        featuresConfig.isResultChecksumEnabled(),
                         false),
                 new PropertyMetadata<>(
                         EXCHANGE_COMPRESSION_CODEC,
@@ -2378,6 +2394,16 @@ public final class SystemSessionProperties
     public static Duration getQueryAnalyzerTimeout(Session session)
     {
         return session.getSystemProperty(QUERY_ANALYZER_TIMEOUT, Duration.class);
+    }
+
+    public static CompressionCodec getResultCompressionCodec(Session session)
+    {
+        return session.getSystemProperty(RESULT_COMPRESSION_CODEC, CompressionCodec.class);
+    }
+
+    public static boolean isResultChecksumEnabled(Session session)
+    {
+        return session.getSystemProperty(RESULT_CHECKSUM, Boolean.class);
     }
 
     public static CompressionCodec getExchangeCompressionCodec(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -117,6 +117,8 @@ public class FeaturesConfig
     private boolean enableIntermediateAggregations;
     private boolean optimizeCaseExpressionPredicate;
     private boolean pushTableWriteThroughUnion = true;
+    private CompressionCodec resultCompressionCodec = CompressionCodec.NONE;
+    private boolean resultChecksumEnabled;
     private CompressionCodec exchangeCompressionCodec = CompressionCodec.NONE;
     private boolean exchangeChecksumEnabled;
     private boolean optimizeMixedDistinctAggregations;
@@ -1512,6 +1514,30 @@ public class FeaturesConfig
     public FeaturesConfig setOptimizeMixedDistinctAggregations(boolean value)
     {
         this.optimizeMixedDistinctAggregations = value;
+        return this;
+    }
+
+    public CompressionCodec getResultCompressionCodec()
+    {
+        return resultCompressionCodec;
+    }
+
+    public boolean isResultChecksumEnabled()
+    {
+        return resultChecksumEnabled;
+    }
+
+    @Config("result.compression-codec")
+    public FeaturesConfig setResultCompressionCodec(CompressionCodec resultCompressionCodec)
+    {
+        this.resultCompressionCodec = resultCompressionCodec;
+        return this;
+    }
+
+    @Config("result.checksum-enabled")
+    public FeaturesConfig setResultChecksumEnabled(boolean resultChecksumEnabled)
+    {
+        this.resultChecksumEnabled = resultChecksumEnabled;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -75,11 +75,11 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.MoreFutures.addTimeout;
-import static com.facebook.presto.SystemSessionProperties.getExchangeCompressionCodec;
 import static com.facebook.presto.SystemSessionProperties.getQueryRetryLimit;
 import static com.facebook.presto.SystemSessionProperties.getQueryRetryMaxExecutionTime;
+import static com.facebook.presto.SystemSessionProperties.getResultCompressionCodec;
 import static com.facebook.presto.SystemSessionProperties.getTargetResultSize;
-import static com.facebook.presto.SystemSessionProperties.isExchangeChecksumEnabled;
+import static com.facebook.presto.SystemSessionProperties.isResultChecksumEnabled;
 import static com.facebook.presto.SystemSessionProperties.retryQueryWithHistoryBasedOptimizationEnabled;
 import static com.facebook.presto.SystemSessionProperties.trackHistoryBasedPlanStatisticsEnabled;
 import static com.facebook.presto.SystemSessionProperties.useHistoryBasedPlanStatisticsEnabled;
@@ -263,7 +263,7 @@ class Query
         this.resultsProcessorExecutor = resultsProcessorExecutor;
         this.timeoutExecutor = timeoutExecutor;
 
-        this.serde = new PagesSerdeFactory(blockEncodingSerde, getExchangeCompressionCodec(session), isExchangeChecksumEnabled(session)).createPagesSerde();
+        this.serde = new PagesSerdeFactory(blockEncodingSerde, getResultCompressionCodec(session), isResultChecksumEnabled(session)).createPagesSerde();
         this.retryCircuitBreaker = retryCircuitBreaker;
         this.retryConfig = retryConfig;
     }


### PR DESCRIPTION
Summary:
The exchange compression format session property controls the encoding across exchanges, but also the encoding for results returning via the serialized result interface

There are a few reasons we may want to independently control these:

1. result compression occurs on the coordinator, which likely has different resource constraints than worker nodes
2. the transfer from coordinator to client may operate over a higher latency or lower bandwidth link: for this reason the expectation is that  a more rigorous compression format may be preferable to that used for worker-worker or worker-coordinator exchanges

Differential Revision: D81504585
