### PR TITLE
Add ThriftFilterPushdown for native execution

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.metadata.Metadata;
@@ -63,6 +62,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
@@ -102,7 +102,7 @@ public class IndexJoinOptimizer
         requireNonNull(idAllocator, "idAllocator is null");
 
         IndexJoinRewriter rewriter;
-        if (SystemSessionProperties.isNativeExecutionEnabled(session)) {
+        if (isNativeExecutionEnabled(session)) {
             rewriter = new NativeIndexJoinRewriter(idAllocator, metadata, session);
         }
         else {
@@ -621,7 +621,7 @@ public class IndexJoinOptimizer
         @Override
         public PlanNode visitProject(ProjectNode node, RewriteContext<Context> context)
         {
-            if (SystemSessionProperties.isNativeExecutionEnabled(session)) {
+            if (isNativeExecutionEnabled(session)) {
                 // Preserve the lookup variables for native execution.
                 ProjectNode rewrittenNode = (ProjectNode) context.defaultRewrite(node, context.get());
                 Set<VariableReferenceExpression> directVariables = Maps.filterValues(node.getAssignments().getMap(), IndexJoinOptimizer::isVariable).keySet();

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-expressions</artifactId>
+        </dependency>
+
+
+        <dependency>
             <groupId>com.facebook.airlift.drift</groupId>
             <artifactId>drift-client</artifactId>
         </dependency>
@@ -205,6 +211,13 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main-base</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnector.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnector.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorIndexProvider;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.session.PropertyMetadata;
@@ -40,6 +41,7 @@ public class ThriftConnector
     private final ThriftPageSourceProvider pageSourceProvider;
     private final ThriftSessionProperties sessionProperties;
     private final ThriftIndexProvider indexProvider;
+    private final ThriftConnectorOptimizerProvider planOptimizerProvider;
 
     @Inject
     public ThriftConnector(
@@ -48,7 +50,8 @@ public class ThriftConnector
             ThriftSplitManager splitManager,
             ThriftPageSourceProvider pageSourceProvider,
             ThriftSessionProperties sessionProperties,
-            ThriftIndexProvider indexProvider)
+            ThriftIndexProvider indexProvider,
+            ThriftConnectorOptimizerProvider planOptimizerProvider)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
@@ -56,6 +59,7 @@ public class ThriftConnector
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
         this.indexProvider = requireNonNull(indexProvider, "indexProvider is null");
+        this.planOptimizerProvider = requireNonNull(planOptimizerProvider, "planOptimizerProvider is null");
     }
 
     @Override
@@ -92,6 +96,12 @@ public class ThriftConnector
     public ConnectorIndexProvider getIndexProvider()
     {
         return indexProvider;
+    }
+
+    @Override
+    public ConnectorPlanOptimizerProvider getConnectorPlanOptimizerProvider()
+    {
+        return planOptimizerProvider;
     }
 
     @Override

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
@@ -18,9 +18,11 @@ import com.facebook.drift.transport.netty.client.DriftNettyClientModule;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.connector.thrift.util.RebindSafeMBeanServer;
 import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.spi.relation.RowExpressionService;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import org.weakref.jmx.guice.MBeanModule;
@@ -67,6 +69,8 @@ public class ThriftConnectorFactory
                     binder -> {
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(getPlatformMBeanServer()));
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
+                        binder.bind(ConnectorSystemConfig.class).toInstance(context.getConnectorSystemConfig());
                     },
                     locationModule,
                     new ThriftModule(catalogName));

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorOptimizerProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorOptimizerProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorSystemConfig;
+import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
+import com.facebook.presto.spi.relation.RowExpressionService;
+import com.google.common.collect.ImmutableSet;
+import jakarta.inject.Inject;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class ThriftConnectorOptimizerProvider
+        implements ConnectorPlanOptimizerProvider
+{
+    private static final Logger log = Logger.get(ThriftConnectorOptimizerProvider.class);
+    private final Set<ConnectorPlanOptimizer> planOptimizers;
+
+    @Inject
+    public ThriftConnectorOptimizerProvider(
+            ThriftMetadata metadata,
+            RowExpressionService rowExpressionService,
+            ConnectorSystemConfig connectorSystemConfig)
+    {
+        if (connectorSystemConfig.isNativeExecution()) {
+            log.warn("ThriftFilterPushdown added");
+            ImmutableSet.Builder<ConnectorPlanOptimizer> planOptimizerBuilder = ImmutableSet.builder();
+            planOptimizerBuilder.add(new ThriftFilterPushdown(
+                    requireNonNull(metadata, "metadata is null"),
+                    requireNonNull(rowExpressionService, "rowExpressionService is null")));
+            this.planOptimizers = planOptimizerBuilder.build();
+        }
+        else {
+            this.planOptimizers = ImmutableSet.of();
+        }
+    }
+
+    @Override
+    public Set<ConnectorPlanOptimizer> getLogicalPlanOptimizers()
+    {
+        return planOptimizers;
+    }
+
+    @Override
+    public Set<ConnectorPlanOptimizer> getPhysicalPlanOptimizers()
+    {
+        return planOptimizers;
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftFilterPushdown.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftFilterPushdown.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorPlanRewriter;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.IndexSourceNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.RowExpressionService;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.connector.thrift.ThriftWarningCode.THRIFT_INDEXSOURCE_CONVERTED_TO_VALUESNODE;
+import static com.facebook.presto.expressions.LogicalRowExpressions.FALSE_CONSTANT;
+import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.expressions.RowExpressionNodeInliner.replaceExpression;
+import static com.facebook.presto.spi.ConnectorPlanRewriter.rewriteWith;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableBiMap.toImmutableBiMap;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Runs during both logical and physical phases of connector-aided plan optimization.
+ * In most cases filter pushdown will occur during logical phase. However, in cases
+ * when new filter is added between logical and physical phases, e.g. a filter on a join
+ * key from one side of a join is added to the other side, the new filter will get
+ * merged with the one already pushed down.
+ */
+public class ThriftFilterPushdown
+        implements ConnectorPlanOptimizer
+{
+    private final ThriftMetadata metadata;
+    protected final RowExpressionService rowExpressionService;
+
+    public ThriftFilterPushdown(ThriftMetadata metadata, RowExpressionService rowExpressionService)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode maxSubplan, ConnectorSession session, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        return rewriteWith(new Rewriter(session, idAllocator, metadata), maxSubplan);
+    }
+
+    public static class Rewriter
+            extends ConnectorPlanRewriter<Void>
+    {
+        private final ConnectorSession session;
+        private final PlanNodeIdAllocator idAllocator;
+        private final ConnectorMetadata metadata;
+
+        public Rewriter(ConnectorSession session, PlanNodeIdAllocator idAllocator, ConnectorMetadata metadata)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode project, RewriteContext<Void> context)
+        {
+            // Thrift connector in Prestissimo must have no other PlanNode be present
+            // between IndexJoinNode and IndexSourceNode.
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : project.getAssignments().entrySet()) {
+                if (!entry.getKey().equals(entry.getValue())) {
+                    return visitPlan(project, context);
+                }
+            }
+            // If all assignments are identical, remove the current ProjectNode.
+            return visitPlan(project.getSource(), context);
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode filter, RewriteContext<Void> context)
+        {
+            if (!(filter.getSource() instanceof IndexSourceNode)) {
+                return visitPlan(filter, context);
+            }
+
+            IndexSourceNode indexSource = (IndexSourceNode) filter.getSource();
+            checkArgument(indexSource.getTableHandle().getConnectorHandle() instanceof ThriftTableHandle, "pushdownFilter is never supported on a non-thrift TableHandle");
+
+            RowExpression expression = filter.getPredicate();
+            TableHandle handle = indexSource.getTableHandle();
+            BiMap<VariableReferenceExpression, VariableReferenceExpression> symbolToColumnMapping
+                    = indexSource.getAssignments().entrySet().stream()
+                    .collect(toImmutableBiMap(Map.Entry::getKey, entry ->
+                            new VariableReferenceExpression(
+                                    entry.getKey().getSourceLocation(),
+                                    getColumnName(session, metadata, handle.getConnectorHandle(), entry.getValue()),
+                                    entry.getKey().getType())));
+
+            // replaceExpression() may further optimize the expression;
+            RowExpression optimizedExpression = replaceExpression(expression, symbolToColumnMapping);
+
+            // If the resulting expression is always false, then return an empty ValuesNode.
+            if (FALSE_CONSTANT.equals(optimizedExpression)) {
+                return createEmptyValuesNode(indexSource);
+            }
+
+            // If the resulting expression is always true, then remove the FilterNode altogether.
+            if (TRUE_CONSTANT.equals(optimizedExpression)) {
+                return indexSource;
+            }
+
+            ThriftTableLayoutHandle layoutHandle = (ThriftTableLayoutHandle) handle.getLayoutHandle();
+            checkArgument(layoutHandle.getRemainingPredicate() == null || TRUE_CONSTANT.equals(layoutHandle.getRemainingPredicate()),
+                    "remaining predicate already exists");
+            ThriftTableHandle tableHandle = (ThriftTableHandle) handle.getConnectorHandle();
+
+            return createIndexSourceNode(
+                    indexSource,
+                    handle,
+                    tableHandle,
+                    new ThriftTableLayoutHandle(
+                            layoutHandle.getSchemaName(),
+                            layoutHandle.getSchemaName(),
+                            layoutHandle.getColumns(),
+                            layoutHandle.getConstraint(),
+                            optimizedExpression));
+        }
+
+        private static String getColumnName(ConnectorSession session, ConnectorMetadata metadata, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+        {
+            return metadata.getColumnMetadata(session, tableHandle, columnHandle).getName();
+        }
+
+        private static IndexSourceNode createIndexSourceNode(
+                IndexSourceNode indexSource,
+                TableHandle tableHandle,
+                ConnectorTableHandle connectorTableHandle,
+                ConnectorTableLayoutHandle connectorTableLayoutHandle)
+        {
+            return new IndexSourceNode(
+                    indexSource.getSourceLocation(),
+                    indexSource.getId(),
+                    indexSource.getIndexHandle(),
+                    new TableHandle(tableHandle.getConnectorId(),
+                            connectorTableHandle,
+                            tableHandle.getTransaction(),
+                            Optional.of(connectorTableLayoutHandle)),
+                    indexSource.getLookupVariables(),
+                    indexSource.getOutputVariables(),
+                    indexSource.getAssignments(),
+                    indexSource.getCurrentConstraint());
+        }
+
+        private ValuesNode createEmptyValuesNode(IndexSourceNode indexSource)
+        {
+            session.getWarningCollector().add(
+                    new PrestoWarning(THRIFT_INDEXSOURCE_CONVERTED_TO_VALUESNODE,
+                            format("Table '%s' returns 0 rows, and is converted to an empty %s by %s",
+                                    indexSource.getTableHandle().getConnectorHandle(),
+                                    ValuesNode.class.getSimpleName(),
+                                    ThriftFilterPushdown.class.getSimpleName())));
+            return new ValuesNode(
+                    indexSource.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    indexSource.getOutputVariables(),
+                    ImmutableList.of(),
+                    Optional.of(indexSource.getTableHandle().getConnectorHandle().toString()));
+        }
+    }
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftMetadata.java
@@ -53,6 +53,7 @@ import java.util.concurrent.Executor;
 
 import static com.facebook.presto.connector.thrift.ThriftErrorCode.THRIFT_SERVICE_INVALID_RESPONSE;
 import static com.facebook.presto.connector.thrift.util.ThriftExceptions.toPrestoException;
+import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.google.common.cache.CacheLoader.asyncReloading;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -120,7 +121,8 @@ public class ThriftMetadata
                 tableHandle.getSchemaName(),
                 tableHandle.getTableName(),
                 desiredColumns,
-                constraint.getSummary());
+                constraint.getSummary(),
+                TRUE_CONSTANT);
         return new ConnectorTableLayoutResult(new ConnectorTableLayout(layoutHandle), constraint.getSummary());
     }
 

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftModule.java
@@ -66,6 +66,7 @@ public class ThriftModule
                     return NORMAL_EXCEPTION;
                 });
 
+        binder.bind(ThriftConnectorOptimizerProvider.class).in(Scopes.SINGLETON);
         binder.bind(ThriftConnector.class).in(Scopes.SINGLETON);
         binder.bind(ThriftMetadata.class).in(Scopes.SINGLETON);
         binder.bind(ThriftSplitManager.class).in(Scopes.SINGLETON);

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableLayoutHandle.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftTableLayoutHandle.java
@@ -16,6 +16,7 @@ package com.facebook.presto.connector.thrift;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
@@ -24,6 +25,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftTableLayoutHandle
@@ -33,18 +36,21 @@ public class ThriftTableLayoutHandle
     private final String tableName;
     private final Optional<Set<ColumnHandle>> columns;
     private final TupleDomain<ColumnHandle> constraint;
+    private final RowExpression remainingPredicate;
 
     @JsonCreator
     public ThriftTableLayoutHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("columns") Optional<Set<ColumnHandle>> columns,
-            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("remainingPredicate") RowExpression remainingPredicate)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.columns = requireNonNull(columns, "columns is null").map(ImmutableSet::copyOf);
         this.constraint = requireNonNull(constraint, "constraint is null");
+        this.remainingPredicate = requireNonNull(remainingPredicate, "remainingPredicate is null");
     }
 
     @JsonProperty
@@ -71,6 +77,12 @@ public class ThriftTableLayoutHandle
         return constraint;
     }
 
+    @JsonProperty
+    public RowExpression getRemainingPredicate()
+    {
+        return remainingPredicate;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -84,18 +96,23 @@ public class ThriftTableLayoutHandle
         return schemaName.equals(other.schemaName)
                 && tableName.equals(other.tableName)
                 && columns.equals(other.columns)
-                && constraint.equals(other.constraint);
+                && constraint.equals(other.constraint)
+                && remainingPredicate.equals(other.remainingPredicate);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, columns, constraint);
+        return Objects.hash(schemaName, tableName, columns, constraint, remainingPredicate);
     }
 
     @Override
     public String toString()
     {
-        return schemaName + ":" + tableName;
+        return toStringHelper(this)
+                .add("schemaName", schemaName)
+                .add("tableName", tableName)
+                .add("remainingPredicate", TRUE_CONSTANT.equals(remainingPredicate) ? null : remainingPredicate.toString())
+                .toString();
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftWarningCode.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftWarningCode.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.spi.WarningCode;
+import com.facebook.presto.spi.WarningCodeSupplier;
+
+public enum ThriftWarningCode
+        implements WarningCodeSupplier
+{
+    THRIFT_INDEXSOURCE_CONVERTED_TO_VALUESNODE(1),
+    /**/;
+
+    private final WarningCode warningCode;
+
+    public static final int WARNING_CODE_MASK = 0x0400_0000;
+
+    ThriftWarningCode(int code)
+    {
+        warningCode = new WarningCode(code + WARNING_CODE_MASK, name());
+    }
+
+    @Override
+    public WarningCode toWarningCode()
+    {
+        return warningCode;
+    }
+}

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftLogicalPlanner.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftLogicalPlanner.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift.integration;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_HASH_GENERATION;
+import static com.facebook.presto.connector.thrift.integration.ThriftQueryRunner.createThriftQueryRunner;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.indexJoin;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.indexSource;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+
+@Test(singleThreaded = true)
+public class TestThriftLogicalPlanner
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createThriftQueryRunner(2, 2, true, ImmutableMap.of("native-execution-enabled", "true"));
+    }
+
+    @Test
+    public void testFilterPushdown()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(OPTIMIZE_HASH_GENERATION, "false")
+                .build();
+
+        assertPlan(session,
+                "SELECT *\n" +
+                        "FROM (\n" +
+                        "  SELECT *\n" +
+                        "  FROM lineitem\n" +
+                        "  WHERE partkey % 8 = 0) l\n" +
+                        "LEFT JOIN orders o\n" +
+                        "  ON l.orderkey = o.orderkey" +
+                        "  AND o.orderstatus = 'F'",
+                anyTree(
+                        indexJoin(
+                                exchange(filter(tableScan("lineitem"))),
+                                indexSource("orders"))));
+
+        assertPlan(session,
+                "SELECT *\n" +
+                        "FROM lineitem l\n" +
+                        "LEFT JOIN orders o\n" +
+                        "  ON l.orderkey = o.orderkey" +
+                        "  AND o.orderkey IS NOT NULL",
+                anyTree(
+                        indexJoin(
+                                exchange(tableScan("lineitem")),
+                                indexSource("orders"))));
+    }
+}


### PR DESCRIPTION
Index join doesn't support FilterNode in native execution. This change adds a connector optimizer to push down the FilterNode into table layout, which can be evaluated as remaining filter.

```
== NO RELEASE NOTE ==
```

