### PR TITLE
[pos] Fix array function signature related tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeArrayFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeArrayFunctionQueries.java
@@ -14,9 +14,9 @@
 package com.facebook.presto.spark;
 
 import com.facebook.presto.nativeworker.AbstractTestNativeArrayFunctionQueries;
+import com.facebook.presto.scalar.sql.SqlInvokedFunctionsPlugin;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
-import org.testng.annotations.Ignore;
 
 public class TestPrestoSparkNativeArrayFunctionQueries
         extends AbstractTestNativeArrayFunctionQueries
@@ -24,18 +24,21 @@ public class TestPrestoSparkNativeArrayFunctionQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
+        QueryRunner queryRunner = PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
+
+        // Install plugins needed for extra array functions.
+        queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
+        return queryRunner;
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
-    }
+        QueryRunner queryRunner = PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
 
-    // Caused by: com.facebook.presto.sql.analyzer.SemanticException: line 1:32: Function array_sort_desc not registered
-    @Override
-    @Ignore
-    public void testArraySort() {}
+        // Install plugins needed for extra array functions.
+        queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
+        return queryRunner;
+    }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spark;
 import com.facebook.airlift.log.Level;
 import com.facebook.airlift.log.Logging;
 import com.facebook.presto.nativeworker.AbstractTestNativeGeneralQueries;
+import com.facebook.presto.scalar.sql.SqlInvokedFunctionsPlugin;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import org.testng.annotations.Ignore;
@@ -31,14 +32,22 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
+        QueryRunner queryRunner = PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
+
+        // Install plugins needed for extra array functions.
+        queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
+        return queryRunner;
     }
 
     @Override
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+        QueryRunner queryRunner = PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
+
+        // Install plugins needed for extra array functions.
+        queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
+        return queryRunner;
     }
 
     @Override
@@ -107,18 +116,8 @@ public class TestPrestoSparkNativeGeneralQueries
     @Ignore
     public void testAnalyzeStatsOnDecimals() {}
 
-    //Caused by: com.facebook.presto.sql.analyzer.SemanticException: line 1:31: Function array_duplicates not registered
-    @Override
-    @Ignore
-    public void testArrayAndMapFunctions() {}
-
     // VeloxRuntimeError: it != connectors().end() Connector with ID 'hivecached' not registered
     @Override
     @Ignore
     public void testCatalogWithCacheEnabled() {}
-
-    // Caused by: com.facebook.presto.spi.PrestoException: Sampling function: key_sampling_percent not cannot be resolved
-    @Override
-    @Ignore
-    public void testKeyBasedSamplingInlined() {}
 }


### PR DESCRIPTION
## Description
Three tests in TestPrestoSparkNativeArrayFunctionQueries and TestPrestoSparkNativeGeneralQueries fail due to array function signature issues. The tests fail because these array functions are essentially defined in SqlInvokedFunctionsPlugin which is not installed for both query runners. Installing it makes the test pass.

```
== NO RELEASE NOTE ==
```

