### PR TITLE
[native] Add parameterized varchar type in the list of supported types in NativeTypeManager

### DIFF
--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -220,6 +220,7 @@ public class TestNativeSidecarPlugin
                 "date_trunc('second', from_unixtime(orderkey, '+00:00')) FROM orders");
         assertQuery("SELECT mod(orderkey, linenumber) FROM lineitem");
         assertQueryFails("SELECT IF(true, 0/0, 1)", "[\\s\\S]*/ by zero native.default.fail[\\s\\S]*");
+        assertQuery("select CASE WHEN true THEN 'Yes' ELSE 'No' END");
     }
 
     @Test
@@ -353,6 +354,11 @@ public class TestNativeSidecarPlugin
     {
         assertQuery("select lower(table_name) from information_schema.tables "
                 + "where table_name = 'lineitem' or table_name = 'LINEITEM' ");
+        assertQuery("SELECT table_name, CASE WHEN abs(ordinal_position) > 3 THEN 'high' WHEN abs(ordinal_position) > 1 THEN 'medium' ELSE 'low' END as position_category, COUNT(*) \n" +
+                "FROM information_schema.columns " +
+                "WHERE table_catalog = 'hive' AND table_name IN ('nation', 'region', 'lineitem', 'orders') " +
+                "GROUP BY table_name, CASE WHEN abs(ordinal_position) > 3 THEN 'high' WHEN abs(ordinal_position) > 1 THEN 'medium' ELSE 'low' END " +
+                "ORDER BY table_name, position_category");
     }
 
     @Test

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestWindowQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestWindowQueries.java
@@ -13,18 +13,11 @@
  */
 package com.facebook.presto.nativetests;
 
-import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestWindowQueries;
-import org.intellij.lang.annotations.Language;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.common.type.BigintType.BIGINT;
-import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
-import static com.facebook.presto.common.type.VarcharType.createVarcharType;
-import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
-import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static java.lang.Boolean.parseBoolean;
 
 public class TestWindowQueries
@@ -233,30 +226,5 @@ public class TestWindowQueries
                         "(INTERVAL '1' month, ARRAY[INTERVAL '1' month, INTERVAL '2' month]), " +
                         "(INTERVAL '2' month, ARRAY[INTERVAL '1' month, INTERVAL '2' month]), " +
                         "(INTERVAL '5' year, ARRAY[INTERVAL '5' year])");
-    }
-
-    // Todo: Refactor this test case when support for varchar(N) is added in native execution.
-    // The return types do not match on the native query runner : types=[varchar, bigint] and the java query runner:  types=[varchar(3), bigint].
-    @Override
-    @Test
-    public void testWindowFunctionWithGroupBy()
-    {
-        @Language("SQL") String sql = "SELECT *, rank() OVER (PARTITION BY x)\n" +
-                "FROM (SELECT 'foo' x)\n" +
-                "GROUP BY 1";
-
-        MaterializedResult actual = computeActual(sql);
-        MaterializedResult expected;
-        if (sidecarEnabled) {
-            expected = resultBuilder(getSession(), createUnboundedVarcharType(), BIGINT)
-                    .row("foo", 1L)
-                    .build();
-        }
-        else {
-            expected = resultBuilder(getSession(), createVarcharType(3), BIGINT)
-                    .row("foo", 1L)
-                    .build();
-        }
-        assertEquals(actual, expected);
     }
 }


### PR DESCRIPTION
## Description
Add parameterized varchar type `(varchar(N))` in the list of supported types in `NativeTypeManager`.

## Motivation and Context
https://github.com/prestodb/presto/issues/25816

## Impact
No impact

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add parameterized varchar type in the list of supported types in NativeTypeManager.
```

