### PR TITLE
[native][iceberg] Fix iceberg mixed case column name query error

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
@@ -833,11 +833,20 @@ std::unique_ptr<connector::ConnectorTableHandle> toHiveTableHandle(
     std::vector<std::string> names;
     std::vector<TypePtr> types;
     velox::type::fbhive::HiveTypeParser hiveTypeParser;
+    auto icebergTableHandle =
+    std::dynamic_pointer_cast<const protocol::iceberg::IcebergTableHandle>(
+        tableHandle.connectorHandle);
     names.reserve(dataColumns.size());
     types.reserve(dataColumns.size());
     for (auto& column : dataColumns) {
       std::string name = column.name;
-      folly::toLowerAscii(name);
+      // For iceberg, the column name should be consistent with
+      // names in iceberg manifest file. The names in iceberg
+      // manifest file are consistent with the field names in
+      // parquet data file.
+      if (!icebergTableHandle) {
+        folly::toLowerAscii(name);
+      }
       names.emplace_back(std::move(name));
       auto parsedType = hiveTypeParser.parse(column.type);
       // The type from the metastore may have upper case letters


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Resolve https://github.com/prestodb/presto/issues/26162

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix Prestissimo iceberg connector mixed case column name query error.

```

