### PR TITLE
Fix druid connector read when column key has null values

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
@@ -130,7 +130,7 @@ public class DruidBrokerPageSource
                         Type type = columnTypes.get(i);
                         BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
                         JsonNode value = rootNode.get(((DruidColumnHandle) columnHandles.get(i)).getColumnName());
-                        if (value == null) {
+                        if (value == null || value.isNull()) {
                             blockBuilder.appendNull();
                             continue;
                         }

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidPageSourceNullHandling.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidPageSourceNullHandling.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpStatus;
+import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.airlift.http.client.testing.TestingResponse;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.spi.ColumnHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertTrue;
+
+public class TestDruidPageSourceNullHandling
+{
+    @Test
+    public void testNullAndMissingColumns()
+    {
+        String jsonRows =
+                "{\"region.Id\":1,\"city\":\"Boston\",\"fare\":10.0}\n" +
+                        "{\"region.Id\":2,\"city\":null,\"fare\":20.0}\n" + // city column is having null value
+                        "{\"region.Id\":3,\"fare\":30.0}\n" + // missing city column
+                        "\n";
+
+        ListMultimap<String, String> headers = ImmutableListMultimap.of(
+                "Content-Type", "application/json");
+        TestingResponse response = new TestingResponse(
+                HttpStatus.OK,
+                headers,
+                jsonRows.getBytes(StandardCharsets.UTF_8));
+        HttpClient httpClient = new TestingHttpClient(request -> response);
+
+        DruidConfig druidConfig = new DruidConfig()
+                .setDruidSchema("default")
+                .setDruidCoordinatorUrl("http://localhost:8081")
+                .setDruidBrokerUrl("http://localhost:8082");
+
+        ImmutableList<ColumnHandle> columnHandles = ImmutableList.of(new DruidColumnHandle("region.Id", BIGINT),
+                new DruidColumnHandle("city", VARCHAR),
+                new DruidColumnHandle("fare", DOUBLE));
+
+        DruidBrokerPageSource pageSource = new DruidBrokerPageSource(
+                new DruidQueryGenerator.GeneratedDql("testTable", "SELECT region.Id, city, fare FROM test", true),
+                columnHandles,
+                new DruidClient(druidConfig, httpClient));
+
+        Page page;
+        boolean foundNull = false;
+        boolean foundMissing = false;
+
+        while ((page = pageSource.getNextPage()) != null) {
+            Block cityBlock = page.getBlock(1);
+            for (int i = 0; i < cityBlock.getPositionCount(); i++) {
+                if (cityBlock.isNull(i)) {
+                    if (i == 1) {
+                        foundNull = true; // row with "city":null
+                    }
+                    if (i == 2) {
+                        foundMissing = true; // row missing "city"
+                    }
+                }
+            }
+        }
+
+        assertTrue(foundNull, "Expected null value in column 'city'");
+        assertTrue(foundMissing, "Expected missing column to be treated as null");
+    }
+}


### PR DESCRIPTION
## Description
Fix druid connector read when column key has null values

## Motivation and Context
Fix druid connector read when column key has null values.

When column has `null` value something like -
```
{
  "__time": "2016-06-27T00:00:11.080Z",
  "isRobot": "true",
  "channel": "#sv.wikipedia",
  "isAnonymous": "false",
  "cityName": null,
  "countryName": null,
  "regionIsoCode": null,
}
```
Select query fails with below error -
```
Query 20250924_055620_00006_xubn5 failed: string is null
java.lang.NullPointerException: string is null
        at java.base/java.util.Objects.requireNonNull(Objects.java:235)
        at io.airlift.slice.Slices.copiedBuffer(Slices.java:291)
        at io.airlift.slice.Slices.utf8Slice(Slices.java:299)
        at com.facebook.presto.druid.DruidBrokerPageSource.getNextPage(DruidBrokerPageSource.java:154)
        at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:266)
        at com.facebook.presto.operator.Driver.processInternal(Driver.java:440)
        at com.facebook.presto.operator.Driver.lambda$processFor$10(Driver.java:323)
        at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:749)
        at com.facebook.presto.operator.Driver.processFor(Driver.java:316)
        at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1078)
        at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
        at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:620)
        at com.facebook.presto.$gen.Presto_null__testversion5____20250924_053710_1.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

## Impact
Add check when column exist and has `null` data. So it allows the query to handle `null` data.


<img width="441" height="176" alt="image" src="https://github.com/user-attachments/assets/1e960827-798c-4092-a4f4-360812d8ddda" />


## Test Plan
Test case covers both scenarios -
1. When column is missing in a row
2. When column exist and has `null` value

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

