### PR TITLE
Fix the sql to create web_site in AbstractTestNativeTpcdsQueries

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpcdsQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpcdsQueries.java
@@ -345,7 +345,7 @@ public abstract class AbstractTestNativeTpcdsQueries
                             "SELECT web_site_sk, web_site_id, cast(web_rec_start_date as varchar) as web_rec_start_date, " +
                             "   cast(web_rec_end_date as varchar) as web_rec_end_date, web_name, web_open_date_sk, web_close_date_sk, web_class, " +
                             "   web_manager, web_mkt_id, web_mkt_class, web_mkt_desc, web_market_manager, web_company_id, web_company_name, " +
-                            "   web_street_number, web_street_name, web_street_type, web_suite_number, web_city, web_county, web_state, as web_zip, web_country, " +
+                            "   web_street_number, web_street_name, web_street_type, web_suite_number, web_city, web_county, web_state, web_zip, web_country, " +
                             "   cast(web_gmt_offset as double) as web_gmt_offset, cast(web_tax_percentage as double) as web_tax_percentage " +
                             "FROM tpcds.tiny.web_site");
                     break;


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Fix the sql to create web_site in AbstractTestNativeTpcdsQueries.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Remove stray 'as' alias causing a syntax error before the web_zip column in the web_site creation SQL within native TPC-DS tests.