### PR TITLE
Wrap http servlet request to read body multiple times

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/CustomPrestoAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/CustomPrestoAuthenticator.java
@@ -45,9 +45,9 @@ public class CustomPrestoAuthenticator
         try {
             // Extracting headers into a Map
             Map<String, List<String>> headers = getHeadersMap(request);
+            String body = ((AuthenticationFilter.ModifiedHttpServletRequest) request).getCachedBodyAsString();
 
-            // Passing the header map to the authenticator (instead of HttpServletRequest)
-            return authenticatorManager.getAuthenticator().createAuthenticatedPrincipal(headers);
+            return authenticatorManager.getAuthenticator().createAuthenticatedPrincipal(headers, body, request.getRequestURI());
         }
         catch (AccessDeniedException e) {
             throw new AuthenticationException(e.getMessage());

--- a/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/MockHttpServletRequest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
+import jakarta.servlet.ReadListener;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
@@ -32,6 +33,9 @@ import jakarta.servlet.http.HttpUpgradeHandler;
 import jakarta.servlet.http.Part;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -175,7 +179,7 @@ public class MockHttpServletRequest
     @Override
     public String getRequestURI()
     {
-        throw new UnsupportedOperationException();
+        return "/v1/statement";
     }
 
     @Override
@@ -271,7 +275,7 @@ public class MockHttpServletRequest
     @Override
     public String getCharacterEncoding()
     {
-        throw new UnsupportedOperationException();
+        return "UTF-8";
     }
 
     @Override
@@ -301,7 +305,32 @@ public class MockHttpServletRequest
     @Override
     public ServletInputStream getInputStream()
     {
-        throw new UnsupportedOperationException();
+        InputStream is = new ByteArrayInputStream(new byte[0]); // empty stream
+        return new ServletInputStream()
+        {
+            @Override
+            public boolean isFinished()
+            {
+                return true;
+            }
+
+            @Override
+            public boolean isReady()
+            {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener)
+            {}
+
+            @Override
+            public int read()
+                    throws IOException
+            {
+                return is.read();
+            }
+        };
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/PrestoAuthenticator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/PrestoAuthenticator.java
@@ -26,4 +26,9 @@ public interface PrestoAuthenticator
      * @throws AccessDeniedException if not allowed
      */
     Principal createAuthenticatedPrincipal(Map<String, List<String>> headers);
+
+    default Principal createAuthenticatedPrincipal(Map<String, List<String>> headers, String body, String requestUri)
+    {
+        return createAuthenticatedPrincipal(headers);
+    }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This change will wrap HttpServletRequest inside of a wrapper that will cache the inputStream of the body, allowing the body of the request to be read multiple times.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
https://github.com/prestodb/presto/issues/25696

Currently, authenticators in Presto are not allowed to read the body from HttpServletRequest. This is due to the inputStream of the request being consumed if it is read. So if an authenticator reads the body of the request, the Presto server later on will fail to read the body since it has already been read.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

No impact. Any authenticator will be able to use the body of http request for authentication logic.

## Test Plan
<!---Please fill in how you tested your change-->

Using CustomPrestoAuthenticator in the unit test, it can read the body of the request without a failure.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```