### PR TITLE
feat(plugin-kafka): Enable case-senstive support for Kafka connector 

### DIFF
--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -73,6 +73,10 @@ Property Name                       Description
 ``kafka.truststore.password``       Password for the truststore file
 ``kafka.truststore.type``           File format of the truststore file, defaults to ``JKS``
 ``kafka.config.resources``          A comma-separated list of Kafka client configuration files. If a specialized authentication method is required, it can be specified in these additional Kafka client properties files. Example: `/etc/kafka-configuration.properties`
+``case-sensitive-name-matching``    Enable case-sensitive identifier support for schema,
+                                    table, and column names for the connector. When disabled,
+                                    names are matched case-insensitively using lowercase
+                                    normalization. Default is ``false``.
 =================================== ==============================================================
 
 ``kafka.table-names``

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
@@ -70,6 +70,8 @@ public class KafkaConnectorConfig
      */
     private List<File> resourceConfigFiles = ImmutableList.of();
 
+    private boolean caseSensitiveNameMatching;
+
     @NotNull
     public String getDefaultSchema()
     {
@@ -171,6 +173,20 @@ public class KafkaConnectorConfig
         this.resourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files).stream()
                 .map(File::new)
                 .collect(toImmutableList());
+        return this;
+    }
+
+    public boolean isCaseSensitiveNameMatching()
+    {
+        return caseSensitiveNameMatching;
+    }
+
+    @Config("case-sensitive-name-matching")
+    @ConfigDescription("Enable case-sensitive matching of schema, table names across the connector. " +
+            "When disabled, names are matched case-insensitively using lowercase normalization.")
+    public KafkaConnectorConfig setCaseSensitiveNameMatching(boolean caseSensitiveNameMatchingEnabled)
+    {
+        this.caseSensitiveNameMatching = caseSensitiveNameMatchingEnabled;
         return this;
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
@@ -50,6 +50,7 @@ import static com.facebook.presto.kafka.KafkaHandleResolver.convertColumnHandle;
 import static com.facebook.presto.kafka.KafkaHandleResolver.convertTableHandle;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -63,6 +64,7 @@ public class KafkaMetadata
     private final String connectorId;
     private final boolean hideInternalColumns;
     private final TableDescriptionSupplier tableDescriptionSupplier;
+    private final boolean caseSensitiveNameMatching;
 
     @Inject
     public KafkaMetadata(
@@ -75,6 +77,7 @@ public class KafkaMetadata
         requireNonNull(kafkaConnectorConfig, "kafkaConfig is null");
         this.hideInternalColumns = kafkaConnectorConfig.isHideInternalColumns();
         this.tableDescriptionSupplier = requireNonNull(tableDescriptionSupplier, "tableDescriptionSupplier is null");
+        this.caseSensitiveNameMatching = kafkaConnectorConfig.isCaseSensitiveNameMatching();
     }
 
     @Override
@@ -304,5 +307,10 @@ public class KafkaMetadata
     private Optional<KafkaTopicDescription> getTopicDescription(SchemaTableName schemaTableName)
     {
         return tableDescriptionSupplier.getTopicDescription(schemaTableName);
+    }
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier)
+    {
+        return caseSensitiveNameMatching ? identifier : identifier.toLowerCase(ROOT);
     }
 }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
@@ -33,7 +33,8 @@ public class TestKafkaConnectorConfig
                 .setHideInternalColumns(true)
                 .setMaxPartitionFetchBytes(1048576)
                 .setMaxPollRecords(500)
-                .setResourceConfigFiles(""));
+                .setResourceConfigFiles("")
+                .setCaseSensitiveNameMatching(false));
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestKafkaConnectorConfig
                 .put("kafka.max-partition-fetch-bytes", "1024")
                 .put("kafka.max-poll-records", "1000")
                 .put("kafka.config.resources", tempFile1 + "," + tempFile2)
+                .put("case-sensitive-name-matching", "true")
                 .build();
 
         KafkaConnectorConfig expected = new KafkaConnectorConfig()
@@ -61,7 +63,8 @@ public class TestKafkaConnectorConfig
                 .setHideInternalColumns(false)
                 .setMaxPartitionFetchBytes(1024)
                 .setMaxPollRecords(1000)
-                .setResourceConfigFiles(tempFile1 + "," + tempFile2);
+                .setResourceConfigFiles(tempFile1 + "," + tempFile2)
+                .setCaseSensitiveNameMatching(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
@@ -16,6 +16,8 @@ package com.facebook.presto.kafka;
 import com.facebook.presto.kafka.util.EmbeddedKafka;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueries;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -36,7 +38,7 @@ public class TestKafkaDistributed
             throws Exception
     {
         this.embeddedKafka = createEmbeddedKafka();
-        return createKafkaQueryRunner(embeddedKafka, TpchTable.getTables());
+        return createKafkaQueryRunner(embeddedKafka, TpchTable.getTables(), ImmutableMap.of(), ImmutableList.of());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationMixedCase.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationMixedCase.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.kafka.util.EmbeddedKafka;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.kafka.KafkaQueryRunner.createKafkaQueryRunner;
+import static com.facebook.presto.kafka.util.EmbeddedKafka.createEmbeddedKafka;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.QueryAssertions.assertContains;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class TestKafkaIntegrationMixedCase
+        extends AbstractTestQueryFramework
+{
+    private EmbeddedKafka embeddedKafka;
+    private Session session;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        List<SchemaTableName> extraTables = ImmutableList.of(
+                new SchemaTableName("TPCH", "ORDERS"));
+        embeddedKafka = createEmbeddedKafka();
+
+        return createKafkaQueryRunner(embeddedKafka, ImmutableList.of(TpchTable.ORDERS),
+                ImmutableMap.of("case-sensitive-name-matching", "true"), extraTables);
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public final void setUp()
+    {
+        session = testSessionBuilder()
+                .setCatalog("kafka")
+                .setSchema("tpch")
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+            throws IOException
+    {
+        if (embeddedKafka != null) {
+            embeddedKafka.close();
+        }
+    }
+
+    @Test
+    public void testTableExists()
+    {
+        assertTrue(getQueryRunner().tableExists(session, "orders"));
+        assertFalse(getQueryRunner().tableExists(session, "Orders"));
+        assertFalse(getQueryRunner().tableExists(session, "oRdErS"));
+
+        assertFalse(getQueryRunner().tableExists(session, "nonexistent"));
+        assertFalse(getQueryRunner().tableExists(session, "NONEXISTENT"));
+    }
+
+    @Test
+    public void testSelect()
+    {
+        // Should work with exact case
+        assertQuerySucceeds(session, "SELECT count(*) FROM orders");
+        assertQuerySucceeds(session, "SELECT count(*) FROM tpch.orders");
+        assertQuerySucceeds(session, "SELECT count(*) FROM TPCH.ORDERS");
+        assertQuerySucceeds(session, "SELECT CASE WHEN (SELECT count(*) FROM tpch.orders) = (SELECT count(*) FROM TPCH.\"ORDERS\") THEN 1 ELSE 0 END");
+        assertQuerySucceeds(session, "SELECT CASE WHEN (SELECT min(orderkey) FROM tpch.orders) = (SELECT min(ORDERKEY) FROM TPCH.\"ORDERS\") THEN 1 ELSE 0 END");
+        assertQuerySucceeds(session, "SELECT CASE WHEN (SELECT max(totalprice) FROM tpch.orders) = (SELECT max(TOTALPRICE) FROM TPCH.\"ORDERS\") THEN 1 ELSE 0 END");
+
+        // Should fail with wrong case when case-sensitive is enabled
+        assertQueryFails(session, "SELECT count(*) FROM Orders", "Table kafka.tpch.Orders does not exist");
+        assertQueryFails(session, "SELECT count(*) FROM oRdErS", "Table kafka.tpch.oRdErS does not exist");
+        assertQueryFails(session, "SELECT count(*) FROM TPCH.orders", "Table kafka.TPCH.orders does not exist");
+    }
+
+    @Test
+    public void testDescribeTable()
+    {
+        assertQuerySucceeds(session, "DESCRIBE orders");
+        assertQuerySucceeds(session, "DESCRIBE tpch.orders");
+        assertQuerySucceeds(session, "DESCRIBE TPCH.ORDERS");
+
+        assertQueryFails(session, "DESCRIBE Orders", "line 1:1: Table 'kafka.tpch.Orders' does not exist");
+        assertQueryFails(session, "DESCRIBE oRdErS", "line 1:1: Table 'kafka.tpch.oRdErS' does not exist");
+        assertQueryFails(session, "DESCRIBE TPCH.orders", "line 1:1: Table 'kafka.TPCH.orders' does not exist");
+
+            // Validate full column metadata for lowercase
+        assertQuery(
+                session,
+                "SELECT column_name, data_type FROM information_schema.columns " +
+                        "WHERE table_catalog = 'kafka' AND table_schema = 'tpch' AND table_name = 'orders' " +
+                        "ORDER BY column_name",
+                "SELECT * FROM (VALUES " +
+                        "('clerk','varchar(15)')," +
+                        "('comment','varchar(79)')," +
+                        "('custkey','bigint')," +
+                        "('orderdate','date')," +
+                        "('orderkey','bigint')," +
+                        "('orderpriority','varchar(15)')," +
+                        "('orderstatus','varchar(1)')," +
+                        "('shippriority','integer')," +
+                        "('totalprice','double')) AS t(column_name, data_type)");
+            // Validate full column metadata for uppercase
+        assertQuery(
+                session,
+                "SELECT column_name, data_type FROM information_schema.columns " +
+                        "WHERE table_catalog = 'kafka' AND table_schema = 'TPCH' AND table_name = 'ORDERS' " +
+                        "ORDER BY column_name",
+                "SELECT * FROM (VALUES " +
+                        "('CLERK','varchar(15)')," +
+                        "('COMMENT','varchar(79)')," +
+                        "('CUSTKEY','bigint')," +
+                        "('ORDERDATE','date')," +
+                        "('ORDERKEY','bigint')," +
+                        "('ORDERPRIORITY','varchar(15)')," +
+                        "('ORDERSTATUS','varchar(1)')," +
+                        "('OrderStatus','varchar(1)')," +
+                        "('SHIPPRIORITY','integer')," +
+                        "('TOTALPRICE','double')) AS t(column_name, data_type)");
+    }
+
+    @Test
+    public void testShowTables()
+    {
+        // Both lowercase and uppercase tables are registered
+        assertQuery(session, "SHOW TABLES FROM tpch", "VALUES ('orders')");
+        assertQuery(session, "SHOW TABLES FROM TPCH", "VALUES ('ORDERS')");
+    }
+
+    @Test
+    public void testInformationSchema()
+    {
+        assertQuery(session, "SELECT table_name FROM information_schema.tables WHERE table_name = 'orders'", "VALUES ('orders')");
+
+        assertQuerySucceeds(session, "SELECT table_name FROM information_schema.tables WHERE table_schema = 'tpch'");
+        assertQuerySucceeds(session, "SELECT table_name FROM information_schema.tables WHERE table_schema = 'TPCH'");
+
+        assertQuery(session, "SELECT table_name FROM information_schema.tables WHERE table_name = 'Orders'", "SELECT 'empty' WHERE false");
+        assertQuery(session, "SELECT table_name FROM information_schema.tables WHERE table_schema = 'Tpch'", "SELECT 'empty' WHERE false");
+    }
+
+    @Test
+    public void testMixedCaseQueries()
+    {
+        assertQuerySucceeds(session, "SELECT count(*) FROM orders WHERE orderkey > 100");
+        assertQuerySucceeds(session, "SELECT o.orderkey FROM orders o LIMIT 1");
+
+        assertQuerySucceeds(session, "SELECT count(*) FROM TPCH.ORDERS WHERE ORDERKEY > 100");
+        assertQuerySucceeds(session, "SELECT o.ORDERKEY FROM TPCH.ORDERS o LIMIT 1");
+
+        assertQueryFails(session, "SELECT COUNT(*) FROM Orders WHERE OrderKey > 100", "Table kafka.tpch.Orders does not exist");
+        assertQueryFails(session, "SELECT * FROM TPCH.Orders", "Table kafka.TPCH.Orders does not exist");
+    }
+
+    @Test
+    public void testJoinsWithCaseSensitivity()
+    {
+        assertQuerySucceeds(session, "SELECT count(*) FROM orders o1 JOIN orders o2 ON o1.orderkey = o2.orderkey LIMIT 10");
+
+        assertQueryFails(session, "SELECT count(*) FROM Orders o1 JOIN orders o2 ON o1.orderkey = o2.orderkey", "Table kafka.tpch.Orders does not exist");
+        assertQueryFails(session, "SELECT count(*) FROM orders o1 JOIN Orders o2 ON o1.orderkey = o2.orderkey", "Table kafka.tpch.Orders does not exist");
+    }
+
+    @Test
+    public void testSchemaCasing()
+    {
+        assertQuerySucceeds(session, "SHOW TABLES FROM tpch");
+        assertQuerySucceeds("SHOW TABLES FROM TPCH");
+        assertQueryFails(session, "SHOW TABLES FROM Tpch", "line 1:1: Schema 'Tpch' does not exist");
+
+        assertQuery(session,
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'tpch'",
+                "VALUES ('orders')");
+
+        assertQuery(
+                session,
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'TPCH'",
+                "VALUES ('ORDERS')");
+
+        assertQuery(
+                session,
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'Tpch'",
+                "SELECT 'empty' WHERE false");
+    }
+
+    @Test
+    public void testShowColumns()
+    {
+        MaterializedResult actual = computeActual("SHOW COLUMNS FROM tpch.orders");
+
+        MaterializedResult expected = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), createUnboundedVarcharType())
+                .row("orderkey", "bigint", "", "", Long.valueOf(19), null, null)
+                .row("custkey", "bigint", "", "", Long.valueOf(19), null, null)
+                .row("orderstatus", "varchar(1)", "", "", null, null, Long.valueOf(1))
+                .row("totalprice", "double", "", "", Long.valueOf(53), null, null)
+                .row("orderdate", "date", "", "", null, null, null)
+                .row("orderpriority", "varchar(15)", "", "", null, null, Long.valueOf(15))
+                .row("clerk", "varchar(15)", "", "", null, null, Long.valueOf(15))
+                .row("shippriority", "integer", "", "", Long.valueOf(10), null, null)
+                .row("comment", "varchar(79)", "", "", null, null, Long.valueOf(79))
+                .build();
+        assertContains(actual, expected);
+    }
+}

--- a/presto-kafka/src/test/resources/tpch/orders_upper.json
+++ b/presto-kafka/src/test/resources/tpch/orders_upper.json
@@ -1,0 +1,72 @@
+{
+  "tableName": "ORDERS",
+  "schemaName": "TPCH",
+  "topicName": "TPCH.ORDERS",
+  "key": {
+    "dataFormat": "raw",
+    "fields": [
+      {
+        "name": "kafka_key",
+        "dataFormat": "LONG",
+        "type": "BIGINT",
+        "hidden": "true"
+      }
+    ]
+  },
+  "message": {
+    "dataFormat": "json",
+    "fields": [
+      {
+        "name": "ORDERKEY",
+        "mapping": "ORDERKEY",
+        "type": "BIGINT"
+      },
+      {
+        "name": "CUSTKEY",
+        "mapping": "CUSTKEY",
+        "type": "BIGINT"
+      },
+      {
+        "name": "ORDERSTATUS",
+        "mapping": "ORDERSTATUS",
+        "type": "VARCHAR(1)"
+      },
+      {
+        "name": "OrderStatus",
+        "mapping": "OrderStatus",
+        "type": "VARCHAR(1)"
+      },
+      {
+        "name": "TOTALPRICE",
+        "mapping": "TOTALPRICE",
+        "type": "DOUBLE"
+      },
+      {
+        "name": "ORDERDATE",
+        "mapping": "ORDERDATE",
+        "type": "DATE",
+        "dataFormat": "iso8601"
+      },
+      {
+        "name": "ORDERPRIORITY",
+        "mapping": "ORDERPRIORITY",
+        "type": "VARCHAR(15)"
+      },
+      {
+        "name": "CLERK",
+        "mapping": "CLERK",
+        "type": "VARCHAR(15)"
+      },
+      {
+        "name": "SHIPPRIORITY",
+        "mapping": "SHIPPRIORITY",
+        "type": "INTEGER"
+      },
+      {
+        "name": "COMMENT",
+        "mapping": "COMMENT",
+        "type": "VARCHAR(79)"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
This PR adds support for case-sensitive identifiers in the Kafka connector.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.
```
==RELEASE NOTE ==

Kafka Connector Changes
* Add mixed case support for Kafka connector.
```

