### PR TITLE
 Upgrade org.jetbrains:annotations version  26.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1472,7 +1472,7 @@
             <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
-                <version>19.0.0</version>
+                <version>26.0.2</version>
             </dependency>
 
             <dependency>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -354,7 +354,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>19.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -225,7 +225,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>19.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/presto-hana/pom.xml
+++ b/presto-hana/pom.xml
@@ -161,7 +161,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>19.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -173,7 +173,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>19.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -176,7 +176,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>19.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-singlestore/pom.xml
+++ b/presto-singlestore/pom.xml
@@ -179,7 +179,6 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>19.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Description
 Upgrade org.jetbrains:annotations version  26.0.2

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade org.jetbrains:annotations version to 26.0.2 in response to the use of an outdated version.
```

