### PR TITLE
chore(connector): Upgrade com.google.api-client version to 2.8.0

### DIFF
--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -15,9 +15,9 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <google.auth.library.version>1.33.1</google.auth.library.version>
+        <google.auth.library.version>1.39.1</google.auth.library.version>
         <google.auto.value.version>1.11.0</google.auto.value.version>
-        <google.http.client.version>1.46.3</google.http.client.version>
+        <google.http.client.version>2.0.0</google.http.client.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
@@ -26,7 +26,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>16.3.0</version>
+                <version>26.68.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>com.google.api-client</groupId>
                 <artifactId>google-api-client</artifactId>
-                <version>1.31.1</version>
+                <version>2.8.0</version>
             </dependency>
 
             <dependency>

--- a/presto-google-sheets/pom.xml
+++ b/presto-google-sheets/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
+        <dep.http-client.version>2.0.0</dep.http-client.version>
     </properties>
 
     <dependencies>
@@ -34,7 +35,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-sheets</artifactId>
-            <version>v4-rev516-1.23.0</version>
+            <version>v4-rev20250616-2.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -89,7 +90,7 @@
         <dependency>
             <groupId>com.google.oauth-client</groupId>
             <artifactId>google-oauth-client</artifactId>
-            <version>1.33.3</version>
+            <version>1.39.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.http-client</groupId>
@@ -116,7 +117,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
-            <version>1.27.0</version>
+            <version>${dep.http-client.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -128,7 +129,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
-            <version>1.27.0</version>
+            <version>${dep.http-client.version}</version>
         </dependency>
 
         <dependency>
@@ -145,7 +146,7 @@
         <dependency>
             <groupId>com.google.api-client</groupId>
             <artifactId>google-api-client</artifactId>
-            <version>1.27.0</version>
+            <version>2.8.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Upgraded com.google.api-client  version from 1.27.0 to 2.8.0
As part this change  upgraded com.google.apis:google-api-services-sheets to 4-rev20250616-2.0.0
com.google.http-client to 2.0.0

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade com.google.api:google-api-client version to 2.8.0 in response to the use of an outdated version.


