### PR TITLE
[native] Assign createFinishTimeMs at point of task completion in pre…

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -573,10 +573,10 @@ std::unique_ptr<TaskInfo> TaskManager::createOrUpdateTaskImpl(
       prestoTask->task = std::move(newExecTask);
       prestoTask->info.needsPlan = false;
       startTask = true;
+      prestoTask->createFinishTimeMs = getCurrentTimeMs();
     }
     execTask = prestoTask->task;
   }
-  prestoTask->createFinishTimeMs = getCurrentTimeMs();
   // Outside of prestoTask->mutex.
   VELOX_CHECK_NOT_NULL(
       execTask,


### PR DESCRIPTION
Previously, prestoTask->createFinishTimeMs was set after the lock scope,
potentially not reflecting the actual task creation finish time. Now, the
assignment is moved inside the lock, right after the task is created and
assigned, to more accurately capture when the task creation completes.

```
== NO RELEASE NOTE ==
```

