### PR TITLE
Presto add sqlText to accessControlContext

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlUtils.java
@@ -49,7 +49,8 @@ public class AccessControlUtils
                             sessionContext.getRuntimeStats(),
                             Optional.empty(),
                             Optional.ofNullable(sessionContext.getCatalog()),
-                            Optional.ofNullable(sessionContext.getSchema())),
+                            Optional.ofNullable(sessionContext.getSchema()),
+                            getSqlText(sessionContext, securityConfig)),
                     identity.getPrincipal(),
                     identity.getUser());
         }
@@ -77,10 +78,19 @@ public class AccessControlUtils
                             sessionContext.getRuntimeStats(),
                             Optional.empty(),
                             Optional.ofNullable(sessionContext.getCatalog()),
-                            Optional.ofNullable(sessionContext.getSchema())),
+                            Optional.ofNullable(sessionContext.getSchema()),
+                            getSqlText(sessionContext, securityConfig)),
                     identity.getUser(),
                     sessionContext.getCertificates());
             return Optional.of(authorizedIdentity);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> getSqlText(SessionContext sessionContext, SecurityConfig securityConfig)
+    {
+        if (securityConfig.isEnableSqlQueryTextContextField()) {
+            return Optional.of(sessionContext.getSqlText());
         }
         return Optional.empty();
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/server/SessionContext.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/SessionContext.java
@@ -50,6 +50,8 @@ public interface SessionContext
     @Nullable
     String getSchema();
 
+    String getSqlText();
+
     @Nullable
     String getSource();
 

--- a/presto-main-base/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/security/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig
     private List<AuthenticationType> authenticationTypes = ImmutableList.of();
     private boolean allowForwardedHttps;
     private boolean authorizedIdentitySelectionEnabled;
+    private boolean enableSqlQueryTextContextField;
 
     public enum AuthenticationType
     {
@@ -96,5 +97,18 @@ public class SecurityConfig
     public boolean isAuthorizedIdentitySelectionEnabled()
     {
         return authorizedIdentitySelectionEnabled;
+    }
+
+    @Config("permissions.enable-sql-query-text-context-field")
+    @ConfigDescription("Allow sql query text to be stored inside access control context")
+    public SecurityConfig setEnableSqlQueryTextContextField(boolean enableSqlQueryTextContextField)
+    {
+        this.enableSqlQueryTextContextField = enableSqlQueryTextContextField;
+        return this;
+    }
+
+    public boolean isEnableSqlQueryTextContextField()
+    {
+        return enableSqlQueryTextContextField;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/security/TestSecurityConfig.java
@@ -31,7 +31,8 @@ public class TestSecurityConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SecurityConfig.class)
                 .setAuthenticationTypes("")
                 .setAllowForwardedHttps(false)
-                .setAuthorizedIdentitySelectionEnabled(false));
+                .setAuthorizedIdentitySelectionEnabled(false)
+                .setEnableSqlQueryTextContextField(false));
     }
 
     @Test
@@ -41,12 +42,14 @@ public class TestSecurityConfig
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
                 .put("http-server.authentication.allow-forwarded-https", "true")
                 .put("permissions.authorized-identity-selection-enabled", "true")
+                .put("permissions.enable-sql-query-text-context-field", "true")
                 .build();
 
         SecurityConfig expected = new SecurityConfig()
                 .setAuthenticationTypes(ImmutableList.of(KERBEROS, PASSWORD))
                 .setAllowForwardedHttps(true)
-                .setAuthorizedIdentitySelectionEnabled(true);
+                .setAuthorizedIdentitySelectionEnabled(true)
+                .setEnableSqlQueryTextContextField(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -99,6 +99,8 @@ public final class HttpRequestSessionContext
     private final String catalog;
     private final String schema;
 
+    private final String sqlText;
+
     private final Identity identity;
     private final Optional<AuthorizedIdentity> authorizedIdentity;
     private final List<X509Certificate> certificates;
@@ -128,7 +130,7 @@ public final class HttpRequestSessionContext
 
     public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions)
     {
-        this(servletRequest, sqlParserOptions, NoopTracerProvider.NOOP_TRACER_PROVIDER, Optional.empty());
+        this(servletRequest, sqlParserOptions, NoopTracerProvider.NOOP_TRACER_PROVIDER, Optional.empty(), "");
     }
 
     /**
@@ -138,13 +140,16 @@ public final class HttpRequestSessionContext
      * @param sessionPropertyManager is used to provide with some default session values. In some scenarios we need
      * those default values even before session for a query is created. This is how we can get it at this
      * session context creation stage.
+     * @param sqlText query string
      * @throws WebApplicationException
      */
-    public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions, TracerProvider tracerProvider, Optional<SessionPropertyManager> sessionPropertyManager)
+    public HttpRequestSessionContext(HttpServletRequest servletRequest, SqlParserOptions sqlParserOptions, TracerProvider tracerProvider, Optional<SessionPropertyManager> sessionPropertyManager, String sqlText)
             throws WebApplicationException
     {
         catalog = trimEmptyToNull(servletRequest.getHeader(PRESTO_CATALOG));
         schema = trimEmptyToNull(servletRequest.getHeader(PRESTO_SCHEMA));
+        this.sqlText = requireNonNull(sqlText, "sqlText is null");
+
         assertRequest((catalog != null) || (schema == null), "Schema is set but catalog is not");
 
         String user = trimEmptyToNull(servletRequest.getHeader(PRESTO_USER));
@@ -429,6 +434,12 @@ public final class HttpRequestSessionContext
     public String getSchema()
     {
         return schema;
+    }
+
+    @Override
+    public String getSqlText()
+    {
+        return sqlText;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -251,7 +251,8 @@ public class QueuedStatementResource
                 servletRequest,
                 sqlParserOptions,
                 tracerProviderManager.getTracerProvider(),
-                Optional.of(sessionPropertyManager));
+                Optional.of(sessionPropertyManager),
+                statement);
         QueryId newQueryId = dispatchManager.createQueryId();
         Query query = new Query(
                 statement,
@@ -324,7 +325,8 @@ public class QueuedStatementResource
                 servletRequest,
                 sqlParserOptions,
                 tracerProviderManager.getTracerProvider(),
-                Optional.of(sessionPropertyManager));
+                Optional.of(sessionPropertyManager),
+                statement);
         Query attemptedQuery = new Query(statement, sessionContext, dispatchManager, executingQueryResponseProvider, 0, queryId, slug);
         Query query = queries.computeIfAbsent(queryId, unused -> attemptedQuery);
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -609,7 +609,8 @@ public class PrestoSparkQueryExecutionFactory
         SessionContext sessionContext = PrestoSparkSessionContext.createFromSessionInfo(
                 prestoSparkSession,
                 credentialsProviders,
-                authenticatorProviders);
+                authenticatorProviders,
+                sql);
 
         SessionBuilder sessionBuilder = sessionSupplier.createSessionBuilder(queryId, sessionContext, warningCollectorFactory);
         sessionPropertyDefaults.applyDefaultProperties(sessionBuilder, Optional.empty(), Optional.empty());

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionContext.java
@@ -43,6 +43,8 @@ public class PrestoSparkSessionContext
     private final String schema;
     private final String source;
 
+    private final String sqlText;
+
     private final String userAgent;
     private final String clientInfo;
     private final Set<String> clientTags;
@@ -57,7 +59,8 @@ public class PrestoSparkSessionContext
     public static PrestoSparkSessionContext createFromSessionInfo(
             PrestoSparkSession prestoSparkSession,
             Set<PrestoSparkCredentialsProvider> credentialsProviders,
-            Set<PrestoSparkAuthenticatorProvider> authenticatorProviders)
+            Set<PrestoSparkAuthenticatorProvider> authenticatorProviders,
+            String sqlQueryText)
     {
         ImmutableMap.Builder<String, String> extraCredentials = ImmutableMap.builder();
         extraCredentials.putAll(prestoSparkSession.getExtraCredentials());
@@ -78,6 +81,7 @@ public class PrestoSparkSessionContext
                 prestoSparkSession.getCatalog().orElse(null),
                 prestoSparkSession.getSchema().orElse(null),
                 prestoSparkSession.getSource().orElse(null),
+                sqlQueryText,
                 prestoSparkSession.getUserAgent().orElse(null),
                 prestoSparkSession.getClientInfo().orElse(null),
                 prestoSparkSession.getClientTags(),
@@ -93,6 +97,7 @@ public class PrestoSparkSessionContext
             String catalog,
             String schema,
             String source,
+            String sqlText,
             String userAgent,
             String clientInfo,
             Set<String> clientTags,
@@ -106,6 +111,7 @@ public class PrestoSparkSessionContext
         this.catalog = catalog;
         this.schema = schema;
         this.source = source;
+        this.sqlText = requireNonNull(sqlText, "sqlText is null");
         this.userAgent = userAgent;
         this.clientInfo = clientInfo;
         this.clientTags = ImmutableSet.copyOf(requireNonNull(clientTags, "clientTags is null"));
@@ -134,6 +140,12 @@ public class PrestoSparkSessionContext
     public String getSchema()
     {
         return schema;
+    }
+
+    @Override
+    public String getSqlText()
+    {
+        return sqlText;
     }
 
     @Nullable

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControlContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/AccessControlContext.java
@@ -35,6 +35,7 @@ public class AccessControlContext
     private final Optional<QueryType> queryType;
     private final Optional<String> catalog;
     private final Optional<String> schema;
+    private final Optional<String> sqlText;
 
     public AccessControlContext(
             QueryId queryId,
@@ -47,6 +48,30 @@ public class AccessControlContext
             Optional<String> catalog,
             Optional<String> schema)
     {
+        this(queryId,
+                clientInfo,
+                clientTags,
+                source,
+                warningCollector,
+                runtimeStats,
+                queryType,
+                catalog,
+                schema,
+                Optional.empty());
+    }
+
+    public AccessControlContext(
+            QueryId queryId,
+            Optional<String> clientInfo,
+            Set<String> clientTags,
+            Optional<String> source,
+            WarningCollector warningCollector,
+            RuntimeStats runtimeStats,
+            Optional<QueryType> queryType,
+            Optional<String> catalog,
+            Optional<String> schema,
+            Optional<String> sqlText)
+    {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
         this.clientTags = requireNonNull(clientTags, "clientTags is null");
@@ -56,6 +81,7 @@ public class AccessControlContext
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
+        this.sqlText = requireNonNull(sqlText, "sqlText is null");
     }
 
     public QueryId getQueryId()
@@ -103,10 +129,15 @@ public class AccessControlContext
         return schema;
     }
 
+    public Optional<String> getSqlText()
+    {
+        return sqlText;
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(queryId, clientInfo, clientTags, source, queryType, catalog, schema);
+        return Objects.hash(queryId, clientInfo, clientTags, source, queryType, catalog, schema, sqlText);
     }
 
     @Override
@@ -125,6 +156,7 @@ public class AccessControlContext
                 Objects.equals(this.source, other.source) &&
                 Objects.equals(this.queryType, other.queryType) &&
                 Objects.equals(this.catalog, other.catalog) &&
-                Objects.equals(this.schema, other.schema);
+                Objects.equals(this.schema, other.schema) &&
+                Objects.equals(this.sqlText, other.sqlText);
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestingSessionContext.java
@@ -61,6 +61,12 @@ public class TestingSessionContext
     }
 
     @Override
+    public String getSqlText()
+    {
+        return session.getAccessControlContext().getSqlText().orElse("");
+    }
+
+    @Override
     public String getSource()
     {
         return session.getSource().orElse(null);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Currently, sqlText is not accessible to AccessControlContext. This change allow the sqlText to be accessible from the system access control APIs called within AccessControlUtils.java

Differential Revision: D82132353

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
sqlText is currently inaccessible from within system access control APIs, such as selectAuthorizedIdentity and checkCanSetUser

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
- Add sqlText to SessionContext implementations
- Add sqlText to AccessControlContext, which is gated behind an opt-in config feature

## Test Plan
<!---Please fill in how you tested your change-->
AccessControlUtils is able to access sqlText in the tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== RELEASE NOTES ==
General Changes
* Add sqlText to SessionContext to be used by system access control APIs 
```




