### PR TITLE
Fix local presto server start on latest master

### DIFF
--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -52,7 +52,7 @@ plugin.bundles=\
   ../presto-hive-function-namespace/pom.xml,\
   ../presto-delta/pom.xml,\
   ../presto-hudi/pom.xml, \
-  ../presto-sql-invoked-functions-plugin/pom.xml
+  ../presto-sql-helpers/presto-sql-invoked-functions-plugin/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true


### PR DESCRIPTION
## Description
Fix the local Presto server to start on the latest master

## Motivation and Context
After rebasing to the latest master, I was getting the following error while starting the server on the IDE with default configs -

<img width="1602" height="300" alt="image" src="https://github.com/user-attachments/assets/7e9e011d-e14c-4b53-8235-6a3d8bb2a8be" />


## Impact
Presto server start fails on local IDE

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

