### PR TITLE
feat(iceberg): Enable alter tbl-properties to manage old metadata files

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1491,10 +1491,16 @@ Use ``ARRAY[...]`` instead of a string to specify multiple partition transforms 
 
     ALTER TABLE iceberg.web.page_views ADD COLUMN dt date WITH (partitioning = ARRAY['year', 'bucket(16)', 'identity']);
 
-Table properties can be modified for an Iceberg table using an ALTER TABLE SET PROPERTIES statement. Only `commit_retries` can be modified at present.
-For example, to set `commit_retries` to 6 for the table `iceberg.web.page_views_v2`, use::
+Some Iceberg table properties can be modified using an ALTER TABLE SET PROPERTIES statement. The modifiable table properties are
+``commit.retry.num-retries``, ``read.split.target-size``, ``write.metadata.delete-after-commit.enabled``, and ``write.metadata.previous-versions-max``.
 
-    ALTER TABLE iceberg.web.page_views_v2 SET PROPERTIES (commit_retries = 6);
+For example, to set ``commit.retry.num-retries`` to 6 for the table ``iceberg.web.page_views_v2``, use::
+
+    ALTER TABLE iceberg.web.page_views_v2 SET PROPERTIES ("commit.retry.num-retries" = 6);
+
+To set ``write.metadata.delete-after-commit.enabled`` to true and set ``write.metadata.previous-versions-max`` to 5, use::
+
+    ALTER TABLE iceberg.web.page_views_v2 SET PROPERTIES ("write.metadata.delete-after-commit.enabled" = true, "write.metadata.previous-versions-max" = 5);
 
 ALTER VIEW
 ^^^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -44,6 +44,8 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
+import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED;
+import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 
@@ -99,14 +101,18 @@ public class IcebergTableProperties
             .put(COMMIT_RETRIES, TableProperties.COMMIT_NUM_RETRIES)
             .put(DELETE_MODE, TableProperties.DELETE_MODE)
             .put(METADATA_PREVIOUS_VERSIONS_MAX, TableProperties.METADATA_PREVIOUS_VERSIONS_MAX)
-            .put(METADATA_DELETE_AFTER_COMMIT, TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED)
-            .put(METRICS_MAX_INFERRED_COLUMN, TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS)
+            .put(METADATA_DELETE_AFTER_COMMIT, METADATA_DELETE_AFTER_COMMIT_ENABLED)
+            .put(METRICS_MAX_INFERRED_COLUMN, METRICS_MAX_INFERRED_COLUMN_DEFAULTS)
             .build();
 
     private static final Set<String> UPDATABLE_PROPERTIES = ImmutableSet.<String>builder()
             .add(COMMIT_RETRIES)
             .add(COMMIT_NUM_RETRIES)
             .add(TARGET_SPLIT_SIZE)
+            .add(METADATA_DELETE_AFTER_COMMIT)
+            .add(METADATA_DELETE_AFTER_COMMIT_ENABLED)
+            .add(METADATA_PREVIOUS_VERSIONS_MAX)
+            .add(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX)
             .build();
 
     private static final String DEFAULT_FORMAT_VERSION = "2";
@@ -183,12 +189,12 @@ public class IcebergTableProperties
                         icebergConfig.getMetadataPreviousVersionsMax(),
                         false))
                 .add(booleanProperty(
-                        TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED,
+                        METADATA_DELETE_AFTER_COMMIT_ENABLED,
                         "Whether enables to delete the oldest metadata file after commit",
                         icebergConfig.isMetadataDeleteAfterCommit(),
                         false))
                 .add(integerProperty(
-                        TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS,
+                        METRICS_MAX_INFERRED_COLUMN_DEFAULTS,
                         "The maximum number of columns for which metrics are collected",
                         icebergConfig.getMetricsMaxInferredColumn(),
                         false))
@@ -315,12 +321,12 @@ public class IcebergTableProperties
 
     public Boolean isMetadataDeleteAfterCommit(ConnectorSession session, Map<String, Object> tableProperties)
     {
-        return (Boolean) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED);
+        return (Boolean) getTablePropertyWithDeprecationWarning(session, tableProperties, METADATA_DELETE_AFTER_COMMIT_ENABLED);
     }
 
     public Integer getMetricsMaxInferredColumn(ConnectorSession session, Map<String, Object> tableProperties)
     {
-        return (Integer) getTablePropertyWithDeprecationWarning(session, tableProperties, TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS);
+        return (Integer) getTablePropertyWithDeprecationWarning(session, tableProperties, METRICS_MAX_INFERRED_COLUMN_DEFAULTS);
     }
 
     public RowLevelOperationMode getUpdateMode(Map<String, Object> tableProperties)


### PR DESCRIPTION
## Description

We have supported table properties `metadata_previous_versions_max`(`write.metadata.previous-versions-max`) and `metadata_delete_after_commit`(`write.metadata.delete-after-commit.enabled`) in PR #23260 to manage previous metadata files that need to be tracked.

This PR enable us to alter them through the `ALTER TABLE ... SET PROPERTIES (...)` statement. This allows us to modify these two table properties when necessary (for example, when there are too many previous metadata versions maintained by the table, or when there are too many useless metadata files that are not cleaned up automatically).

## Motivation and Context

 - Enable us to alter the table properties to manage previous metadata files as needed

## Impact

N/A

## Test Plan

 - Test cases added to show the impact of altering these two table properties

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

