### PR TITLE
[Doc] Correct session property details in release notes

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -313,7 +313,7 @@ jobs:
             -T1C
 
   prestocpp-linux-presto-on-spark-e2e-tests:
-    needs: prestocpp-linux-build-for-test
+    needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/presto-docs/src/main/sphinx/release/release-0.292.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.292.rst
@@ -49,7 +49,7 @@ _______________
 * Add pagesink for DELETES to support future use. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
 * Add serialization for new types. `#24528 <https://github.com/prestodb/presto/pull/24528>`_
 * Add support to build Presto with JDK 17. `#24677 <https://github.com/prestodb/presto/pull/24677>`_
-* Add a new optimizer rule to add exchanges below a combination of partial aggregation+ GroupId . Enabled with the boolean session property ``enable_forced_exchange_below_group_id``. `#24047 <https://github.com/prestodb/presto/pull/24047>`_
+* Add a new optimizer rule to add exchanges below a combination of partial aggregation+ GroupId . Enabled with the boolean session property ``add_exchange_below_partial_aggregation_over_group_id``. `#24047 <https://github.com/prestodb/presto/pull/24047>`_
 * Add module presto-native-tests to run end-to-end tests with Presto native workers. `#24234 <https://github.com/prestodb/presto/pull/24234>`_
 * Add map of node ID to plan node to QueryCompletedEvent in the event listener interface. `#24590 <https://github.com/prestodb/presto/pull/24590>`_
 * Add support for multiple query event listeners. `#24456 <https://github.com/prestodb/presto/pull/24456>`_


### PR DESCRIPTION
## Description
Correct session property details in release notes
Looks like release notes in PR mentioned different session property name - https://github.com/prestodb/presto/pull/24047#issue-2658625523

## Motivation and Context
Correct release notes information

## Impact
Correct release notes information

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

