### PR TITLE
chore: Remove deprecated comments from TableHandle.java

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/TableHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/TableHandle.java
@@ -33,9 +33,6 @@ public final class TableHandle
     private final ConnectorId connectorId;
     private final ConnectorTableHandle connectorHandle;
     private final ConnectorTransactionHandle transaction;
-
-    // ConnectorTableHandle will represent the engine's view of data set on a table, we will deprecate ConnectorTableLayoutHandle later.
-    // TODO remove table layout once it is fully deprecated.
     private final Optional<ConnectorTableLayoutHandle> layout;
 
     // This is not serializable; for local execution only


### PR DESCRIPTION
Removed deprecated comments regarding ConnectorTableLayoutHandle.

## Description
I don't think this comment is true.  We still use TableLayoutHandle quite extensively.  There is no current SPI to support the assertion of this comment, nor are there any plans to complete any such hypothetical refactoring.

## Motivation and Context
Remove a confusing comment.

## Impact
Remove a confusing comment.

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

