### PR TITLE
Allow client request filters overwrite headers

### DIFF
--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/ArrowFlightQueryRunner.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/ArrowFlightQueryRunner.java
@@ -26,8 +26,6 @@ import org.apache.arrow.flight.Location;
 import org.apache.arrow.memory.RootAllocator;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
@@ -44,15 +42,8 @@ public class ArrowFlightQueryRunner
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
 
-    public static int findUnusedPort()
-            throws IOException
-    {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        }
-    }
-
-    public static DistributedQueryRunner createQueryRunner(int flightServerPort) throws Exception
+    public static DistributedQueryRunner createQueryRunner(int flightServerPort)
+            throws Exception
     {
         return createQueryRunner(flightServerPort, ImmutableMap.of(), ImmutableMap.of(), Optional.empty());
     }

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightEchoQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightEchoQueries.java
@@ -102,6 +102,7 @@ import static com.facebook.presto.common.block.MethodHandleUtil.nativeValueGette
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -123,7 +124,7 @@ public class TestArrowFlightEchoQueries
     public TestArrowFlightEchoQueries()
             throws IOException
     {
-        this.serverPort = ArrowFlightQueryRunner.findUnusedPort();
+        this.serverPort = getAvailablePort();
     }
 
     @BeforeClass
@@ -165,7 +166,8 @@ public class TestArrowFlightEchoQueries
     }
 
     @Test
-    public void testVarCharVector() throws Exception
+    public void testVarCharVector()
+            throws Exception
     {
         try (BufferAllocator bufferAllocator = allocator.newChildAllocator("echo-test-client", 0, Long.MAX_VALUE);
                 IntVector intVector = new IntVector("id", bufferAllocator);
@@ -197,7 +199,8 @@ public class TestArrowFlightEchoQueries
     }
 
     @Test
-    public void testListVector() throws Exception
+    public void testListVector()
+            throws Exception
     {
         try (BufferAllocator bufferAllocator = allocator.newChildAllocator("echo-test-client", 0, Long.MAX_VALUE);
                 IntVector intVector = new IntVector("id", bufferAllocator);
@@ -253,7 +256,8 @@ public class TestArrowFlightEchoQueries
     }
 
     @Test
-    public void testMapVector() throws Exception
+    public void testMapVector()
+            throws Exception
     {
         try (BufferAllocator bufferAllocator = allocator.newChildAllocator("echo-test-client", 0, Long.MAX_VALUE);
                 IntVector intVector = new IntVector("id", bufferAllocator);
@@ -299,7 +303,8 @@ public class TestArrowFlightEchoQueries
     }
 
     @Test
-    public void testStructVector() throws Exception
+    public void testStructVector()
+            throws Exception
     {
         try (BufferAllocator bufferAllocator = allocator.newChildAllocator("echo-test-client", 0, Long.MAX_VALUE);
                 IntVector intVector = new IntVector("id", bufferAllocator);
@@ -343,7 +348,8 @@ public class TestArrowFlightEchoQueries
     }
 
     @Test
-    public void testDictionaryVector() throws Exception
+    public void testDictionaryVector()
+            throws Exception
     {
         try (BufferAllocator bufferAllocator = allocator.newChildAllocator("echo-test-client", 0, Long.MAX_VALUE);
                 IntVector intVector = new IntVector("id", bufferAllocator);
@@ -405,7 +411,8 @@ public class TestArrowFlightEchoQueries
                 keyBlockHashCode);
     }
 
-    private static FlightClient createFlightClient(BufferAllocator allocator, int serverPort) throws IOException
+    private static FlightClient createFlightClient(BufferAllocator allocator, int serverPort)
+            throws IOException
     {
         InputStream trustedCertificate = new ByteArrayInputStream(Files.readAllBytes(Paths.get("src/test/resources/server.crt")));
         Location location = Location.forGrpcTls("localhost", serverPort);

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightIntegrationSmokeTest.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightIntegrationSmokeTest.java
@@ -28,6 +28,8 @@ import org.testng.annotations.BeforeClass;
 import java.io.File;
 import java.io.IOException;
 
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
+
 public class TestArrowFlightIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
@@ -40,7 +42,7 @@ public class TestArrowFlightIntegrationSmokeTest
     public TestArrowFlightIntegrationSmokeTest()
             throws IOException
     {
-        this.serverPort = ArrowFlightQueryRunner.findUnusedPort();
+        this.serverPort = getAvailablePort();
     }
 
     @BeforeClass

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightMtls.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightMtls.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.plugin.arrow.testingConnector.TestingArrowFlightPlugin.ARROW_FLIGHT_CONNECTOR;
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 
 public class TestArrowFlightMtls
         extends AbstractTestQueryFramework
@@ -48,7 +49,7 @@ public class TestArrowFlightMtls
     public TestArrowFlightMtls()
             throws IOException
     {
-        this.serverPort = ArrowFlightQueryRunner.findUnusedPort();
+        this.serverPort = getAvailablePort();
     }
 
     @BeforeClass

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightNativeQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightNativeQueries.java
@@ -42,6 +42,7 @@ import java.util.function.BiFunction;
 import static com.facebook.plugin.arrow.ArrowFlightQueryRunner.getProperty;
 import static com.facebook.plugin.arrow.testingConnector.TestingArrowFlightPlugin.ARROW_FLIGHT_CATALOG;
 import static com.facebook.plugin.arrow.testingConnector.TestingArrowFlightPlugin.ARROW_FLIGHT_CONNECTOR;
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static java.lang.String.format;
 import static org.testng.Assert.assertTrue;
 
@@ -57,7 +58,7 @@ public class TestArrowFlightNativeQueries
     public TestArrowFlightNativeQueries()
             throws IOException
     {
-        this.serverPort = ArrowFlightQueryRunner.findUnusedPort();
+        this.serverPort = getAvailablePort();
     }
 
     @BeforeClass
@@ -366,10 +367,10 @@ public class TestArrowFlightNativeQueries
 
                         Files.write(catalogDirectoryPath.resolve(format("%s.properties", ARROW_FLIGHT_CATALOG)),
                                 format("connector.name=%s\n" +
-                                       "arrow-flight.server=localhost\n" +
-                                       "arrow-flight.server.port=%d\n" +
-                                       "arrow-flight.server-ssl-enabled=true\n" +
-                                       "arrow-flight.server-ssl-certificate=%s", ARROW_FLIGHT_CONNECTOR, flightServerPort, flightCertPath).getBytes());
+                                        "arrow-flight.server=localhost\n" +
+                                        "arrow-flight.server.port=%d\n" +
+                                        "arrow-flight.server-ssl-enabled=true\n" +
+                                        "arrow-flight.server-ssl-certificate=%s", ARROW_FLIGHT_CONNECTOR, flightServerPort, flightCertPath).getBytes());
 
                         // Disable stack trace capturing as some queries (using TRY) generate a lot of exceptions.
                         return new ProcessBuilder(prestoServerPath, "--logtostderr=1", "--v=1")

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightQueries.java
@@ -45,6 +45,7 @@ import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
@@ -62,7 +63,7 @@ public class TestArrowFlightQueries
     public TestArrowFlightQueries()
             throws IOException
     {
-        this.serverPort = ArrowFlightQueryRunner.findUnusedPort();
+        this.serverPort = getAvailablePort();
     }
 
     @BeforeClass

--- a/presto-function-server/src/test/java/com/facebook/presto/tests/TestRestRemoteFunctions.java
+++ b/presto-function-server/src/test/java/com/facebook/presto/tests/TestRestRemoteFunctions.java
@@ -27,13 +27,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.List;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -49,19 +48,11 @@ public class TestRestRemoteFunctions
             .build();
     private TestingFunctionServer functionServer;
 
-    private static int findRandomPort()
-            throws IOException
-    {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        }
-    }
-
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        int functionServerPort = findRandomPort();
+        int functionServerPort = getAvailablePort();
         functionServer = new TestingFunctionServer(functionServerPort);
         return FunctionServerQueryRunner.createQueryRunner(
                 functionServerPort,

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverAuth.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverAuth.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 
 import static com.facebook.presto.jdbc.TestPrestoDriver.closeQuietly;
 import static com.facebook.presto.jdbc.TestPrestoDriver.waitForNodeRefresh;
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static com.google.common.io.Files.asCharSource;
 import static com.google.common.io.Resources.getResource;
 import static io.jsonwebtoken.JwsHeader.KEY_ID;
@@ -82,6 +83,7 @@ public class TestPrestoDriverAuth
                         .put("http-server.https.enabled", "true")
                         .put("http-server.https.keystore.path", getResource("localhost.keystore").getPath())
                         .put("http-server.https.keystore.key", "changeit")
+                        .put("http-server.http.port", String.valueOf(getAvailablePort()))
                         .build(),
                 null,
                 null,

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedKafka.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedKafka.java
@@ -29,7 +29,7 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import static com.facebook.presto.kafka.util.TestUtils.findUnusedPort;
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -59,7 +59,7 @@ public class EmbeddedKafka
     EmbeddedKafka()
             throws IOException
     {
-        this.port = findUnusedPort();
+        this.port = getAvailablePort();
         this.kafkaDataDir = Files.createTempDir();
         TestKitNodes nodes = new TestKitNodes.Builder()
                 .setNumBrokerNodes(1)

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedZookeeper.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/EmbeddedZookeeper.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 
@@ -42,7 +43,7 @@ public class EmbeddedZookeeper
     public EmbeddedZookeeper()
             throws IOException
     {
-        this(TestUtils.findUnusedPort());
+        this(getAvailablePort());
     }
 
     public EmbeddedZookeeper(int port)

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/TestUtils.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/TestUtils.java
@@ -31,7 +31,6 @@ import com.google.common.io.ByteStreams;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Optional;
@@ -46,14 +45,6 @@ public final class TestUtils
     private static final String TEST = "test";
 
     private TestUtils() {}
-
-    public static int findUnusedPort()
-            throws IOException
-    {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        }
-    }
 
     public static Properties toProperties(Map<String, String> map)
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -47,6 +47,7 @@ import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
 import java.io.File;
+import java.io.IOException;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
@@ -120,10 +121,15 @@ public class AccessControlManager
     }
 
     public void loadSystemAccessControl()
-            throws Exception
     {
         if (ACCESS_CONTROL_CONFIGURATION.exists()) {
-            Map<String, String> properties = loadProperties(ACCESS_CONTROL_CONFIGURATION);
+            final Map<String, String> properties;
+            try {
+                properties = loadProperties(ACCESS_CONTROL_CONFIGURATION);
+            }
+            catch (IOException e) {
+                throw new RuntimeException("Failed to load access control properties", e);
+            }
             checkArgument(!isNullOrEmpty(properties.get(ACCESS_CONTROL_PROPERTY_NAME)),
                     "Access control configuration %s does not contain %s",
                     ACCESS_CONTROL_CONFIGURATION.getAbsoluteFile(),

--- a/presto-main-base/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig
     private boolean allowForwardedHttps;
     private boolean authorizedIdentitySelectionEnabled;
     private boolean allowRequestFilterOverwriteHeaders;
+    private boolean testingClientRequestFilters;
 
     public enum AuthenticationType
     {
@@ -108,5 +109,18 @@ public class SecurityConfig
     public boolean isAllowRequestFilterOverwriteHeaders()
     {
         return allowRequestFilterOverwriteHeaders;
+    }
+
+    @Config("permissions.testing-client-request-filters")
+    @ConfigDescription("Testing mode of client request filters")
+    public SecurityConfig setTestingClientRequestFilters(boolean testingClientRequestFilters)
+    {
+        this.testingClientRequestFilters = testingClientRequestFilters;
+        return this;
+    }
+
+    public boolean getTestingClientRequestFilters()
+    {
+        return testingClientRequestFilters;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig
     private List<AuthenticationType> authenticationTypes = ImmutableList.of();
     private boolean allowForwardedHttps;
     private boolean authorizedIdentitySelectionEnabled;
+    private boolean allowRequestFilterOverwriteHeaders;
 
     public enum AuthenticationType
     {
@@ -94,5 +95,18 @@ public class SecurityConfig
     public boolean isAuthorizedIdentitySelectionEnabled()
     {
         return authorizedIdentitySelectionEnabled;
+    }
+
+    @Config("permissions.allow-request-filter-overwrite-headers")
+    @ConfigDescription("Enable client request filters to overwrite the request headers of servlet request. Cannot overwrite blocklist headers")
+    public SecurityConfig setAllowRequestFilterOverwriteHeaders(boolean allowRequestFilterOverwriteHeaders)
+    {
+        this.allowRequestFilterOverwriteHeaders = allowRequestFilterOverwriteHeaders;
+        return this;
+    }
+
+    public boolean isAllowRequestFilterOverwriteHeaders()
+    {
+        return allowRequestFilterOverwriteHeaders;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
@@ -102,8 +102,15 @@ public class TestingAccessControlManager
     @Inject
     public TestingAccessControlManager(TransactionManager transactionManager)
     {
+        this(transactionManager, true);
+    }
+
+    public TestingAccessControlManager(TransactionManager transactionManager, boolean loadDefaultSystemAccessControl)
+    {
         super(transactionManager);
-        setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
+        if (loadDefaultSystemAccessControl) {
+            setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
+        }
     }
 
     public static TestingPrivilege privilege(String entityName, TestingPrivilegeType type)

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/TestingPrestoServerModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/TestingPrestoServerModule.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing;
+
+import com.facebook.presto.eventlistener.EventListenerConfig;
+import com.facebook.presto.eventlistener.EventListenerManager;
+import com.facebook.presto.security.AccessControlManager;
+import com.facebook.presto.server.GracefulShutdownHandler;
+import com.facebook.presto.server.security.PrestoAuthenticatorManager;
+import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.storage.TempStorageManager;
+import com.facebook.presto.transaction.TransactionManager;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingPrestoServerModule
+        implements Module
+{
+    private final boolean loadDefaultSystemAccessControl;
+
+    public TestingPrestoServerModule(boolean loadDefaultSystemAccessControl)
+    {
+        this.loadDefaultSystemAccessControl = loadDefaultSystemAccessControl;
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(PrestoAuthenticatorManager.class).in(Scopes.SINGLETON);
+        binder.bind(TestingEventListenerManager.class).in(Scopes.SINGLETON);
+        binder.bind(TestingTempStorageManager.class).in(Scopes.SINGLETON);
+        binder.bind(EventListenerManager.class).to(TestingEventListenerManager.class).in(Scopes.SINGLETON);
+        binder.bind(EventListenerConfig.class).in(Scopes.SINGLETON);
+        binder.bind(TempStorageManager.class).to(TestingTempStorageManager.class).in(Scopes.SINGLETON);
+        binder.bind(AccessControl.class).to(AccessControlManager.class).in(Scopes.SINGLETON);
+        binder.bind(GracefulShutdownHandler.class).in(Scopes.SINGLETON);
+        binder.bind(ProcedureTester.class).in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    public AccessControlManager createAccessControlManager(TransactionManager transactionManager)
+    {
+        requireNonNull(transactionManager, "transactionManager is null");
+        return new TestingAccessControlManager(transactionManager, loadDefaultSystemAccessControl);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -32,7 +32,8 @@ public class TestSecurityConfig
                 .setAuthenticationTypes("")
                 .setAllowForwardedHttps(false)
                 .setAuthorizedIdentitySelectionEnabled(false)
-                .setAllowRequestFilterOverwriteHeaders(false));
+                .setAllowRequestFilterOverwriteHeaders(false)
+                .setTestingClientRequestFilters(false));
     }
 
     @Test
@@ -50,7 +51,8 @@ public class TestSecurityConfig
                 .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD))
                 .setAllowForwardedHttps(true)
                 .setAuthorizedIdentitySelectionEnabled(true)
-                .setAllowRequestFilterOverwriteHeaders(true));
+                .setAllowRequestFilterOverwriteHeaders(true)
+                .setTestingClientRequestFilters(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -31,7 +31,8 @@ public class TestSecurityConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SecurityConfig.class)
                 .setAuthenticationTypes("")
                 .setAllowForwardedHttps(false)
-                .setAuthorizedIdentitySelectionEnabled(false));
+                .setAuthorizedIdentitySelectionEnabled(false)
+                .setAllowRequestFilterOverwriteHeaders(false));
     }
 
     @Test
@@ -41,12 +42,15 @@ public class TestSecurityConfig
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
                 .put("http-server.authentication.allow-forwarded-https", "true")
                 .put("permissions.authorized-identity-selection-enabled", "true")
+                .put("permissions.allow-request-filter-overwrite-headers", "true")
+                .put("permissions.testing-client-request-filters", "true")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
                 .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD))
                 .setAllowForwardedHttps(true)
-                .setAuthorizedIdentitySelectionEnabled(true);
+                .setAuthorizedIdentitySelectionEnabled(true)
+                .setAllowRequestFilterOverwriteHeaders(true));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/CustomPrestoAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/CustomPrestoAuthenticator.java
@@ -45,9 +45,9 @@ public class CustomPrestoAuthenticator
         try {
             // Extracting headers into a Map
             Map<String, List<String>> headers = getHeadersMap(request);
+            String body = ((AuthenticationFilter.ModifiedHttpServletRequest) request).getCachedBodyAsString();
 
-            // Passing the header map to the authenticator (instead of HttpServletRequest)
-            return authenticatorManager.getAuthenticator().createAuthenticatedPrincipal(headers);
+            return authenticatorManager.getAuthenticator().createAuthenticatedPrincipal(headers, body, request.getRequestURI());
         }
         catch (AccessDeniedException e) {
             throw new AuthenticationException(e.getMessage());

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -21,6 +21,7 @@ import com.facebook.airlift.discovery.client.ServiceAnnouncement;
 import com.facebook.airlift.discovery.client.ServiceSelectorManager;
 import com.facebook.airlift.discovery.client.testing.TestingDiscoveryModule;
 import com.facebook.airlift.event.client.EventModule;
+import com.facebook.airlift.http.server.HttpServerInfo;
 import com.facebook.airlift.http.server.TheServlet;
 import com.facebook.airlift.http.server.testing.TestingHttpServer;
 import com.facebook.airlift.http.server.testing.TestingHttpServerModule;
@@ -60,6 +61,7 @@ import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.resourcemanager.ResourceManagerClusterStateProvider;
 import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.server.GracefulShutdownHandler;
+import com.facebook.presto.server.HttpServerModule;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.ServerInfoResource;
 import com.facebook.presto.server.ServerMainModule;
@@ -115,6 +117,7 @@ import org.weakref.jmx.guice.MBeanModule;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -135,7 +138,6 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
-import static java.lang.Integer.parseInt;
 import static java.nio.file.Files.createTempDirectory;
 import static java.nio.file.Files.isDirectory;
 import static java.util.Objects.requireNonNull;
@@ -152,7 +154,8 @@ public class TestingPrestoServer
     private final FunctionAndTypeManager functionAndTypeManager;
     private final WorkerFunctionRegistryTool workerFunctionRegistryTool;
     private final ConnectorManager connectorManager;
-    private final TestingHttpServer server;
+    private final URI httpBaseUri;
+    private final URI httpsUri;
     private final CatalogManager catalogManager;
     private final TransactionManager transactionManager;
     private final SqlParser sqlParser;
@@ -225,7 +228,7 @@ public class TestingPrestoServer
     public TestingPrestoServer(List<Module> additionalModules)
             throws Exception
     {
-        this(true, ImmutableMap.of(), null, null, new SqlParserOptions(), additionalModules);
+        this(true, ImmutableMap.of("http-server.http.port", String.valueOf(getAvailablePort())), null, null, new SqlParserOptions(), additionalModules);
     }
 
     public TestingPrestoServer(
@@ -284,6 +287,42 @@ public class TestingPrestoServer
             Optional<Path> dataDirectory)
             throws Exception
     {
+        this(
+                resourceManager,
+                resourceManagerEnabled,
+                catalogServer,
+                catalogServerEnabled,
+                coordinatorSidecar,
+                coordinatorSidecarEnabled,
+                coordinator,
+                skipLoadingResourceGroupConfigurationManager,
+                true,
+                properties,
+                environment,
+                discoveryUri,
+                parserOptions,
+                additionalModules,
+                dataDirectory);
+    }
+
+    public TestingPrestoServer(
+            boolean resourceManager,
+            boolean resourceManagerEnabled,
+            boolean catalogServer,
+            boolean catalogServerEnabled,
+            boolean coordinatorSidecar,
+            boolean coordinatorSidecarEnabled,
+            boolean coordinator,
+            boolean skipLoadingResourceGroupConfigurationManager,
+            boolean loadDefaultSystemAccessControl,
+            Map<String, String> properties,
+            String environment,
+            URI discoveryUri,
+            SqlParserOptions parserOptions,
+            List<Module> additionalModules,
+            Optional<Path> dataDirectory)
+            throws Exception
+    {
         this.resourceManager = resourceManager;
         this.catalogServer = catalogServer;
         this.coordinatorSidecar = coordinatorSidecar;
@@ -294,16 +333,15 @@ public class TestingPrestoServer
 
         properties = new HashMap<>(properties);
         this.nodeSchedulerIncludeCoordinator = (properties.getOrDefault("node-scheduler.include-coordinator", "true")).equals("true");
-        String coordinatorPort = properties.remove("http-server.http.port");
-        if (coordinatorPort == null) {
-            coordinatorPort = "0";
+
+        if (!coordinator) {
+            properties.remove("http-server.http.port");
         }
 
         Map<String, String> serverProperties = getServerProperties(resourceManagerEnabled, catalogServerEnabled, coordinatorSidecarEnabled, properties, environment, discoveryUri);
 
         ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
                 .add(new TestingNodeModule(Optional.ofNullable(environment)))
-                .add(new TestingHttpServerModule(parseInt(coordinator ? coordinatorPort : "0")))
                 .add(new JsonModule())
                 .add(installModuleIf(
                         FeaturesConfig.class,
@@ -338,6 +376,13 @@ public class TestingPrestoServer
                     newSetBinder(binder, Filter.class, TheServlet.class).addBinding()
                             .to(RequestBlocker.class).in(Scopes.SINGLETON);
                 });
+
+        if (coordinator) {
+            modules.add(new HttpServerModule());
+        }
+        else {
+            modules.add(new TestingHttpServerModule(0));
+        }
 
         if (discoveryUri != null) {
             requireNonNull(environment, "environment required when discoveryUri is present");
@@ -374,7 +419,15 @@ public class TestingPrestoServer
         functionAndTypeManager = injector.getInstance(FunctionAndTypeManager.class);
         workerFunctionRegistryTool = injector.getInstance(WorkerFunctionRegistryTool.class);
 
-        server = injector.getInstance(TestingHttpServer.class);
+        if (coordinator) {
+            httpBaseUri = injector.getInstance(HttpServerInfo.class).getHttpUri();
+            httpsUri = injector.getInstance(HttpServerInfo.class).getHttpsUri();
+        }
+        else {
+            httpBaseUri = injector.getInstance(TestingHttpServer.class).getBaseUrl();
+            httpsUri = injector.getInstance(TestingHttpServer.class).getHttpServerInfo().getHttpsUri();
+        }
+
         catalogManager = injector.getInstance(CatalogManager.class);
         transactionManager = injector.getInstance(TransactionManager.class);
         sqlParser = injector.getInstance(SqlParser.class);
@@ -600,12 +653,12 @@ public class TestingPrestoServer
 
     public URI getBaseUrl()
     {
-        return server.getBaseUrl();
+        return httpBaseUri;
     }
 
     public URI resolve(String path)
     {
-        return server.getBaseUrl().resolve(path);
+        return httpBaseUri.resolve(path);
     }
 
     public HostAndPort getAddress()
@@ -615,7 +668,6 @@ public class TestingPrestoServer
 
     public HostAndPort getHttpsAddress()
     {
-        URI httpsUri = server.getHttpServerInfo().getHttpsUri();
         return HostAndPort.fromParts(httpsUri.getHost(), httpsUri.getPort());
     }
 
@@ -901,5 +953,13 @@ public class TestingPrestoServer
         requestFilterFactory.forEach(clientRequestFilterManager::registerClientRequestFilterFactory);
         clientRequestFilterManager.loadClientRequestFilters();
         return clientRequestFilterManager;
+    }
+
+    public static int getAvailablePort()
+            throws IOException
+    {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/TestClientRequestFilterPlugin.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestClientRequestFilterPlugin.java
@@ -20,6 +20,7 @@ import com.facebook.presto.server.security.SecurityConfig;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.ClientRequestFilter;
 import com.facebook.presto.spi.ClientRequestFilterFactory;
+import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -33,16 +34,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static org.testng.Assert.assertEquals;
 
 public class TestClientRequestFilterPlugin
 {
     @Test
-    public void testCustomRequestFilterWithHeaders() throws Exception
+    public void testCustomRequestFilterWithHeaders()
+            throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of("X-Custom-Header", "CustomValue"));
         List<ClientRequestFilterFactory> requestFilterFactory = getClientRequestFilterFactory();
-        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory);
+        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory, false);
         PrincipalStub testPrincipal = new PrincipalStub();
 
         HttpServletRequest wrappedRequest = filter.mergeExtraHeaders(request, testPrincipal);
@@ -55,11 +58,12 @@ public class TestClientRequestFilterPlugin
             expectedExceptions = RuntimeException.class,
             expectedExceptionsMessageRegExp = "Modification attempt detected: The header X-Presto-Transaction-Id is not allowed to be modified. The following headers cannot be modified: " +
                     "X-Presto-Transaction-Id, X-Presto-Started-Transaction-Id, X-Presto-Clear-Transaction-Id, X-Presto-Trace-Token")
-    public void testCustomRequestFilterWithHeadersInBlockList() throws Exception
+    public void testCustomRequestFilterWithHeadersInBlockList()
+            throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of("X-Custom-Header", "CustomValue"));
         List<ClientRequestFilterFactory> requestFilterFactory = getClientRequestFilterInBlockList();
-        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory);
+        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory, false);
         PrincipalStub testPrincipal = new PrincipalStub();
 
         filter.mergeExtraHeaders(request, testPrincipal);
@@ -68,14 +72,29 @@ public class TestClientRequestFilterPlugin
     @Test(
             expectedExceptions = RuntimeException.class,
             expectedExceptionsMessageRegExp = "Header conflict detected: ExpectedExtraValue already added by another filter.")
-    public void testCustomRequestFilterHandlesConflict() throws Exception
+    public void testCustomRequestFilterHandlesConflict()
+            throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of("X-Custom-Header", "CustomValue"));
         List<ClientRequestFilterFactory> requestFilterFactory = getClientRequestFilterFactoryHandlesConflict();
-        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory);
+        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory, false);
         PrincipalStub testPrincipal = new PrincipalStub();
 
         filter.mergeExtraHeaders(request, testPrincipal);
+    }
+
+    @Test
+    public void testCustomRequestFilterOverwriteCredential()
+            throws Exception
+    {
+        MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of("X-Presto-Extra-Credential", "OldValue"));
+        List<ClientRequestFilterFactory> requestFilterFactory = getClientRequestFilterFactoryOverwriteCredential();
+        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory, true);
+        PrincipalStub testPrincipal = new PrincipalStub();
+
+        HttpServletRequest wrappedRequest = filter.mergeExtraHeaders(request, testPrincipal);
+
+        assertEquals("UPDATED_VALUE", wrappedRequest.getHeader("X-Presto-Extra-Credential"));
     }
 
     private List<ClientRequestFilterFactory> getClientRequestFilterFactory()
@@ -103,13 +122,22 @@ public class TestClientRequestFilterPlugin
                 });
     }
 
-    private AuthenticationFilter setupAuthenticationFilter(List<ClientRequestFilterFactory> requestFilterFactory) throws Exception
+    private List<ClientRequestFilterFactory> getClientRequestFilterFactoryOverwriteCredential()
     {
-        try (TestingPrestoServer testingPrestoServer = new TestingPrestoServer()) {
+        return createFilterFactories(
+                new String[][] {
+                        {"OverwriteCredential", "X-Presto-Extra-Credential", "UPDATED_VALUE"},
+                });
+    }
+
+    private AuthenticationFilter setupAuthenticationFilter(List<ClientRequestFilterFactory> requestFilterFactory, boolean allowOverwriteHeaders)
+            throws Exception
+    {
+        try (TestingPrestoServer testingPrestoServer = new TestingPrestoServer(true, ImmutableMap.of("http-server.http.port", String.valueOf(getAvailablePort())), null, null, new SqlParserOptions(), ImmutableList.of())) {
             ClientRequestFilterManager clientRequestFilterManager = testingPrestoServer.getClientRequestFilterManager(requestFilterFactory);
 
             List<Authenticator> authenticators = createAuthenticators();
-            SecurityConfig securityConfig = createSecurityConfig();
+            SecurityConfig securityConfig = createSecurityConfig(allowOverwriteHeaders);
 
             return new AuthenticationFilter(authenticators, securityConfig, clientRequestFilterManager);
         }
@@ -129,13 +157,20 @@ public class TestClientRequestFilterPlugin
         return Collections.emptyList();
     }
 
-    private SecurityConfig createSecurityConfig()
+    private SecurityConfig createSecurityConfig(boolean allowOverwriteHeaders)
     {
-        return new SecurityConfig() {
+        return new SecurityConfig()
+        {
             @Override
             public boolean getAllowForwardedHttps()
             {
                 return true;
+            }
+
+            @Override
+            public boolean isAllowRequestFilterOverwriteHeaders()
+            {
+                return allowOverwriteHeaders;
             }
         };
     }
@@ -179,6 +214,15 @@ public class TestClientRequestFilterPlugin
             public Map<String, String> getExtraHeaders(Principal principal)
             {
                 return ImmutableMap.of(headerName, headerValue);
+            }
+
+            @Override
+            public String resolveHeaderConflict(String headerName, String clientHeaderValue, String filterHeaderValue)
+            {
+                if (headerName.equals("X-Presto-Extra-Credential")) {
+                    return filterHeaderValue;
+                }
+                return clientHeaderValue;
             }
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
+import jakarta.servlet.ReadListener;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
@@ -32,6 +33,9 @@ import jakarta.servlet.http.HttpUpgradeHandler;
 import jakarta.servlet.http.Part;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -175,7 +179,7 @@ public class MockHttpServletRequest
     @Override
     public String getRequestURI()
     {
-        throw new UnsupportedOperationException();
+        return "/v1/statement";
     }
 
     @Override
@@ -271,7 +275,7 @@ public class MockHttpServletRequest
     @Override
     public String getCharacterEncoding()
     {
-        throw new UnsupportedOperationException();
+        return "UTF-8";
     }
 
     @Override
@@ -301,7 +305,32 @@ public class MockHttpServletRequest
     @Override
     public ServletInputStream getInputStream()
     {
-        throw new UnsupportedOperationException();
+        InputStream is = new ByteArrayInputStream(new byte[0]); // empty stream
+        return new ServletInputStream()
+        {
+            @Override
+            public boolean isFinished()
+            {
+                return true;
+            }
+
+            @Override
+            public boolean isReady()
+            {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener)
+            {}
+
+            @Override
+            public int read()
+                    throws IOException
+            {
+                return is.read();
+            }
+        };
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestCustomPrestoAuthenticator.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestCustomPrestoAuthenticator.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server.security;
 
+import com.facebook.airlift.http.server.AuthenticationException;
 import com.facebook.presto.security.BasicPrincipal;
 import com.facebook.presto.server.MockHttpServletRequest;
 import com.facebook.presto.spi.security.AccessDeniedException;
@@ -27,14 +28,11 @@ import org.testng.annotations.Test;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.Collections.list;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 
 public class TestCustomPrestoAuthenticator
 {
@@ -44,6 +42,9 @@ public class TestCustomPrestoAuthenticator
     private static final String TEST_FACTORY = "test_factory";
     private static final String TEST_USER = "TEST_USER";
     private static final String TEST_REMOTE_ADDRESS = "remoteAddress";
+    private static final String TEST_REQUEST_URI_VALID_VALUE = "/v1/statement";
+    private static final String TEST_REQUEST_URI_INVALID_VALUE = "/v1/memory";
+    private static final String TEST_BODY_VALID_VALUE = "";
 
     @Test
     public void testPrestoAuthenticator()
@@ -55,9 +56,13 @@ public class TestCustomPrestoAuthenticator
         prestoAuthenticatorManager.addPrestoAuthenticatorFactory(
                 new TestingPrestoAuthenticatorFactory(
                         TEST_FACTORY,
-                        TEST_HEADER_VALID_VALUE));
+                        TEST_HEADER_VALID_VALUE,
+                        TEST_REQUEST_URI_VALID_VALUE,
+                        TEST_BODY_VALID_VALUE));
 
         prestoAuthenticatorManager.loadAuthenticator(TEST_FACTORY);
+
+        CustomPrestoAuthenticator customPrestoAuthenticator = new CustomPrestoAuthenticator(prestoAuthenticatorManager);
 
         // Test successful authentication
         HttpServletRequest request = new MockHttpServletRequest(
@@ -65,9 +70,18 @@ public class TestCustomPrestoAuthenticator
                 TEST_REMOTE_ADDRESS,
                 ImmutableMap.of());
 
-        Optional<Principal> principal = checkAuthentication(prestoAuthenticatorManager.getAuthenticator(), request);
-        assertTrue(principal.isPresent());
-        assertEquals(principal.get().getName(), TEST_USER);
+        request = new AuthenticationFilter.ModifiedHttpServletRequest(request, ImmutableMap.of());
+
+        Principal principal;
+        try {
+            principal = customPrestoAuthenticator.authenticate(request);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Unexpected test error: ", e);
+        }
+
+        assertNotNull(principal);
+        assertEquals(principal.getName(), TEST_USER);
 
         // Test failed authentication
         request = new MockHttpServletRequest(
@@ -75,31 +89,8 @@ public class TestCustomPrestoAuthenticator
                 TEST_REMOTE_ADDRESS,
                 ImmutableMap.of());
 
-        principal = checkAuthentication(prestoAuthenticatorManager.getAuthenticator(), request);
-        assertFalse(principal.isPresent());
-    }
-
-    private Optional<Principal> checkAuthentication(PrestoAuthenticator authenticator, HttpServletRequest request)
-    {
-        try {
-            // Converting HttpServletRequest to Map<String, String>
-            Map<String, List<String>> headers = getHeadersMap(request);
-
-            // Passing the headers Map to the authenticator
-            return Optional.of(authenticator.createAuthenticatedPrincipal(headers));
-        }
-        catch (AccessDeniedException e) {
-            return Optional.empty();
-        }
-    }
-
-    private Map<String, List<String>> getHeadersMap(HttpServletRequest request)
-    {
-        return list(request.getHeaderNames())
-                .stream()
-                .collect(toImmutableMap(
-                        headerName -> headerName,
-                        headerName -> list(request.getHeaders(headerName))));
+        HttpServletRequest finalRequest = request;
+        assertThrows(AuthenticationException.class, () -> customPrestoAuthenticator.authenticate(new AuthenticationFilter.ModifiedHttpServletRequest(finalRequest, ImmutableMap.of())));
     }
 
     private static class TestingPrestoAuthenticatorFactory
@@ -107,11 +98,15 @@ public class TestCustomPrestoAuthenticator
     {
         private final String name;
         private final String validHeaderValue;
+        private final String validRequestUri;
+        private final String validBody;
 
-        TestingPrestoAuthenticatorFactory(String name, String validHeaderValue)
+        TestingPrestoAuthenticatorFactory(String name, String validHeaderValue, String validRequestUri, String validBody)
         {
             this.name = requireNonNull(name, "name is null");
             this.validHeaderValue = requireNonNull(validHeaderValue, "validHeaderValue is null");
+            this.validRequestUri = requireNonNull(validRequestUri, "validRequestUri is null");
+            this.validBody = requireNonNull(validBody, "validBody is null");
         }
 
         @Override
@@ -123,16 +118,41 @@ public class TestCustomPrestoAuthenticator
         @Override
         public PrestoAuthenticator create(Map<String, String> config)
         {
-            return (headers) -> {
-                // TEST_HEADER will have value of the form PART1:PART2
-                String[] header = headers.get(TEST_HEADER).get(0).split(":");
+            return new TestingPrestoAuthenticator(this.validHeaderValue, this.validRequestUri, this.validBody);
+        }
+    }
 
-                if (header[0].equals(this.validHeaderValue)) {
-                    return new BasicPrincipal(header[1]);
-                }
+    private static class TestingPrestoAuthenticator
+            implements PrestoAuthenticator
+    {
+        private final String validHeaderValue;
+        private final String validRequestUri;
+        private final String validBody;
 
-                throw new AccessDeniedException("Authentication Failed!");
-            };
+        public TestingPrestoAuthenticator(String validHeaderValue, String validRequestUri, String validBody)
+        {
+            this.validHeaderValue = requireNonNull(validHeaderValue, "validHeaderValue is null");
+            this.validRequestUri = requireNonNull(validRequestUri, "validRequestUri is null");
+            this.validBody = requireNonNull(validBody, "validBody is null");
+        }
+
+        @Override
+        public Principal createAuthenticatedPrincipal(Map<String, List<String>> headers)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Principal createAuthenticatedPrincipal(Map<String, List<String>> headers, String body, String requestUri)
+        {
+            // TEST_HEADER will have value of the form PART1:PART2
+            String[] header = headers.get(TEST_HEADER).get(0).split(":");
+
+            if (header[0].equals(this.validHeaderValue) && body.equals(this.validBody) && requestUri.equals(this.validRequestUri)) {
+                return new BasicPrincipal(header[1]);
+            }
+
+            throw new AccessDeniedException("Authentication Failed!");
         }
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -337,15 +337,15 @@ public class PrestoSparkQueryRunner
                 // Sql-Standard Access Control Checker
                 // needs us to specify our role
                 .setIdentity(
-                    new Identity(
-                        "hive",
-                        Optional.empty(),
-                        ImmutableMap.of(defaultCatalog,
-                            new SelectedRole(Type.ROLE, Optional.of("admin"))),
-                        ImmutableMap.of(),
-                        ImmutableMap.of(),
-                        Optional.empty(),
-                        Optional.empty()))
+                        new Identity(
+                                "hive",
+                                Optional.empty(),
+                                ImmutableMap.of(defaultCatalog,
+                                        new SelectedRole(Type.ROLE, Optional.of("admin"))),
+                                ImmutableMap.of(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                Optional.empty()))
                 .build();
 
         transactionManager = injector.getInstance(TransactionManager.class);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ClientRequestFilter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ClientRequestFilter.java
@@ -22,4 +22,9 @@ public interface ClientRequestFilter
     Set<String> getExtraHeaderKeys();
 
     Map<String, String> getExtraHeaders(Principal principal);
+
+    default String resolveHeaderConflict(String headerName, String clientHeaderValue, String filterHeaderValue)
+    {
+        return clientHeaderValue;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/PrestoAuthenticator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/PrestoAuthenticator.java
@@ -26,4 +26,9 @@ public interface PrestoAuthenticator
      * @throws AccessDeniedException if not allowed
      */
     Principal createAuthenticatedPrincipal(Map<String, List<String>> headers);
+
+    default Principal createAuthenticatedPrincipal(Map<String, List<String>> headers, String body, String requestUri)
+    {
+        return createAuthenticatedPrincipal(headers);
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -89,6 +89,7 @@ import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.airlift.units.Duration.nanosSince;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_USER;
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static com.facebook.presto.spi.NodePoolType.INTERMEDIATE;
 import static com.facebook.presto.spi.NodePoolType.LEAF;
 import static com.facebook.presto.testing.TestingSession.TESTING_CATALOG;
@@ -477,7 +478,8 @@ public class DistributedQueryRunner
                 .put("task.max-index-memory", "16kB") // causes index joins to fault load
                 .put("datasources", "system")
                 .put("distributed-index-joins-enabled", "true")
-                .put("exchange.checksum-enabled", "true");
+                .put("exchange.checksum-enabled", "true")
+                .put("http-server.http.port", String.valueOf(getAvailablePort()));
         if (coordinator) {
             propertiesBuilder.put("node-scheduler.include-coordinator", extraProperties.getOrDefault("node-scheduler.include-coordinator", "true"));
             propertiesBuilder.put("join-distribution-type", "PARTITIONED");

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -31,6 +31,7 @@ import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.security.AllowAllSystemAccessControl;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.ConnectorId;
@@ -134,6 +135,9 @@ public class DistributedQueryRunner
     private final int resourceManagerCount;
     private final AtomicReference<Handle> testFunctionNamespacesHandle = new AtomicReference<>();
 
+    private final Map<String, String> accessControlProperties;
+    private final Map<String, String> prestoAuthenticatorProperties;
+
     @Deprecated
     public DistributedQueryRunner(Session defaultSession, int nodeCount)
             throws Exception
@@ -163,7 +167,9 @@ public class DistributedQueryRunner
                 ENVIRONMENT,
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ImmutableMap.of("access-control.name", AllowAllSystemAccessControl.NAME),
+                ImmutableMap.of());
     }
 
     public static Builder builder(Session defaultSession)
@@ -189,11 +195,15 @@ public class DistributedQueryRunner
             String environment,
             Optional<Path> dataDirectory,
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
-            List<Module> extraModules)
+            List<Module> extraModules,
+            Map<String, String> accessControlProperties,
+            Map<String, String> prestoAuthenticatorProperties)
             throws Exception
     {
         requireNonNull(defaultSession, "defaultSession is null");
         this.extraModules = requireNonNull(extraModules, "extraModules is null");
+        this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null");
+        this.prestoAuthenticatorProperties = requireNonNull(prestoAuthenticatorProperties, "prestoAuthenticatorProperties is null");
 
         try {
             long start = nanoTime();
@@ -243,6 +253,7 @@ public class DistributedQueryRunner
                             coordinatorSidecarEnabled,
                             false,
                             skipLoadingResourceGroupConfigurationManager,
+                            false,
                             workerProperties,
                             parserOptions,
                             environment,
@@ -273,6 +284,7 @@ public class DistributedQueryRunner
                             false,
                             false,
                             skipLoadingResourceGroupConfigurationManager,
+                            false,
                             rmProperties,
                             parserOptions,
                             environment,
@@ -294,6 +306,7 @@ public class DistributedQueryRunner
                         false,
                         false,
                         skipLoadingResourceGroupConfigurationManager,
+                        false,
                         catalogServerProperties,
                         parserOptions,
                         environment,
@@ -313,6 +326,7 @@ public class DistributedQueryRunner
                         true,
                         false,
                         skipLoadingResourceGroupConfigurationManager,
+                        false,
                         coordinatorSidecarProperties,
                         parserOptions,
                         environment,
@@ -320,6 +334,9 @@ public class DistributedQueryRunner
                         extraModules)));
                 servers.add(coordinatorSidecar.get());
             }
+
+            final boolean loadDefaultSystemAccessControl = !accessControlProperties.containsKey("access-control.name") ||
+                    accessControlProperties.get("access-control.name").equals("allow-all");
 
             for (int i = 0; i < coordinatorCount; i++) {
                 TestingPrestoServer coordinator = closer.register(createTestingPrestoServer(
@@ -332,6 +349,7 @@ public class DistributedQueryRunner
                         false,
                         true,
                         skipLoadingResourceGroupConfigurationManager,
+                        loadDefaultSystemAccessControl,
                         extraCoordinatorProperties,
                         parserOptions,
                         environment,
@@ -464,6 +482,7 @@ public class DistributedQueryRunner
             boolean coordinatorSidecarEnabled,
             boolean coordinator,
             boolean skipLoadingResourceGroupConfigurationManager,
+            boolean loadDefaultSystemAccessControl,
             Map<String, String> extraProperties,
             SqlParserOptions parserOptions,
             String environment,
@@ -496,6 +515,7 @@ public class DistributedQueryRunner
                 coordinatorSidecarEnabled,
                 coordinator,
                 skipLoadingResourceGroupConfigurationManager,
+                loadDefaultSystemAccessControl,
                 properties,
                 environment,
                 discoveryUri,
@@ -799,6 +819,36 @@ public class DistributedQueryRunner
         testFunctionNamespacesHandle.get().execute("INSERT INTO function_namespaces SELECT ?, ?", catalogName, schemaName);
     }
 
+    public void loadSystemAccessControl()
+    {
+        for (TestingPrestoServer server : servers) {
+            if (server.isCoordinator()) {
+                server.getAccessControl().loadSystemAccessControl(accessControlProperties);
+            }
+        }
+    }
+
+    public void loadPrestoAuthenticator()
+    {
+        if (prestoAuthenticatorProperties.containsKey("presto-authenticator.name")) {
+            String name = prestoAuthenticatorProperties.get("presto-authenticator.name");
+            for (TestingPrestoServer server : servers) {
+                if (server.isCoordinator()) {
+                    server.getPrestoAuthenticatorManager().loadAuthenticator(name);
+                }
+            }
+        }
+    }
+
+    public void loadClientRequestFilter()
+    {
+        for (TestingPrestoServer server : servers) {
+            if (server.isCoordinator()) {
+                server.getClientRequestFilterManager().loadClientRequestFilters();
+            }
+        }
+    }
+
     private boolean isConnectorVisibleToAllNodes(ConnectorId connectorId)
     {
         if (!externalWorkers.isEmpty()) {
@@ -1088,6 +1138,8 @@ public class DistributedQueryRunner
         private boolean skipLoadingResourceGroupConfigurationManager;
         private List<Module> extraModules = ImmutableList.of();
         private int resourceManagerCount = 1;
+        private Map<String, String> accessControlProperties = ImmutableMap.of("access-control.name", AllowAllSystemAccessControl.NAME);
+        private Map<String, String> prestoAuthenticatorProperties = ImmutableMap.of();
 
         protected Builder(Session defaultSession)
         {
@@ -1223,6 +1275,18 @@ public class DistributedQueryRunner
             return this;
         }
 
+        public Builder setAccessControlProperties(Map<String, String> accessControlProperties)
+        {
+            this.accessControlProperties = accessControlProperties;
+            return this;
+        }
+
+        public Builder setPrestoAuthenticatorProperties(Map<String, String> prestoAuthenticatorProperties)
+        {
+            this.prestoAuthenticatorProperties = prestoAuthenticatorProperties;
+            return this;
+        }
+
         public DistributedQueryRunner build()
                 throws Exception
         {
@@ -1244,7 +1308,9 @@ public class DistributedQueryRunner
                     environment,
                     dataDirectory,
                     externalWorkerLauncher,
-                    extraModules);
+                    extraModules,
+                    accessControlProperties,
+                    prestoAuthenticatorProperties);
         }
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -47,6 +47,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
 import static com.facebook.presto.tests.AbstractTestQueries.TEST_CATALOG_PROPERTIES;
 import static com.facebook.presto.tests.AbstractTestQueries.TEST_SYSTEM_PROPERTIES;
 import static java.util.Objects.requireNonNull;
@@ -293,7 +294,8 @@ public final class StandaloneQueryRunner
                 .put("query.client.timeout", "10m")
                 .put("exchange.http-client.idle-timeout", "1h")
                 .put("node-scheduler.min-candidates", "1")
-                .put("datasources", "system");
+                .put("datasources", "system")
+                .put("http-server.http.port", String.valueOf(getAvailablePort()));
 
         return new TestingPrestoServer(true, properties.build(), null, null, new SqlParserOptions(), ImmutableList.of());
     }

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsWithThrift.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsWithThrift.java
@@ -16,6 +16,8 @@ package com.facebook.presto.tpcds;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableMap;
 
+import static com.facebook.presto.server.testing.TestingPrestoServer.getAvailablePort;
+
 public class TestTpcdsWithThrift
         extends AbstractTestTpcds
 {
@@ -26,6 +28,7 @@ public class TestTpcdsWithThrift
         return TpcdsQueryRunner.createQueryRunner(ImmutableMap.<String, String>builder()
                 .put("experimental.internal-communication.task-info-response-thrift-serde-enabled", "true")
                 .put("experimental.internal-communication.task-update-request-thrift-serde-enabled", "true")
+                .put("http-server.http.port", String.valueOf(getAvailablePort()))
                 .build());
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enable configurable header overwriting in client request filters and extend authentication to handle request body and URI. Refactor testing infrastructure by centralizing port allocation, exposing new testing APIs, and consolidating Guice modules.

New Features:
- Enable client request filters to overwrite existing headers when configured
- Cache servlet request body in ModifiedHttpServletRequest to allow multiple reads and include body in authentication
- Extend PrestoAuthenticator SPI to accept request URI and body parameters
- Add SecurityConfig properties for allow-request-filter-overwrite-headers and testing-client-request-filters

Enhancements:
- Centralize ephemeral port allocation using TestingPrestoServer.getAvailablePort and remove duplicate utility methods
- Refactor TestingPrestoServer and DistributedQueryRunner to expose authenticators, client request filters, and system access control loading APIs
- Introduce TestingPrestoServerModule for unified Guice bindings in tests

Tests:
- Add and update tests for header overwrite behavior, conflict resolution, and authentication using cached request body and URI
- Update existing tests to use getAvailablePort and new ModifiedHttpServletRequest wrapper