### PR TITLE
feat(arrow): Enable case-sensitive support

### DIFF
--- a/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowFlightConfig.java
+++ b/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowFlightConfig.java
@@ -25,6 +25,7 @@ public class ArrowFlightConfig
     private String flightClientSSLKey;
     private boolean arrowFlightServerSslEnabled;
     private Integer arrowFlightPort;
+    private boolean caseSensitiveNameMatchingEnabled;
 
     public String getFlightServerName()
     {
@@ -109,6 +110,20 @@ public class ArrowFlightConfig
     public ArrowFlightConfig setFlightClientSSLKey(String flightClientSSLKey)
     {
         this.flightClientSSLKey = flightClientSSLKey;
+        return this;
+    }
+
+    public boolean isCaseSensitiveNameMatching()
+    {
+        return caseSensitiveNameMatchingEnabled;
+    }
+
+    @Config("case-sensitive-name-matching")
+    @ConfigDescription("Enable case-sensitive matching of schema, table names across the connector. " +
+            "When disabled, names are matched case-insensitively using lowercase normalization.")
+    public ArrowFlightConfig setCaseSensitiveNameMatching(boolean caseSensitiveNameMatchingEnabled)
+    {
+        this.caseSensitiveNameMatchingEnabled = caseSensitiveNameMatchingEnabled;
         return this;
     }
 }

--- a/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowMetadata.java
+++ b/presto-base-arrow-flight/src/main/java/com/facebook/plugin/arrow/ArrowMetadata.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import static com.facebook.plugin.arrow.ArrowErrorCode.ARROW_FLIGHT_METADATA_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 public class ArrowMetadata
@@ -50,12 +51,14 @@ public class ArrowMetadata
 {
     private final BaseArrowFlightClientHandler clientHandler;
     private final ArrowBlockBuilder arrowBlockBuilder;
+    private final ArrowFlightConfig arrowFlightConfig;
 
     @Inject
-    public ArrowMetadata(BaseArrowFlightClientHandler clientHandler, ArrowBlockBuilder arrowBlockBuilder)
+    public ArrowMetadata(BaseArrowFlightClientHandler clientHandler, ArrowBlockBuilder arrowBlockBuilder, ArrowFlightConfig arrowFlightConfig)
     {
         this.clientHandler = requireNonNull(clientHandler, "clientHandler is null");
         this.arrowBlockBuilder = requireNonNull(arrowBlockBuilder, "arrowBlockBuilder is null");
+        this.arrowFlightConfig = requireNonNull(arrowFlightConfig, "arrowFlightConfig is null");
     }
 
     @Override
@@ -190,6 +193,12 @@ public class ArrowMetadata
             }
         }
         return columns.build();
+    }
+
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier)
+    {
+        return arrowFlightConfig.isCaseSensitiveNameMatching() ? identifier : identifier.toLowerCase(ROOT);
     }
 
     private Type getPrestoTypeFromArrowField(Field field)

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/ArrowFlightQueryRunner.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/ArrowFlightQueryRunner.java
@@ -132,7 +132,7 @@ public class ArrowFlightQueryRunner
 
         RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
         Location serverLocation = Location.forGrpcTls("localhost", 9443);
-        FlightServer.Builder serverBuilder = FlightServer.builder(allocator, serverLocation, new TestingArrowProducer(allocator));
+        FlightServer.Builder serverBuilder = FlightServer.builder(allocator, serverLocation, new TestingArrowProducer(allocator, false));
 
         File serverCert = new File("src/test/resources/certs/server.crt");
         File serverKey = new File("src/test/resources/certs/server.key");

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightIntegrationMixedCase.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightIntegrationMixedCase.java
@@ -1,0 +1,148 @@
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.plugin.arrow;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.plugin.arrow.testingServer.TestingArrowProducer;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.flight.FlightServer;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.memory.RootAllocator;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.plugin.arrow.testingConnector.TestingArrowFlightPlugin.ARROW_FLIGHT_CONNECTOR;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.tests.QueryAssertions.assertContains;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class TestArrowFlightIntegrationMixedCase
+        extends AbstractTestQueryFramework
+{
+    private static final Logger logger = Logger.get(TestArrowFlightIntegrationMixedCase.class);
+    private static final String ARROW_FLIGHT_MIXED_CATALOG = "arrow_mixed_catalog";
+    private int serverPort;
+    private RootAllocator allocator;
+    private FlightServer server;
+    private DistributedQueryRunner arrowFlightQueryRunner;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        arrowFlightQueryRunner = getDistributedQueryRunner();
+        arrowFlightQueryRunner.createCatalog(ARROW_FLIGHT_MIXED_CATALOG, ARROW_FLIGHT_CONNECTOR, getCatalogProperties());
+        File certChainFile = new File("src/test/resources/certs/server.crt");
+        File privateKeyFile = new File("src/test/resources/certs/server.key");
+
+        allocator = new RootAllocator(Long.MAX_VALUE);
+        Location location = Location.forGrpcTls("localhost", serverPort);
+        server = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator, true))
+                .useTls(certChainFile, privateKeyFile)
+                .build();
+
+        server.start();
+        logger.info("Server listening on port %s", server.getPort());
+    }
+
+    private Map<String, String> getCatalogProperties()
+    {
+        ImmutableMap.Builder<String, String> catalogProperties = ImmutableMap.<String, String>builder()
+                .put("arrow-flight.server.port", String.valueOf(serverPort))
+                .put("arrow-flight.server", "localhost")
+                .put("arrow-flight.server-ssl-enabled", "true")
+                .put("arrow-flight.server-ssl-certificate", "src/test/resources/certs/server.crt")
+                .put("case-sensitive-name-matching", "true");
+        return catalogProperties.build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void close()
+            throws InterruptedException
+    {
+        arrowFlightQueryRunner.close();
+        server.close();
+        allocator.close();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        serverPort = ArrowFlightQueryRunner.findUnusedPort();
+        return ArrowFlightQueryRunner.createQueryRunner(serverPort, ImmutableMap.of(), ImmutableMap.of(), Optional.empty(), Optional.empty());
+    }
+
+    @Test
+    public void testShowSchemas()
+    {
+        MaterializedResult actualRow = computeActual("SHOW schemas FROM arrow_mixed_catalog");
+        MaterializedResult expectedRow = resultBuilder(getSession(), createVarcharType(50))
+                .row("Tpch_Mx")
+                .row("tpch_mx")
+                .build();
+
+        assertContains(actualRow, expectedRow);
+    }
+
+    @Test
+    public void testShowTables()
+    {
+        MaterializedResult actualRow = computeActual("SHOW TABLES FROM arrow_mixed_catalog.tpch_mx");
+        MaterializedResult expectedRow = resultBuilder(getSession(), createVarcharType(50))
+                .row("MXTEST")
+                .row("mxtest")
+                .build();
+
+        assertContains(actualRow, expectedRow);
+    }
+
+    @Test
+    public void testShowColumns()
+    {
+        MaterializedResult actualRow = computeActual("SHOW columns FROM arrow_mixed_catalog.tpch_mx.mxtest");
+        MaterializedResult expectedRow = resultBuilder(getSession(), createVarcharType(50))
+                .row("ID", "integer", "", "", Long.valueOf(10), null, null)
+                .row("NAME", "varchar(50)", "", "", null, null, Long.valueOf(50))
+                .row("name", "varchar(50)", "", "", null, null, Long.valueOf(50))
+                .row("Address", "varchar(50)", "", "", null, null, Long.valueOf(50))
+                .build();
+
+        assertContains(actualRow, expectedRow);
+    }
+
+    @Test
+    public void testSelect()
+    {
+        MaterializedResult actualRow = computeActual("SELECT * from arrow_mixed_catalog.tpch_mx.mxtest");
+        MaterializedResult expectedRow = resultBuilder(getSession(), INTEGER, createVarcharType(50), createVarcharType(50), createVarcharType(50))
+                .row(1, "TOM", "test", "kochi")
+                .row(2, "MARY", "test", "kochi")
+                .build();
+        assertTrue(actualRow.equals(expectedRow));
+    }
+}

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightIntegrationSmokeTest.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightIntegrationSmokeTest.java
@@ -46,7 +46,7 @@ public class TestArrowFlightIntegrationSmokeTest
 
         allocator = new RootAllocator(Long.MAX_VALUE);
         Location location = Location.forGrpcTls("127.0.0.1", serverPort);
-        server = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator))
+        server = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator, false))
                 .useTls(certChainFile, privateKeyFile)
                 .build();
 

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightMtls.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightMtls.java
@@ -60,7 +60,7 @@ public class TestArrowFlightMtls
         allocator = new RootAllocator(Long.MAX_VALUE);
 
         Location location = Location.forGrpcTls("localhost", serverPort);
-        server = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator))
+        server = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator, false))
                 .useTls(certChainFile, privateKeyFile)
                 .useMTlsClientVerification(caCertFile)
                 .build();

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightNativeQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightNativeQueries.java
@@ -66,7 +66,7 @@ public class TestArrowFlightNativeQueries
         arrowFlightQueryRunner = getDistributedQueryRunner();
         allocator = new RootAllocator(Long.MAX_VALUE);
         Location location = Location.forGrpcTls("localhost", serverPort);
-        FlightServer.Builder serverBuilder = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator));
+        FlightServer.Builder serverBuilder = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator, false));
 
         File serverCert = new File("src/test/resources/certs/server.crt");
         File serverKey = new File("src/test/resources/certs/server.key");

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightQueries.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightQueries.java
@@ -68,7 +68,7 @@ public class TestArrowFlightQueries
 
         allocator = new RootAllocator(Long.MAX_VALUE);
         Location location = Location.forGrpcTls("localhost", serverPort);
-        server = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator))
+        server = FlightServer.builder(allocator, location, new TestingArrowProducer(allocator, false))
                 .useTls(certChainFile, privateKeyFile)
                 .build();
 

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/testingServer/TestingH2DatabaseSetup.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/testingServer/TestingH2DatabaseSetup.java
@@ -193,6 +193,25 @@ public class TestingH2DatabaseSetup
                 " ) ");
         insertRows(tpchMetadata, SUPPLIER, handle);
 
+        stmt.execute("CREATE SCHEMA IF NOT EXISTS \"Tpch_Mx\"");
+        stmt.execute("CREATE SCHEMA IF NOT EXISTS \"tpch_mx\"");
+
+        stmt.execute("CREATE TABLE \"tpch_mx\".\"mxtest\" (" +
+                " ID INTEGER PRIMARY KEY," +
+                " \"NAME\" VARCHAR(50)," +
+                " \"name\" VARCHAR(50)," +
+                " \"Address\" VARCHAR(50)" +
+                ")");
+
+        stmt.execute("INSERT INTO \"tpch_mx\".\"mxtest\" VALUES(1, 'TOM','test', 'kochi'),(2, 'MARY', 'test', 'kochi')");
+
+        stmt.execute("CREATE TABLE \"tpch_mx\".\"MXTEST\" (" +
+                " ID INTEGER PRIMARY KEY," +
+                " \"NAME\" VARCHAR(50)," +
+                " \"name\" VARCHAR(50)," +
+                " \"Address\" VARCHAR(50)" +
+                ")");
+
         ResultSet resultSet1 = stmt.executeQuery("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'TPCH'");
         List<String> tables = new ArrayList<>();
         while (resultSet1.next()) {

--- a/presto-docs/src/main/sphinx/connector/base-arrow-flight.rst
+++ b/presto-docs/src/main/sphinx/connector/base-arrow-flight.rst
@@ -57,6 +57,7 @@ Property Name                               Description
 ``arrow-flight.client-ssl-key``             Path to SSL key that Flight clients will use for mTLS authentication with the Flight server
 ``arrow-flight.server.verify``              To verify server
 ``arrow-flight.server-ssl-enabled``         Port is ssl enabled
+``case-sensitive-name-matching``            Enable case sensitive identifier support for schema, table, and column names for the connector. When disabled, names are matched case-insensitively using lowercase normalization. Defaults to ``false``.
 ========================================== ==============================================================
 
 Mutual TLS (mTLS) Support


### PR DESCRIPTION
## Description
Enable case-sensitive configuration flag for arrow

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Arrow Flight Connector Changes
* Add support for case-sensitive identifiers in Arrow. To enable, set ``case-sensitive-name-matching=true``.
```

