### PR TITLE
[pos] Fix connector caused test failures

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -141,7 +141,17 @@ public abstract class AbstractTestNativeGeneralQueries
                 .put("hive.pushdown-filter-enabled", "true")
                 .build();
 
-        getQueryRunner().createCatalog("hivecached", "hive", hiveProperties);
+        try {
+            getQueryRunner().createCatalog("hivecached", "hive", hiveProperties);
+        }
+        catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("A catalog already exists")) {
+                System.out.println("Catalog 'hivecached' already exists, skipping creation");
+            }
+            else {
+                throw e;
+            }
+        }
 
         Session actualSession = Session.builder(getSession())
                 .setCatalog("hivecached")

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeGeneralQueries.java
@@ -19,6 +19,7 @@ import com.facebook.presto.nativeworker.AbstractTestNativeGeneralQueries;
 import com.facebook.presto.scalar.sql.SqlInvokedFunctionsPlugin;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Ignore;
 
 import java.util.ArrayList;
@@ -32,7 +33,12 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        QueryRunner queryRunner = PrestoSparkNativeQueryRunnerUtils.createHiveRunner();
+        // Adding additional catalog needed in some tests in the suite.
+        QueryRunner queryRunner = PrestoSparkNativeQueryRunnerUtils.createHiveRunner(
+                ImmutableMap.of("hivecached",
+                        ImmutableMap.of("connector.name", "hive",
+                                "hive.storage-format", "DWRF",
+                                "hive.pushdown-filter-enabled", "true")));
 
         // Install plugins needed for extra array functions.
         queryRunner.installPlugin(new SqlInvokedFunctionsPlugin());
@@ -115,9 +121,4 @@ public class TestPrestoSparkNativeGeneralQueries
     @Override
     @Ignore
     public void testAnalyzeStatsOnDecimals() {}
-
-    // VeloxRuntimeError: it != connectors().end() Connector with ID 'hivecached' not registered
-    @Override
-    @Ignore
-    public void testCatalogWithCacheEnabled() {}
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spark;
 import com.facebook.presto.nativeworker.AbstractTestNativeTpchConnectorQueries;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
-import org.testng.annotations.Ignore;
 
 public class TestPrestoSparkNativeTpchConnectorQueries
         extends AbstractTestNativeTpchConnectorQueries
@@ -39,13 +38,4 @@ public class TestPrestoSparkNativeTpchConnectorQueries
     {
         super.testMissingTpchConnector(".*Catalog tpch does not exist*");
     }
-
-    @Override
-    @Ignore
-    public void testTpchTinyTables() {}
-
-    // VeloxRuntimeError: it != connectors().end() Connector with ID 'tpchstandard' not registered
-    @Override
-    @Ignore
-    public void testTpchDateFilter() {}
 }


### PR DESCRIPTION
## Description
Fixes 3 tests that were previously failing due to connector issues. Connectors for presto on spark native were not created correctly. Because presto on spark native query runner does not allow adding new catalogs after creation, the fix allows presto on spark native to be able to create query runners with multiple catalogs up-front. 

```
== NO RELEASE NOTE ==
```

