### PR TITLE
[Native]Fix typo in NativeSidecarPluginQueryRunner configuration

### DIFF
--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -222,7 +222,7 @@ Run NativeSidecarPluginQueryRunner:
   * VM options : `-ea -Xmx5G -XX:+ExitOnOutOfMemoryError -Duser.timezone=America/Bahia_Banderas -Dhive.security=legacy`.
   * Working directory: `$MODULE_DIR$`
   * Environment variables: `PRESTO_SERVER=/Users/<user>/git/presto/presto-native-execution/cmake-build-debug/presto_cpp/main/presto_server;DATA_DIR=/Users/<user>/Desktop/data;WORKER_COUNT=0`
-  * Use classpath of module: choose `presto-native-execution` module.
+  * Use classpath of module: choose `presto-native-sidecar-plugin` module.
 
 Run CLion:
 * File->Close Project if any is open.


### PR DESCRIPTION
## Description

This PR fix a simple typo in native `README.md`. `NativeSidecarPluginQueryRunner` should choose `presto-native-sicecar-plugin` rather than `presto-native-execution` when configuring `Use classpath of module`.

## Motivation and Context

Fix typo in docs.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

