### PR TITLE
Split Provisio plugin packaging into plugins and native-plugins directory

### DIFF
--- a/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst
+++ b/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst
@@ -26,6 +26,8 @@ Property Name                                Description                        
 ``coordinator-sidecar-enabled``              Enables sidecar in the coordinator                                    true
 ``native-execution-enabled``                 Enables native execution                                              true
 ``presto.default-namespace``                 Sets the default function namespace                                   `native.default`
+``plugin.dir``                               Specifies which directory under installation root                     `{root-directory}/native-plugins/`
+                                             to scan for plugins at startup.
 ============================================ ===================================================================== ==============================
 
 .. _sidecar-worker-properties:

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -39,16 +39,6 @@ if [[ -z "${PRESTO_SERVER_DIR:-}" ]]; then
     source "${PRODUCT_TESTS_ROOT}/target/classes/presto.env"
     PRESTO_SERVER_DIR="${PROJECT_ROOT}/presto-server/target/presto-server-${PRESTO_VERSION}/"
 fi
-
-# The following plugin results in a function signature conflict when loaded in Java/ sidecar disabled native clusters.
-# This plugin is only meant for sidecar enabled native clusters, hence exclude it.
-PLUGIN_TO_EXCLUDE="native-sql-invoked-functions-plugin"
-
-if [[ -d "${PRESTO_SERVER_DIR}/plugin/${PLUGIN_TO_EXCLUDE}" ]]; then
-    echo "Excluding plugin: $PLUGIN_TO_EXCLUDE"
-    rm -rf "${PRESTO_SERVER_DIR}/plugin/${PLUGIN_TO_EXCLUDE}"
-fi
-
 export_canonical_path PRESTO_SERVER_DIR
 
 if [[ -z "${PRESTO_CLI_JAR:-}" ]]; then

--- a/presto-server/src/main/provisio/presto.xml
+++ b/presto-server/src/main/provisio/presto.xml
@@ -28,7 +28,7 @@
         <artifact id="${project.groupId}:presto-main:${project.version}" />
     </artifactSet>
 
-    <!-- Plugins -->
+    <!-- Java Plugins -->
     <artifactSet to="plugin/resource-group-managers">
         <artifact id="${project.groupId}:presto-resource-group-managers:zip:${project.version}">
             <unpack />
@@ -281,19 +281,92 @@
         </artifact>
     </artifactSet>
 
-    <artifactSet to="plugin/native-sidecar-plugin">
-        <artifact id="${project.groupId}:presto-native-sidecar-plugin:zip:${project.version}">
-            <unpack />
-        </artifact>
-    </artifactSet>
-
     <artifactSet to="plugin/sql-invoked-functions-plugin">
         <artifact id="${project.groupId}:presto-sql-invoked-functions-plugin:zip:${project.version}">
             <unpack />
         </artifact>
     </artifactSet>
 
-    <artifactSet to="plugin/native-sql-invoked-functions-plugin">
+    <!-- Native Plugins -->
+    <artifactSet to="native-plugin/resource-group-managers">
+        <artifact id="${project.groupId}:presto-resource-group-managers:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/password-authenticators">
+        <artifact id="${project.groupId}:presto-password-authenticators:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/file-session-property-manager">
+        <artifact id="${project.groupId}:presto-file-session-property-manager:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/db-session-property-manager">
+        <artifact id="${project.groupId}:presto-db-session-property-manager:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/function-namespace-managers">
+        <artifact id="${project.groupId}:presto-function-namespace-managers:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/jmx">
+        <artifact id="${project.groupId}:presto-jmx:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/hive-hadoop2">
+        <artifact id="${project.groupId}:presto-hive-hadoop2:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/ml">
+        <artifact id="${project.groupId}:presto-ml:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/prometheus">
+        <artifact id="${project.groupId}:presto-prometheus:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/tpch">
+        <artifact id="${project.groupId}:presto-tpch:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/tpcds">
+        <artifact id="${project.groupId}:presto-tpcds:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/iceberg">
+        <artifact id="${project.groupId}:presto-iceberg:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/native-sidecar-plugin">
+        <artifact id="${project.groupId}:presto-native-sidecar-plugin:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="native-plugin/native-sql-invoked-functions-plugin">
         <artifact id="${project.groupId}:presto-native-sql-invoked-functions-plugin:zip:${project.version}">
             <unpack />
         </artifact>


### PR DESCRIPTION
## Description
Split Provisio plugin packaging into `plugins/` and `native-plugins` directory.

## Motivation and Context
With the change added in https://github.com/prestodb/presto/pull/25870, depending on the cluster type, we need to load different plugins. This PR introduces parallel plugin roots:` plugins/ ` (Java/non-sidecar native clusters) and `native-plugins/` (native sidecar enabled clusters).

## Impact
Existing Java clusters and non-sidecar enabled native clusters continue to load from plugins/.
Native clusters(with sidecar enabled) would need to explicitly set the config property `plugin.dir` to load from `native-plugins/`.

## Test Plan
CI -> `presto-product-tests`

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Update Provisio packaging to split plugin packaging into plugins and native-plugins directory
```
