### PR TITLE
fix(iceberg): Correct fallback logic for column matching in ORC files

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -527,20 +527,13 @@ public class IcebergPageSourceProvider
             List<Boolean> isRowPositionList = new ArrayList<>();
             for (IcebergColumnHandle column : regularColumns) {
                 IcebergOrcColumn icebergOrcColumn;
-                boolean isExcludeColumn = false;
 
                 if (fileOrcColumnByIcebergId.isEmpty()) {
+                    // This is a migrated table
                     icebergOrcColumn = fileOrcColumnsByName.get(column.getName());
                 }
                 else {
                     icebergOrcColumn = fileOrcColumnByIcebergId.get(column.getId());
-                    if (icebergOrcColumn == null) {
-                        // Cannot get orc column from 'fileOrcColumnByIcebergId', which means SchemaEvolution may have happened, so we get orc column by column name.
-                        icebergOrcColumn = fileOrcColumnsByName.get(column.getName());
-                        if (icebergOrcColumn != null) {
-                            isExcludeColumn = true;
-                        }
-                    }
                 }
 
                 if (icebergOrcColumn != null) {
@@ -555,11 +548,8 @@ public class IcebergPageSourceProvider
                             Optional.empty());
 
                     physicalColumnHandles.add(columnHandle);
-                    // Skip SchemaEvolution column
-                    if (!isExcludeColumn) {
-                        includedColumns.put(columnHandle.getHiveColumnIndex(), typeManager.getType(columnHandle.getTypeSignature()));
-                        columnReferences.add(new TupleDomainOrcPredicate.ColumnReference<>(columnHandle, columnHandle.getHiveColumnIndex(), typeManager.getType(columnHandle.getTypeSignature())));
-                    }
+                    includedColumns.put(columnHandle.getHiveColumnIndex(), typeManager.getType(columnHandle.getTypeSignature()));
+                    columnReferences.add(new TupleDomainOrcPredicate.ColumnReference<>(columnHandle, columnHandle.getHiveColumnIndex(), typeManager.getType(columnHandle.getTypeSignature())));
                 }
                 else {
                     physicalColumnHandles.add(new HiveColumnHandle(


### PR DESCRIPTION
## Description

Currently in Presto, the logic for column matching on ORC files which complies with Iceberg specification (meaning they record column IDs) have some issues. Based on Iceberg specification [here](https://iceberg.apache.org/spec/#column-projection), when columns IDs are present in the data files, we should match the columns strictly based on IDs. There is no need to do any name-based fallback matching logic when a column fails to match by ID, since it may introduce extra unnecessary problems. Refer to the following example:

```
    CREATE TABLE test_table(a int, b varchar) with ("write.format.default" = 'ORC');
    INSERT INTO test_table VALUES(1, '1001'), (2, '1002');
    ALTER TABLE test_table RENAME COLUMN a to a2;
    SELECT * FROM test_table;

    ALTER TABLE test_table ADD COLUMN a varchar;
    SELECT * FROM test_table;

    ALTER TABLE test_table DROP COLUMN a;
    ALTER TABLE test_table ADD COLUMN a int;
    SELECT * FROM test_table;
```

## Motivation and Context

 - Correct column mapping behavior for Iceberg with ORC files

## Impact

N/A 

## Test Plan

 - Newly added test case to show the column mapping behaviors on certain schema evolution, which would fail with ORC file before this change

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```
