### PR TITLE
Add new ConnectorMetadata.finishDeleteWithOutput() to allow DELETE queries to log outputs

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1064,7 +1064,7 @@ public abstract class IcebergAbstractMetadata
     }
 
     @Override
-    public void finishDelete(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishDeleteWithOutput(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
@@ -1107,6 +1107,7 @@ public abstract class IcebergAbstractMetadata
 
         rowDelta.commit();
         transaction.commitTransaction();
+        return Optional.empty();
     }
 
     @Override

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
@@ -380,8 +380,9 @@ public class KuduMetadata
     }
 
     @Override
-    public void finishDelete(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishDeleteWithOutput(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
+        return Optional.empty();
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/DelegatingMetadataManager.java
@@ -395,9 +395,9 @@ public abstract class DelegatingMetadataManager
     }
 
     @Override
-    public void finishDelete(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishDeleteWithOutput(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
-        delegate.finishDelete(session, tableHandle, fragments);
+        return delegate.finishDeleteWithOutput(session, tableHandle, fragments);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -339,7 +339,7 @@ public interface Metadata
     /**
      * Finish delete query
      */
-    void finishDelete(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments);
+    Optional<ConnectorOutputMetadata> finishDeleteWithOutput(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments);
 
     /**
      * Begin update query

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -953,11 +953,11 @@ public class MetadataManager
     }
 
     @Override
-    public void finishDelete(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishDeleteWithOutput(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         ConnectorId connectorId = tableHandle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        metadata.finishDelete(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), fragments);
+        return metadata.finishDeleteWithOutput(session.toConnectorSession(connectorId), tableHandle.getConnectorHandle(), fragments);
     }
 
     @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -3485,8 +3485,7 @@ public class LocalExecutionPlanner
                 return metadata.finishInsert(session, ((InsertHandle) target).getHandle(), fragments, statistics);
             }
             else if (target instanceof DeleteHandle) {
-                metadata.finishDelete(session, ((DeleteHandle) target).getHandle(), fragments);
-                return Optional.empty();
+                return metadata.finishDeleteWithOutput(session, ((DeleteHandle) target).getHandle(), fragments);
             }
             else if (target instanceof RefreshMaterializedViewHandle) {
                 return metadata.finishRefreshMaterializedView(session, ((RefreshMaterializedViewHandle) target).getHandle(), fragments, statistics);

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -430,7 +430,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void finishDelete(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
+    public Optional<ConnectorOutputMetadata> finishDeleteWithOutput(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -573,10 +573,21 @@ public interface ConnectorMetadata
      * Finish delete query
      *
      * @param fragments all fragments returned by {@link com.facebook.presto.spi.UpdatablePageSource#finish()}
+     *
+     * @deprecated Implementors should override {@link #finishDeleteWithOutput(ConnectorSession, ConnectorDeleteTableHandle, Collection)} instead.
      */
     default void finishDelete(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector does not support deletes");
+    }
+
+    /**
+     * Finish delete query
+     */
+    default Optional<ConnectorOutputMetadata> finishDeleteWithOutput(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        finishDelete(session, tableHandle, fragments);
+        return Optional.empty();
     }
 
     default ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -629,6 +629,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<ConnectorOutputMetadata> finishDeleteWithOutput(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.finishDeleteWithOutput(session, tableHandle, fragments);
+        }
+    }
+
+    @Override
     public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
Summary:
Currently the ConnectorMetadata exposes a finishDelete() method invoked as part of the commit process for DELETE requests:
```
void finishDelete(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
```

However, the `void` return type means that no outputs get recorded with the query metadata.

This adds a new method finishDeleteWithOutputs():
```
default Optional<ConnectorOutputMetadata> finishDeleteWithOutput(ConnectorSession session, ConnectorDeleteTableHandle tableHandle, Collection<Slice> fragments)
{
    finishDelete(session, tableHandle, fragments);
    return Optional.empty();
}
```

By default, this delegates to the existing finishDelete() method to avoid impacting existing connectors.  However, new connectors or those wishing to log output metadata for DELETE queries should implement the new methods.

Reviewed By: shelton408

Differential Revision: D82515881

### Release Notes 
```
== RELEASE NOTES ==
General Changes
* Adds support and plumbing for DELETE queries to identify modified partitions as outputs in the generated QueryIOMetadata.

Iceberg Connector Changes
* Updated to implement ConnectorMetadata::finishDeleteWithOutput()

Kudu Connector Changes
* Updated to implement ConnectorMetadata::finishDeleteWithOutput()

SPI Changes
* Adds a new ConnectorMetadata::finishDeleteWithOutput() method, returning Optional<ConnectorOutputMetadata>. This allows connectors implementing DELETE to identify partitions modified in queries, which can be important for tracing lineage. 
* Deprecates the existing ConnectorMetadata::finishDelete() method.  By default the new finishDeleteWithOutput() method will delegate to the existing finishDelete() method, and return Optional.empty().  This allows existing connectors to continue working without changes.
```


