### PR TITLE
[presissimo]refactor: used estimateFlatSize instead of BaseVector::inMemoryBytes API

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowFlightConnector.cpp
@@ -183,7 +183,7 @@ std::optional<velox::RowVectorPtr> ArrowFlightDataSource::next(
   auto output = projectOutputColumns(chunk.data);
 
   completedRows_ += output->size();
-  completedBytes_ += output->inMemoryBytes();
+  completedBytes_ += output->estimateFlatSize();
   return output;
 }
 


### PR DESCRIPTION
Differential Revision: D83361478


