### PR TITLE
fix(docs): Fix redis-hbo-provider docs

### DIFF
--- a/presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst
+++ b/presto-docs/src/main/sphinx/plugin/redis-hbo-provider.rst
@@ -9,27 +9,27 @@ Redis HBO Provider supports loading a custom configured Redis Client for storing
 Configuration
 -------------
 
-Create ``etc/catalog/redis-provider.properties`` to mount the Redis HBO Provider Plugin. 
+Create ``etc/redis-provider.properties`` to mount the Redis HBO Provider Plugin.
 
 Edit the configuration properties as appropriate:
 
 Configuration properties
 ------------------------
 
-The following configuration properties are available for use in ``etc/catalog/redis-provider.properties``:
+The following configuration properties are available for use in ``etc/redis-provider.properties``:
 
 
 ============================================ =====================================================================
 Property Name                                Description
 ============================================ =====================================================================
-``coordinator``                              Boolean property whether Presto server is a coordinator
+``coordinator``                              Boolean property to decide whether Presto server is a coordinator
 ``hbo.redis-provider.server_uri``            Redis Server URI
 ``hbo.redis-provider.total-fetch-timeoutms`` Maximum timeout in ms for Redis fetch requests
 ``hbo.redis-provider.total-set-timeoutms``   Maximum timeout in ms for Redis set requests
 ``hbo.redis-provider.default-ttl-seconds``   TTL in seconds of the Redis data to be stored
-``hbo.redis-provider.enabled``               Boolean property whether this plugin is enabled in production
+``hbo.redis-provider.enabled``               Boolean property to enable this plugin
 ``credentials-path``                         Path for Redis credentials
-``hbo.redis-provider.cluster-mode-enabled``  Boolean property whether cluster mode is enabled
+``hbo.redis-provider.cluster-mode-enabled``  Boolean property to enable cluster mode
 ============================================ =====================================================================
 
 Coordinator Configuration for Historical Based Optimization
@@ -80,29 +80,18 @@ You can place the plugin JARs in the production's ``plugins`` directory.
 
 Alternatively, follow this method to ensure that the plugin is loaded during the Presto build.
 
-1. Add the following to register the plugin in ``<fileSets>`` in ``presto-server/src/main/assembly/presto.xml``:
+1. Add the following to register the plugin in ``presto-server/src/main/provisio/presto.xml``:
    
    .. code-block:: text
-   
-       <fileSet>
-          <directory>${project.build.directory}/dependency/redis-hbo-provider-${project.version}</directory>
-          <outputDirectory>plugin/redis-hbo-provider</outputDirectory>
-       </fileSet>
+
+       <artifactSet to="plugin/redis-hbo-provider">
+           <artifact id="${project.groupId}:redis-hbo-provider:zip:${project.version}">
+               <unpack />
+           </artifact>
+       </artifactSet>
 
 2. In ``redis-hbo-provider/src/main/resources``, create the file ``META-INF.services`` with the Plugin entry class ``com.facebook.presto.statistic.RedisProviderPlugin``.
 
-3. Add the dependency on the module in ``presto-server/pom.xml``:
-   
-   .. code-block:: text
-   
-       <dependency>
-           <groupId>com.facebook.presto</groupId>
-           <artifactId>redis-hbo-provider</artifactId>
-           <version>${project.version}</version>
-           <type>zip</type>
-           <scope>provided</scope>
-       </dependency>
-
-4. (Optional) Add your custom Redis client connection login in ``com.facebook.presto.statistic.RedisClusterAsyncCommandsFactory``. 
+3. (Optional) Add your custom Redis client connection login in ``com.facebook.presto.statistic.RedisClusterAsyncCommandsFactory``.
 
    Note: The AsyncCommands must be provided properly.


### PR DESCRIPTION
I am not very sure about maven provisio plugin details and I could not find good documentation around it. Please correct if I have missed anything around packaging redis-hbo-provider plugin in presto distribution tar file.

Ref: https://github.com/jvanzyl/provisio

## Description
Fix docs

## Motivation and Context
User facing docs need to be upto date.

## Impact
Docs change

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

