### PR TITLE
[docs] Fix subheading formatting in develop/functions.rst

### DIFF
--- a/presto-docs/src/main/sphinx/develop/functions.rst
+++ b/presto-docs/src/main/sphinx/develop/functions.rst
@@ -113,7 +113,7 @@ a wrapper around ``byte[]``, rather than ``String`` for its native container typ
   ``@SqlNullable`` if it can return ``NULL`` when the arguments are non-null.
 
 Parametric Scalar Functions
----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Scalar functions that have type parameters have some additional complexity.
 To make our previous example work with any type we need the following:
@@ -187,7 +187,7 @@ To make our previous example work with any type we need the following:
     }
 
 Another Scalar Function Example
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``lowercaser`` function takes a single ``VARCHAR`` argument and returns a
 ``VARCHAR``, which is the argument converted to lower case:
@@ -214,7 +214,7 @@ has no ``@SqlNullable`` annotations, meaning that if the argument is ``NULL``,
 the result will automatically be ``NULL`` (the function will not be called).
 
 Codegen Scalar Function Implementation
---------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Scalar functions can also be implemented in bytecode, allowing us to specialize
 and optimize functions according to the ``@TypeParameter``


### PR DESCRIPTION
## Description
Noticed the subheadings under the [Scalar Function](https://prestodb.io/docs/current/develop/functions.html#scalar-function-implementation) topics in [develop/functions.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/develop/functions.rst) were top-level, and should be one level subordinate. Fixed them.

## Motivation and Context
Correct hierarchy of topics improves readability. 

## Impact
Documentation. 

## Test Plan
Local doc build. 

In the two screenshots, compare the headings "Scalar Function Implementation" and "Parametric Scalar Functions", and the page table of contents in the right sidebar. 

Before change:
<img width="862" height="828" alt="Screenshot 2025-09-29 at 3 17 31 PM" src="https://github.com/user-attachments/assets/7dea6c94-a449-41c2-880b-cf9452f0660e" />

After change: 
<img width="880" height="807" alt="Screenshot 2025-09-29 at 3 18 26 PM" src="https://github.com/user-attachments/assets/b8d17dee-5b97-424b-abb7-3d91374235aa" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

