### PR TITLE
Resolve "No suitable driver found" error in DB-based SPM

### DIFF
--- a/presto-db-session-property-manager/src/main/java/com/facebook/presto/session/db/DbSessionPropertyManagerConfig.java
+++ b/presto-db-session-property-manager/src/main/java/com/facebook/presto/session/db/DbSessionPropertyManagerConfig.java
@@ -23,6 +23,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class DbSessionPropertyManagerConfig
 {
     private String configDbUrl;
+    private String jdbcDriverName = "com.mysql.jdbc.Driver";
     private Duration specsRefreshPeriod = new Duration(10, SECONDS);
 
     @NotNull
@@ -35,6 +36,19 @@ public class DbSessionPropertyManagerConfig
     public DbSessionPropertyManagerConfig setConfigDbUrl(String configDbUrl)
     {
         this.configDbUrl = configDbUrl;
+        return this;
+    }
+
+    @NotNull
+    public String getJdbcDriverName()
+    {
+        return jdbcDriverName;
+    }
+
+    @Config("session-property-manager.db.driver-name")
+    public DbSessionPropertyManagerConfig setJdbcDriverName(String jdbcDriverName)
+    {
+        this.jdbcDriverName = jdbcDriverName;
         return this;
     }
 

--- a/presto-db-session-property-manager/src/main/java/com/facebook/presto/session/db/SessionPropertiesDaoProvider.java
+++ b/presto-db-session-property-manager/src/main/java/com/facebook/presto/session/db/SessionPropertiesDaoProvider.java
@@ -33,6 +33,14 @@ public class SessionPropertiesDaoProvider
     {
         requireNonNull(config, "config is null");
         requireNonNull(config.getConfigDbUrl(), "db url is null");
+
+        try {
+            Class.forName(config.getJdbcDriverName());
+        }
+        catch (ClassNotFoundException e) {
+            throw new RuntimeException("JDBC driver class not found: " + config.getJdbcDriverName(), e);
+        }
+
         this.dao = Jdbi.create(() -> DriverManager.getConnection(config.getConfigDbUrl()))
                 .installPlugin(new SqlObjectPlugin())
                 .onDemand(SessionPropertiesDao.class);

--- a/presto-db-session-property-manager/src/test/java/com/facebook/presto/session/db/TestDbSessionPropertyManagerConfig.java
+++ b/presto-db-session-property-manager/src/test/java/com/facebook/presto/session/db/TestDbSessionPropertyManagerConfig.java
@@ -32,6 +32,7 @@ public class TestDbSessionPropertyManagerConfig
     {
         assertRecordedDefaults(recordDefaults(DbSessionPropertyManagerConfig.class)
                 .setConfigDbUrl(null)
+                .setJdbcDriverName("com.mysql.jdbc.Driver")
                 .setSpecsRefreshPeriod(new Duration(10, SECONDS)));
     }
 
@@ -40,11 +41,13 @@ public class TestDbSessionPropertyManagerConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("session-property-manager.db.url", "foo")
+                .put("session-property-manager.db.driver-name", "org.mariadb.jdbc.Driver")
                 .put("session-property-manager.db.refresh-period", "50s")
                 .build();
 
         DbSessionPropertyManagerConfig expected = new DbSessionPropertyManagerConfig()
                 .setConfigDbUrl("foo")
+                .setJdbcDriverName("org.mariadb.jdbc.Driver")
                 .setSpecsRefreshPeriod(new Duration(50, TimeUnit.SECONDS));
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Fixes the runtime error:

    Caused by: ConnectionException: SQLException: No suitable driver found for jdbc:mysql://...

The issue can occur when both MariaDB and MySQL JDBC drivers are present on the classpath, causing conflicts in driver resolution. This fix ensures the correct driver is selected at runtime.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

