### PR TITLE
[IDS] Add enable IDS CAT propagation to session properties

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -352,6 +352,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_ENFORCE_JOIN_BUILD_INPUT_PARTITION = "native_enforce_join_build_input_partition";
     public static final String NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED = "native_execution_scale_writer_threads_enabled";
     public static final String NATIVE_EXECUTION_TYPE_REWRITE_ENABLED = "native_execution_type_rewrite_enabled";
+    public static final String ENABLE_IDS_CAT_PROPAGATION = "enable_ids_cat_propagation";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1953,6 +1954,11 @@ public final class SystemSessionProperties
                 booleanProperty(ADD_DISTINCT_BELOW_SEMI_JOIN_BUILD,
                         "Add distinct aggregation below semi join build",
                         featuresConfig.isAddDistinctBelowSemiJoinBuild(),
+                        false),
+                booleanProperty(
+                        ENABLE_IDS_CAT_PROPAGATION,
+                        "Enable propagation of IDS CAT across workers and coordinator",
+                        featuresConfig.isEnableIdsCatPropagation(),
                         false));
     }
 
@@ -3333,5 +3339,10 @@ public final class SystemSessionProperties
     public static long getMaxSerializableObjectSize(Session session)
     {
         return session.getSystemProperty(MAX_SERIALIZABLE_OBJECT_SIZE, Long.class);
+    }
+
+    public static boolean isEnableIdsCatPropagationEnabled(Session session)
+    {
+        return session.getSystemProperty(ENABLE_IDS_CAT_PROPAGATION, Boolean.class);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -312,6 +312,8 @@ public class FeaturesConfig
 
     private boolean builtInSidecarFunctionsEnabled;
 
+    private boolean enableIdsCatPropagation;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -3125,5 +3127,18 @@ public class FeaturesConfig
     public boolean isBuiltInSidecarFunctionsEnabled()
     {
         return this.builtInSidecarFunctionsEnabled;
+    }
+
+    public boolean isEnableIdsCatPropagation()
+    {
+        return enableIdsCatPropagation;
+    }
+
+    @Config("enable-ids-cat-propagation")
+    @ConfigDescription("Enable propagation of IDS CAT across workers and coordinator")
+    public FeaturesConfig setEnableIdsCatPropagation(boolean enableIdsCatPropagation)
+    {
+        this.enableIdsCatPropagation = enableIdsCatPropagation;
+        return this;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -268,7 +268,8 @@ public class TestFeaturesConfig
                 .setInEqualityJoinPushdownEnabled(false)
                 .setRewriteMinMaxByToTopNEnabled(false)
                 .setPrestoSparkExecutionEnvironment(false)
-                .setMaxSerializableObjectSize(1000));
+                .setMaxSerializableObjectSize(1000)
+                .setEnableIdsCatPropagation(false));
     }
 
     @Test
@@ -484,6 +485,7 @@ public class TestFeaturesConfig
                 .put("optimizer.pushdown-subfield-for-map-functions", "false")
                 .put("optimizer.add-exchange-below-partial-aggregation-over-group-id", "true")
                 .put("max_serializable_object_size", "50")
+                .put("enable-ids-cat-propagation", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -697,7 +699,8 @@ public class TestFeaturesConfig
                 .setRewriteMinMaxByToTopNEnabled(true)
                 .setInnerJoinPushdownEnabled(true)
                 .setPrestoSparkExecutionEnvironment(true)
-                .setMaxSerializableObjectSize(50);
+                .setMaxSerializableObjectSize(50)
+                .setEnableIdsCatPropagation(true);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
Summary:
Follow the example of this [PR](https://github.com/kewang1024/presto/commit/f811f7e4077e551f2e56959647e13b7dd6f4fa97). In this diff, we introduce session properties to only limit the traffic in presto client to populate IDS CAT.

Rollback Plan:

Differential Revision: D82347678


