### PR TITLE
Add feature reordering config fetching for Prism connector

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -261,6 +261,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kHttpSrvIoEvbViolationThresholdMs, 1000),
           NUM_PROP(kMaxLocalExchangePartitionBufferSize, 65536),
           BOOL_PROP(kTextWriterEnabled, true),
+          BOOL_PROP(kFeatureReorderingConfigEnabled, false),
           BOOL_PROP(kCharNToVarcharImplicitCast, false),
           BOOL_PROP(kEnumTypesEnabled, true),
       };
@@ -926,6 +927,11 @@ uint64_t SystemConfig::maxLocalExchangePartitionBufferSize() const {
 
 bool SystemConfig::textWriterEnabled() const {
   return optionalProperty<bool>(kTextWriterEnabled).value();
+}
+
+bool SystemConfig::featureReorderingConfigEnabled() const {
+  return optionalProperty<bool>(kFeatureReorderingConfigEnabled)
+      .value_or(false);
 }
 
 bool SystemConfig::charNToVarcharImplicitCast() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -284,6 +284,13 @@ class SystemConfig : public ConfigBase {
 
   static constexpr std::string_view kSpillerSpillPath{
       "experimental.spiller-spill-path"};
+
+  /// If true, enable fetching feature reordering config from manifold during
+  /// insert operations. This allows feature reordering to be applied on the
+  /// worker based on configuration files stored in manifold.
+  static constexpr std::string_view kFeatureReorderingConfigEnabled{
+      "feature-reordering-config-enabled"};
+
   static constexpr std::string_view kShutdownOnsetSec{"shutdown-onset-sec"};
 
   /// Memory allocation limit enforced via internal memory allocator.
@@ -768,8 +775,8 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kCharNToVarcharImplicitCast{
     "char-n-to-varchar-implicit-cast"};
 
-  /// Enable BigintEnum and VarcharEnum types to be parsed and used in Velox. 
-  /// When set to false, BigintEnum or VarcharEnum types will throw an 
+  /// Enable BigintEnum and VarcharEnum types to be parsed and used in Velox.
+  /// When set to false, BigintEnum or VarcharEnum types will throw an
   //  unsupported error during type parsing.
   static constexpr std::string_view kEnumTypesEnabled{
     "enum-types-enabled"};
@@ -1064,6 +1071,8 @@ class SystemConfig : public ConfigBase {
   uint64_t maxLocalExchangePartitionBufferSize() const;
 
   bool textWriterEnabled() const;
+
+  bool featureReorderingConfigEnabled() const;
 
   bool charNToVarcharImplicitCast() const;
 


### PR DESCRIPTION
Summary:
The implementation adds the ability to fetch feature reordering configuration from external storage (like Manifold) during insert operations, allowing dynamic feature reordering to be applied on workers based on configuration files.

Key changes:
- Added `fetchFeatureReorderingConfig()` function to retrieve config from external storage
- Modified `toVeloxInsertTableHandle()` to check for feature reordering config in serde parameters and fetch the config content if present
- Added system property `feature-reordering-config-enabled` to control the feature
- Added comprehensive unit tests for the new functionality
- Updated BUCK files with necessary dependencies

The feature is gated behind a system configuration flag and gracefully handles failures by logging warnings without breaking query execution. When enabled, it looks for the `feature.reordering.config` key in table serde parameters, fetches the config content from the specified path, and adds it as `feature.reordering.config.content` to the serde parameters for use during writing operations.

Differential Revision: D83014779


