### PR TITLE
Enable and fix all Cassandra connector tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
           - ":presto-tests -P ci-only-plan-determinism"
           - ":presto-tests -P ci-only-resource-manager" 
           - ":presto-accumulo"
-          - ":presto-cassandra -P test-cassandra-integration-smoke-test"
+          - ":presto-cassandra -P ci-full-tests"
           - ":presto-hive"
           - ":presto-hive -P test-hive-materialized-queries"
           - ":presto-hive -P test-hive-materialized-aggregations"

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -272,18 +272,14 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Full test suite for CI/CD pipelines -->
         <profile>
-            <id>test-cassandra-integration-smoke-test</id>
+            <id>ci-full-tests</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <includes>
-                                <include>**/TestCassandraIntegrationSmokeTest.java</include>
-                            </includes>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraDistributed.java
@@ -19,6 +19,7 @@ import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Optional;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -119,16 +120,16 @@ public class TestCassandraDistributed
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
 
-        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "", "")
-                .row("custkey", "bigint", "", "")
-                .row("orderstatus", "varchar", "", "")
-                .row("totalprice", "double", "", "")
-                .row("orderdate", "varchar", "", "")
-                .row("orderpriority", "varchar", "", "")
-                .row("clerk", "varchar", "", "")
-                .row("shippriority", "integer", "", "")
-                .row("comment", "varchar", "", "")
+        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR, BIGINT, BIGINT, BIGINT)
+                .row("orderkey", "bigint", "", "", Long.valueOf(19), null, null)
+                .row("custkey", "bigint", "", "", Long.valueOf(19), null, null)
+                .row("orderstatus", "varchar", "", "", null, null, Long.valueOf(2147483647))
+                .row("totalprice", "double", "", "", Long.valueOf(53), null, null)
+                .row("orderdate", "varchar", "", "", null, null, Long.valueOf(2147483647))
+                .row("orderpriority", "varchar", "", "", null, null, Long.valueOf(2147483647))
+                .row("clerk", "varchar", "", "", null, null, Long.valueOf(2147483647))
+                .row("shippriority", "integer", "", "", Long.valueOf(10), null, null)
+                .row("comment", "varchar", "", "", null, null, Long.valueOf(2147483647))
                 .build();
 
         assertEquals(actual, expectedParametrizedVarchar);
@@ -150,5 +151,52 @@ public class TestCassandraDistributed
     public void testWrittenStats()
     {
         // TODO Cassandra connector supports CTAS and inserts, but the test would fail
+    }
+
+    @Override
+    public void testPayloadJoinApplicability()
+    {
+        // no op -- test not supported due to lack of support for array types.
+    }
+
+    @Override
+    public void testPayloadJoinCorrectness()
+    {
+        // no op -- test not supported due to lack of support for array types.
+    }
+    @Override
+    public void testNonAutoCommitTransactionWithCommit()
+    {
+        // Connector only supports writes using ctas
+    }
+
+    @Override
+    public void testNonAutoCommitTransactionWithRollback()
+    {
+        // Connector only supports writes using ctas
+    }
+
+    @Override
+    public void testRemoveRedundantCastToVarcharInJoinClause()
+    {
+        // no op -- test not supported due to lack of support for array types.
+    }
+
+    @Override
+    public void testStringFilters()
+    {
+        // no op -- test not supported due to lack of support for char type.
+    }
+
+    @Override
+    public void testSubfieldAccessControl()
+    {
+        // no op -- test not supported due to lack of support for array types.
+    }
+
+    @Override
+    protected String getDateExpression(String storageFormat, String columnExpression)
+    {
+        return "cast(" + columnExpression + " as DATE)";
     }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraTokenSplitManager.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraTokenSplitManager.java
@@ -76,12 +76,16 @@ public class TestCassandraTokenSplitManager
             throws Exception
     {
         String tableName = "empty_table";
-        session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
-        server.refreshSizeEstimates(KEYSPACE, tableName);
-        List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName, Optional.empty());
-        // even for the empty table at least one split must be produced, in case the statistics are inaccurate
-        assertEquals(splits.size(), 1);
-        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+        try {
+            session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
+            server.refreshSizeEstimates(KEYSPACE, tableName);
+            List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName, Optional.empty());
+            // even for the empty table at least one split must be produced, in case the statistics are inaccurate
+            assertEquals(splits.size(), 1);
+        }
+        finally {
+            session.execute(format("DROP TABLE IF EXISTS %s.%s", KEYSPACE, tableName));
+        }
     }
 
     @Test
@@ -89,13 +93,17 @@ public class TestCassandraTokenSplitManager
             throws Exception
     {
         String tableName = "non_empty_table";
-        session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
-        for (int i = 0; i < PARTITION_COUNT; i++) {
-            session.execute(format("INSERT INTO %s.%s (key) VALUES ('%s')", KEYSPACE, tableName, "value" + i));
+        try {
+            session.execute(format("CREATE TABLE %s.%s (key text PRIMARY KEY)", KEYSPACE, tableName));
+            for (int i = 0; i < PARTITION_COUNT; i++) {
+                session.execute(format("INSERT INTO %s.%s (key) VALUES ('%s')", KEYSPACE, tableName, "value" + i));
+            }
+            server.refreshSizeEstimates(KEYSPACE, tableName);
+            List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName, Optional.empty());
+            assertEquals(splits.size(), PARTITION_COUNT / SPLIT_SIZE);
         }
-        server.refreshSizeEstimates(KEYSPACE, tableName);
-        List<TokenSplit> splits = splitManager.getSplits(KEYSPACE, tableName, Optional.empty());
-        assertEquals(splits.size(), PARTITION_COUNT / SPLIT_SIZE);
-        session.execute(format("DROP TABLE %s.%s", KEYSPACE, tableName));
+        finally {
+            session.execute(format("DROP TABLE IF EXISTS %s.%s", KEYSPACE, tableName));
+        }
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6920,8 +6920,8 @@ public abstract class AbstractTestQueries
 
         // DWRF does not support date type.
         String format = (System.getProperty("storageFormat") == null) ? storageFormat : System.getProperty("storageFormat");
-        String orderdate = format.equals("DWRF") ? "cast(o.orderdate as DATE)" : "o.orderdate";
-        String shipdate = format.equals("DWRF") ? "cast(l.shipdate as DATE)" : "l.shipdate";
+        String orderdate = getDateExpression(format, "o.orderdate");
+        String shipdate = getDateExpression(format, "l.shipdate");
 
         assertQuery(enableOptimization, "select o.orderkey, o.custkey, l.linenumber from orders o join (select orderkey, linenumber from lineitem where false) l on o.orderkey = l.orderkey");
         assertQuery(enableOptimization, "select o.orderkey, o.custkey, l.linenumber from orders o left join (select orderkey, linenumber from lineitem where false) l on o.orderkey = l.orderkey");
@@ -7877,7 +7877,7 @@ public abstract class AbstractTestQueries
 
         // DWRF does not support date type.
         String format = (System.getProperty("storageFormat") == null) ? storageFormat : System.getProperty("storageFormat");
-        String orderdate = format.equals("DWRF") ? "cast(o.orderdate as DATE)" : "o.orderdate";
+        String orderdate = getDateExpression(format, "o.orderdate");
 
         @Language("SQL") String sql = format("SELECT * FROM customer c WHERE custkey in ( SELECT custkey FROM orders o WHERE %s > date('1995-01-01'))", orderdate);
         assertQueryWithSameQueryRunner(enabled, sql, disabled);
@@ -8087,5 +8087,14 @@ public abstract class AbstractTestQueries
         return inputRows.stream()
                 .filter(row -> Pattern.matches(sessionPropertyName, row.getFields().get(4).toString()))
                 .collect(toList());
+    }
+
+    /**
+     * Returns a date expression, casting to DATE if storageFormat is DWRF.
+     */
+    protected String getDateExpression(String storageFormat, String columnExpression)
+    {
+        // DWRF does not support date type.
+        return storageFormat.equals("DWRF") ? "cast(" + columnExpression + " as DATE)" : columnExpression;
     }
 }


### PR DESCRIPTION
## Description
Enable and fix all Cassandra connector tests in CI

## Motivation and Context
Cassandra test cases were not enabled in the CI. After the PR [#25351](https://github.com/prestodb/presto/pull/25351)
 to enhance SHOW COLUMNS was merged, some Cassandra test cases started failing. This change re-enables the Cassandra tests and fixes the test failures.

## Impact
Enabled all cassandra tests

## Test Plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

