### PR TITLE
feat(redis): Enable case-sensitive support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
           - ":presto-main-base"
           - ":presto-main"
           - ":presto-mongodb -P ci-full-tests"
-          - ":presto-redis -P test-redis-integration-smoke-test"
+          - ":presto-redis -P ci-full-tests"
           - ":presto-elasticsearch"
           - ":presto-orc"
           - ":presto-thrift-connector"

--- a/presto-docs/src/main/sphinx/connector/redis.rst
+++ b/presto-docs/src/main/sphinx/connector/redis.rst
@@ -54,6 +54,7 @@ Property Name                       Description
 ``redis.user``                      Redis server username
 ``redis.tls.enabled``               Whether TLS security is enabled (defaults to ``false``)
 ``redis.tls.truststore-path``       Path to the TLS certificate file
+``case-sensitive-name-matching``    Enable case sensitive identifier support for schema, table, and column names for the connector. When disabled, names are matched case-insensitively using lowercase normalization. Defaults to ``false``.
 =================================   ==============================================================
 
 ``redis.table-names``

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -260,18 +260,14 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Full test suite for CI/CD pipelines -->
         <profile>
-            <id>test-redis-integration-smoke-test</id>
+            <id>ci-full-tests</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <includes>
-                                <include>**/TestRedisIntegrationSmokeTest.java</include>
-                            </includes>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisConnectorConfig.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisConnectorConfig.java
@@ -94,6 +94,7 @@ public class RedisConnectorConfig
 
     private boolean tlsEnabled;
     private File truststorePath;
+    private boolean caseSensitiveNameMatchingEnabled;
 
     @NotNull
     public File getTableDescriptionDir()
@@ -278,6 +279,18 @@ public class RedisConnectorConfig
     public RedisConnectorConfig setTruststorePath(File truststorePath)
     {
         this.truststorePath = truststorePath;
+        return this;
+    }
+
+    public boolean isCaseSensitiveNameMatchingEnabled()
+    {
+        return caseSensitiveNameMatchingEnabled;
+    }
+
+    @Config("case-sensitive-name-matching")
+    public RedisConnectorConfig setCaseSensitiveNameMatchingEnabled(boolean caseSensitiveNameMatchingEnabled)
+    {
+        this.caseSensitiveNameMatchingEnabled = caseSensitiveNameMatchingEnabled;
         return this;
     }
 }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisMetadata.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisMetadata.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import static com.facebook.presto.redis.RedisHandleResolver.convertColumnHandle;
 import static com.facebook.presto.redis.RedisHandleResolver.convertLayout;
 import static com.facebook.presto.redis.RedisHandleResolver.convertTableHandle;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -59,6 +60,7 @@ public class RedisMetadata
 
     private final String connectorId;
     private final boolean hideInternalColumns;
+    private boolean caseSensitiveNameMatchingEnabled;
 
     private final Supplier<Map<SchemaTableName, RedisTableDescription>> redisTableDescriptionSupplier;
 
@@ -76,6 +78,7 @@ public class RedisMetadata
         log.debug("Loading redis table definitions from %s", redisConnectorConfig.getTableDescriptionDir().getAbsolutePath());
 
         this.redisTableDescriptionSupplier = Suppliers.memoize(redisTableDescriptionSupplier::get)::get;
+        this.caseSensitiveNameMatchingEnabled = redisConnectorConfig.isCaseSensitiveNameMatchingEnabled();
     }
 
     @Override
@@ -270,5 +273,11 @@ public class RedisMetadata
                 }
             }
         }
+    }
+
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier)
+    {
+        return caseSensitiveNameMatchingEnabled ? identifier : identifier.toLowerCase(ROOT);
     }
 }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/RedisQueryRunner.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/RedisQueryRunner.java
@@ -69,7 +69,7 @@ public final class RedisQueryRunner
 
             Map<SchemaTableName, RedisTableDescription> tableDescriptions = createTpchTableDescriptions(queryRunner.getCoordinator().getMetadata(), tables, dataFormat);
 
-            installRedisPlugin(embeddedRedis, queryRunner, tableDescriptions);
+            installRedisPlugin(embeddedRedis, queryRunner, tableDescriptions, ImmutableMap.of());
 
             TestingPrestoClient prestoClient = queryRunner.getRandomClient();
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestMinimalFunctionality.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestMinimalFunctionality.java
@@ -34,7 +34,7 @@ import redis.clients.jedis.Jedis;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.facebook.presto.redis.util.RedisTestUtils.createEmptyTableDescription;
+import static com.facebook.presto.redis.util.RedisTestUtils.createEmptyTableDescriptions;
 import static com.facebook.presto.redis.util.RedisTestUtils.installRedisPlugin;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -76,10 +76,12 @@ public class TestMinimalFunctionality
 
         this.queryRunner = new StandaloneQueryRunner(SESSION);
 
-        installRedisPlugin(embeddedRedis, queryRunner,
+        installRedisPlugin(
+                embeddedRedis,
+                queryRunner,
                 ImmutableMap.<SchemaTableName, RedisTableDescription>builder()
-                        .put(createEmptyTableDescription(new SchemaTableName("default", tableName)))
-                        .build());
+                        .putAll(createEmptyTableDescriptions(
+                                new SchemaTableName("default", tableName))).build(), ImmutableMap.of());
     }
 
     @AfterMethod(alwaysRun = true)

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisConnectorConfig.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisConnectorConfig.java
@@ -39,7 +39,8 @@ public class TestRedisConnectorConfig
                 .setRedisDataBaseIndex(0)
                 .setRedisPassword(null)
                 .setRedisScanCount(100)
-                .setHideInternalColumns(true));
+                .setHideInternalColumns(true)
+                .setCaseSensitiveNameMatchingEnabled(false));
     }
 
     @Test
@@ -60,6 +61,7 @@ public class TestRedisConnectorConfig
                 .put("redis.tls.enabled", "true")
                 .put("redis.tls.truststore-path", "/dev/null")
                 .put("redis.password", "secret")
+                .put("case-sensitive-name-matching", "true")
                 .build();
 
         RedisConnectorConfig expected = new RedisConnectorConfig()
@@ -76,7 +78,8 @@ public class TestRedisConnectorConfig
                 .setTruststorePath(new File("/dev/null"))
                 .setRedisPassword("secret")
                 .setRedisKeyDelimiter(",")
-                .setKeyPrefixSchemaTable(true);
+                .setKeyPrefixSchemaTable(true)
+                .setCaseSensitiveNameMatchingEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationMixedCase.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationMixedCase.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.redis;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.redis.util.EmbeddedRedis;
+import com.facebook.presto.redis.util.JsonEncoder;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.security.AllowAllAccessControl;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.StandaloneQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import redis.clients.jedis.Jedis;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.facebook.presto.redis.util.RedisTestUtils.createEmptyTableDescriptions;
+import static com.facebook.presto.redis.util.RedisTestUtils.createTableDescriptionsWithColumns;
+import static com.facebook.presto.redis.util.RedisTestUtils.installRedisPlugin;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static com.facebook.presto.tests.QueryAssertions.assertContains;
+import static com.facebook.presto.transaction.TransactionBuilder.transaction;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestRedisIntegrationMixedCase
+{
+    private static final Session SESSION = testSessionBuilder()
+            .setCatalog("redis")
+            .setSchema("default")
+            .build();
+
+    private EmbeddedRedis embeddedRedis;
+    private final String lowerCaseTable = "test";
+    private final String camelCaseTable = "Test";
+    private final String upperCaseTable = "TEST";
+    private final String testTable = "testTable";
+    private StandaloneQueryRunner queryRunner;
+
+    @BeforeClass
+    public void startRedis()
+            throws Exception
+    {
+        embeddedRedis = EmbeddedRedis.createEmbeddedRedis();
+        embeddedRedis.start();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stopRedis()
+    {
+        embeddedRedis.close();
+        embeddedRedis = null;
+    }
+
+    @BeforeMethod
+    public void spinUp()
+            throws Exception
+    {
+        this.queryRunner = new StandaloneQueryRunner(SESSION);
+
+        installRedisPlugin(
+                embeddedRedis,
+                queryRunner,
+                ImmutableMap.<SchemaTableName, RedisTableDescription>builder()
+                        .putAll(createEmptyTableDescriptions(
+                                new SchemaTableName("default", lowerCaseTable),
+                                new SchemaTableName("default", camelCaseTable),
+                                new SchemaTableName("default", upperCaseTable)))
+                        .putAll(createTableDescriptionsWithColumns(
+                                ImmutableMap.of(
+                                        new SchemaTableName("default", testTable),
+                                        ImmutableList.of(
+                                                new RedisTableFieldDescription("id", BIGINT, "id", null, null, null, false),
+                                                new RedisTableFieldDescription("name", VARCHAR, "name", null, null, null, false),
+                                                new RedisTableFieldDescription("NAME", VARCHAR, "NAME", null, null, null, false),
+                                                new RedisTableFieldDescription("Address", VARCHAR, "Address", null, null, null, false),
+                                                new RedisTableFieldDescription("age", BIGINT, "age", null, null, null, false),
+                                                new RedisTableFieldDescription("BAND", VARCHAR, "BAND", null, null, null, false)))))
+                        .build(),
+                ImmutableMap.of("case-sensitive-name-matching", "true"));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
+    }
+
+    private void populateData(int count)
+    {
+        JsonEncoder jsonEncoder = new JsonEncoder();
+        for (long i = 0; i < count; i++) {
+            Object value = ImmutableMap.of("id", Long.toString(i), "value", UUID.randomUUID().toString());
+            try (Jedis jedis = embeddedRedis.getJedisPool().getResource()) {
+                jedis.set(lowerCaseTable + ":" + i, jsonEncoder.toString(value));
+                jedis.set(camelCaseTable + ":" + i, jsonEncoder.toString(value));
+                jedis.set(upperCaseTable + ":" + i, jsonEncoder.toString(value));
+            }
+        }
+    }
+
+    @Test
+    public void testTableExists()
+    {
+        QualifiedObjectName lowerCaseObjName = new QualifiedObjectName("redis", "default", lowerCaseTable);
+        QualifiedObjectName camelCaseObjName = new QualifiedObjectName("redis", "default", camelCaseTable);
+        QualifiedObjectName upperCaseObjName = new QualifiedObjectName("redis", "default", upperCaseTable);
+        transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
+                .singleStatement()
+                .execute(SESSION, session -> {
+                    Optional<TableHandle> lowerCaseHandle = queryRunner.getServer().getMetadata().getMetadataResolver(session).getTableHandle(lowerCaseObjName);
+                    Optional<TableHandle> camelCaseHandle = queryRunner.getServer().getMetadata().getMetadataResolver(session).getTableHandle(camelCaseObjName);
+                    Optional<TableHandle> upperCaseHandle = queryRunner.getServer().getMetadata().getMetadataResolver(session).getTableHandle(upperCaseObjName);
+                    assertTrue(lowerCaseHandle.isPresent());
+                    assertTrue(camelCaseHandle.isPresent());
+                    assertTrue(upperCaseHandle.isPresent());
+                });
+    }
+
+    private void assertTableCount(String tableName, long expectedCount)
+    {
+        MaterializedResult result = queryRunner.execute("SELECT count(1) from " + tableName);
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BIGINT).row(expectedCount).build();
+        assertEquals(result, expected);
+    }
+
+    @Test
+    public void testTableHasData()
+    {
+        assertTableCount(lowerCaseTable, 0L);
+        assertTableCount(camelCaseTable, 0L);
+        assertTableCount(upperCaseTable, 0L);
+
+        int count = 10;
+        populateData(count);
+
+        assertTableCount(lowerCaseTable, (long) count);
+        assertTableCount(camelCaseTable, (long) count);
+        assertTableCount(upperCaseTable, (long) count);
+    }
+
+    @Test
+    public void testShowTables()
+    {
+        MaterializedResult result = queryRunner.execute("show tables from redis.default");
+        assertEquals(result.getRowCount(), 4);
+
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, createUnboundedVarcharType())
+                .row("test")
+                .row("Test")
+                .row("TEST")
+                .row("testTable")
+                .build();
+
+        assertContains(result, expected);
+    }
+
+    @Test
+    public void testShowColumns()
+    {
+        MaterializedResult result = queryRunner.execute("show columns from redis.default.testTable");
+
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, createUnboundedVarcharType())
+                .row("id", "bigint", "", "", Long.valueOf(19), null, null)
+                .row("name", "varchar", "", "", null, null, Long.valueOf(2147483647))
+                .row("NAME", "varchar", "", "", null, null, Long.valueOf(2147483647))
+                .row("Address", "varchar", "", "", null, null, Long.valueOf(2147483647))
+                .row("age", "bigint", "", "", Long.valueOf(19), null, null)
+                .row("BAND", "varchar", "", "", null, null, Long.valueOf(2147483647))
+                .build();
+        assertContains(result, expected);
+    }
+
+    private void populateTestTable(long count)
+    {
+        JsonEncoder jsonEncoder = new JsonEncoder();
+        for (long i = 0; i < count; i++) {
+            Object value = ImmutableMap.of("id", Long.toString(i), "name", "name_value_" + i, "NAME", "NAME_value_" + i, "Address", "Address_value_" + i, "age", Long.toString(25), "BAND", "BAND_value_" + i);
+            try (Jedis jedis = embeddedRedis.getJedisPool().getResource()) {
+                jedis.set(testTable + ":" + i, jsonEncoder.toString(value));
+            }
+        }
+    }
+
+    @Test
+    public void testSelect()
+    {
+        populateTestTable(3);
+        MaterializedResult result = queryRunner.execute("SELECT * FROM " + testTable);
+
+        MaterializedResult expected = MaterializedResult.resultBuilder(SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
+                .row(Long.valueOf(0), "name_value_0", "NAME_value_0", "Address_value_0", Long.valueOf(25), "BAND_value_0")
+                .row(Long.valueOf(1), "name_value_1", "NAME_value_1", "Address_value_1", Long.valueOf(25), "BAND_value_1")
+                .row(Long.valueOf(2), "name_value_2", "NAME_value_2", "Address_value_2", Long.valueOf(25), "BAND_value_2")
+                .build();
+        assertContains(result, expected);
+    }
+}


### PR DESCRIPTION
## Description
Enable case sensitive support for Redis connector

## Motivation and Context

## Impact

## Test Plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Redis Connector Changes
* Add support for case-sensitive identifiers in Redis. It can be enabled by setting ``case-sensitive-name-matching=true`` configuration in the catalog configuration
```

