### PR TITLE
[Native]Remove redundant loops and unnecessary task launches

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskManager.cpp
@@ -768,7 +768,6 @@ void TaskManager::maybeStartNextQueuedTask() {
 
       // Get all the still valid tasks from the entry.
       bool queryTasksAreGoodToStart{true};
-      tasksToStart.clear();
       for (auto& queuedTask : queuedTasks) {
         auto taskToStart = queuedTask.lock();
 
@@ -776,7 +775,7 @@ void TaskManager::maybeStartNextQueuedTask() {
         if (taskToStart == nullptr || taskToStart->task == nullptr) {
           LOG(WARNING) << "TASK QUEUE: Skipping null task in the queue.";
           queryTasksAreGoodToStart = false;
-          continue;
+          break;
         }
 
         // Sanity check.
@@ -792,7 +791,7 @@ void TaskManager::maybeStartNextQueuedTask() {
                     << taskToStart->info.taskId << " because state is "
                     << prestoTaskStateString(taskState);
           queryTasksAreGoodToStart = false;
-          continue;
+          break;
         }
 
         tasksToStart.emplace_back(taskToStart);
@@ -801,6 +800,7 @@ void TaskManager::maybeStartNextQueuedTask() {
       if (queryTasksAreGoodToStart) {
         break;
       }
+      tasksToStart.clear();
     }
   }
 


### PR DESCRIPTION

## Description

In `TaskManager.maybeStartNextQueuedTask`, if we found that one task is gone or aborted, then we can directly skip the whole queue of tasks that belongs to the same query; there is no need to continue the inner loop and check the rest ones.

Besides, if every queue of tasks in the `taskQueue_` contains invalid tasks—for example, if there's only one batch and it has an invalid task—then `tasksToStart` is not properly cleared. This means we might unnecessarily start tasks that should not be launched at all.

This PR did some minor refactor in `TaskManager.maybeStartNextQueuedTask` in order to fix the issues described above.

## Motivation and Context

 - Remove redundant loops and unnecessary task launches in task manager

## Impact

 - N/A

## Test Plan

 - N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

