### PR TITLE
feat(ci): Add github action to publish docker images

### DIFF
--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -1,5 +1,8 @@
 name: Presto Stable Release - Publish
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -34,10 +37,6 @@ on:
         type: boolean
         default: true
         required: false
-      dependency_image:
-        description: prestissimo dependency image(e.g., prestodb/presto-native-dependency:latest)
-        required: false
-        default: ''
       tag_image_as_latest:
         description: Tag the published images as latest
         type: boolean
@@ -53,9 +52,6 @@ env:
   JAVA_VERSION: ${{ vars.JAVA_VERSION || '17' }}
   JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
   MAVEN_OPTS: ${{ vars.MAVEN_OPTS }}
-  DOCKER_REPO: ${{ github.repository }}
-  ORG_NAME: ${{ github.repository_owner }}
-  IMAGE_NAME: presto-native
   RELEASE_BRANCH: release-${{ inputs.RELEASE_VERSION }}
   RELEASE_TAG: ${{ inputs.RELEASE_VERSION }}
   RELEASE_NOTES_COMMIT: ${{ inputs.release-notes-commit }}
@@ -64,7 +60,37 @@ env:
   MAVEN_AUTO_PUBLISH: ${{ vars.MAVEN_AUTO_PUBLISH || 'true' }}
 
 jobs:
+  display-inputs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Display workflow inputs
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.RELEASE_VERSION }}
+          PUBLISH_RELEASE_TAG: ${{ github.event.inputs.publish_release_tag }}
+          RELEASE_NOTES_COMMIT: ${{ github.event.inputs.release-notes-commit }}
+          PUBLISH_MAVEN: ${{ github.event.inputs.publish_maven }}
+          PUBLISH_GITHUB_RELEASE: ${{ github.event.inputs.publish_github_release }}
+          PUBLISH_IMAGE: ${{ github.event.inputs.publish_image }}
+          PUBLISH_NATIVE_IMAGE: ${{ github.event.inputs.publish_native_image }}
+          TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
+          PUBLISH_DOCS: ${{ github.event.inputs.publish_docs }}
+        run: |
+          echo "=== Workflow Inputs ==="
+          echo "Release Version: ${RELEASE_VERSION}"
+          echo "Publish Release Tag: ${PUBLISH_RELEASE_TAG}"
+          echo "Release Notes Commit: ${RELEASE_NOTES_COMMIT}"
+          echo "Publish Maven: ${PUBLISH_MAVEN}"
+          echo "Publish GitHub Release: ${PUBLISH_GITHUB_RELEASE}"
+          echo "Publish Image: ${PUBLISH_IMAGE}"
+          echo "Publish Native Image: ${PUBLISH_NATIVE_IMAGE}"
+          echo "Tag Image as Latest: ${TAG_IMAGE_AS_LATEST}"
+          echo "Publish Docs: ${PUBLISH_DOCS}"
+          echo "======================="
+
   publish-release-tag:
+    needs: display-inputs
     if: github.event.inputs.publish_release_tag == 'true'
     runs-on: ubuntu-latest
     environment: release
@@ -113,11 +139,10 @@ jobs:
           git push origin $RELEASE_BRANCH --tags
 
   publish-maven-artifacts:
-    needs: publish-release-tag
+    needs: [display-inputs, publish-release-tag]
     if: |
       (!failure() &&!cancelled()) && (
         github.event.inputs.publish_maven == 'true' ||
-        github.event.inputs.publish_image == 'true' ||
         github.event.inputs.publish_docs == 'true' ||
         github.event.inputs.publish_github_release == 'true'
       )
@@ -293,180 +318,25 @@ jobs:
             ./presto-testing-server-launcher/target/presto-testing-server-launcher-*-executable.jar
             ./presto-function-server/target/presto-function-server-*-executable.jar
 
-  publish-docker-image:
-    needs: publish-maven-artifacts
-    if: (!failure() && !cancelled()) && github.event.inputs.publish_image == 'true'
-    runs-on: ubuntu-latest
-    environment: release
-    timeout-minutes: 150
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG}}
-          persist-credentials: false
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: presto-artifacts-${{ env.RELEASE_TAG }}
-          path: ./
-
-      - name: Login to dockerhub
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up qemu
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-
-      - name: Set up docker buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
-      - name: Create and use builder
-        run: |
-          docker buildx create --name container --use
-          docker buildx inspect --bootstrap
-
-      - name: Move artifacts to docker directory
-        run: |
-          mv ./presto-server/target/presto-server-*.tar.gz docker/
-          mv ./presto-cli/target/presto-cli-*-executable.jar docker/
-          mv ./presto-function-server/target/presto-function-server-*-executable.jar docker/
-
-      - name: Build docker image and publish
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          context: docker
-          platforms: linux/amd64,linux/arm64,linux/ppc64le
-          file: docker/Dockerfile
-          push: true
-          build-args: |
-            PRESTO_VERSION=${{ env.RELEASE_TAG }}
-            JMX_PROMETHEUS_JAVAAGENT_VERSION=0.20.0
-          tags: |
-            ${{ env.DOCKER_REPO }}:${{ env.RELEASE_TAG }}
-            ${{ github.event.inputs.tag_image_as_latest == 'true' && format('{0}:latest', env.DOCKER_REPO) || '' }}
-
-  publish-native-image:
-    needs: publish-release-tag
-    if: (!failure() && !cancelled()) && github.event.inputs.publish_native_image == 'true'
-    runs-on: ubuntu-latest
+  publish-docker-images:
+    needs: [publish-maven-artifacts, publish-release-tag]
+    if: (!failure() && !cancelled()) && (github.event.inputs.publish_image == 'true' || github.event.inputs.publish_native_image == 'true')
+    uses: ./.github/workflows/publish-docker-images.yml
+    with:
+      branch_or_tag: ${{  github.event.inputs.RELEASE_VERSION }}
+      publish_presto: ${{ github.event.inputs.publish_image == 'true' }}
+      publish_dependency: ${{ github.event.inputs.publish_native_image == 'true' }}
+      publish_prestissimo: ${{ github.event.inputs.publish_native_image == 'true' }}
+      tag_latest: ${{ github.event.inputs.tag_image_as_latest == 'true' }}
+      tag_suffix: ''
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
-    environment: release
-    timeout-minutes: 300
-    steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          submodules: true
-          persist-credentials: false
-
-      - name: Initialize Prestissimo submodules
-        run: |
-          df -h
-          cd presto-native-execution && make submodules
-          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-      - name: Login to DockerHub
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set dependency image tag
-        env:
-          DEPENDENCY_IMAGE: ${{ github.event.inputs.dependency_image }}
-          RELEASE_TAG: ${{ env.RELEASE_TAG }}
-        run: |
-          if [[ -n "$DEPENDENCY_IMAGE" ]]; then
-            echo "DEPENDENCY_IMAGE=$DEPENDENCY_IMAGE" >> $GITHUB_ENV
-          else
-            echo "DEPENDENCY_IMAGE=${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}" >> $GITHUB_ENV
-          fi
-
-      - name: Build Dependency Image
-        working-directory: presto-native-execution
-        env:
-          PUBLISH_NATIVE_IMAGE: ${{ github.event.inputs.publish_native_image }}
-          TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
-          RELEASE_TAG: ${{ env.RELEASE_TAG }}
-        run: |
-          df -h
-          if docker pull ${{ env.DEPENDENCY_IMAGE }}; then
-            echo "Using dependency image ${{ env.DEPENDENCY_IMAGE }}"
-            docker tag ${{ env.DEPENDENCY_IMAGE }} presto/prestissimo-dependency:centos9
-          else
-            echo "Building new depedency image"
-            docker compose build centos-native-dependency
-            if [[ "$PUBLISH_NATIVE_IMAGE" == "true" ]]; then
-              docker tag presto/prestissimo-dependency:centos9 ${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}
-              docker push ${{ github.repository_owner }}/presto-native-dependency:$RELEASE_TAG-${{ env.COMMIT_SHA }}
-
-              if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-                docker tag presto/prestissimo-dependency:centos9 ${{ github.repository_owner }}/presto-native-dependency:latest
-                docker push ${{ github.repository_owner }}/presto-native-dependency:latest
-              fi
-            fi
-          fi
-          docker images
-
-      - name: Build Runtime Image
-        working-directory: presto-native-execution
-        run: |
-          df -h
-          docker compose build --build-arg EXTRA_CMAKE_FLAGS=" \
-            -DPRESTO_ENABLE_PARQUET=ON \
-            -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON \
-            -DPRESTO_ENABLE_JWT=ON \
-            -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
-            -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
-            -DPRESTO_ENABLE_SPATIAL=ON \
-            -DPRESTO_ENABLE_TESTING=OFF \
-            -DPRESTO_ENABLE_S3=ON" \
-            --build-arg NUM_THREADS=2 \
-            centos-native-runtime
-
-      - name: Add release tag
-        working-directory: presto-native-execution
-        env:
-          TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
-          ORG_NAME: ${{ env.ORG_NAME }}
-          RELEASE_TAG: ${{ env.RELEASE_TAG }}
-        run: |
-          docker tag presto/prestissimo-runtime:centos9 $ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG
-          if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-            docker tag presto/prestissimo-runtime:centos9 $ORG_NAME/${{ env.IMAGE_NAME }}:latest
-          fi
-
-      - name: Push to DockerHub
-        env:
-          TAG_IMAGE_AS_LATEST: ${{ github.event.inputs.tag_image_as_latest }}
-          ORG_NAME: ${{ env.ORG_NAME }}
-          RELEASE_TAG: ${{ env.RELEASE_TAG }}
-        run: |
-          docker push $ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG
-          if [[ "$TAG_IMAGE_AS_LATEST" == "true" ]]; then
-            docker tag $ORG_NAME/${{ env.IMAGE_NAME }}:$RELEASE_TAG $ORG_NAME/${{ env.IMAGE_NAME }}:latest
-            docker push $ORG_NAME/${{ env.IMAGE_NAME }}:latest
-          fi
 
   publish-docs:
     needs: publish-maven-artifacts

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,0 +1,590 @@
+name: Publish Docker Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_or_tag:
+        description: Branch or tag to checkout (e.g., master, 0.297)
+        required: true
+        default: master
+      publish_presto:
+        description: Publish presto images
+        type: boolean
+        default: true
+        required: false
+      publish_dependency:
+        description: Publish dependency image
+        type: boolean
+        default: true
+        required: false
+      publish_prestissimo:
+        description: Publish prestissimo images
+        type: boolean
+        default: true
+        required: false
+      tag_latest:
+        description: Tag the image as latest
+        type: boolean
+        default: true
+        required: false
+      tag_suffix:
+        description: Tag suffix (can be empty)
+        required: false
+        default: ''
+  workflow_call:
+    inputs:
+      branch_or_tag:
+        description: Branch or tag to checkout (e.g., master, 0.297)
+        required: true
+        type: string
+      publish_presto:
+        description: Publish presto images
+        type: boolean
+        default: true
+        required: false
+      publish_dependency:
+        description: Publish dependency image
+        type: boolean
+        default: true
+        required: false
+      publish_prestissimo:
+        description: Publish prestissimo images
+        type: boolean
+        default: true
+        required: false
+      tag_latest:
+        description: Tag the image as latest
+        type: boolean
+        default: true
+        required: false
+      tag_suffix:
+        description: Tag suffix (can be empty)
+        required: false
+        type: string
+        default: ''
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: DockerHub username
+        required: true
+      DOCKERHUB_TOKEN:
+        description: DockerHub token
+        required: true
+
+concurrency:
+  group: publish-docker-images-${{ inputs.branch_or_tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: ${{ vars.JAVA_VERSION || '17' }}
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
+  MAVEN_OPTS: ${{ vars.MAVEN_OPTS }}
+  DOCKER_REPO: ${{ github.repository }}
+  ORG_NAME: ${{ github.repository_owner }}
+  GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
+  GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
+  JMX_PROMETHEUS_JAVAAGENT_VERSION: 0.20.0
+  PRESTO_IMAGE_NAME: presto
+  NATIVE_IMAGE_NAME: presto-native
+  DEPENDENCY_IMAGE_NAME: presto-native-dependency
+  TAG_SUFFIX: ${{ inputs.tag_suffix }}
+  INPUT_OS: centos
+  INPUT_TAG_LATEST: ${{ inputs.tag_latest }}
+  INPUT_PUBLISH_DEPENDENCY: ${{ inputs.publish_dependency }}
+  EXTRA_CMAKE_FLAGS: ${{ vars.EXTRA_CMAKE_FLAGS || '-DPRESTO_ENABLE_PARQUET=ON -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON -DPRESTO_ENABLE_JWT=ON -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER -DPRESTO_ENABLE_SPATIAL=ON -DPRESTO_ENABLE_TESTING=OFF -DPRESTO_ENABLE_S3=ON' }}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
+      commit_sha: ${{ steps.extract-commit.outputs.commit_sha }}
+      presto_version: ${{ steps.extract-version.outputs.presto_version }}
+    steps:
+      - name: Display workflow inputs
+        env:
+          BRANCH_OR_TAG: ${{ inputs.branch_or_tag }}
+          TAG_SUFFIX: ${{ inputs.tag_suffix }}
+          TAG_LATEST: ${{ inputs.tag_latest }}
+          PUBLISH_DEPENDENCY: ${{ inputs.publish_dependency }}
+          PUBLISH_PRESTO: ${{ inputs.publish_presto }}
+          PUBLISH_PRESTISSIMO: ${{ inputs.publish_prestissimo }}
+        run: |
+          echo "=== Workflow Inputs ==="
+          echo "Branch or Tag: ${BRANCH_OR_TAG}"
+          echo "Publish Presto: ${PUBLISH_PRESTO}"
+          echo "Publish Dependency: ${PUBLISH_DEPENDENCY}"
+          echo "Publish Prestissimo: ${PUBLISH_PRESTISSIMO}"
+          echo "Tag Latest: ${TAG_LATEST}"
+          echo "Tag Suffix: ${TAG_SUFFIX}"
+          echo "======================="
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_or_tag }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure git
+        run: |
+          git config --global user.email "${GIT_CI_EMAIL}"
+          git config --global user.name "${GIT_CI_USER}"
+
+      - name: Extract commit SHA
+        id: extract-commit
+        run: |
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "Commit SHA: ${COMMIT_SHA}"
+
+      - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - name: Extract version
+        id: extract-version
+        env:
+          COMMIT_SHA: ${{ steps.extract-commit.outputs.commit_sha }}
+        run: |
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Raw version: $VERSION"
+
+          if [ -z "$VERSION" ]; then
+            echo "Failed to extract project version with Maven"
+            exit 1
+          fi
+
+          if [[ "$VERSION" == *"-SNAPSHOT" ]]; then
+            # Remove -SNAPSHOT and append commit SHA
+            CLEAN_VERSION=${VERSION%-SNAPSHOT}
+            TAG_VERSION="${CLEAN_VERSION}-${COMMIT_SHA}"
+            echo "SNAPSHOT version detected, using: $TAG_VERSION"
+          else
+            TAG_VERSION="$VERSION"
+            echo "Release version detected, using: $TAG_VERSION"
+          fi
+
+          echo "version=${TAG_VERSION}" >> $GITHUB_OUTPUT
+          echo "presto_version=${VERSION}" >> $GITHUB_OUTPUT
+
+  publish-dependency-image:
+    needs: prepare
+    if: ( !failure() && !cancelled() && inputs.publish_dependency )
+    strategy:
+      matrix:
+        arch: [amd64, arm64-mac, arm64-linux]
+      fail-fast: false
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    environment: release
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          docker-images: false
+          large-packages: false
+
+      - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_or_tag }}
+          fetch-depth: 10
+          persist-credentials: false
+
+      - name: Reset to specific commit
+        env:
+          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
+        run: |
+          git reset --hard ${COMMIT_SHA}
+          echo "Using commit SHA: ${COMMIT_SHA}"
+
+      - name: Configure git
+        run: |
+          git config --global user.email "${GIT_CI_EMAIL}"
+          git config --global user.name "${GIT_CI_USER}"
+
+      - name: Checkout submodules
+        working-directory: presto-native-execution
+        run: |
+          df -h
+          make submodules
+
+      - name: Set version
+        env:
+          PREP_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          echo "VERSION=${PREP_VERSION}" >> $GITHUB_ENV
+          echo "Using version: ${PREP_VERSION}"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set image tag
+        run: |
+          TAG_BASE="${ORG_NAME}/${DEPENDENCY_IMAGE_NAME}:${VERSION}-${{ matrix.arch }}"
+          echo "IMAGE_TAG=${TAG_BASE}${TAG_SUFFIX}" >> $GITHUB_ENV
+
+          echo "DEPENDENCY_TARGET=centos-native-dependency" >> $GITHUB_ENV
+          echo "LOCAL_IMAGE_TAG=presto/prestissimo-dependency:centos9" >> $GITHUB_ENV
+
+          # Store the dependency image tag for later jobs
+          echo "DEPENDENCY_IMAGE_TAG=${TAG_BASE}" >> $GITHUB_ENV
+
+      - name: Build image
+        working-directory: presto-native-execution
+        run: |
+          df -h
+          echo "Using image tag: $IMAGE_TAG"
+
+          if [[ "${{ matrix.arch }}" == "arm64-mac" ]]; then
+            BUILD_ARGS="--build-arg ARM_BUILD_TARGET=generic"
+          else
+            BUILD_ARGS=""
+          fi
+
+          echo "BUILD_ARGS=${BUILD_ARGS}"
+          docker compose build ${BUILD_ARGS} ${{ env.DEPENDENCY_TARGET }}
+
+      - name: Publish image
+        run: |
+          set -e
+          docker tag ${LOCAL_IMAGE_TAG} ${IMAGE_TAG}
+          docker push ${IMAGE_TAG}
+
+          # Only push single-platform latest tags for arm64-linux
+          # amd64 and arm64-mac will be part of multi-arch manifests only
+          if [[ "${INPUT_TAG_LATEST}" == "true" && "${{ matrix.arch }}" == "arm64-linux" ]]; then
+            LATEST_TAG="${ORG_NAME}/${DEPENDENCY_IMAGE_NAME}:${{ matrix.arch }}-latest"
+            docker tag ${LOCAL_IMAGE_TAG} ${LATEST_TAG}
+            docker push ${LATEST_TAG}
+            echo "Tagged and pushed as latest: ${LATEST_TAG}"
+          fi
+
+  create-dependency-manifest:
+    if: ( !failure() && !cancelled() && inputs.publish_dependency )
+    needs: [prepare, publish-dependency-image]
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set version
+        env:
+          PREP_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          echo "VERSION=${PREP_VERSION}" >> $GITHUB_ENV
+          echo "Using version: ${PREP_VERSION}"
+
+      - name: Create and push multi-arch manifest
+        run: |
+          # Create manifest for the versioned tag (amd64 + arm64-mac only)
+          MANIFEST_TAG="${ORG_NAME}/${DEPENDENCY_IMAGE_NAME}:${VERSION}${TAG_SUFFIX}"
+          AMD64_TAG="${ORG_NAME}/${DEPENDENCY_IMAGE_NAME}:${VERSION}-amd64${TAG_SUFFIX}"
+          ARM64_MAC_TAG="${ORG_NAME}/${DEPENDENCY_IMAGE_NAME}:${VERSION}-arm64-mac${TAG_SUFFIX}"
+
+          echo "Creating manifest: ${MANIFEST_TAG}"
+          docker manifest create ${MANIFEST_TAG} ${AMD64_TAG} ${ARM64_MAC_TAG}
+          docker manifest push ${MANIFEST_TAG}
+
+          # Create latest manifest if requested (reuse versioned tags)
+          if [[ "${INPUT_TAG_LATEST}" == "true" ]]; then
+            GLOBAL_LATEST="${ORG_NAME}/${DEPENDENCY_IMAGE_NAME}:latest"
+            echo "Creating global latest manifest: ${GLOBAL_LATEST}"
+            docker manifest create ${GLOBAL_LATEST} ${AMD64_TAG} ${ARM64_MAC_TAG}
+            docker manifest push ${GLOBAL_LATEST}
+          fi
+
+  publish-presto-image:
+    if: (!failure() && !cancelled() && inputs.publish_presto)
+    needs: prepare
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          docker-images: false
+          large-packages: false
+
+      - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_or_tag }}
+          fetch-depth: 10
+          persist-credentials: false
+
+      - name: Reset to specific commit
+        env:
+          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
+        run: |
+          git reset --hard ${COMMIT_SHA}
+          echo "Using commit SHA: ${COMMIT_SHA}"
+
+      - name: Configure git
+        run: |
+          git config --global user.email "${GIT_CI_EMAIL}"
+          git config --global user.name "${GIT_CI_USER}"
+
+      - name: Set version
+        env:
+          PREP_VERSION: ${{ needs.prepare.outputs.version }}
+          PREP_PRESTO_VERSION: ${{ needs.prepare.outputs.presto_version }}
+        run: |
+          echo "VERSION=${PREP_VERSION}" >> $GITHUB_ENV
+          echo "PRESTO_VERSION=${PREP_PRESTO_VERSION}" >> $GITHUB_ENV
+          echo "Using version: ${PREP_VERSION}"
+
+      - name: Build Presto Server
+        run: |
+          df -h
+          ./mvnw clean install -DskipTests -T1C
+          df -h
+
+      - name: Login to DockerHub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up qemu
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Create and use builder
+        run: |
+          docker buildx create --name container --use
+          docker buildx inspect --bootstrap
+
+      - name: Set image tag and base image
+        run: |
+          TAG_BASE="${ORG_NAME}/${PRESTO_IMAGE_NAME}:${VERSION}"
+          echo "IMAGE_TAG=${TAG_BASE}${TAG_SUFFIX}" >> $GITHUB_ENV
+
+      - name: Move artifacts to docker directory
+        run: |
+          mkdir -p docker_build
+          cp presto-server/target/presto-server-*.tar.gz docker/
+          cp presto-cli/target/presto-cli-*-executable.jar docker/
+          cp presto-function-server/target/presto-function-server-*-executable.jar docker/
+
+      - name: Build docker image and publish
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: docker
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          file: docker/Dockerfile
+          push: true
+          build-args: |
+            PRESTO_VERSION=${{ env.PRESTO_VERSION }}
+            JMX_PROMETHEUS_JAVAAGENT_VERSION=0.20.0
+          tags: |
+            ${{ env.IMAGE_TAG }}
+            ${{ inputs.tag_latest && format('{0}/{1}:latest', env.ORG_NAME, env.PRESTO_IMAGE_NAME) }}
+
+  publish-prestissimo-image:
+    if: (!failure() && !cancelled() && inputs.publish_prestissimo)
+    needs: [prepare, publish-dependency-image]
+    strategy:
+      matrix:
+        arch: [amd64, arm64-mac, arm64-linux]
+      fail-fast: false
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    environment: release
+    timeout-minutes: 150
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          docker-images: false
+          large-packages: false
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_or_tag }}
+          fetch-depth: 10
+          persist-credentials: false
+
+      - name: Reset to specific commit
+        env:
+          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
+        run: |
+          git reset --hard ${COMMIT_SHA}
+          echo "Using commit SHA: ${COMMIT_SHA}"
+
+      - name: Configure git
+        run: |
+          git config --global user.email "${GIT_CI_EMAIL}"
+          git config --global user.name "${GIT_CI_USER}"
+
+      - name: Checkout submodules
+        working-directory: presto-native-execution
+        run: |
+          df -h
+          make submodules
+
+      # Use version from prepare job
+      - name: Set version
+        env:
+          PREP_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          echo "VERSION=${PREP_VERSION}" >> $GITHUB_ENV
+          echo "Using version: ${PREP_VERSION}"
+
+      - name: Login to DockerHub
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set image tag and base image
+        run: |
+          TAG_BASE="${ORG_NAME}/${NATIVE_IMAGE_NAME}:${VERSION}-${{ matrix.arch }}"
+          echo "IMAGE_TAG=${TAG_BASE}${TAG_SUFFIX}" >> $GITHUB_ENV
+
+          echo "BASE_IMAGE=quay.io/centos/centos:stream9" >> $GITHUB_ENV
+
+          # Set dependency image based on whether we built it or need to use latest from dockerhub
+          if [[ "${INPUT_PUBLISH_DEPENDENCY}" == "true" ]]; then
+            # Use the dependency image we just built
+            DEPENDENCY_IMAGE="${ORG_NAME}/presto-native-dependency:${VERSION}-${{ matrix.arch }}${TAG_SUFFIX}"
+          else
+            # Use the latest dependency image from dockerhub
+            # For amd64 and arm64-mac, use the manifest tag; for arm64-linux, use the specific tag
+            if [[ "${{ matrix.arch }}" == "arm64-linux" ]]; then
+              DEPENDENCY_IMAGE="${ORG_NAME}/presto-native-dependency:${{ matrix.arch }}-latest"
+            else
+              DEPENDENCY_IMAGE="${ORG_NAME}/presto-native-dependency:latest"
+            fi
+          fi
+          echo "DEPENDENCY_IMAGE=${DEPENDENCY_IMAGE}" >> $GITHUB_ENV
+
+          LOCAL_IMAGE_TAG="presto/prestissimo-dependency:centos9"
+          docker pull ${DEPENDENCY_IMAGE}
+          docker tag ${DEPENDENCY_IMAGE} ${LOCAL_IMAGE_TAG}
+
+      - name: Build prestissimo image
+        working-directory: presto-native-execution
+        run: |
+          df -h
+          echo "Using image tag: $IMAGE_TAG"
+          echo "Using dependency image: ${{ env.DEPENDENCY_IMAGE }}"
+          echo "Using base image: $BASE_IMAGE"
+
+          # Use EXTRA_CMAKE_FLAGS from environment (configurable via vars)
+          CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS}"
+
+          echo "Using CMAKE flags: $CMAKE_FLAGS"
+          if [[ "${{ matrix.arch }}" == "arm64-mac" ]]; then
+            BUILD_ARGS="--build-arg ARM_BUILD_TARGET=generic"
+          else
+            BUILD_ARGS=""
+          fi
+
+          # Build the prestissimo image using standard Docker build
+          docker build \
+            --build-arg EXTRA_CMAKE_FLAGS="$CMAKE_FLAGS" \
+            --build-arg DEPENDENCY_IMAGE=${{ env.DEPENDENCY_IMAGE }} \
+            --build-arg BASE_IMAGE=$BASE_IMAGE \
+            --build-arg OSNAME=${INPUT_OS} \
+            --build-arg BUILD_TYPE=Release \
+            --build-arg NUM_THREADS=2 \
+            ${BUILD_ARGS} \
+            -f scripts/dockerfiles/prestissimo-runtime.dockerfile \
+            -t ${{ env.IMAGE_TAG }} \
+            .
+
+      - name: Publish image
+        run: |
+          set -e
+          docker push ${IMAGE_TAG}
+
+          # Only push single-platform latest tags for arm64-linux
+          # amd64 and arm64-mac will be part of multi-arch manifests only
+          if [[ "${INPUT_TAG_LATEST}" == "true" && "${{ matrix.arch }}" == "arm64-linux" ]]; then
+            LATEST_TAG="${ORG_NAME}/${NATIVE_IMAGE_NAME}:${{ matrix.arch }}-latest"
+            docker tag ${IMAGE_TAG} ${LATEST_TAG}
+            docker push ${LATEST_TAG}
+            echo "Tagged and pushed as latest: ${LATEST_TAG}"
+          fi
+
+  create-prestissimo-manifest:
+    if: (!failure() && !cancelled() && inputs.publish_prestissimo)
+    needs: [prepare, publish-prestissimo-image]
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set version
+        env:
+          PREP_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          echo "VERSION=${PREP_VERSION}" >> $GITHUB_ENV
+          echo "Using version: ${PREP_VERSION}"
+
+      - name: Create and push multi-arch manifest
+        run: |
+          # Create manifest for the versioned tag (amd64 + arm64-mac only)
+          MANIFEST_TAG="${ORG_NAME}/${NATIVE_IMAGE_NAME}:${VERSION}${TAG_SUFFIX}"
+          AMD64_TAG="${ORG_NAME}/${NATIVE_IMAGE_NAME}:${VERSION}-amd64${TAG_SUFFIX}"
+          ARM64_MAC_TAG="${ORG_NAME}/${NATIVE_IMAGE_NAME}:${VERSION}-arm64-mac${TAG_SUFFIX}"
+
+          echo "Creating manifest: ${MANIFEST_TAG}"
+          docker manifest create ${MANIFEST_TAG} ${AMD64_TAG} ${ARM64_MAC_TAG}
+          docker manifest push ${MANIFEST_TAG}
+
+          # Create latest manifest if requested (reuse versioned tags)
+          if [[ "${INPUT_TAG_LATEST}" == "true" ]]; then
+            GLOBAL_LATEST="${ORG_NAME}/${NATIVE_IMAGE_NAME}:latest"
+            echo "Creating global latest manifest: ${GLOBAL_LATEST}"
+            docker manifest create ${GLOBAL_LATEST} ${AMD64_TAG} ${ARM64_MAC_TAG}
+            docker manifest push ${GLOBAL_LATEST}
+          fi


### PR DESCRIPTION
## Description
Add the action to build and publish the docker images  
1. presto java images(amd64/arm64/ppc64le)
2. prestissimo dependency images(amd64/arm64-mac/arm64-linux) (centos)
3. prestissimo runtime(amd64/arm64-mac/arm64-linux) (centos)
Also update release action to call this

## Motivation and Context
N/A

## Impact
New release

## Test Plan
Release action: https://github.com/unix280/presto/actions/runs/24581344644
Presto images: https://hub.docker.com/r/unix280/presto/tags
Dependency images: https://hub.docker.com/r/unix280/presto-native-dependency/tags
Prestissimo images: https://hub.docker.com/r/unix280/presto-native/tags

Take 0.297 for example (with set latest):
- Presto images will have `0.297` and `latest` tags.
- Dependency and Prestissimo images will have the following tags(also in screenshot below): 
   - manifest `0.297` and `latest`. (compsed by amd64 and arm64-mac)
   - `arm64-linux-latest` (arm-linux only)
   - `0.297-amd64`, `0.297-arm64-linux`, `0.297-arm64-mac`
<img width="497" height="781" alt="image" src="https://github.com/user-attachments/assets/aa612a8f-7471-4c97-81dd-331e6ba38b95" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add prestissimo arm64 docker images
```

