### PR TITLE
Bump org.glassfish.jaxb:jaxb-runtime jar to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <dep.pinot.version>0.11.0</dep.pinot.version>
         <dep.druid.version>30.0.1</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
+        <dep.jaxb.runtime.version>4.0.5</dep.jaxb.runtime.version>
         <dep.hudi.version>0.14.0</dep.hudi.version>
         <dep.testcontainers.version>1.20.5</dep.testcontainers.version>
         <dep.docker-java.version>3.4.1</dep.docker-java.version>
@@ -1410,7 +1411,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>${dep.jaxb.version}</version>
+                <version>${dep.jaxb.runtime.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
Upgrade org.glassfish.jaxb:jaxb-runtime:2.3.1 to :4.0.5 

Addresses CVE-2020-15250.

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade jaxb-runtime to v4.0.5 in response to CVE-2020-15250


