### PR TITLE
Add optional detailed stats for SAC calls

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import jakarta.inject.Inject;
+import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -68,6 +69,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
 
 public class AccessControlManager
         implements AccessControl
@@ -75,6 +77,7 @@ public class AccessControlManager
     private static final Logger log = Logger.get(AccessControlManager.class);
     private static final File ACCESS_CONTROL_CONFIGURATION = new File("etc/access-control.properties");
     private static final String ACCESS_CONTROL_PROPERTY_NAME = "access-control.name";
+    private static final String ACCESS_CONTROL_DETAILED_STATS = "access-control.detailed-stats";
 
     private final TransactionManager transactionManager;
     private final Map<String, SystemAccessControlFactory> systemAccessControlFactories = new ConcurrentHashMap<>();
@@ -82,16 +85,18 @@ public class AccessControlManager
 
     private final AtomicReference<SystemAccessControl> systemAccessControl = new AtomicReference<>(new InitializingSystemAccessControl());
     private final AtomicBoolean systemAccessControlLoading = new AtomicBoolean();
-
     private final CounterStat authenticationSuccess = new CounterStat();
     private final CounterStat authenticationFail = new CounterStat();
     private final CounterStat authorizationSuccess = new CounterStat();
     private final CounterStat authorizationFail = new CounterStat();
+    private final MBeanExporter exporter;
 
     @Inject
-    public AccessControlManager(TransactionManager transactionManager)
+    public AccessControlManager(TransactionManager transactionManager, MBeanExporter exporter)
     {
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.exporter = requireNonNull(exporter, "exporter is null");
+
         addSystemAccessControlFactory(new AllowAllSystemAccessControl.Factory());
         addSystemAccessControlFactory(new ReadOnlySystemAccessControl.Factory());
         addSystemAccessControlFactory(new FileBasedSystemAccessControl.Factory());
@@ -158,8 +163,21 @@ public class AccessControlManager
         SystemAccessControlFactory systemAccessControlFactory = systemAccessControlFactories.get(name);
         checkState(systemAccessControlFactory != null, "Access control %s is not registered", name);
 
-        SystemAccessControl systemAccessControl = systemAccessControlFactory.create(ImmutableMap.copyOf(properties));
-        this.systemAccessControl.set(systemAccessControl);
+        if (Boolean.parseBoolean(properties.get(ACCESS_CONTROL_DETAILED_STATS))) {
+            log.info("Enabling detailed stats recording for system access control");
+
+            properties = new HashMap<>(properties);
+            properties.remove(ACCESS_CONTROL_DETAILED_STATS);
+            StatsRecordingSystemAccessControl statsRecordingSystemAccessControl =
+                    new StatsRecordingSystemAccessControl(systemAccessControlFactory.create(ImmutableMap.copyOf(properties)));
+            // Export the stats JMX MBean
+            exporter.export(generatedNameOf(AccessControlManager.class, "DetailedSystemAccessControlStats"), statsRecordingSystemAccessControl.getStats());
+
+            systemAccessControl.set(statsRecordingSystemAccessControl);
+        }
+        else {
+            systemAccessControl.set(systemAccessControlFactory.create(ImmutableMap.copyOf(properties)));
+        }
 
         log.info("-- Loaded system access control %s --", name);
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/security/StatsRecordingSystemAccessControl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/StatsRecordingSystemAccessControl.java
@@ -1,0 +1,1077 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.RuntimeUnit;
+import com.facebook.presto.spi.CatalogSchemaTableName;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.AuthorizedIdentity;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.security.PrestoPrincipal;
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.SystemAccessControl;
+import com.facebook.presto.spi.security.ViewExpression;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public final class StatsRecordingSystemAccessControl
+        implements SystemAccessControl
+{
+    private final Stats stats = new Stats();
+    private final SystemAccessControl delegate;
+
+    public StatsRecordingSystemAccessControl(SystemAccessControl delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    public Stats getStats()
+    {
+        return stats;
+    }
+
+    @Override
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanSetUser(identity, context, principal, userName);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanSetUser.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanSetUser", RuntimeUnit.NANO, duration);
+            stats.checkCanSetUser.record(duration);
+        }
+    }
+
+    @Override
+    public AuthorizedIdentity selectAuthorizedIdentity(Identity identity, AccessControlContext context, String userName, List<X509Certificate> certificates)
+    {
+        long start = System.nanoTime();
+        try {
+            return delegate.selectAuthorizedIdentity(identity, context, userName, certificates);
+        }
+        catch (RuntimeException e) {
+            stats.selectAuthorizedIdentity.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.selectAuthorizedIdentity", RuntimeUnit.NANO, duration);
+            stats.selectAuthorizedIdentity.record(duration);
+        }
+    }
+
+    @Override
+    public void checkQueryIntegrity(Identity identity, AccessControlContext context, String query, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkQueryIntegrity(identity, context, query, viewDefinitions, materializedViewDefinitions);
+        }
+        catch (RuntimeException e) {
+            stats.checkQueryIntegrity.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkQueryIntegrity", RuntimeUnit.NANO, duration);
+            stats.checkQueryIntegrity.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanSetSystemSessionProperty(Identity identity, AccessControlContext context, String propertyName)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanSetSystemSessionProperty(identity, context, propertyName);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanSetSystemSessionProperty.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanSetSystemSessionProperty", RuntimeUnit.NANO, duration);
+            stats.checkCanSetSystemSessionProperty.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanAccessCatalog(Identity identity, AccessControlContext context, String catalogName)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanAccessCatalog(identity, context, catalogName);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanAccessCatalog.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanAccessCatalog", RuntimeUnit.NANO, duration);
+            stats.checkCanAccessCatalog.record(duration);
+        }
+    }
+
+    @Override
+    public Set<String> filterCatalogs(Identity identity, AccessControlContext context, Set<String> catalogs)
+    {
+        long start = System.nanoTime();
+        try {
+            return delegate.filterCatalogs(identity, context, catalogs);
+        }
+        catch (RuntimeException e) {
+            stats.filterCatalogs.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.filterCatalogs", RuntimeUnit.NANO, duration);
+            stats.filterCatalogs.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanCreateSchema(Identity identity, AccessControlContext context, CatalogSchemaName schema)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanCreateSchema(identity, context, schema);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanCreateSchema.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanCreateSchema", RuntimeUnit.NANO, duration);
+            stats.checkCanCreateSchema.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanDropSchema(Identity identity, AccessControlContext context, CatalogSchemaName schema)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanDropSchema(identity, context, schema);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanDropSchema.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanDropSchema", RuntimeUnit.NANO, duration);
+            stats.checkCanDropSchema.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanRenameSchema(Identity identity, AccessControlContext context, CatalogSchemaName schema, String newSchemaName)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanRenameSchema(identity, context, schema, newSchemaName);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanRenameSchema.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanRenameSchema", RuntimeUnit.NANO, duration);
+            stats.checkCanRenameSchema.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanShowSchemas(Identity identity, AccessControlContext context, String catalogName)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanShowSchemas(identity, context, catalogName);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanShowSchemas.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanShowSchemas", RuntimeUnit.NANO, duration);
+            stats.checkCanShowSchemas.record(duration);
+        }
+    }
+
+    @Override
+    public Set<String> filterSchemas(Identity identity, AccessControlContext context, String catalogName, Set<String> schemaNames)
+    {
+        long start = System.nanoTime();
+        try {
+            return delegate.filterSchemas(identity, context, catalogName, schemaNames);
+        }
+        catch (RuntimeException e) {
+            stats.filterSchemas.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.filterSchemas", RuntimeUnit.NANO, duration);
+            stats.filterSchemas.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanShowCreateTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanShowCreateTable(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanShowCreateTable.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanShowCreateTable", RuntimeUnit.NANO, duration);
+            stats.checkCanShowCreateTable.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanCreateTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanCreateTable(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanCreateTable.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanCreateTable", RuntimeUnit.NANO, duration);
+            stats.checkCanCreateTable.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanSetTableProperties(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanSetTableProperties(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanSetTableProperties.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanSetTableProperties", RuntimeUnit.NANO, duration);
+            stats.checkCanSetTableProperties.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanDropTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanDropTable(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanDropTable.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanDropTable", RuntimeUnit.NANO, duration);
+            stats.checkCanDropTable.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanRenameTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table, CatalogSchemaTableName newTable)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanRenameTable(identity, context, table, newTable);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanRenameTable.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanRenameTable", RuntimeUnit.NANO, duration);
+            stats.checkCanRenameTable.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanShowTablesMetadata(Identity identity, AccessControlContext context, CatalogSchemaName schema)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanShowTablesMetadata(identity, context, schema);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanShowTablesMetadata.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanShowTablesMetadata", RuntimeUnit.NANO, duration);
+            stats.checkCanShowTablesMetadata.record(duration);
+        }
+    }
+
+    @Override
+    public Set<SchemaTableName> filterTables(Identity identity, AccessControlContext context, String catalogName, Set<SchemaTableName> tableNames)
+    {
+        long start = System.nanoTime();
+        try {
+            return delegate.filterTables(identity, context, catalogName, tableNames);
+        }
+        catch (RuntimeException e) {
+            stats.filterTables.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.filterTables", RuntimeUnit.NANO, duration);
+            stats.filterTables.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanShowColumnsMetadata(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanShowColumnsMetadata(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanShowColumnsMetadata.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanShowColumnsMetadata", RuntimeUnit.NANO, duration);
+            stats.checkCanShowColumnsMetadata.record(duration);
+        }
+    }
+
+    @Override
+    public List<ColumnMetadata> filterColumns(Identity identity, AccessControlContext context, CatalogSchemaTableName table, List<ColumnMetadata> columns)
+    {
+        long start = System.nanoTime();
+        try {
+            return delegate.filterColumns(identity, context, table, columns);
+        }
+        catch (RuntimeException e) {
+            stats.filterColumns.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.filterColumns", RuntimeUnit.NANO, duration);
+            stats.filterColumns.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanAddColumn(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanAddColumn(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanAddColumn.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanAddColumn", RuntimeUnit.NANO, duration);
+            stats.checkCanAddColumn.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanDropColumn(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanDropColumn(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanDropColumn.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanDropColumn", RuntimeUnit.NANO, duration);
+            stats.checkCanDropColumn.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanRenameColumn(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanRenameColumn(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanRenameColumn.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanRenameColumn", RuntimeUnit.NANO, duration);
+            stats.checkCanRenameColumn.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanSelectFromColumns(Identity identity, AccessControlContext context, CatalogSchemaTableName table, Set<String> columns)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanSelectFromColumns(identity, context, table, columns);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanSelectFromColumns.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanSelectFromColumns", RuntimeUnit.NANO, duration);
+            stats.checkCanSelectFromColumns.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanInsertIntoTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanInsertIntoTable(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanInsertIntoTable.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanInsertIntoTable", RuntimeUnit.NANO, duration);
+            stats.checkCanInsertIntoTable.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanDeleteFromTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanDeleteFromTable(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanDeleteFromTable.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanDeleteFromTable", RuntimeUnit.NANO, duration);
+            stats.checkCanDeleteFromTable.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanTruncateTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanTruncateTable(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanTruncateTable.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanTruncateTable", RuntimeUnit.NANO, duration);
+            stats.checkCanTruncateTable.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanUpdateTableColumns(Identity identity, AccessControlContext context, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanUpdateTableColumns(identity, context, table, updatedColumnNames);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanUpdateTableColumns.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanUpdateTableColumns", RuntimeUnit.NANO, duration);
+            stats.checkCanUpdateTableColumns.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanCreateView(Identity identity, AccessControlContext context, CatalogSchemaTableName view)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanCreateView(identity, context, view);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanCreateView.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanCreateView", RuntimeUnit.NANO, duration);
+            stats.checkCanCreateView.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanRenameView(Identity identity, AccessControlContext context, CatalogSchemaTableName view, CatalogSchemaTableName newView)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanRenameView(identity, context, view, newView);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanRenameView.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanRenameView", RuntimeUnit.NANO, duration);
+            stats.checkCanRenameView.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanDropView(Identity identity, AccessControlContext context, CatalogSchemaTableName view)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanDropView(identity, context, view);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanDropView.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanDropView", RuntimeUnit.NANO, duration);
+            stats.checkCanDropView.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanCreateViewWithSelectFromColumns(Identity identity, AccessControlContext context, CatalogSchemaTableName table, Set<String> columns)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanCreateViewWithSelectFromColumns(identity, context, table, columns);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanCreateViewWithSelectFromColumns.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanCreateViewWithSelectFromColumns", RuntimeUnit.NANO, duration);
+            stats.checkCanCreateViewWithSelectFromColumns.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanSetCatalogSessionProperty(Identity identity, AccessControlContext context, String catalogName, String propertyName)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanSetCatalogSessionProperty(identity, context, catalogName, propertyName);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanSetCatalogSessionProperty.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanSetCatalogSessionProperty", RuntimeUnit.NANO, duration);
+            stats.checkCanSetCatalogSessionProperty.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanGrantTablePrivilege(Identity identity, AccessControlContext context, Privilege privilege, CatalogSchemaTableName table, PrestoPrincipal grantee, boolean withGrantOption)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanGrantTablePrivilege(identity, context, privilege, table, grantee, withGrantOption);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanGrantTablePrivilege.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanGrantTablePrivilege", RuntimeUnit.NANO, duration);
+            stats.checkCanGrantTablePrivilege.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanRevokeTablePrivilege(Identity identity, AccessControlContext context, Privilege privilege, CatalogSchemaTableName table, PrestoPrincipal revokee, boolean grantOptionFor)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanRevokeTablePrivilege(identity, context, privilege, table, revokee, grantOptionFor);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanRevokeTablePrivilege.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanRevokeTablePrivilege", RuntimeUnit.NANO, duration);
+            stats.checkCanRevokeTablePrivilege.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanDropConstraint(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanDropConstraint(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanDropConstraint.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanDropConstraint", RuntimeUnit.NANO, duration);
+            stats.checkCanDropConstraint.record(duration);
+        }
+    }
+
+    @Override
+    public void checkCanAddConstraint(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
+    {
+        long start = System.nanoTime();
+        try {
+            delegate.checkCanAddConstraint(identity, context, table);
+        }
+        catch (RuntimeException e) {
+            stats.checkCanAddConstraint.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.checkCanAddConstraint", RuntimeUnit.NANO, duration);
+            stats.checkCanAddConstraint.record(duration);
+        }
+    }
+
+    @Override
+    public List<ViewExpression> getRowFilters(Identity identity, AccessControlContext context, CatalogSchemaTableName tableName)
+    {
+        long start = System.nanoTime();
+        try {
+            return delegate.getRowFilters(identity, context, tableName);
+        }
+        catch (RuntimeException e) {
+            stats.getRowFilters.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.getRowFilters", RuntimeUnit.NANO, duration);
+            stats.getRowFilters.record(duration);
+        }
+    }
+
+    @Override
+    public Map<ColumnMetadata, ViewExpression> getColumnMasks(Identity identity, AccessControlContext context, CatalogSchemaTableName tableName, List<ColumnMetadata> columns)
+    {
+        long start = System.nanoTime();
+        try {
+            return delegate.getColumnMasks(identity, context, tableName, columns);
+        }
+        catch (RuntimeException e) {
+            stats.getColumnMasks.recordFailure();
+            throw e;
+        }
+        finally {
+            long duration = System.nanoTime() - start;
+            context.getRuntimeStats().addMetricValue("systemAccessControl.getColumnMasks", RuntimeUnit.NANO, duration);
+            stats.getColumnMasks.record(duration);
+        }
+    }
+
+    public static class Stats
+    {
+        static final Stats EMPTY = new Stats();
+        final SystemAccessControlStats checkCanSetUser = new SystemAccessControlStats();
+        final SystemAccessControlStats selectAuthorizedIdentity = new SystemAccessControlStats();
+        final SystemAccessControlStats checkQueryIntegrity = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanSetSystemSessionProperty = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanAccessCatalog = new SystemAccessControlStats();
+        final SystemAccessControlStats filterCatalogs = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanCreateSchema = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanDropSchema = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanRenameSchema = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanShowSchemas = new SystemAccessControlStats();
+        final SystemAccessControlStats filterSchemas = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanShowCreateTable = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanCreateTable = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanSetTableProperties = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanDropTable = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanRenameTable = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanShowTablesMetadata = new SystemAccessControlStats();
+        final SystemAccessControlStats filterTables = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanShowColumnsMetadata = new SystemAccessControlStats();
+        final SystemAccessControlStats filterColumns = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanAddColumn = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanDropColumn = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanRenameColumn = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanSelectFromColumns = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanInsertIntoTable = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanDeleteFromTable = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanTruncateTable = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanUpdateTableColumns = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanCreateView = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanRenameView = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanDropView = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanCreateViewWithSelectFromColumns = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanSetCatalogSessionProperty = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanGrantTablePrivilege = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanRevokeTablePrivilege = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanDropConstraint = new SystemAccessControlStats();
+        final SystemAccessControlStats checkCanAddConstraint = new SystemAccessControlStats();
+        final SystemAccessControlStats getRowFilters = new SystemAccessControlStats();
+        final SystemAccessControlStats getColumnMasks = new SystemAccessControlStats();
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanSetUser()
+        {
+            return checkCanSetUser;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getSelectAuthorizedIdentity()
+        {
+            return selectAuthorizedIdentity;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckQueryIntegrity()
+        {
+            return checkQueryIntegrity;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanSetSystemSessionProperty()
+        {
+            return checkCanSetSystemSessionProperty;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanAccessCatalog()
+        {
+            return checkCanAccessCatalog;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getFilterCatalogs()
+        {
+            return filterCatalogs;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanCreateSchema()
+        {
+            return checkCanCreateSchema;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanDropSchema()
+        {
+            return checkCanDropSchema;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanRenameSchema()
+        {
+            return checkCanRenameSchema;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanShowSchemas()
+        {
+            return checkCanShowSchemas;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getFilterSchemas()
+        {
+            return filterSchemas;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanShowCreateTable()
+        {
+            return checkCanShowCreateTable;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanCreateTable()
+        {
+            return checkCanCreateTable;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanSetTableProperties()
+        {
+            return checkCanSetTableProperties;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanDropTable()
+        {
+            return checkCanDropTable;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanRenameTable()
+        {
+            return checkCanRenameTable;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanShowTablesMetadata()
+        {
+            return checkCanShowTablesMetadata;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getFilterTables()
+        {
+            return filterTables;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanShowColumnsMetadata()
+        {
+            return checkCanShowColumnsMetadata;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getFilterColumns()
+        {
+            return filterColumns;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanAddColumn()
+        {
+            return checkCanAddColumn;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanDropColumn()
+        {
+            return checkCanDropColumn;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanRenameColumn()
+        {
+            return checkCanRenameColumn;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanSelectFromColumns()
+        {
+            return checkCanSelectFromColumns;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanInsertIntoTable()
+        {
+            return checkCanInsertIntoTable;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanDeleteFromTable()
+        {
+            return checkCanDeleteFromTable;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanTruncateTable()
+        {
+            return checkCanTruncateTable;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanUpdateTableColumns()
+        {
+            return checkCanUpdateTableColumns;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanCreateView()
+        {
+            return checkCanCreateView;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanRenameView()
+        {
+            return checkCanRenameView;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanDropView()
+        {
+            return checkCanDropView;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanCreateViewWithSelectFromColumns()
+        {
+            return checkCanCreateViewWithSelectFromColumns;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanSetCatalogSessionProperty()
+        {
+            return checkCanSetCatalogSessionProperty;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanGrantTablePrivilege()
+        {
+            return checkCanGrantTablePrivilege;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanRevokeTablePrivilege()
+        {
+            return checkCanRevokeTablePrivilege;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanDropConstraint()
+        {
+            return checkCanDropConstraint;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getCheckCanAddConstraint()
+        {
+            return checkCanAddConstraint;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getGetRowFilters()
+        {
+            return getRowFilters;
+        }
+
+        @Managed
+        @Nested
+        public SystemAccessControlStats getGetColumnMasks()
+        {
+            return getColumnMasks;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/security/SystemAccessControlStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/SystemAccessControlStats.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.airlift.stats.CounterStat;
+import com.facebook.airlift.stats.TimeStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class SystemAccessControlStats
+{
+    private final CounterStat failures = new CounterStat();
+    private final TimeStat time = new TimeStat(MICROSECONDS);
+
+    public void record(long nanos)
+    {
+        time.add(nanos, NANOSECONDS);
+    }
+
+    public void recordFailure()
+    {
+        failures.update(1);
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getTime()
+    {
+        return time;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFailures()
+    {
+        return failures;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
@@ -27,6 +27,8 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import jakarta.inject.Inject;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.testing.TestingMBeanServer;
 
 import java.security.Principal;
 import java.util.ArrayList;
@@ -102,7 +104,7 @@ public class TestingAccessControlManager
     @Inject
     public TestingAccessControlManager(TransactionManager transactionManager)
     {
-        super(transactionManager);
+        super(transactionManager, new MBeanExporter(new TestingMBeanServer()));
         setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -63,6 +63,7 @@ import static com.facebook.presto.execution.QueryState.RUNNING;
 import static com.facebook.presto.execution.QueryState.STARTING;
 import static com.facebook.presto.execution.QueryState.WAITING_FOR_PREREQUISITES;
 import static com.facebook.presto.execution.QueryState.WAITING_FOR_RESOURCES;
+import static com.facebook.presto.security.TestAccessControlManager.MBEAN_EXPORTER;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.USER_CANCELED;
 import static com.facebook.presto.transaction.InMemoryTransactionManager.createTestTransactionManager;
@@ -626,7 +627,7 @@ public class TestQueryStateMachine
     private QueryStateMachine createQueryStateMachineWithTicker(Ticker ticker, TransactionManager transactionManager)
     {
         Metadata metadata = MetadataManager.createTestMetadataManager();
-        AccessControl accessControl = new AccessControlManager(transactionManager);
+        AccessControl accessControl = new AccessControlManager(transactionManager, MBEAN_EXPORTER);
         QueryStateMachine stateMachine = QueryStateMachine.beginWithTicker(
                 QUERY,
                 Optional.empty(),

--- a/presto-main-base/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -52,6 +52,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.testing.TestingMBeanServer;
 
 import java.security.Principal;
 import java.util.Collections;
@@ -78,6 +80,7 @@ import static org.testng.Assert.fail;
 
 public class TestAccessControlManager
 {
+    public static final MBeanExporter MBEAN_EXPORTER = new MBeanExporter(new TestingMBeanServer());
     private static final Principal PRINCIPAL = new BasicPrincipal("principal");
     private static final String USER_NAME = "user_name";
     private static final String QUERY_TOKEN_FIELD = "query_token";
@@ -86,7 +89,7 @@ public class TestAccessControlManager
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Presto server is still initializing")
     public void testInitializing()
     {
-        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
+        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager(), MBEAN_EXPORTER);
         accessControlManager.checkCanSetUser(
                 new Identity(USER_NAME, Optional.of(PRINCIPAL)),
                 new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty(), Optional.empty(), Optional.empty()),
@@ -97,7 +100,7 @@ public class TestAccessControlManager
     @Test
     public void testNoneSystemAccessControl()
     {
-        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
+        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager(), MBEAN_EXPORTER);
         accessControlManager.setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
         accessControlManager.checkCanSetUser(
                 new Identity(USER_NAME, Optional.of(PRINCIPAL)),
@@ -112,7 +115,7 @@ public class TestAccessControlManager
         Identity identity = new Identity(USER_NAME, Optional.of(PRINCIPAL));
         QualifiedObjectName tableName = new QualifiedObjectName("catalog", "schema", "table");
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, MBEAN_EXPORTER);
         AccessControlContext context = new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty(), Optional.empty(), Optional.empty());
 
         accessControlManager.setSystemAccessControl(ReadOnlySystemAccessControl.NAME, ImmutableMap.of());
@@ -148,7 +151,7 @@ public class TestAccessControlManager
     @Test
     public void testSetAccessControl()
     {
-        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
+        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager(), MBEAN_EXPORTER);
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
@@ -166,7 +169,7 @@ public class TestAccessControlManager
     @Test
     public void testCheckQueryIntegrity()
     {
-        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
+        AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager(), MBEAN_EXPORTER);
         AccessControlContext context = new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty(), Optional.empty(), Optional.empty());
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
@@ -214,7 +217,7 @@ public class TestAccessControlManager
     public void testNoCatalogAccessControl()
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, MBEAN_EXPORTER);
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
@@ -233,7 +236,7 @@ public class TestAccessControlManager
     {
         CatalogManager catalogManager = new CatalogManager();
         TransactionManager transactionManager = createTestTransactionManager(catalogManager);
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, MBEAN_EXPORTER);
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
@@ -255,7 +258,7 @@ public class TestAccessControlManager
     {
         CatalogManager catalogManager = new CatalogManager();
         TransactionManager transactionManager = createTestTransactionManager(catalogManager);
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, MBEAN_EXPORTER);
 
         TestSystemAccessControlFactory accessControlFactory = new TestSystemAccessControlFactory("test");
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
@@ -277,7 +280,7 @@ public class TestAccessControlManager
     {
         CatalogManager catalogManager = new CatalogManager();
         TransactionManager transactionManager = createTestTransactionManager(catalogManager);
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, MBEAN_EXPORTER);
 
         accessControlManager.addSystemAccessControlFactory(new SystemAccessControlFactory() {
             @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -39,6 +39,7 @@ import java.util.Set;
 
 import static com.facebook.presto.plugin.base.security.FileBasedAccessControlConfig.SECURITY_CONFIG_FILE;
 import static com.facebook.presto.plugin.base.security.FileBasedAccessControlConfig.SECURITY_REFRESH_PERIOD;
+import static com.facebook.presto.security.TestAccessControlManager.MBEAN_EXPORTER;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.facebook.presto.spi.security.Privilege.SELECT;
 import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
@@ -477,7 +478,7 @@ public class TestFileBasedSystemAccessControl
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, MBEAN_EXPORTER);
         File configFile = newTemporaryFile();
         configFile.deleteOnExit();
         copy(getResourceFile("catalog.json"), configFile);
@@ -533,7 +534,7 @@ public class TestFileBasedSystemAccessControl
 
     private AccessControlManager newAccessControlManager(TransactionManager transactionManager, String resourceName) throws IOException
     {
-        AccessControlManager accessControlManager = new AccessControlManager(transactionManager);
+        AccessControlManager accessControlManager = new AccessControlManager(transactionManager, MBEAN_EXPORTER);
 
         accessControlManager.setSystemAccessControl(FileBasedSystemAccessControl.NAME, ImmutableMap.of("security.config-file", getResourceFile(resourceName).getAbsolutePath()));
 

--- a/presto-main-base/src/test/java/com/facebook/presto/security/TestStatsRecordingSystemAccessControl.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/security/TestStatsRecordingSystemAccessControl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.security;
+
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.SystemAccessControl;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+import static org.testng.Assert.assertEquals;
+
+public class TestStatsRecordingSystemAccessControl
+{
+    public static final AccessControlContext CONTEXT = new AccessControlContext(new QueryId("query_id"), Optional.empty(), Collections.emptySet(), Optional.empty(), WarningCollector.NOOP, new RuntimeStats(), Optional.empty(), Optional.empty(), Optional.empty());
+
+    @Test
+    public void testEverythingDelegated()
+    {
+        assertAllMethodsOverridden(SystemAccessControl.class, StatsRecordingSystemAccessControl.class);
+    }
+
+    @Test
+    public void testStatsRecording()
+            throws InterruptedException
+    {
+        SystemAccessControl delegate = new AllowAllSystemAccessControl();
+        StatsRecordingSystemAccessControl statsRecordingAccessControl = new StatsRecordingSystemAccessControl(delegate);
+
+        assertEquals(statsRecordingAccessControl.getStats().getCheckCanAccessCatalog().getTime().getAllTime().getCount(), 0.0);
+
+        statsRecordingAccessControl.checkCanAccessCatalog(null, CONTEXT, "test-catalog");
+
+        assertEquals(statsRecordingAccessControl.getStats().getCheckCanAccessCatalog().getTime().getAllTime().getCount(), 1.0);
+    }
+}


### PR DESCRIPTION
This will help users with custom SystemAccessControl (SAC) implementations get detailed metrics about latency and failures of the various SAC calls

## Motivation and Context
Fixes https://github.com/prestodb/presto/issues/25574

## Impact
- No change in behavior for default/existing configs
- Detailed stats captured as JMX metrics and per-query runtime stats if `access-control.detailed-stats=true` is set in `/etc/access-control.properties`

## Test Plan
- New unit test
- Manual testing to confirm JMX and runtime stats wireup

## Other details
I used the [Github co-pilot agent](https://github.com/aaneja/presto2/pull/3) to help bootstrap and iterate on the branch. I wanted to test its effectiveness in helping address well-defined issues like this one. It helped avoid some repetitive work .I have attributed it as co-author on the commit

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add detailed latency and failure count metrics for the system access control plugin

``

