### PR TITLE
[sapphire-velox]fix: Fix to handle multiple TaskSource have the same source node

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -121,9 +121,4 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testKeyBasedSamplingInlined() {}
-
-    // VeloxRuntimeError: !noMoreSplits_
-    @Override
-    @Ignore
-    public void testUnionAllInsert() {}
 }


### PR DESCRIPTION
Summary: Sapphire-Velox might send multiple task sources with the same source node. Task manager doesn't expect this and directly send splits of each task source to velox task. Since Sapphire-Velox send all splits once for each velox task, then all such task sources have no more splits set. This hit the check failure in the recent added no-more split check in Velox task split add API. This PR fixes the issue by merge the splits from multiple task sources if they share the same source node id.

Differential Revision: D82367224


