### PR TITLE
Upgrade org.apache.yetus:audience-annotations version to 0.15.1

### DIFF
--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -16,6 +16,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <kudu.version>1.12.0</kudu.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
+        <yetus.audience-annotations.version>0.15.1</yetus.audience-annotations.version>
     </properties>
 
     <dependencies>
@@ -127,7 +128,7 @@
         <dependency>
             <groupId>org.apache.yetus</groupId>
             <artifactId>audience-annotations</artifactId>
-            <version>0.8.0</version>
+            <version>${yetus.audience-annotations.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -220,7 +221,7 @@
                             <additionalDependency>
                                 <groupId>org.apache.yetus</groupId>
                                 <artifactId>audience-annotations</artifactId>
-                                <version>0.8.0</version>
+                                <version>${yetus.audience-annotations.version}</version>
                             </additionalDependency>
                         </additionalDependencies>
                     </configuration>


### PR DESCRIPTION
## Description
Bump up org.apache.yetus:audience-annotations version to 0.15.1

## Motivation and Context
Upgrading to a most recent version

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade org.apache.yetus:audience-annotations version to 0.15.1 in response to the use of an outdated version.

```

