### PR TITLE
fix: Allow DELETE queries to run on Presto on Spark

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/AbstractPrestoSparkQueryExecution.java
@@ -816,6 +816,12 @@ public abstract class AbstractPrestoSparkQueryExecution
     }
 
     @VisibleForTesting
+    public Session getSession()
+    {
+        return session;
+    }
+
+    @VisibleForTesting
     public TableWriteInfo getTableWriteInfo(Session session, SubPlan plan)
     {
         StreamingPlanSection streamingPlanSection = extractStreamingSections(plan);
@@ -841,7 +847,7 @@ public abstract class AbstractPrestoSparkQueryExecution
     {
         ConnectorId connectorId;
         if (writerTarget instanceof ExecutionWriterTarget.DeleteHandle) {
-            throw new PrestoException(NOT_SUPPORTED, "delete queries are not supported by presto on spark");
+            connectorId = ((ExecutionWriterTarget.DeleteHandle) writerTarget).getHandle().getConnectorId();
         }
         else if (writerTarget instanceof ExecutionWriterTarget.CreateHandle) {
             connectorId = ((ExecutionWriterTarget.CreateHandle) writerTarget).getHandle().getConnectorId();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/MockDeleteConnector.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/MockDeleteConnector.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorDeleteTableHandle;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.FixedPageSource;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.facebook.presto.testing.TestingHandleResolver;
+import com.facebook.presto.testing.TestingMetadata;
+import com.facebook.presto.testing.TestingPageSinkProvider;
+import com.facebook.presto.testing.TestingSplitManager;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.spi.connector.ConnectorCapabilities.SUPPORTS_PAGE_SINK_COMMIT;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A mock connector that supports DELETE operations, for use in tests.
+ * The default TestingMetadata / Hive connectors do not support beginDelete().
+ */
+public class MockDeleteConnector
+{
+    private static final String CONNECTOR_NAME = "delete_test";
+
+    private final DeleteMetadata metadata;
+
+    public MockDeleteConnector()
+    {
+        this.metadata = new DeleteMetadata();
+    }
+
+    public DeleteMetadata getMetadata()
+    {
+        return metadata;
+    }
+
+    public Plugin createPlugin()
+    {
+        return new DeletePlugin(metadata);
+    }
+
+    public static String getConnectorName()
+    {
+        return CONNECTOR_NAME;
+    }
+
+    public static class DeleteTableHandle
+            implements ConnectorDeleteTableHandle
+    {
+        @JsonCreator
+        public DeleteTableHandle() {}
+    }
+
+    public static class DeleteMetadata
+            extends TestingMetadata
+    {
+        @Override
+        public Optional<ColumnHandle> getDeleteRowIdColumn(ConnectorSession session, ConnectorTableHandle tableHandle)
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean supportsMetadataDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle)
+        {
+            return false;
+        }
+
+        @Override
+        public ConnectorDeleteTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+        {
+            return new DeleteTableHandle();
+        }
+    }
+
+    public static class DeleteHandleResolver
+            extends TestingHandleResolver
+    {
+        @Override
+        public Class<? extends ConnectorDeleteTableHandle> getDeleteTableHandleClass()
+        {
+            return DeleteTableHandle.class;
+        }
+    }
+
+    private static class DeleteConnector
+            implements Connector
+    {
+        private final ConnectorMetadata metadata;
+
+        private DeleteConnector(ConnectorMetadata metadata)
+        {
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+        {
+            return TestingTransactionHandle.create();
+        }
+
+        @Override
+        public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
+        {
+            return metadata;
+        }
+
+        @Override
+        public ConnectorSplitManager getSplitManager()
+        {
+            return new TestingSplitManager(ImmutableList.of());
+        }
+
+        @Override
+        public ConnectorPageSourceProvider getPageSourceProvider()
+        {
+            return new ConnectorPageSourceProvider()
+            {
+                @Override
+                public ConnectorPageSource createPageSource(
+                        ConnectorTransactionHandle transactionHandle,
+                        ConnectorSession session,
+                        ConnectorSplit split,
+                        ConnectorTableLayoutHandle layout,
+                        List<ColumnHandle> columns,
+                        SplitContext splitContext,
+                        RuntimeStats runtimeStats)
+                {
+                    return new FixedPageSource(ImmutableList.of());
+                }
+            };
+        }
+
+        @Override
+        public ConnectorPageSinkProvider getPageSinkProvider()
+        {
+            return new TestingPageSinkProvider();
+        }
+
+        @Override
+        public Set<ConnectorCapabilities> getCapabilities()
+        {
+            return ImmutableSet.of(SUPPORTS_PAGE_SINK_COMMIT);
+        }
+    }
+
+    private static class DeletePlugin
+            implements Plugin
+    {
+        private final DeleteMetadata metadata;
+
+        private DeletePlugin(DeleteMetadata metadata)
+        {
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public Iterable<ConnectorFactory> getConnectorFactories()
+        {
+            return ImmutableList.of(new ConnectorFactory()
+            {
+                @Override
+                public String getName()
+                {
+                    return CONNECTOR_NAME;
+                }
+
+                @Override
+                public ConnectorHandleResolver getHandleResolver()
+                {
+                    return new DeleteHandleResolver();
+                }
+
+                @Override
+                public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+                {
+                    return new DeleteConnector(metadata);
+                }
+            });
+        }
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecution.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryExecution.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spark;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.execution.scheduler.ExecutionWriterTarget;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecution;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
@@ -22,12 +23,17 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskRdd;
 import com.facebook.presto.spark.execution.FragmentExecutionResult;
 import com.facebook.presto.spark.execution.PrestoSparkAdaptiveQueryExecution;
 import com.facebook.presto.spark.execution.PrestoSparkStaticQueryExecution;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.facebook.presto.tests.QueryAssertions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.spark.Dependency;
 import org.apache.spark.MapOutputStatistics;
 import org.apache.spark.rdd.RDD;
@@ -39,6 +45,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.spark.PrestoSparkQueryRunner.createHivePrestoSparkQueryRunner;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_ADAPTIVE_QUERY_EXECUTION_ENABLED;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED;
@@ -59,6 +66,17 @@ public class TestPrestoSparkQueryExecution
     protected QueryRunner createQueryRunner()
     {
         prestoSparkQueryRunner = createHivePrestoSparkQueryRunner();
+
+        MockDeleteConnector mockDelete = new MockDeleteConnector();
+        prestoSparkQueryRunner.installPlugin(mockDelete.createPlugin());
+        prestoSparkQueryRunner.createCatalog(MockDeleteConnector.getConnectorName(), MockDeleteConnector.getConnectorName(), ImmutableMap.of());
+        mockDelete.getMetadata().createTable(
+                TestingConnectorSession.SESSION,
+                new ConnectorTableMetadata(
+                        new SchemaTableName("default", "test_delete_table"),
+                        ImmutableList.of(ColumnMetadata.builder().setName("id").setType(BIGINT).build())),
+                false);
+
         return prestoSparkQueryRunner;
     }
 
@@ -187,6 +205,25 @@ public class TestPrestoSparkQueryExecution
                 .build();
         String sql = "select * from lineitem l join orders o on l.orderkey = o.orderkey";
         validateFragmentedRddCreation(session, sql);
+    }
+
+    @Test
+    public void testRddCreationForDelete()
+    {
+        Session session = Session.builder(getSession())
+                .setCatalog(MockDeleteConnector.getConnectorName())
+                .setSchema("default")
+                .build();
+
+        String sql = "DELETE FROM test_delete_table WHERE id > 5";
+        IPrestoSparkQueryExecution queryExecution = getPrestoSparkQueryExecution(session, sql);
+        assertTrue(queryExecution instanceof PrestoSparkStaticQueryExecution);
+        PrestoSparkStaticQueryExecution sparkQueryExecution = (PrestoSparkStaticQueryExecution) queryExecution;
+        SubPlan rootPlanFragment = sparkQueryExecution.createFragmentedPlan();
+        Session executionSession = sparkQueryExecution.getSession();
+        TableWriteInfo writeInfo = sparkQueryExecution.getTableWriteInfo(executionSession, rootPlanFragment.getFragment().getRoot());
+        assertTrue(writeInfo.getWriterTarget().isPresent());
+        assertTrue(writeInfo.getWriterTarget().get() instanceof ExecutionWriterTarget.DeleteHandle);
     }
 
     @Test

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -130,6 +130,28 @@ public class TestPrestoSparkQueryRunner
     }
 
     @Test
+    public void testDelete()
+    {
+        Session session = getSession();
+        assertUpdate(
+                session,
+                "CREATE TABLE hive.hive_test.test_delete WITH ( partitioned_by=ARRAY['orderstatus']) AS " +
+                        "SELECT orderkey, custkey, totalprice, orderdate, orderpriority, clerk, shippriority, comment, orderstatus " +
+                        "FROM orders",
+                15000);
+
+        assertQueryFails(
+                session,
+                "DELETE FROM hive.hive_test.test_delete WHERE orderpriority = '1-URGENT'",
+                "This connector only supports delete where one or more partitions are deleted entirely",
+                true);
+
+        assertUpdate(
+                session,
+                "DELETE FROM hive.hive_test.test_delete WHERE orderstatus = 'O'");
+    }
+
+    @Test
     public void testZeroFileCreatorForBucketedTable()
     {
         assertUpdate(


### PR DESCRIPTION
## Description
Simple change to allow DELETE queries to run in Presto-on-Spark for connectors that implement them

Reviewed By: shelton408

Differential Revision: D83402171

## Release Notes
```
== RELEASE NOTES ==
General Changes
* Fix a gap in query commit for DELETE queries when running on Spark.
```
