### PR TITLE
Client request filter overwrite headers

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -33,6 +33,8 @@ public class SecurityConfig
     private List<AuthenticationType> authenticationTypes = ImmutableList.of();
     private boolean allowForwardedHttps;
     private boolean authorizedIdentitySelectionEnabled;
+    private boolean allowRequestFilterOverwriteHeaders;
+    private boolean allowTestingClientRequestFilters;
 
     public enum AuthenticationType
     {
@@ -94,5 +96,31 @@ public class SecurityConfig
     public boolean isAuthorizedIdentitySelectionEnabled()
     {
         return authorizedIdentitySelectionEnabled;
+    }
+
+    @Config("permissions.allow-request-filter-overwrite-headers")
+    @ConfigDescription("Enable client request filters to overwrite the request headers of servlet request. Cannot overwrite blocklist headers")
+    public SecurityConfig setAllowRequestFilterOverwriteHeaders(boolean allowRequestFilterOverwriteHeaders)
+    {
+        this.allowRequestFilterOverwriteHeaders = allowRequestFilterOverwriteHeaders;
+        return this;
+    }
+
+    public boolean isAllowRequestFilterOverwriteHeaders()
+    {
+        return allowRequestFilterOverwriteHeaders;
+    }
+
+    @Config("permissions.allow-testing-client-request-filters")
+    @ConfigDescription("Enables testing mode of client request filters so that they are used during tests.")
+    public SecurityConfig setAllowTestingClientRequestFilters(boolean allowTestingClientRequestFilters)
+    {
+        this.allowTestingClientRequestFilters = allowTestingClientRequestFilters;
+        return this;
+    }
+
+    public boolean isAllowTestingClientRequestFilters()
+    {
+        return allowTestingClientRequestFilters;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -31,7 +31,9 @@ public class TestSecurityConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SecurityConfig.class)
                 .setAuthenticationTypes("")
                 .setAllowForwardedHttps(false)
-                .setAuthorizedIdentitySelectionEnabled(false));
+                .setAuthorizedIdentitySelectionEnabled(false)
+                .setAllowRequestFilterOverwriteHeaders(false)
+                .setAllowTestingClientRequestFilters(false));
     }
 
     @Test
@@ -41,12 +43,16 @@ public class TestSecurityConfig
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
                 .put("http-server.authentication.allow-forwarded-https", "true")
                 .put("permissions.authorized-identity-selection-enabled", "true")
+                .put("permissions.allow-request-filter-overwrite-headers", "true")
+                .put("permissions.allow-testing-client-request-filters", "true")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
                 .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD))
                 .setAllowForwardedHttps(true)
-                .setAuthorizedIdentitySelectionEnabled(true);
+                .setAuthorizedIdentitySelectionEnabled(true)
+                .setAllowRequestFilterOverwriteHeaders(true)
+                .setAllowTestingClientRequestFilters(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/AuthenticationFilter.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.security.Principal;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -64,6 +65,8 @@ public class AuthenticationFilter
     private final boolean allowForwardedHttps;
     private final ClientRequestFilterManager clientRequestFilterManager;
     private final List<String> headersBlockList = ImmutableList.of("X-Presto-Transaction-Id", "X-Presto-Started-Transaction-Id", "X-Presto-Clear-Transaction-Id", "X-Presto-Trace-Token");
+    private final boolean allowRequestFilterOverwriteHeaders;
+    private final boolean isAllowTestingClientRequestFilters;
 
     @Inject
     public AuthenticationFilter(List<Authenticator> authenticators, SecurityConfig securityConfig, ClientRequestFilterManager clientRequestFilterManager)
@@ -71,6 +74,8 @@ public class AuthenticationFilter
         this.authenticators = ImmutableList.copyOf(requireNonNull(authenticators, "authenticators is null"));
         this.allowForwardedHttps = requireNonNull(securityConfig, "securityConfig is null").getAllowForwardedHttps();
         this.clientRequestFilterManager = requireNonNull(clientRequestFilterManager, "clientRequestFilterManager is null");
+        this.allowRequestFilterOverwriteHeaders = securityConfig.isAllowRequestFilterOverwriteHeaders();
+        this.isAllowTestingClientRequestFilters = securityConfig.isAllowTestingClientRequestFilters();
     }
 
     @Override
@@ -147,43 +152,65 @@ public class AuthenticationFilter
             return request;
         }
 
-        ImmutableMap.Builder<String, String> extraHeadersMapBuilder = ImmutableMap.builder();
-        Set<String> addedHeaders = new HashSet<>();
-
-        for (ClientRequestFilter requestFilter : clientRequestFilters) {
-            boolean headersPresent = requestFilter.getExtraHeaderKeys().stream()
-                    .allMatch(headerName -> request.getHeader(headerName) != null);
-
-            if (!headersPresent) {
+        Map<String, String> completeExtraHeaders;
+        if (allowRequestFilterOverwriteHeaders) {
+            Map<String, String> extraHeadersMap = new HashMap<>();
+            for (ClientRequestFilter requestFilter : clientRequestFilters) {
                 Map<String, String> extraHeaderValueMap = requestFilter.getExtraHeaders(principal);
 
-                if (!extraHeaderValueMap.isEmpty()) {
-                    for (Map.Entry<String, String> extraHeaderEntry : extraHeaderValueMap.entrySet()) {
-                        String headerKey = extraHeaderEntry.getKey();
-                        if (headersBlockList.contains(headerKey)) {
-                            throw new PrestoException(HEADER_MODIFICATION_ATTEMPT,
-                                    "Modification attempt detected: The header " + headerKey + " is not allowed to be modified. The following headers cannot be modified: " +
-                                            String.join(", ", headersBlockList));
-                        }
-                        if (addedHeaders.contains(headerKey)) {
-                            throw new PrestoException(HEADER_MODIFICATION_ATTEMPT, "Header conflict detected: " + headerKey + " already added by another filter.");
-                        }
-                        if (request.getHeader(headerKey) == null && requestFilter.getExtraHeaderKeys().contains(headerKey)) {
-                            extraHeadersMapBuilder.put(headerKey, extraHeaderEntry.getValue());
-                            addedHeaders.add(headerKey);
+                for (Map.Entry<String, String> extraHeaderEntry : extraHeaderValueMap.entrySet()) {
+                    String headerKey = extraHeaderEntry.getKey();
+                    if (headersBlockList.contains(headerKey)) {
+                        throw new PrestoException(HEADER_MODIFICATION_ATTEMPT,
+                                "Modification attempt detected: The header " + headerKey + " is not allowed to be modified. The following headers cannot be modified: " +
+                                        String.join(", ", headersBlockList));
+                    }
+                    String existingValue = extraHeadersMap.getOrDefault(headerKey, request.getHeader(headerKey));
+                    extraHeadersMap.put(headerKey, requestFilter.resolveHeaderConflict(headerKey, existingValue, extraHeaderEntry.getValue()));
+                }
+            }
+            completeExtraHeaders = ImmutableMap.copyOf(extraHeadersMap);
+        }
+        else {
+            ImmutableMap.Builder<String, String> extraHeadersMapBuilder = ImmutableMap.builder();
+            Set<String> addedHeaders = new HashSet<>();
+            for (ClientRequestFilter requestFilter : clientRequestFilters) {
+                boolean headersPresent = requestFilter.getExtraHeaderKeys().stream()
+                        .allMatch(headerName -> request.getHeader(headerName) != null);
+                if (!headersPresent) {
+                    Map<String, String> extraHeaderValueMap = requestFilter.getExtraHeaders(principal);
+
+                    if (!extraHeaderValueMap.isEmpty()) {
+                        for (Map.Entry<String, String> extraHeaderEntry : extraHeaderValueMap.entrySet()) {
+                            String headerKey = extraHeaderEntry.getKey();
+                            if (headersBlockList.contains(headerKey)) {
+                                throw new PrestoException(HEADER_MODIFICATION_ATTEMPT,
+                                        "Modification attempt detected: The header " + headerKey + " is not allowed to be modified. The following headers cannot be modified: " +
+                                                String.join(", ", headersBlockList));
+                            }
+                            if (addedHeaders.contains(headerKey)) {
+                                throw new PrestoException(HEADER_MODIFICATION_ATTEMPT, "Header conflict detected: " + headerKey + " already added by another filter.");
+                            }
+                            if (request.getHeader(headerKey) == null && requestFilter.getExtraHeaderKeys().contains(headerKey)) {
+                                extraHeadersMapBuilder.put(headerKey, extraHeaderEntry.getValue());
+                                addedHeaders.add(headerKey);
+                            }
                         }
                     }
                 }
             }
+            completeExtraHeaders = extraHeadersMapBuilder.build();
         }
-
-        return new ModifiedHttpServletRequest(request, extraHeadersMapBuilder.build());
+        return new ModifiedHttpServletRequest(request, completeExtraHeaders);
     }
 
     private boolean doesRequestSupportAuthentication(HttpServletRequest request)
     {
         if (authenticators.isEmpty()) {
             return false;
+        }
+        if (isAllowTestingClientRequestFilters) {
+            return true;
         }
         if (request.isSecure()) {
             return true;

--- a/presto-main/src/test/java/com/facebook/presto/TestClientRequestFilterPlugin.java
+++ b/presto-main/src/test/java/com/facebook/presto/TestClientRequestFilterPlugin.java
@@ -38,11 +38,12 @@ import static org.testng.Assert.assertEquals;
 public class TestClientRequestFilterPlugin
 {
     @Test
-    public void testCustomRequestFilterWithHeaders() throws Exception
+    public void testCustomRequestFilterWithHeaders()
+            throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of("X-Custom-Header", "CustomValue"));
         List<ClientRequestFilterFactory> requestFilterFactory = getClientRequestFilterFactory();
-        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory);
+        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory, false);
         PrincipalStub testPrincipal = new PrincipalStub();
 
         HttpServletRequest wrappedRequest = filter.mergeExtraHeaders(request, testPrincipal);
@@ -55,11 +56,12 @@ public class TestClientRequestFilterPlugin
             expectedExceptions = RuntimeException.class,
             expectedExceptionsMessageRegExp = "Modification attempt detected: The header X-Presto-Transaction-Id is not allowed to be modified. The following headers cannot be modified: " +
                     "X-Presto-Transaction-Id, X-Presto-Started-Transaction-Id, X-Presto-Clear-Transaction-Id, X-Presto-Trace-Token")
-    public void testCustomRequestFilterWithHeadersInBlockList() throws Exception
+    public void testCustomRequestFilterWithHeadersInBlockList()
+            throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of("X-Custom-Header", "CustomValue"));
         List<ClientRequestFilterFactory> requestFilterFactory = getClientRequestFilterInBlockList();
-        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory);
+        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory, false);
         PrincipalStub testPrincipal = new PrincipalStub();
 
         filter.mergeExtraHeaders(request, testPrincipal);
@@ -68,14 +70,29 @@ public class TestClientRequestFilterPlugin
     @Test(
             expectedExceptions = RuntimeException.class,
             expectedExceptionsMessageRegExp = "Header conflict detected: ExpectedExtraValue already added by another filter.")
-    public void testCustomRequestFilterHandlesConflict() throws Exception
+    public void testCustomRequestFilterHandlesConflict()
+            throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of("X-Custom-Header", "CustomValue"));
         List<ClientRequestFilterFactory> requestFilterFactory = getClientRequestFilterFactoryHandlesConflict();
-        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory);
+        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory, false);
         PrincipalStub testPrincipal = new PrincipalStub();
 
         filter.mergeExtraHeaders(request, testPrincipal);
+    }
+
+    @Test
+    public void testCustomRequestFilterOverwriteCredential()
+            throws Exception
+    {
+        MockHttpServletRequest request = new MockHttpServletRequest(ImmutableListMultimap.of("X-Presto-Extra-Credential", "OldValue"));
+        List<ClientRequestFilterFactory> requestFilterFactory = getClientRequestFilterFactoryOverwriteCredential();
+        AuthenticationFilter filter = setupAuthenticationFilter(requestFilterFactory, true);
+        PrincipalStub testPrincipal = new PrincipalStub();
+
+        HttpServletRequest wrappedRequest = filter.mergeExtraHeaders(request, testPrincipal);
+
+        assertEquals("UPDATED_VALUE", wrappedRequest.getHeader("X-Presto-Extra-Credential"));
     }
 
     private List<ClientRequestFilterFactory> getClientRequestFilterFactory()
@@ -103,13 +120,22 @@ public class TestClientRequestFilterPlugin
                 });
     }
 
-    private AuthenticationFilter setupAuthenticationFilter(List<ClientRequestFilterFactory> requestFilterFactory) throws Exception
+    private List<ClientRequestFilterFactory> getClientRequestFilterFactoryOverwriteCredential()
+    {
+        return createFilterFactories(
+                new String[][] {
+                        {"OverwriteCredential", "X-Presto-Extra-Credential", "UPDATED_VALUE"},
+                });
+    }
+
+    private AuthenticationFilter setupAuthenticationFilter(List<ClientRequestFilterFactory> requestFilterFactory, boolean allowOverwriteHeaders)
+            throws Exception
     {
         try (TestingPrestoServer testingPrestoServer = new TestingPrestoServer()) {
             ClientRequestFilterManager clientRequestFilterManager = testingPrestoServer.getClientRequestFilterManager(requestFilterFactory);
 
             List<Authenticator> authenticators = createAuthenticators();
-            SecurityConfig securityConfig = createSecurityConfig();
+            SecurityConfig securityConfig = createSecurityConfig(allowOverwriteHeaders);
 
             return new AuthenticationFilter(authenticators, securityConfig, clientRequestFilterManager);
         }
@@ -129,13 +155,20 @@ public class TestClientRequestFilterPlugin
         return Collections.emptyList();
     }
 
-    private SecurityConfig createSecurityConfig()
+    private SecurityConfig createSecurityConfig(boolean allowOverwriteHeaders)
     {
-        return new SecurityConfig() {
+        return new SecurityConfig()
+        {
             @Override
             public boolean getAllowForwardedHttps()
             {
                 return true;
+            }
+
+            @Override
+            public boolean isAllowRequestFilterOverwriteHeaders()
+            {
+                return allowOverwriteHeaders;
             }
         };
     }
@@ -179,6 +212,15 @@ public class TestClientRequestFilterPlugin
             public Map<String, String> getExtraHeaders(Principal principal)
             {
                 return ImmutableMap.of(headerName, headerValue);
+            }
+
+            @Override
+            public String resolveHeaderConflict(String headerName, String clientHeaderValue, String filterHeaderValue)
+            {
+                if (headerName.equals("X-Presto-Extra-Credential")) {
+                    return filterHeaderValue;
+                }
+                return clientHeaderValue;
             }
         }
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ClientRequestFilter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ClientRequestFilter.java
@@ -22,4 +22,9 @@ public interface ClientRequestFilter
     Set<String> getExtraHeaderKeys();
 
     Map<String, String> getExtraHeaders(Principal principal);
+
+    default String resolveHeaderConflict(String headerName, String clientHeaderValue, String filterHeaderValue)
+    {
+        return clientHeaderValue;
+    }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add the ability for header values from an HTTP request to be overwritten in preprocessing. This ability will be gated by a server property `permissions.allow-request-filter-overwrite-headers`. If enabled, then a ClientRequestFilter will have the ability to specify header values to be overwritten, and the logic for handling header conflicts will be delegated to the ClientRequestFilter implementation.

Also add a `permissions.allow-testing-client-request-filters` server property that will allow ClientRequestFilters to be used during testing environments.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
https://github.com/prestodb/presto/issues/25696

AuthenticationFilter currently does not have the ability to overwrite existing header values provided by the client. It will only allow Authenticators to add values that are not already existing in the headers map.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

Changes to existing interfaces:
- ClientRequestFilter has new default method to resolve header conflicts. By default, this method will use the header value provided by the client. However, this gives the ability to override the logic so that authenticators can override existing header values
- PrestoAuthenticator has a new signature for authenticate method that takes in body as well as requestURI. Currently, only headers map is provided to the authenticator method


## Test Plan
<!---Please fill in how you tested your change-->
Added unit testing that tests the overwrite of HTTP request headers


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```


