### PR TITLE
fix: Add generic array_frequency array support to any element type

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/tests/FunctionMetadataTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/FunctionMetadataTest.cpp
@@ -68,7 +68,7 @@ TEST_F(FunctionMetadataTest, approxMostFrequent) {
 }
 
 TEST_F(FunctionMetadataTest, arrayFrequency) {
-  testFunction("array_frequency", "ArrayFrequency.json", 10);
+  testFunction("array_frequency", "ArrayFrequency.json", 11);
 }
 
 TEST_F(FunctionMetadataTest, combinations) {

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ArrayFrequency.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ArrayFrequency.json
@@ -174,9 +174,9 @@
       "docString": "presto.default.array_frequency",
       "functionKind": "SCALAR",
       "longVariableConstraints":[],
-      "outputType": "map(array(varchar),integer)",
+      "outputType": "map(array(__user_t1),integer)",
       "paramTypes": [
-        "array(array(varchar))"
+        "array(array(__user_t1))"
       ],
       "routineCharacteristics": {
         "determinism": "DETERMINISTIC",
@@ -184,7 +184,15 @@
         "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
       },
       "schema": "default",
-      "typeVariableConstraints":[],
+      "typeVariableConstraints":[
+        {
+          "comparableRequired": false,
+          "name": "__user_t1",
+          "nonDecimalNumericRequired": false,
+          "orderableRequired": false,
+          "variadicBound": ""
+        }
+      ],
       "variableArity":false
     }
   ]

--- a/presto-native-execution/presto_cpp/main/types/tests/data/ArrayFrequency.json
+++ b/presto-native-execution/presto_cpp/main/types/tests/data/ArrayFrequency.json
@@ -169,6 +169,23 @@
       "schema": "default",
       "typeVariableConstraints":[],
       "variableArity":false
+    },
+    {
+      "docString": "presto.default.array_frequency",
+      "functionKind": "SCALAR",
+      "longVariableConstraints":[],
+      "outputType": "map(array(varchar),integer)",
+      "paramTypes": [
+        "array(array(varchar))"
+      ],
+      "routineCharacteristics": {
+        "determinism": "DETERMINISTIC",
+        "language": "CPP",
+        "nullCallClause": "RETURNS_NULL_ON_NULL_INPUT"
+      },
+      "schema": "default",
+      "typeVariableConstraints":[],
+      "variableArity":false
     }
   ]
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/14864

Add the array_frequency function's nested array implementation to support arrays of any element type, not just varchar arrays. This change replaces the Array<Varchar> specialization with a more generic Array<Generic<T1>> template that can handle nested arrays containing integers, dates, timestamps, maps, and other types.

The key improvements include:
- Replace Array<Varchar> specialization with Array<Generic<T1>> to support any element type like array(array(bigint)), array(map(bigint, bigint)), etc.
- Use element.hash() instead of string-specific hashing for better performance and generality
- Implement proper null-safe comparison using CompareFlags::equality with kNullAsIndeterminate for robust element equality checks
- Add comprehensive error handling for unsupported null-containing elements with clear user error messages
- Update function registration to use the generic template approach instead of explicit Array<Varchar> registration
- Add test coverage for nested integer arrays to validate the generic implementation

This addresses the requirement to support array(generic) argument types since we cannot enumerate all possible nested array types that customers may use in Presto.

Differential Revision: D82320316
