### PR TITLE
fix(security): Bump grpc to 1.75.0 to resolve CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <air.test.parallel>methods</air.test.parallel>
         <air.test.thread-count>2</air.test.thread-count>
         <air.test.jvmsize>4g</air.test.jvmsize>
-        <grpc.version>1.70.0</grpc.version>
+        <grpc.version>1.75.0</grpc.version>
         <air.javadoc.lint>-missing</air.javadoc.lint>
         <dep.commons.codec.version>1.17.1</dep.commons.codec.version>
         <aws.sdk.version>2.32.9</aws.sdk.version>


### PR DESCRIPTION
## Description
Bump grpc to 1.75.0 to resolve CVE-2025-55163

## Motivation and Context

## Impact

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== RELEASE NOTES ==

Security Changes
* Upgrade grpc version to 1.75.0 to resolve 'CVE-2025-55163  <https://github.com/advisories/GHSA-prj3-ccx8-p6x4>'_.
```
