### PR TITLE
Wire session start time from Presto to Velox QueryConfig

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -90,6 +90,11 @@ void updateFromSessionConfigs(
         velox::tz::getTimeZoneName(session.timeZoneKey));
   }
 
+  // Always set sessionStartTime (in millis since epoch).
+  queryConfigs.emplace(
+      velox::core::QueryConfig::kSessionStartTime,
+      std::to_string(session.startTimeMillis));
+
   // Construct query tracing regex and pass to Velox config.
   // It replaces the given native_query_trace_task_reg_exp if also set.
   if (traceFragmentId.has_value() || traceShardId.has_value()) {

--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -93,7 +93,7 @@ void updateFromSessionConfigs(
   // Always set sessionStartTime (in millis since epoch).
   queryConfigs.emplace(
       velox::core::QueryConfig::kSessionStartTime,
-      std::to_string(session.getStartTime()));
+      std::to_string(session.startTime));
 
   // Construct query tracing regex and pass to Velox config.
   // It replaces the given native_query_trace_task_reg_exp if also set.

--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -93,7 +93,7 @@ void updateFromSessionConfigs(
   // Always set sessionStartTime (in millis since epoch).
   queryConfigs.emplace(
       velox::core::QueryConfig::kSessionStartTime,
-      std::to_string(session.startTimeMillis));
+      std::to_string(session.getStartTime()));
 
   // Construct query tracing regex and pass to Velox config.
   // It replaces the given native_query_trace_task_reg_exp if also set.


### PR DESCRIPTION
## Description
This change wires the session start time from Presto into Velox’s QueryConfig.
Specifically, session.getStartTime() from the Presto session is added to the query configs under the key start_time, making it available to Velox functions such as current_timestamp and now().
This would be needed in : https://github.com/facebookincubator/velox/pull/14139

## Motivation and Context
Presto Java evaluates current_timestamp and related functions against the session start time, ensuring that all workers return a consistent and deterministic value for the duration of a query.

Previously, Velox used `Timestamp::now()`, which could cause different workers to return slightly different values. kSessionStartTime has been added recently to velox to we can now use that.

This change aligns Velox’s semantics with Presto Java by making `kSessionStartTime` available through the `QueryConfig`.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

