### PR TITLE
[pos] Add exception stack information to PrestoSparkFailure to facilitate debugging

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -236,12 +236,12 @@ public abstract class AbstractTestNativeAggregations
         // timestamp
         assertQuery("SELECT min(from_unixtime(orderkey)), max(from_unixtime(orderkey)) FROM lineitem");
         assertQueryFails("SELECT min(from_unixtime(orderkey), 2), max(from_unixtime(orderkey), 3) FROM lineitem",
-                ".*Aggregate function signature is not supported.*");
+                "(?s).*Aggregate function signature is not supported.*");
         // Commitdate is cast to date here since the original commitdate column read from lineitem in dwrf format is
         // of type char. The cast to date can be removed for Parquet which has date support.
         assertQuery("SELECT min(cast(commitdate as date)), max(cast(commitdate as date)) FROM lineitem");
         assertQueryFails("SELECT min(cast(commitdate as date), 2), max(cast(commitdate as date), 3) FROM lineitem",
-                ".*Aggregate function signature is not supported.*");
+                "(?s).*Aggregate function signature is not supported.*");
     }
 
     @Test(dataProvider = "exchangeEncodingProvider")
@@ -370,7 +370,7 @@ public abstract class AbstractTestNativeAggregations
         assertQuery(session, "SELECT count(distinct orderkey), count(distinct linenumber) FROM lineitem");
         assertQuery(session, "SELECT count(distinct orderkey), sum(distinct linenumber), array_sort(array_agg(distinct linenumber)) FROM lineitem");
         assertQueryFails(session, "SELECT count(distinct orderkey), array_agg(distinct linenumber ORDER BY linenumber) FROM lineitem",
-                ".*Aggregations over sorted unique values are not supported yet");
+                "(?s).*Aggregations over sorted unique values are not supported yet.*");
     }
 
     @Test(dataProvider = "exchangeEncodingProvider")

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeArrayFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeArrayFunctionQueries.java
@@ -40,9 +40,9 @@ public abstract class AbstractTestNativeArrayFunctionQueries
         assertQuery("SELECT try(repeat(orderkey, -2)) FROM lineitem");
         assertQuery("SELECT try(repeat(orderkey, 10001)) FROM lineitem");
         assertQueryFails("SELECT repeat(orderkey, -2) FROM lineitem",
-                ".*Count argument of repeat function must be greater than or equal to 0.*");
+                "(?s).*Count argument of repeat function must be greater than or equal to 0.*");
         assertQueryFails("SELECT repeat(orderkey, 10001) FROM lineitem",
-                ".*Count argument of repeat function must be less than or equal to 10000.*");
+                "(?s).*Count argument of repeat function must be less than or equal to 10000.*");
     }
 
     @Test
@@ -90,7 +90,7 @@ public abstract class AbstractTestNativeArrayFunctionQueries
         assertQuery("SELECT trim_array(quantities, 1) FROM orders_ex where cardinality(quantities) > 5");
         assertQuery("SELECT trim_array(quantities, 2) FROM orders_ex where cardinality(quantities) > 5");
         assertQuery("SELECT trim_array(quantities, 3) FROM orders_ex where cardinality(quantities) > 5");
-        assertQueryFails("SELECT trim_array(quantities, 3) FROM orders_ex where cardinality(quantities) = 2", ".*size must not exceed array cardinality.*");
+        assertQueryFails("SELECT trim_array(quantities, 3) FROM orders_ex where cardinality(quantities) = 2", "(?s).*size must not exceed array cardinality.*");
     }
 
     @Test

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeBitwiseFunctionQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeBitwiseFunctionQueries.java
@@ -34,10 +34,10 @@ public abstract class AbstractTestNativeBitwiseFunctionQueries
     {
         this.assertQuery("SELECT nationkey, bit_count(nationkey, 10) FROM nation ORDER BY 1");
         this.assertQueryFails("SELECT nationkey, bit_count(nationkey, 2) FROM nation ORDER BY 1",
-                ".*Number must be representable with the bits specified.*");
+                "(?s).*Number must be representable with the bits specified.*");
         this.assertQueryFails("SELECT nationkey, bit_count(nationkey, 1) FROM nation ORDER BY 1",
-                ".*Bits specified in bit_count must be between 2 and 64, got 1.*");
+                "(?s).*Bits specified in bit_count must be between 2 and 64, got 1.*");
         this.assertQueryFails("SELECT nationkey, bit_count(nationkey, 65) FROM nation ORDER BY 1",
-                ".*Bits specified in bit_count must be between 2 and 64, got 65.*");
+                "(?s).*Bits specified in bit_count must be between 2 and 64, got 65.*");
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -511,13 +511,13 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("SELECT cast(size as JSON), cast(partkey as JSON), cast(brand as JSON), cast(name as JSON) FROM part");
         assertQuery("SELECT cast(nationkey + 1e-2 as JSON), cast(array[suppkey, nationkey] as JSON), cast(map(array[name, address, phone], array[1.1, 2.2, 3.3]) as JSON), cast(row(name, suppkey) as JSON), cast(array[map(array[name, address], array[1, 2]), map(array[name, phone], array[3, 4])] as JSON), cast(map(array[name, address, phone], array[array[1e0, 2], array[3, 4], array[5, 6]]) as JSON), cast(map(array[suppkey], array[name]) as JSON), cast(row(array[name, address], array[], array[null], map(array[phone], array[null])) as JSON) from supplier");
         assertQuery("SELECT cast(orderdate as JSON) FROM orders");
-        assertQueryFails("SELECT cast(map(array[from_unixtime(suppkey)], array[1]) as JSON) from supplier", "Cannot cast .* to JSON");
+        assertQueryFails("SELECT cast(map(array[from_unixtime(suppkey)], array[1]) as JSON) from supplier", "(?s)Cannot cast .* to JSON.*");
 
         assertQuery("SELECT try_cast(regionkey = 2 as JSON) FROM nation");
         assertQuery("SELECT try_cast(size as JSON), try_cast(partkey as JSON), try_cast(brand as JSON), try_cast(name as JSON) FROM part");
         assertQuery("SELECT try_cast(nationkey + 1e-2 as JSON), try_cast(array[suppkey, nationkey] as JSON), try_cast(map(array[name, address, phone], array[1.1, 2.2, 3.3]) as JSON), try_cast(row(name, suppkey) as JSON), try_cast(array[map(array[name, address], array[1, 2]), map(array[name, phone], array[3, 4])] as JSON), try_cast(map(array[name, address, phone], array[array[1e0, 2], array[3, 4], array[5, 6]]) as JSON), try_cast(map(array[suppkey], array[name]) as JSON), try_cast(row(array[name, address], array[], array[null], map(array[phone], array[null])) as JSON) from supplier");
         assertQuery("SELECT try_cast(orderdate as JSON) FROM orders");
-        assertQueryFails("SELECT try_cast(map(array[from_unixtime(suppkey)], array[1]) as JSON) from supplier", "Cannot cast .* to JSON");
+        assertQueryFails("SELECT try_cast(map(array[from_unixtime(suppkey)], array[1]) as JSON) from supplier", "(?s)Cannot cast .* to JSON.*");
 
         // Cast from Json type.
         assertQuery("SELECT cast(json_parse(json_format(cast(array[nationkey, regionkey] as json))) as array(smallint)) FROM nation");
@@ -770,11 +770,11 @@ public abstract class AbstractTestNativeGeneralQueries
         // numeric limits
         assertQueryFails("SELECT n + m from (values (DECIMAL'99999999999999999999999999999999999999'," +
                         "CAST('1' as DECIMAL(2,0)))) t(n, m)",
-                ".*Decimal.*");
+                "(?s).*Decimal.*");
         assertQueryFails(
                 "SELECT n + m from (values (CAST('-99999999999999999999999999999999999999' as DECIMAL(38,0))," +
                         "CAST('-1' as DECIMAL(15,0)))) t(n,m)",
-                ".*Decimal.*");
+                "(?s).*Decimal.*");
 
         // Subtraction of long decimals.
         assertQuery(
@@ -793,7 +793,7 @@ public abstract class AbstractTestNativeGeneralQueries
         // Subtraction Overflow
         assertQueryFails(
                 "SELECT n - m from (values (DECIMAL'-99999999999999999999999999999999999999', decimal'1')) " +
-                        "t(n,m)", ".*Decimal.*");
+                        "t(n,m)", "(?s).*Decimal.*");
         // Multiplication.
         assertQuery("SELECT n * m from (values (DECIMAL'99999999999999999999', DECIMAL'-0.000003')," +
                 "(DECIMAL'-0.00000000000000001', DECIMAL'10000000000'),(DECIMAL'-12345678902345.124', DECIMAL'-0.275')," +
@@ -802,7 +802,7 @@ public abstract class AbstractTestNativeGeneralQueries
                 "(DECIMAL '-3.4', DECIMAL '-625'), (DECIMAL '-0.0004', DECIMAL '-0.0123')) t(n,m)");
         // Multiplication overflow.
         assertQueryFails("SELECT n*m from (values (DECIMAL'14621507953634074601941877663083790335', DECIMAL'10')) " +
-                "t(n,m)", ".*Decimal.*");
+                "t(n,m)", "(?s).*Decimal.*");
         // Division long decimals.
         assertQuery("SELECT n/m from(values " +
                 "(CAST('10000000000000000.00' as decimal(19, 2)), DECIMAL'30000000000000.00')," +
@@ -812,7 +812,7 @@ public abstract class AbstractTestNativeGeneralQueries
                 ") t(n, m)");
         // Divide by zero error.
         assertQueryFails("SELECT n/m from(values (DECIMAL'100', DECIMAL'0.0')) t(n,m)",
-                ".*Division by zero.*");
+                "(?s).*Division by zero.*");
 
         // Division short decimals.
         assertQuery("SELECT n/m from(values (DECIMAL'100', DECIMAL'299'),(DECIMAL'5.4', DECIMAL'-125')," +
@@ -826,7 +826,7 @@ public abstract class AbstractTestNativeGeneralQueries
 
         // Division overflow.
         assertQueryFails("SELECT n/m from(values (DECIMAL'99999999999999999999999999999999999999', DECIMAL'0.01'))" +
-                " t(n,m)", ".*Decimal.*");
+                " t(n,m)", "(?s).*Decimal.*");
     }
 
     @Test
@@ -1256,13 +1256,13 @@ public abstract class AbstractTestNativeGeneralQueries
     @Test(groups = {"no_json_reader"})
     public void testReadTableWithUnsupportedJsonFormat()
     {
-        assertQueryFails("SELECT * FROM nation_json", ".*ReaderFactory is not registered for format json.*");
+        assertQueryFails("SELECT * FROM nation_json", "(?s).*ReaderFactory is not registered for format json.*");
     }
 
     @Test(groups = {"no_textfile_reader"})
     public void testReadTableWithUnsupportedTextfileFormat()
     {
-        assertQueryFails("SELECT * FROM nation_text", ".*ReaderFactory is not registered for format text.*");
+        assertQueryFails("SELECT * FROM nation_text", "(?s).*ReaderFactory is not registered for format text.*");
     }
 
     @Test(groups = {"textfile_reader"})
@@ -1297,7 +1297,7 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery("SELECT name FROM nation WHERE regionkey = (SELECT regionkey FROM region WHERE regionkey < 0)");
 
         // Subquery returns more than one row.
-        assertQueryFails("SELECT name FROM nation WHERE regionkey = (SELECT regionkey FROM region)", ".*Expected single row of input. Received 5 rows.*");
+        assertQueryFails("SELECT name FROM nation WHERE regionkey = (SELECT regionkey FROM region)", "(?s).*Expected single row of input. Received 5 rows.*");
     }
 
     @Test
@@ -1814,7 +1814,7 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQueryFails(
                 "SELECT count(*) FROM orders o1 LEFT JOIN orders o2 " +
                         "ON NOT EXISTS(SELECT 1 FROM orders i WHERE o1.orderkey < o2.orderkey)",
-                "line .*: Correlated subquery in given context is not supported");
+                "(?s)line .*: Correlated subquery in given context is not supported.*");
 
         // subrelation
         assertQuery(
@@ -1941,7 +1941,7 @@ public abstract class AbstractTestNativeGeneralQueries
         assertQuery(format("SELECT CAST(CAST(c_uuid AS uuid) AS VARCHAR) FROM %s", tmpTableName));
 
         // Invalid cast on both Presto Java and Native.
-        assertQueryFails(format("SELECT CAST(CAST(c_uuid as uuid) AS INTEGER) FROM %s", tmpTableName), ".*Cannot cast uuid to integer.*");
+        assertQueryFails(format("SELECT CAST(CAST(c_uuid as uuid) AS INTEGER) FROM %s", tmpTableName), "(?s).*Cannot cast uuid to integer.*");
         // Cast from UUID->VARBINARY is valid.
         assertQuery(format("SELECT CAST(CAST(c_uuid AS uuid) AS VARBINARY) FROM %s", tmpTableName));
 
@@ -1985,7 +1985,7 @@ public abstract class AbstractTestNativeGeneralQueries
     {
         // Invalid UUID. Note: This evaluates on the co-ordinator. This is used in subsequent SQL.
         assertQueryFails("SELECT cast('0E984725-C51C-4BF4-9960-H1C80E27ABA0' AS uuid)",
-                "Cannot cast value to UUID: 0E984725-C51C-4BF4-9960-H1C80E27ABA0");
+                "(?s).*Cannot cast value to UUID: 0E984725-C51C-4BF4-9960-H1C80E27ABA0.*");
         assertQuery("SELECT try_cast('0E984725-C51C-4BF4-9960-H1C80E27ABA0' AS uuid)");
 
         String tmpTableName = generateRandomTableName();
@@ -1998,7 +1998,7 @@ public abstract class AbstractTestNativeGeneralQueries
                 "    ('0E984725-C51C-4BF4-9960-H1C80E27ABA0')" +
                 ") AS x (c_uuid)", tmpTableName));
         assertQueryFails(format("SELECT CAST(c_uuid AS uuid) FROM %s", tmpTableName),
-                ".*bad lexical cast: source type value could not be interpreted as target.*");
+                "(?s).*bad lexical cast: source type value could not be interpreted as target.*");
         assertQuery(format("SELECT try_cast(c_uuid AS uuid) FROM %s", tmpTableName));
         getQueryRunner().execute(format("DROP TABLE %s", tmpTableName));
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeSimpleQueries.java
@@ -101,7 +101,7 @@ public class TestPrestoSparkNativeSimpleQueries
     @Test
     public void testFailures()
     {
-        assertQueryFails("SELECT orderkey / 0 FROM orders", ".*division by zero.*");
+        assertQueryFails("SELECT orderkey / 0 FROM orders", "(?s).*division by zero.*");
     }
 
     /**
@@ -174,7 +174,7 @@ public class TestPrestoSparkNativeSimpleQueries
         assertQueryFails(
                 session,
                 query,
-                "Query exceeded per-node broadcast memory limit of 10B \\[Max serialized broadcast size: .*kB\\]");
+                "(?s).*Query exceeded per-node broadcast memory limit of 10B \\[Max serialized broadcast size: .*kB\\].*");
 
         Session expectedSession = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST")

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchConnectorQueries.java
@@ -37,7 +37,7 @@ public class TestPrestoSparkNativeTpchConnectorQueries
     @Override
     public void testMissingTpchConnector()
     {
-        super.testMissingTpchConnector(".*Catalog tpch does not exist*");
+        super.testMissingTpchConnector("(?s).*Catalog tpch does not exist.*");
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkFailureUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkFailureUtils.java
@@ -51,12 +51,21 @@ public class PrestoSparkFailureUtils
                 executionFailureInfo.getErrorCode(),
                 executionFailureInfo.getMessage(),
                 executionFailureInfo.getErrorCause());
+
+        StackTraceElement[] stackTrace = prestoSparkFailure.getStackTrace();
+        StringBuilder sb = new StringBuilder();
+        for (StackTraceElement element : stackTrace) {
+            sb.append("\tat ").append(element).append("\n");
+        }
+        String stackTraceString = sb.toString();
+
         return new PrestoSparkFailure(
-                prestoSparkFailure.getMessage(),
-                prestoSparkFailure.getCause(),
-                prestoSparkFailure.getType(),
-                prestoSparkFailure.getErrorCode(),
-                retryExecutionStrategies);
+            prestoSparkFailure.getMessage() + "\n" + stackTraceString,
+            prestoSparkFailure.getCause(),
+            prestoSparkFailure.getType(),
+            prestoSparkFailure.getErrorCode(),
+            prestoSparkFailure.getStackTrace(),
+            retryExecutionStrategies);
     }
 
     @Nullable
@@ -71,6 +80,7 @@ public class PrestoSparkFailureUtils
                 toPrestoSparkFailure(executionFailureInfo.getCause()),
                 executionFailureInfo.getType(),
                 executionFailureInfo.getErrorCode() == null ? "" : executionFailureInfo.getErrorCode().getName(),
+                executionFailureInfo.toFailure().getStackTrace(),
                 ImmutableList.of());
 
         for (ExecutionFailureInfo suppressed : executionFailureInfo.getSuppressed()) {

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkDynamicMemoryPoolTuning.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkDynamicMemoryPoolTuning.java
@@ -47,7 +47,7 @@ public class TestPrestoSparkDynamicMemoryPoolTuning
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                ".*Query exceeded per-node total memory limit.*");
+                "(?s).*Query exceeded per-node total memory limit.*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "100B")

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -754,7 +754,7 @@ public class TestPrestoSparkQueryRunner
     @Test
     public void testFailures()
     {
-        assertQueryFails("SELECT * FROM orders WHERE custkey / (orderkey - orderkey) = 0", "/ by zero");
+        assertQueryFails("SELECT * FROM orders WHERE custkey / (orderkey - orderkey) = 0", "(?s)/ by zero.*");
         assertQueryFails(
                 "CREATE TABLE hive.hive_test.hive_orders_test_failures AS " +
                         "(SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
@@ -763,7 +763,7 @@ public class TestPrestoSparkQueryRunner
                         "(SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
                         "FROM orders " +
                         "WHERE custkey / (orderkey - orderkey) = 0 )",
-                "/ by zero");
+                "(?s)/ by zero.*");
     }
 
     @Test
@@ -822,13 +822,13 @@ public class TestPrestoSparkQueryRunner
         Session queryMaxRunTimeLimitSession = Session.builder(getSession())
                 .setSystemProperty("query_max_run_time", "2s")
                 .build();
-        assertQueryFails(queryMaxRunTimeLimitSession, longRunningCrossJoin, "Query exceeded maximum time limit of 2.00s");
+        assertQueryFails(queryMaxRunTimeLimitSession, longRunningCrossJoin, "(?s)Query exceeded maximum time limit of 2.00s.*");
 
         Session queryMaxExecutionTimeLimitSession = Session.builder(getSession())
                 .setSystemProperty("query_max_run_time", "3s")
                 .setSystemProperty("query_max_execution_time", "2s")
                 .build();
-        assertQueryFails(queryMaxExecutionTimeLimitSession, longRunningCrossJoin, "Query exceeded maximum time limit of 2.00s");
+        assertQueryFails(queryMaxExecutionTimeLimitSession, longRunningCrossJoin, "(?s)Query exceeded maximum time limit of 2.00s.*");
 
         // Test whether waitTime is being considered while computing timeouts.
         // Expected run time for this query is ~30s. We will set `dummyServiceWaitTime` as 600s.
@@ -920,7 +920,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                "Query exceeded per-node broadcast memory limit of 1MB \\[Broadcast size: .*MB\\]");
+                "(?s)Query exceeded per-node broadcast memory limit of 1MB \\[Broadcast size: .*MB\\].*");
     }
 
     @Test
@@ -936,7 +936,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                "Query exceeded per-node broadcast memory limit of 1MB \\[Broadcast size: .*MB\\]");
+                "(?s)Query exceeded per-node broadcast memory limit of 1MB \\[Broadcast size: .*MB\\].*");
     }
 
     @Test
@@ -961,7 +961,7 @@ public class TestPrestoSparkQueryRunner
                 .build();
         assertQueryFails(session,
                 query,
-                "Number of stages in the query.* exceeds the allowed maximum.*");
+                "(?s)Number of stages in the query.* exceeds the allowed maximum.*");
     }
 
     @Test
@@ -985,7 +985,7 @@ public class TestPrestoSparkQueryRunner
                 .build();
         assertQueryFails(session,
                 query,
-                "Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
+                "(?s)Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
@@ -998,7 +998,7 @@ public class TestPrestoSparkQueryRunner
                 .build();
         assertQueryFails(session,
                 query,
-                "Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
+                "(?s)Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
@@ -1036,7 +1036,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                "Query exceeded per-node broadcast memory limit of 10B \\[Broadcast size: .*MB\\]");
+                "(?s)Query exceeded per-node broadcast memory limit of 10B \\[Broadcast size: .*MB\\].*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST")
@@ -1064,7 +1064,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                ".*Query exceeded per-node .* memory limit of 2MB.*");
+                "(?s).*Query exceeded per-node .* memory limit of 2MB.*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "2MB")
@@ -1093,7 +1093,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                ".*Query exceeded per-node .* memory limit of 2MB.*");
+                "(?s).*Query exceeded per-node .* memory limit of 2MB.*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "2MB")
@@ -1109,7 +1109,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                ".*Query exceeded per-node .* memory limit of 2MB.*");
+                "(?s).*Query exceeded per-node .* memory limit of 2MB.*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "2MB")
@@ -1166,7 +1166,7 @@ public class TestPrestoSparkQueryRunner
                         "FROM orders", 15000);
         assertQuery("select count(*) from hive.hive_test.hive_orders1", "select 15000");
         assertQuerySucceeds("DROP TABLE hive.hive_test.hive_orders1");
-        assertQueryFails("select count(*) from hive.hive_test.hive_orders1", ".*Table hive.hive_test.hive_orders1 does not exist");
+        assertQueryFails("select count(*) from hive.hive_test.hive_orders1", "(?s).*Table hive.hive_test.hive_orders1 does not exist.*");
     }
 
     @Test
@@ -1174,10 +1174,10 @@ public class TestPrestoSparkQueryRunner
     {
         assertQuerySucceeds("CREATE SCHEMA hive.hive_test_new");
         assertQuerySucceeds("CREATE TABLE  hive.hive_test_new.test (x bigint)");
-        assertQueryFails("DROP SCHEMA hive.hive_test_new", "Schema not empty: hive_test_new");
+        assertQueryFails("DROP SCHEMA hive.hive_test_new", "(?s)Schema not empty: hive_test_new.*");
         assertQuerySucceeds("DROP TABLE hive.hive_test_new.test");
         assertQuerySucceeds("ALTER SCHEMA hive.hive_test_new RENAME TO hive_test_new1");
-        assertQueryFails("DROP SCHEMA hive.hive_test_new", ".* Schema 'hive.hive_test_new' does not exist");
+        assertQueryFails("DROP SCHEMA hive.hive_test_new", "(?s).* Schema 'hive.hive_test_new' does not exist.*");
         assertQuerySucceeds("DROP SCHEMA hive.hive_test_new1");
     }
 
@@ -1195,7 +1195,7 @@ public class TestPrestoSparkQueryRunner
         MaterializedResult actual = computeActual("SHOW CREATE TABLE hive.hive_test.hive_orders_new");
         assertEquals(createTableSql, actual.getOnlyValue());
         assertQuerySucceeds("ALTER TABLE hive.hive_test.hive_orders_new RENAME TO hive.hive_test.hive_orders_new1");
-        assertQueryFails("DROP TABLE hive.hive_test.hive_orders_new", ".* Table 'hive.hive_test.hive_orders_new' does not exist");
+        assertQueryFails("DROP TABLE hive.hive_test.hive_orders_new", "(?s).* Table 'hive.hive_test.hive_orders_new' does not exist.*");
         assertQuerySucceeds("DROP TABLE hive.hive_test.hive_orders_new1");
     }
 
@@ -1307,8 +1307,8 @@ public class TestPrestoSparkQueryRunner
     {
         assertQuerySucceeds("CREATE TABLE test_add_column (a bigint COMMENT 'test comment AAA')");
         assertQuerySucceeds("ALTER TABLE test_add_column ADD COLUMN b bigint COMMENT 'test comment BBB'");
-        assertQueryFails("ALTER TABLE test_add_column ADD COLUMN a varchar", ".* Column 'a' already exists");
-        assertQueryFails("ALTER TABLE test_add_column ADD COLUMN c bad_type", ".* Unknown type 'bad_type' for column 'c'");
+        assertQueryFails("ALTER TABLE test_add_column ADD COLUMN a varchar", "(?s).* Column 'a' already exists.*");
+        assertQueryFails("ALTER TABLE test_add_column ADD COLUMN c bad_type", "(?s).* Unknown type 'bad_type' for column 'c'.*");
         assertQuery("SHOW COLUMNS FROM test_add_column", "VALUES ('a', 'bigint', '', 'test comment AAA', 19L, null, null), ('b', 'bigint', '', 'test comment BBB', 19L, null, null)");
         assertQuerySucceeds("DROP TABLE test_add_column");
     }
@@ -1327,8 +1327,8 @@ public class TestPrestoSparkQueryRunner
         assertUpdate(createTable, "SELECT count(*) FROM orders");
         assertQuerySucceeds("ALTER TABLE test_rename_column RENAME COLUMN orderkey TO new_orderkey");
         assertQuery("SELECT new_orderkey, orderstatus FROM test_rename_column", "SELECT orderkey, orderstatus FROM orders");
-        assertQueryFails("ALTER TABLE test_rename_column RENAME COLUMN \"$path\" TO test", ".* Cannot rename hidden column");
-        assertQueryFails("ALTER TABLE test_rename_column RENAME COLUMN orderstatus TO new_orderstatus", "Renaming partition columns is not supported");
+        assertQueryFails("ALTER TABLE test_rename_column RENAME COLUMN \"$path\" TO test", "(?s).* Cannot rename hidden column.*");
+        assertQueryFails("ALTER TABLE test_rename_column RENAME COLUMN orderstatus TO new_orderstatus", "(?s)Renaming partition columns is not supported.*");
         assertQuery("SELECT new_orderkey, orderstatus FROM test_rename_column", "SELECT orderkey, orderstatus FROM orders");
         assertQuerySucceeds("DROP TABLE test_rename_column");
     }
@@ -1336,7 +1336,7 @@ public class TestPrestoSparkQueryRunner
     @Test
     public void testDropColumn()
     {
-        assertQueryFails("DROP TABLE hive.hive_test.hive_orders_new", ".* Table 'hive.hive_test.hive_orders_new' does not exist");
+        assertQueryFails("DROP TABLE hive.hive_test.hive_orders_new", "(?s).* Table 'hive.hive_test.hive_orders_new' does not exist.*");
         String createTable = "" +
                 "CREATE TABLE test_drop_column\n" +
                 "WITH (\n" +
@@ -1348,10 +1348,10 @@ public class TestPrestoSparkQueryRunner
         assertUpdate(createTable, "SELECT count(*) FROM orders");
         assertQuery("SELECT orderkey, orderstatus FROM test_drop_column", "SELECT orderkey, orderstatus FROM orders");
 
-        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN \"$path\"", ".* Cannot drop hidden column");
-        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN orderstatus", "Cannot drop partition columns");
+        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN \"$path\"", "(?s).* Cannot drop hidden column.*");
+        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN orderstatus", "(?s)Cannot drop partition columns.*");
         assertQuerySucceeds("ALTER TABLE test_drop_column DROP COLUMN orderkey");
-        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN custkey", "Cannot drop the only non-partition column in a table");
+        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN custkey", "(?s)Cannot drop the only non-partition column in a table.*");
         assertQuery("SELECT * FROM test_drop_column", "SELECT custkey, orderstatus FROM orders");
 
         assertQuerySucceeds("DROP TABLE test_drop_column");
@@ -1409,7 +1409,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                "Query exceeded per-node broadcast memory limit of 10B \\[Broadcast size: .*MB\\]");
+                "(?s)Query exceeded per-node broadcast memory limit of 10B \\[Broadcast size: .*MB\\].*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST")
@@ -1441,7 +1441,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                ".*Query exceeded per-node .* memory limit of 2MB.*");
+                "(?s).*Query exceeded per-node .* memory limit of 2MB.*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(QUERY_MAX_MEMORY_PER_NODE, "2MB")
@@ -1480,7 +1480,7 @@ public class TestPrestoSparkQueryRunner
                 .build();
         assertQueryFails(session,
                 query,
-                "Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
+                "(?s)Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
 
         session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkFailure.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkFailure.java
@@ -22,13 +22,21 @@ public class PrestoSparkFailure
 {
     private final String type;
     private final String errorCode;
+    private final StackTraceElement[] stackTrace;
     private final List<ExecutionStrategy> retryExecutionStrategies;
 
-    public PrestoSparkFailure(String message, Throwable cause, String type, String errorCode, List<ExecutionStrategy> retryExecutionStrategies)
+    public PrestoSparkFailure(
+            String message,
+            Throwable cause,
+            String type,
+            String errorCode,
+            StackTraceElement[] stackTrace,
+            List<ExecutionStrategy> retryExecutionStrategies)
     {
         super(message, cause);
         this.type = requireNonNull(type, "type is null");
         this.errorCode = requireNonNull(errorCode, "errorCode is null");
+        this.stackTrace = requireNonNull(stackTrace, "stackTrace is null");
         this.retryExecutionStrategies = requireNonNull(retryExecutionStrategies, "retryExecutionStrategies is null");
     }
 
@@ -50,10 +58,15 @@ public class PrestoSparkFailure
     @Override
     public String toString()
     {
+        StringBuilder sb = new StringBuilder();
+        sb.append(type).append(":");
         String message = getMessage();
         if (message != null) {
-            return type + ": " + message;
+            sb.append(message);
         }
-        return type;
+        for (StackTraceElement element : stackTrace) {
+            sb.append(" ").append(element).append("\n");
+        }
+        return sb.toString();
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestJoinQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestJoinQueries.java
@@ -947,7 +947,7 @@ public abstract class AbstractTestJoinQueries
             for (String joinCondition : ImmutableList.of("x IN (VALUES 1)", "y in (VALUES 1)")) {
                 assertQueryFails(
                         queryTemplate.replace(joinType, condition.of(joinCondition)),
-                        ".*IN with subquery predicate in join condition is not supported");
+                        "(?s).*IN with subquery predicate in join condition is not supported.*");
             }
         }
 
@@ -990,7 +990,7 @@ public abstract class AbstractTestJoinQueries
                     queryTemplate.replace(
                             joinType,
                             condition.of("(x+y in (VALUES 4,5)) AND (x in (VALUES 4,5)) != (y in (VALUES 4,5))")),
-                    ".*IN with subquery predicate in join condition is not supported");
+                    "(?s).*IN with subquery predicate in join condition is not supported.*");
         }
     }
 
@@ -1014,7 +1014,7 @@ public abstract class AbstractTestJoinQueries
                 condition);
 
         queryTemplate.replaceAll(
-                (query) -> assertQueryFails(query, "line .*: .* is not supported"),
+                (query) -> assertQueryFails(query, "(?s)line .*: .* is not supported.*"),
                 ImmutableList.of(type.of("left"), type.of("right"), type.of("full")),
                 ImmutableList.of(
                         condition.of("EXISTS(SELECT 1 WHERE x = y)"),
@@ -2432,13 +2432,13 @@ public abstract class AbstractTestJoinQueries
 
         assertQueryFails(
                 "SELECT * FROM (VALUES array[2, 2]) a(x) LEFT OUTER JOIN LATERAL(VALUES x) ON true",
-                "line .*: LATERAL on other than the right side of CROSS JOIN is not supported");
+                "(?s)line .*: LATERAL on other than the right side of CROSS JOIN is not supported.*");
         assertQueryFails(
                 "SELECT * FROM (VALUES array[2, 2]) a(x) RIGHT OUTER JOIN LATERAL(VALUES x) ON true",
-                "line .*: LATERAL on other than the right side of CROSS JOIN is not supported");
+                "(?s)line .*: LATERAL on other than the right side of CROSS JOIN is not supported.*");
         assertQueryFails(
                 "SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN LATERAL(VALUES x) ON true",
-                "line .*: LATERAL on other than the right side of CROSS JOIN is not supported");
+                "(?s)line .*: LATERAL on other than the right side of CROSS JOIN is not supported.*");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestOrderByQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestOrderByQueries.java
@@ -79,7 +79,7 @@ public abstract class AbstractTestOrderByQueries
         assertQueryOrdered("SELECT -a AS a FROM (values (1,2),(3,2)) t(a,b) GROUP BY GROUPING SETS ((a), (a, b)) ORDER BY -a", "VALUES -1, -1, -3, -3");
         assertQueryOrdered("SELECT a AS foo FROM (values (1,2),(3,2)) t(a,b) GROUP BY GROUPING SETS ((a), (a, b)) HAVING b IS NOT NULL ORDER BY -a", "VALUES 3, 1");
         assertQueryOrdered("SELECT max(a) FROM (values (1,2),(3,2)) t(a,b) ORDER BY max(-a)", "VALUES 3");
-        assertQueryFails("SELECT max(a) AS a FROM (values (1,2)) t(a,b) GROUP BY b ORDER BY max(a+b)", ".*Invalid reference to output projection attribute from ORDER BY aggregation");
+        assertQueryFails("SELECT max(a) AS a FROM (values (1,2)) t(a,b) GROUP BY b ORDER BY max(a+b)", "(?s).*Invalid reference to output projection attribute from ORDER BY aggregation.*");
         assertQueryOrdered("SELECT -a AS a, a AS b FROM (VALUES 1, 2) t(a) GROUP BY t.a ORDER BY a", "VALUES (-2, 2), (-1, 1)");
         assertQueryOrdered("SELECT -a AS a, a AS b FROM (VALUES 1, 2) t(a) GROUP BY t.a ORDER BY t.a", "VALUES (-1, 1), (-2, 2)");
         assertQueryOrdered("SELECT -a AS a, a AS b FROM (VALUES 1, 2) t(a) GROUP BY a ORDER BY t.a", "VALUES (-1, 1), (-2, 2)");
@@ -90,15 +90,15 @@ public abstract class AbstractTestOrderByQueries
         assertQueryOrdered("SELECT DISTINCT -a AS b FROM (VALUES 1, 2) t(a) ORDER BY b", "VALUES -2, -1");
         assertQueryOrdered("SELECT DISTINCT -a AS b FROM (VALUES 1, 2) t(a) ORDER BY 1", "VALUES -2, -1");
         assertQueryOrdered("SELECT DISTINCT max(a) AS b FROM (values (1,2), (2,1)) t(a,b) GROUP BY b ORDER BY b", "VALUES 1, 2");
-        assertQueryFails("SELECT DISTINCT -a AS b FROM (VALUES (1, 2), (3, 4)) t(a, c) ORDER BY c", ".*For SELECT DISTINCT, ORDER BY expressions must appear in select list");
-        assertQueryFails("SELECT DISTINCT -a AS b FROM (VALUES (1, 2), (3, 4)) t(a, c) ORDER BY 2", ".*ORDER BY position 2 is not in select list");
+        assertQueryFails("SELECT DISTINCT -a AS b FROM (VALUES (1, 2), (3, 4)) t(a, c) ORDER BY c", "(?s).*For SELECT DISTINCT, ORDER BY expressions must appear in select list.*");
+        assertQueryFails("SELECT DISTINCT -a AS b FROM (VALUES (1, 2), (3, 4)) t(a, c) ORDER BY 2", "(?s).*ORDER BY position 2 is not in select list.*");
 
         // window
         assertQueryOrdered("SELECT a FROM (VALUES 1, 2) t(a) ORDER BY -row_number() OVER ()", "VALUES 2, 1");
         assertQueryOrdered("SELECT -a AS a, first_value(-a) OVER (ORDER BY a ROWS 0 PRECEDING) AS b FROM (VALUES 1, 2) t(a) ORDER BY first_value(a) OVER (ORDER BY a ROWS 0 PRECEDING)", "VALUES (-2, -2), (-1, -1)");
         assertQueryOrdered("SELECT -a AS a FROM (VALUES 1, 2) t(a) ORDER BY first_value(a+t.a*2) OVER (ORDER BY a ROWS 0 PRECEDING)", "VALUES -1, -2");
 
-        assertQueryFails("SELECT a, a* -1 AS a FROM (VALUES -1, 0, 2) t(a) ORDER BY a", ".*'a' is ambiguous");
+        assertQueryFails("SELECT a, a* -1 AS a FROM (VALUES -1, 0, 2) t(a) ORDER BY a", "(?s).*'a' is ambiguous.*");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -122,6 +122,7 @@ import static com.facebook.presto.tests.QueryTemplate.parameter;
 import static com.facebook.presto.tests.QueryTemplate.queryTemplate;
 import static com.facebook.presto.tests.StatefulSleepingSum.STATEFUL_SLEEPING_SUM;
 import static com.facebook.presto.tests.StructuralTestUtil.mapType;
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Iterables.transform;
@@ -183,14 +184,14 @@ public abstract class AbstractTestQueries
                     99.0,
                     false));
 
-    public static final String UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG = "line .*: Given correlated subquery is not supported";
+    public static final String UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG = "(?s)line .*: Given correlated subquery is not supported.*";
 
     private static final DateTimeFormatter ZONED_DATE_TIME_FORMAT = DateTimeFormatter.ofPattern(SqlTimestampWithTimeZone.JSON_FORMAT);
 
     @Test
     public void testParsingError()
     {
-        assertQueryFails("SELECT foo FROM", "line 1:16: mismatched input '<EOF>'. Expecting: .*");
+        assertQueryFails("SELECT foo FROM", "(?s)line 1:16: mismatched input '<EOF>'. Expecting: .*");
     }
 
     @Test
@@ -682,7 +683,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT a.col0, count(*) FROM (VALUES ROW(cast(ROW(1, 1) AS ROW(col0 integer, col1 integer)))) t(a)",
-                "line 1:8: 'a.col0' must be an aggregate expression or appear in GROUP BY clause");
+                "(?s)line 1:8: 'a.col0' must be an aggregate expression or appear in GROUP BY clause.*");
     }
 
     @Test
@@ -769,13 +770,13 @@ public abstract class AbstractTestQueries
 
         assertQueryFails(
                 "SELECT * FROM (VALUES array[2, 2]) a(x) LEFT OUTER JOIN UNNEST(x) ON true",
-                "line .*: UNNEST on other than the right side of CROSS JOIN is not supported");
+                "(?s)line .*: UNNEST on other than the right side of CROSS JOIN is not supported.*");
         assertQueryFails(
                 "SELECT * FROM (VALUES array[2, 2]) a(x) RIGHT OUTER JOIN UNNEST(x) ON true",
-                "line .*: UNNEST on other than the right side of CROSS JOIN is not supported");
+                "(?s)line .*: UNNEST on other than the right side of CROSS JOIN is not supported.*");
         assertQueryFails(
                 "SELECT * FROM (VALUES array[2, 2]) a(x) FULL OUTER JOIN UNNEST(x) ON true",
-                "line .*: UNNEST on other than the right side of CROSS JOIN is not supported");
+                "(?s)line .*: UNNEST on other than the right side of CROSS JOIN is not supported.*");
     }
 
     @Test
@@ -1063,7 +1064,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT DISTINCT custkey FROM orders ORDER BY orderkey LIMIT 10",
-                "line 1:1: For SELECT DISTINCT, ORDER BY expressions must appear in select list");
+                "(?s)line 1:1: For SELECT DISTINCT, ORDER BY expressions must appear in select list.*");
     }
 
     @Test
@@ -1597,7 +1598,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testIntersectAllFails()
     {
-        assertQueryFails("SELECT * FROM (VALUES 1, 2, 3, 4) INTERSECT ALL SELECT * FROM (VALUES 3, 4)", "line 1:35: INTERSECT ALL not yet implemented");
+        assertQueryFails("SELECT * FROM (VALUES 1, 2, 3, 4) INTERSECT ALL SELECT * FROM (VALUES 3, 4)", "(?s)line 1:35: INTERSECT ALL not yet implemented.*");
     }
 
     @Test
@@ -1660,7 +1661,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testExceptAllFails()
     {
-        assertQueryFails("SELECT * FROM (VALUES 1, 2, 3, 4) EXCEPT ALL SELECT * FROM (VALUES 3, 4)", "line 1:35: EXCEPT ALL not yet implemented");
+        assertQueryFails("SELECT * FROM (VALUES 1, 2, 3, 4) EXCEPT ALL SELECT * FROM (VALUES 3, 4)", "(?s)line 1:35: EXCEPT ALL not yet implemented.*");
     }
 
     @Test
@@ -2213,7 +2214,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT CAST(1 AS DATE)",
-                "line 1:8: Cannot cast integer to date");
+                "(?s)line 1:8: Cannot cast integer to date.*");
     }
 
     @Test
@@ -2223,7 +2224,7 @@ public abstract class AbstractTestQueries
                 "SELECT CAST(totalprice AS BIGINT),\n" +
                         "CAST(2015 AS DATE),\n" +
                         "CAST(orderkey AS DOUBLE) FROM orders",
-                "line 2:1: Cannot cast integer to date");
+                "(?s)line 2:1: Cannot cast integer to date.*");
     }
 
     @Test
@@ -2250,7 +2251,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT * FROM lineitem l JOIN (SELECT orderkey_1, custkey FROM orders) o on l.orderkey = o.orderkey_1",
-                "line 1:39: Column 'orderkey_1' cannot be resolved");
+                "(?s)line 1:39: Column 'orderkey_1' cannot be resolved.*");
     }
 
     @Test
@@ -2358,7 +2359,7 @@ public abstract class AbstractTestQueries
                 "WITH a AS (VALUES 1), " +
                         "     a AS (VALUES 2)" +
                         "SELECT * FROM a",
-                "line 1:28: WITH query name 'a' specified more than once");
+                "(?s)line 1:28: WITH query name 'a' specified more than once.*");
     }
 
     @Test
@@ -2366,7 +2367,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "WITH RECURSIVE a AS (SELECT 123) SELECT * FROM a",
-                "line 1:1: Recursive WITH queries are not supported");
+                "(?s)line 1:1: Recursive WITH queries are not supported.*");
     }
 
     @Test
@@ -2380,7 +2381,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT orderkey, CASE orderstatus WHEN 'O' THEN 'a' WHEN '1' THEN 2 END FROM orders",
-                "\\Qline 1:67: All CASE results must be the same type: varchar(1)\\E");
+                "(?s)\\Qline 1:67: All CASE results must be the same type: varchar(1)\\E.*");
     }
 
     @Test
@@ -2832,18 +2833,18 @@ public abstract class AbstractTestQueries
         String catalog = sessionWithDefaultCatalogAndSchema.getCatalog().get();
         String schema = sessionWithDefaultCatalogAndSchema.getSchema().get();
 
-        assertQueryFails(sessionWithDefaultCatalogAndSchema, "USE non_exist_schema", format("Schema does not exist: %s.non_exist_schema", catalog));
-        assertQueryFails(sessionWithDefaultCatalogAndSchema, "USE non_exist_catalog.any_schema", "Catalog does not exist: non_exist_catalog");
-        assertQueryFails(sessionWithDefaultCatalogAndSchema, format("USE %s.non_exist_schema", catalog), format("Schema does not exist: %s.non_exist_schema", catalog));
+        assertQueryFails(sessionWithDefaultCatalogAndSchema, "USE non_exist_schema", format("(?s)Schema does not exist: %s.non_exist_schema.*", catalog));
+        assertQueryFails(sessionWithDefaultCatalogAndSchema, "USE non_exist_catalog.any_schema", "(?s)Catalog does not exist: non_exist_catalog.*");
+        assertQueryFails(sessionWithDefaultCatalogAndSchema, format("USE %s.non_exist_schema", catalog), format("(?s)Schema does not exist: %s.non_exist_schema.*", catalog));
         assertUpdate(sessionWithDefaultCatalogAndSchema, format("USE %s.%s", catalog, schema));
 
         Session sessionWithoutDefaultCatalogAndSchema = Session.builder(getSession())
                 .setCatalog(null)
                 .setSchema(null)
                 .build();
-        assertQueryFails(sessionWithoutDefaultCatalogAndSchema, "USE any_schema", ".* Catalog must be specified when session catalog is not set");
-        assertQueryFails(sessionWithoutDefaultCatalogAndSchema, "USE non_exist_catalog.any_schema", "Catalog does not exist: non_exist_catalog");
-        assertQueryFails(sessionWithoutDefaultCatalogAndSchema, format("USE %s.non_exist_schema", catalog), format("Schema does not exist: %s.non_exist_schema", catalog));
+        assertQueryFails(sessionWithoutDefaultCatalogAndSchema, "USE any_schema", "(?s).* Catalog must be specified when session catalog is not set.*");
+        assertQueryFails(sessionWithoutDefaultCatalogAndSchema, "USE non_exist_catalog.any_schema", "(?s)Catalog does not exist: non_exist_catalog.*");
+        assertQueryFails(sessionWithoutDefaultCatalogAndSchema, format("USE %s.non_exist_schema", catalog), format("(?s)Schema does not exist: %s.non_exist_schema.*", catalog));
         assertUpdate(sessionWithoutDefaultCatalogAndSchema, format("USE %s.%s", catalog, schema));
     }
 
@@ -2857,9 +2858,9 @@ public abstract class AbstractTestQueries
     @Test
     public void testShowSchemasLikeWithEscape()
     {
-        assertQueryFails("SHOW SCHEMAS IN foo LIKE '%$_%' ESCAPE", "line 1:39: mismatched input '<EOF>'. Expecting: <string>");
-        assertQueryFails("SHOW SCHEMAS LIKE 't$_%' ESCAPE ''", "Escape string must be a single character");
-        assertQueryFails("SHOW SCHEMAS LIKE 't$_%' ESCAPE '$$'", "Escape string must be a single character");
+        assertQueryFails("SHOW SCHEMAS IN foo LIKE '%$_%' ESCAPE", "(?s)line 1:39: mismatched input '<EOF>'. Expecting: <string>.*");
+        assertQueryFails("SHOW SCHEMAS LIKE 't$_%' ESCAPE ''", "(?s)Escape string must be a single character.*");
+        assertQueryFails("SHOW SCHEMAS LIKE 't$_%' ESCAPE '$$'", "(?s)Escape string must be a single character.*");
 
         Set<Object> allSchemas = computeActual("SHOW SCHEMAS").getOnlyColumnAsSet();
         assertEquals(allSchemas, computeActual("SHOW SCHEMAS LIKE '%_%'").getOnlyColumnAsSet());
@@ -2891,8 +2892,8 @@ public abstract class AbstractTestQueries
         result = computeActual("SHOW TABLES FROM " + catalog + "." + schema);
         assertTrue(result.getOnlyColumnAsSet().containsAll(expectedTables));
 
-        assertQueryFails("SHOW TABLES FROM UNKNOWN", "line 1:1: Schema 'unknown' does not exist");
-        assertQueryFails("SHOW TABLES FROM UNKNOWNCATALOG.UNKNOWNSCHEMA", "line 1:1: Catalog 'unknowncatalog' does not exist");
+        assertQueryFails("SHOW TABLES FROM UNKNOWN", "(?s)line 1:1: Schema 'unknown' does not exist.*");
+        assertQueryFails("SHOW TABLES FROM UNKNOWNCATALOG.UNKNOWNSCHEMA", "(?s)line 1:1: Catalog 'unknowncatalog' does not exist.*");
     }
 
     @Test
@@ -2906,9 +2907,9 @@ public abstract class AbstractTestQueries
     @Test
     public void testShowTablesLikeWithEscape()
     {
-        assertQueryFails("SHOW TABLES IN a LIKE '%$_%' ESCAPE", "line 1:36: mismatched input '<EOF>'. Expecting: <string>");
-        assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE ''", "Escape string must be a single character");
-        assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE '$$'", "Escape string must be a single character");
+        assertQueryFails("SHOW TABLES IN a LIKE '%$_%' ESCAPE", "(?s)line 1:36: mismatched input '<EOF>'. Expecting: <string>.*");
+        assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE ''", "(?s)Escape string must be a single character.*");
+        assertQueryFails("SHOW TABLES LIKE 't$_%' ESCAPE '$$'", "(?s)Escape string must be a single character.*");
 
         Set<Object> allTables = computeActual("SHOW TABLES FROM information_schema").getOnlyColumnAsSet();
         assertEquals(allTables, computeActual("SHOW TABLES FROM information_schema LIKE '%_%'").getOnlyColumnAsSet());
@@ -3246,10 +3247,10 @@ public abstract class AbstractTestQueries
                 "SELECT SUM(CASE WHEN CAST(round(totalprice/100) AS BIGINT) BETWEEN 2 AND 36 THEN 1 ELSE 0 END) FROM orders");
 
         // missing function argument
-        assertQueryFails("SELECT TRY()", "line 1:8: The 'try' function must have exactly one argument");
+        assertQueryFails("SELECT TRY()", "(?s)line 1:8: The 'try' function must have exactly one argument.*");
 
         // check that TRY is not pushed down
-        assertQueryFails("SELECT TRY(x) IS NULL FROM (SELECT 1/y AS x FROM (VALUES 1, 2, 3, 0, 4) t(y))", ".*(/|division) by zero.*");
+        assertQueryFails("SELECT TRY(x) IS NULL FROM (SELECT 1/y AS x FROM (VALUES 1, 2, 3, 0, 4) t(y))", "(?s).*(/|division) by zero.*");
         assertQuery("SELECT x IS NULL FROM (SELECT TRY(1/y) AS x FROM (VALUES 3, 0, 4) t(y))", "VALUES false, true, false");
 
         // test try with invalid JSON
@@ -3290,7 +3291,7 @@ public abstract class AbstractTestQueries
     public void testTryNoMergeProjections()
     {
         // no regexp specified because the JVM optimizes away exception message constructor if run enough times
-        assertQueryFails("SELECT TRY(x) FROM (SELECT 1/y AS x FROM (VALUES 1, 2, 3, 0, 4) t(y))", ".*");
+        assertQueryFails("SELECT TRY(x) FROM (SELECT 1/y AS x FROM (VALUES 1, 2, 3, 0, 4) t(y))", "(?s).*");
     }
 
     @Test
@@ -3691,7 +3692,7 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT orderkey, totalprice FROM orders ORDER BY (SELECT 2)");
 
         // subquery returns multiple rows
-        String multipleRowsErrorMsg = "Scalar sub-query has returned multiple rows";
+        String multipleRowsErrorMsg = "(?s)Scalar sub-query has returned multiple rows.*";
         assertQueryFails("SELECT * FROM lineitem WHERE orderkey = (\n" +
                         "SELECT orderkey FROM orders ORDER BY totalprice)",
                 multipleRowsErrorMsg);
@@ -3834,7 +3835,7 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT * FROM (SELECT (SELECT 1))");
         assertQueryFails(
                 "SELECT * FROM (SELECT (SELECT 1, 2))",
-                "line 1:23: Multiple columns returned by subquery are not yet supported. Found 2");
+                "(?s)line 1:23: Multiple columns returned by subquery are not yet supported. Found 2.*");
     }
 
     @Test
@@ -3923,7 +3924,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testCorrelatedNonAggregationScalarSubqueries()
     {
-        String subqueryReturnedTooManyRows = "Scalar sub-query has returned multiple rows";
+        String subqueryReturnedTooManyRows = "(?s)Scalar sub-query has returned multiple rows.*";
 
         assertQuery("SELECT (SELECT 1 WHERE a = 2) FROM (VALUES 1) t(a)", "SELECT null");
         assertQuery("SELECT (SELECT 2 WHERE a = 1) FROM (VALUES 1) t(a)", "SELECT 2");
@@ -4041,8 +4042,7 @@ public abstract class AbstractTestQueries
                         "ON NOT 1 = (SELECT count(*) WHERE o1.orderkey = o2.orderkey)");
         assertQueryFails(
                 "SELECT count(*) FROM orders o1 LEFT JOIN orders o2 " +
-                        "ON NOT 1 = (SELECT count(*) WHERE o1.orderkey = o2.orderkey)",
-                "line .*: Correlated subquery in given context is not supported");
+                        "ON NOT 1 = (SELECT count(*) WHERE o1.orderkey = o2.orderkey)", "(?s)line .*: Correlated subquery in given context is not supported.*");
 
         // subrelation
         assertQuery(
@@ -4102,8 +4102,7 @@ public abstract class AbstractTestQueries
                         "ON NOT 1 = (SELECT avg(i.orderkey) FROM orders i WHERE o1.orderkey < o2.orderkey AND i.orderkey % 10000 = 0)");
         assertQueryFails(
                 "SELECT count(*) FROM orders o1 LEFT JOIN orders o2 " +
-                        "ON NOT 1 = (SELECT avg(i.orderkey) FROM orders i WHERE o1.orderkey < o2.orderkey)",
-                "line .*: Correlated subquery in given context is not supported");
+                        "ON NOT 1 = (SELECT avg(i.orderkey) FROM orders i WHERE o1.orderkey < o2.orderkey)", "(?s)line .*: Correlated subquery in given context is not supported.*");
 
         // subrelation
         assertQuery(
@@ -4250,7 +4249,7 @@ public abstract class AbstractTestQueries
         assertQueryFails(
                 "SELECT count(*) FROM orders o1 LEFT JOIN orders o2 " +
                         "ON NOT EXISTS(SELECT 1 WHERE o1.orderkey = o2.orderkey)",
-                "line .*: Correlated subquery in given context is not supported");
+                "(?s)line .*: Correlated subquery in given context is not supported.*");
 
         // subrelation
         assertQuery(
@@ -4330,8 +4329,7 @@ public abstract class AbstractTestQueries
                         "ON NOT EXISTS(SELECT 1 FROM orders i WHERE o1.orderkey < o2.orderkey AND i.orderkey % 10000 = 0)");
         assertQueryFails(
                 "SELECT count(*) FROM orders o1 LEFT JOIN orders o2 " +
-                        "ON NOT EXISTS(SELECT 1 FROM orders i WHERE o1.orderkey < o2.orderkey)",
-                "line .*: Correlated subquery in given context is not supported");
+                        "ON NOT EXISTS(SELECT 1 FROM orders i WHERE o1.orderkey < o2.orderkey)", "(?s)line .*: Correlated subquery in given context is not supported.*");
 
         // subrelation
         assertQuery(
@@ -4527,7 +4525,7 @@ public abstract class AbstractTestQueries
     public void testFunctionNotRegistered()
     {
         assertQueryFails(
-                "SELECT length(1)", ".*Unexpected parameters \\(integer\\) for function .*length. Expected:.*");
+                "SELECT length(1)", "(?s).*Unexpected parameters \\(integer\\) for function .*length. Expected:.*");
     }
 
     @Test
@@ -4535,19 +4533,19 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT greatest(rgb(255, 0, 0))",
-                "\\Qline 1:8: Unexpected parameters (color) for function greatest. Expected: greatest(E) E:orderable\\E.*");
+                "(?s)\\Qline 1:8: Unexpected parameters (color) for function greatest. Expected: greatest(E) E:orderable\\E.*");
     }
 
     @Test
     public void testTypeMismatch()
     {
-        assertQueryFails("SELECT 1 <> 'x'", "\\Qline 1:10: '<>' cannot be applied to integer, varchar(1)\\E");
+        assertQueryFails("SELECT 1 <> 'x'", "(?s)\\Qline 1:10: '<>' cannot be applied to integer, varchar(1)\\E.*");
     }
 
     @Test
     public void testInvalidType()
     {
-        assertQueryFails("SELECT CAST(null AS array(foo))", "\\Qline 1:8: Unknown type: array(foo)\\E");
+        assertQueryFails("SELECT CAST(null AS array(foo))", "(?s)\\Qline 1:8: Unknown type: array(foo)\\E.*");
     }
 
     @Test
@@ -4556,19 +4554,19 @@ public abstract class AbstractTestQueries
         // Comment on why error message references varchar(214783647) instead of varchar(2) which seems expected result type for concatenation in expression.
         // Currently variable argument functions do not play well with arguments using parametrized types.
         // The variable argument functions mechanism requires that all the arguments are of exactly same type. We cannot enforce that base must match but parameters may differ.
-        assertQueryFails("SELECT ('a' || 'z') + (3 * 4) / 5", "\\Qline 1:21: '+' cannot be applied to varchar, integer\\E");
+        assertQueryFails("SELECT ('a' || 'z') + (3 * 4) / 5", "(?s)\\Qline 1:21: '+' cannot be applied to varchar, integer\\E.*");
     }
 
     @Test
     public void testInvalidTypeBetweenOperator()
     {
-        assertQueryFails("SELECT 'a' BETWEEN 3 AND 'z'", "\\Qline 1:12: Cannot check if varchar(1) is BETWEEN integer and varchar(1)\\E");
+        assertQueryFails("SELECT 'a' BETWEEN 3 AND 'z'", "(?s)\\Qline 1:12: Cannot check if varchar(1) is BETWEEN integer and varchar(1)\\E.*");
     }
 
     @Test
     public void testInvalidTypeArray()
     {
-        assertQueryFails("SELECT ARRAY[1, 2, 'a']", "\\Qline 1:20: All ARRAY elements must be the same type: integer\\E");
+        assertQueryFails("SELECT ARRAY[1, 2, 'a']", "(?s)\\Qline 1:20: All ARRAY elements must be the same type: integer\\E.*");
     }
 
     @Test
@@ -4945,7 +4943,7 @@ public abstract class AbstractTestQueries
     public void testMergeEmptyNonEmptyApproxSetWithDifferentMaxError()
     {
         assertQueryFails("SELECT cardinality(merge(c)) FROM (SELECT create_hll(custkey, 0.1) c FROM orders UNION ALL SELECT empty_approx_set(0.2))",
-                "Cannot merge HLLs with different number of buckets.*");
+                "(?s)Cannot merge HLLs with different number of buckets.*");
     }
 
     @Test
@@ -5154,24 +5152,24 @@ public abstract class AbstractTestQueries
     @Test
     public void testAccessControl()
     {
-        assertAccessDenied("INSERT INTO orders SELECT * FROM orders", "Cannot insert into table .*.orders.*", privilege("orders", INSERT_TABLE));
-        assertAccessDenied("DELETE FROM orders", "Cannot delete from table .*.orders.*", privilege("orders", DELETE_TABLE));
-        assertAccessDenied("CREATE TABLE foo AS SELECT * FROM orders", "Cannot create table .*.foo.*", privilege("foo", CREATE_TABLE));
-        assertAccessDenied("SELECT * FROM nation", "Cannot select from columns \\[comment, name, nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT * FROM (SELECT * FROM nation)", "Cannot select from columns \\[comment, name, nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
+        assertAccessDenied("INSERT INTO orders SELECT * FROM orders", "(?s)Cannot insert into table .*.orders.*", privilege("orders", INSERT_TABLE));
+        assertAccessDenied("DELETE FROM orders", "(?s)Cannot delete from table .*.orders.*", privilege("orders", DELETE_TABLE));
+        assertAccessDenied("CREATE TABLE foo AS SELECT * FROM orders", "(?s)Cannot create table .*.foo.*", privilege("foo", CREATE_TABLE));
+        assertAccessDenied("SELECT * FROM nation", "(?s)Cannot select from columns \\[comment, name, nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT * FROM (SELECT * FROM nation)", "(?s)Cannot select from columns \\[comment, name, nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
         assertAccessAllowed("SELECT name FROM (SELECT * FROM nation)", privilege("nationkey", SELECT_COLUMN));
         assertAccessAllowed("SELECT name FROM nation", privilege("nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT n1.nationkey, n2.regionkey FROM nation n1, nation n2", "Cannot select from columns \\[nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT count(name) as c FROM nation where comment > 'abc' GROUP BY regionkey having max(nationkey) > 10", "Cannot select from columns \\[comment, name, nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT 1 FROM region, nation where region.regionkey = nation.nationkey", "Cannot select from columns \\[nationkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT count(*) FROM nation", "Cannot select from columns \\[\\] in table .*.nation.*", privilege("nation", SELECT_COLUMN));
-        assertAccessDenied("WITH t1 AS (SELECT * FROM nation) SELECT * FROM t1", "Cannot select from columns \\[comment, name, nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT n1.nationkey, n2.regionkey FROM nation n1, nation n2", "(?s)Cannot select from columns \\[nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT count(name) as c FROM nation where comment > 'abc' GROUP BY regionkey having max(nationkey) > 10", "(?s)Cannot select from columns \\[comment, name, nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT 1 FROM region, nation where region.regionkey = nation.nationkey", "(?s)Cannot select from columns \\[nationkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT count(*) FROM nation", "(?s)Cannot select from columns \\[\\] in table .*.nation.*", privilege("nation", SELECT_COLUMN));
+        assertAccessDenied("WITH t1 AS (SELECT * FROM nation) SELECT * FROM t1", "(?s)Cannot select from columns \\[comment, name, nationkey, regionkey\\] in table .*.nation.*", privilege("nationkey", SELECT_COLUMN));
         assertAccessAllowed("SELECT name AS my_alias FROM nation", privilege("my_alias", SELECT_COLUMN));
         assertAccessAllowed("SELECT my_alias from (SELECT name AS my_alias FROM nation)", privilege("my_alias", SELECT_COLUMN));
-        assertAccessDenied("SELECT name AS my_alias FROM nation", "Cannot select from columns \\[name\\] in table .*.nation.*", privilege("name", SELECT_COLUMN));
-        assertAccessDenied("SELECT regionkey FROM nation as n1 join region as r1 using (regionkey)", "Cannot select from columns \\[regionkey\\] in table .*", privilege("regionkey", SELECT_COLUMN));
-        assertAccessDenied("SELECT array_agg(regionkey ORDER BY regionkey) FROM nation JOIN region USING (regionkey)", "Cannot select from columns \\[regionkey\\] in table .*", privilege("regionkey", SELECT_COLUMN));
-        assertAccessDenied("SHOW CREATE TABLE orders", "Cannot show create table for .*.orders.*", privilege("orders", SHOW_CREATE_TABLE));
+        assertAccessDenied("SELECT name AS my_alias FROM nation", "(?s)Cannot select from columns \\[name\\] in table .*.nation.*", privilege("name", SELECT_COLUMN));
+        assertAccessDenied("SELECT regionkey FROM nation as n1 join region as r1 using (regionkey)", "(?s)Cannot select from columns \\[regionkey\\] in table .*", privilege("regionkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT array_agg(regionkey ORDER BY regionkey) FROM nation JOIN region USING (regionkey)", "(?s)Cannot select from columns \\[regionkey\\] in table .*", privilege("regionkey", SELECT_COLUMN));
+        assertAccessDenied("SHOW CREATE TABLE orders", "(?s)Cannot show create table for .*.orders.*", privilege("orders", SHOW_CREATE_TABLE));
         assertAccessAllowed("SHOW CREATE TABLE lineitem", privilege("orders", SHOW_CREATE_TABLE));
     }
 
@@ -5445,7 +5443,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testExecuteNoSuchQuery()
     {
-        assertQueryFails("EXECUTE my_query", "Prepared statement not found: my_query");
+        assertQueryFails("EXECUTE my_query", "(?s)Prepared statement not found: my_query.*");
     }
 
     @Test
@@ -5459,7 +5457,7 @@ public abstract class AbstractTestQueries
             assertEquals(e.getCode(), INVALID_PARAMETER_USAGE);
         }
         catch (RuntimeException e) {
-            assertEquals(e.getMessage(), "line 1:1: Incorrect number of parameters: expected 1 but found 0");
+            assertTrue(nullToEmpty(e.getMessage()).matches("(?s)line 1:1: Incorrect number of parameters: expected 1 but found 0.*"));
         }
     }
 
@@ -5505,7 +5503,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testDescribeInputNoSuchQuery()
     {
-        assertQueryFails("DESCRIBE INPUT my_query", "Prepared statement not found: my_query");
+        assertQueryFails("DESCRIBE INPUT my_query", "(?s)Prepared statement not found: my_query.*");
     }
 
     @Test
@@ -5721,7 +5719,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testDescribeOutputNoSuchQuery()
     {
-        assertQueryFails("DESCRIBE OUTPUT my_query", "Prepared statement not found: my_query");
+        assertQueryFails("DESCRIBE OUTPUT my_query", "(?s)Prepared statement not found: my_query.*");
     }
 
     @Test
@@ -5843,7 +5841,7 @@ public abstract class AbstractTestQueries
         }
 
         stringBuilder.append("else x = random() end");
-        assertQueryFails(stringBuilder.toString(), "Query results in large bytecode exceeding the limits imposed by JVM|Compiler failed");
+        assertQueryFails(stringBuilder.toString(), "(?s)Query results in large bytecode exceeding the limits imposed by JVM.*|(?s)Compiler failed.*");
     }
 
     @Test(timeOut = 60_000)
@@ -6322,10 +6320,10 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT map_union_sum(x) from (select cast(MAP() as map<varchar, varchar>) x)",
-                ".*line 1:8: Unexpected parameters \\(map\\(varchar,varchar\\)\\) for function (?:native.default.)?map_union_sum. Expected: (?:native.default.)?map_union_sum\\(map\\((K|k),(V|v)\\)\\) (K|k):comparable, (V|v):nonDecimalNumeric.*");
+                "(?s).*line 1:8: Unexpected parameters \\(map\\(varchar,varchar\\)\\) for function (?:native.default.)?map_union_sum. Expected: (?:native.default.)?map_union_sum\\(map\\((K|k),(V|v)\\)\\) (K|k):comparable, (V|v):nonDecimalNumeric.*");
         assertQueryFails(
                 "SELECT map_union_sum(x) from (select cast(MAP() as map<varchar, decimal(10,2)>) x)",
-                ".*line 1:8: Unexpected parameters \\(map\\(varchar,decimal\\(10,2\\)\\)\\) for function (?:native.default.)?map_union_sum. Expected: (?:native.default.)?map_union_sum\\(map\\((K|k),(V|v)\\)\\) (K|k):comparable, (V|v):nonDecimalNumeric.*");
+                "(?s).*line 1:8: Unexpected parameters \\(map\\(varchar,decimal\\(10,2\\)\\)\\) for function (?:native.default.)?map_union_sum. Expected: (?:native.default.)?map_union_sum\\(map\\((K|k),(V|v)\\)\\) (K|k):comparable, (V|v):nonDecimalNumeric.*");
     }
 
     @Test
@@ -6333,10 +6331,10 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "select y, map_union_sum(x) from (select 1 y, map(array['x', 'z', 'y'], cast(array[null,30,100] as array<tinyint>)) x " +
-                        "union all select 1 y, map(array['x', 'y'], cast(array[1,100] as array<tinyint>))x) group by y", ".*Value 200 exceeds.*");
+                        "union all select 1 y, map(array['x', 'y'], cast(array[1,100] as array<tinyint>))x) group by y", "(?s).*Value 200 exceeds.*");
         assertQueryFails(
                 "select y, map_union_sum(x) from (select 1 y, map(array['x', 'z', 'y'], cast(array[null,30, 32760] as array<smallint>)) x " +
-                        "union all select 1 y, map(array['x', 'y'], cast(array[1,100] as array<smallint>))x) group by y", ".*Value 32860 exceeds.*");
+                        "union all select 1 y, map(array['x', 'y'], cast(array[1,100] as array<smallint>))x) group by y", "(?s).*Value 32860 exceeds.*");
     }
 
     @Test
@@ -6356,8 +6354,8 @@ public abstract class AbstractTestQueries
     @Test
     public void testReduceAggWithNulls()
     {
-        assertQueryFails("select reduce_agg(x, null, (x,y)->try(x+y), (x,y)->try(x+y)) from (select 1 union all select 10) T(x)", ".*REDUCE_AGG only supports non-NULL literal as the initial value.*");
-        assertQueryFails("select reduce_agg(x, cast(null as bigint), (x,y)->coalesce(x, 0)+coalesce(y, 0), (x,y)->coalesce(x, 0)+coalesce(y, 0)) from (values cast(10 as bigint),10)T(x)", ".*REDUCE_AGG only supports non-NULL literal as the initial value.*");
+        assertQueryFails("select reduce_agg(x, null, (x,y)->try(x+y), (x,y)->try(x+y)) from (select 1 union all select 10) T(x)", "(?s).*REDUCE_AGG only supports non-NULL literal as the initial value.*");
+        assertQueryFails("select reduce_agg(x, cast(null as bigint), (x,y)->coalesce(x, 0)+coalesce(y, 0), (x,y)->coalesce(x, 0)+coalesce(y, 0)) from (values cast(10 as bigint),10)T(x)", "(?s).*REDUCE_AGG only supports non-NULL literal as the initial value.*");
 
         // here some reduce_aggs coalesce overflow/zero-divide errors to null in the input/combine functions
         assertQuery("select reduce_agg(x, 0, (x,y)->try(1/x+1/y), (x,y)->try(1/x+1/y)) from ((select 0) union all select 10.) T(x)", "select null");
@@ -6386,7 +6384,7 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "SELECT reduce(a, 0, (s, x) -> x, s->s), count(*) FROM (VALUES (array[1]), (array[1, 2, 3]), (array[3])) t(a) GROUP BY reduce(a, 0, (s, x) -> x, s->s)",
-                "GROUP BY does not support lambda expressions, please use GROUP BY # instead");
+                "(?s)GROUP BY does not support lambda expressions, please use GROUP BY # instead.*");
         assertQuery(
                 "SELECT reduce(a, 0, (s, x) -> x, s->s), count(*) FROM (VALUES (array[1]), (array[1, 2, 3]), (array[3])) t(a) GROUP BY 1",
                 "VALUES (3, 2), (1, 1)");
@@ -7041,7 +7039,7 @@ public abstract class AbstractTestQueries
         assertQuery(sql, "values array[cast(5 as integer), cast(11 as integer), cast(11 as integer)], array[], null");
 
         sql = "select array_cum_sum(k) from (values (array[cast(5 as INTEGER), 6, 0]), (ARRAY[]), (CAST(NULL AS array(integer))), (ARRAY [cast(2147483647 as INTEGER), 2147483647, 2147483647])) t(k)";
-        assertQueryFails(sql, "integer (addition )?overflow:.*", true);
+        assertQueryFails(sql, "(?s)integer (addition )?overflow:.*", true);
 
         sql = "select array_cum_sum(k) from (values (array[cast(5 as INTEGER), 6, null, 2, 3])) t(k)";
         assertQuery(sql, "values array[cast(5 as integer), cast(11 as integer), cast(null as integer), cast(null as integer), cast(null as integer)]");
@@ -7142,10 +7140,10 @@ public abstract class AbstractTestQueries
     public void testArrayCumSumVarchar()
     {
         String sql = "select array_cum_sum(k) from (values (array[cast('5.1' as varchar), '6', '0']), (ARRAY[]), (CAST(NULL AS array(varchar)))) t(k)";
-        assertQueryFails(sql, ".*cannot be applied to.*");
+        assertQueryFails(sql, "(?s).*cannot be applied to.*");
 
         sql = "select array_cum_sum(k) from (values (array[cast(null as varchar), '6', '0'])) t(k)";
-        assertQueryFails(sql, ".*cannot be applied to.*");
+        assertQueryFails(sql, "(?s).*cannot be applied to.*");
     }
 
     @Test
@@ -7214,12 +7212,12 @@ public abstract class AbstractTestQueries
                 .build();
 
         String query = "SELECT name from nation1";
-        String errorMessage = "Table .*nation1 does not exist";
+        String errorMessage = "(?s)Table .*nation1 does not exist.*";
         assertQueryFails(query, errorMessage);
         assertQueryFails(enablePreProcessMetadataCalls, query, errorMessage);
 
         query = "SELECT name1 from nation";
-        errorMessage = ".*Column 'name1' cannot be resolved";
+        errorMessage = "(?s).*Column 'name1' cannot be resolved.*";
         assertQueryFails(query, errorMessage);
         assertQueryFails(enablePreProcessMetadataCalls, query, errorMessage);
     }
@@ -7625,7 +7623,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testMapBlockBug()
     {
-        assertQueryFails(" VALUES(MAP_AGG(12345,123))", ".*Cannot evaluate non-scalar function.*");
+        assertQueryFails(" VALUES(MAP_AGG(12345,123))", "(?s).*Cannot evaluate non-scalar function.*");
     }
 
     @Test
@@ -7761,8 +7759,7 @@ public abstract class AbstractTestQueries
         Session enableOptimization = Session.builder(getSession())
                 .setSystemProperty(REMOVE_MAP_CAST, "true")
                 .build();
-        assertQueryFails(enableOptimization, "select feature[key] from (values (map(array[cast(1 as integer), 2, 3, 4], array[0.3, 0.5, 0.9, 0.1]), cast(2 as bigint)), (map(array[cast(1 as integer), 2, 3, 4], array[0.3, 0.5, 0.9, 0.1]), 400000000000)) t(feature, key)",
-                ".*Out of range for integer.*");
+        assertQueryFails(enableOptimization, "select feature[key] from (values (map(array[cast(1 as integer), 2, 3, 4], array[0.3, 0.5, 0.9, 0.1]), cast(2 as bigint)), (map(array[cast(1 as integer), 2, 3, 4], array[0.3, 0.5, 0.9, 0.1]), 400000000000)) t(feature, key)", "(?s).*Out of range for integer.*");
     }
 
     // Test to guardrail problems in constraint framework mentioned in https://github.com/prestodb/presto/pull/22171
@@ -7782,7 +7779,7 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT id, reduce_agg(value, 's', (a, b) -> concat(a, b, 's'), (a, b) -> concat(a, b, 's')) FROM ( VALUES (1, '2'), (1, '3'), (1, '4'), (2, '20'), (2, '30'), (2, '40') ) AS t(id, value) GROUP BY id",
                 "values (1, 's2s3s4s'), (2, 's20s30s40s')");
         assertQueryFails("SELECT id, reduce_agg(value, array[id, value], (a, b) -> a || b, (a, b) -> a || b) FROM ( VALUES (1, 2), (1, 3), (1, 4), (2, 20), (2, 30), (2, 40) ) AS t(id, value) GROUP BY id",
-                ".*REDUCE_AGG only supports non-NULL literal as the initial value.*");
+                "(?s).*REDUCE_AGG only supports non-NULL literal as the initial value.*");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
@@ -583,7 +583,7 @@ public abstract class AbstractTestWindowQueries
     {
         assertQueryFails("SELECT abs(x) OVER ()\n" +
                         "FROM (VALUES (1), (2), (3)) t(x)",
-                "line 1:1: Not a window function: abs");
+                "(?s)line 1:1: Not a window function: abs.*");
     }
 
     @Test
@@ -1181,89 +1181,89 @@ public abstract class AbstractTestWindowQueries
     {
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a ASC RANGE x PRECEDING) " +
                         "FROM (VALUES (1, 0.1), (2, -0.2)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a ASC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 0.1), (2, -0.2)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE x PRECEDING) " +
                         "FROM (VALUES (1, 0.1), (2, -0.2)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 0.1), (2, -0.2)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE x PRECEDING) " +
                         "FROM (VALUES (1, 0.1), (2, null)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 0.1), (2, null)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         // fail if offset is invalid for null sort key
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 0.1), (null, null)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 0.1), (null, -0.1)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         // test invalid offset of different types
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (1, BIGINT '-1')) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (1, INTEGER '-1')) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (SMALLINT '1', SMALLINT '-1')) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (TINYINT '1', TINYINT '-1')) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (1, -1.1e0)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (1, REAL '-1.1')) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (1, -1.0001)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' YEAR)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' MONTH)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' DAY)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' HOUR)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' MINUTE)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
                         "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' SECOND)) T(a, x)",
-                "Window frame offset value must not be negative or null");
+                "(?s)Window frame offset value must not be negative or null.*");
     }
 
     @Test
@@ -1661,48 +1661,48 @@ public abstract class AbstractTestWindowQueries
     {
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a ASC GROUPS x PRECEDING) " +
                         "FROM (VALUES (1, 1), (2, -2)) T(a, x)",
-                "Window frame -2 offset must not be negative");
+                "(?s)Window frame -2 offset must not be negative.*");
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a ASC GROUPS x PRECEDING) " +
                         "FROM (VALUES (1, 1), (2, -2)) T(a, x)",
-                "Window frame -2 offset must not be negative");
+                "(?s)Window frame -2 offset must not be negative.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a ASC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 1), (2, -2)) T(a, x)",
-                "Window frame -2 offset must not be negative");
+                "(?s)Window frame -2 offset must not be negative.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS x PRECEDING) " +
                         "FROM (VALUES (1, 1), (2, -2)) T(a, x)",
-                "Window frame -2 offset must not be negative");
+                "(?s)Window frame -2 offset must not be negative.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 1), (2, -2)) T(a, x)",
-                "Window frame -2 offset must not be negative");
+                "(?s)Window frame -2 offset must not be negative.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS x PRECEDING) " +
                         "FROM (VALUES (1, 1), (2, null)) T(a, x)",
-                "Window frame starting offset must not be null");
+                "(?s)Window frame starting offset must not be null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 1), (2, null)) T(a, x)",
-                "Window frame ending offset must not be null");
+                "(?s)Window frame ending offset must not be null.*");
 
         // fail if offset is invalid for null sort key
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 1), (null, null)) T(a, x)",
-                "Window frame ending offset must not be null");
+                "(?s)Window frame ending offset must not be null.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
                         "FROM (VALUES (1, 1), (null, -1)) T(a, x)",
-                "Window frame -1 offset must not be negative");
+                "(?s)Window frame -1 offset must not be negative.*");
 
         // test invalid offset of different types
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a GROUPS x PRECEDING) " +
                         "FROM (VALUES (1, BIGINT '-1')) T(a, x)",
-                "Window frame -1 offset must not be negative");
+                "(?s)Window frame -1 offset must not be negative.*");
 
         assertQueryFails("SELECT array_agg(a) OVER(ORDER BY a GROUPS x PRECEDING) " +
                         "FROM (VALUES (1, INTEGER '-1')) T(a, x)",
-                "Window frame -1 offset must not be negative");
+                "(?s)Window frame -1 offset must not be negative.*");
     }
 
     @Test


### PR DESCRIPTION
## Description
PrestoSparkFailure currently does not store stack information, making debugging of rethrowing exceptions extremely challenging. Adding this information to make debugging easier.

```
== NO RELEASE NOTE ==
```

