### PR TITLE
Use NodeAssignmentStats::getQueuedSplitsWeightForStage in task-based split scheduling

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleNodeSelector.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleNodeSelector.java
@@ -256,13 +256,11 @@ public class SimpleNodeSelector
             RemoteTask remoteTask = tasksByNodeId.get(node.getNodeIdentifier());
             if (remoteTask == null) {
                 // No task for this node, return only the queued splits weight for the stage
-                return assignmentStats.getAssignedSplitsWeightForStage(node);
+                return assignmentStats.getQueuedSplitsWeightForStage(node);
             }
 
             TaskStatus taskStatus = remoteTask.getTaskStatus();
-            return taskStatus.getQueuedPartitionedSplitsWeight() +
-                    taskStatus.getRunningPartitionedSplitsWeight() +
-                    assignmentStats.getAssignedSplitsWeightForStage(node);
+            return taskStatus.getRunningPartitionedSplitsWeight() + assignmentStats.getQueuedSplitsWeightForStage(node);
         };
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -1324,7 +1324,6 @@ public class TestNodeScheduler
                 assertTrue(node.getNodeIdentifier().equals("other2") || node.getNodeIdentifier().equals("other3"));
             }
 
-            Map<RemoteTask, Multimap<PlanNodeId, Split>> splitsForTasks = new HashMap<>();
             PlanNodeId planNodeId = new PlanNodeId("sourceId");
             for (InternalNode node : assignments.keySet()) {
                 Multimap<PlanNodeId, Split> splits = ArrayListMultimap.create();


### PR DESCRIPTION
## Description
In the initial PR which introduces "task-based split scheduling" in the last update I have replaced `assignmentStats.getQueuedSplitsWeightForStage(node)` calls by `assignmentStats.getAssignedSplitsWeightForStage(node)` thinking that we get queued splits from the `TaskStatus` and don't need extra queued from the `NodeAssignmentStats`.

But as it happened, while working on the issue of HttpRemoteTaskWithEventLoop, I noticed that the `getQueuedSplitsWeightForStage` is a misnomer and actually returns not queued, but scheduled and unacknowled splits plus the splits what we assigned in the current split scheduling run.
While `getAssignedSplitsWeightForStage` only returns splits what we assigned in the current split scheduling run.

This PR fixes it.

Actually, it would be good to follow up this with a PR doing some renaming in the NodeAssignmentStats and HttpRemoteTask classes as we have the same things called different names and different things called the same names and also some methods returning A + B not reflecting this in their names.
Hard to follow and reason about the code.