### PR TITLE
[docs] Add node selection strategy documentation to develop/connectors.rst

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -541,7 +541,8 @@ Property Name                                         Description               
                                                       assign a split to. Splits which read data from the same file within
                                                       the same chunk will hash to the same node. A smaller chunk size will
                                                       result in a higher probability splits being distributed evenly across
-                                                      the cluster, but reduce locality.
+                                                      the cluster, but reduce locality. 
+                                                      See :ref:`develop/connectors:Node Selection Strategy`.
 ``iceberg.parquet_dereference_pushdown_enabled``      Overrides the behavior of the connector property                        Yes                 No
                                                       ``iceberg.enable-parquet-dereference-pushdown`` in the current session.
 ===================================================== ======================================================================= =================== =============================================

--- a/presto-docs/src/main/sphinx/develop/connectors.rst
+++ b/presto-docs/src/main/sphinx/develop/connectors.rst
@@ -8,7 +8,8 @@ you adapt your data source to the API expected by Presto, you can write
 queries against this data.
 
 ConnectorSplit
-----------------
+--------------
+
 Instances of your connector splits.
 
 The ``getNodeSelectionStrategy`` method indicates the node affinity
@@ -81,3 +82,14 @@ Given a split and a list of columns, the record set provider is
 responsible for delivering data to the Presto execution engine.
 It creates a ``RecordSet``, which in turn creates a ``RecordCursor``
 that is used by Presto to read the column values for each row.
+
+Node Selection Strategy
+-----------------------
+
+The node selection strategy is specified by a connector on each split.  The possible values are:
+
+* HARD_AFFINITY - The Presto runtime must schedule this split on the nodes specified on ``ConnectorSplit#getPreferredNodes``.
+* SOFT_AFFINITY - The Presto runtime should prefer ``ConnectorSplit#getPreferredNodes`` nodes, but doesn't have to. Use this value primarily for caching.
+* NO_PREFERENCE - No preference. 
+
+Use the ``node_selection_strategy`` session property in Hive and Iceberg to override this. 


### PR DESCRIPTION
## Description
* Add Node Selection Strategy documentation to [develop/connectors.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/develop/connectors.rst).

* Add a cross-reference link from ``iceberg.affinity_scheduling_file_section_size`` in [Session Properties](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/connector/iceberg.rst#session-properties) in the Iceberg connector doc to the new Node Selection Strategy topic. 

## Motivation and Context
Fixes #24200.

## Impact
Documentation.

## Test Plan
Local doc builds. 

Screenshot of new Node Selection Strategy topic in develop/connectors.rst:
<img width="633" height="286" alt="Screenshot 2025-09-03 at 10 56 55 AM" src="https://github.com/user-attachments/assets/5bf76402-5c60-461b-939e-f055a078b774" />

Screenshot of cross-reference added to Session Properties in connector/iceberg.rst:
<img width="622" height="408" alt="Screenshot 2025-09-03 at 10 56 49 AM" src="https://github.com/user-attachments/assets/81867642-675b-41b1-b275-3e49fa19d7cc" />

Note: 
``hive.affinity_scheduling_file_section_size`` is not present in connector/hive.rst, and I don't know if it exists as a counterpart to the documented ``iceberg.affinity_scheduling_file_section_size``. Therefore I was unable to easily add the cross-reference link to the Hive documentation. 

(There is no Session Properties topic in connector/hive.rst. There's an open doc issue #25110 for that but I don't want to fix that issue in this PR, I'd like to address #25110 separately.)

In the meantime, I'm open to suggestions of what should be added to the Hive connector doc in this PR that would include a cross-reference to the new Node Selection Strategy topic in develop/connectors.rst. I am also okay with "Nothing, let's do that in a separate PR"; if that's what we think is best I will open a new doc issue to track that work. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

