### PR TITLE
Fix the behaviour of File-based Session Property Manager

### DIFF
--- a/presto-file-session-property-manager/src/test/java/com/facebook/presto/session/file/TestFileSessionPropertyManager.java
+++ b/presto-file-session-property-manager/src/test/java/com/facebook/presto/session/file/TestFileSessionPropertyManager.java
@@ -19,12 +19,14 @@ import com.facebook.presto.session.AbstractTestSessionPropertyManager;
 import com.facebook.presto.session.SessionMatchSpec;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManager;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.session.file.FileSessionPropertyManager.CODEC;
 import static org.testng.Assert.assertEquals;
@@ -58,5 +60,61 @@ public class TestFileSessionPropertyManager
             assertEquals(propertyConfiguration.systemPropertyOverrides, overrideProperties);
             assertEquals(manager.getCatalogSessionProperties(CONTEXT), catalogProperties);
         }
+    }
+
+    @Test
+    public void testNullSessionProperties()
+            throws IOException
+    {
+        ImmutableMap<String, Map<String, String>> catalogProperties = ImmutableMap.of("CATALOG", ImmutableMap.of("PROPERTY", "VALUE"));
+        SessionMatchSpec spec = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                null,
+                catalogProperties);
+
+        assertProperties(ImmutableMap.of(), ImmutableMap.of(), catalogProperties, spec);
+    }
+
+    @Test
+    public void testNullCatalogSessionProperties()
+            throws IOException
+    {
+        Map<String, String> properties = ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2");
+        SessionMatchSpec spec = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                properties,
+                null);
+
+        assertProperties(properties, spec);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Either sessionProperties or catalogSessionProperties must be provided")
+    public void testNullBothSessionProperties()
+            throws IOException
+    {
+        SessionMatchSpec spec = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                null,
+                null);
+
+        assertProperties(ImmutableMap.of(), spec);
     }
 }

--- a/presto-session-property-managers-common/src/main/java/com/facebook/presto/session/SessionMatchSpec.java
+++ b/presto-session-property-managers-common/src/main/java/com/facebook/presto/session/SessionMatchSpec.java
@@ -69,9 +69,12 @@ public class SessionMatchSpec
         this.resourceGroupRegex = requireNonNull(resourceGroupRegex, "resourceGroupRegex is null");
         this.clientInfoRegex = requireNonNull(clientInfoRegex, "clientInfoRegex is null");
         this.overrideSessionProperties = requireNonNull(overrideSessionProperties, "overrideSessionProperties is null");
-        requireNonNull(sessionProperties, "sessionProperties is null");
-        this.sessionProperties = ImmutableMap.copyOf(sessionProperties);
-        this.catalogSessionProperties = ImmutableMap.copyOf(catalogSessionProperties);
+
+        checkArgument(sessionProperties != null || catalogSessionProperties != null,
+                "Either sessionProperties or catalogSessionProperties must be provided");
+
+        this.sessionProperties = ImmutableMap.copyOf(Optional.ofNullable(sessionProperties).orElse(ImmutableMap.of()));
+        this.catalogSessionProperties = ImmutableMap.copyOf(Optional.ofNullable(catalogSessionProperties).orElse(ImmutableMap.of()));
     }
 
     public <T> Map<String, T> match(Map<String, T> object, SessionConfigurationContext context)


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
After this change, Presto allows one of the sessionProperties or catalogSessionProperties arguments to be null. If both are null, an exception is thrown.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Resolves #25965 

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Allow sessionProperties or catalogSessionProperties to be passed as null by defaulting them to empty maps, and enforce that at least one is provided

Enhancements:
- Require at least one of sessionProperties or catalogSessionProperties and default null inputs to empty maps

Tests:
- Add unit tests for null sessionProperties, null catalogSessionProperties, and both-null argument scenarios with expected exception