### PR TITLE
Bump jdbi-core and jdbi-sqlclient to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
         <dep.aws-sdk.version>1.12.782</dep.aws-sdk.version>
         <dep.okhttp.version>4.12.0</dep.okhttp.version>
-        <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
+        <dep.jdbi3.version>3.49.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>${dep.airlift.version}</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata


### PR DESCRIPTION
## Description

Upgrade org.jdbi:jdbi3-core:3.4.0 to org.jdbi:jdbi3-core:3.49.0
org.jdbi:jdbi3-sqlobject:3.4.0 to org.jdbi:jdbi3-sqlobject:3.49.0

This upgrade will fix below vulnerabilities
CVE-2024-1597, CVE-2023-32697
CVE-2023-2976, CVE-2022-41946
CVE-2022-41853, CVE-2022-31197
CVE-2022-26520, CVE-2022-23221
CVE-2022-21724, CVE-2021-42392
CVE-2020-8908, CVE-2020-13692
CVE-2018-10237.

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade jdbi3-core:3.4.0 to 3.49.0 and jdbi3-sqlobject:3.4.0 to 3.49.0 in response to the use of an outdated version.


