### PR TITLE
[ci] Fix maven error when getting project version

### DIFF
--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -62,14 +62,9 @@ jobs:
           git config pull.rebase false
 
       - name: Set presto release version
-        run: |
-          unset MAVEN_CONFIG && ./mvnw versions:set -DremoveSnapshot -ntp
-
-      - name: Get presto release version
         id: get-version
         run: |
-          PRESTO_RELEASE_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
-            -Dexpression=project.version -q -ntp -DforceStdout | tail -n 1)
+          PRESTO_RELEASE_VERSION=$(grep -m 1 "^    <version>" pom.xml | sed -e 's/.*<version>\(.*\)<\/version>.*/\1/' | sed -e 's/-SNAPSHOT//')
           echo "PRESTO_RELEASE_VERSION=$PRESTO_RELEASE_VERSION" >> $GITHUB_ENV
           echo "PRESTO_RELEASE_VERSION=$PRESTO_RELEASE_VERSION"
 


### PR DESCRIPTION
## Description
Due to the profile `spark3` reference unpublished jar files, the command `mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -ntp -DforceStdout` will fail.

## Motivation and Context
Keep the workaround until the issue is fixed in profile spark3

## Impact
Release 0.295

## Test Plan
In my repo

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

