### PR TITLE
Free more space for product-tests-specific-environment2

### DIFF
--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -42,11 +42,9 @@ jobs:
     steps:
       - name: Free Disk Space
         if: needs.changes.outputs.codechange == 'true'
-        run: |
-          df -h
-          sudo apt-get clean
-          rm -rf /opt/hostedtoolcache
-          df -h
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          docker-images: false
       - uses: actions/checkout@v4
         if: needs.changes.outputs.codechange == 'true'
         with:
@@ -108,11 +106,9 @@ jobs:
     steps:
       - name: Free Disk Space
         if: needs.changes.outputs.codechange == 'true'
-        run: |
-          df -h
-          sudo apt-get clean
-          rm -rf /opt/hostedtoolcache
-          df -h
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          docker-images: false
       - uses: actions/checkout@v4
         if: needs.changes.outputs.codechange == 'true'
         with:


### PR DESCRIPTION
## Description

The action report no space:
```
Docker compose containers stopped: [singlenode-sqlserver]
Docker compose containers stopped: [singlenode]
Pulling docker image [mcr.microsoft.com/mssql/server:2022-latest]
failed to register layer: write /opt/mssql/lib/system.netfx.sfp: no space left on device
Error: Process completed with exit code 1.
```

## Motivation and Context


## Impact
CI

## Test Plan
PR

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

