### PR TITLE
Add function mapping for hash_code operator

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -79,6 +79,9 @@ std::string mapScalarFunction(const std::string& name) {
       {"presto.default.combine_hash",
        util::addDefaultNamespacePrefix(
            prestoDefaultNamespacePrefix, "combine_hash_internal")},
+      {"presto.default.$operator$hash_code",
+       util::addDefaultNamespacePrefix(
+           prestoDefaultNamespacePrefix, "hash_code_internal")},
       // Special form function overrides.
       {"presto.default.in", "in"},
   };


### PR DESCRIPTION
Summary: As title

Differential Revision: D81262637

## Summary by Sourcery

New Features:
- Add function mapping for the hash_code operator

```
== NO RELEASE NOTE ==
```