### PR TITLE
Make SplitRunner threads daemon threads

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/executor/TaskExecutor.java
@@ -67,7 +67,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
-import static com.facebook.airlift.concurrent.Threads.threadsNamed;
 import static com.facebook.presto.execution.executor.MultilevelSplitQueue.computeLevel;
 import static com.facebook.presto.util.MoreMath.min;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -266,7 +265,7 @@ public class TaskExecutor
         checkArgument(interruptSplitInterval.getValue(SECONDS) >= 1.0, "interruptSplitInterval must be at least 1 second");
 
         // we manage thread pool size directly, so create an unlimited pool
-        this.executor = newCachedThreadPool(threadsNamed("task-processor-%s"));
+        this.executor = newCachedThreadPool(daemonThreadsNamed("task-processor-%s"));
         this.executorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) executor);
         this.runnerThreads = runnerThreads;
         this.embedVersion = requireNonNull(embedVersion, "embedVersion is null");


### PR DESCRIPTION
## Description
When presto_on_spark starts and there is exception during bootstrap, non-daemon split runner threads prevents JVM shut down. This causes JVM to be hung forever until manually killed. 

This PR makes split runner threads daemon which will enable JVM shutdown to proceed without waiting on these threads to complete.

## Motivation and Context
When the server fails during early startup, non-daemon worker threads created for SplitRunners can keep the JVM alive even though the main thread has exited. This results in a hung process that can't terminate on it's own.

This change switches the SplitRunner thread factory to create daemon threads. Daemon threads don’t prevent JVM shutdown, allowing the process to terminate cleanly when the main thread exits abnormally during bootstrap.

## Test Plan
- [x] Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

