### PR TITLE
Fix constant folding for `SpecialFormExpression` and `LambdaDefinitionExpression` in sidecar enabled clusters

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -264,7 +264,7 @@ public class RowExpressionInterpreter
                     (!functionMetadata.isDeterministic() ||
                             hasUnresolvedValue(argumentValues) ||
                             isDynamicFilter(node) ||
-                            resolution.isFailFunction(functionHandle))) {
+                            resolution.isJavaBuiltInFailFunction(functionHandle))) {
                 return call(node.getDisplayName(), functionHandle, node.getType(), toRowExpressions(argumentValues, node.getArguments()));
             }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -300,9 +300,12 @@ public final class FunctionResolution
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().getObjectName().equals("$internal$try");
     }
 
-    public boolean isFailFunction(FunctionHandle functionHandle)
+    public boolean isJavaBuiltInFailFunction(FunctionHandle functionHandle)
     {
-        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(functionAndTypeResolver.qualifyObjectName(QualifiedName.of("fail")));
+        // todo: Revert this hack once constant folding support lands in C++.
+        // For now, we always use the presto.default.fail function even when the default namespace is switched.
+        // This is done for consistency since the BuiltInNamespaceRewriter rewrites the functionHandles to presto.default functionHandles.
+        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "fail"));
     }
 
     @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestRowExpressionOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestRowExpressionOptimizer.java
@@ -15,9 +15,11 @@ package com.facebook.presto.sql.relational;
 
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.IntArrayBlock;
+import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.functionNamespace.SqlInvokedFunctionNamespaceManagerConfig;
 import com.facebook.presto.functionNamespace.execution.NoopSqlFunctionExecutor;
 import com.facebook.presto.functionNamespace.execution.SqlFunctionExecutors;
@@ -33,6 +35,7 @@ import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.sql.analyzer.FunctionsConfig;
@@ -42,10 +45,15 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.List;
+import java.util.Optional;
+
 import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
 import static com.facebook.presto.block.BlockAssertions.toValues;
 import static com.facebook.presto.common.function.OperatorType.ADD;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -94,7 +102,7 @@ public class TestRowExpressionOptimizer
             RoutineCharacteristics.builder().setLanguage(CPP).setDeterminism(DETERMINISTIC).setNullCallClause(RETURNS_NULL_ON_NULL_INPUT).build(),
             "",
             notVersioned());
-    public static final SqlInvokedFunction CPP_CUSTOM_FUNCTION = new SqlInvokedFunction(
+    private static final SqlInvokedFunction CPP_CUSTOM_FUNCTION = new SqlInvokedFunction(
             new QualifiedObjectName("native", "default", "cpp_custom_func"),
             ImmutableList.of(new Parameter("x", parseTypeSignature(StandardTypes.BIGINT))),
             parseTypeSignature(StandardTypes.BIGINT),
@@ -103,6 +111,28 @@ public class TestRowExpressionOptimizer
             "",
             notVersioned());
     private static final String nativePrefix = "native.default";
+
+    private static final RowExpression CUBE_ROOT_EXP = call(
+            "cbrt",
+            new SqlFunctionHandle(
+                    new SqlFunctionId(
+                            QualifiedObjectName.valueOf(format("%s.cbrt", nativePrefix)),
+                            ImmutableList.of(BIGINT.getTypeSignature())),
+                    "1"),
+            DOUBLE,
+            ImmutableList.of(
+                    constant(27L, BIGINT)));
+
+    private static final RowExpression SQUARE_ROOT_EXP = call(
+                "sqrt",
+                new SqlFunctionHandle(
+                        new SqlFunctionId(
+                                QualifiedObjectName.valueOf(format("%s.sqrt", nativePrefix)),
+                                ImmutableList.of(BIGINT.getTypeSignature())),
+                        "1"),
+                DOUBLE,
+                ImmutableList.of(
+                        constant(64L, BIGINT)));
 
     private FunctionAndTypeManager functionAndTypeManager;
     private RowExpressionOptimizer optimizer;
@@ -186,59 +216,17 @@ public class TestRowExpressionOptimizer
     public void testDefaultExpressionOptimizerUsesJavaNamespaceForBuiltInFunctions()
     {
         RowExpressionOptimizer nativeOptimizer = getNativeOptimizer();
-        RowExpression simpleAddition = call(
-                "sqrt",
-                new SqlFunctionHandle(
-                        new SqlFunctionId(
-                                QualifiedObjectName.valueOf(format("%s.sqrt", nativePrefix)),
-                                ImmutableList.of(BIGINT.getTypeSignature())),
-                        "1"),
-                DOUBLE,
-                ImmutableList.of(
-                        constant(4L, BIGINT)));
-        assertEquals(nativeOptimizer.optimize(simpleAddition, OPTIMIZED, SESSION), constant(2.0, DOUBLE));
-        assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(simpleAddition, OPTIMIZED, SESSION));
+        assertEquals(nativeOptimizer.optimize(SQUARE_ROOT_EXP, OPTIMIZED, SESSION), constant(8.0, DOUBLE));
+        assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(SQUARE_ROOT_EXP, OPTIMIZED, SESSION));
 
-        RowExpression sqrt = call(
-                "sqrt",
-                new SqlFunctionHandle(
-                        new SqlFunctionId(
-                                QualifiedObjectName.valueOf(format("%s.sqrt", nativePrefix)),
-                                ImmutableList.of(BIGINT.getTypeSignature())),
-                        "1"),
-                DOUBLE,
-                ImmutableList.of(
-                        constant(64L, BIGINT)));
-
-        RowExpression cbrt = call(
-                "cbrt",
-                new SqlFunctionHandle(
-                        new SqlFunctionId(
-                                QualifiedObjectName.valueOf(format("%s.cbrt", nativePrefix)),
-                                ImmutableList.of(BIGINT.getTypeSignature())),
-                        "1"),
-                DOUBLE,
-                ImmutableList.of(sqrt));
-
-        assertEquals(nativeOptimizer.optimize(cbrt, OPTIMIZED, SESSION), constant(2.0, DOUBLE));
-        assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(cbrt, OPTIMIZED, SESSION));
+        assertEquals(nativeOptimizer.optimize(CUBE_ROOT_EXP, OPTIMIZED, SESSION), constant(3.0, DOUBLE));
+        assertThrows(IllegalArgumentException.class, () -> optimizer.optimize(CUBE_ROOT_EXP, OPTIMIZED, SESSION));
     }
 
     @Test
     public void testFunctionNotInPrestoDefaultNamespaceIsNotEvaluated()
     {
         RowExpressionOptimizer nativeOptimizer = getNativeOptimizer();
-
-        RowExpression sqrt = call(
-                "sqrt",
-                new SqlFunctionHandle(
-                        new SqlFunctionId(
-                                QualifiedObjectName.valueOf(format("%s.sqrt", nativePrefix)),
-                                ImmutableList.of(BIGINT.getTypeSignature())),
-                        "1"),
-                DOUBLE,
-                ImmutableList.of(
-                        constant(64L, BIGINT)));
 
         // Create a call expression to the custom native function
         RowExpression customFunctionCall = call(
@@ -270,7 +258,7 @@ public class TestRowExpressionOptimizer
                                 ImmutableList.of(BIGINT.getTypeSignature())),
                         "1"),
                 BIGINT,
-                ImmutableList.of(sqrt));
+                ImmutableList.of(SQUARE_ROOT_EXP));
 
         // The inner CallExpression should be optimized, but the outer shouldn't since the function doesn't exist in presto.default namespace
         optimized = nativeOptimizer.optimize(customFunctionWithCallExpressionCall, OPTIMIZED, SESSION);
@@ -292,14 +280,96 @@ public class TestRowExpressionOptimizer
         assertEquals(optimizedCall.getChildren().get(0), constant(8.0, DOUBLE));
     }
 
+    @Test
+    public void testSpecialFormExpressionsWhenDefaultNamespaceIsSwitched()
+    {
+        RowExpressionOptimizer nativeOptimizer = getNativeOptimizer();
+
+        RowExpression leftCondition = callOperator(
+                GREATER_THAN,
+                SQUARE_ROOT_EXP,
+                constant(5.0, DOUBLE));
+
+        RowExpression rightCondition = callOperator(
+                LESS_THAN,
+                CUBE_ROOT_EXP,
+                constant(10.0, DOUBLE));
+
+        RowExpression andExpr = new SpecialFormExpression(
+                SpecialFormExpression.Form.AND,
+                BOOLEAN,
+                ImmutableList.of(leftCondition, rightCondition));
+
+        RowExpression optimized = nativeOptimizer.optimize(andExpr, OPTIMIZED, SESSION);
+        assertEquals(optimized, constant(true, BOOLEAN));
+
+        // Lambda expressions inside Special form expressions
+        List<Type> lambdaTypes = ImmutableList.of(DOUBLE, DOUBLE);
+        LambdaDefinitionExpression lambda =
+                new LambdaDefinitionExpression(
+                        Optional.empty(),
+                        lambdaTypes,
+                        ImmutableList.of("s", "x"),
+                        callOperator(ADD, SQUARE_ROOT_EXP, CUBE_ROOT_EXP));
+
+        andExpr = new SpecialFormExpression(
+                SpecialFormExpression.Form.AND,
+                BOOLEAN,
+                ImmutableList.of(lambda, rightCondition));
+
+        // rightCondition is always true, hence the expression should be reduced to "(s, x) -> 11.0".
+        optimized = nativeOptimizer.optimize(andExpr, OPTIMIZED, SESSION);
+
+        assertInstanceOf(optimized, LambdaDefinitionExpression.class);
+        LambdaDefinitionExpression lambdaExpression = (LambdaDefinitionExpression) optimized;
+        assertEquals(lambdaExpression.getArgumentTypes(), lambdaTypes);
+        assertEquals(lambdaExpression.getBody(), constant(11.0, DOUBLE));
+    }
+
+    @Test
+    public void testLambdaExpressionsWhenDefaultNamespaceIsSwitched()
+    {
+        RowExpressionOptimizer nativeOptimizer = getNativeOptimizer();
+
+        List<Type> lambdaTypes = ImmutableList.of(DOUBLE, DOUBLE);
+
+        LambdaDefinitionExpression lambda =
+                new LambdaDefinitionExpression(
+                        Optional.empty(),
+                        lambdaTypes,
+                        ImmutableList.of("s", "x"),
+                        callOperator(ADD, SQUARE_ROOT_EXP, CUBE_ROOT_EXP));
+
+        LambdaDefinitionExpression nestedLambda =
+                new LambdaDefinitionExpression(
+                        Optional.empty(),
+                        ImmutableList.of(DOUBLE),
+                        ImmutableList.of("y"),
+                        lambda);
+
+        RowExpression optimized = nativeOptimizer.optimize(lambda, OPTIMIZED, SESSION);
+
+        assertInstanceOf(optimized, LambdaDefinitionExpression.class);
+        LambdaDefinitionExpression lambdaExpression = (LambdaDefinitionExpression) optimized;
+        assertEquals(lambdaExpression.getArgumentTypes(), lambdaTypes);
+        assertEquals(lambdaExpression.getBody(), constant(11.0, DOUBLE));
+
+        // Nested lambda
+        RowExpression optimizedOuterLambda = nativeOptimizer.optimize(nestedLambda, OPTIMIZED, SESSION);
+
+        assertInstanceOf(optimizedOuterLambda, LambdaDefinitionExpression.class);
+        LambdaDefinitionExpression outerLambdaExpression = (LambdaDefinitionExpression) optimizedOuterLambda;
+        assertEquals(outerLambdaExpression.getArgumentTypes(), ImmutableList.of(DOUBLE));
+        assertInstanceOf(outerLambdaExpression.getBody(), LambdaDefinitionExpression.class);
+
+        LambdaDefinitionExpression innerLambdaExpression = (LambdaDefinitionExpression) outerLambdaExpression.getBody();
+        assertEquals(innerLambdaExpression.getArgumentTypes(), lambdaTypes);
+        assertEquals(innerLambdaExpression.getBody(), constant(11.0, DOUBLE));
+    }
+
     private static RowExpression ifExpression(RowExpression condition, long trueValue, long falseValue)
     {
         return new SpecialFormExpression(IF, BIGINT, ImmutableList.of(condition, constant(trueValue, BIGINT), constant(falseValue, BIGINT)));
-    }
-
-    private RowExpression optimize(RowExpression expression)
-    {
-        return optimizer.optimize(expression, OPTIMIZED, SESSION);
     }
 
     private static RowExpressionOptimizer getNativeOptimizer()
@@ -322,5 +392,16 @@ public class TestRowExpressionOptimizer
         // Create a custom function that only exists in native namespace
         metadata.getFunctionAndTypeManager().createFunction(CPP_CUSTOM_FUNCTION, true);
         return new RowExpressionOptimizer(metadata);
+    }
+
+    private RowExpression callOperator(OperatorType operator, RowExpression left, RowExpression right)
+    {
+        FunctionHandle functionHandle = functionAndTypeManager.resolveOperator(operator, fromTypes(left.getType(), right.getType()));
+        return Expressions.call(operator.getOperator(), functionHandle, left.getType(), left, right);
+    }
+
+    private RowExpression optimize(RowExpression expression)
+    {
+        return optimizer.optimize(expression, OPTIMIZED, SESSION);
     }
 }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -219,7 +219,7 @@ public class TestNativeSidecarPlugin
                 "date_trunc('hour', from_unixtime(orderkey, '-09:30')), date_trunc('minute', from_unixtime(orderkey, '+05:30')), " +
                 "date_trunc('second', from_unixtime(orderkey, '+00:00')) FROM orders");
         assertQuery("SELECT mod(orderkey, linenumber) FROM lineitem");
-        assertQueryFails("SELECT IF(true, 0/0, 1)", "/ by zero");
+        assertQueryFails("SELECT IF(true, 0/0, 1)", "/ by zero", true);
         assertQuery("select CASE WHEN true THEN 'Yes' ELSE 'No' END");
     }
 


### PR DESCRIPTION
## Description
Fix constant folding for `SpecialFormExpression` and `LambdaDefinitionExpression` in sidecar enabled clusters.

## Motivation and Context
In sidecar clusters, constant folding was not correctly applied for `SpecialFormExpression` and `LambdaDefinitionExpression`, which led to expressions being left unoptimized.

## Impact
No impact

## Test Plan
Unit tests, CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix constant folding for `SpecialFormExpression` and `LambdaDefinitionExpression` in sidecar enabled clusters
```

