### PR TITLE
[DRAFT] Use range overlap percent

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/cost/ComparisonStatsCalculator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/ComparisonStatsCalculator.java
@@ -242,8 +242,10 @@ public final class ComparisonStatsCalculator
         double filterFactor = 1.0 / max(leftNdv, rightNdv, 1);
         double retainedNdv = min(leftNdv, rightNdv);
 
+        double overlapPercent = leftExpressionRange.overlapPercentWith(rightExpressionRange);
+        double outputRowCount = overlapPercent == 0D ? 0D : inputStatistics.getOutputRowCount() * nullsFilterFactor * filterFactor;
         PlanNodeStatsEstimate.Builder estimate = PlanNodeStatsEstimate.buildFrom(inputStatistics)
-                .setOutputRowCount(inputStatistics.getOutputRowCount() * nullsFilterFactor * filterFactor);
+                .setOutputRowCount(outputRowCount);
 
         VariableStatsEstimate equalityStats = VariableStatsEstimate.builder()
                 .setAverageRowSize(averageExcludingNaNs(leftExpressionStatistics.getAverageRowSize(), rightExpressionStatistics.getAverageRowSize()))

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/JoinStatsRule.java
@@ -261,8 +261,9 @@ public class JoinStatsRule
             newRightStats.setHistogram(rightStats.getHistogram().map(rightHistogram -> addConjunction(rightHistogram, intersect.toPrestoRange())));
         }
 
+        double outputRowCount = leftRange.overlapPercentWith(rightRange) == 0D ? 0D : stats.getOutputRowCount() * UNKNOWN_FILTER_COEFFICIENT;
         PlanNodeStatsEstimate.Builder result = PlanNodeStatsEstimate.buildFrom(stats)
-                .setOutputRowCount(stats.getOutputRowCount() * UNKNOWN_FILTER_COEFFICIENT)
+                .setOutputRowCount(outputRowCount)
                 .addVariableStatistics(clause.getLeft(), newLeftStats.build())
                 .addVariableStatistics(clause.getRight(), newRightStats.build());
         return normalizer.normalize(result.build());

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/StatsNormalizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/StatsNormalizer.java
@@ -94,7 +94,7 @@ public class StatsNormalizer
         }
 
         double outputRowCount = stats.getOutputRowCount();
-        checkArgument(outputRowCount > 0, "outputRowCount must be greater than zero: %s", outputRowCount);
+        checkArgument(outputRowCount >= 0, "outputRowCount must be greater than or equal to zero: %s", outputRowCount);
         double distinctValuesCount = variableStats.getDistinctValuesCount();
         double nullsFraction = variableStats.getNullsFraction();
 


### PR DESCRIPTION
to determine PlanNodeStatsEstimate row count

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

