### PR TITLE
[native] Introduce firstTimeReceiveTaskUpdateMs in PrestoTask

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -769,7 +769,8 @@ void PrestoTask::updateTimeInfoLocked(
     taskRuntimeStats["endTime"].addValue(veloxTaskStats.endTimeMs);
   }
   taskRuntimeStats.insert({"nativeProcessCpuTime", fromNanos(processCpuTime_)});
-  taskRuntimeStats.insert({"taskCreationTime", fromNanos((createFinishTimeMs - createTimeMs) * 1'000'000)});
+  // Represents the time between receiving first taskUpdate and task creation time
+  taskRuntimeStats.insert({"taskCreationTime", fromNanos((createFinishTimeMs - firstTimeReceiveTaskUpdateMs) * 1'000'000)});
 }
 
 void PrestoTask::updateMemoryInfoLocked(

--- a/presto-native-execution/presto_cpp/main/PrestoTask.h
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.h
@@ -123,6 +123,8 @@ struct PrestoTask {
   uint64_t lastMemoryReservation{0};
   /// Time point (in ms) when the time we start task creating.
   uint64_t createTimeMs{0};
+  /// Time point (in ms) when the first time we receive task update.
+  uint64_t firstTimeReceiveTaskUpdateMs{0};
   /// Time point (in ms) when the time we finish task creating.
   uint64_t createFinishTimeMs{0};
   uint64_t startTimeMs{0};


### PR DESCRIPTION
PrestoTask can be created in different endpoints:
- getTaskStatus
- getTaskInfo
- receive task update etc

PrestoTask can be created in getTaskStatus, but it won't be able to create velox plan 
and start. It has to wait until receiving taskUpdate

Make taskCreationTime represent the time between receiving first taskUpdate and
task creation time


```
== NO RELEASE NOTE ==
```

