### PR TITLE
chore: Cleanup native tests

### DIFF
--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/NativeTestsUtils.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/NativeTestsUtils.java
@@ -15,13 +15,6 @@ package com.facebook.presto.nativetests;
 
 import com.facebook.presto.nativeworker.NativeQueryRunnerUtils;
 import com.facebook.presto.testing.QueryRunner;
-import com.google.common.collect.ImmutableList;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder;
@@ -31,33 +24,19 @@ public class NativeTestsUtils
 {
     private NativeTestsUtils() {}
 
-    public static QueryRunner createNativeQueryRunner(String storageFormat, boolean charNToVarcharImplicitCast, boolean sidecarEnabled, boolean customFunctionsEnabled)
+    public static QueryRunner createNativeQueryRunner(String storageFormat, boolean sidecarEnabled)
             throws Exception
     {
         QueryRunner queryRunner = nativeHiveQueryRunnerBuilder()
                 .setStorageFormat(storageFormat)
                 .setAddStorageFormatToPath(true)
                 .setUseThrift(true)
-                .setImplicitCastCharNToVarchar(charNToVarcharImplicitCast)
                 .setCoordinatorSidecarEnabled(sidecarEnabled)
-                .setPluginDirectory(customFunctionsEnabled ? Optional.of(getCustomFunctionsPluginDirectory().toString()) : Optional.empty())
                 .build();
         if (sidecarEnabled) {
             setupNativeSidecarPlugin(queryRunner);
         }
         return queryRunner;
-    }
-
-    public static QueryRunner createNativeQueryRunner(String storageFormat, boolean charNToVarcharImplicitCast, boolean sidecarEnabled)
-            throws Exception
-    {
-        return createNativeQueryRunner(storageFormat, false, sidecarEnabled, false);
-    }
-
-    public static QueryRunner createNativeQueryRunner(String storageFormat, boolean sidecarEnabled)
-            throws Exception
-    {
-        return createNativeQueryRunner(storageFormat, false, sidecarEnabled);
     }
 
     public static void createTables(String storageFormat)
@@ -78,41 +57,5 @@ public class NativeTestsUtils
         catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    // TODO: remove and directly return charNToVarcharImplicitCast after addressing Issue #25894 and adding support for Char(n) type
-    // to class NativeTypeManager for Sidecar.
-    public static boolean getCharNToVarcharImplicitCastForTest(boolean sidecarEnabled, boolean charNToVarcharImplicitCast)
-    {
-        return sidecarEnabled ? false : charNToVarcharImplicitCast;
-    }
-
-    public static Path getCustomFunctionsPluginDirectory()
-            throws Exception
-    {
-        Path prestoRoot = findPrestoRoot();
-
-        // All candidate paths relative to prestoRoot
-        List<Path> candidates = ImmutableList.of(
-                prestoRoot.resolve("presto-native-tests/_build/debug/presto_cpp/tests/custom_functions"),
-                prestoRoot.resolve("presto-native-tests/_build/release/presto_cpp/tests/custom_functions"));
-
-        return candidates.stream()
-                .filter(Files::exists)
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Could not locate custom functions directory"));
-    }
-
-    private static Path findPrestoRoot()
-    {
-        Path dir = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
-        while (dir != null) {
-            if (Files.exists(dir.resolve("presto-native-tests")) ||
-                    Files.exists(dir.resolve("presto-native-execution"))) {
-                return dir;
-            }
-            dir = dir.getParent();
-        }
-        throw new IllegalStateException("Could not locate presto root directory.");
     }
 }

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestOptimizeMixedDistinctAggregations.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestOptimizeMixedDistinctAggregations.java
@@ -36,7 +36,7 @@ public class TestOptimizeMixedDistinctAggregations
     {
         storageFormat = System.getProperty("storageFormat", "PARQUET");
         sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "true"));
-        charNToVarcharImplicitCast = NativeTestsUtils.getCharNToVarcharImplicitCastForTest(
+        charNToVarcharImplicitCast = getCharNToVarcharImplicitCastForTest(
                 sidecarEnabled, parseBoolean(System.getProperty("charNToVarcharImplicitCast", "false")));
         super.init(storageFormat, charNToVarcharImplicitCast, sidecarEnabled);
         super.init();


### PR DESCRIPTION
## Description
Cleans up tests from `presto-native-tests`.

## Motivation and Context
Helper methods used to test custom functions are only used in `TestCustomFunctions` and should not be a part of `NativeTestUtils`.
Builder pattern should be used to get the `queryRunner` in tests and function `NativeTestUtils.createNativeQueryRunner` should not be overloaded with different arguments.
Enables tests with time type in `AbstractTestAggregationsNative`, since it is now supported in Velox.

## Impact
NA


```
== NO RELEASE NOTE ==
```

