### PR TITLE
[pos] Re-enable broadcast related tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
@@ -16,7 +16,6 @@ package com.facebook.presto.spark;
 import com.facebook.presto.nativeworker.AbstractTestNativeTpchQueries;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
-import org.testng.annotations.Ignore;
 
 public class TestPrestoSparkNativeTpchQueries
         extends AbstractTestNativeTpchQueries
@@ -33,34 +32,4 @@ public class TestPrestoSparkNativeTpchQueries
     {
         return PrestoSparkNativeQueryRunnerUtils.createJavaQueryRunner();
     }
-
-    // TODO: Enable following Ignored tests after fixing (Tests can be enabled by removing the method)
-    // Following tests require broadcast join
-    @Override
-    @Ignore
-    public void testTpchQ7() {}
-
-    @Override
-    @Ignore
-    public void testTpchQ8() {}
-
-    @Override
-    @Ignore
-    public void testTpchQ11() {}
-
-    @Override
-    @Ignore
-    public void testTpchQ15() {}
-
-    @Override
-    @Ignore
-    public void testTpchQ18() {}
-
-    @Override
-    @Ignore
-    public void testTpchQ21() {}
-
-    @Override
-    @Ignore
-    public void testTpchQ22() {}
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Broadcast join is already supported in POS native. Re-enabling these related tests.
```
== NO RELEASE NOTE ==
```

