### PR TITLE
Update `current_time` and `localtime` DateTimeFunctions to align with the session date/time

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -143,7 +143,8 @@ public final class DateTimeFunctions
     public static long localTime(SqlFunctionProperties properties)
     {
         if (properties.isLegacyTimestamp()) {
-            return UTC_CHRONOLOGY.millisOfDay().get(properties.getSessionStartTime());
+            long millis = UTC_CHRONOLOGY.millisOfDay().get(properties.getSessionStartTime());
+            return millis - valueToSessionTimeZoneOffsetDiff(properties.getSessionStartTime(), getDateTimeZone(properties.getTimeZoneKey()));
         }
         ISOChronology localChronology = getChronology(properties.getTimeZoneKey());
         return localChronology.millisOfDay().get(properties.getSessionStartTime());

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -117,13 +117,12 @@ public final class DateTimeFunctions
         // and we need to have UTC millis for packDateTimeWithZone
         long millis = UTC_CHRONOLOGY.millisOfDay().get(properties.getSessionStartTime());
 
-        if (!properties.isLegacyTimestamp()) {
-            // However, those UTC millis are pointing to the correct UTC timestamp
-            // Our TIME WITH TIME ZONE representation does use UTC 1970-01-01 representation
-            // So we have to hack here in order to get valid representation
-            // of TIME WITH TIME ZONE
-            millis -= valueToSessionTimeZoneOffsetDiff(properties.getSessionStartTime(), getDateTimeZone(properties.getTimeZoneKey()));
-        }
+        // However, those UTC millis are pointing to the correct UTC timestamp
+        // Our TIME WITH TIME ZONE representation does use UTC 1970-01-01 representation
+        // So we have to hack here in order to get valid representation
+        // of TIME WITH TIME ZONE
+        millis -= valueToSessionTimeZoneOffsetDiff(properties.getSessionStartTime(), getDateTimeZone(properties.getTimeZoneKey()));
+
         try {
             return packDateTimeWithZone(millis, properties.getTimeZoneKey());
         }

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -20,7 +20,6 @@ import com.facebook.presto.common.type.TimestampType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 
@@ -54,20 +53,6 @@ public class TestDateTimeFunctions
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "14:30:00.000");
-        }
-    }
-
-    @Test
-    public void testCurrentTime()
-    {
-        Session localSession = Session.builder(session)
-                // we use Asia/Kathmandu here to test the difference in semantic change of current_time
-                // between legacy and non-legacy timestamp
-                .setTimeZoneKey(KATHMANDU_ZONE_KEY)
-                .setStartTime(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis())
-                .build();
-        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
-            localAssertion.assertFunctionString("CURRENT_TIME", TIME_WITH_TIME_ZONE, "15:45:00.000 Asia/Kathmandu");
         }
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -15,7 +15,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.TimestampType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
@@ -43,17 +42,6 @@ public class TestDateTimeFunctions
         assertInvalidFunction(
                 "format_datetime(" + TIMESTAMP_LITERAL + ", 'YYYY/MM/dd HH:mm ZZZZ')",
                 "format_datetime for TIMESTAMP type, cannot use 'Z' nor 'z' in format, as this type does not contain TZ information");
-    }
-
-    @Test
-    public void testLocalTime()
-    {
-        Session localSession = Session.builder(session)
-                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
-                .build();
-        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
-            localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "14:30:00.000");
-        }
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -187,6 +187,17 @@ public abstract class TestDateTimeFunctionsBase
     }
 
     @Test
+    public void testLocalTime()
+    {
+        Session localSession = Session.builder(session)
+                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
+                .build();
+        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
+            localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "14:30:00.000");
+        }
+    }
+
+    @Test
     public void testCurrentTime()
     {
         Session localSession = Session.builder(session)

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -187,6 +187,19 @@ public abstract class TestDateTimeFunctionsBase
     }
 
     @Test
+    public void testCurrentTime()
+    {
+        Session localSession = Session.builder(session)
+                // we use Asia/Kathmandu here, as it has different zone offset on 2017-03-01 and on 1970-01-01
+                .setTimeZoneKey(KATHMANDU_ZONE_KEY)
+                .setStartTime(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis())
+                .build();
+        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
+            localAssertion.assertFunctionString("CURRENT_TIME", TIME_WITH_TIME_ZONE, "15:45:00.000 Asia/Kathmandu");
+        }
+    }
+
+    @Test
     public void testFromUnixTime()
     {
         DateTime dateTime = new DateTime(2001, 1, 22, 3, 4, 5, 0, DATE_TIME_ZONE);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsLegacy.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsLegacy.java
@@ -20,7 +20,6 @@ import com.facebook.presto.common.type.TimestampType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
@@ -53,20 +52,6 @@ public class TestDateTimeFunctionsLegacy
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "13:30:00.000");
-        }
-    }
-
-    @Test
-    public void testCurrentTime()
-    {
-        Session localSession = Session.builder(session)
-                // we use Asia/Kathmandu here to test the difference in semantic change of current_time
-                // between legacy and non-legacy timestamp
-                .setTimeZoneKey(KATHMANDU_ZONE_KEY)
-                .setStartTime(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis())
-                .build();
-        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
-            localAssertion.assertFunctionString("CURRENT_TIME", TIME_WITH_TIME_ZONE, "15:30:00.000 Asia/Kathmandu");
         }
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsLegacy.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsLegacy.java
@@ -15,7 +15,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.TimestampType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
@@ -42,17 +41,6 @@ public class TestDateTimeFunctionsLegacy
     public void testFormatDateCanImplicitlyAddTimeZoneToTimestampLiteral()
     {
         assertFunction("format_datetime(" + TIMESTAMP_LITERAL + ", 'YYYY/MM/dd HH:mm ZZZZ')", VARCHAR, "2001/08/22 03:04 " + DATE_TIME_ZONE.getID());
-    }
-
-    @Test
-    public void testLocalTime()
-    {
-        Session localSession = Session.builder(session)
-                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
-                .build();
-        try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
-            localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "13:30:00.000");
-        }
     }
 
     @Test


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Fix `localtime` and `current_time` handling for legacy timestamp semantics

Correct `localtime` and `current_time` behavior in legacy timestamp semantics when the session time zone’s current offset differs from its offset on 1970-01-01.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Related to #25957 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
`localtime` and `current_time` will now return time based on the session time zone's offset on the current date, rather than 1970-01-01 when legacy timestamp semantics are enabled

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix `localtime` and `current_time` in legacy timestamp semantics

```