### PR TITLE
Upgrade org.fusesource.jansi:jansi version to 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1537,7 +1537,7 @@
             <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
-                <version>1.18</version>
+                <version>2.4.2</version>
             </dependency>
 
             <dependency>

--- a/presto-cli/src/main/java/com/facebook/presto/cli/KeyReader.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/KeyReader.java
@@ -18,11 +18,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.fusesource.jansi.internal.CLibrary.STDIN_FILENO;
 import static org.fusesource.jansi.internal.CLibrary.isatty;
 
 public final class KeyReader
 {
+    private static final int STDIN_FILENO = 0;
+
     private KeyReader() {}
 
     @SuppressWarnings("resource")


### PR DESCRIPTION
## Description
Bump up org.fusesource.jansi:jansi version to 2.4.2

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade org.fusesource.jansi:jansi version to 2.4.2  in response to the use of an outdated version.
```

