### PR TITLE
Fix aggregate function builtin special functions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -493,6 +493,12 @@ public class FunctionAndTypeManager
         }
     }
 
+    @VisibleForTesting
+    public void registerWorkerAggregateFunctions(List<? extends SqlFunction> aggregateFunctions)
+    {
+        builtInWorkerFunctionNamespaceManager.registerAggregateFunctions(aggregateFunctions);
+    }
+
     public void registerPluginFunctions(List<? extends SqlFunction> functions)
     {
         builtInPluginFunctionNamespaceManager.registerBuiltInSpecialFunctions(functions);
@@ -691,6 +697,13 @@ public class FunctionAndTypeManager
 
     public AggregationFunctionImplementation getAggregateFunctionImplementation(FunctionHandle functionHandle)
     {
+        if (isBuiltInPluginFunctionHandle(functionHandle)) {
+            return builtInPluginFunctionNamespaceManager.getAggregateFunctionImplementation(functionHandle, this);
+        }
+        if (isBuiltInWorkerFunctionHandle(functionHandle)) {
+            return builtInWorkerFunctionNamespaceManager.getAggregateFunctionImplementation(functionHandle, this);
+        }
+
         Optional<FunctionNamespaceManager<?>> functionNamespaceManager = getServingFunctionNamespaceManager(functionHandle.getCatalogSchemaName());
         checkArgument(functionNamespaceManager.isPresent(), "Cannot find function namespace for '%s'", functionHandle.getCatalogSchemaName());
         return functionNamespaceManager.get().getAggregateFunctionImplementation(functionHandle, this);

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -72,6 +72,7 @@ import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.split.PageSourceManager;
@@ -541,6 +542,11 @@ public class TestingPrestoServer
     public void installPlugin(Plugin plugin)
     {
         pluginManager.installPlugin(plugin);
+    }
+
+    public void registerWorkerAggregateFunctions(List<? extends SqlFunction> aggregateFunctions)
+    {
+        functionAndTypeManager.registerWorkerAggregateFunctions(aggregateFunctions);
     }
 
     public void installCoordinatorPlugin(CoordinatorPlugin plugin)

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -130,6 +130,18 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-function-namespace-managers-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-built-in-worker-function-tools</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tpcds</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
@@ -998,6 +999,16 @@ public class DistributedQueryRunner
             server.installPlugin(plugin);
         }
         log.info("Installed plugin %s in %s", plugin.getClass().getSimpleName(), nanosSince(start).convertToMostSuccinctTimeUnit());
+    }
+
+    public void registerWorkerAggregateFunctions(List<? extends SqlFunction> aggregateFunctions)
+    {
+        for (TestingPrestoServer server : servers) {
+            if (!server.isCoordinator()) {
+                continue;
+            }
+            server.registerWorkerAggregateFunctions(aggregateFunctions);
+        }
     }
 
     private void installCoordinatorPlugin(CoordinatorPlugin plugin, boolean coordinatorOnly)


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Currently, builtInWorkerFunctionNamespaceManager and builtInPluginFunctionNamespaceManager do not support aggregate functions. They only support scalar functions. This PR will add support for those functions that are registered in these namespace managers.

For the worker namespace manager, the functions can be pulled in from native sidecar. For the plugin namespace manager, the functions can be pulled in the Plugin#getSqlInvokedFunctions.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

Add support for aggregate functions in from these namespace managers.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No impact on existing APIs

## Test Plan
<!---Please fill in how you tested your change-->
Added unit test registering a dummy aggregate function and successfully accessing during Query plan generation.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```



