### PR TITLE
[native] Serialize session property metadata with protocol

### DIFF
--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -24,16 +24,6 @@ const std::string boolToString(bool value) {
 }
 } // namespace
 
-json SessionProperty::serialize() {
-  json j;
-  j["name"] = name_;
-  j["description"] = description_;
-  j["typeSignature"] = type_;
-  j["defaultValue"] = defaultValue_;
-  j["hidden"] = hidden_;
-  return j;
-}
-
 SessionProperties* SessionProperties::instance() {
   static std::unique_ptr<SessionProperties> instance =
       std::make_unique<SessionProperties>();
@@ -553,22 +543,18 @@ SessionProperties::SessionProperties() {
       std::to_string(c.unnestSplitOutput()));
 }
 
-const std::unordered_map<std::string, std::shared_ptr<SessionProperty>>&
-SessionProperties::testingSessionProperties() const {
-  return sessionProperties_;
-}
-
 const std::string SessionProperties::toVeloxConfig(
     const std::string& name) const {
   auto it = sessionProperties_.find(name);
-  return it == sessionProperties_.end() ? name
-                                        : it->second->getVeloxConfigName();
+  return it == sessionProperties_.end() ? name : it->second->getVeloxConfig();
 }
 
 json SessionProperties::serialize() const {
   json j = json::array();
-  for (const auto& entry : sessionProperties_) {
-    j.push_back(entry.second->serialize());
+  json tj;
+  for (const auto& sessionProperty : sessionProperties_) {
+    protocol::to_json(tj, sessionProperty.second->getMetadata());
+    j.push_back(tj);
   }
   return j;
 }

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -127,26 +127,9 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       {SessionProperties::kUnnestSplitOutput,
        core::QueryConfig::kUnnestSplitOutput}};
 
-  const auto& sessionProperties =
-      SessionProperties::instance()->testingSessionProperties();
-
-  ASSERT_EQ(expectedMappings.size(), sessionProperties.size());
-
-  for (const auto& [sessionPropertyName, expectedVeloxConfigName] :
-       expectedMappings) {
+  const auto sessionProperties = SessionProperties::instance();
+  for (const auto& [sessionProperty, expectedVeloxConfig] : expectedMappings) {
     ASSERT_EQ(
-        expectedVeloxConfigName,
-        sessionProperties.at(sessionPropertyName)->getVeloxConfigName());
-  }
-}
-
-TEST_F(SessionPropertiesTest, serializeProperty) {
-  auto* sessionProperties = SessionProperties::instance();
-  auto j = sessionProperties->serialize();
-  for (const auto& property : j) {
-    auto name = property["name"];
-    json expectedProperty =
-        sessionProperties->testingSessionProperties().at(name)->serialize();
-    EXPECT_EQ(property, expectedProperty);
+        expectedVeloxConfig, sessionProperties->toVeloxConfig(sessionProperty));
   }
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -212,7 +212,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
 void to_json(json& j, const IcebergInsertTableHandle& p);
 void from_json(const json& j, IcebergInsertTableHandle& p);
 } // namespace facebook::presto::protocol::iceberg
-// IcebergInsertTableHandle is special since it needs an usage of
+// IcebergOutputTableHandle is special since it needs an usage of
 // hive::.
 
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -2810,7 +2810,8 @@ namespace facebook::presto::protocol {
 static const std::pair<BuiltInFunctionKind, json>
     BuiltInFunctionKind_enum_table[] = { // NOLINT: cert-err58-cpp
         {BuiltInFunctionKind::ENGINE, "ENGINE"},
-        {BuiltInFunctionKind::PLUGIN, "PLUGIN"}};
+        {BuiltInFunctionKind::PLUGIN, "PLUGIN"},
+        {BuiltInFunctionKind::WORKER, "WORKER"}};
 void to_json(json& j, const BuiltInFunctionKind& e) {
   static_assert(
       std::is_enum<BuiltInFunctionKind>::value,
@@ -9423,6 +9424,63 @@ void from_json(const json& j, ServerInfo& p) {
       j, "coordinator", p.coordinator, "ServerInfo", "bool", "coordinator");
   from_json_key(j, "starting", p.starting, "ServerInfo", "bool", "starting");
   from_json_key(j, "uptime", p.uptime, "ServerInfo", "Duration", "uptime");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
+void to_json(json& j, const SessionPropertyMetadata& p) {
+  j = json::object();
+  to_json_key(j, "name", p.name, "SessionPropertyMetadata", "String", "name");
+  to_json_key(
+      j,
+      "description",
+      p.description,
+      "SessionPropertyMetadata",
+      "String",
+      "description");
+  to_json_key(
+      j,
+      "typeSignature",
+      p.typeSignature,
+      "SessionPropertyMetadata",
+      "TypeSignature",
+      "typeSignature");
+  to_json_key(
+      j,
+      "defaultValue",
+      p.defaultValue,
+      "SessionPropertyMetadata",
+      "String",
+      "defaultValue");
+  to_json_key(
+      j, "hidden", p.hidden, "SessionPropertyMetadata", "bool", "hidden");
+}
+
+void from_json(const json& j, SessionPropertyMetadata& p) {
+  from_json_key(j, "name", p.name, "SessionPropertyMetadata", "String", "name");
+  from_json_key(
+      j,
+      "description",
+      p.description,
+      "SessionPropertyMetadata",
+      "String",
+      "description");
+  from_json_key(
+      j,
+      "typeSignature",
+      p.typeSignature,
+      "SessionPropertyMetadata",
+      "TypeSignature",
+      "typeSignature");
+  from_json_key(
+      j,
+      "defaultValue",
+      p.defaultValue,
+      "SessionPropertyMetadata",
+      "String",
+      "defaultValue");
+  from_json_key(
+      j, "hidden", p.hidden, "SessionPropertyMetadata", "bool", "hidden");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -829,7 +829,7 @@ void to_json(json& j, const BufferInfo& p);
 void from_json(const json& j, BufferInfo& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-enum class BuiltInFunctionKind { ENGINE, PLUGIN };
+enum class BuiltInFunctionKind { ENGINE, PLUGIN, WORKER };
 extern void to_json(json& j, const BuiltInFunctionKind& e);
 extern void from_json(const json& j, BuiltInFunctionKind& e);
 } // namespace facebook::presto::protocol
@@ -2164,6 +2164,17 @@ struct ServerInfo {
 };
 void to_json(json& j, const ServerInfo& p);
 void from_json(const json& j, ServerInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+struct SessionPropertyMetadata {
+  String name = {};
+  String description = {};
+  TypeSignature typeSignature = {};
+  String defaultValue = {};
+  bool hidden = {};
+};
+void to_json(json& j, const SessionPropertyMetadata& p);
+void from_json(const json& j, SessionPropertyMetadata& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 struct SortNode : public PlanNode {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -346,3 +346,4 @@ JavaClasses:
   - presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInFunctionKind.java
   - presto-spi/src/main/java/com/facebook/presto/spi/NodeStats.java
   - presto-spi/src/main/java/com/facebook/presto/spi/NodeLoadMetrics.java
+  - presto-spi/src/main/java/com/facebook/presto/spi/session/SessionPropertyMetadata.java


### PR DESCRIPTION
## Description
`SessionPropertyMetadata` is serialized to json in sidecar using `presto_protocol` with auto-generated serde functions, this would account for changes to `SessionPropertyMetadata` in SPI on the sidecar.
Since serde of `SessionPropertyMetadata` is autogenerated by `presto_protocol`, function `testingSessionProperties` in `SessionProperties` can be removed, since it is used only to test serialization of session property to json. The internal map of native session properties should only be accessed/modified through helper functions in `SessionProperties` and not directly exposed to the user via `testingSessionProperties`. 

## Motivation and Context
Clean up `SessionProperty`.

## Impact
NA

## Test Plan
Tests are present in `SessionPropertiesTest.cpp` and in sidecar plugin.


```
== NO RELEASE NOTE ==
```

