### PR TITLE
CI: Fix presto-on-spark native tests for PRs that only modify docs

### DIFF
--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -328,13 +328,19 @@ jobs:
       MAVEN_TEST: "-B -Dair.check.skip-all -Dmaven.javadoc.skip=true -DLogTestDurationListener.enabled=true --fail-at-end"
     steps:
       - uses: actions/checkout@v4
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
 
       - name: Fix git permissions
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Download artifacts
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/download-artifact@v4
         with:
           name: presto-native-build
@@ -342,6 +348,8 @@ jobs:
 
       # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
       - name: Restore execute permissions and library path
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
@@ -349,15 +357,21 @@ jobs:
           ldconfig /usr/local/lib
 
       - name: Install OpenJDK17
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17.0.15
           cache: 'maven'
       - name: Download nodejs to maven cache
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
 
       - name: Maven install
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         env:
           # Use different Maven options to install.
           MAVEN_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError"
@@ -365,6 +379,8 @@ jobs:
           for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-native-tests' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
 
       - name: Run presto-on-spark native tests
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server"
           export TESTFILES=`find ./presto-native-execution/src/test -type f -name 'TestPrestoSpark*.java'`


### PR DESCRIPTION
## Description

When we submit a PR that only modifies docs, the CI tests for `prestocpp-linux-presto-on-spark-e2e-tests` fail because of the `download artifacts` step. This PR fix the problem.

## Motivation and Context

 - Fix CI tests failure for PRs that only modify docs

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

