### PR TITLE
[pos] Do not load function namespace managers on native executors

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -214,13 +214,17 @@ public class PrestoSparkInjectorFactory
                 }
             }
 
+            FeaturesConfig featuresConfig = injector.getInstance(FeaturesConfig.class);
             if (sparkProcessType.equals(DRIVER) ||
-                    !injector.getInstance(FeaturesConfig.class).isInlineSqlFunctions()) {
+                    (!featuresConfig.isNativeExecutionEnabled()
+                            && !featuresConfig.isInlineSqlFunctions())) {
                 if (functionNamespaceProperties.isPresent()) {
-                    injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers(functionNamespaceProperties.get());
+                    injector.getInstance(StaticFunctionNamespaceStore.class)
+                            .loadFunctionNamespaceManagers(functionNamespaceProperties.get());
                 }
                 else {
-                    injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
+                    injector.getInstance(StaticFunctionNamespaceStore.class)
+                            .loadFunctionNamespaceManagers();
                 }
             }
             bootstrapTimer.endDriverModulesLoading();


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

On presto-on-spark native executors, function namespace managers are not needed no matter inline or not. This prevents some namespace managers requiring remote connections from overloading the remote service.

```
== NO RELEASE NOTE ==
```

