### PR TITLE
Bump bigdataoss jars to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.parquet.version>1.13.1</dep.parquet.version>
         <dep.asm.version>9.7.1</dep.asm.version>
-        <dep.gcs.version>1.9.17</dep.gcs.version>
+        <dep.gcs.version>3.1.7</dep.gcs.version>
         <dep.alluxio.version>313</dep.alluxio.version>
         <dep.slf4j.version>2.0.16</dep.slf4j.version>
         <dep.kafka.version>3.9.1</dep.kafka.version>
@@ -1903,6 +1903,7 @@
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>util</artifactId>
                 <version>${dep.gcs.version}</version>
+                <scope>runtime</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.guava</groupId>
@@ -1938,7 +1939,7 @@
             <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>util-hadoop</artifactId>
-                <version>hadoop2-${dep.gcs.version}</version>
+                <version>${dep.gcs.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -2060,7 +2061,7 @@
             <dependency>
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>gcs-connector</artifactId>
-                <version>hadoop2-${dep.gcs.version}</version>
+                <version>${dep.gcs.version}</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>log4j</artifactId>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/gcs/HiveGcsConfigurationInitializer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/gcs/HiveGcsConfigurationInitializer.java
@@ -17,11 +17,6 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
 import jakarta.inject.Inject;
 import org.apache.hadoop.conf.Configuration;
 
-import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.AUTHENTICATION_PREFIX;
-import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.AUTH_SERVICE_ACCOUNT_ENABLE;
-import static com.google.cloud.hadoop.util.AccessTokenProviderClassFromConfigFactory.ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX;
-import static com.google.cloud.hadoop.util.EntriesCredentialConfiguration.JSON_KEYFILE_SUFFIX;
-
 public class HiveGcsConfigurationInitializer
         implements GcsConfigurationInitializer
 {
@@ -41,13 +36,11 @@ public class HiveGcsConfigurationInitializer
 
         if (useGcsAccessToken) {
             // use oauth token to authenticate with Google Cloud Storage
-            config.set(AUTH_SERVICE_ACCOUNT_ENABLE.getKey(), "false");
-            config.set(AUTHENTICATION_PREFIX + ACCESS_TOKEN_PROVIDER_IMPL_SUFFIX, GcsAccessTokenProvider.class.getName());
+            config.set("fs.gs.auth.access.token.provider", GcsAccessTokenProvider.class.getName());
         }
         else if (jsonKeyFilePath != null) {
             // use service account key file
-            config.set(AUTH_SERVICE_ACCOUNT_ENABLE.getKey(), "true");
-            config.set(AUTHENTICATION_PREFIX + JSON_KEYFILE_SUFFIX, jsonKeyFilePath);
+            config.set("fs.gs.auth.service.account.json.keyfile", jsonKeyFilePath);
         }
     }
 }


### PR DESCRIPTION
## Description
Upgrade
com.google.cloud.bigdataoss:util:1.9.17 to com.google.cloud.bigdataoss:util:3.1.7 
com.google.cloud.bigdataoss:gcsio:1.9.17 to com.google.cloud.bigdataoss:gcsio:3.1.7
## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* upgrade com.google.cloud.bigdataoss:util and com.google.cloud.bigdataoss:gcsio from 1.9.17 to 3.1.7
