### PR TITLE
Use authenticator and client request filter in testing

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -64,6 +64,7 @@ import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.ServerInfoResource;
 import com.facebook.presto.server.ServerMainModule;
 import com.facebook.presto.server.ShutdownAction;
+import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.spi.ClientRequestFilterFactory;
 import com.facebook.presto.spi.ConnectorId;
@@ -160,6 +161,7 @@ public class TestingPrestoServer
     private final StatsCalculator statsCalculator;
     private final TestingEventListenerManager eventListenerManager;
     private final TestingAccessControlManager accessControl;
+    private final PrestoAuthenticatorManager prestoAuthenticatorManager;
     private final ProcedureTester procedureTester;
     private final Optional<InternalResourceGroupManager<?>> resourceGroupManager;
     private final SplitManager splitManager;
@@ -380,6 +382,7 @@ public class TestingPrestoServer
         sqlParser = injector.getInstance(SqlParser.class);
         metadata = injector.getInstance(Metadata.class);
         accessControl = injector.getInstance(TestingAccessControlManager.class);
+        prestoAuthenticatorManager = injector.getInstance(PrestoAuthenticatorManager.class);
         procedureTester = injector.getInstance(ProcedureTester.class);
         splitManager = injector.getInstance(SplitManager.class);
         pageSourceManager = injector.getInstance(PageSourceManager.class);
@@ -654,6 +657,16 @@ public class TestingPrestoServer
     public TestingAccessControlManager getAccessControl()
     {
         return accessControl;
+    }
+
+    public PrestoAuthenticatorManager getPrestoAuthenticatorManager()
+    {
+        return prestoAuthenticatorManager;
+    }
+
+    public ClientRequestFilterManager getClientRequestFilterManager()
+    {
+        return clientRequestFilterManager;
     }
 
     public ProcedureTester getProcedureTester()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -133,6 +133,8 @@ public class DistributedQueryRunner
     private final int resourceManagerCount;
     private final AtomicReference<Handle> testFunctionNamespacesHandle = new AtomicReference<>();
 
+    private final Map<String, String> prestoAuthenticatorProperties;
+
     @Deprecated
     public DistributedQueryRunner(Session defaultSession, int nodeCount)
             throws Exception
@@ -162,7 +164,8 @@ public class DistributedQueryRunner
                 ENVIRONMENT,
                 Optional.empty(),
                 Optional.empty(),
-                ImmutableList.of());
+                ImmutableList.of(),
+                ImmutableMap.of());
     }
 
     public static Builder builder(Session defaultSession)
@@ -188,11 +191,13 @@ public class DistributedQueryRunner
             String environment,
             Optional<Path> dataDirectory,
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher,
-            List<Module> extraModules)
+            List<Module> extraModules,
+            Map<String, String> prestoAuthenticatorProperties)
             throws Exception
     {
         requireNonNull(defaultSession, "defaultSession is null");
         this.extraModules = requireNonNull(extraModules, "extraModules is null");
+        this.prestoAuthenticatorProperties = requireNonNull(prestoAuthenticatorProperties, "prestoAuthenticatorProperties is null");
 
         try {
             long start = nanoTime();
@@ -797,6 +802,27 @@ public class DistributedQueryRunner
         testFunctionNamespacesHandle.get().execute("INSERT INTO function_namespaces SELECT ?, ?", catalogName, schemaName);
     }
 
+    public void loadPrestoAuthenticator()
+    {
+        if (prestoAuthenticatorProperties.containsKey("presto-authenticator.name")) {
+            String name = prestoAuthenticatorProperties.get("presto-authenticator.name");
+            for (TestingPrestoServer server : servers) {
+                if (server.isCoordinator()) {
+                    server.getPrestoAuthenticatorManager().loadAuthenticator(name);
+                }
+            }
+        }
+    }
+
+    public void loadClientRequestFilter()
+    {
+        for (TestingPrestoServer server : servers) {
+            if (server.isCoordinator()) {
+                server.getClientRequestFilterManager().loadClientRequestFilters();
+            }
+        }
+    }
+
     private boolean isConnectorVisibleToAllNodes(ConnectorId connectorId)
     {
         if (!externalWorkers.isEmpty()) {
@@ -1086,6 +1112,7 @@ public class DistributedQueryRunner
         private boolean skipLoadingResourceGroupConfigurationManager;
         private List<Module> extraModules = ImmutableList.of();
         private int resourceManagerCount = 1;
+        private Map<String, String> prestoAuthenticatorProperties = ImmutableMap.of();
 
         protected Builder(Session defaultSession)
         {
@@ -1221,6 +1248,12 @@ public class DistributedQueryRunner
             return this;
         }
 
+        public Builder setPrestoAuthenticatorProperties(Map<String, String> prestoAuthenticatorProperties)
+        {
+            this.prestoAuthenticatorProperties = prestoAuthenticatorProperties;
+            return this;
+        }
+
         public DistributedQueryRunner build()
                 throws Exception
         {
@@ -1242,7 +1275,8 @@ public class DistributedQueryRunner
                     environment,
                     dataDirectory,
                     externalWorkerLauncher,
-                    extraModules);
+                    extraModules,
+                    prestoAuthenticatorProperties);
         }
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
In DistributedQueryRunner runnable, add functionality to load Authenticators and ClientRequestFilters that are specified in the server properties.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Currently, no way to perform this Authenticator and ClientRequestFilters testing within runnables other than PrestoServer.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

Only impacts testing run configurations

## Test Plan
<!---Please fill in how you tested your change-->

Existing unit tests all pass. Tested the DistributedQueryRunner run configuration to see that it loads Authenticator and ClientRequestFilter

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```


