### PR TITLE
CODEOWNERS: Include pos native tests in presto-on-spark codeownership 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -123,6 +123,7 @@ CODEOWNERS @prestodb/team-tsc
 #####################################################################
 # Presto on Spark module
 /presto-spark* @shrinidhijoshi @prestodb/committers
+/presto-native-execution/*/com/facebook/presto/spark/* @shrinidhijoshi @prestodb/committers
 
 #####################################################################
 # Presto connectors and plugins
@@ -166,4 +167,3 @@ CODEOWNERS @prestodb/team-tsc
 # Presto CI and builds
 /.github @czentgr @unidevel @prestodb/committers
 /docker @czentgr @unidevel @prestodb/committers
-


### PR DESCRIPTION

## Description
Currently, the presto-on-spark native tests are located in `presto-native-execution` module. When 
there are changes to presto-on-spark code, the codeowners can approve and merge changes only if
the changes do not touch presto-on-spark native tests in `presto-native-execution` module.

This diff adds the existing presto-on-spark codeowners to be able to also merge presto-on-spark native tests code
located in `presto-native-execution` module

```
== NO RELEASE NOTE ==
```

