### PR TITLE
Fix version-specific Spark profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,7 @@
         <dep.guice.version>6.0.0</dep.guice.version>
         <dep.arrow.version>17.0.0</dep.arrow.version>
         <dep.mariadb.version>3.5.4</dep.mariadb.version>
-
-        <dep.pos.classloader.module-name.suffix>2</dep.pos.classloader.module-name.suffix>
+        <dep.spark.version>2.0.2-6</dep.spark.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -225,7 +224,6 @@
         <module>presto-router-example-plugin-scheduler</module>
         <module>presto-plan-checker-router-plugin</module>
         <module>presto-sql-invoked-functions-plugin</module>
-        <module>presto-spark-classloader-spark${dep.pos.classloader.module-name.suffix}</module>
     </modules>
 
     <dependencyManagement>
@@ -946,12 +944,6 @@
 
             <dependency>
                 <groupId>com.facebook.presto</groupId>
-                <artifactId>presto-spark-classloader-spark${dep.pos.classloader.module-name.suffix}</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-spark</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -985,6 +977,13 @@
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-spark-package</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto.spark</groupId>
+                <artifactId>spark-core</artifactId>
+                <version>${dep.spark.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <dependency>
@@ -2539,13 +2538,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.facebook.presto.spark</groupId>
-                <artifactId>spark-core</artifactId>
-                <version>2.0.2-6</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>com.clearspring.analytics</groupId>
                 <artifactId>stream</artifactId>
                 <version>2.9.5</version>
@@ -3163,6 +3155,78 @@
             </build>
         </profile>
         <profile>
+            <id>spark2</id>
+
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!spark-version</name>
+                </property>
+            </activation>
+
+            <properties>
+                <dep.spark.version>2.0.2-6</dep.spark.version>
+            </properties>
+
+            <modules>
+                <module>presto-spark-classloader-spark2</module>
+            </modules>
+
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-enforcer-plugin</artifactId>
+                            <version>3.3.0</version>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.codehaus.mojo</groupId>
+                                    <artifactId>extra-enforcer-rules</artifactId>
+                                    <version>1.6.2</version>
+                                </dependency>
+                            </dependencies>
+                            <configuration>
+                                <skip>true</skip>
+                                <rules>
+                                    <requireUpperBoundDeps>
+                                        <excludes combine.children="append">
+                                            <!-- TODO: fix this in Airlift resolver -->
+                                            <exclude>org.codehaus.plexus:plexus-utils</exclude>
+                                            <exclude>com.google.guava:guava</exclude>
+                                            <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
+                                            <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
+                                            <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+                                        </excludes>
+                                    </requireUpperBoundDeps>
+                                </rules>
+                            </configuration>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.basepom.maven</groupId>
+                            <artifactId>duplicate-finder-maven-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                                <ignoredClassPatterns combine.children="append">
+                                    <ignoredClassPattern>com.github.benmanes.caffeine.*</ignoredClassPattern>
+                                    <!-- Duplicate class is being brought in by commons-io & log4j-api -->
+                                    <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                                    <!-- Duplicate class is being brought in by several netty dependencies-->
+                                    <ignoredClassPattern>META-INF.versions.11.module-info</ignoredClassPattern>
+                                    <!-- Ignore duplicate classes related to lucene-core and ranger-apache -->
+                                    <ignoredClassPattern>META-INF.versions.9.org.apache.lucene.*</ignoredClassPattern>
+                                </ignoredClassPatterns>
+
+                            </configuration>
+                        </plugin>
+
+                    </plugins>
+                </pluginManagement>
+            </build>
+
+        </profile>
+        <profile>
             <id>spark3</id>
 
             <activation>
@@ -3173,19 +3237,12 @@
             </activation>
 
             <properties>
-                <dep.pos.classloader.module-name.suffix>3</dep.pos.classloader.module-name.suffix>
+                <dep.spark.version>3.4.1-1</dep.spark.version>
             </properties>
 
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.facebook.presto.spark</groupId>
-                        <artifactId>spark-core</artifactId>
-                        <version>3.4.1-1</version>
-                        <scope>provided</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
+            <modules>
+                <module>presto-spark-classloader-spark3</module>
+            </modules>
 
             <build>
                 <pluginManagement>

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -16,7 +16,6 @@
         <dep.jetty.version>9.4.55.v20240627</dep.jetty.version>
         <dep.okhttp.version>4.12.0</dep.okhttp.version>
         <dep.okio-jvm.version>3.9.1</dep.okio-jvm.version>
-        <dep.pos.classloader.module-name.suffix>2</dep.pos.classloader.module-name.suffix>
     </properties>
 
     <dependencyManagement>
@@ -52,12 +51,6 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spark-classloader-interface</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-spark-classloader-spark${dep.pos.classloader.module-name.suffix}</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -539,6 +532,25 @@
             </build>
         </profile>
         <profile>
+            <id>spark2</id>
+
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!spark-version</name>
+                </property>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.facebook.presto</groupId>
+                    <artifactId>presto-spark-classloader-spark2</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <id>spark3</id>
 
             <activation>
@@ -548,11 +560,13 @@
                 </property>
             </activation>
 
-            <properties>
-                <dep.pos.classloader.module-name.suffix>3</dep.pos.classloader.module-name.suffix>
-            </properties>
-
             <dependencies>
+                <dependency>
+                    <groupId>com.facebook.presto</groupId>
+                    <artifactId>presto-spark-classloader-spark3</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+
                 <dependency>
                     <groupId>com.facebook.presto.spark</groupId>
                     <artifactId>spark-core</artifactId>

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -13,7 +13,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
-        <dep.pos.classloader.module-name.suffix>2</dep.pos.classloader.module-name.suffix>
     </properties>
 
     <dependencies>
@@ -21,11 +20,6 @@
             <groupId>com.facebook.presto.spark</groupId>
             <artifactId>spark-core</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-spark-classloader-spark${dep.pos.classloader.module-name.suffix}</artifactId>
         </dependency>
 
         <dependency>
@@ -41,6 +35,25 @@
 
     <profiles>
         <profile>
+            <id>spark2</id>
+
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!spark-version</name>
+                </property>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.facebook.presto</groupId>
+                    <artifactId>presto-spark-classloader-spark2</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+
+        </profile>
+        <profile>
             <id>spark3</id>
 
             <activation>
@@ -50,22 +63,12 @@
                 </property>
             </activation>
 
-            <properties>
-                <dep.pos.classloader.module-name.suffix>3</dep.pos.classloader.module-name.suffix>
-            </properties>
-
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.facebook.presto.spark</groupId>
-                        <artifactId>spark-core</artifactId>
-                        <version>3.4.1-1</version>
-                        <scope>compile</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-
             <dependencies>
+                <dependency>
+                    <groupId>com.facebook.presto</groupId>
+                    <artifactId>presto-spark-classloader-spark3</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This reworks the presto-spark-classloader-spark2 and presto-spark-classloader-spark3 modules used for binding to version-specific Spark releases.  This changes the way the modules are handled during the build by controlling their inclusion via Maven profiles:
* spark2: (on by default, or when spark-version=2) includes the presto-spark-classloader-spark2 module, and sets the spark-core artifact to v2.0.2
* spark3: (active when spark-version=3) includes the presto-spark-classloader-spark3 module, and sets the spark-core artifact to 3.4.1

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
A prior version of the spark3 profile was added in PR #25552.  However, this controlled the module included by manipulating the module name, appending a version number at the end.  Not having the full module name listed confused other plugins which analyze the project POM, like the versions plugin.  As a result, running `mvn versions:set` was not able to update the version for the presto-spark-classloader-spark2 and presto-spark-classloader-spark3 modules.  With this change `mvn versions:set` is able to update both module versions.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Built with both the spark2 and spark3 modules and verified that the correct presto-spark-classloader-sparkN dependency is included.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

