### PR TITLE
TVF Part 4/X: Plan table function invocation and add tests

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorTableVersion;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
 import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.plan.PartitioningHandle;
@@ -656,5 +657,11 @@ public abstract class DelegatingMetadataManager
     public String normalizeIdentifier(Session session, String catalogName, String identifier)
     {
         return delegate.normalizeIdentifier(session, catalogName, identifier);
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<TableHandle>> applyTableFunction(Session session, TableFunctionHandle handle)
+    {
+        return delegate.applyTableFunction(session, handle);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTableVersion;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
 import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.plan.PartitioningHandle;
@@ -547,4 +548,6 @@ public interface Metadata
     }
 
     String normalizeIdentifier(Session session, String catalogName, String identifier);
+
+    Optional<TableFunctionApplicationResult<TableHandle>> applyTableFunction(Session session, TableFunctionHandle handle);
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -61,6 +61,7 @@ import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorPartitioningMetadata;
 import com.facebook.presto.spi.connector.ConnectorTableVersion;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
 import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.plan.PartitioningHandle;
@@ -1537,6 +1538,18 @@ public class MetadataManager
                 .setProperties(columnMetadata.getProperties())
                 .setExtraInfo(columnMetadata.getExtraInfo().orElse(null))
                 .build();
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<TableHandle>> applyTableFunction(Session session, TableFunctionHandle handle)
+    {
+        ConnectorId connectorId = handle.getConnectorId();
+        ConnectorMetadata metadata = getMetadata(session, connectorId);
+
+        return metadata.applyTableFunction(session.toConnectorSession(connectorId), handle.getFunctionHandle())
+                .map(result -> new TableFunctionApplicationResult<>(
+                        new TableHandle(connectorId, result.getTableHandle(), handle.getTransactionHandle(), Optional.empty()),
+                        result.getColumnHandles()));
     }
 
     private ViewDefinition deserializeView(String data)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/TableFunctionHandle.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/TableFunctionHandle.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+public class TableFunctionHandle
+{
+    private final ConnectorId connectorId;
+    private final ConnectorTableFunctionHandle functionHandle;
+    private final ConnectorTransactionHandle transactionHandle;
+
+    @JsonCreator
+    public TableFunctionHandle(
+            @JsonProperty("connectorId") ConnectorId connectorId,
+            @JsonProperty("functionHandle") ConnectorTableFunctionHandle functionHandle,
+            @JsonProperty("transactionHandle") ConnectorTransactionHandle transactionHandle)
+    {
+        this.connectorId = requireNonNull(connectorId, "connectorId is null");
+        this.functionHandle = requireNonNull(functionHandle, "functionHandle is null");
+        this.transactionHandle = requireNonNull(transactionHandle, "transactionHandle is null");
+    }
+
+    @JsonProperty
+    public ConnectorId getConnectorId()
+    {
+        return connectorId;
+    }
+
+    @JsonProperty
+    public ConnectorTableFunctionHandle getFunctionHandle()
+    {
+        return functionHandle;
+    }
+
+    @JsonProperty
+    public ConnectorTransactionHandle getTransactionHandle()
+    {
+        return transactionHandle;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -210,6 +210,7 @@ import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.StatisticsWriterNode;
+import com.facebook.presto.sql.planner.plan.TableFunctionNode;
 import com.facebook.presto.sql.planner.plan.TableWriterMergeNode;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UpdateNode;
@@ -1202,6 +1203,12 @@ public class LocalExecutionPlanner
                     orderingCompiler);
 
             return new PhysicalOperation(operatorFactory, outputMappings.build(), context, source);
+        }
+
+        @Override
+        public PhysicalOperation visitTableFunction(TableFunctionNode node, LocalExecutionPlanContext context)
+        {
+            throw new UnsupportedOperationException("execution by operator is not yet implemented for table function " + node.getName());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -133,6 +133,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RewriteCaseToMap;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteConstantArrayContainsToInExpression;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteFilterWithExternalFunctionToProject;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteSpatialPartitioningAggregation;
+import com.facebook.presto.sql.planner.iterative.rule.RewriteTableFunctionToTableScan;
 import com.facebook.presto.sql.planner.iterative.rule.RuntimeReorderJoinSides;
 import com.facebook.presto.sql.planner.iterative.rule.ScaledWriterRule;
 import com.facebook.presto.sql.planner.iterative.rule.SimplifyCardinalityMap;
@@ -854,6 +855,14 @@ public class PlanOptimizers
                         statsCalculator,
                         costCalculator,
                         ImmutableSet.of(new ScaledWriterRule())));
+
+        builder.add(
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        costCalculator,
+                        ImmutableSet.of(new RewriteTableFunctionToTableScan(metadata))));
 
         if (!noExchange) {
             builder.add(new ReplicateSemiJoinInDelete()); // Must run before AddExchanges

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteTableFunctionToTableScan.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteTableFunctionToTableScan.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.TableFunctionNode;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.matching.Pattern.empty;
+import static com.facebook.presto.sql.planner.plan.Patterns.sources;
+import static com.facebook.presto.sql.planner.plan.Patterns.tableFunction;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+/*
+ * This process converts connector-resolvable TableFunctionNodes into equivalent
+ * TableScanNodes by invoking the connector’s applyTableFunction() during planning.
+ * It allows table-valued functions whose results can be expressed as a ConnectorTableHandle
+ * to be treated like regular scans and benefit from normal scan optimizations.
+ *
+ * Example:
+ * Before Transformation:
+ *   TableFunction(my_function(arg1, arg2))
+ *
+ * After Transformation:
+ *   TableScan(my_function(arg1, arg2)).applyTableFunction_tableHandle)
+ *    assignments: {outputVar1 -> my_function(arg1, arg2)).applyTableFunction_colHandle1,
+ *                  outputVar2 -> my_function(arg1, arg2)).applyTableFunction_colHandle2}
+ */
+public class RewriteTableFunctionToTableScan
+        implements Rule<TableFunctionNode>
+{
+    private static final Pattern<TableFunctionNode> PATTERN = tableFunction()
+            .with(empty(sources()));
+
+    private final Metadata metadata;
+
+    public RewriteTableFunctionToTableScan(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public Pattern<TableFunctionNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TableFunctionNode tableFunctionNode, Captures captures, Context context)
+    {
+        Optional<TableFunctionApplicationResult<TableHandle>> result = metadata.applyTableFunction(context.getSession(), tableFunctionNode.getHandle());
+
+        if (!result.isPresent()) {
+            return Result.empty();
+        }
+
+        List<ColumnHandle> columnHandles = result.get().getColumnHandles();
+        checkState(tableFunctionNode.getOutputVariables().size() == columnHandles.size(), "returned table does not match the node's output");
+        ImmutableMap.Builder<VariableReferenceExpression, ColumnHandle> assignments = ImmutableMap.builder();
+        for (int i = 0; i < columnHandles.size(); i++) {
+            assignments.put(tableFunctionNode.getOutputVariables().get(i), columnHandles.get(i));
+        }
+
+        return Result.ofPlanNode(new TableScanNode(
+                tableFunctionNode.getSourceLocation(),
+                tableFunctionNode.getId(),
+                result.get().getTableHandle(),
+                tableFunctionNode.getOutputVariables(),
+                assignments.buildOrThrow(),
+                TupleDomain.all(),
+                TupleDomain.all(), Optional.empty()));
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -77,6 +77,7 @@ import com.facebook.presto.sql.planner.plan.LateralJoinNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SequenceNode;
 import com.facebook.presto.sql.planner.plan.StatisticsWriterNode;
+import com.facebook.presto.sql.planner.plan.TableFunctionNode;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
@@ -408,6 +409,12 @@ public class AddExchanges
             }
 
             return rebaseAndDeriveProperties(node, child);
+        }
+
+        @Override
+        public PlanWithProperties visitTableFunction(TableFunctionNode node, PreferredProperties preferredProperties)
+        {
+            throw new UnsupportedOperationException("execution by operator is not yet implemented for table function " + node.getName());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -74,6 +74,7 @@ import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SequenceNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.StatisticsWriterNode;
+import com.facebook.presto.sql.planner.plan.TableFunctionNode;
 import com.facebook.presto.sql.planner.plan.TableWriterMergeNode;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UpdateNode;
@@ -475,6 +476,21 @@ public class UnaliasSymbolReferences
             PlanNode source = context.rewrite(node.getSource());
             SymbolMapper mapper = new SymbolMapper(mapping, types, warningCollector);
             return mapper.map(node, source);
+        }
+
+        @Override
+        public PlanNode visitTableFunction(TableFunctionNode node, RewriteContext<Void> context)
+        {
+            return new TableFunctionNode(
+                    node.getSourceLocation(),
+                    node.getId(),
+                    Optional.empty(),
+                    node.getName(),
+                    node.getArguments(),
+                    node.getOutputVariables(),
+                    node.getSources(),
+                    node.getTableArgumentProperties(),
+                    node.getHandle());
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
@@ -126,4 +126,9 @@ public abstract class InternalPlanVisitor<R, C>
     {
         return visitPlan(node, context);
     }
+
+    public R visitTableFunction(TableFunctionNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -229,6 +229,11 @@ public class Patterns
         return typeOf(WindowNode.class);
     }
 
+    public static Pattern<TableFunctionNode> tableFunction()
+    {
+        return typeOf(TableFunctionNode.class);
+    }
+
     public static Pattern<RowNumberNode> rowNumber()
     {
         return typeOf(RowNumberNode.class);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/TableFunctionNode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/TableFunctionNode.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.metadata.TableFunctionHandle;
+import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.function.table.Argument;
+import com.facebook.presto.spi.plan.DataOrganizationSpecification;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.Immutable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class TableFunctionNode
+        extends InternalPlanNode
+{
+    private final String name;
+    private final Map<String, Argument> arguments;
+    private final List<VariableReferenceExpression> outputVariables;
+    private final List<PlanNode> sources;
+    private final List<TableArgumentProperties> tableArgumentProperties;
+    private final TableFunctionHandle handle;
+
+    @JsonCreator
+    public TableFunctionNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("name") String name,
+            @JsonProperty("arguments") Map<String, Argument> arguments,
+            @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables,
+            @JsonProperty("sources") List<PlanNode> sources,
+            @JsonProperty("tableArgumentProperties") List<TableArgumentProperties> tableArgumentProperties,
+            @JsonProperty("handle") TableFunctionHandle handle)
+    {
+        this(Optional.empty(), id, Optional.empty(), name, arguments, outputVariables, sources, tableArgumentProperties, handle);
+    }
+
+    public TableFunctionNode(
+            Optional<SourceLocation> sourceLocation,
+            PlanNodeId id,
+            Optional<PlanNode> statsEquivalentPlanNode,
+            String name,
+            Map<String, Argument> arguments,
+            List<VariableReferenceExpression> outputVariables,
+            List<PlanNode> sources,
+            List<TableArgumentProperties> tableArgumentProperties,
+            TableFunctionHandle handle)
+    {
+        super(sourceLocation, id, statsEquivalentPlanNode);
+        this.name = requireNonNull(name, "name is null");
+        this.arguments = requireNonNull(arguments, "arguments is null");
+        this.outputVariables = requireNonNull(outputVariables, "outputVariables is null");
+        this.sources = requireNonNull(sources, "sources is null");
+        this.tableArgumentProperties = requireNonNull(tableArgumentProperties, "tableArgumentProperties is null");
+        this.handle = requireNonNull(handle, "handle is null");
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public Map<String, Argument> getArguments()
+    {
+        return arguments;
+    }
+
+    @JsonProperty
+    public List<VariableReferenceExpression> getOutputVariables()
+    {
+        return outputVariables;
+    }
+
+    @JsonProperty
+    public List<TableArgumentProperties> getTableArgumentProperties()
+    {
+        return tableArgumentProperties;
+    }
+
+    @JsonProperty
+    public TableFunctionHandle getHandle()
+    {
+        return handle;
+    }
+
+    @JsonProperty
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return sources;
+    }
+
+    @Override
+    public <R, C> R accept(InternalPlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitTableFunction(this, context);
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newSources)
+    {
+        checkArgument(sources.size() == newSources.size(), "wrong number of new children");
+        return new TableFunctionNode(getId(), name, arguments, outputVariables, newSources, tableArgumentProperties, handle);
+    }
+
+    @Override
+    public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
+    {
+        return new TableFunctionNode(getSourceLocation(), getId(), statsEquivalentPlanNode, name, arguments, outputVariables, sources, tableArgumentProperties, handle);
+    }
+
+    public static class TableArgumentProperties
+    {
+        private final boolean rowSemantics;
+        private final boolean pruneWhenEmpty;
+        private final boolean passThroughColumns;
+        private final Optional<DataOrganizationSpecification> specification;
+
+        @JsonCreator
+        public TableArgumentProperties(
+                @JsonProperty("rowSemantics") boolean rowSemantics,
+                @JsonProperty("pruneWhenEmpty") boolean pruneWhenEmpty,
+                @JsonProperty("passThroughColumns") boolean passThroughColumns,
+                @JsonProperty("specification") Optional<DataOrganizationSpecification> specification)
+        {
+            this.rowSemantics = rowSemantics;
+            this.pruneWhenEmpty = pruneWhenEmpty;
+            this.passThroughColumns = passThroughColumns;
+            this.specification = requireNonNull(specification, "specification is null");
+        }
+
+        @JsonProperty
+        public boolean isRowSemantics()
+        {
+            return rowSemantics;
+        }
+
+        @JsonProperty
+        public boolean isPruneWhenEmpty()
+        {
+            return pruneWhenEmpty;
+        }
+
+        @JsonProperty
+        public boolean isPassThroughColumns()
+        {
+            return passThroughColumns;
+        }
+
+        @JsonProperty
+        public Optional<DataOrganizationSpecification> specification()
+        {
+            return specification;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -98,6 +98,7 @@ import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SequenceNode;
 import com.facebook.presto.sql.planner.plan.StatisticsWriterNode;
+import com.facebook.presto.sql.planner.plan.TableFunctionNode;
 import com.facebook.presto.sql.planner.plan.TableWriterMergeNode;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UpdateNode;
@@ -1317,6 +1318,20 @@ public class PlanPrinter
         public Void visitOffset(OffsetNode node, Void context)
         {
             addNode(node, "Offset", format("[%s]", node.getCount()));
+            return processChildren(node, context);
+        }
+
+        @Override
+        public Void visitTableFunction(TableFunctionNode node, Void context)
+        {
+            NodeRepresentation nodeOutput = addNode(
+                    node,
+                    "TableFunction",
+                    node.getName());
+
+            checkArgument(
+                    node.getSources().isEmpty() && node.getTableArgumentProperties().isEmpty(),
+                    "Table or descriptor arguments are not yet supported in PlanPrinter");
 
             return processChildren(node, context);
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -69,6 +69,7 @@ import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SampleNode;
 import com.facebook.presto.sql.planner.plan.SequenceNode;
 import com.facebook.presto.sql.planner.plan.StatisticsWriterNode;
+import com.facebook.presto.sql.planner.plan.TableFunctionNode;
 import com.facebook.presto.sql.planner.plan.TableWriterMergeNode;
 import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
 import com.facebook.presto.sql.planner.plan.UpdateNode;
@@ -114,6 +115,12 @@ public final class ValidateDependenciesChecker
         public Void visitPlan(PlanNode node, Set<VariableReferenceExpression> boundVariables)
         {
             throw new UnsupportedOperationException("not yet implemented: " + node.getClass().getName());
+        }
+
+        @Override
+        public Void visitTableFunction(TableFunctionNode node, Set<VariableReferenceExpression> boundSymbols)
+        {
+            return null;
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorColumnHandle.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorColumnHandle.java
@@ -23,14 +23,14 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
-public class MockConnectorColumnHandle
+public class TestTVFConnectorColumnHandle
         implements ColumnHandle
 {
     private final String name;
     private final Type type;
 
     @JsonCreator
-    public MockConnectorColumnHandle(
+    public TestTVFConnectorColumnHandle(
             @JsonProperty("name") String name,
             @JsonProperty("type") Type type)
     {
@@ -68,7 +68,7 @@ public class MockConnectorColumnHandle
         if ((o == null) || (getClass() != o.getClass())) {
             return false;
         }
-        MockConnectorColumnHandle other = (MockConnectorColumnHandle) o;
+        TestTVFConnectorColumnHandle other = (TestTVFConnectorColumnHandle) o;
         return Objects.equals(name, other.name) &&
                 Objects.equals(type, other.type);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorFactory.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorFactory.java
@@ -1,0 +1,452 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.tvf;
+
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.FixedSplitSource;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.InMemoryRecordSet;
+import com.facebook.presto.spi.NodeProvider;
+import com.facebook.presto.spi.RecordPageSource;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
+import com.facebook.presto.spi.function.table.ConnectorTableFunction;
+import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchRecordSetProvider;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+public class TestTVFConnectorFactory
+        implements ConnectorFactory
+{
+    private final Function<ConnectorSession, List<String>> listSchemaNames;
+    private final BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables;
+    private final BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorViewDefinition>> getViews;
+    private final BiFunction<ConnectorSession, ConnectorTableHandle, Map<String, TestTVFConnectorColumnHandle>> getColumnHandles;
+    private final Supplier<TableStatistics> getTableStatistics;
+    private final ApplyTableFunction applyTableFunction;
+    private final Set<ConnectorTableFunction> tableFunctions;
+
+    private TestTVFConnectorFactory(
+            Function<ConnectorSession, List<String>> listSchemaNames,
+            BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables,
+            BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorViewDefinition>> getViews,
+            BiFunction<ConnectorSession, ConnectorTableHandle, Map<String, TestTVFConnectorColumnHandle>> getColumnHandles,
+            Supplier<TableStatistics> getTableStatistics,
+            ApplyTableFunction applyTableFunction,
+            Set<ConnectorTableFunction> tableFunctions)
+    {
+        this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
+        this.listTables = requireNonNull(listTables, "listTables is null");
+        this.getViews = requireNonNull(getViews, "getViews is null");
+        this.getColumnHandles = requireNonNull(getColumnHandles, "getColumnHandles is null");
+        this.getTableStatistics = requireNonNull(getTableStatistics, "getTableStatistics is null");
+        this.applyTableFunction = requireNonNull(applyTableFunction, "applyTableFunction is null");
+        this.tableFunctions = requireNonNull(tableFunctions, "tableFunctions is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return "testTVF";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new TestTVFHandleResolver();
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        return new TestTVFConnector(context, listSchemaNames, listTables, getViews, getColumnHandles, getTableStatistics, applyTableFunction, tableFunctions);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Function<SchemaTableName, List<ColumnMetadata>> defaultGetColumns()
+    {
+        return table -> IntStream.range(0, 100)
+                .boxed()
+                .map(i -> ColumnMetadata.builder().setName("column_" + i).setType(createUnboundedVarcharType()).build())
+                .collect(toImmutableList());
+    }
+
+    @FunctionalInterface
+    public interface ApplyTableFunction
+    {
+        Optional<TableFunctionApplicationResult<ConnectorTableHandle>> apply(ConnectorSession session, ConnectorTableFunctionHandle handle);
+    }
+
+    public static class TestTVFConnector
+            implements Connector
+    {
+        private static final String DELETE_ROW_ID = "delete_row_id";
+        private static final String UPDATE_ROW_ID = "update_row_id";
+        private static final String MERGE_ROW_ID = "merge_row_id";
+
+        private final ConnectorContext context;
+        private final Function<ConnectorSession, List<String>> listSchemaNames;
+        private final BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables;
+        private final BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorViewDefinition>> getViews;
+        private final BiFunction<ConnectorSession, ConnectorTableHandle, Map<String, TestTVFConnectorColumnHandle>> getColumnHandles;
+        private final Supplier<TableStatistics> getTableStatistics;
+        private final ApplyTableFunction applyTableFunction;
+        private final Set<ConnectorTableFunction> tableFunctions;
+
+        public TestTVFConnector(
+                ConnectorContext context,
+                Function<ConnectorSession, List<String>> listSchemaNames,
+                BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables,
+                BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorViewDefinition>> getViews,
+                BiFunction<ConnectorSession, ConnectorTableHandle, Map<String, TestTVFConnectorColumnHandle>> getColumnHandles,
+                Supplier<TableStatistics> getTableStatistics,
+                ApplyTableFunction applyTableFunction,
+                Set<ConnectorTableFunction> tableFunctions)
+        {
+            this.context = requireNonNull(context, "context is null");
+            this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
+            this.listTables = requireNonNull(listTables, "listTables is null");
+            this.getViews = requireNonNull(getViews, "getViews is null");
+            this.getColumnHandles = requireNonNull(getColumnHandles, "getColumnHandles is null");
+            this.getTableStatistics = requireNonNull(getTableStatistics, "getTableStatistics is null");
+            this.applyTableFunction = requireNonNull(applyTableFunction, "applyTableFunction is null");
+            this.tableFunctions = requireNonNull(tableFunctions, "tableFunctions is null");
+        }
+
+        @Override
+        public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+        {
+            return TestTVFConnectorTransactionHandle.INSTANCE;
+        }
+
+        @Override
+        public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
+        {
+            return new TestTVFConnectorMetadata();
+        }
+
+        public enum TestTVFConnectorSplit
+                implements ConnectorSplit
+        {
+            TEST_TVF_CONNECTOR_SPLIT;
+
+            @Override
+            public NodeSelectionStrategy getNodeSelectionStrategy()
+            {
+                return NO_PREFERENCE;
+            }
+
+            @Override
+            public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
+            {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Object getInfo()
+            {
+                return null;
+            }
+        }
+
+        @Override
+        public ConnectorSplitManager getSplitManager()
+        {
+            return new ConnectorSplitManager()
+            {
+                @Override
+                public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingContext splitSchedulingContext)
+                {
+                    return new FixedSplitSource(Collections.singleton(TestTVFConnectorSplit.TEST_TVF_CONNECTOR_SPLIT));
+                }
+            };
+        }
+
+        @Override
+        public ConnectorRecordSetProvider getRecordSetProvider()
+        {
+            return new TpchRecordSetProvider();
+        }
+
+        @Override
+        public ConnectorPageSourceProvider getPageSourceProvider()
+        {
+            return new TestTVFConnectorPageSourceProvider();
+        }
+
+        @Override
+        public Set<ConnectorTableFunction> getTableFunctions()
+        {
+            return tableFunctions;
+        }
+
+        private class TestTVFConnectorMetadata
+                implements ConnectorMetadata
+        {
+            @Override
+            public List<String> listSchemaNames(ConnectorSession session)
+            {
+                return listSchemaNames.apply(session);
+            }
+
+            @Override
+            public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+            {
+                return new ConnectorTableHandle() {};
+            }
+
+            @Override
+            public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle tableHandle)
+            {
+                TestTVFConnectorTableHandle table = (TestTVFConnectorTableHandle) tableHandle;
+                return new ConnectorTableMetadata(
+                        table.getTableName(),
+                        defaultGetColumns().apply(table.getTableName()),
+                        ImmutableMap.of());
+            }
+
+            @Override
+            public List<SchemaTableName> listTables(ConnectorSession session, String schemaNameOrNull)
+            {
+                return listTables.apply(session, schemaNameOrNull);
+            }
+
+            public void setTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Object> properties)
+            {
+            }
+
+            @Override
+            public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+            {
+                return (Map<String, ColumnHandle>) (Map) getColumnHandles.apply(session, tableHandle);
+            }
+
+            @Override
+            public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+            {
+                if (columnHandle instanceof TestTVFConnectorColumnHandle) {
+                    TestTVFConnectorColumnHandle testTVFColumnHandle = (TestTVFConnectorColumnHandle) columnHandle;
+                    return ColumnMetadata.builder().setName(testTVFColumnHandle.getName()).setType(testTVFColumnHandle.getType()).build();
+                }
+                else {
+                    TpchColumnHandle tpchColumnHandle = (TpchColumnHandle) columnHandle;
+                    return ColumnMetadata.builder().setName(tpchColumnHandle.getColumnName()).setType(tpchColumnHandle.getType()).build();
+                }
+            }
+
+            @Override
+            public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+            {
+                return listTables(session, prefix.getSchemaName()).stream()
+                        .collect(toImmutableMap(table -> table, table -> IntStream.range(0, 100)
+                                .boxed()
+                                .map(i -> ColumnMetadata.builder().setName("column_" + i).setType(createUnboundedVarcharType()).build())
+                                .collect(toImmutableList())));
+            }
+
+            @Override
+            public ConnectorTableLayoutResult getTableLayoutForConstraint(
+                    ConnectorSession session,
+                    ConnectorTableHandle table,
+                    Constraint<ColumnHandle> constraint,
+                    Optional<Set<ColumnHandle>> desiredColumns)
+            {
+                // TODO: Currently not supporting constraints
+                TestTVFTableLayoutHandle tvfLayout = new TestTVFTableLayoutHandle((TestTVFConnectorTableHandle) table, TupleDomain.none());
+                return new ConnectorTableLayoutResult(new ConnectorTableLayout(tvfLayout,
+                        Optional.empty(),
+                        tvfLayout.getPredicate(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Collections.emptyList(),
+                        Optional.empty()), TupleDomain.none());
+            }
+
+            @Override
+            public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+            {
+                TestTVFTableLayoutHandle tvfTableLayout = (TestTVFTableLayoutHandle) handle;
+                return new ConnectorTableLayout(tvfTableLayout);
+            }
+
+            @Override
+            public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+            {
+                return getViews.apply(session, prefix);
+            }
+
+            @Override
+            public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+            {
+                return getTableStatistics.get();
+            }
+
+            @Override
+            public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(ConnectorSession session, ConnectorTableFunctionHandle handle)
+            {
+                return applyTableFunction.apply(session, handle);
+            }
+        }
+
+        private class TestTVFConnectorPageSourceProvider
+                implements ConnectorPageSourceProvider
+        {
+            @Override
+            public ConnectorPageSource createPageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorSplit split, ConnectorTableLayoutHandle layout, List<ColumnHandle> columns, SplitContext splitContext, RuntimeStats runtimeStats)
+            {
+                TestTVFConnectorTableHandle handle = ((TestTVFTableLayoutHandle) layout).getTable();
+                SchemaTableName tableName = handle.getTableName();
+                List<TestTVFConnectorColumnHandle> projection = columns.stream()
+                        .map(TestTVFConnectorColumnHandle.class::cast)
+                        .collect(toImmutableList());
+                List<Type> types = columns.stream()
+                        .map(TestTVFConnectorColumnHandle.class::cast)
+                        .map(TestTVFConnectorColumnHandle::getType)
+                        .collect(toImmutableList());
+                return new TestTVFConnectorPageSource(new RecordPageSource(new InMemoryRecordSet(types, ImmutableList.of())));
+            }
+
+            private Map<String, Integer> getColumnIndexes(SchemaTableName tableName)
+            {
+                ImmutableMap.Builder<String, Integer> columnIndexes = ImmutableMap.builder();
+                List<ColumnMetadata> columnMetadata = defaultGetColumns().apply(tableName);
+                for (int index = 0; index < columnMetadata.size(); index++) {
+                    columnIndexes.put(columnMetadata.get(index).getName(), index);
+                }
+                return columnIndexes.buildOrThrow();
+            }
+        }
+    }
+
+    public static final class Builder
+    {
+        private Function<ConnectorSession, List<String>> listSchemaNames = (session) -> ImmutableList.of();
+        private BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables = (session, schemaName) -> ImmutableList.of();
+        private BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorViewDefinition>> getViews = (session, schemaTablePrefix) -> ImmutableMap.of();
+        private BiFunction<ConnectorSession, ConnectorTableHandle, Map<String, TestTVFConnectorColumnHandle>> getColumnHandles = (session, tableHandle) -> {
+            TestTVFConnectorTableHandle table = (TestTVFConnectorTableHandle) tableHandle;
+            return defaultGetColumns().apply(table.getTableName()).stream()
+                    .collect(toImmutableMap(ColumnMetadata::getName, column ->
+                            new TestTVFConnectorColumnHandle(column.getName(), column.getType())));
+        };
+        private Supplier<TableStatistics> getTableStatistics = TableStatistics::empty;
+        private ApplyTableFunction applyTableFunction = (session, handle) -> Optional.empty();
+        private Set<ConnectorTableFunction> tableFunctions = ImmutableSet.of();
+
+        public Builder withListSchemaNames(Function<ConnectorSession, List<String>> listSchemaNames)
+        {
+            this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
+            return this;
+        }
+
+        public Builder withListTables(BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables)
+        {
+            this.listTables = requireNonNull(listTables, "listTables is null");
+            return this;
+        }
+
+        public Builder withGetViews(BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorViewDefinition>> getViews)
+        {
+            this.getViews = requireNonNull(getViews, "getViews is null");
+            return this;
+        }
+
+        public Builder withGetColumnHandles(BiFunction<ConnectorSession, ConnectorTableHandle, Map<String, TestTVFConnectorColumnHandle>> getColumnHandles)
+        {
+            this.getColumnHandles = requireNonNull(getColumnHandles, "getColumnHandles is null");
+            return this;
+        }
+
+        public Builder withGetTableStatistics(Supplier<TableStatistics> getTableStatistics)
+        {
+            this.getTableStatistics = requireNonNull(getTableStatistics, "getTableStatistics is null");
+            return this;
+        }
+
+        public Builder withApplyTableFunction(ApplyTableFunction applyTableFunction)
+        {
+            this.applyTableFunction = applyTableFunction;
+            return this;
+        }
+
+        public Builder withTableFunctions(Iterable<ConnectorTableFunction> tableFunctions)
+        {
+            this.tableFunctions = ImmutableSet.copyOf(tableFunctions);
+            return this;
+        }
+
+        public TestTVFConnectorFactory build()
+        {
+            return new TestTVFConnectorFactory(listSchemaNames, listTables, getViews, getColumnHandles, getTableStatistics, applyTableFunction, tableFunctions);
+        }
+
+        private static <T> T notSupported()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorPageSource.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorPageSource.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.tvf;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.spi.ConnectorPageSource;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestTVFConnectorPageSource
+        implements ConnectorPageSource
+{
+    private final ConnectorPageSource delegate;
+
+    public TestTVFConnectorPageSource(ConnectorPageSource delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return delegate.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        return delegate.getNextPage();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        delegate.close();
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return delegate.isBlocked();
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorPlugin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorPlugin.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.tvf;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableList;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestTVFConnectorPlugin
+        implements Plugin
+{
+    private final ConnectorFactory connectorFactory;
+
+    public TestTVFConnectorPlugin(ConnectorFactory connectorFactory)
+    {
+        this.connectorFactory = requireNonNull(connectorFactory, "connectorFactory is null");
+    }
+
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(connectorFactory);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorTableHandle.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorTableHandle.java
@@ -27,28 +27,31 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public class MockConnectorTableHandle
+public class TestTVFConnectorTableHandle
         implements ConnectorTableHandle
 {
+    // These are example fields for a Connector's Table Handle.
+    // For other examples, see TpchTableHandle or any other implementations
+    // of ConnectorTableHandle.
     private final SchemaTableName tableName;
-    private final TupleDomain<ColumnHandle> constraint;
     private final Optional<List<ColumnHandle>> columns;
+    private final TupleDomain<ColumnHandle> constraint;
 
-    public MockConnectorTableHandle(SchemaTableName tableName)
+    public TestTVFConnectorTableHandle(SchemaTableName tableName)
     {
-        this(tableName, TupleDomain.all(), Optional.empty());
+        this(tableName, Optional.empty(), TupleDomain.all());
     }
 
     @JsonCreator
-    public MockConnectorTableHandle(
+    public TestTVFConnectorTableHandle(
             @JsonProperty SchemaTableName tableName,
-            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
-            @JsonProperty("columns") Optional<List<ColumnHandle>> columns)
+            @JsonProperty("columns") Optional<List<ColumnHandle>> columns,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.constraint = requireNonNull(constraint, "constraint is null");
         requireNonNull(columns, "columns is null");
         this.columns = columns.map(ImmutableList::copyOf);
+        this.constraint = requireNonNull(constraint, "constraint is null");
     }
 
     @JsonProperty
@@ -58,15 +61,15 @@ public class MockConnectorTableHandle
     }
 
     @JsonProperty
-    public TupleDomain<ColumnHandle> getConstraint()
-    {
-        return constraint;
-    }
-
-    @JsonProperty
     public Optional<List<ColumnHandle>> getColumns()
     {
         return columns;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
     }
 
     @Override
@@ -78,7 +81,7 @@ public class MockConnectorTableHandle
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MockConnectorTableHandle other = (MockConnectorTableHandle) o;
+        TestTVFConnectorTableHandle other = (TestTVFConnectorTableHandle) o;
         return Objects.equals(tableName, other.tableName) &&
                 Objects.equals(constraint, other.constraint) &&
                 Objects.equals(columns, other.columns);

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorTransactionHandle.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFConnectorTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.tvf;
+
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public enum TestTVFConnectorTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFHandleResolver.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFHandleResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.tvf;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public class TestTVFHandleResolver
+        implements ConnectorHandleResolver
+{
+    @Override
+    public Class<? extends ConnectorTableHandle> getTableHandleClass()
+    {
+        return TestTVFConnectorTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ColumnHandle> getColumnHandleClass()
+    {
+        return TestTVFConnectorColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass()
+    {
+        return TestTVFConnectorFactory.TestTVFConnector.TestTVFConnectorSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableLayoutHandle> getTableLayoutHandleClass()
+    {
+        return TestTVFTableLayoutHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
+    {
+        return TestTVFConnectorTransactionHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass()
+    {
+        return TestTVFPartitioningHandle.class;
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFPartitioningHandle.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFPartitioningHandle.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.tvf;
+
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class TestTVFPartitioningHandle
+        implements ConnectorPartitioningHandle
+{
+    private final String table;
+    private final long totalRows;
+
+    @JsonCreator
+    public TestTVFPartitioningHandle(@JsonProperty("table") String table, @JsonProperty("totalRows") long totalRows)
+    {
+        this.table = requireNonNull(table, "table is null");
+
+        checkArgument(totalRows > 0, "totalRows must be at least 1");
+        this.totalRows = totalRows;
+    }
+
+    @JsonProperty
+    public String getTable()
+    {
+        return table;
+    }
+
+    @JsonProperty
+    public long getTotalRows()
+    {
+        return totalRows;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TestTVFPartitioningHandle that = (TestTVFPartitioningHandle) o;
+        return Objects.equals(table, that.table) &&
+                totalRows == that.totalRows;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, totalRows);
+    }
+
+    @Override
+    public String toString()
+    {
+        return table + ":" + totalRows;
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFTableLayoutHandle.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestTVFTableLayoutHandle.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.tvf;
+
+import com.facebook.presto.common.plan.PlanCanonicalizationStrategy;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
+
+public class TestTVFTableLayoutHandle
+        implements ConnectorTableLayoutHandle
+{
+    private final TestTVFConnectorTableHandle table;
+    private final TupleDomain<ColumnHandle> predicate;
+
+    @JsonCreator
+    public TestTVFTableLayoutHandle(@JsonProperty("table") TestTVFConnectorTableHandle table, @JsonProperty("predicate") TupleDomain<ColumnHandle> predicate)
+    {
+        this.table = table;
+        this.predicate = predicate;
+    }
+
+    @JsonProperty
+    public TestTVFConnectorTableHandle getTable()
+    {
+        return table;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getPredicate()
+    {
+        return predicate;
+    }
+
+    @Override
+    public String toString()
+    {
+        return table.toString();
+    }
+
+    @Override
+    public Object getIdentifier(Optional<ConnectorSplit> split, PlanCanonicalizationStrategy strategy)
+    {
+        return ImmutableMap.builder()
+                .put("table", table)
+                .put("predicate", predicate.canonicalize(ignored -> false))
+                .build();
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestingTableFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestingTableFunctions.java
@@ -163,7 +163,6 @@ public class TestingTableFunctions
     public static class SimpleTableFunction
             extends AbstractConnectorTableFunction
     {
-        private static final String SCHEMA_NAME = "system";
         private static final String FUNCTION_NAME = "simple_table_function";
         private static final String TABLE_NAME = "simple_table";
 
@@ -201,17 +200,17 @@ public class TestingTableFunctions
         public static class SimpleTableFunctionHandle
                 implements ConnectorTableFunctionHandle
         {
-            private final MockConnectorTableHandle tableHandle;
+            private final TestTVFConnectorTableHandle tableHandle;
 
             public SimpleTableFunctionHandle(String schema, String table, String column)
             {
-                this.tableHandle = new MockConnectorTableHandle(
+                this.tableHandle = new TestTVFConnectorTableHandle(
                         new SchemaTableName(schema, table),
-                        TupleDomain.all(),
-                        Optional.of(ImmutableList.of(new MockConnectorColumnHandle(column, BOOLEAN))));
+                        Optional.of(ImmutableList.of(new TestTVFConnectorColumnHandle(column, BOOLEAN))),
+                        TupleDomain.all());
             }
 
-            public MockConnectorTableHandle getTableHandle()
+            public TestTVFConnectorTableHandle getTableHandle()
             {
                 return tableHandle;
             }
@@ -301,17 +300,17 @@ public class TestingTableFunctions
     public static class TestingTableFunctionPushdownHandle
             implements ConnectorTableFunctionHandle
     {
-        private final MockConnectorTableHandle tableHandle;
+        private final TestTVFConnectorTableHandle tableHandle;
 
         public TestingTableFunctionPushdownHandle()
         {
-            this.tableHandle = new MockConnectorTableHandle(
+            this.tableHandle = new TestTVFConnectorTableHandle(
                     new SchemaTableName(SCHEMA_NAME, TABLE_NAME),
-                    TupleDomain.all(),
-                    Optional.of(ImmutableList.of(new MockConnectorColumnHandle(COLUMN_NAME, BOOLEAN))));
+                    Optional.of(ImmutableList.of(new TestTVFConnectorColumnHandle(COLUMN_NAME, BOOLEAN))),
+                    TupleDomain.all());
         }
 
-        public MockConnectorTableHandle getTableHandle()
+        public TestTVFConnectorTableHandle getTableHandle()
         {
             return tableHandle;
         }

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorTableVersion;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
 import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.plan.PartitioningHandle;
@@ -684,5 +685,11 @@ public abstract class AbstractMockMetadata
     public String normalizeIdentifier(Session session, String catalogName, String identifier)
     {
         return identifier.toLowerCase(ENGLISH);
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<TableHandle>> applyTableFunction(Session session, TableFunctionHandle handle)
+    {
+        return Optional.empty();
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestTableFunctionInvocation.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestTableFunctionInvocation.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.connector.tvf.TestTVFConnectorColumnHandle;
+import com.facebook.presto.connector.tvf.TestTVFConnectorFactory;
+import com.facebook.presto.connector.tvf.TestTVFConnectorPlugin;
+import com.facebook.presto.connector.tvf.TestingTableFunctions.SimpleTableFunction;
+import com.facebook.presto.connector.tvf.TestingTableFunctions.SimpleTableFunction.SimpleTableFunctionHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public class TestTableFunctionInvocation
+        extends AbstractTestQueryFramework
+{
+    private static final String TESTING_CATALOG = "testing_catalog1";
+    private static final String TABLE_FUNCTION_SCHEMA = "table_function_schema";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return DistributedQueryRunner.builder(testSessionBuilder()
+                        .setCatalog(TESTING_CATALOG)
+                        .setSchema(TABLE_FUNCTION_SCHEMA)
+                        .build())
+                .build();
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        DistributedQueryRunner queryRunner = getDistributedQueryRunner();
+
+        BiFunction<ConnectorSession, ConnectorTableHandle, Map<String, TestTVFConnectorColumnHandle>> getColumnHandles = (session, tableHandle) -> IntStream.range(0, 100)
+                .boxed()
+                .map(i -> "column_" + i)
+                .collect(toImmutableMap(column -> column, column -> new TestTVFConnectorColumnHandle(column, createUnboundedVarcharType()) {}));
+
+        queryRunner.installPlugin(new TestTVFConnectorPlugin(TestTVFConnectorFactory.builder()
+                .withTableFunctions(ImmutableSet.of(new SimpleTableFunction()))
+                .withApplyTableFunction((session, handle) -> {
+                    if (handle instanceof SimpleTableFunctionHandle) {
+                        SimpleTableFunctionHandle functionHandle = (SimpleTableFunctionHandle) handle;
+                        return Optional.of(new TableFunctionApplicationResult<>(functionHandle.getTableHandle(), functionHandle.getTableHandle().getColumns().orElseThrow(() -> new IllegalStateException("Columns are missing"))));
+                    }
+                    throw new IllegalStateException("Unsupported table function handle: " + handle.getClass().getSimpleName());
+                }).withGetColumnHandles(getColumnHandles)
+                .build()));
+        queryRunner.createCatalog(TESTING_CATALOG, "testTVF");
+    }
+
+    @Test
+    public void testPrimitiveDefaultArgument()
+    {
+        assertQuery("SELECT boolean_column FROM TABLE(system.simple_table_function(column => 'boolean_column', ignored => 1))", "SELECT true WHERE false");
+
+        // skip the `ignored` argument.
+        assertQuery("SELECT boolean_column FROM TABLE(system.simple_table_function(column => 'boolean_column'))",
+                "SELECT true WHERE false");
+    }
+
+    @Test
+    public void testNoArgumentsPassed()
+    {
+        assertQuery("SELECT col FROM TABLE(system.simple_table_function())",
+                  "SELECT true WHERE false");
+    }
+}


### PR DESCRIPTION
This PR contains Planning + optimizer changes for TVF. As well as complete TVF push down to connector scan tests. 

## Description
<!---Describe your changes in detail-->
Changes adapted from trino/PR#11336, 12951, 14175
Original commit:
d4c73389bbdb6b48c24a0969b259286b05a99ade
565700985baff0c4b29fdb1e3e26139a29318b9e
ec8b9fd2b2cc9c8bc78c0ca1317dc34fcf2c48c7
98fc1ee8b29fca86f2a1b3abe4989524940333a6
1aea489884346822c812b1a242acc286e3e1248e
8bd17171a8469b9351e2fd7d9f2f49f4af9ea209
Author: kasiafi

Modifications were made to adapt to Presto including: Change CatalogName to ConnectorId
Change Symbol to VariableReferenceExpression
TableFunctionNode extends InternalPlanNode instead of PlanNode. Add applyTableFunction to all implementations of Metadata Add empty ConnectorTableLayoutHandle to TableHandle in MetadataManger::applyTableFunction Removal of PlannerContext and replaced with Metadata

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
TestTableFunctionInvocation.java

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

