### PR TITLE
feat: Add enable IDS CAT propagation to session properties

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -514,3 +514,14 @@ Queries with higher priority are scheduled first than the ones with lower priori
 Use to configure how long a query can be queued before it is terminated.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`query.max-queued-time\`\``.
+
+AUTH Properties
+---------------
+
+``enable_ids_cat_propagation``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+This property enables crypto auth tokens for IDS UDFs.

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1201,3 +1201,14 @@ Comma-separated list of error codes that allow cross-cluster retry. When a query
 fails with one of these error codes, it can be automatically retried on a backup
 cluster if a retry URL is provided. Available error codes include standard Presto
 error codes such as ``REMOTE_TASK_ERROR``, ``CLUSTER_OUT_OF_MEMORY``, etc.
+
+AUTH Properties
+---------------
+
+``enable_ids_cat_propagation``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+This property enables crypto auth tokens for IDS UDFs.

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -352,6 +352,7 @@ public final class SystemSessionProperties
     public static final String NATIVE_ENFORCE_JOIN_BUILD_INPUT_PARTITION = "native_enforce_join_build_input_partition";
     public static final String NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED = "native_execution_scale_writer_threads_enabled";
     public static final String NATIVE_EXECUTION_TYPE_REWRITE_ENABLED = "native_execution_type_rewrite_enabled";
+    public static final String ENABLE_IDS_CAT_PROPAGATION = "enable_ids_cat_propagation";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1953,6 +1954,11 @@ public final class SystemSessionProperties
                 booleanProperty(ADD_DISTINCT_BELOW_SEMI_JOIN_BUILD,
                         "Add distinct aggregation below semi join build",
                         featuresConfig.isAddDistinctBelowSemiJoinBuild(),
+                        false),
+                booleanProperty(
+                        ENABLE_IDS_CAT_PROPAGATION,
+                        "Enable propagation of IDS CAT across workers and coordinator",
+                        featuresConfig.isEnableIdsCatPropagation(),
                         false));
     }
 
@@ -3333,5 +3339,10 @@ public final class SystemSessionProperties
     public static long getMaxSerializableObjectSize(Session session)
     {
         return session.getSystemProperty(MAX_SERIALIZABLE_OBJECT_SIZE, Long.class);
+    }
+
+    public static boolean isEnableIdsCatPropagationEnabled(Session session)
+    {
+        return session.getSystemProperty(ENABLE_IDS_CAT_PROPAGATION, Boolean.class);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -312,6 +312,8 @@ public class FeaturesConfig
 
     private boolean builtInSidecarFunctionsEnabled;
 
+    private boolean enableIdsCatPropagation;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -3125,5 +3127,18 @@ public class FeaturesConfig
     public boolean isBuiltInSidecarFunctionsEnabled()
     {
         return this.builtInSidecarFunctionsEnabled;
+    }
+
+    public boolean isEnableIdsCatPropagation()
+    {
+        return enableIdsCatPropagation;
+    }
+
+    @Config("enable-ids-cat-propagation")
+    @ConfigDescription("Enable propagation of IDS CAT across workers and coordinator")
+    public FeaturesConfig setEnableIdsCatPropagation(boolean enableIdsCatPropagation)
+    {
+        this.enableIdsCatPropagation = enableIdsCatPropagation;
+        return this;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -268,7 +268,8 @@ public class TestFeaturesConfig
                 .setInEqualityJoinPushdownEnabled(false)
                 .setRewriteMinMaxByToTopNEnabled(false)
                 .setPrestoSparkExecutionEnvironment(false)
-                .setMaxSerializableObjectSize(1000));
+                .setMaxSerializableObjectSize(1000)
+                .setEnableIdsCatPropagation(false));
     }
 
     @Test
@@ -484,6 +485,7 @@ public class TestFeaturesConfig
                 .put("optimizer.pushdown-subfield-for-map-functions", "false")
                 .put("optimizer.add-exchange-below-partial-aggregation-over-group-id", "true")
                 .put("max_serializable_object_size", "50")
+                .put("enable-ids-cat-propagation", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -697,7 +699,8 @@ public class TestFeaturesConfig
                 .setRewriteMinMaxByToTopNEnabled(true)
                 .setInnerJoinPushdownEnabled(true)
                 .setPrestoSparkExecutionEnvironment(true)
-                .setMaxSerializableObjectSize(50);
+                .setMaxSerializableObjectSize(50)
+                .setEnableIdsCatPropagation(true);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
## Description

This PR introduces a new session property (enable_ids_cat_propagation) and adds corresponding tests.

## Motivation and Context

This PR introduces a new session property (enable_ids_cat_propagation)

## Impact

 - N/A

## Test Plan

Tested on clusters
<img width="995" height="112" alt="Screenshot 2025-09-15 at 4 04 16 PM" src="https://github.com/user-attachments/assets/dd6fb4a2-bf5e-4c4b-bb8a-02d64a80af18" />


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```