### PR TITLE
feat(protocol): Add thrift support to JDBC connector

### DIFF
--- a/.github/workflows/jdbc-connector-tests.yml
+++ b/.github/workflows/jdbc-connector-tests.yml
@@ -66,7 +66,7 @@ jobs:
         if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-mysql,:presto-postgresql
+          ${RETRY} ./mvnw -U install ${MAVEN_FAST_INSTALL} -am -pl :presto-mysql,:presto-postgresql
       - name: Run MySQL and PostgreSQL Tests
         if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -P ci -pl :presto-mysql,:presto-postgresql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
           - :presto-iceberg
           - :presto-iceberg -P test-iceberg-others
           - :presto-clickhouse -P ci
-    timeout-minutes: 80
+    timeout-minutes: ${{ matrix.modules == ':presto-tests -P presto-tests-general' && 120 || 80 }}
     concurrency:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -83,6 +83,26 @@
             <artifactId>jts-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.airlift.drift</groupId>
+            <artifactId>drift-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift.drift</groupId>
+            <artifactId>drift-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift.drift</groupId>
+            <artifactId>drift-codec-utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-thrift-connector-toolkit</artifactId>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -223,6 +243,41 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.facebook.airlift.drift</groupId>
+                <artifactId>drift-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>execution</id>
+                        <goals>
+                            <goal>generate-thrift-idl</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <classes>
+                                <class>com.facebook.presto.common.type.Type</class>
+                                <class>com.facebook.presto.common.block.Block</class>
+                                <class>com.facebook.presto.plugin.jdbc.JdbcColumnHandle</class>
+                                <class>com.facebook.presto.plugin.jdbc.JdbcTableHandle</class>
+                                <class>com.facebook.presto.plugin.jdbc.JdbcTableLayoutHandle</class>
+                                <class>com.facebook.presto.plugin.jdbc.JdbcSplit</class>
+                                <class>com.facebook.presto.plugin.jdbc.JdbcTransactionHandle</class>
+                                <class>com.facebook.presto.plugin.jdbc.JdbcOutputTableHandle</class>
+                            </classes>
+                            <namespaces>
+                                <cpp2>facebook.presto.thrift.jdbc</cpp2>
+                            </namespaces>
+                            <customCodecs>
+                                <codec>com.facebook.presto.thrift.codec.TypeCodec</codec>
+                                <codec>com.facebook.presto.thrift.codec.BlockCodec</codec>
+                                <codec>com.facebook.drift.codec.utils.UuidToLeachSalzBinaryEncodingThriftCodec</codec>
+                            </customCodecs>
+                            <recursive>true</recursive>
+                            <outputFile>target/thrift/presto_jdbc.thrift</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
@@ -240,6 +295,27 @@
                         <ignoredNonTestScopedDependency>javax.inject:javax.inject</ignoredNonTestScopedDependency>
                     </ignoredNonTestScopedDependencies>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/thrift/presto_jdbc.thrift</file>
+                                    <type>thrift</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcColumnHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcColumnHandle.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -26,6 +29,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public final class JdbcColumnHandle
         implements ColumnHandle
 {
@@ -37,6 +41,7 @@ public final class JdbcColumnHandle
     private final Optional<String> comment;
 
     @JsonCreator
+    @ThriftConstructor
     public JdbcColumnHandle(
             @JsonProperty("connectorId") String connectorId,
             @JsonProperty("columnName") String columnName,
@@ -54,36 +59,42 @@ public final class JdbcColumnHandle
     }
 
     @JsonProperty
+    @ThriftField(1)
     public String getConnectorId()
     {
         return connectorId;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public String getColumnName()
     {
         return columnName;
     }
 
     @JsonProperty
+    @ThriftField(3)
     public JdbcTypeHandle getJdbcTypeHandle()
     {
         return jdbcTypeHandle;
     }
 
     @JsonProperty
+    @ThriftField(4)
     public Type getColumnType()
     {
         return columnType;
     }
 
     @JsonProperty
+    @ThriftField(5)
     public boolean isNullable()
     {
         return nullable;
     }
 
     @JsonProperty
+    @ThriftField(6)
     public Optional<String> getComment()
     {
         return comment;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -15,10 +15,15 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.airlift.log.Logger;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.utils.UuidToLeachSalzBinaryEncodingThriftCodec;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.plugin.jdbc.optimization.JdbcPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
@@ -33,6 +38,9 @@ import com.facebook.presto.spi.procedure.Procedure;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.facebook.presto.thrift.codec.BlockCodec;
+import com.facebook.presto.thrift.codec.ThriftCodecProvider;
+import com.facebook.presto.thrift.codec.TypeCodec;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import jakarta.inject.Inject;
@@ -70,6 +78,7 @@ public class JdbcConnector
     private final RowExpressionService rowExpressionService;
     private final JdbcClient jdbcClient;
     private final List<PropertyMetadata<?>> sessionProperties;
+    private final ConnectorCodecProvider codecProvider;
 
     @Inject
     public JdbcConnector(
@@ -83,6 +92,8 @@ public class JdbcConnector
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
             RowExpressionService rowExpressionService,
+            TypeManager typeManager,
+            BlockEncodingSerde blockEncodingSerde,
             JdbcClient jdbcClient,
             Optional<JdbcSessionPropertiesProvider> sessionPropertiesProvider)
     {
@@ -97,6 +108,7 @@ public class JdbcConnector
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
+        this.codecProvider = createCodecProvider(typeManager, blockEncodingSerde);
         this.sessionProperties = requireNonNull(sessionPropertiesProvider, "sessionPropertiesProvider is null").map(JdbcSessionPropertiesProvider::getSessionProperties).orElse(ImmutableList.of());
     }
 
@@ -200,5 +212,29 @@ public class JdbcConnector
     public Set<ConnectorCapabilities> getCapabilities()
     {
         return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);
+    }
+
+    @Override
+    public ConnectorCodecProvider getConnectorCodecProvider()
+    {
+        return codecProvider;
+    }
+
+    static ThriftCodecProvider createCodecProvider(TypeManager typeManager, BlockEncodingSerde blockEncodingSerde)
+    {
+        ThriftCodecManager manager = new ThriftCodecManager();
+        manager.addCodec(new UuidToLeachSalzBinaryEncodingThriftCodec(manager.getCatalog()));
+        manager.addCodec(new BlockCodec(blockEncodingSerde));
+        manager.addCodec(new TypeCodec(typeManager));
+        return new ThriftCodecProvider.Builder()
+                .setThriftCodecManager(manager)
+                .setConnectorSplitType(JdbcSplit.class)
+                .setConnectorTransactionHandle(JdbcTransactionHandle.class)
+                .setConnectorTableLayoutHandle(JdbcTableLayoutHandle.class)
+                .setConnectorTableHandle(JdbcTableHandle.class)
+                .setConnectorColumnHandle(JdbcColumnHandle.class)
+                .setConnectorOutputTableHandle(JdbcOutputTableHandle.class)
+                .setConnectorInsertTableHandle(JdbcOutputTableHandle.class)
+                .build();
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnectorFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnectorFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
@@ -68,6 +69,7 @@ public class JdbcConnectorFactory
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
                     binder -> {
+                        binder.bind(BlockEncodingSerde.class).toInstance(context.getBlockEncodingSerde());
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());
                         binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());
                         binder.bind(StandardFunctionResolution.class).toInstance(context.getStandardFunctionResolution());

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcOutputTableHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcOutputTableHandle.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
@@ -28,6 +31,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class JdbcOutputTableHandle
         implements ConnectorOutputTableHandle, ConnectorInsertTableHandle
 {
@@ -40,6 +44,7 @@ public class JdbcOutputTableHandle
     private final String temporaryTableName;
 
     @JsonCreator
+    @ThriftConstructor
     public JdbcOutputTableHandle(
             @JsonProperty("connectorId") String connectorId,
             @JsonProperty("catalogName") @Nullable String catalogName,
@@ -63,6 +68,7 @@ public class JdbcOutputTableHandle
     }
 
     @JsonProperty
+    @ThriftField(1)
     public String getConnectorId()
     {
         return connectorId;
@@ -70,6 +76,7 @@ public class JdbcOutputTableHandle
 
     @JsonProperty
     @Nullable
+    @ThriftField(2)
     public String getCatalogName()
     {
         return catalogName;
@@ -77,30 +84,35 @@ public class JdbcOutputTableHandle
 
     @JsonProperty
     @Nullable
+    @ThriftField(3)
     public String getSchemaName()
     {
         return schemaName;
     }
 
     @JsonProperty
+    @ThriftField(4)
     public String getTableName()
     {
         return tableName;
     }
 
     @JsonProperty
+    @ThriftField(5)
     public List<String> getColumnNames()
     {
         return columnNames;
     }
 
     @JsonProperty
+    @ThriftField(6)
     public List<Type> getColumnTypes()
     {
         return columnTypes;
     }
 
     @JsonProperty
+    @ThriftField(7)
     public String getTemporaryTableName()
     {
         return temporaryTableName;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.plugin.jdbc.optimization.JdbcExpression;
 import com.facebook.presto.spi.ColumnHandle;
@@ -26,11 +29,13 @@ import com.google.common.collect.ImmutableList;
 import jakarta.annotation.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class JdbcSplit
         implements ConnectorSplit
 {
@@ -58,13 +63,27 @@ public class JdbcSplit
         this.additionalPredicate = requireNonNull(additionalPredicate, "additionalPredicate is null");
     }
 
+    @ThriftConstructor
+    public JdbcSplit(
+            String connectorId,
+            @Nullable String catalogName,
+            @Nullable String schemaName,
+            String tableName,
+            @ThriftField(5) JdbcThriftTupleDomain thriftTupleDomain,
+            Optional<JdbcExpression> additionalPredicate)
+    {
+        this(connectorId, catalogName, schemaName, tableName, thriftTupleDomain.getTupleDomain().transform(columnHandle -> (ColumnHandle) columnHandle), additionalPredicate);
+    }
+
     @JsonProperty
+    @ThriftField(1)
     public String getConnectorId()
     {
         return connectorId;
     }
 
     @JsonProperty
+    @ThriftField(2)
     @Nullable
     public String getCatalogName()
     {
@@ -72,6 +91,7 @@ public class JdbcSplit
     }
 
     @JsonProperty
+    @ThriftField(3)
     @Nullable
     public String getSchemaName()
     {
@@ -79,6 +99,7 @@ public class JdbcSplit
     }
 
     @JsonProperty
+    @ThriftField(4)
     public String getTableName()
     {
         return tableName;
@@ -90,7 +111,14 @@ public class JdbcSplit
         return tupleDomain;
     }
 
+    @ThriftField(value = 5, name = "tupleDomain")
+    public JdbcThriftTupleDomain getThriftTupleDomain()
+    {
+        return new JdbcThriftTupleDomain(tupleDomain.transform(columnHandle -> (JdbcColumnHandle) columnHandle));
+    }
+
     @JsonProperty
+    @ThriftField(6)
     public Optional<JdbcExpression> getAdditionalPredicate()
     {
         return additionalPredicate;
@@ -117,5 +145,35 @@ public class JdbcSplit
     public Object getInfo()
     {
         return this;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(
+                connectorId,
+                catalogName,
+                schemaName,
+                tableName,
+                tupleDomain,
+                additionalPredicate);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        JdbcSplit other = (JdbcSplit) obj;
+        return Objects.equals(this.connectorId, other.connectorId) &&
+                Objects.equals(this.catalogName, other.catalogName) &&
+                Objects.equals(this.schemaName, other.schemaName) &&
+                Objects.equals(this.tableName, other.tableName) &&
+                Objects.equals(this.tupleDomain, other.tupleDomain) &&
+                Objects.equals(this.additionalPredicate, other.additionalPredicate);
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTableHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTableHandle.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -24,6 +27,7 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public final class JdbcTableHandle
         implements ConnectorTableHandle
 {
@@ -36,6 +40,7 @@ public final class JdbcTableHandle
     private final String tableName;
 
     @JsonCreator
+    @ThriftConstructor
     public JdbcTableHandle(
             @JsonProperty("connectorId") String connectorId,
             @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
@@ -51,18 +56,21 @@ public final class JdbcTableHandle
     }
 
     @JsonProperty
+    @ThriftField(1)
     public String getConnectorId()
     {
         return connectorId;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public SchemaTableName getSchemaTableName()
     {
         return schemaTableName;
     }
 
     @JsonProperty
+    @ThriftField(3)
     @Nullable
     public String getCatalogName()
     {
@@ -70,6 +78,7 @@ public final class JdbcTableHandle
     }
 
     @JsonProperty
+    @ThriftField(4)
     @Nullable
     public String getSchemaName()
     {
@@ -77,6 +86,7 @@ public final class JdbcTableHandle
     }
 
     @JsonProperty
+    @ThriftField(5)
     public String getTableName()
     {
         return tableName;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTableLayoutHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTableLayoutHandle.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.plugin.jdbc.optimization.JdbcExpression;
@@ -27,6 +30,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class JdbcTableLayoutHandle
         implements ConnectorTableLayoutHandle
 {
@@ -50,6 +54,16 @@ public class JdbcTableLayoutHandle
                         .toString());
     }
 
+    @ThriftConstructor
+    public JdbcTableLayoutHandle(
+            JdbcTableHandle table,
+            @ThriftField(2) JdbcThriftTupleDomain domain,
+            Optional<JdbcExpression> additionalPredicate,
+            String layoutString)
+    {
+        this(table, domain.getTupleDomain().transform(jdbcColumnHandle -> jdbcColumnHandle), additionalPredicate, layoutString);
+    }
+
     @JsonCreator
     public JdbcTableLayoutHandle(
             @JsonProperty("table") JdbcTableHandle table,
@@ -64,12 +78,7 @@ public class JdbcTableLayoutHandle
     }
 
     @JsonProperty
-    public Optional<JdbcExpression> getAdditionalPredicate()
-    {
-        return additionalPredicate;
-    }
-
-    @JsonProperty
+    @ThriftField(1)
     public JdbcTableHandle getTable()
     {
         return table;
@@ -81,7 +90,21 @@ public class JdbcTableLayoutHandle
         return tupleDomain;
     }
 
+    @ThriftField(value = 2, name = "tupleDomain")
+    public JdbcThriftTupleDomain getThriftTupleDomain()
+    {
+        return new JdbcThriftTupleDomain(tupleDomain.transform(columnHandle -> (JdbcColumnHandle) columnHandle));
+    }
+
     @JsonProperty
+    @ThriftField(3)
+    public Optional<JdbcExpression> getAdditionalPredicate()
+    {
+        return additionalPredicate;
+    }
+
+    @JsonProperty
+    @ThriftField(4)
     public String getLayoutString()
     {
         return layoutString;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcThriftTupleDomain.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcThriftTupleDomain.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.common.predicate.TupleDomain.toLinkedMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+@ThriftStruct
+public class JdbcThriftTupleDomain
+{
+    private final TupleDomain<JdbcColumnHandle> tupleDomain;
+
+    public JdbcThriftTupleDomain(TupleDomain<JdbcColumnHandle> tupleDomain)
+    {
+        this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
+    }
+
+    @ThriftConstructor
+    public JdbcThriftTupleDomain(Optional<List<JdbcThriftColumnDomain>> columnDomains)
+    {
+        this(columnDomains
+                        .map(domains -> TupleDomain.withColumnDomains(
+                                domains.stream().collect(toLinkedMap(JdbcThriftColumnDomain::getColumn, JdbcThriftColumnDomain::getDomain))))
+                        .orElse(TupleDomain.none()));
+    }
+
+    @ThriftField(1)
+    public Optional<List<JdbcThriftColumnDomain>> getColumnDomains()
+    {
+        return tupleDomain.getDomains().map(map ->
+                map.entrySet().stream()
+                        .map(entry -> new JdbcThriftColumnDomain(entry.getKey(), entry.getValue()))
+                        .collect(toList()));
+    }
+
+    public TupleDomain<JdbcColumnHandle> getTupleDomain()
+    {
+        return tupleDomain;
+    }
+
+    @ThriftStruct
+    public static class JdbcThriftColumnDomain
+    {
+        private final JdbcColumnHandle column;
+        private final Domain domain;
+
+        @ThriftConstructor
+        public JdbcThriftColumnDomain(JdbcColumnHandle column, Domain domain)
+        {
+            this.column = requireNonNull(column, "column is null");
+            this.domain = requireNonNull(domain, "domain is null");
+        }
+
+        @ThriftField(1)
+        public JdbcColumnHandle getColumn()
+        {
+            return column;
+        }
+
+        @ThriftField(2)
+        public Domain getDomain()
+        {
+            return domain;
+        }
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTransactionHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTransactionHandle.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,6 +26,7 @@ import java.util.UUID;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class JdbcTransactionHandle
         implements ConnectorTransactionHandle
 {
@@ -34,12 +38,14 @@ public class JdbcTransactionHandle
     }
 
     @JsonCreator
+    @ThriftConstructor
     public JdbcTransactionHandle(@JsonProperty("uuid") UUID uuid)
     {
         this.uuid = requireNonNull(uuid, "uuid is null");
     }
 
     @JsonProperty
+    @ThriftField(1)
     public UUID getUuid()
     {
         return uuid;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTypeHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTypeHandle.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -21,6 +24,7 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public final class JdbcTypeHandle
 {
     private final int jdbcType;
@@ -29,6 +33,7 @@ public final class JdbcTypeHandle
     private final int decimalDigits;
 
     @JsonCreator
+    @ThriftConstructor
     public JdbcTypeHandle(
             @JsonProperty("jdbcType") int jdbcType,
             @JsonProperty("jdbcTypeName") String jdbcTypeName,
@@ -42,24 +47,28 @@ public final class JdbcTypeHandle
     }
 
     @JsonProperty
+    @ThriftField(1)
     public int getJdbcType()
     {
         return jdbcType;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public String getJdbcTypeName()
     {
         return jdbcTypeName;
     }
 
     @JsonProperty
+    @ThriftField(3)
     public int getColumnSize()
     {
         return columnSize;
     }
 
     @JsonProperty
+    @ThriftField(4)
     public int getDecimalDigits()
     {
         return decimalDigits;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcExpression.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcExpression.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.plugin.jdbc.optimization;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,6 +26,7 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class JdbcExpression
 {
     private final String expression;
@@ -34,15 +38,17 @@ public class JdbcExpression
     }
 
     @JsonCreator
+    @ThriftConstructor
     public JdbcExpression(
             @JsonProperty("translatedString") String expression,
-            @JsonProperty("boundConstantValues") List<ConstantExpression> constantBindValues)
+            @JsonProperty("boundConstantValues") List<ConstantExpression> boundConstantValues)
     {
         this.expression = requireNonNull(expression, "expression is null");
-        this.boundConstantValues = requireNonNull(constantBindValues, "boundConstantValues is null");
+        this.boundConstantValues = requireNonNull(boundConstantValues, "boundConstantValues is null");
     }
 
     @JsonProperty
+    @ThriftField(1)
     public String getExpression()
     {
         return expression;
@@ -56,6 +62,7 @@ public class JdbcExpression
      * @return List of constants to replace in the SQL string.
      */
     @JsonProperty
+    @ThriftField(value = 2, name = "boundConstantValues")
     public List<ConstantExpression> getBoundConstantValues()
     {
         return boundConstantValues;

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/JdbcQueryRunner.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/JdbcQueryRunner.java
@@ -56,7 +56,12 @@ public final class JdbcQueryRunner
     {
         DistributedQueryRunner queryRunner = null;
         try {
-            queryRunner = new DistributedQueryRunner(createSession(), 3);
+            queryRunner = DistributedQueryRunner.builder(createSession())
+                    .setNodeCount(3)
+                    .setExtraProperties(ImmutableMap.of(
+                            "experimental.internal-communication.task-info-response-thrift-serde-enabled", "true",
+                            "experimental.internal-communication.task-update-request-thrift-serde-enabled", "true"))
+                    .build();
 
             queryRunner.installPlugin(new TpchPlugin());
             queryRunner.createCatalog("tpch", "tpch");

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/MetadataUtil.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/MetadataUtil.java
@@ -16,8 +16,16 @@ package com.facebook.presto.plugin.jdbc;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.JsonCodecFactory;
 import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorCodec;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.thrift.codec.ThriftCodecProvider;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.google.common.collect.ImmutableMap;
@@ -34,17 +42,28 @@ final class MetadataUtil
 {
     private MetadataUtil() {}
 
-    public static final JsonCodec<JdbcColumnHandle> COLUMN_CODEC;
-    public static final JsonCodec<JdbcTableHandle> TABLE_CODEC;
-    public static final JsonCodec<JdbcOutputTableHandle> OUTPUT_TABLE_CODEC;
+    public static final JsonCodec<JdbcColumnHandle> COLUMN_JSON_CODEC;
+    public static final JsonCodec<JdbcTableHandle> TABLE_JSON_CODEC;
+    public static final JsonCodec<JdbcOutputTableHandle> OUTPUT_TABLE_JSON_CODEC;
+
+    public static final ConnectorCodec<ColumnHandle> COLUMN_THRIFT_CODEC;
+    public static final ConnectorCodec<ConnectorTableHandle> TABLE_THRIFT_CODEC;
+    public static final ConnectorCodec<ConnectorOutputTableHandle> OUTPUT_TABLE_THRIFT_CODEC;
+    public static final ConnectorCodec<ConnectorSplit> SPLIT_THRIFT_CODEC;
 
     static {
-        JsonObjectMapperProvider provider = new JsonObjectMapperProvider();
-        provider.setJsonDeserializers(ImmutableMap.of(Type.class, new TestingTypeDeserializer()));
-        JsonCodecFactory codecFactory = new JsonCodecFactory(provider);
-        COLUMN_CODEC = codecFactory.jsonCodec(JdbcColumnHandle.class);
-        TABLE_CODEC = codecFactory.jsonCodec(JdbcTableHandle.class);
-        OUTPUT_TABLE_CODEC = codecFactory.jsonCodec(JdbcOutputTableHandle.class);
+        JsonObjectMapperProvider jsonProvider = new JsonObjectMapperProvider();
+        jsonProvider.setJsonDeserializers(ImmutableMap.of(Type.class, new TestingTypeDeserializer()));
+        JsonCodecFactory codecFactory = new JsonCodecFactory(jsonProvider);
+        COLUMN_JSON_CODEC = codecFactory.jsonCodec(JdbcColumnHandle.class);
+        TABLE_JSON_CODEC = codecFactory.jsonCodec(JdbcTableHandle.class);
+        OUTPUT_TABLE_JSON_CODEC = codecFactory.jsonCodec(JdbcOutputTableHandle.class);
+        ThriftCodecProvider thriftProvider = JdbcConnector.createCodecProvider(
+                FunctionAndTypeManager.createTestFunctionAndTypeManager(), new BlockEncodingManager());
+        COLUMN_THRIFT_CODEC = thriftProvider.getColumnHandleCodec().get();
+        TABLE_THRIFT_CODEC = thriftProvider.getConnectorTableHandleCodec().get();
+        OUTPUT_TABLE_THRIFT_CODEC = thriftProvider.getConnectorOutputTableHandleCodec().get();
+        SPLIT_THRIFT_CODEC = thriftProvider.getConnectorSplitCodec().get();
     }
 
     public static final class TestingTypeDeserializer
@@ -72,6 +91,13 @@ final class MetadataUtil
     {
         String json = codec.toJson(object);
         T copy = codec.fromJson(json);
+        assertEquals(copy, object);
+    }
+
+    public static <T> void assertThriftRoundTrip(ConnectorCodec<T> codec, T object)
+    {
+        byte[] data = codec.serialize(object);
+        T copy = codec.deserialize(data);
         assertEquals(copy, object);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcColumnHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcColumnHandle.java
@@ -20,8 +20,10 @@ import java.util.Optional;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
-import static com.facebook.presto.plugin.jdbc.MetadataUtil.COLUMN_CODEC;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.COLUMN_JSON_CODEC;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.COLUMN_THRIFT_CODEC;
 import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertThriftRoundTrip;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 
@@ -30,7 +32,13 @@ public class TestJdbcColumnHandle
     @Test
     public void testJsonRoundTrip()
     {
-        assertJsonRoundTrip(COLUMN_CODEC, new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR, true, Optional.empty()));
+        assertJsonRoundTrip(COLUMN_JSON_CODEC, new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR, true, Optional.empty()));
+    }
+
+    @Test
+    public void testThriftRoundTrip()
+    {
+        assertThriftRoundTrip(COLUMN_THRIFT_CODEC, new JdbcColumnHandle("connectorId", "columnName", JDBC_VARCHAR, VARCHAR, true, Optional.empty()));
     }
 
     @Test

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcConnectorFactory.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcConnectorFactory.java
@@ -13,19 +13,51 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.presto.spi.ConnectorSystemConfig;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCodecProvider;
 import com.facebook.presto.testing.TestingConnectorContext;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 public class TestJdbcConnectorFactory
 {
-    @Test
-    public void test()
+    @DataProvider
+    public Object[][] nativeExecution()
+    {
+        return new Object[][] {{false}, {true}};
+    }
+
+    @Test(dataProvider = "nativeExecution")
+    public void test(boolean nativeExecution)
     {
         JdbcConnectorFactory connectorFactory = new JdbcConnectorFactory(
                 "test",
                 new TestingH2JdbcModule(),
                 getClass().getClassLoader());
 
-        connectorFactory.create("test", TestingH2JdbcModule.createProperties(), new TestingConnectorContext());
+        Connector connector = connectorFactory.create("test", TestingH2JdbcModule.createProperties(), new TestingConnectorContext()
+        {
+            @Override
+            public ConnectorSystemConfig getConnectorSystemConfig()
+            {
+                return () -> nativeExecution;
+            }
+        });
+        try {
+            ConnectorCodecProvider provider = connector.getConnectorCodecProvider();
+            assertEquals(provider.getConnectorSplitCodec().isPresent(), true);
+            assertEquals(provider.getConnectorTransactionHandleCodec().isPresent(), true);
+            assertEquals(provider.getConnectorTableHandleCodec().isPresent(), true);
+            assertEquals(provider.getConnectorTableLayoutHandleCodec().isPresent(), true);
+            assertEquals(provider.getColumnHandleCodec().isPresent(), true);
+            assertEquals(provider.getConnectorInsertTableHandleCodec().isPresent(), true);
+            assertEquals(provider.getConnectorOutputTableHandleCodec().isPresent(), true);
+        }
+        finally {
+            connector.shutdown();
+        }
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcOutputTableHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcOutputTableHandle.java
@@ -17,23 +17,31 @@ import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
-import static com.facebook.presto.plugin.jdbc.MetadataUtil.OUTPUT_TABLE_CODEC;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.OUTPUT_TABLE_JSON_CODEC;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.OUTPUT_TABLE_THRIFT_CODEC;
 import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertThriftRoundTrip;
 
 public class TestJdbcOutputTableHandle
 {
+    private final JdbcOutputTableHandle handle = new JdbcOutputTableHandle(
+            "connectorId",
+            "catalog",
+            "schema",
+            "table",
+            ImmutableList.of("abc", "xyz"),
+            ImmutableList.of(VARCHAR, VARCHAR),
+            "tmp_table");
+
     @Test
     public void testJsonRoundTrip()
     {
-        JdbcOutputTableHandle handle = new JdbcOutputTableHandle(
-                "connectorId",
-                "catalog",
-                "schema",
-                "table",
-                ImmutableList.of("abc", "xyz"),
-                ImmutableList.of(VARCHAR, VARCHAR),
-                "tmp_table");
+        assertJsonRoundTrip(OUTPUT_TABLE_JSON_CODEC, handle);
+    }
 
-        assertJsonRoundTrip(OUTPUT_TABLE_CODEC, handle);
+    @Test
+    public void testThriftRoundTrip()
+    {
+        assertThriftRoundTrip(OUTPUT_TABLE_THRIFT_CODEC, handle);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcSplit.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcSplit.java
@@ -14,19 +14,68 @@
 package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.plugin.jdbc.optimization.JdbcExpression;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorCodec;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.thrift.codec.ThriftCodecProvider;
+import com.facebook.presto.type.TypeDeserializer;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.common.type.JsonType.JSON;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.SPLIT_THRIFT_CODEC;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertThriftRoundTrip;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+import static io.airlift.slice.Slices.utf8Slice;
 import static org.testng.Assert.assertEquals;
 
 public class TestJdbcSplit
 {
     private final JdbcSplit split = new JdbcSplit("connectorId", "catalog", "schemaName", "tableName", TupleDomain.all(), Optional.empty());
+
+    @Test
+    public void testNativeThriftSchema()
+            throws IOException
+    {
+        Path basedir = Path.of(System.getProperty("basedir", "."));
+        String generated = Files.readString(basedir.resolve("target/thrift/presto_jdbc.thrift"));
+        String nativeSchema = Files.readString(basedir.resolve("../presto-native-execution/presto_cpp/main/thrift/presto_jdbc.thrift"));
+        assertEquals(nativeSchema.substring(nativeSchema.indexOf("namespace cpp2")), generated);
+    }
 
     @Test
     public void testAddresses()
@@ -43,13 +92,129 @@ public class TestJdbcSplit
     public void testJsonRoundTrip()
     {
         JsonCodec<JdbcSplit> codec = jsonCodec(JdbcSplit.class);
-        String json = codec.toJson(split);
-        JdbcSplit copy = codec.fromJson(json);
-        assertEquals(copy.getConnectorId(), split.getConnectorId());
-        assertEquals(copy.getSchemaName(), split.getSchemaName());
-        assertEquals(copy.getTableName(), split.getTableName());
+        assertJsonRoundTrip(codec, split);
+    }
 
-        assertEquals(copy.getAddresses(), ImmutableList.of());
-        assertEquals(copy.getNodeSelectionStrategy(), NO_PREFERENCE);
+    @Test
+    public void testThriftRoundTrip()
+    {
+        assertThriftRoundTrip(SPLIT_THRIFT_CODEC, (ConnectorSplit) split);
+    }
+
+    @Test
+    public void testThriftPredicatesAndHandles()
+    {
+        ThriftCodecProvider provider = JdbcConnector.createCodecProvider(
+                FunctionAndTypeManager.createTestFunctionAndTypeManager(), new BlockEncodingManager());
+        JdbcColumnHandle column = new JdbcColumnHandle("connectorId", "column", new JdbcTypeHandle(java.sql.Types.BIGINT, "bigint", 19, 0), BIGINT, true, Optional.of("column description"));
+        List<TupleDomain<ColumnHandle>> domains = ImmutableList.of(
+                TupleDomain.all(),
+                TupleDomain.none(),
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, Domain.onlyNull(BIGINT))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, Domain.notNull(BIGINT))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, Domain.singleValue(BIGINT, 42L))),
+                TupleDomain.withColumnDomains(ImmutableMap.of(column, Domain.create(ValueSet.ofRanges(
+                        Range.lessThan(BIGINT, -10L), Range.range(BIGINT, 1L, true, 10L, false), Range.greaterThan(BIGINT, 100L)), true))));
+        JdbcExpression predicate = new JdbcExpression("a = ? AND b = ? AND c = ? AND d = ?", ImmutableList.of(
+                new ConstantExpression(42L, BIGINT),
+                new ConstantExpression(utf8Slice("hello"), VARCHAR),
+                new ConstantExpression(null, BIGINT),
+                new ConstantExpression(true, BOOLEAN)));
+        JdbcTableHandle table = new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), null, null, "table");
+        for (TupleDomain<ColumnHandle> domain : domains) {
+            for (Optional<JdbcExpression> additionalPredicate : ImmutableList.of(Optional.<JdbcExpression>empty(), Optional.of(predicate))) {
+                JdbcSplit original = new JdbcSplit("connectorId", null, null, "table", domain, additionalPredicate);
+                assertThriftRoundTrip(provider.getConnectorSplitCodec().get(), original);
+                JdbcTableLayoutHandle layout = new JdbcTableLayoutHandle(table, domain, additionalPredicate, "layout");
+                JdbcTableLayoutHandle copy = (JdbcTableLayoutHandle) provider.getConnectorTableLayoutHandleCodec().get()
+                        .deserialize(provider.getConnectorTableLayoutHandleCodec().get().serialize(layout));
+                assertEquals(copy.getTable(), table);
+                assertEquals(copy.getTupleDomain(), domain);
+                assertEquals(copy.getAdditionalPredicate(), additionalPredicate);
+                assertEquals(copy.getLayoutString(), "layout");
+            }
+        }
+        assertThriftRoundTrip(provider.getConnectorTableHandleCodec().get(), table);
+        assertThriftRoundTrip(provider.getColumnHandleCodec().get(), column);
+        assertThriftRoundTrip(provider.getConnectorTransactionHandleCodec().get(), new JdbcTransactionHandle());
+        List<Type> types = ImmutableList.of(BIGINT, VARCHAR, createDecimalType(18, 4));
+        JdbcOutputTableHandle output = new JdbcOutputTableHandle("connectorId", null, null, "table",
+                ImmutableList.of("a", "b", "c"), types, "temporary");
+        assertThriftRoundTrip(provider.getConnectorOutputTableHandleCodec().get(), output);
+        assertThriftRoundTrip(provider.getConnectorInsertTableHandleCodec().get(), output);
+    }
+
+    @Test
+    public void testThriftValueSets()
+    {
+        ThriftCodecProvider provider = JdbcConnector.createCodecProvider(
+                FunctionAndTypeManager.createTestFunctionAndTypeManager(), new BlockEncodingManager());
+        for (Domain domain : ImmutableList.of(
+                Domain.singleValue(JSON, utf8Slice("{\"a\":1}")),
+                Domain.create(ValueSet.of(JSON, utf8Slice("1"), utf8Slice("2")).complement(), true),
+                Domain.notNull(HYPER_LOG_LOG),
+                Domain.onlyNull(HYPER_LOG_LOG))) {
+            JdbcColumnHandle column = new JdbcColumnHandle("connectorId", "column", new JdbcTypeHandle(java.sql.Types.OTHER, "other", 0, 0), domain.getType(), true, Optional.empty());
+            JdbcSplit original = new JdbcSplit("connectorId", "catalog", "schema", "table",
+                    TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)), Optional.empty());
+            assertThriftRoundTrip(provider.getConnectorSplitCodec().get(), original);
+        }
+    }
+
+    @Test
+    public void testNativeThriftFixtures()
+            throws Exception
+    {
+        FunctionAndTypeManager typeManager = FunctionAndTypeManager.createTestFunctionAndTypeManager();
+        BlockEncodingManager blockEncodingManager = new BlockEncodingManager();
+        ThriftCodecProvider provider = JdbcConnector.createCodecProvider(typeManager, blockEncodingManager);
+        JsonObjectMapperProvider jsonProvider = new JsonObjectMapperProvider();
+        jsonProvider.setJsonDeserializers(ImmutableMap.of(
+                Type.class, new TypeDeserializer(typeManager),
+                Block.class, new BlockJsonSerde.Deserializer(blockEncodingManager),
+                ColumnHandle.class, new JsonDeserializer<ColumnHandle>()
+                {
+                    @Override
+                    public ColumnHandle deserialize(JsonParser parser, DeserializationContext context)
+                            throws IOException
+                    {
+                        return parser.readValueAs(JdbcColumnHandle.class);
+                    }
+                }));
+        jsonProvider.setJsonSerializers(ImmutableMap.of(Block.class, new BlockJsonSerde.Serializer(blockEncodingManager)));
+        ObjectMapper mapper = jsonProvider.get();
+        try (InputStream input = getClass().getResourceAsStream("/jdbc-thrift.json")) {
+            for (JsonNode fixture : mapper.readTree(input)) {
+                switch (fixture.get("kind").asText()) {
+                    case "column":
+                        assertNativeFixture(mapper, fixture, JdbcColumnHandle.class, provider.getColumnHandleCodec().get());
+                        break;
+                    case "table":
+                        assertNativeFixture(mapper, fixture, JdbcTableHandle.class, provider.getConnectorTableHandleCodec().get());
+                        break;
+                    case "transaction":
+                        assertNativeFixture(mapper, fixture, JdbcTransactionHandle.class, provider.getConnectorTransactionHandleCodec().get());
+                        break;
+                    case "layout":
+                        assertNativeFixture(mapper, fixture, JdbcTableLayoutHandle.class, provider.getConnectorTableLayoutHandleCodec().get());
+                        break;
+                    case "split":
+                        assertNativeFixture(mapper, fixture, JdbcSplit.class, provider.getConnectorSplitCodec().get());
+                        break;
+                    default:
+                        throw new AssertionError("Unknown fixture kind: " + fixture.get("kind"));
+                }
+            }
+        }
+    }
+
+    private static <T> void assertNativeFixture(ObjectMapper mapper, JsonNode fixture, Class<? extends T> type, ConnectorCodec<T> codec)
+            throws IOException
+    {
+        T original = mapper.treeToValue(fixture.get("json"), type);
+        byte[] bytes = Base64.getDecoder().decode(fixture.get("thrift").asText());
+        assertEquals(codec.deserialize(codec.serialize(original)), original);
+        T copy = codec.deserialize(bytes);
+        assertEquals(copy, original);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTableHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTableHandle.java
@@ -17,15 +17,23 @@ import com.facebook.airlift.testing.EquivalenceTester;
 import com.facebook.presto.spi.SchemaTableName;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.plugin.jdbc.MetadataUtil.TABLE_CODEC;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.TABLE_JSON_CODEC;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.TABLE_THRIFT_CODEC;
 import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
+import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertThriftRoundTrip;
 
 public class TestJdbcTableHandle
 {
     @Test
     public void testJsonRoundTrip()
     {
-        assertJsonRoundTrip(TABLE_CODEC, new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable"));
+        assertJsonRoundTrip(TABLE_JSON_CODEC, new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable"));
+    }
+
+    @Test
+    public void testThriftRoundTrip()
+    {
+        assertThriftRoundTrip(TABLE_THRIFT_CODEC, new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable"));
     }
 
     @Test

--- a/presto-base-jdbc/src/test/resources/jdbc-thrift.json
+++ b/presto-base-jdbc/src/test/resources/jdbc-thrift.json
@@ -1,0 +1,1870 @@
+[ {
+  "kind" : "column",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAIAAAABYQwAAwgAAf////sLAAIAAAAGYmlnaW50CAADAAAAEwgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBCwAGAAAAC2Rlc2NyaXB0aW9uAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "columnName" : "a",
+    "jdbcTypeHandle" : {
+      "jdbcType" : -5,
+      "jdbcTypeName" : "bigint",
+      "columnSize" : 19,
+      "decimalDigits" : 0
+    },
+    "columnType" : "bigint",
+    "nullable" : true,
+    "comment" : "description",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "table",
+  "thrift" : "CwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUA",
+  "json" : {
+    "connectorId" : "catalog",
+    "schemaTableName" : {
+      "schema" : "schema",
+      "table" : "table"
+    },
+    "schemaName" : "schema",
+    "tableName" : "table",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "transaction",
+  "thrift" : "CwABAAAAEBI0VngSNFZ4mrze8BI0VngA",
+  "json" : {
+    "uuid" : "12345678-1234-5678-9abc-def012345678",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAAAA",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAAACwAEAAAABmxheW91dAA=",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAAAMAAYLAAEAAAAZYSA9ID8gQU5EIGIgPSA/IEFORCBjID0gPw8AAgwAAAADDAABCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAqAAAAAAAAAAAMAAILAAEAAAAGYmlnaW50AAAMAAELAAEAAAAkDgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxvAAwAAgsAAQAAAAd2YXJjaGFyAAAMAAELAAEAAAAfAwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgAAMAAILAAEAAAAGYmlnaW50AAAAAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAAADAADCwABAAAAGWEgPSA/IEFORCBiID0gPyBBTkQgYyA9ID8PAAIMAAAAAwwAAQsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAADAACCwABAAAABmJpZ2ludAAADAABCwABAAAAJA4AAABWQVJJQUJMRV9XSURUSAEAAAAFAAAAAAUAAABoZWxsbwAMAAILAAEAAAAHdmFyY2hhcgAADAABCwABAAAAHwMAAABSTEUBAAAACgAAAExPTkdfQVJSQVkBAAAAAYAADAACCwABAAAABmJpZ2ludAAAAAsABAAAAAZsYXlvdXQA",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUAAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : { },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACAAsABAAAAAZsYXlvdXQA",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : { },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUADAAGCwABAAAAGWEgPSA/IEFORCBiID0gPyBBTkQgYyA9ID8PAAIMAAAAAwwAAQsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAADAACCwABAAAABmJpZ2ludAAADAABCwABAAAAJA4AAABWQVJJQUJMRV9XSURUSAEAAAAFAAAAAAUAAABoZWxsbwAMAAILAAEAAAAHdmFyY2hhcgAADAABCwABAAAAHwMAAABSTEUBAAAACgAAAExPTkdfQVJSQVkBAAAAAYAADAACCwABAAAABmJpZ2ludAAAAAA=",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : { },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACAAwAAwsAAQAAABlhID0gPyBBTkQgYiA9ID8gQU5EIGMgPSA/DwACDAAAAAMMAAELAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAwAAgsAAQAAAAZiaWdpbnQAAAwAAQsAAQAAACQOAAAAVkFSSUFCTEVfV0lEVEgBAAAABQAAAAAFAAAAaGVsbG8ADAACCwABAAAAB3ZhcmNoYXIAAAwAAQsAAQAAAB8DAAAAUkxFAQAAAAoAAABMT05HX0FSUkFZAQAAAAGAAAwAAgsAAQAAAAZiaWdpbnQAAAALAAQAAAAGbGF5b3V0AA==",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : { },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBAAwAAgwAAQwAAgwAAQsAAQAAAAZiaWdpbnQADwACDAAAAAAAAAIAAgEAAAAA",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ ]
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAZiaWdpbnQAAgAFAQAMAAIMAAEMAAIMAAELAAEAAAAGYmlnaW50AA8AAgwAAAAAAAACAAIBAAAACwAEAAAABmxheW91dAA=",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ ]
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBAAwAAgwAAQwAAgwAAQsAAQAAAAZiaWdpbnQADwACDAAAAAAAAAIAAgEAAAAMAAYLAAEAAAAZYSA9ID8gQU5EIGIgPSA/IEFORCBjID0gPw8AAgwAAAADDAABCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAqAAAAAAAAAAAMAAILAAEAAAAGYmlnaW50AAAMAAELAAEAAAAkDgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxvAAwAAgsAAQAAAAd2YXJjaGFyAAAMAAELAAEAAAAfAwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgAAMAAILAAEAAAAGYmlnaW50AAAAAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ ]
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAZiaWdpbnQAAgAFAQAMAAIMAAEMAAIMAAELAAEAAAAGYmlnaW50AA8AAgwAAAAAAAACAAIBAAAADAADCwABAAAAGWEgPSA/IEFORCBiID0gPyBBTkQgYyA9ID8PAAIMAAAAAwwAAQsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAADAACCwABAAAABmJpZ2ludAAADAABCwABAAAAJA4AAABWQVJJQUJMRV9XSURUSAEAAAAFAAAAAAUAAABoZWxsbwAMAAILAAEAAAAHdmFyY2hhcgAADAABCwABAAAAHwMAAABSTEUBAAAACgAAAExPTkdfQVJSQVkBAAAAAYAADAACCwABAAAABmJpZ2ludAAAAAsABAAAAAZsYXlvdXQA",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ ]
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBAAwAAgwAAQwAAgwAAQsAAQAAAAZiaWdpbnQADwACDAAAAAEMAAEMAAELAAEAAAAGYmlnaW50AAgAAwAAAAIADAACDAABCwABAAAABmJpZ2ludAAIAAMAAAAAAAAAAAIAAgAAAAAA",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "bound" : "BELOW"
+              }
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAZiaWdpbnQAAgAFAQAMAAIMAAEMAAIMAAELAAEAAAAGYmlnaW50AA8AAgwAAAABDAABDAABCwABAAAABmJpZ2ludAAIAAMAAAACAAwAAgwAAQsAAQAAAAZiaWdpbnQACAADAAAAAAAAAAACAAIAAAAACwAEAAAABmxheW91dAA=",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "bound" : "BELOW"
+              }
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBAAwAAgwAAQwAAgwAAQsAAQAAAAZiaWdpbnQADwACDAAAAAEMAAEMAAELAAEAAAAGYmlnaW50AAgAAwAAAAIADAACDAABCwABAAAABmJpZ2ludAAIAAMAAAAAAAAAAAIAAgAAAAAMAAYLAAEAAAAZYSA9ID8gQU5EIGIgPSA/IEFORCBjID0gPw8AAgwAAAADDAABCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAqAAAAAAAAAAAMAAILAAEAAAAGYmlnaW50AAAMAAELAAEAAAAkDgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxvAAwAAgsAAQAAAAd2YXJjaGFyAAAMAAELAAEAAAAfAwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgAAMAAILAAEAAAAGYmlnaW50AAAAAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "bound" : "BELOW"
+              }
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAZiaWdpbnQAAgAFAQAMAAIMAAEMAAIMAAELAAEAAAAGYmlnaW50AA8AAgwAAAABDAABDAABCwABAAAABmJpZ2ludAAIAAMAAAACAAwAAgwAAQsAAQAAAAZiaWdpbnQACAADAAAAAAAAAAACAAIAAAAADAADCwABAAAAGWEgPSA/IEFORCBiID0gPyBBTkQgYyA9ID8PAAIMAAAAAwwAAQsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAADAACCwABAAAABmJpZ2ludAAADAABCwABAAAAJA4AAABWQVJJQUJMRV9XSURUSAEAAAAFAAAAAAUAAABoZWxsbwAMAAILAAEAAAAHdmFyY2hhcgAADAABCwABAAAAHwMAAABSTEUBAAAACgAAAExPTkdfQVJSQVkBAAAAAYAADAACCwABAAAABmJpZ2ludAAAAAsABAAAAAZsYXlvdXQA",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "bound" : "BELOW"
+              }
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBAAwAAgwAAQwAAgwAAQsAAQAAAAZiaWdpbnQADwACDAAAAAEMAAEMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAACAADAAAAAQAMAAIMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAACAADAAAAAQAAAAACAAIAAAAAAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+                "bound" : "EXACTLY"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+                "bound" : "EXACTLY"
+              }
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAZiaWdpbnQAAgAFAQAMAAIMAAEMAAIMAAELAAEAAAAGYmlnaW50AA8AAgwAAAABDAABDAABCwABAAAABmJpZ2ludAAMAAILAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAgAAwAAAAEADAACDAABCwABAAAABmJpZ2ludAAMAAILAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAgAAwAAAAEAAAAAAgACAAAAAAsABAAAAAZsYXlvdXQA",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+                "bound" : "EXACTLY"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+                "bound" : "EXACTLY"
+              }
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBAAwAAgwAAQwAAgwAAQsAAQAAAAZiaWdpbnQADwACDAAAAAEMAAEMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAACAADAAAAAQAMAAIMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAACAADAAAAAQAAAAACAAIAAAAADAAGCwABAAAAGWEgPSA/IEFORCBiID0gPyBBTkQgYyA9ID8PAAIMAAAAAwwAAQsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAADAACCwABAAAABmJpZ2ludAAADAABCwABAAAAJA4AAABWQVJJQUJMRV9XSURUSAEAAAAFAAAAAAUAAABoZWxsbwAMAAILAAEAAAAHdmFyY2hhcgAADAABCwABAAAAHwMAAABSTEUBAAAACgAAAExPTkdfQVJSQVkBAAAAAYAADAACCwABAAAABmJpZ2ludAAAAAA=",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+                "bound" : "EXACTLY"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+                "bound" : "EXACTLY"
+              }
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAZiaWdpbnQAAgAFAQAMAAIMAAEMAAIMAAELAAEAAAAGYmlnaW50AA8AAgwAAAABDAABDAABCwABAAAABmJpZ2ludAAMAAILAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAgAAwAAAAEADAACDAABCwABAAAABmJpZ2ludAAMAAILAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAgAAwAAAAEAAAAAAgACAAAAAAwAAwsAAQAAABlhID0gPyBBTkQgYiA9ID8gQU5EIGMgPSA/DwACDAAAAAMMAAELAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAwAAgsAAQAAAAZiaWdpbnQAAAwAAQsAAQAAACQOAAAAVkFSSUFCTEVfV0lEVEgBAAAABQAAAAAFAAAAaGVsbG8ADAACCwABAAAAB3ZhcmNoYXIAAAwAAQsAAQAAAB8DAAAAUkxFAQAAAAoAAABMT05HX0FSUkFZAQAAAAGAAAwAAgsAAQAAAAZiaWdpbnQAAAALAAQAAAAGbGF5b3V0AA==",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+                "bound" : "EXACTLY"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+                "bound" : "EXACTLY"
+              }
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBAAwAAgwAAQwAAgwAAQsAAQAAAAZiaWdpbnQADwACDAAAAAMMAAEMAAELAAEAAAAGYmlnaW50AAgAAwAAAAIADAACDAABCwABAAAABmJpZ2ludAAMAAILAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAAPb/////////AAgAAwAAAAAAAAwAAQwAAQsAAQAAAAZiaWdpbnQADAACCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAABAAAAAAAAAAAIAAMAAAABAAwAAgwAAQsAAQAAAAZiaWdpbnQADAACCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAKAAAAAAAAAAAIAAMAAAAAAAAMAAEMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAZAAAAAAAAAAACAADAAAAAgAMAAIMAAELAAEAAAAGYmlnaW50AAgAAwAAAAAAAAAAAgACAQAAAAA=",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAPb/////////",
+                "bound" : "BELOW"
+              }
+            }, {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAEAAAAAAAAA",
+                "bound" : "EXACTLY"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAoAAAAAAAAA",
+                "bound" : "BELOW"
+              }
+            }, {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAGQAAAAAAAAA",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "bound" : "BELOW"
+              }
+            } ]
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAZiaWdpbnQAAgAFAQAMAAIMAAEMAAIMAAELAAEAAAAGYmlnaW50AA8AAgwAAAADDAABDAABCwABAAAABmJpZ2ludAAIAAMAAAACAAwAAgwAAQsAAQAAAAZiaWdpbnQADAACCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAD2/////////wAIAAMAAAAAAAAMAAEMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAAQAAAAAAAAAACAADAAAAAQAMAAIMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAACgAAAAAAAAAACAADAAAAAAAADAABDAABCwABAAAABmJpZ2ludAAMAAILAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAAGQAAAAAAAAAAAgAAwAAAAIADAACDAABCwABAAAABmJpZ2ludAAIAAMAAAAAAAAAAAIAAgEAAAALAAQAAAAGbGF5b3V0AA==",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAPb/////////",
+                "bound" : "BELOW"
+              }
+            }, {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAEAAAAAAAAA",
+                "bound" : "EXACTLY"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAoAAAAAAAAA",
+                "bound" : "BELOW"
+              }
+            }, {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAGQAAAAAAAAA",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "bound" : "BELOW"
+              }
+            } ]
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABmJpZ2ludAACAAUBAAwAAgwAAQwAAgwAAQsAAQAAAAZiaWdpbnQADwACDAAAAAMMAAEMAAELAAEAAAAGYmlnaW50AAgAAwAAAAIADAACDAABCwABAAAABmJpZ2ludAAMAAILAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAAPb/////////AAgAAwAAAAAAAAwAAQwAAQsAAQAAAAZiaWdpbnQADAACCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAABAAAAAAAAAAAIAAMAAAABAAwAAgwAAQsAAQAAAAZiaWdpbnQADAACCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAKAAAAAAAAAAAIAAMAAAAAAAAMAAEMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAZAAAAAAAAAAACAADAAAAAgAMAAIMAAELAAEAAAAGYmlnaW50AAgAAwAAAAAAAAAAAgACAQAAAAwABgsAAQAAABlhID0gPyBBTkQgYiA9ID8gQU5EIGMgPSA/DwACDAAAAAMMAAELAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAwAAgsAAQAAAAZiaWdpbnQAAAwAAQsAAQAAACQOAAAAVkFSSUFCTEVfV0lEVEgBAAAABQAAAAAFAAAAaGVsbG8ADAACCwABAAAAB3ZhcmNoYXIAAAwAAQsAAQAAAB8DAAAAUkxFAQAAAAoAAABMT05HX0FSUkFZAQAAAAGAAAwAAgsAAQAAAAZiaWdpbnQAAAAA",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAPb/////////",
+                "bound" : "BELOW"
+              }
+            }, {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAEAAAAAAAAA",
+                "bound" : "EXACTLY"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAoAAAAAAAAA",
+                "bound" : "BELOW"
+              }
+            }, {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAGQAAAAAAAAA",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "bound" : "BELOW"
+              }
+            } ]
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAZiaWdpbnQAAgAFAQAMAAIMAAEMAAIMAAELAAEAAAAGYmlnaW50AA8AAgwAAAADDAABDAABCwABAAAABmJpZ2ludAAIAAMAAAACAAwAAgwAAQsAAQAAAAZiaWdpbnQADAACCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAD2/////////wAIAAMAAAAAAAAMAAEMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAAQAAAAAAAAAACAADAAAAAQAMAAIMAAELAAEAAAAGYmlnaW50AAwAAgsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAACgAAAAAAAAAACAADAAAAAAAADAABDAABCwABAAAABmJpZ2ludAAMAAILAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAAGQAAAAAAAAAAAgAAwAAAAIADAACDAABCwABAAAABmJpZ2ludAAIAAMAAAAAAAAAAAIAAgEAAAAMAAMLAAEAAAAZYSA9ID8gQU5EIGIgPSA/IEFORCBjID0gPw8AAgwAAAADDAABCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAqAAAAAAAAAAAMAAILAAEAAAAGYmlnaW50AAAMAAELAAEAAAAkDgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxvAAwAAgsAAQAAAAd2YXJjaGFyAAAMAAELAAEAAAAfAwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgAAMAAILAAEAAAAGYmlnaW50AAAACwAEAAAABmxheW91dAA=",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "bigint",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "sortable",
+            "type" : "bigint",
+            "ranges" : [ {
+              "low" : {
+                "type" : "bigint",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAPb/////////",
+                "bound" : "BELOW"
+              }
+            }, {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAEAAAAAAAAA",
+                "bound" : "EXACTLY"
+              },
+              "high" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAAoAAAAAAAAA",
+                "bound" : "BELOW"
+              }
+            }, {
+              "low" : {
+                "type" : "bigint",
+                "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAAGQAAAAAAAAA",
+                "bound" : "ABOVE"
+              },
+              "high" : {
+                "type" : "bigint",
+                "bound" : "BELOW"
+              }
+            } ]
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABGpzb24AAgAFAQAMAAIMAAEMAAEMAAELAAEAAAAEanNvbgACAAIBDgADDAAAAAEMAAELAAEAAAAEanNvbgAMAAILAAEAAAAgDgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADEAAAAAAgACAAAAAAA=",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "json",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "equatable",
+            "type" : "json",
+            "whiteList" : true,
+            "entries" : [ {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADE="
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAARqc29uAAIABQEADAACDAABDAABDAABCwABAAAABGpzb24AAgACAQ4AAwwAAAABDAABCwABAAAABGpzb24ADAACCwABAAAAIA4AAABWQVJJQUJMRV9XSURUSAEAAAABAAAAAAEAAAAxAAAAAAIAAgAAAAALAAQAAAAGbGF5b3V0AA==",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "json",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "equatable",
+            "type" : "json",
+            "whiteList" : true,
+            "entries" : [ {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADE="
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABGpzb24AAgAFAQAMAAIMAAEMAAEMAAELAAEAAAAEanNvbgACAAIBDgADDAAAAAEMAAELAAEAAAAEanNvbgAMAAILAAEAAAAgDgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADEAAAAAAgACAAAAAAwABgsAAQAAABlhID0gPyBBTkQgYiA9ID8gQU5EIGMgPSA/DwACDAAAAAMMAAELAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAwAAgsAAQAAAAZiaWdpbnQAAAwAAQsAAQAAACQOAAAAVkFSSUFCTEVfV0lEVEgBAAAABQAAAAAFAAAAaGVsbG8ADAACCwABAAAAB3ZhcmNoYXIAAAwAAQsAAQAAAB8DAAAAUkxFAQAAAAoAAABMT05HX0FSUkFZAQAAAAGAAAwAAgsAAQAAAAZiaWdpbnQAAAAA",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "json",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "equatable",
+            "type" : "json",
+            "whiteList" : true,
+            "entries" : [ {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADE="
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAARqc29uAAIABQEADAACDAABDAABDAABCwABAAAABGpzb24AAgACAQ4AAwwAAAABDAABCwABAAAABGpzb24ADAACCwABAAAAIA4AAABWQVJJQUJMRV9XSURUSAEAAAABAAAAAAEAAAAxAAAAAAIAAgAAAAAMAAMLAAEAAAAZYSA9ID8gQU5EIGIgPSA/IEFORCBjID0gPw8AAgwAAAADDAABCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAqAAAAAAAAAAAMAAILAAEAAAAGYmlnaW50AAAMAAELAAEAAAAkDgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxvAAwAAgsAAQAAAAd2YXJjaGFyAAAMAAELAAEAAAAfAwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgAAMAAILAAEAAAAGYmlnaW50AAAACwAEAAAABmxheW91dAA=",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "json",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "equatable",
+            "type" : "json",
+            "whiteList" : true,
+            "entries" : [ {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADE="
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABGpzb24AAgAFAQAMAAIMAAEMAAEMAAELAAEAAAAEanNvbgACAAIADgADDAAAAAIMAAELAAEAAAAEanNvbgAMAAILAAEAAAAgDgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADIAAAwAAQsAAQAAAARqc29uAAwAAgsAAQAAACAOAAAAVkFSSUFCTEVfV0lEVEgBAAAAAQAAAAABAAAAMwAAAAACAAIAAAAAAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "json",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "equatable",
+            "type" : "json",
+            "whiteList" : false,
+            "entries" : [ {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADI="
+            }, {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADM="
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAARqc29uAAIABQEADAACDAABDAABDAABCwABAAAABGpzb24AAgACAA4AAwwAAAACDAABCwABAAAABGpzb24ADAACCwABAAAAIA4AAABWQVJJQUJMRV9XSURUSAEAAAABAAAAAAEAAAAyAAAMAAELAAEAAAAEanNvbgAMAAILAAEAAAAgDgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADMAAAAAAgACAAAAAAsABAAAAAZsYXlvdXQA",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "json",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "equatable",
+            "type" : "json",
+            "whiteList" : false,
+            "entries" : [ {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADI="
+            }, {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADM="
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAABGpzb24AAgAFAQAMAAIMAAEMAAEMAAELAAEAAAAEanNvbgACAAIADgADDAAAAAIMAAELAAEAAAAEanNvbgAMAAILAAEAAAAgDgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADIAAAwAAQsAAQAAAARqc29uAAwAAgsAAQAAACAOAAAAVkFSSUFCTEVfV0lEVEgBAAAAAQAAAAABAAAAMwAAAAACAAIAAAAADAAGCwABAAAAGWEgPSA/IEFORCBiID0gPyBBTkQgYyA9ID8PAAIMAAAAAwwAAQsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAADAACCwABAAAABmJpZ2ludAAADAABCwABAAAAJA4AAABWQVJJQUJMRV9XSURUSAEAAAAFAAAAAAUAAABoZWxsbwAMAAILAAEAAAAHdmFyY2hhcgAADAABCwABAAAAHwMAAABSTEUBAAAACgAAAExPTkdfQVJSQVkBAAAAAYAADAACCwABAAAABmJpZ2ludAAAAAA=",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "json",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "equatable",
+            "type" : "json",
+            "whiteList" : false,
+            "entries" : [ {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADI="
+            }, {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADM="
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAARqc29uAAIABQEADAACDAABDAABDAABCwABAAAABGpzb24AAgACAA4AAwwAAAACDAABCwABAAAABGpzb24ADAACCwABAAAAIA4AAABWQVJJQUJMRV9XSURUSAEAAAABAAAAAAEAAAAyAAAMAAELAAEAAAAEanNvbgAMAAILAAEAAAAgDgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADMAAAAAAgACAAAAAAwAAwsAAQAAABlhID0gPyBBTkQgYiA9ID8gQU5EIGMgPSA/DwACDAAAAAMMAAELAAEAAAAbCgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAAAAwAAgsAAQAAAAZiaWdpbnQAAAwAAQsAAQAAACQOAAAAVkFSSUFCTEVfV0lEVEgBAAAABQAAAAAFAAAAaGVsbG8ADAACCwABAAAAB3ZhcmNoYXIAAAwAAQsAAQAAAB8DAAAAUkxFAQAAAAoAAABMT05HX0FSUkFZAQAAAAGAAAwAAgsAAQAAAAZiaWdpbnQAAAALAAQAAAAGbGF5b3V0AA==",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "json",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "equatable",
+            "type" : "json",
+            "whiteList" : false,
+            "entries" : [ {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADI="
+            }, {
+              "type" : "json",
+              "block" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAEAAAAAAQAAADM="
+            } ]
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAAC0h5cGVyTG9nTG9nAAIABQEADAACDAABDAADDAABCwABAAAAC0h5cGVyTG9nTG9nAAIAAgAAAAIAAgEAAAAA",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "HyperLogLog",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "allOrNone",
+            "type" : "HyperLogLog",
+            "all" : false
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAtIeXBlckxvZ0xvZwACAAUBAAwAAgwAAQwAAwwAAQsAAQAAAAtIeXBlckxvZ0xvZwACAAIAAAACAAIBAAAACwAEAAAABmxheW91dAA=",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "HyperLogLog",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "allOrNone",
+            "type" : "HyperLogLog",
+            "all" : false
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAAC0h5cGVyTG9nTG9nAAIABQEADAACDAABDAADDAABCwABAAAAC0h5cGVyTG9nTG9nAAIAAgAAAAIAAgEAAAAMAAYLAAEAAAAZYSA9ID8gQU5EIGIgPSA/IEFORCBjID0gPw8AAgwAAAADDAABCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAqAAAAAAAAAAAMAAILAAEAAAAGYmlnaW50AAAMAAELAAEAAAAkDgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxvAAwAAgsAAQAAAAd2YXJjaGFyAAAMAAELAAEAAAAfAwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgAAMAAILAAEAAAAGYmlnaW50AAAAAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "HyperLogLog",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "allOrNone",
+            "type" : "HyperLogLog",
+            "all" : false
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAtIeXBlckxvZ0xvZwACAAUBAAwAAgwAAQwAAwwAAQsAAQAAAAtIeXBlckxvZ0xvZwACAAIAAAACAAIBAAAADAADCwABAAAAGWEgPSA/IEFORCBiID0gPyBBTkQgYyA9ID8PAAIMAAAAAwwAAQsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAADAACCwABAAAABmJpZ2ludAAADAABCwABAAAAJA4AAABWQVJJQUJMRV9XSURUSAEAAAAFAAAAAAUAAABoZWxsbwAMAAILAAEAAAAHdmFyY2hhcgAADAABCwABAAAAHwMAAABSTEUBAAAACgAAAExPTkdfQVJSQVkBAAAAAYAADAACCwABAAAABmJpZ2ludAAAAAsABAAAAAZsYXlvdXQA",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "HyperLogLog",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "allOrNone",
+            "type" : "HyperLogLog",
+            "all" : false
+          },
+          "nullAllowed" : true
+        }
+      } ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAAC0h5cGVyTG9nTG9nAAIABQEADAACDAABDAADDAABCwABAAAAC0h5cGVyTG9nTG9nAAIAAgEAAAIAAgAAAAAA",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "HyperLogLog",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "allOrNone",
+            "type" : "HyperLogLog",
+            "all" : true
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAtIeXBlckxvZ0xvZwACAAUBAAwAAgwAAQwAAwwAAQsAAQAAAAtIeXBlckxvZ0xvZwACAAIBAAACAAIAAAAACwAEAAAABmxheW91dAA=",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "HyperLogLog",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "allOrNone",
+            "type" : "HyperLogLog",
+            "all" : true
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "split",
+  "thrift" : "CwABAAAAB2NhdGFsb2cLAAQAAAAFdGFibGUMAAUPAAEMAAAAAQwAAQsAAQAAAAdjYXRhbG9nCwACAAAAAWEMAAMIAAEAAARXCwACAAAABW90aGVyCAADAAAAAAgABAAAAAAADAAECwABAAAAC0h5cGVyTG9nTG9nAAIABQEADAACDAABDAADDAABCwABAAAAC0h5cGVyTG9nTG9nAAIAAgEAAAIAAgAAAAAMAAYLAAEAAAAZYSA9ID8gQU5EIGIgPSA/IEFORCBjID0gPw8AAgwAAAADDAABCwABAAAAGwoAAABMT05HX0FSUkFZAQAAAAAqAAAAAAAAAAAMAAILAAEAAAAGYmlnaW50AAAMAAELAAEAAAAkDgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxvAAwAAgsAAQAAAAd2YXJjaGFyAAAMAAELAAEAAAAfAwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgAAMAAILAAEAAAAGYmlnaW50AAAAAA==",
+  "json" : {
+    "connectorId" : "catalog",
+    "tableName" : "table",
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "HyperLogLog",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "allOrNone",
+            "type" : "HyperLogLog",
+            "all" : true
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalProperty" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "@type" : "arrow-federation"
+  }
+}, {
+  "kind" : "layout",
+  "thrift" : "DAABCwABAAAAB2NhdGFsb2cMAAILAAEAAAAGc2NoZW1hCwACAAAABXRhYmxlAAsABAAAAAZzY2hlbWELAAUAAAAFdGFibGUADAACDwABDAAAAAEMAAELAAEAAAAHY2F0YWxvZwsAAgAAAAFhDAADCAABAAAEVwsAAgAAAAVvdGhlcggAAwAAAAAIAAQAAAAAAAwABAsAAQAAAAtIeXBlckxvZ0xvZwACAAUBAAwAAgwAAQwAAwwAAQsAAQAAAAtIeXBlckxvZ0xvZwACAAIBAAACAAIAAAAADAADCwABAAAAGWEgPSA/IEFORCBiID0gPyBBTkQgYyA9ID8PAAIMAAAAAwwAAQsAAQAAABsKAAAATE9OR19BUlJBWQEAAAAAKgAAAAAAAAAADAACCwABAAAABmJpZ2ludAAADAABCwABAAAAJA4AAABWQVJJQUJMRV9XSURUSAEAAAAFAAAAAAUAAABoZWxsbwAMAAILAAEAAAAHdmFyY2hhcgAADAABCwABAAAAHwMAAABSTEUBAAAACgAAAExPTkdfQVJSQVkBAAAAAYAADAACCwABAAAABmJpZ2ludAAAAAsABAAAAAZsYXlvdXQA",
+  "json" : {
+    "table" : {
+      "connectorId" : "catalog",
+      "schemaTableName" : {
+        "schema" : "schema",
+        "table" : "table"
+      },
+      "schemaName" : "schema",
+      "tableName" : "table"
+    },
+    "tupleDomain" : {
+      "columnDomains" : [ {
+        "column" : {
+          "connectorId" : "catalog",
+          "columnName" : "a",
+          "jdbcTypeHandle" : {
+            "jdbcType" : 1111,
+            "jdbcTypeName" : "other",
+            "columnSize" : 0,
+            "decimalDigits" : 0
+          },
+          "columnType" : "HyperLogLog",
+          "nullable" : true
+        },
+        "domain" : {
+          "values" : {
+            "@type" : "allOrNone",
+            "type" : "HyperLogLog",
+            "all" : true
+          },
+          "nullAllowed" : false
+        }
+      } ]
+    },
+    "additionalPredicate" : {
+      "translatedString" : "a = ? AND b = ? AND c = ?",
+      "boundConstantValues" : [ {
+        "@type" : "constant",
+        "valueBlock" : "CgAAAExPTkdfQVJSQVkBAAAAACoAAAAAAAAA",
+        "type" : "bigint"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "DgAAAFZBUklBQkxFX1dJRFRIAQAAAAUAAAAABQAAAGhlbGxv",
+        "type" : "varchar"
+      }, {
+        "@type" : "constant",
+        "valueBlock" : "AwAAAFJMRQEAAAAKAAAATE9OR19BUlJBWQEAAAABgA==",
+        "type" : "bigint"
+      } ]
+    },
+    "layoutString" : "layout",
+    "@type" : "arrow-federation"
+  }
+} ]

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/AllOrNoneValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/AllOrNoneValueSet.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
@@ -28,6 +31,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Set that either includes all values, or excludes all values.
  */
+@ThriftStruct
 public class AllOrNoneValueSet
         implements ValueSet
 {
@@ -35,6 +39,7 @@ public class AllOrNoneValueSet
     private final boolean all;
 
     @JsonCreator
+    @ThriftConstructor
     public AllOrNoneValueSet(@JsonProperty("type") Type type, @JsonProperty("all") boolean all)
     {
         this.type = requireNonNull(type, "type is null");
@@ -53,6 +58,7 @@ public class AllOrNoneValueSet
 
     @Override
     @JsonProperty
+    @ThriftField(1)
     public Type getType()
     {
         return type;
@@ -66,6 +72,7 @@ public class AllOrNoneValueSet
 
     @Override
     @JsonProperty
+    @ThriftField(2)
     public boolean isAll()
     {
         return all;

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
@@ -40,6 +43,7 @@ import static java.util.Objects.requireNonNull;
  * </ul>
  * <p>
  */
+@ThriftStruct
 public final class Domain
 {
     private final ValueSet values;
@@ -49,6 +53,12 @@ public final class Domain
     {
         this.values = requireNonNull(values, "values is null");
         this.nullAllowed = nullAllowed;
+    }
+
+    @ThriftConstructor
+    public Domain(ValueSet.ThriftValueSet values, boolean nullAllowed)
+    {
+        this(values.getValueSet(), nullAllowed);
     }
 
     @JsonCreator
@@ -106,7 +116,14 @@ public final class Domain
         return values;
     }
 
+    @ThriftField(value = 1, name = "values")
+    public ValueSet.ThriftValueSet getThriftValues()
+    {
+        return new ValueSet.ThriftValueSet(values);
+    }
+
     @JsonProperty
+    @ThriftField(2)
     public boolean isNullAllowed()
     {
         return nullAllowed;

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/EquatableValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/EquatableValueSet.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.Utils;
 import com.facebook.presto.common.block.Block;
@@ -47,6 +50,7 @@ import static java.util.stream.Collectors.toList;
  * Assumes an infinite number of possible values. The values may be collectively included (aka whitelist)
  * or collectively excluded (aka !whitelist).
  */
+@ThriftStruct
 public class EquatableValueSet
         implements ValueSet
 {
@@ -55,6 +59,7 @@ public class EquatableValueSet
     private final Set<ValueEntry> entries;
 
     @JsonCreator
+    @ThriftConstructor
     public EquatableValueSet(
             @JsonProperty("type") Type type,
             @JsonProperty("whiteList") boolean whiteList,
@@ -102,6 +107,7 @@ public class EquatableValueSet
     }
 
     @JsonProperty
+    @ThriftField(1)
     @Override
     public Type getType()
     {
@@ -109,12 +115,14 @@ public class EquatableValueSet
     }
 
     @JsonProperty
+    @ThriftField(2)
     public boolean isWhiteList()
     {
         return whiteList;
     }
 
     @JsonProperty
+    @ThriftField(3)
     public Set<ValueEntry> getEntries()
     {
         return entries;
@@ -324,12 +332,14 @@ public class EquatableValueSet
         return toCollection(LinkedHashSet::new);
     }
 
+    @ThriftStruct
     public static class ValueEntry
     {
         private final Type type;
         private final Block block;
 
         @JsonCreator
+        @ThriftConstructor
         public ValueEntry(
                 @JsonProperty("type") Type type,
                 @JsonProperty("block") Block block)
@@ -348,12 +358,14 @@ public class EquatableValueSet
         }
 
         @JsonProperty
+        @ThriftField(1)
         public Type getType()
         {
             return type;
         }
 
         @JsonProperty
+        @ThriftField(2)
         public Block getBlock()
         {
             return block;

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Marker.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Marker.java
@@ -13,6 +13,11 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.Utils;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
@@ -29,14 +34,29 @@ import static java.util.Objects.requireNonNull;
  * A point on the continuous space defined by the specified type.
  * Each point may be just below, exact, or just above the specified value according to the Bound.
  */
+@ThriftStruct
 public final class Marker
         implements Comparable<Marker>
 {
+    @ThriftEnum
     public enum Bound
     {
-        BELOW,   // lower than the value, but infinitesimally close to the value
-        EXACTLY, // exactly the value
-        ABOVE    // higher than the value, but infinitesimally close to the value
+        BELOW(0),    // lower than the value, but infinitesimally close to the value
+        EXACTLY(1),  // exactly the value
+        ABOVE(2);    // higher than the value, but infinitesimally close to the value
+
+        private final int value;
+
+        Bound(int value)
+        {
+            this.value = value;
+        }
+
+        @ThriftEnumValue
+        public int getValue()
+        {
+            return value;
+        }
     }
 
     private final Type type;
@@ -48,6 +68,7 @@ public final class Marker
      * UPPER UNBOUNDED is specified with an empty value and a BELOW bound
      */
     @JsonCreator
+    @ThriftConstructor
     public Marker(
             @JsonProperty("type") Type type,
             @JsonProperty("valueBlock") Optional<Block> valueBlock,
@@ -110,12 +131,14 @@ public final class Marker
     }
 
     @JsonProperty
+    @ThriftField(1)
     public Type getType()
     {
         return type;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public Optional<Block> getValueBlock()
     {
         return valueBlock;
@@ -143,6 +166,7 @@ public final class Marker
     }
 
     @JsonProperty
+    @ThriftField(3)
     public Bound getBound()
     {
         return bound;

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -27,12 +30,14 @@ import static java.util.Objects.requireNonNull;
 /**
  * A Range of values across the continuous space defined by the types of the Markers
  */
+@ThriftStruct
 public final class Range
 {
     private final Marker low;
     private final Marker high;
 
     @JsonCreator
+    @ThriftConstructor
     public Range(
             @JsonProperty("low") Marker low,
             @JsonProperty("high") Marker high)
@@ -105,12 +110,14 @@ public final class Range
     }
 
     @JsonProperty
+    @ThriftField(1)
     public Marker getLow()
     {
         return low;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public Marker getHigh()
     {
         return high;

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
@@ -47,6 +50,7 @@ import static java.util.stream.Collectors.toMap;
  * allows iteration across these compacted Ranges in increasing order, as well as other common
  * set-related operation.
  */
+@ThriftStruct
 public final class SortedRangeSet
         implements ValueSet
 {
@@ -63,6 +67,12 @@ public final class SortedRangeSet
         }
         this.type = type;
         this.lowIndexedRanges = lowIndexedRanges;
+    }
+
+    @ThriftConstructor
+    public SortedRangeSet(@ThriftField(2) List<Range> ranges, @ThriftField(1) Type type)
+    {
+        this(type, copyOf(type, (Iterable<Range>) ranges).lowIndexedRanges);
     }
 
     static SortedRangeSet none(Type type)
@@ -127,12 +137,14 @@ public final class SortedRangeSet
 
     @Override
     @JsonProperty
+    @ThriftField(1)
     public Type getType()
     {
         return type;
     }
 
     @JsonProperty("ranges")
+    @ThriftField(value = 2, name = "ranges")
     public List<Range> getOrderedRanges()
     {
         return new ArrayList<>(lowIndexedRanges.values());
@@ -421,6 +433,26 @@ public final class SortedRangeSet
                                 TreeMap::new)));
     }
 
+    private static NavigableMap<Marker, Range> normalizeBooleanRanges(Type type, NavigableMap<Marker, Range> ranges)
+    {
+        if (type != BOOLEAN) {
+            return ranges;
+        }
+        boolean trueAllowed = false;
+        boolean falseAllowed = false;
+        for (Range range : ranges.values()) {
+            trueAllowed |= range.includes(Marker.exactly(BOOLEAN, true));
+            falseAllowed |= range.includes(Marker.exactly(BOOLEAN, false));
+        }
+        if (trueAllowed && falseAllowed) {
+            NavigableMap<Marker, Range> result = new TreeMap<>();
+            Range all = Range.all(BOOLEAN);
+            result.put(all.getLow(), all);
+            return result;
+        }
+        return ranges;
+    }
+
     static class Builder
     {
         private final Type type;
@@ -481,26 +513,7 @@ public final class SortedRangeSet
             }
 
             // TODO find a more generic way to do this
-            if (type == BOOLEAN) {
-                boolean trueAllowed = false;
-                boolean falseAllowed = false;
-                for (Map.Entry<Marker, Range> entry : result.entrySet()) {
-                    if (entry.getValue().includes(Marker.exactly(BOOLEAN, true))) {
-                        trueAllowed = true;
-                    }
-                    if (entry.getValue().includes(Marker.exactly(BOOLEAN, false))) {
-                        falseAllowed = true;
-                    }
-                }
-
-                if (trueAllowed && falseAllowed) {
-                    result = new TreeMap<>();
-                    result.put(Range.all(BOOLEAN).getLow(), Range.all(BOOLEAN));
-                    return new SortedRangeSet(BOOLEAN, result);
-                }
-            }
-
-            return new SortedRangeSet(type, result);
+            return new SortedRangeSet(type, normalizeBooleanRanges(type, result));
         }
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.common.predicate;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftUnion;
+import com.facebook.drift.annotations.ThriftUnionId;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -22,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Collection;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 @JsonTypeInfo(
@@ -172,4 +177,77 @@ public interface ValueSet
      * All types and bounds information is preserved.
      */
     ValueSet canonicalize(boolean removeSafeConstants);
+
+    /*
+        For Thrift serialization ONLY
+     */
+    @ThriftUnion
+    final class ThriftValueSet
+    {
+        private final ValueSet valueSet;
+
+        @ThriftUnionId
+        public short getSetField()
+        {
+            if (valueSet instanceof EquatableValueSet) {
+                return 1;
+            }
+            if (valueSet instanceof SortedRangeSet) {
+                return 2;
+            }
+            if (valueSet instanceof AllOrNoneValueSet) {
+                return 3;
+            }
+            throw new IllegalStateException("No value set in ThriftValueSet");
+        }
+
+        @ThriftField(1)
+        public EquatableValueSet getEquatableValueSet()
+        {
+            return valueSet instanceof EquatableValueSet ? (EquatableValueSet) valueSet : null;
+        }
+
+        @ThriftConstructor
+        public ThriftValueSet(EquatableValueSet equatableValueSet)
+        {
+            this((ValueSet) equatableValueSet);
+        }
+
+        @ThriftField(2)
+        public SortedRangeSet getSortedRangeSet()
+        {
+            return valueSet instanceof SortedRangeSet ? (SortedRangeSet) valueSet : null;
+        }
+
+        @ThriftConstructor
+        public ThriftValueSet(SortedRangeSet sortedRangeSet)
+        {
+            this((ValueSet) sortedRangeSet);
+        }
+
+        @ThriftField(3)
+        public AllOrNoneValueSet getAllOrNoneValueSet()
+        {
+            return valueSet instanceof AllOrNoneValueSet ? (AllOrNoneValueSet) valueSet : null;
+        }
+
+        @ThriftConstructor
+        public ThriftValueSet(AllOrNoneValueSet allOrNoneValueSet)
+        {
+            this((ValueSet) allOrNoneValueSet);
+        }
+
+        public ThriftValueSet(ValueSet valueSet)
+        {
+            this.valueSet = requireNonNull(valueSet, "valueSet is null");
+            if (!(valueSet instanceof EquatableValueSet) && !(valueSet instanceof SortedRangeSet) && !(valueSet instanceof AllOrNoneValueSet)) {
+                throw new IllegalArgumentException("Unsupported value set: " + valueSet.getClass().getName());
+            }
+        }
+
+        public ValueSet getValueSet()
+        {
+            return valueSet;
+        }
+    }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/predicate/TestSortedRangeSet.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/predicate/TestSortedRangeSet.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterables;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -54,6 +55,24 @@ public class TestSortedRangeSet
                         .addDeserializer(Type.class, new TestingTypeDeserializer(typeManager))
                         .addSerializer(Block.class, new TestingBlockJsonSerde.Serializer(blockEncodingSerde))
                         .addDeserializer(Block.class, new TestingBlockJsonSerde.Deserializer(blockEncodingSerde)));
+    }
+
+    @Test
+    public void testThriftConstructorPreservesInput()
+    {
+        List<Range> ranges = ImmutableList.of(Range.equal(BIGINT, 2L), Range.equal(BIGINT, 1L));
+        SortedRangeSet result = new SortedRangeSet(ranges, BIGINT);
+        assertEquals(result.getOrderedRanges(), ImmutableList.of(Range.equal(BIGINT, 1L), Range.equal(BIGINT, 2L)));
+        assertEquals(ranges, ImmutableList.of(Range.equal(BIGINT, 2L), Range.equal(BIGINT, 1L)));
+    }
+
+    @Test
+    public void testThriftConstructorNormalizesBooleanRanges()
+    {
+        assertTrue(new SortedRangeSet(ImmutableList.of(Range.equal(BOOLEAN, true), Range.equal(BOOLEAN, false)), BOOLEAN).isAll());
+        assertFalse(new SortedRangeSet(ImmutableList.of(Range.equal(BOOLEAN, true)), BOOLEAN).isAll());
+        assertFalse(new SortedRangeSet(ImmutableList.of(Range.equal(BOOLEAN, false)), BOOLEAN).isAll());
+        assertTrue(new SortedRangeSet(ImmutableList.of(), BOOLEAN).isNone());
     }
 
     @Test

--- a/presto-common/src/test/java/com/facebook/presto/common/predicate/TestThriftValueSet.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/predicate/TestThriftValueSet.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.predicate;
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Proxy;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
+import static com.facebook.presto.common.type.JsonType.JSON;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+
+public class TestThriftValueSet
+{
+    @Test
+    public void testUnionAlternatives()
+    {
+        EquatableValueSet equatable = EquatableValueSet.all(JSON);
+        SortedRangeSet sorted = SortedRangeSet.all(BIGINT);
+        AllOrNoneValueSet allOrNone = AllOrNoneValueSet.all(HYPER_LOG_LOG);
+        ValueSet.ThriftValueSet first = new ValueSet.ThriftValueSet(equatable);
+        ValueSet.ThriftValueSet second = new ValueSet.ThriftValueSet(sorted);
+        ValueSet.ThriftValueSet third = new ValueSet.ThriftValueSet(allOrNone);
+        assertSame(first.getValueSet(), equatable);
+        assertSame(second.getValueSet(), sorted);
+        assertSame(third.getValueSet(), allOrNone);
+        assertSame(first.getEquatableValueSet(), equatable);
+        assertNull(first.getSortedRangeSet());
+        assertNull(first.getAllOrNoneValueSet());
+        assertNull(second.getEquatableValueSet());
+        assertSame(second.getSortedRangeSet(), sorted);
+        assertNull(second.getAllOrNoneValueSet());
+        assertNull(third.getEquatableValueSet());
+        assertNull(third.getSortedRangeSet());
+        assertSame(third.getAllOrNoneValueSet(), allOrNone);
+        assertEquals(first.getSetField(), (short) 1);
+        assertEquals(second.getSetField(), (short) 2);
+        assertEquals(third.getSetField(), (short) 3);
+    }
+
+    @Test
+    public void testRejectsEmptyUnion()
+    {
+        assertThrows(NullPointerException.class, () -> new ValueSet.ThriftValueSet((ValueSet) null));
+        assertThrows(NullPointerException.class, () -> new ValueSet.ThriftValueSet((EquatableValueSet) null));
+        assertThrows(NullPointerException.class, () -> new ValueSet.ThriftValueSet((SortedRangeSet) null));
+        assertThrows(NullPointerException.class, () -> new ValueSet.ThriftValueSet((AllOrNoneValueSet) null));
+    }
+
+    @Test
+    public void testRejectsUnsupportedValueSet()
+    {
+        ValueSet unsupported = (ValueSet) Proxy.newProxyInstance(
+                ValueSet.class.getClassLoader(), new Class<?>[] {ValueSet.class}, (proxy, method, args) -> null);
+        assertThrows(IllegalArgumentException.class, () -> new ValueSet.ThriftValueSet(unsupported));
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/server/thrift/HandleThriftModule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/thrift/HandleThriftModule.java
@@ -35,14 +35,7 @@ public class HandleThriftModule
     @Override
     public void configure(Binder binder)
     {
-        thriftCodecBinder(binder).bindCustomThriftCodec(ConnectorSplitThriftCodec.class);
-        thriftCodecBinder(binder).bindCustomThriftCodec(TransactionHandleThriftCodec.class);
-        thriftCodecBinder(binder).bindCustomThriftCodec(OutputTableHandleThriftCodec.class);
-        thriftCodecBinder(binder).bindCustomThriftCodec(InsertTableHandleThriftCodec.class);
-        thriftCodecBinder(binder).bindCustomThriftCodec(DeleteTableHandleThriftCodec.class);
-        thriftCodecBinder(binder).bindCustomThriftCodec(MergeTableHandleThriftCodec.class);
-        thriftCodecBinder(binder).bindCustomThriftCodec(TableLayoutHandleThriftCodec.class);
-        thriftCodecBinder(binder).bindCustomThriftCodec(TableHandleThriftCodec.class);
+        bindHandleThriftCodecs(binder);
 
         jsonCodecBinder(binder).bindJsonCodec(ConnectorSplit.class);
         jsonCodecBinder(binder).bindJsonCodec(ConnectorTransactionHandle.class);
@@ -54,5 +47,17 @@ public class HandleThriftModule
         jsonCodecBinder(binder).bindJsonCodec(ConnectorTableHandle.class);
 
         binder.bind(HandleResolver.class).in(Scopes.SINGLETON);
+    }
+
+    public static void bindHandleThriftCodecs(Binder binder)
+    {
+        thriftCodecBinder(binder).bindCustomThriftCodec(ConnectorSplitThriftCodec.class);
+        thriftCodecBinder(binder).bindCustomThriftCodec(TransactionHandleThriftCodec.class);
+        thriftCodecBinder(binder).bindCustomThriftCodec(OutputTableHandleThriftCodec.class);
+        thriftCodecBinder(binder).bindCustomThriftCodec(InsertTableHandleThriftCodec.class);
+        thriftCodecBinder(binder).bindCustomThriftCodec(DeleteTableHandleThriftCodec.class);
+        thriftCodecBinder(binder).bindCustomThriftCodec(MergeTableHandleThriftCodec.class);
+        thriftCodecBinder(binder).bindCustomThriftCodec(TableLayoutHandleThriftCodec.class);
+        thriftCodecBinder(binder).bindCustomThriftCodec(TableHandleThriftCodec.class);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskConnectorCodec.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskConnectorCodec.java
@@ -75,14 +75,7 @@ import com.facebook.presto.metadata.TableLayoutHandleJacksonModule;
 import com.facebook.presto.metadata.TransactionHandleJacksonModule;
 import com.facebook.presto.server.InternalCommunicationConfig;
 import com.facebook.presto.server.TaskUpdateRequest;
-import com.facebook.presto.server.thrift.ConnectorSplitThriftCodec;
-import com.facebook.presto.server.thrift.DeleteTableHandleThriftCodec;
-import com.facebook.presto.server.thrift.InsertTableHandleThriftCodec;
-import com.facebook.presto.server.thrift.MergeTableHandleThriftCodec;
-import com.facebook.presto.server.thrift.OutputTableHandleThriftCodec;
-import com.facebook.presto.server.thrift.TableHandleThriftCodec;
-import com.facebook.presto.server.thrift.TableLayoutHandleThriftCodec;
-import com.facebook.presto.server.thrift.TransactionHandleThriftCodec;
+import com.facebook.presto.server.thrift.HandleThriftModule;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorDeleteTableHandle;
@@ -721,14 +714,7 @@ public class TestHttpRemoteTaskConnectorCodec
 
                         binder.bind(ConnectorCodecManager.class).in(Scopes.SINGLETON);
 
-                        thriftCodecBinder(binder).bindCustomThriftCodec(ConnectorSplitThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(TransactionHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(OutputTableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(InsertTableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(DeleteTableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(MergeTableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(TableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(TableLayoutHandleThriftCodec.class);
+                        HandleThriftModule.bindHandleThriftCodecs(binder);
                         thriftCodecBinder(binder).bindThriftCodec(TaskStatus.class);
                         thriftCodecBinder(binder).bindThriftCodec(TaskInfo.class);
                         thriftCodecBinder(binder).bindThriftCodec(TaskUpdateRequest.class);

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskWithEventLoop.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTaskWithEventLoop.java
@@ -58,14 +58,7 @@ import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.server.InternalCommunicationConfig;
 import com.facebook.presto.server.TaskUpdateRequest;
-import com.facebook.presto.server.thrift.ConnectorSplitThriftCodec;
-import com.facebook.presto.server.thrift.DeleteTableHandleThriftCodec;
-import com.facebook.presto.server.thrift.InsertTableHandleThriftCodec;
-import com.facebook.presto.server.thrift.MergeTableHandleThriftCodec;
-import com.facebook.presto.server.thrift.OutputTableHandleThriftCodec;
-import com.facebook.presto.server.thrift.TableHandleThriftCodec;
-import com.facebook.presto.server.thrift.TableLayoutHandleThriftCodec;
-import com.facebook.presto.server.thrift.TransactionHandleThriftCodec;
+import com.facebook.presto.server.thrift.HandleThriftModule;
 import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
@@ -407,14 +400,7 @@ public class TestHttpRemoteTaskWithEventLoop
 
                         binder.bind(ConnectorCodecManager.class).in(Scopes.SINGLETON);
 
-                        thriftCodecBinder(binder).bindCustomThriftCodec(ConnectorSplitThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(TransactionHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(OutputTableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(InsertTableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(DeleteTableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(MergeTableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(TableHandleThriftCodec.class);
-                        thriftCodecBinder(binder).bindCustomThriftCodec(TableLayoutHandleThriftCodec.class);
+                        HandleThriftModule.bindHandleThriftCodecs(binder);
                         thriftCodecBinder(binder).bindThriftCodec(TaskStatus.class);
                         thriftCodecBinder(binder).bindThriftCodec(TaskInfo.class);
                         thriftCodecBinder(binder).bindThriftCodec(TaskUpdateRequest.class);

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/ArrowFederationPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/ArrowFederationPrestoToVeloxConnector.cpp
@@ -86,6 +86,13 @@ ArrowFederationPrestoToVeloxConnector::toVeloxTableHandle(
 
 std::unique_ptr<protocol::ConnectorProtocol>
 ArrowFederationPrestoToVeloxConnector::createConnectorProtocol() const {
+  const auto& name = connectorName();
+  if (name == "mysql" || name == "postgresql" || name == "sqlserver" ||
+      name == "redshift" || name == "oracle" || name == "hana" ||
+      name == "singlestore") {
+    return std::make_unique<
+        protocol::arrow_federation::JdbcArrowFederationConnectorProtocol>();
+  }
   return std::make_unique<
       protocol::arrow_federation::ArrowFederationConnectorProtocol>();
 }

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/arrow_federation/CMakeLists.txt
@@ -21,6 +21,7 @@ target_compile_definitions(presto_federation_connector PUBLIC PRESTO_ENABLE_ARRO
 target_link_libraries(
   presto_federation_connector
   velox_connector
+  presto_jdbc_thrift
   ArrowFlight::arrow_flight_shared
   presto_flight_connector_utils
   presto_flight_connector_auth

--- a/presto-native-execution/presto_cpp/main/thrift/.clang-format
+++ b/presto-native-execution/presto_cpp/main/thrift/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: InheritParentConfig
+FixNamespaceComments: false

--- a/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
@@ -55,6 +55,25 @@ set(presto_native_INCLUDES ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(presto_native-cpp2 PUBLIC ${presto_native_INCLUDES} ${GLOG_INCLUDE_DIR})
 target_include_directories(presto_native-cpp2-obj PUBLIC ${THRIFT_INCLUDES} ${GLOG_INCLUDE_DIR})
 
+thrift_library(
+  presto_jdbc
+  ""
+  cpp2
+  ""
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}/presto_cpp/main/thrift
+  ".."
+  THRIFT_INCLUDE_DIRECTORIES
+  ${THRIFT_INCLUDES}
+)
+target_link_libraries(presto_jdbc-cpp2 ${presto_thrift_library_dependencies})
+set(presto_jdbc_INCLUDES ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(presto_jdbc-cpp2 PUBLIC ${presto_jdbc_INCLUDES} ${GLOG_INCLUDE_DIR})
+target_include_directories(presto_jdbc-cpp2-obj PUBLIC ${THRIFT_INCLUDES} ${GLOG_INCLUDE_DIR})
+
+add_library(presto_jdbc_thrift JdbcThriftToJson.cpp)
+target_link_libraries(presto_jdbc_thrift PUBLIC presto_jdbc-cpp2)
+
 add_library(presto_thrift_extra ProtocolToThrift.cpp)
 target_include_directories(
   presto_thrift_extra

--- a/presto-native-execution/presto_cpp/main/thrift/JdbcThriftToJson.cpp
+++ b/presto-native-execution/presto_cpp/main/thrift/JdbcThriftToJson.cpp
@@ -1,0 +1,254 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "presto_cpp/main/thrift/JdbcThriftToJson.h"
+#include <folly/base64.h>
+
+#include <array>
+#include <stdexcept>
+#include "presto_cpp/main/thrift/ThriftIO.h"
+#include "presto_cpp/main/thrift/gen-cpp2/presto_jdbc_types.h"
+
+namespace facebook::presto::protocol::arrow_federation {
+namespace {
+using nlohmann::json;
+
+json toJson(const thrift::jdbc::PrestoType& value) {
+  return *value.signature();
+}
+
+json toJson(const thrift::jdbc::Block& value) {
+  return folly::base64Encode(*value.data());
+}
+
+json toJson(const std::string& value) {
+  return value;
+}
+
+json toJson(const thrift::jdbc::JdbcExpression& value);
+
+template <typename T>
+json optionalJson(const T& field) {
+  return field.has_value() ? toJson(*field) : json(nullptr);
+}
+
+template <typename T>
+json optionalJson(const apache::thrift::field_ref<T>& field) {
+  return apache::thrift::is_non_optional_field_set_manually_or_by_serializer(
+             field)
+      ? toJson(*field)
+      : json(nullptr);
+}
+
+json toJson(const thrift::jdbc::JdbcTypeHandle& value) {
+  return {
+      {"jdbcType", *value.jdbcType()},
+      {"jdbcTypeName", *value.jdbcTypeName()},
+      {"columnSize", *value.columnSize()},
+      {"decimalDigits", *value.decimalDigits()}};
+}
+
+json toJson(const thrift::jdbc::JdbcColumnHandle& value) {
+  return {
+      {"connectorId", *value.connectorId()},
+      {"columnName", *value.columnName()},
+      {"jdbcTypeHandle", toJson(*value.jdbcTypeHandle())},
+      {"columnType", toJson(*value.columnType())},
+      {"nullable", *value.nullable()},
+      {"comment", optionalJson(value.comment())}};
+}
+
+json toJson(const thrift::jdbc::Marker& value) {
+  static const std::array<std::string, 3> bounds = {
+      "BELOW", "EXACTLY", "ABOVE"};
+  return {
+      {"type", toJson(*value.type())},
+      {"valueBlock", optionalJson(value.valueBlock())},
+      {"bound", bounds.at(static_cast<size_t>(*value.bound()))}};
+}
+
+json toJson(const thrift::jdbc::Range& value) {
+  return {{"low", toJson(*value.low())}, {"high", toJson(*value.high())}};
+}
+
+json toJson(const thrift::jdbc::ValueEntry& value) {
+  return {{"type", toJson(*value.type())}, {"block", toJson(*value.block())}};
+}
+
+template <typename T>
+json toJsonArray(const T& values) {
+  auto result = json::array();
+  for (const auto& value : values) {
+    result.push_back(toJson(value));
+  }
+  return result;
+}
+
+json toJson(const thrift::jdbc::ThriftValueSet& value) {
+  switch (value.getType()) {
+    case thrift::jdbc::ThriftValueSet::Type::equatableValueSet: {
+      const auto& set = value.get_equatableValueSet();
+      return {
+          {"@type", "equatable"},
+          {"type", toJson(*set.type())},
+          {"whiteList", *set.whiteList()},
+          {"entries", toJsonArray(*set.entries())}};
+    }
+    case thrift::jdbc::ThriftValueSet::Type::sortedRangeSet: {
+      const auto& set = value.get_sortedRangeSet();
+      return {
+          {"@type", "sortable"},
+          {"type", toJson(*set.type())},
+          {"ranges", toJsonArray(*set.ranges())}};
+    }
+    case thrift::jdbc::ThriftValueSet::Type::allOrNoneValueSet: {
+      const auto& set = value.get_allOrNoneValueSet();
+      return {
+          {"@type", "allOrNone"},
+          {"type", toJson(*set.type())},
+          {"all", *set.all()}};
+    }
+    default:
+      throw std::invalid_argument("Empty JDBC value set");
+  }
+}
+
+json toJson(const thrift::jdbc::Domain& value) {
+  return {
+      {"values", toJson(*value.values())},
+      {"nullAllowed", *value.nullAllowed()}};
+}
+
+json toJson(const thrift::jdbc::JdbcThriftTupleDomain& value) {
+  json domains = nullptr;
+  if (value.columnDomains().has_value()) {
+    domains = json::array();
+    for (const auto& entry : *value.columnDomains()) {
+      domains.push_back(
+          {{"column", toJson(*entry.column())},
+           {"domain", toJson(*entry.domain())}});
+    }
+  }
+  return {{"columnDomains", domains}};
+}
+
+json toJson(const thrift::jdbc::JdbcExpression& value) {
+  auto constants = json::array();
+  for (const auto& constant : *value.boundConstantValues()) {
+    constants.push_back(
+        {{"@type", "constant"},
+         {"valueBlock", toJson(*constant.valueBlock())},
+         {"type", toJson(*constant.type())}});
+  }
+  return {
+      {"translatedString", *value.expression()},
+      {"boundConstantValues", constants}};
+}
+
+json toJson(const thrift::jdbc::JdbcTableHandle& value) {
+  return {
+      {"connectorId", *value.connectorId()},
+      {"schemaTableName",
+       {{"schema", *value.schemaTableName()->schema()},
+        {"table", *value.schemaTableName()->table()}}},
+      {"catalogName", optionalJson(value.catalogName())},
+      {"schemaName", optionalJson(value.schemaName())},
+      {"tableName", *value.tableName()}};
+}
+
+json toJson(const thrift::jdbc::JdbcTableLayoutHandle& value) {
+  return {
+      {"table", toJson(*value.table())},
+      {"tupleDomain", toJson(*value.tupleDomain())},
+      {"additionalPredicate", optionalJson(value.additionalPredicate())},
+      {"layoutString", *value.layoutString()}};
+}
+
+json toJson(const thrift::jdbc::JdbcSplit& value) {
+  return {
+      {"connectorId", *value.connectorId()},
+      {"catalogName", optionalJson(value.catalogName())},
+      {"schemaName", optionalJson(value.schemaName())},
+      {"tableName", *value.tableName()},
+      {"tupleDomain", toJson(*value.tupleDomain())},
+      {"additionalProperty", optionalJson(value.additionalPredicate())}};
+}
+
+json toJson(const thrift::jdbc::JdbcTransactionHandle& value) {
+  const auto& bytes = *value.uuid();
+  if (bytes.size() != 16) {
+    throw std::invalid_argument("JDBC transaction UUID must contain 16 bytes");
+  }
+  const char* hex = "0123456789abcdef";
+  std::string uuid;
+  for (size_t i = 0; i < bytes.size(); ++i) {
+    if (i == 4 || i == 6 || i == 8 || i == 10) {
+      uuid += '-';
+    }
+    const auto byte = static_cast<unsigned char>(bytes[i]);
+    uuid += hex[byte >> 4];
+    uuid += hex[byte & 15];
+  }
+  return {{"@type", "arrow-federation"}, {"uuid", uuid}};
+}
+
+void removeNullFields(json& value) {
+  if (value.is_object()) {
+    for (auto it = value.begin(); it != value.end();) {
+      if (it->is_null()) {
+        it = value.erase(it);
+      } else {
+        removeNullFields(*it);
+        ++it;
+      }
+    }
+  } else if (value.is_array()) {
+    for (auto& element : value) {
+      removeNullFields(element);
+    }
+  }
+}
+
+template <typename T>
+json decode(const std::string& data) {
+  auto value = std::make_shared<T>();
+  thriftRead(data, value);
+  auto result = toJson(*value);
+  result["@type"] = "arrow-federation";
+  removeNullFields(result);
+  return result;
+}
+
+}
+
+json jdbcTableHandleFromThrift(const std::string& data) {
+  return decode<thrift::jdbc::JdbcTableHandle>(data);
+}
+
+json jdbcTableLayoutHandleFromThrift(const std::string& data) {
+  return decode<thrift::jdbc::JdbcTableLayoutHandle>(data);
+}
+
+json jdbcColumnHandleFromThrift(const std::string& data) {
+  return decode<thrift::jdbc::JdbcColumnHandle>(data);
+}
+
+json jdbcSplitFromThrift(const std::string& data) {
+  return decode<thrift::jdbc::JdbcSplit>(data);
+}
+
+json jdbcTransactionHandleFromThrift(const std::string& data) {
+  return decode<thrift::jdbc::JdbcTransactionHandle>(data);
+}
+
+}

--- a/presto-native-execution/presto_cpp/main/thrift/JdbcThriftToJson.h
+++ b/presto-native-execution/presto_cpp/main/thrift/JdbcThriftToJson.h
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include "presto_cpp/external/json/nlohmann/json.hpp"
+
+namespace facebook::presto::protocol::arrow_federation {
+nlohmann::json jdbcTableHandleFromThrift(const std::string& data);
+nlohmann::json jdbcTableLayoutHandleFromThrift(const std::string& data);
+nlohmann::json jdbcColumnHandleFromThrift(const std::string& data);
+nlohmann::json jdbcSplitFromThrift(const std::string& data);
+nlohmann::json jdbcTransactionHandleFromThrift(const std::string& data);
+}

--- a/presto-native-execution/presto_cpp/main/thrift/presto_jdbc.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_jdbc.thrift
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+include "thrift/annotation/thrift.thrift"
+
+@thrift.AllowLegacyMissingUris
+package;
+
+namespace cpp2 facebook.presto.thrift.jdbc
+
+enum Bound {
+  BELOW = 0,
+  EXACTLY = 1,
+  ABOVE = 2,
+}
+
+struct PrestoType {
+  1: required string signature;
+}
+
+struct Block {
+  1: required binary data;
+}
+
+struct JdbcTransactionHandle {
+  1: binary uuid;
+}
+
+struct JdbcOutputTableHandle {
+  1: string connectorId;
+  2: string catalogName;
+  3: string schemaName;
+  4: string tableName;
+  5: list<string> columnNames;
+  6: list<PrestoType> columnTypes;
+  7: string temporaryTableName;
+}
+
+struct JdbcTypeHandle {
+  1: i32 jdbcType;
+  2: string jdbcTypeName;
+  3: i32 columnSize;
+  4: i32 decimalDigits;
+}
+
+struct SchemaTableName {
+  1: string schema;
+  2: string table;
+}
+
+struct JdbcThriftTupleDomain {
+  1: optional list<JdbcThriftColumnDomain> columnDomains;
+}
+
+struct EquatableValueSet {
+  1: PrestoType type;
+  2: bool whiteList;
+  3: set<ValueEntry> entries;
+}
+
+struct ValueEntry {
+  1: PrestoType type;
+  2: Block block;
+}
+
+struct SortedRangeSet {
+  1: PrestoType type;
+  2: list<Range> ranges;
+}
+
+struct AllOrNoneValueSet {
+  1: PrestoType type;
+  2: bool all;
+}
+
+struct JdbcExpression {
+  1: string expression;
+  2: list<ConstantExpression> boundConstantValues;
+}
+
+struct ConstantExpression {
+  1: Block valueBlock;
+  2: PrestoType type;
+}
+
+struct JdbcColumnHandle {
+  1: string connectorId;
+  2: string columnName;
+  3: JdbcTypeHandle jdbcTypeHandle;
+  4: PrestoType columnType;
+  5: bool nullable;
+  6: optional string comment;
+}
+
+struct JdbcTableHandle {
+  1: string connectorId;
+  2: SchemaTableName schemaTableName;
+  3: string catalogName;
+  4: string schemaName;
+  5: string tableName;
+}
+
+struct JdbcTableLayoutHandle {
+  1: JdbcTableHandle table;
+  2: JdbcThriftTupleDomain tupleDomain;
+  3: optional JdbcExpression additionalPredicate;
+  4: string layoutString;
+}
+
+struct JdbcSplit {
+  1: string connectorId;
+  2: string catalogName;
+  3: string schemaName;
+  4: string tableName;
+  5: JdbcThriftTupleDomain tupleDomain;
+  6: optional JdbcExpression additionalPredicate;
+}
+
+union ThriftValueSet {
+  1: EquatableValueSet equatableValueSet;
+  2: SortedRangeSet sortedRangeSet;
+  3: AllOrNoneValueSet allOrNoneValueSet;
+}
+
+struct Marker {
+  1: PrestoType type;
+  2: optional Block valueBlock;
+  3: Bound bound;
+}
+
+struct Domain {
+  1: ThriftValueSet values;
+  2: bool nullAllowed;
+}
+
+struct Range {
+  1: Marker low;
+  2: Marker high;
+}
+
+struct JdbcThriftColumnDomain {
+  1: JdbcColumnHandle column;
+  2: Domain domain;
+}

--- a/presto-native-execution/presto_cpp/main/thrift/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/thrift/tests/CMakeLists.txt
@@ -10,7 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(thrift_io_test ThriftIOTest.cpp)
+add_executable(thrift_io_test ThriftIOTest.cpp JdbcThriftToJsonTest.cpp)
+target_compile_definitions(
+  thrift_io_test
+  PRIVATE
+    PRESTO_JDBC_THRIFT_FIXTURES="${CMAKE_CURRENT_SOURCE_DIR}/../../../../../presto-base-jdbc/src/test/resources/jdbc-thrift.json"
+)
 
 add_test(NAME thrift_io_test COMMAND thrift_io_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -22,6 +27,8 @@ target_include_directories(
 target_link_libraries(
   thrift_io_test
   presto_thrift_extra
+  presto_jdbc_thrift
+  presto_protocol
   presto_thrift-cpp2
   presto_native-cpp2
   ${RE2}

--- a/presto-native-execution/presto_cpp/main/thrift/tests/JdbcThriftToJsonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/thrift/tests/JdbcThriftToJsonTest.cpp
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <fstream>
+#include "presto_cpp/main/thrift/ProtocolToThrift.h"
+#include "presto_cpp/main/thrift/ThriftIO.h"
+#include "presto_cpp/presto_protocol/connector/arrow_federation/ArrowFederationConnectorProtocol.h"
+
+using namespace facebook::presto::protocol;
+using namespace facebook::presto::protocol::arrow_federation;
+
+namespace {
+namespace thrift = facebook::presto::thrift;
+
+template <typename Base, typename Concrete>
+json decodeHandle(
+    const json& envelope,
+    const std::string& bytes,
+    const std::string Concrete::* member) {
+  std::shared_ptr<Base> handle;
+  from_json(envelope, handle);
+  auto concrete = std::dynamic_pointer_cast<Concrete>(handle);
+  EXPECT_NE(concrete, nullptr);
+  if (!concrete) {
+    return nullptr;
+  }
+  auto decoded = json::parse(folly::base64Decode(concrete.get()->*member));
+
+  std::shared_ptr<Base> direct;
+  getConnectorProtocol("mysql").deserialize(bytes, direct);
+  auto directConcrete = std::dynamic_pointer_cast<Concrete>(direct);
+  EXPECT_NE(directConcrete, nullptr);
+  if (!directConcrete) {
+    return nullptr;
+  }
+  EXPECT_EQ(concrete.get()->*member, directConcrete.get()->*member);
+  auto legacyJson = decoded;
+  legacyJson["@type"] = "mysql";
+  std::shared_ptr<Base> legacy;
+  from_json(legacyJson, legacy);
+  auto legacyConcrete = std::dynamic_pointer_cast<Concrete>(legacy);
+  EXPECT_NE(legacyConcrete, nullptr);
+  if (legacyConcrete) {
+    EXPECT_EQ(
+        json::parse(folly::base64Decode(legacyConcrete.get()->*member)),
+        legacyJson);
+  }
+  return decoded;
+}
+
+template <typename Thrift, typename Base, typename Concrete>
+void checkThriftEnvelope(
+    const json& fixture,
+    const std::string Concrete::* member) {
+  Thrift envelope;
+  envelope.connectorId() = "mysql";
+  envelope.customSerializedValue() =
+      folly::base64Decode(fixture.at("thrift").get<std::string>());
+  auto decodedEnvelope = std::make_shared<Thrift>();
+  thriftRead(thriftWrite(envelope), decodedEnvelope);
+  std::shared_ptr<Base> handle;
+  thrift::fromThrift(*decodedEnvelope, handle);
+  auto concrete = std::dynamic_pointer_cast<Concrete>(handle);
+  ASSERT_NE(concrete, nullptr);
+  EXPECT_EQ(
+      json::parse(folly::base64Decode(concrete.get()->*member)),
+      fixture.at("json"));
+}
+}
+
+class JdbcThriftToJsonTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    registerConnectorProtocol(
+        "mysql", std::make_unique<JdbcArrowFederationConnectorProtocol>());
+  }
+
+  void TearDown() override {
+    unregisterConnectorProtocol("mysql");
+  }
+};
+
+TEST_F(JdbcThriftToJsonTest, javaWireFixtures) {
+  std::ifstream input(PRESTO_JDBC_THRIFT_FIXTURES);
+  ASSERT_TRUE(input.is_open());
+  json fixtures;
+  input >> fixtures;
+  ASSERT_FALSE(fixtures.empty());
+  for (const auto& fixture : fixtures) {
+    const std::string kind = fixture.at("kind");
+    SCOPED_TRACE(kind + ": " + fixture.at("json").dump());
+    const std::string bytes =
+        folly::base64Decode(fixture.at("thrift").get<std::string>());
+    const json envelope = {
+        {"@type", "mysql"}, {"customSerializedValue", fixture.at("thrift")}};
+    json decoded;
+    if (kind == "column") {
+      decoded = decodeHandle<ColumnHandle, ArrowFederationColumnHandle>(
+          envelope, bytes, &ArrowFederationColumnHandle::columnHandleBytes);
+    } else if (kind == "table") {
+      decoded = decodeHandle<ConnectorTableHandle, ArrowFederationTableHandle>(
+          envelope, bytes, &ArrowFederationTableHandle::tableHandleBytes);
+    } else if (kind == "transaction") {
+      decoded = decodeHandle<
+          ConnectorTransactionHandle,
+          ArrowFederationTransactionHandle>(
+          envelope,
+          bytes,
+          &ArrowFederationTransactionHandle::transactionHandleBytes);
+    } else if (kind == "layout") {
+      decoded = decodeHandle<
+          ConnectorTableLayoutHandle,
+          ArrowFederationTableLayoutHandle>(
+          envelope,
+          bytes,
+          &ArrowFederationTableLayoutHandle::tableLayoutHandleBytes);
+    } else if (kind == "split") {
+      decoded = decodeHandle<ConnectorSplit, ArrowFederationSplit>(
+          envelope, bytes, &ArrowFederationSplit::splitBytes);
+    } else {
+      FAIL() << "Unknown fixture kind: " << kind;
+    }
+    EXPECT_EQ(decoded, fixture.at("json"));
+    if (kind == "split") {
+      checkThriftEnvelope<
+          thrift::ConnectorSplit,
+          ConnectorSplit,
+          ArrowFederationSplit>(fixture, &ArrowFederationSplit::splitBytes);
+    } else if (kind == "transaction") {
+      checkThriftEnvelope<
+          thrift::ConnectorTransactionHandle,
+          ConnectorTransactionHandle,
+          ArrowFederationTransactionHandle>(
+          fixture, &ArrowFederationTransactionHandle::transactionHandleBytes);
+    } else if (kind == "table") {
+      checkThriftEnvelope<
+          thrift::ConnectorTableHandle,
+          ConnectorTableHandle,
+          ArrowFederationTableHandle>(
+          fixture, &ArrowFederationTableHandle::tableHandleBytes);
+    } else if (kind == "layout") {
+      checkThriftEnvelope<
+          thrift::ConnectorTableLayoutHandle,
+          ConnectorTableLayoutHandle,
+          ArrowFederationTableLayoutHandle>(
+          fixture, &ArrowFederationTableLayoutHandle::tableLayoutHandleBytes);
+    }
+  }
+}
+
+TEST_F(JdbcThriftToJsonTest, rejectsMalformedPayloads) {
+  EXPECT_THROW(jdbcSplitFromThrift("bad thrift"), std::exception);
+  EXPECT_THROW(
+      jdbcTransactionHandleFromThrift(std::string(1, '\0')),
+      std::invalid_argument);
+}

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_federation/ArrowFederationConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_federation/ArrowFederationConnectorProtocol.h
@@ -12,10 +12,43 @@
  * limitations under the License.
  */
 #pragma once
+#include <folly/base64.h>
+#include "presto_cpp/main/thrift/JdbcThriftToJson.h"
 #include "presto_cpp/presto_protocol/connector/arrow_federation/presto_protocol_arrow_federation.h"
 #include "presto_cpp/presto_protocol/core/ConnectorProtocol.h"
 
 namespace facebook::presto::protocol::arrow_federation {
+template <typename Protocol, json (*Decode)(const std::string&)>
+struct JdbcFederationHandle : Protocol {
+  static std::shared_ptr<JdbcFederationHandle> deserialize(
+      const std::string& data,
+      std::shared_ptr<JdbcFederationHandle>) {
+    auto result = std::make_shared<JdbcFederationHandle>();
+    from_json(Decode(data), static_cast<Protocol&>(*result));
+    return result;
+  }
+};
+
+using JdbcArrowFederationConnectorProtocol = ConnectorProtocolTemplate<
+    JdbcFederationHandle<ArrowFederationTableHandle, jdbcTableHandleFromThrift>,
+    JdbcFederationHandle<
+        ArrowFederationTableLayoutHandle,
+        jdbcTableLayoutHandleFromThrift>,
+    JdbcFederationHandle<
+        ArrowFederationColumnHandle,
+        jdbcColumnHandleFromThrift>,
+    UnsupportedOperation,
+    UnsupportedOperation,
+    JdbcFederationHandle<ArrowFederationSplit, jdbcSplitFromThrift>,
+    NotImplemented,
+    JdbcFederationHandle<
+        ArrowFederationTransactionHandle,
+        jdbcTransactionHandleFromThrift>,
+    NotImplemented,
+    UnsupportedOperation,
+    NotImplemented,
+    UnsupportedOperation>;
+
 using ArrowFederationConnectorProtocol = ConnectorProtocolTemplate<
     ArrowFederationTableHandle,
     ArrowFederationTableLayoutHandle,

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -76,6 +76,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -125,11 +126,13 @@ public class TestPrestoSparkHttpClient
     private static final int HTTP_STATUS_OK = 200;
     private static final String CONTENT_TYPE_JSON = "application/json";
     private ScheduledExecutorService scheduledExecutorService;
+    private ScheduledExecutorService responseExecutorService;
 
     @BeforeClass
     public void beforeClass()
     {
         scheduledExecutorService = newScheduledThreadPool(4);
+        responseExecutorService = newScheduledThreadPool(4);
     }
 
     @AfterClass(alwaysRun = true)
@@ -138,6 +141,37 @@ public class TestPrestoSparkHttpClient
         if (scheduledExecutorService != null) {
             scheduledExecutorService.shutdownNow();
             scheduledExecutorService = null;
+        }
+        if (responseExecutorService != null) {
+            responseExecutorService.shutdownNow();
+            responseExecutorService = null;
+        }
+    }
+
+    @Test
+    public void testResultGetWithBusyScheduler()
+            throws Exception
+    {
+        CountDownLatch started = new CountDownLatch(4);
+        CountDownLatch release = new CountDownLatch(1);
+        try {
+            for (int i = 0; i < 4; i++) {
+                scheduledExecutorService.submit(() -> {
+                    started.countDown();
+                    release.await();
+                    return null;
+                });
+            }
+            assertTrue(started.await(10, TimeUnit.SECONDS));
+            TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
+            PageBufferClient.PagesResponse response = createWorkerClient(taskId)
+                    .getResults(taskId, 0, new DataSize(32, MEGABYTE))
+                    .get(10, TimeUnit.SECONDS);
+            assertTrue(response.isClientComplete());
+            assertEquals(response.getTaskInstanceId(), taskId.toString());
+        }
+        finally {
+            release.countDown();
         }
     }
 
@@ -180,15 +214,15 @@ public class TestPrestoSparkHttpClient
     private PrestoSparkHttpTaskClient createWorkerClient(TaskId taskId)
     {
         return new PrestoSparkHttpTaskClient(
-                new TestingOkHttpClient(scheduledExecutorService,
+                new TestingOkHttpClient(responseExecutorService,
                         new TestingResponseManager(taskId.toString())),
                 BASE_URI,
                 TASK_INFO_JSON_CODEC,
                 PLAN_FRAGMENT_JSON_CODEC,
                 TASK_UPDATE_REQUEST_JSON_CODEC,
                 new Duration(1, TimeUnit.SECONDS),
-                scheduledExecutorService,
-                scheduledExecutorService,
+                responseExecutorService,
+                responseExecutorService,
                 new Duration(1, TimeUnit.SECONDS));
     }
 
@@ -201,8 +235,8 @@ public class TestPrestoSparkHttpClient
                 PLAN_FRAGMENT_JSON_CODEC,
                 TASK_UPDATE_REQUEST_JSON_CODEC,
                 new Duration(1, TimeUnit.SECONDS),
-                scheduledExecutorService,
-                scheduledExecutorService,
+                responseExecutorService,
+                responseExecutorService,
                 new Duration(1, TimeUnit.SECONDS))
         {
             @Override
@@ -222,8 +256,8 @@ public class TestPrestoSparkHttpClient
                 PLAN_FRAGMENT_JSON_CODEC,
                 TASK_UPDATE_REQUEST_JSON_CODEC,
                 new Duration(1, TimeUnit.SECONDS),
-                scheduledExecutorService,
-                scheduledExecutorService,
+                responseExecutorService,
+                responseExecutorService,
                 new Duration(1, TimeUnit.SECONDS));
     }
 
@@ -281,12 +315,12 @@ public class TestPrestoSparkHttpClient
             }
         };
 
-        createWorkerClient(new TestingOkHttpClient(scheduledExecutorService, responseManager)).deleteTask(taskId);
+        createWorkerClient(new TestingOkHttpClient(responseExecutorService, responseManager)).deleteTask(taskId);
 
         assertEquals(deleteTaskCount.get(), 1);
         assertNull(dropTaskOnDeleteParam.get());
 
-        createDropTaskOnDeleteWorkerClient(new TestingOkHttpClient(scheduledExecutorService, responseManager)).deleteTask(taskId);
+        createDropTaskOnDeleteWorkerClient(new TestingOkHttpClient(responseExecutorService, responseManager)).deleteTask(taskId);
 
         assertEquals(deleteTaskCount.get(), 2);
         assertEquals(dropTaskOnDeleteParam.get(), "true");
@@ -340,7 +374,7 @@ public class TestPrestoSparkHttpClient
     {
         TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(
-                new TestingOkHttpClient(scheduledExecutorService,
+                new TestingOkHttpClient(responseExecutorService,
                         new TestingResponseManager(taskId.toString(),
                                 new UnexpectedResponseTaskInfoRetryResponseManager())));
         assertThatThrownBy(() -> workerClient.updateTask(
@@ -361,7 +395,7 @@ public class TestPrestoSparkHttpClient
     {
         TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(
-                new TestingOkHttpClient(scheduledExecutorService,
+                new TestingOkHttpClient(responseExecutorService,
                         new TestingResponseManager(taskId.toString(),
                                 new FailureRetryTaskInfoResponseManager(2))));
         workerClient.updateTask(
@@ -382,7 +416,7 @@ public class TestPrestoSparkHttpClient
         ServerInfo expected = new ServerInfo(UNKNOWN, "test", true, false, Optional.of(Duration.valueOf("2m")));
 
         PrestoSparkHttpServerClient workerClient = new PrestoSparkHttpServerClient(
-                new TestingOkHttpClient(scheduledExecutorService, new TestingResponseManager(taskId.toString())),
+                new TestingOkHttpClient(responseExecutorService, new TestingResponseManager(taskId.toString())),
                 BASE_URI,
                 SERVER_INFO_JSON_CODEC);
         ListenableFuture<BaseResponse<ServerInfo>> future = workerClient.getServerInfo();
@@ -478,7 +512,7 @@ public class TestPrestoSparkHttpClient
         int numPages = 10;
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(
                 new TestingOkHttpClient(
-                        scheduledExecutorService,
+                        responseExecutorService,
                         new TestingResponseManager(taskId.toString(), new TestingResponseManager.TestingResultResponseManager()
                         {
                             private int requestCount;
@@ -595,7 +629,7 @@ public class TestPrestoSparkHttpClient
 
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(
                 new TestingOkHttpClient(
-                        scheduledExecutorService,
+                        responseExecutorService,
                         new TestingResponseManager(
                                 taskId.toString(),
                                 breakingLimitResponseManager)));
@@ -713,7 +747,7 @@ public class TestPrestoSparkHttpClient
 
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(
                 new TestingOkHttpClient(
-                        scheduledExecutorService,
+                        responseExecutorService,
                         new TestingResponseManager(taskId.toString(), timeoutResponseManager)));
         HttpNativeExecutionTaskResultFetcher taskResultFetcher = createResultFetcher(taskId,
                 workerClient);
@@ -740,7 +774,7 @@ public class TestPrestoSparkHttpClient
 
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(
                 new TestingOkHttpClient(
-                        scheduledExecutorService,
+                        responseExecutorService,
                         new TestingResponseManager(taskId.toString(),
                                 new TimeoutResponseManager(0, 10, 10))));
         HttpNativeExecutionTaskResultFetcher taskResultFetcher = createResultFetcher(taskId,
@@ -764,7 +798,7 @@ public class TestPrestoSparkHttpClient
         TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(
                 new TestingOkHttpClient(
-                        scheduledExecutorService,
+                        responseExecutorService,
                         new TestingResponseManager(taskId.toString(),
                                 new PrestoExceptionResponseManager())));
         Object monitor = new Object();
@@ -949,9 +983,9 @@ public class TestPrestoSparkHttpClient
         try {
             NativeExecutionTaskFactory taskFactory = new NativeExecutionTaskFactory(
                     new TestingOkHttpClient(
-                            scheduledExecutorService,
+                            responseExecutorService,
                             responseManager),
-                    scheduledExecutorService,
+                    responseExecutorService,
                     scheduledExecutorService,
                     TASK_INFO_JSON_CODEC,
                     PLAN_FRAGMENT_JSON_CODEC,
@@ -1004,8 +1038,8 @@ public class TestPrestoSparkHttpClient
                 new NativeExecutionNodeConfig(),
                 new NativeExecutionSystemConfig(ImmutableMap.of()));
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(
-                new TestingOkHttpClient(scheduledExecutorService, responseManager),
-                scheduledExecutorService,
+                new TestingOkHttpClient(responseExecutorService, responseManager),
+                responseExecutorService,
                 scheduledExecutorService,
                 SERVER_INFO_JSON_CODEC,
                 workerProperty,
@@ -1030,7 +1064,7 @@ public class TestPrestoSparkHttpClient
             TestingResponseManager testingResponseManager, Duration maxErrorDuration, Object lock)
     {
         PrestoSparkHttpTaskClient workerClient = createWorkerClient(
-                new TestingOkHttpClient(scheduledExecutorService, testingResponseManager));
+                new TestingOkHttpClient(responseExecutorService, testingResponseManager));
         return new HttpNativeExecutionTaskInfoFetcher(
                 taskId,
                 scheduledExecutorService,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi.relation;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.Utils;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.predicate.Primitives;
@@ -30,6 +33,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
+@ThriftStruct
 public final class ConstantExpression
         extends RowExpression
 {
@@ -52,6 +56,12 @@ public final class ConstantExpression
         this(Optional.empty(), value, type);
     }
 
+    @ThriftConstructor
+    public ConstantExpression(@ThriftField(2) Type type, @ThriftField(1) Block valueBlock)
+    {
+        this(Utils.blockToNativeValue(type, valueBlock), type);
+    }
+
     @JsonCreator
     public static ConstantExpression createConstantExpression(
             @JsonProperty("valueBlock") Block valueBlock,
@@ -61,6 +71,7 @@ public final class ConstantExpression
     }
 
     @JsonProperty
+    @ThriftField(1)
     public Block getValueBlock()
     {
         return Utils.nativeValueToBlock(type, value);
@@ -78,6 +89,7 @@ public final class ConstantExpression
 
     @Override
     @JsonProperty
+    @ThriftField(2)
     public Type getType()
     {
         return type;

--- a/presto-thrift-connector-toolkit/pom.xml
+++ b/presto-thrift-connector-toolkit/pom.xml
@@ -19,6 +19,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift.drift</groupId>
             <artifactId>drift-codec</artifactId>
         </dependency>

--- a/presto-thrift-connector-toolkit/src/main/java/com/facebook/presto/thrift/codec/BlockCodec.java
+++ b/presto-thrift-connector-toolkit/src/main/java/com/facebook/presto/thrift/codec/BlockCodec.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.thrift.codec;
+
+import com.facebook.drift.annotations.ThriftField.Requiredness;
+import com.facebook.drift.codec.CodecThriftType;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.internal.ProtocolReader;
+import com.facebook.drift.codec.internal.ProtocolWriter;
+import com.facebook.drift.codec.metadata.DefaultThriftTypeReference;
+import com.facebook.drift.codec.metadata.FieldKind;
+import com.facebook.drift.codec.metadata.ThriftFieldMetadata;
+import com.facebook.drift.codec.metadata.ThriftMethodInjection;
+import com.facebook.drift.codec.metadata.ThriftStructMetadata;
+import com.facebook.drift.codec.metadata.ThriftType;
+import com.facebook.drift.protocol.TProtocolException;
+import com.facebook.drift.protocol.TProtocolReader;
+import com.facebook.drift.protocol.TProtocolWriter;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.DynamicSliceOutput;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.util.Objects.requireNonNull;
+
+public final class BlockCodec
+        implements ThriftCodec<Block>
+{
+    private static final ThriftType THRIFT_TYPE = createThriftType();
+
+    private final BlockEncodingSerde blockEncodingSerde;
+
+    public BlockCodec(BlockEncodingSerde blockEncodingSerde)
+    {
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+    }
+
+    @Override
+    public ThriftType getType()
+    {
+        return THRIFT_TYPE;
+    }
+
+    @Override
+    public Block read(TProtocolReader protocol)
+            throws Exception
+    {
+        ProtocolReader reader = new ProtocolReader(protocol);
+        reader.readStructBegin();
+        ByteBuffer value = null;
+        while (reader.nextField()) {
+            if (reader.getFieldId() == 1) {
+                value = reader.readBinaryField();
+            }
+            else {
+                reader.skipFieldData();
+            }
+        }
+        reader.readStructEnd();
+        if (value == null) {
+            throw new TProtocolException("Missing data");
+        }
+        return blockEncodingSerde.readBlock(wrappedBuffer(value).getInput());
+    }
+
+    @Override
+    public void write(Block value, TProtocolWriter protocol)
+            throws Exception
+    {
+        DynamicSliceOutput output = new DynamicSliceOutput(1024);
+        blockEncodingSerde.writeBlock(output, value);
+        ProtocolWriter writer = new ProtocolWriter(protocol);
+        writer.writeStructBegin("Block");
+        writer.writeBinaryField("data", (short) 1, output.slice().toByteBuffer());
+        writer.writeStructEnd();
+    }
+
+    @CodecThriftType
+    public static ThriftType createThriftType()
+    {
+        try {
+            ThriftFieldMetadata field = new ThriftFieldMetadata(
+                    (short) 1,
+                    false,
+                    false,
+                    Requiredness.REQUIRED,
+                    ImmutableMap.of(),
+                    new DefaultThriftTypeReference(ThriftType.BINARY),
+                    "data",
+                    FieldKind.THRIFT_FIELD,
+                    ImmutableList.of(),
+                    Optional.empty(),
+                    Optional.of(new ThriftMethodInjection(BlockCodec.class.getMethod("getType"), ImmutableList.of())),
+                    Optional.empty(),
+                    Optional.empty());
+            return ThriftType.struct(new ThriftStructMetadata(
+                    "Block",
+                    ImmutableMap.of(),
+                    Block.class,
+                    null,
+                    ThriftStructMetadata.MetadataType.STRUCT,
+                    Optional.empty(),
+                    ImmutableList.of(),
+                    ImmutableList.of(field),
+                    Optional.empty(),
+                    ImmutableList.of()));
+        }
+        catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/presto-thrift-connector-toolkit/src/main/java/com/facebook/presto/thrift/codec/ThriftCodecProvider.java
+++ b/presto-thrift-connector-toolkit/src/main/java/com/facebook/presto/thrift/codec/ThriftCodecProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.thrift.codec;
 
 import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorCodec;
 import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
@@ -33,6 +34,7 @@ public class ThriftCodecProvider
         implements ConnectorCodecProvider
 {
     private final ThriftCodecManager thriftCodecManager;
+    private final Optional<ConnectorCodec<ColumnHandle>> columnHandleCodec;
     private final Optional<ConnectorCodec<ConnectorSplit>> connectorSplitCodec;
     private final Optional<ConnectorCodec<ConnectorTransactionHandle>> connectorTransactionHandleCodec;
     private final Optional<ConnectorCodec<ConnectorTableLayoutHandle>> connectorTableLayoutHandleCodec;
@@ -44,6 +46,7 @@ public class ThriftCodecProvider
     private ThriftCodecProvider(Builder builder)
     {
         this.thriftCodecManager = requireNonNull(builder.thriftCodecManager, "thriftCodecManager is null");
+        this.columnHandleCodec = builder.connectorColumnHandle.map(type -> new GenericThriftCodec<>(thriftCodecManager, type));
         this.connectorSplitCodec = builder.connectorSplitType.map(type -> new GenericThriftCodec<>(thriftCodecManager, type));
         this.connectorTransactionHandleCodec = builder.connectorTransactionHandle.map(type -> new GenericThriftCodec<>(thriftCodecManager, type));
         this.connectorTableLayoutHandleCodec = builder.connectorTableLayoutHandle.map(type -> new GenericThriftCodec<>(thriftCodecManager, type));
@@ -95,6 +98,12 @@ public class ThriftCodecProvider
         return connectorDeleteTableHandleCodec;
     }
 
+    @Override
+    public Optional<ConnectorCodec<ColumnHandle>> getColumnHandleCodec()
+    {
+        return columnHandleCodec;
+    }
+
     public ThriftCodecManager getThriftCodecManager()
     {
         return thriftCodecManager;
@@ -103,6 +112,7 @@ public class ThriftCodecProvider
     public static class Builder
     {
         private ThriftCodecManager thriftCodecManager;
+        private Optional<Type> connectorColumnHandle = Optional.empty();
         private Optional<Type> connectorSplitType = Optional.empty();
         private Optional<Type> connectorTransactionHandle = Optional.empty();
         private Optional<Type> connectorTableLayoutHandle = Optional.empty();
@@ -156,6 +166,12 @@ public class ThriftCodecProvider
         public Builder setConnectorDeleteTableHandle(Class<? extends ConnectorDeleteTableHandle> type)
         {
             this.connectorDeleteTableHandle = Optional.ofNullable(type);
+            return this;
+        }
+
+        public Builder setConnectorColumnHandle(Class<? extends ColumnHandle> type)
+        {
+            this.connectorColumnHandle = Optional.ofNullable(type);
             return this;
         }
 

--- a/presto-thrift-connector-toolkit/src/main/java/com/facebook/presto/thrift/codec/TypeCodec.java
+++ b/presto-thrift-connector-toolkit/src/main/java/com/facebook/presto/thrift/codec/TypeCodec.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.thrift.codec;
+
+import com.facebook.drift.annotations.ThriftField.Requiredness;
+import com.facebook.drift.codec.CodecThriftType;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.internal.ProtocolReader;
+import com.facebook.drift.codec.internal.ProtocolWriter;
+import com.facebook.drift.codec.metadata.DefaultThriftTypeReference;
+import com.facebook.drift.codec.metadata.FieldKind;
+import com.facebook.drift.codec.metadata.ThriftFieldMetadata;
+import com.facebook.drift.codec.metadata.ThriftMethodInjection;
+import com.facebook.drift.codec.metadata.ThriftStructMetadata;
+import com.facebook.drift.codec.metadata.ThriftType;
+import com.facebook.drift.protocol.TProtocolException;
+import com.facebook.drift.protocol.TProtocolReader;
+import com.facebook.drift.protocol.TProtocolWriter;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.util.Objects.requireNonNull;
+
+public final class TypeCodec
+        implements ThriftCodec<Type>
+{
+    private static final ThriftType THRIFT_TYPE = createThriftType();
+
+    private final TypeManager typeManager;
+
+    public TypeCodec(TypeManager typeManager)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    public ThriftType getType()
+    {
+        return THRIFT_TYPE;
+    }
+
+    @Override
+    public Type read(TProtocolReader protocol)
+            throws Exception
+    {
+        ProtocolReader reader = new ProtocolReader(protocol);
+        reader.readStructBegin();
+        String value = null;
+        while (reader.nextField()) {
+            if (reader.getFieldId() == 1) {
+                value = reader.readStringField();
+            }
+            else {
+                reader.skipFieldData();
+            }
+        }
+        reader.readStructEnd();
+        if (value == null) {
+            throw new TProtocolException("Missing signature");
+        }
+        Type type = typeManager.getType(parseTypeSignature(value));
+        if (type == null) {
+            throw new TProtocolException("Unknown type signature: " + value);
+        }
+        return type;
+    }
+
+    @Override
+    public void write(Type value, TProtocolWriter protocol)
+            throws Exception
+    {
+        ProtocolWriter writer = new ProtocolWriter(protocol);
+        writer.writeStructBegin("PrestoType");
+        writer.writeStringField("signature", (short) 1, value.getTypeSignature().toString());
+        writer.writeStructEnd();
+    }
+
+    @CodecThriftType
+    public static ThriftType createThriftType()
+    {
+        try {
+            ThriftFieldMetadata field = new ThriftFieldMetadata(
+                    (short) 1,
+                    false,
+                    false,
+                    Requiredness.REQUIRED,
+                    ImmutableMap.of(),
+                    new DefaultThriftTypeReference(ThriftType.STRING),
+                    "signature",
+                    FieldKind.THRIFT_FIELD,
+                    ImmutableList.of(),
+                    Optional.empty(),
+                    Optional.of(new ThriftMethodInjection(TypeCodec.class.getMethod("getType"), ImmutableList.of())),
+                    Optional.empty(),
+                    Optional.empty());
+            return ThriftType.struct(new ThriftStructMetadata(
+                    "PrestoType",
+                    ImmutableMap.of(),
+                    Type.class,
+                    null,
+                    ThriftStructMetadata.MetadataType.STRUCT,
+                    Optional.empty(),
+                    ImmutableList.of(),
+                    ImmutableList.of(field),
+                    Optional.empty(),
+                    ImmutableList.of()));
+        }
+        catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Add Thrift serialization for JDBC connector handles, splits, and predicates. Add native support through Arrow Federation.

## Motivation and Context
Allow Java and native workers read JDBC connector data in the Thrift format.


## Impact
This keeps JSON support.


## Test Plan
UTs

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

JDBC Connector Changes
* Added Thrift serialization support for JDBC connector metadata in Java and native execution.
```

## Summary by Sourcery

Enable JDBC connector metadata and execution handles to be serialized with Thrift for interoperability with Presto native execution.

New Features:
- Add Thrift serialization support for JDBC connector handles, splits, predicates, transactions, and table metadata.
- Introduce reusable codecs for Presto types and blocks through the thrift connector toolkit.
- Enable native execution to consume JDBC Thrift payloads for supported Arrow Flight federation connectors.

Bug Fixes:
- Prevent response handling in Presto Spark HTTP client tests from being blocked by a busy scheduling executor.

Enhancements:
- Add generated JDBC Thrift schemas and native C++ conversion support for interoperating with Java connector metadata.

Build:
- Configure JDBC Thrift IDL generation and package the generated schema as a Maven artifact.
- Add native build targets and dependencies for the JDBC Thrift library.

Tests:
- Add Java and native round-trip, schema compatibility, fixture interoperability, predicate, and malformed-payload tests for JDBC Thrift serialization.
- Expand JDBC connector factory coverage for codec availability with native execution enabled and disabled.