### PR TITLE
[native] Pass extra_credential into QueryConfig

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -180,7 +180,7 @@ void updateFromSystemConfigs(
 }
 } // namespace
 
-velox::core::QueryConfig toVeloxConfigs(
+std::unordered_map<std::string, std::string> toVeloxConfigs(
     const protocol::SessionRepresentation& session) {
   std::unordered_map<std::string, std::string> configs;
 
@@ -192,6 +192,23 @@ velox::core::QueryConfig toVeloxConfigs(
 
   // Finally apply special case configs.
   updateVeloxConfigsWithSpecialCases(configs);
+  return configs;
+}
+
+velox::core::QueryConfig toVeloxConfigs(
+  const protocol::SessionRepresentation& session,
+  const std::map<std::string, std::string>& extraCredentials) {
+  // Start with the session-based configuration
+  auto configs = toVeloxConfigs(session);
+
+  // If there are any extra credentials, add them all to the config
+  if (!extraCredentials.empty()) {
+    // Create new config map with all extra credentials added
+    configs.insert(
+        extraCredentials.begin(),
+        extraCredentials.end());
+  }
+  
   return velox::core::QueryConfig(configs);
 }
 

--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.h
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.h
@@ -25,10 +25,20 @@ class QueryConfig;
 
 namespace facebook::presto {
 
-/// Translates Presto configs to Velox 'QueryConfig'. Presto query session
-/// properties take precedence over Presto system config properties.
-velox::core::QueryConfig toVeloxConfigs(
+/// Translates Presto configs to Velox 'QueryConfig' config map. Presto query 
+/// session properties take precedence over Presto system config properties.
+std::unordered_map<std::string, std::string> toVeloxConfigs(
     const protocol::SessionRepresentation& session);
+
+/// Translates Presto configs to Velox 'QueryConfig' config map. It is the 
+/// temporary overload that builds a QueryConfig from session properties and
+/// extraCredentials, including all extraCredentials so they can be consumed by 
+/// UDFs and connectors.
+/// This implementation is a temporary solution until a more unified
+/// configuration mechanism (TokenProvider) is available.
+velox::core::QueryConfig toVeloxConfigs(
+  const protocol::SessionRepresentation& session,
+  const std::map<std::string, std::string>& extraCredentials);
 
 std::unordered_map<std::string, std::shared_ptr<velox::config::ConfigBase>>
 toConnectorConfigs(const protocol::TaskUpdateRequest& taskUpdateRequest);

--- a/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
+++ b/presto-native-execution/presto_cpp/main/QueryContextManager.cpp
@@ -45,7 +45,7 @@ QueryContextManager::findOrCreateQueryCtx(
     const protocol::TaskUpdateRequest& taskUpdateRequest) {
   return findOrCreateQueryCtx(
       taskId,
-      toVeloxConfigs(taskUpdateRequest.session),
+      toVeloxConfigs(taskUpdateRequest.session, taskUpdateRequest.extraCredentials),
       toConnectorConfigs(taskUpdateRequest));
 }
 


### PR DESCRIPTION
## Description
Some UDFs need to access credentials for authorization.
Pass extra_credential into QueryConfig to support credentials access in both VectorFunction and SimpleFunction.

Add the temporary overload that builds a QueryConfig from session properties and extraCredentials, including all extraCredentials so they can be consumed by UDFs and connectors.
This implementation is a temporary solution until a more unified configuration mechanism (TokenProvider) is available.

## Motivation and Context

## Impact

## Test Plan
Tested on verifier clusters

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```