### PR TITLE
Avoid problematic Hadoop download pending a better solution

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -33,7 +33,12 @@ RUN bash -c "mkdir build && \
                  ../scripts/setup-adapters.sh && \
                  source ../velox/scripts/setup-centos9.sh && \
                  source ../velox/scripts/setup-centos-adapters.sh && \
-                 install_adapters && \
+                 # equivalent of install_adapters() but without problematic Hadoop SDK download
+                 install_adapters_deps_from_dnf && \
+                 install_s3 && \
+                 install_gcs-sdk-cpp && \
+                 install_azure-storage-sdk-cpp && \
+                 # continue as before
                  install_clang15 && \
                  install_cuda 12.8) && \
     rm -rf build"


### PR DESCRIPTION
## Description

In the Presto Dependencies Container Docker build, replace the `install_adapters` call with the body of that function except for the HDFS deps installation, to avoid the problematic download of Hadoop 3.3.0 source from Apache, which takes over an hour when it works, and often fails.

Not intended to land in mainline Presto. Further discussion required.
