### PR TITLE
[pos] Refactor catalog config to be inside NativeExecutionConfigModule

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -30,7 +30,6 @@ import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.server.security.PrestoAuthenticatorManager;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkBootstrapTimer;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
-import com.facebook.presto.spark.execution.property.NativeExecutionConfigModule;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -61,7 +60,6 @@ public class PrestoSparkInjectorFactory
     private final SparkProcessType sparkProcessType;
     private final Map<String, String> configProperties;
     private final Map<String, Map<String, String>> catalogProperties;
-    private final Optional<Map<String, String>> nativeWorkerConfigProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
@@ -75,7 +73,6 @@ public class PrestoSparkInjectorFactory
             SparkProcessType sparkProcessType,
             Map<String, String> configProperties,
             Map<String, Map<String, String>> catalogProperties,
-            Optional<Map<String, String>> nativeWorkerConfigProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
@@ -88,7 +85,6 @@ public class PrestoSparkInjectorFactory
                 sparkProcessType,
                 configProperties,
                 catalogProperties,
-                nativeWorkerConfigProperties,
                 eventListenerProperties,
                 accessControlProperties,
                 sessionPropertyConfigurationProperties,
@@ -103,7 +99,6 @@ public class PrestoSparkInjectorFactory
             SparkProcessType sparkProcessType,
             Map<String, String> configProperties,
             Map<String, Map<String, String>> catalogProperties,
-            Optional<Map<String, String>> nativeWorkerConfigProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
@@ -117,7 +112,6 @@ public class PrestoSparkInjectorFactory
         this.configProperties = ImmutableMap.copyOf(requireNonNull(configProperties, "configProperties is null"));
         this.catalogProperties = requireNonNull(catalogProperties, "catalogProperties is null").entrySet().stream()
                 .collect(toImmutableMap(Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue())));
-        this.nativeWorkerConfigProperties = requireNonNull(nativeWorkerConfigProperties, "nativeWorkerConfigProperties is null").map(ImmutableMap::copyOf);
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null").map(ImmutableMap::copyOf);
         this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null").map(ImmutableMap::copyOf);
         this.sessionPropertyConfigurationProperties = requireNonNull(sessionPropertyConfigurationProperties, "sessionPropertyConfigurationProperties is null").map(ImmutableMap::copyOf);
@@ -165,11 +159,6 @@ public class PrestoSparkInjectorFactory
             modules.add(new AccessControlModule());
             modules.add(new TempStorageModule());
         }
-
-        Map<String, String> nativeWorkerConfigs = new HashMap<>(
-                this.nativeWorkerConfigProperties.orElse(ImmutableMap.of()));
-        nativeWorkerConfigs.put("node.environment", "spark");
-        modules.add(new NativeExecutionConfigModule(nativeWorkerConfigs));
 
         modules.addAll(additionalModules);
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -121,7 +121,6 @@ import com.facebook.presto.spark.execution.BroadcastFileInfo;
 import com.facebook.presto.spark.execution.PrestoSparkBroadcastTableCacheManager;
 import com.facebook.presto.spark.execution.PrestoSparkExecutionExceptionFactory;
 import com.facebook.presto.spark.execution.http.BatchTaskUpdateRequest;
-import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleReadInfo;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleWriteInfo;
 import com.facebook.presto.spark.execution.task.PrestoSparkNativeTaskExecutorFactory;
@@ -283,7 +282,6 @@ public class PrestoSparkModule
         configBinder(binder).bindConfig(SessionPropertyProviderConfig.class);
         configBinder(binder).bindConfig(PrestoSparkConfig.class);
         configBinder(binder).bindConfig(TracingConfig.class);
-        configBinder(binder).bindConfig(NativeExecutionNodeConfig.class);
         configBinder(binder).bindConfig(PlanCheckerProviderManagerConfig.class);
         configBinder(binder).bindConfig(SecurityConfig.class);
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionModule.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.spark.execution.nativeprocess;
 
-import com.facebook.presto.spark.execution.property.NativeExecutionCatalogProperties;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
 import com.facebook.presto.spark.execution.property.WorkerProperty;
 import com.facebook.presto.spark.execution.shuffle.PrestoSparkLocalShuffleInfoTranslator;
@@ -21,7 +20,6 @@ import com.facebook.presto.spark.execution.shuffle.PrestoSparkShuffleInfoTransla
 import com.facebook.presto.spark.execution.task.ForNativeExecutionTask;
 import com.facebook.presto.spark.execution.task.NativeExecutionTaskFactory;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -30,8 +28,6 @@ import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import okhttp3.OkHttpClient;
 
-import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
@@ -39,15 +35,10 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 public class NativeExecutionModule
         implements Module
 {
-    private Optional<Map<String, Map<String, String>>> catalogProperties;
-
     // In the future, we would make more bindings injected into NativeExecutionModule
     // to be able to test various configuration parameters
     @VisibleForTesting
-    public NativeExecutionModule(Optional<Map<String, Map<String, String>>> catalogProperties)
-    {
-        this.catalogProperties = catalogProperties;
-    }
+    public NativeExecutionModule() {}
 
     @Override
     public void configure(Binder binder)
@@ -67,10 +58,6 @@ public class NativeExecutionModule
 
     protected void bindWorkerProperties(Binder binder)
     {
-        // Bind NativeExecutionCatalogProperties - this is not bound elsewhere
-        binder.bind(NativeExecutionCatalogProperties.class).toInstance(
-                new NativeExecutionCatalogProperties(catalogProperties.orElse(ImmutableMap.of())));
-
         // Bind worker property classes
         newOptionalBinder(binder, new TypeLiteral<WorkerProperty<?, ?, ?>>() {
         }).setDefault().to(PrestoSparkWorkerProperty.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/nativeprocess/NativeExecutionProcess.java
@@ -85,7 +85,7 @@ public class NativeExecutionProcess
     private static final String NATIVE_EXECUTION_TASK_ERROR_MESSAGE = "Native process launch failed with multiple retries.";
     private static final String WORKER_CONFIG_FILE = "/config.properties";
     private static final String WORKER_NODE_CONFIG_FILE = "/node.properties";
-    private static final String WORKER_CONNECTOR_CONFIG_FILE = "/catalog/";
+    private static final String WORKER_CONNECTOR_CONFIG_DIR = "/catalog/";
     private static final String NATIVE_PROCESS_MEMORY_SPARK_CONF_NAME = "spark.memory.offHeap.size";
     private static final int SIGSYS = 31;
 
@@ -338,7 +338,7 @@ public class NativeExecutionProcess
         workerProperty.populateAllProperties(
                 Paths.get(configBasePath, WORKER_CONFIG_FILE),
                 Paths.get(configBasePath, WORKER_NODE_CONFIG_FILE),
-                Paths.get(configBasePath, WORKER_CONNECTOR_CONFIG_FILE));  // Directory path for catalogs
+                Paths.get(configBasePath, WORKER_CONNECTOR_CONFIG_DIR));  // Directory path for catalogs
     }
 
     private void updateWorkerProperties()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionCatalogConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionCatalogConfig.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spark.execution.property;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -21,16 +24,20 @@ import static java.util.Objects.requireNonNull;
  * This class holds catalog properties for native execution process.
  * Each catalog will generate a separate <catalog-name>.properties file.
  */
-public class NativeExecutionCatalogProperties
+public class NativeExecutionCatalogConfig
 {
+    public static final String NATIVE_EXECUTION_CATALOG_CONFIG = "native-execution-catalog-config";
+
     private final Map<String, Map<String, String>> catalogProperties;
 
-    public NativeExecutionCatalogProperties(Map<String, Map<String, String>> catalogProperties)
+    @Inject
+    public NativeExecutionCatalogConfig(
+            @Named(NATIVE_EXECUTION_CATALOG_CONFIG) Map<String, Map<String, String>> catalogProperties)
     {
         this.catalogProperties = requireNonNull(catalogProperties, "catalogProperties is null");
     }
 
-    public Map<String, Map<String, String>> getAllCatalogProperties()
+    public Map<String, Map<String, String>> getAllProperties()
     {
         return catalogProperties;
     }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConfigModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConfigModule.java
@@ -31,11 +31,15 @@ public class NativeExecutionConfigModule
         extends AbstractModule
 {
     private final Map<String, String> systemConfigs;
+    private final Map<String, Map<String, String>> catalogConfigs;
 
-    public NativeExecutionConfigModule(Map<String, String> systemConfigs)
+    public NativeExecutionConfigModule(Map<String, String> systemConfigs,
+            Map<String, Map<String, String>> catalogConfigs)
     {
         this.systemConfigs = ImmutableMap.copyOf(
                 requireNonNull(systemConfigs, "systemConfigs is null"));
+        this.catalogConfigs = ImmutableMap.copyOf(
+                requireNonNull(catalogConfigs, "catalogConfigs is null"));
     }
 
     @Override
@@ -45,7 +49,13 @@ public class NativeExecutionConfigModule
                 .annotatedWith(
                         Names.named(NativeExecutionSystemConfig.NATIVE_EXECUTION_SYSTEM_CONFIG))
                 .toInstance(systemConfigs);
+        bind(new TypeLiteral<Map<String, Map<String, String>>>() {})
+            .annotatedWith(
+                Names.named(NativeExecutionCatalogConfig.NATIVE_EXECUTION_CATALOG_CONFIG))
+            .toInstance(catalogConfigs);
 
         bind(NativeExecutionSystemConfig.class).in(Scopes.SINGLETON);
+        bind(NativeExecutionCatalogConfig.class).in(Scopes.SINGLETON);
+        bind(NativeExecutionNodeConfig.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/PrestoSparkWorkerProperty.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/PrestoSparkWorkerProperty.java
@@ -19,11 +19,11 @@ import com.google.inject.Inject;
  * A utility class that helps with properties and its materialization.
  */
 public class PrestoSparkWorkerProperty
-        extends WorkerProperty<NativeExecutionCatalogProperties, NativeExecutionNodeConfig, NativeExecutionSystemConfig>
+        extends WorkerProperty<NativeExecutionCatalogConfig, NativeExecutionNodeConfig, NativeExecutionSystemConfig>
 {
     @Inject
     public PrestoSparkWorkerProperty(
-            NativeExecutionCatalogProperties catalogProperties,
+            NativeExecutionCatalogConfig catalogProperties,
             NativeExecutionNodeConfig nodeConfig,
             NativeExecutionSystemConfig systemConfig)
     {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/WorkerProperty.java
@@ -64,25 +64,25 @@ import static java.util.Objects.requireNonNull;
  * }
  * }
  */
-public class WorkerProperty<T1 extends NativeExecutionCatalogProperties, T2 extends NativeExecutionNodeConfig, T3 extends NativeExecutionSystemConfig>
+public class WorkerProperty<T1 extends NativeExecutionCatalogConfig, T2 extends NativeExecutionNodeConfig, T3 extends NativeExecutionSystemConfig>
 {
-    private final T1 catalogProperties;
+    private final T1 catalogConfig;
     private final T2 nodeConfig;
     private final T3 systemConfig;
 
     public WorkerProperty(
-            T1 catalogProperties,
+            T1 catalogConfig,
             T2 nodeConfig,
             T3 systemConfig)
     {
         this.systemConfig = requireNonNull(systemConfig, "systemConfig is null");
         this.nodeConfig = requireNonNull(nodeConfig, "nodeConfig is null");
-        this.catalogProperties = requireNonNull(catalogProperties, "catalogProperties is null");
+        this.catalogConfig = requireNonNull(catalogConfig, "catalogConfig is null");
     }
 
-    public T1 getCatalogProperties()
+    public T1 getCatalogConfig()
     {
-        return catalogProperties;
+        return catalogConfig;
     }
 
     public T2 getNodeConfig()
@@ -95,12 +95,12 @@ public class WorkerProperty<T1 extends NativeExecutionCatalogProperties, T2 exte
         return systemConfig;
     }
 
-    public void populateAllProperties(Path systemConfigPath, Path nodeConfigPath, Path catalogConfigsPath)
+    public void populateAllProperties(Path systemConfigPath, Path nodeConfigPath, Path catalogConfigsDir)
             throws IOException
     {
         populateProperty(systemConfig.getAllProperties(), systemConfigPath);
         populateProperty(nodeConfig.getAllProperties(), nodeConfigPath);
-        populateCatalogProperties(catalogProperties.getAllCatalogProperties(), catalogConfigsPath);
+        populateCatalogConfig(catalogConfig.getAllProperties(), catalogConfigsDir);
     }
 
     private void populateProperty(Map<String, String> properties, Path path)
@@ -123,7 +123,7 @@ public class WorkerProperty<T1 extends NativeExecutionCatalogProperties, T2 exte
         }
     }
 
-    private void populateCatalogProperties(Map<String, Map<String, String>> catalogProperties, Path path)
+    private void populateCatalogConfig(Map<String, Map<String, String>> catalogProperties, Path path)
             throws IOException
     {
         File catalogDir = path.toFile();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -58,6 +58,7 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkSession;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
 import com.facebook.presto.spark.execution.AbstractPrestoSparkQueryExecution;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionModule;
+import com.facebook.presto.spark.execution.property.NativeExecutionConfigModule;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.WarningCollector;
@@ -247,8 +248,9 @@ public class PrestoSparkQueryRunner
                         .build(),
                 ImmutableMap.of(),
                 dataDirectory,
-                ImmutableList.of(new NativeExecutionModule(
-                        Optional.of(ImmutableMap.of("hive", ImmutableMap.of("connector.name", "hive"))))),
+                ImmutableList.of(new NativeExecutionModule(),
+                        new NativeExecutionConfigModule(ImmutableMap.of(), ImmutableMap.of("hive",
+                                ImmutableMap.of("connector.name", "hive")))),
                 DEFAULT_AVAILABLE_CPU_COUNT);
         ExtendedHiveMetastore metastore = queryRunner.getMetastore();
         if (!metastore.getDatabase(METASTORE_CONTEXT, "tpch").isPresent()) {
@@ -320,7 +322,6 @@ public class PrestoSparkQueryRunner
                 DRIVER,
                 configProperties.build(),
                 ImmutableMap.of(),
-                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestNativeExecutionProcess.java
@@ -23,7 +23,7 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkFatalException
 import com.facebook.presto.spark.execution.http.TestPrestoSparkHttpClient;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcess;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcessFactory;
-import com.facebook.presto.spark.execution.property.NativeExecutionCatalogProperties;
+import com.facebook.presto.spark.execution.property.NativeExecutionCatalogConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
@@ -227,7 +227,7 @@ public class TestNativeExecutionProcess
 
         NativeExecutionSystemConfig systemConfig = new NativeExecutionSystemConfig(systemConfigs);
         PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
-                new NativeExecutionCatalogProperties(ImmutableMap.of()),
+                new NativeExecutionCatalogConfig(ImmutableMap.of()),
                 new NativeExecutionNodeConfig(),
                 systemConfig);
 
@@ -301,7 +301,7 @@ public class TestNativeExecutionProcess
         TaskId taskId = new TaskId("testid", 0, 0, 0, 0);
         ScheduledExecutorService errorScheduler = newScheduledThreadPool(4);
         PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
-                new NativeExecutionCatalogProperties(ImmutableMap.of()),
+                new NativeExecutionCatalogConfig(ImmutableMap.of()),
                 new NativeExecutionNodeConfig(),
                 new NativeExecutionSystemConfig(ImmutableMap.of()));
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -33,7 +33,7 @@ import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTask
 import com.facebook.presto.spark.execution.nativeprocess.HttpNativeExecutionTaskResultFetcher;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcess;
 import com.facebook.presto.spark.execution.nativeprocess.NativeExecutionProcessFactory;
-import com.facebook.presto.spark.execution.property.NativeExecutionCatalogProperties;
+import com.facebook.presto.spark.execution.property.NativeExecutionCatalogConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionNodeConfig;
 import com.facebook.presto.spark.execution.property.NativeExecutionSystemConfig;
 import com.facebook.presto.spark.execution.property.PrestoSparkWorkerProperty;
@@ -897,7 +897,7 @@ public class TestPrestoSparkHttpClient
             TestingResponseManager responseManager)
     {
         PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
-                new NativeExecutionCatalogProperties(ImmutableMap.of()),
+                new NativeExecutionCatalogConfig(ImmutableMap.of()),
                 new NativeExecutionNodeConfig(),
                 new NativeExecutionSystemConfig(ImmutableMap.of()));
         NativeExecutionProcessFactory factory = new NativeExecutionProcessFactory(

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -204,22 +204,22 @@ public class TestNativeExecutionSystemConfig
     public void testNativeExecutionCatalogProperties()
     {
         // Test default constructor
-        NativeExecutionCatalogProperties config = new NativeExecutionCatalogProperties(ImmutableMap.of());
-        assertEquals(config.getAllCatalogProperties(), ImmutableMap.of());
+        NativeExecutionCatalogConfig config = new NativeExecutionCatalogConfig(ImmutableMap.of());
+        assertEquals(config.getAllProperties(), ImmutableMap.of());
 
         // Test constructor with catalog properties
         Map<String, Map<String, String>> catalogProperties = ImmutableMap.of(
                 "hive", ImmutableMap.of("hive.metastore.uri", "thrift://localhost:9083"),
                 "tpch", ImmutableMap.of("tpch.splits-per-node", "4"));
-        NativeExecutionCatalogProperties configWithProps = new NativeExecutionCatalogProperties(catalogProperties);
-        assertEquals(configWithProps.getAllCatalogProperties(), catalogProperties);
+        NativeExecutionCatalogConfig configWithProps = new NativeExecutionCatalogConfig(catalogProperties);
+        assertEquals(configWithProps.getAllProperties(), catalogProperties);
     }
 
     @Test
     public void testFilePropertiesPopulator()
     {
         PrestoSparkWorkerProperty workerProperty = new PrestoSparkWorkerProperty(
-                new NativeExecutionCatalogProperties(ImmutableMap.of()), new NativeExecutionNodeConfig(),
+                new NativeExecutionCatalogConfig(ImmutableMap.of()), new NativeExecutionNodeConfig(),
                 new NativeExecutionSystemConfig(ImmutableMap.of()));
         testPropertiesPopulate(workerProperty);
     }
@@ -237,7 +237,7 @@ public class TestNativeExecutionSystemConfig
             verifyProperties(workerProperty.getSystemConfig().getAllProperties(), readPropertiesFromDisk(configPropertiesPath));
             verifyProperties(workerProperty.getNodeConfig().getAllProperties(), readPropertiesFromDisk(nodePropertiesPath));
             // Verify each catalog file was created properly
-            workerProperty.getCatalogProperties().getAllCatalogProperties().forEach(
+            workerProperty.getCatalogConfig().getAllProperties().forEach(
                     (catalogName, catalogProperties) -> {
                         Path catalogFilePath = catalogDirectory.resolve(catalogName + ".properties");
                         verifyProperties(catalogProperties, readPropertiesFromDisk(catalogFilePath));

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
@@ -31,6 +31,7 @@ public class PrestoSparkConfiguration
     private final Map<String, Map<String, String>> catalogProperties;
     private final Map<String, String> prestoSparkProperties;
     private final Optional<Map<String, String>> nativeWorkerConfigProperties;
+    private final Optional<Map<String, Map<String, String>>> nativeWorkerCatalogProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
@@ -43,6 +44,7 @@ public class PrestoSparkConfiguration
             Map<String, Map<String, String>> catalogProperties,
             Map<String, String> prestoSparkProperties,
             Optional<Map<String, String>> nativeWorkerConfigProperties,
+            Optional<Map<String, Map<String, String>>> nativeWorkerCatalogProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
@@ -56,6 +58,7 @@ public class PrestoSparkConfiguration
         this.prestoSparkProperties = unmodifiableMap(new HashMap<>(requireNonNull(prestoSparkProperties, "prestoSparkProperties is null")));
         requireNonNull(prestoSparkProperties.get(METADATA_STORAGE_TYPE_KEY), "prestoSparkProperties must contain " + METADATA_STORAGE_TYPE_KEY);
         this.nativeWorkerConfigProperties = requireNonNull(nativeWorkerConfigProperties, "nativeWorkerConfigProperties is null");
+        this.nativeWorkerCatalogProperties = requireNonNull(nativeWorkerCatalogProperties, "nativeWorkerCatalogProperties is null");
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null")
@@ -98,6 +101,11 @@ public class PrestoSparkConfiguration
     public Optional<Map<String, String>> getNativeWorkerConfigProperties()
     {
         return nativeWorkerConfigProperties;
+    }
+
+    public Optional<Map<String, Map<String, String>>> getNativeWorkerCatalogProperties()
+    {
+        return nativeWorkerCatalogProperties;
     }
 
     public Optional<Map<String, String>> getEventListenerProperties()

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkClientOptions.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkClientOptions.java
@@ -32,6 +32,9 @@ public class PrestoSparkClientOptions
     @Option(name = {"--catalogs"}, title = "directory", description = "catalog configuration directory path", required = true)
     public String catalogs;
 
+    @Option(name = {"-nca", "--native-worker-catalogs"}, title = "directory", description = "native worker catalog configuration directory path")
+    public String nativeWorkerCatalogs;
+
     @Option(name = "--catalog", title = "catalog", description = "Default catalog")
     public String catalog;
 

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
@@ -34,6 +34,7 @@ public class PrestoSparkDistribution
     private final Map<String, Map<String, String>> catalogProperties;
     private final Map<String, String> prestoSparkProperties;
     private final Optional<Map<String, String>> nativeWorkerConfigProperties;
+    private final Optional<Map<String, Map<String, String>>> nativeWorkerCatalogConfigProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
@@ -48,6 +49,7 @@ public class PrestoSparkDistribution
             Map<String, Map<String, String>> catalogProperties,
             String metadataStorageType,
             Optional<Map<String, String>> nativeWorkerConfigProperties,
+            Optional<Map<String, Map<String, String>>> nativeWorkerCatalogConfigProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
@@ -61,6 +63,7 @@ public class PrestoSparkDistribution
                 catalogProperties,
                 ImmutableMap.of(METADATA_STORAGE_TYPE_KEY, metadataStorageType),
                 nativeWorkerConfigProperties,
+                nativeWorkerCatalogConfigProperties,
                 eventListenerProperties,
                 accessControlProperties,
                 sessionPropertyConfigurationProperties,
@@ -75,6 +78,7 @@ public class PrestoSparkDistribution
             Map<String, Map<String, String>> catalogProperties,
             Map<String, String> prestoSparkProperties,
             Optional<Map<String, String>> nativeWorkerConfigProperties,
+            Optional<Map<String, Map<String, String>>> nativeWorkerCatalogConfigProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
@@ -88,6 +92,7 @@ public class PrestoSparkDistribution
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue())));
         this.prestoSparkProperties = ImmutableMap.copyOf(requireNonNull(prestoSparkProperties, "prestoSparkProperties is null"));
         this.nativeWorkerConfigProperties = requireNonNull(nativeWorkerConfigProperties, "nativeWorkerConfigProperties is null");
+        this.nativeWorkerCatalogConfigProperties = requireNonNull(nativeWorkerCatalogConfigProperties, "nativeWorkerCatalogConfigProperties is null");
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null")
@@ -130,6 +135,11 @@ public class PrestoSparkDistribution
     public Optional<Map<String, String>> getNativeWorkerConfigProperties()
     {
         return nativeWorkerConfigProperties;
+    }
+
+    public Optional<Map<String, Map<String, String>>> getNativeWorkerCatalogConfigProperties()
+    {
+        return nativeWorkerCatalogConfigProperties;
     }
 
     public Optional<Map<String, String>> getEventListenerProperties()

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
@@ -61,8 +61,10 @@ public class PrestoSparkLauncherCommand
                 ImmutableMap.of(METADATA_STORAGE_TYPE_KEY, METADATA_STORAGE_TYPE_LOCAL),
                 clientOptions.nativeWorkerConfig == null ? Optional.empty() : Optional.of(
                         loadProperties(checkFile(new File(clientOptions.nativeWorkerConfig)))),
-                    Optional.empty(),
-                    Optional.empty(),
+                clientOptions.nativeWorkerCatalogs == null ? Optional.empty() : Optional.of(
+                        loadCatalogProperties(new File(clientOptions.nativeWorkerCatalogs))),
+                Optional.empty(),
+                Optional.empty(),
                 clientOptions.sessionPropertyConfig == null ? Optional.empty() : Optional.of(
                         loadProperties(checkFile(new File(clientOptions.sessionPropertyConfig)))),
                     Optional.empty(),

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -71,6 +71,7 @@ public class PrestoSparkRunner
                 distribution.getCatalogProperties(),
                 distribution.getPrestoSparkProperties(),
                 distribution.getNativeWorkerConfigProperties(),
+                distribution.getNativeWorkerCatalogConfigProperties(),
                 distribution.getEventListenerProperties(),
                 distribution.getAccessControlProperties(),
                 distribution.getSessionPropertyConfigurationProperties(),
@@ -234,6 +235,7 @@ public class PrestoSparkRunner
             Map<String, Map<String, String>> catalogProperties,
             Map<String, String> prestoSparkProperties,
             Optional<Map<String, String>> nativeWorkerConfigProperties,
+            Optional<Map<String, Map<String, String>>> nativeWorkerCatalogConfigProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
@@ -252,6 +254,7 @@ public class PrestoSparkRunner
                 catalogProperties,
                 prestoSparkProperties,
                 nativeWorkerConfigProperties,
+                nativeWorkerCatalogConfigProperties,
                 eventListenerProperties,
                 accessControlProperties,
                 sessionPropertyConfigurationProperties,
@@ -278,6 +281,7 @@ public class PrestoSparkRunner
         private final Map<String, String> configProperties;
         private final Map<String, String> nativeWorkerConfigProperties;
         private final Map<String, Map<String, String>> catalogProperties;
+        private final Map<String, Map<String, String>> nativeWorkerCatalogConfigProperties;
         private final Map<String, String> prestoSparkProperties;
         private final Map<String, String> eventListenerProperties;
         private final Map<String, String> accessControlProperties;
@@ -296,6 +300,7 @@ public class PrestoSparkRunner
             this.configProperties = distribution.getConfigProperties();
             this.nativeWorkerConfigProperties = distribution.getNativeWorkerConfigProperties().orElse(null);
             this.catalogProperties = distribution.getCatalogProperties();
+            this.nativeWorkerCatalogConfigProperties = distribution.getNativeWorkerCatalogConfigProperties().orElse(null);
             this.prestoSparkProperties = distribution.getPrestoSparkProperties();
             this.bootstrapMetricsCollector = requireNonNull(bootstrapMetricsCollector);
             // Optional is not Serializable
@@ -328,6 +333,7 @@ public class PrestoSparkRunner
         private static Map<String, String> currentConfigProperties;
         private static Map<String, String> currentNativeWorkerConfigProperties;
         private static Map<String, Map<String, String>> currentCatalogProperties;
+        private static Map<String, Map<String, String>> currentNativeWorkerCatalogConfigProperties;
         private static Map<String, String> currentPrestoSparkProperties;
         private static Map<String, String> currentEventListenerProperties;
         private static Map<String, String> currentAccessControlProperties;
@@ -346,6 +352,7 @@ public class PrestoSparkRunner
                             catalogProperties,
                             prestoSparkProperties,
                             Optional.ofNullable(nativeWorkerConfigProperties),
+                            Optional.ofNullable(nativeWorkerCatalogConfigProperties),
                             Optional.ofNullable(eventListenerProperties),
                             Optional.ofNullable(accessControlProperties),
                             Optional.ofNullable(sessionPropertyConfigurationProperties),
@@ -357,6 +364,7 @@ public class PrestoSparkRunner
                     currentConfigProperties = configProperties;
                     currentNativeWorkerConfigProperties = nativeWorkerConfigProperties;
                     currentCatalogProperties = catalogProperties;
+                    currentNativeWorkerCatalogConfigProperties = nativeWorkerCatalogConfigProperties;
                     currentPrestoSparkProperties = prestoSparkProperties;
                     currentEventListenerProperties = eventListenerProperties;
                     currentAccessControlProperties = accessControlProperties;
@@ -369,6 +377,7 @@ public class PrestoSparkRunner
                     checkEquals("configProperties", currentConfigProperties, configProperties);
                     checkEquals("nativeWorkerConfigProperties", currentNativeWorkerConfigProperties, nativeWorkerConfigProperties);
                     checkEquals("catalogProperties", currentCatalogProperties, catalogProperties);
+                    checkEquals("nativeWorkerCatalogConfigProperties", currentNativeWorkerCatalogConfigProperties, nativeWorkerCatalogConfigProperties);
                     checkEquals("prestoSparkProperties", currentPrestoSparkProperties, prestoSparkProperties);
                     checkEquals("eventListenerProperties", currentEventListenerProperties, eventListenerProperties);
                     checkEquals("accessControlProperties", currentAccessControlProperties, accessControlProperties);


### PR DESCRIPTION
## Description

Refactor to make all configs managed by NativeExecutionConfigModule. Most of this PR is dealing with catalog config. After refactoring, the class NativeExecutionCatalogConfig class will contain configs that are to be populated in files for native worker's consumption. The properties managed by this class shall have no overlapping with the ones that are used by Java part of pos. The populated is not a combination of java catalog properties with native catalog properties but rather JUST native catalog properties.

```
== NO RELEASE NOTE ==
```

