### PR TITLE
feat(readers): Add session properties for small batch size mitigation

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -54,6 +54,10 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_DEBUG_MEMORY_POOL_NAME_REGEX = "native_debug_memory_pool_name_regex";
     public static final String NATIVE_DEBUG_MEMORY_POOL_WARN_THRESHOLD_BYTES = "native_debug_memory_pool_warn_threshold_bytes";
     public static final String NATIVE_SELECTIVE_NIMBLE_READER_ENABLED = "native_selective_nimble_reader_enabled";
+    public static final String NATIVE_ROW_SIZE_TRACKING_ENABLED = "row_size_tracking_enabled";
+    public static final String NATIVE_PREFERRED_OUTPUT_BATCH_BYTES = "preferred_output_batch_bytes";
+    public static final String NATIVE_PREFERRED_OUTPUT_BATCH_ROWS = "preferred_output_batch_rows";
+    public static final String NATIVE_MAX_OUTPUT_BATCH_ROWS = "max_output_batch_rows";
     public static final String NATIVE_MAX_PARTIAL_AGGREGATION_MEMORY = "native_max_partial_aggregation_memory";
     public static final String NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY = "native_max_extended_partial_aggregation_memory";
     public static final String NATIVE_MAX_SPILL_BYTES = "native_max_spill_bytes";
@@ -233,10 +237,28 @@ public class NativeWorkerSessionPropertyProvider
                                 "reader is fully rolled out.",
                         false,
                         !nativeExecution),
+                booleanProperty(
+                        NATIVE_ROW_SIZE_TRACKING_ENABLED,
+                        "Flag to control whether row size tracking should be enabled as a fallback " +
+                                "for reader row size estimates.",
+                        true,
+                        !nativeExecution),
                 longProperty(
-                        NATIVE_MAX_PARTIAL_AGGREGATION_MEMORY,
-                        "The max partial aggregation memory when data reduction is not optimal.",
-                        1L << 24,
+                        NATIVE_PREFERRED_OUTPUT_BATCH_BYTES,
+                        "Prefered memory budget for operator output batches. " +
+                                "Used in tandem with average row size estimates when available.",
+                        10L << 20,
+                        !nativeExecution),
+                integerProperty(
+                        NATIVE_PREFERRED_OUTPUT_BATCH_ROWS,
+                        "Preferred row count per operator output batch. Used when average row size estimates are unknown.",
+                        1024,
+                        !nativeExecution),
+                integerProperty(
+                        NATIVE_MAX_OUTPUT_BATCH_ROWS,
+                        "Upperbound for row count per output batch, used together with " +
+                                "preferred_output_batch_bytes and average row size estimates.",
+                        10000,
                         !nativeExecution),
                 longProperty(
                         NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -541,6 +541,38 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kUnnestSplitOutput,
       std::to_string(c.unnestSplitOutput()));
+  
+  addSessionProperty(
+      kPreferredOutputBatchBytes,
+      "Prefered memory budget for operator output batches. Used in tandem with average row size estimates when available.",
+      BIGINT(),
+      10UL * 1048576,
+      QueryConfig::kPreferredOutputBatchBytes,
+      std::to_string(c.preferredOutputBatchBytes()));
+  
+  addSessionProperty(
+      kPreferredOutputBatchRows,
+      "Preferred row count per operator output batch. Used when average row size estimates are unknown.",
+      INTEGER(),
+      1024,
+      QueryConfig::kPreferredOutputBatchRows,
+      std::to_string(c.preferredOutputBatchRows()));
+
+  addSessionProperty(
+      kMaxOutputBatchRows,
+      "Upperbound for row count per output batch, used together with preferred_output_batch_bytes and average row size estimates.",
+      INTEGER(),
+      10'000,
+      QueryConfig::kMaxOutputBatchRows,
+      std::to_string(c.maxOutputBatchRows()));
+
+  addSessionProperty(
+      kRowSizeTrackingEnabled,
+      "A fallback for average row size estimate when not supported for certain readers. Turned on by default.",
+      BOOLEAN(),
+      true,
+      QueryConfig::kRowSizeTrackingEnabled,
+      std::to_string(c.rowSizeTrackingEnabled()));
 }
 
 const std::string SessionProperties::toVeloxConfig(

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -339,6 +339,29 @@ class SessionProperties {
   /// a single output for each input batch.
   static constexpr const char* kUnnestSplitOutput =
       "native_unnest_split_output";
+  
+  /// Preferred size of batches in bytes to be returned by operators from
+  /// Operator::getOutput. It is used when an estimate of average row size is
+  /// known. Otherwise kPreferredOutputBatchRows is used.
+  static constexpr const char* kPreferredOutputBatchBytes =
+      "preferred_output_batch_bytes";
+
+  /// Preferred number of rows to be returned by operators from
+  /// Operator::getOutput. It is used when an estimate of average row size is
+  /// not known. When the estimate of average row size is known,
+  /// kPreferredOutputBatchBytes is used.
+  static constexpr const char* kPreferredOutputBatchRows =
+      "preferred_output_batch_rows";
+
+  /// Max number of rows that could be return by operators from
+  /// Operator::getOutput. It is used when an estimate of average row size is
+  /// known and kPreferredOutputBatchBytes is used to compute the number of
+  /// output rows.
+  static constexpr const char* kMaxOutputBatchRows = "max_output_batch_rows";
+
+  /// Enable (reader) row size tracker as a fallback to file level row size estimates.
+  static constexpr const char* kRowSizeTrackingEnabled =
+      "row_size_tracking_enabled";
 
   static SessionProperties* instance();
 

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -57,6 +57,9 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
           {"native_debug_disable_expression_with_memoization", "true"},
           {"native_debug_disable_expression_with_lazy_inputs", "true"},
           {"native_selective_nimble_reader_enabled", "true"},
+          {"preferred_output_batch_bytes", "10485760"},
+          {"preferred_output_batch_rows", "1024"},
+          {"row_size_tracking_enabled", "true"},
           {"aggregation_spill_all", "true"},
           {"native_expression_max_array_size_in_reduce", "99999"},
           {"native_expression_max_compiled_regexes", "54321"},
@@ -75,6 +78,9 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithMemoization());
   EXPECT_TRUE(queryCtx->queryConfig().debugDisableExpressionsWithLazyInputs());
   EXPECT_TRUE(queryCtx->queryConfig().selectiveNimbleReaderEnabled());
+  EXPECT_TRUE(queryCtx->queryConfig().rowSizeTrackingEnabled());
+  EXPECT_EQ(queryCtx->queryConfig().preferredOutputBatchBytes(), 10UL << 20);
+  EXPECT_EQ(queryCtx->queryConfig().preferredOutputBatchRows(), 1024);
   EXPECT_EQ(queryCtx->queryConfig().spillWriteBufferSize(), 1024);
   EXPECT_EQ(queryCtx->queryConfig().exprMaxArraySizeInReduce(), 99999);
   EXPECT_EQ(queryCtx->queryConfig().exprMaxCompiledRegexes(), 54321);


### PR DESCRIPTION
Summary:
Add the relevant session properties that can help control and mitigate specific regressions. 

Notably `preferred_output_batch_bytes`, `preferred_output_batch_rows` and `max_output_batch_rows` are existing velox query configs that were just not exposed.

`row_size_tracking_enabled` is to expose the newly added fallback to missing/failed average row size estimates.

Differential Revision: D81291261

```
== NO RELEASE NOTE ==
```

