### PR TITLE
revert: Prepare for next development iteration - 0.295-edge23

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-accumulo</artifactId>

--- a/presto-analyzer/pom.xml
+++ b/presto-analyzer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-analyzer</artifactId>

--- a/presto-atop/pom.xml
+++ b/presto-atop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-atop</artifactId>

--- a/presto-base-arrow-flight/pom.xml
+++ b/presto-base-arrow-flight/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-base-arrow-flight</artifactId>

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-base-jdbc</artifactId>

--- a/presto-benchmark-driver/pom.xml
+++ b/presto-benchmark-driver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-benchmark-driver</artifactId>

--- a/presto-benchmark-runner/pom.xml
+++ b/presto-benchmark-runner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-benchmark-runner</artifactId>

--- a/presto-benchmark/pom.xml
+++ b/presto-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-benchmark</artifactId>

--- a/presto-benchto-benchmarks/pom.xml
+++ b/presto-benchto-benchmarks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-benchto-benchmarks</artifactId>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-bigquery</artifactId>

--- a/presto-blackhole/pom.xml
+++ b/presto-blackhole/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-blackhole</artifactId>

--- a/presto-built-in-worker-function-tools/pom.xml
+++ b/presto-built-in-worker-function-tools/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-bytecode/pom.xml
+++ b/presto-bytecode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-bytecode</artifactId>

--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-cache</artifactId>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-cassandra</artifactId>

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-cli</artifactId>

--- a/presto-clickhouse/pom.xml
+++ b/presto-clickhouse/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-clickhouse</artifactId>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-client</artifactId>

--- a/presto-cluster-ttl-providers/pom.xml
+++ b/presto-cluster-ttl-providers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-common/pom.xml
+++ b/presto-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-common</artifactId>

--- a/presto-db-session-property-manager/pom.xml
+++ b/presto-db-session-property-manager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-db-session-property-manager</artifactId>

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-delta</artifactId>

--- a/presto-docs/pom.xml
+++ b/presto-docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-docs</artifactId>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-druid</artifactId>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <artifactId>presto-elasticsearch</artifactId>
     <name>presto-elasticsearch</name>

--- a/presto-example-http/pom.xml
+++ b/presto-example-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-example-http</artifactId>

--- a/presto-expressions/pom.xml
+++ b/presto-expressions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-expressions</artifactId>

--- a/presto-file-session-property-manager/pom.xml
+++ b/presto-file-session-property-manager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-file-session-property-manager</artifactId>

--- a/presto-function-namespace-managers-common/pom.xml
+++ b/presto-function-namespace-managers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-function-server/pom.xml
+++ b/presto-function-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-function-server</artifactId>

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-geospatial-toolkit</artifactId>

--- a/presto-google-sheets/pom.xml
+++ b/presto-google-sheets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-google-sheets</artifactId>

--- a/presto-grpc-api/pom.xml
+++ b/presto-grpc-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-grpc-testing-udf-server/pom.xml
+++ b/presto-grpc-testing-udf-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-hana/pom.xml
+++ b/presto-hana/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hana</artifactId>

--- a/presto-hdfs-core/pom.xml
+++ b/presto-hdfs-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/presto-hive-common/pom.xml
+++ b/presto-hive-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/presto-hive-function-namespace/pom.xml
+++ b/presto-hive-function-namespace/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hive-function-namespace</artifactId>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hive-hadoop2</artifactId>

--- a/presto-hive-metastore/pom.xml
+++ b/presto-hive-metastore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hive-metastore</artifactId>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-hive</artifactId>

--- a/presto-hudi/pom.xml
+++ b/presto-hudi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <artifactId>presto-hudi</artifactId>
     <name>presto-hudi</name>

--- a/presto-i18n-functions/pom.xml
+++ b/presto-i18n-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-i18n-functions</artifactId>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <artifactId>presto-iceberg</artifactId>
     <name>presto-iceberg</name>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-jdbc</artifactId>

--- a/presto-jmx/pom.xml
+++ b/presto-jmx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-jmx</artifactId>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-kafka</artifactId>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-kudu</artifactId>

--- a/presto-lark-sheets/pom.xml
+++ b/presto-lark-sheets/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-local-file/pom.xml
+++ b/presto-local-file/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-local-file</artifactId>

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-main-base</artifactId>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-main</artifactId>

--- a/presto-matching/pom.xml
+++ b/presto-matching/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-matching</artifactId>

--- a/presto-memory-context/pom.xml
+++ b/presto-memory-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-memory-context</artifactId>

--- a/presto-memory/pom.xml
+++ b/presto-memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-memory</artifactId>

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-ml</artifactId>

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-mongodb</artifactId>

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-mysql</artifactId>

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-native-execution</artifactId>

--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-native-sidecar-plugin</artifactId>

--- a/presto-native-tests/pom.xml
+++ b/presto-native-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-native-tests</artifactId>

--- a/presto-node-ttl-fetchers/pom.xml
+++ b/presto-node-ttl-fetchers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-node-ttl-fetchers</artifactId>

--- a/presto-open-telemetry/pom.xml
+++ b/presto-open-telemetry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-open-telemetry</artifactId>

--- a/presto-openapi/pom.xml
+++ b/presto-openapi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-openapi</artifactId>

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-oracle</artifactId>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-orc</artifactId>

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-parquet</artifactId>

--- a/presto-parser/pom.xml
+++ b/presto-parser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-parser</artifactId>

--- a/presto-password-authenticators/pom.xml
+++ b/presto-password-authenticators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-password-authenticators</artifactId>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-pinot-toolkit</artifactId>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-pinot</artifactId>

--- a/presto-plan-checker-router-plugin/pom.xml
+++ b/presto-plan-checker-router-plugin/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <groupId>com.facebook.presto.router</groupId>
     <artifactId>presto-plan-checker-router-plugin</artifactId>
-    <version>0.295-edge23</version>
+    <version>0.296-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>presto-plan-checker-router-plugin</name>
     <description>Presto plan checker router plugin</description>

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-plugin-toolkit</artifactId>

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-postgresql</artifactId>

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-product-tests</artifactId>

--- a/presto-prometheus/pom.xml
+++ b/presto-prometheus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-prometheus</artifactId>

--- a/presto-proxy/pom.xml
+++ b/presto-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-proxy</artifactId>

--- a/presto-rcfile/pom.xml
+++ b/presto-rcfile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-rcfile</artifactId>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-record-decoder</artifactId>

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-redis</artifactId>

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-redshift</artifactId>

--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-resource-group-managers</artifactId>

--- a/presto-router-example-plugin-scheduler/pom.xml
+++ b/presto-router-example-plugin-scheduler/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <groupId>com.facebook.presto.router</groupId>
     <artifactId>presto-router-example-plugin-scheduler</artifactId>
-    <version>0.295-edge23</version>
+    <version>0.296-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>presto-router-example-plugin-scheduler</name>
     <description>Presto-router example custom plugin scheduler</description>

--- a/presto-router/pom.xml
+++ b/presto-router/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-router</artifactId>

--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-server</artifactId>

--- a/presto-session-property-managers-common/pom.xml
+++ b/presto-session-property-managers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-session-property-managers-common</artifactId>

--- a/presto-singlestore/pom.xml
+++ b/presto-singlestore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-singlestore</artifactId>

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-classloader-spark2/pom.xml
+++ b/presto-spark-classloader-spark2/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>presto-root</artifactId>
     <groupId>com.facebook.presto</groupId>
-    <version>0.295-edge23</version>
+    <version>0.296-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-classloader-spark3/pom.xml
+++ b/presto-spark-classloader-spark3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>presto-root</artifactId>
     <groupId>com.facebook.presto</groupId>
-    <version>0.295-edge23</version>
+    <version>0.295-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-common/pom.xml
+++ b/presto-spark-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-spark-common</artifactId>

--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark-package/pom.xml
+++ b/presto-spark-package/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-spark-package</artifactId>

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spark/pom.xml
+++ b/presto-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-spi</artifactId>

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-teradata-functions</artifactId>

--- a/presto-test-coverage/pom.xml
+++ b/presto-test-coverage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-test-coverage</artifactId>

--- a/presto-testing-docker/pom.xml
+++ b/presto-testing-docker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-testing-docker</artifactId>

--- a/presto-testing-server-launcher/pom.xml
+++ b/presto-testing-server-launcher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-testing-server-launcher</artifactId>

--- a/presto-testng-services/pom.xml
+++ b/presto-testng-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-testng-services</artifactId>

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-tests</artifactId>

--- a/presto-thrift-api/pom.xml
+++ b/presto-thrift-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-api</artifactId>

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-connector</artifactId>

--- a/presto-thrift-spec/pom.xml
+++ b/presto-thrift-spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-spec</artifactId>

--- a/presto-thrift-testing-server/pom.xml
+++ b/presto-thrift-testing-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-testing-server</artifactId>

--- a/presto-thrift-testing-udf-server/pom.xml
+++ b/presto-thrift-testing-udf-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-thrift-testing-udf-server</artifactId>

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-tpcds</artifactId>

--- a/presto-tpch/pom.xml
+++ b/presto-tpch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-tpch</artifactId>

--- a/presto-ui/pom.xml
+++ b/presto-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-ui</artifactId>

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <artifactId>presto-verifier</artifactId>

--- a/redis-hbo-provider/pom.xml
+++ b/redis-hbo-provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>presto-root</artifactId>
         <groupId>com.facebook.presto</groupId>
-        <version>0.295-edge23</version>
+        <version>0.296-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
This reverts commit 993944acc13e9f931cddd2038208ecf4cabf3316.

## Description
Revert unexpected edge release 

## Motivation and Context

## Impact
The current version

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

