### PR TITLE
[native] Fix incorrect initialization of empty 'folly::Promise' object

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -518,7 +518,7 @@ void PrestoExchangeSource::handleAbortResponse(
 }
 
 bool PrestoExchangeSource::checkSetRequestPromise() {
-  VeloxPromise<Response> promise;
+  VeloxPromise<Response> promise{VeloxPromise<Response>::makeEmpty()};
   {
     std::lock_guard<std::mutex> l(queue_->mutex());
     promise = std::move(promise_);


### PR DESCRIPTION
This is followup for https://github.com/prestodb/presto/issues/26094

For a `folly::Promise` object that is expected to be overwritten, we
should use `folly::makeEmpty()` to initialize it (it is 'invalid')
instead of the default constructor (it will be 'valid' but
'not fulfilled', assigning to it will cause an exception. Creating an
exception triggers a stack unwind, which can saturate the CPU in
high-concurrency scenarios, **causing significant performance issues**.

```
== NO RELEASE NOTE ==
```

