### PR TITLE
[native] Add native session property native_skip_integer_upcasts_for_…

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -83,7 +83,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_INDEX_LOOKUP_JOIN_MAX_PREFETCH_BATCHES = "native_index_lookup_join_max_prefetch_batches";
     public static final String NATIVE_INDEX_LOOKUP_JOIN_SPLIT_OUTPUT = "native_index_lookup_join_split_output";
     public static final String NATIVE_UNNEST_SPLIT_OUTPUT = "native_unnest_split_output";
-
+    public static final String NATIVE_SKIP_INTEGER_UPCASTS_FOR_HASHJOIN = "native_skip_integer_upcasts_for_hash_join";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -397,6 +397,11 @@ public class NativeWorkerSessionPropertyProvider
                                 "batch based on the output batch size control. Otherwise, it produces a single " +
                                 "output for each input batch.",
                         true,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_SKIP_INTEGER_UPCASTS_FOR_HASHJOIN,
+                        "Native Execution only. skip integer type upcasts if they are just used as join keys",
+                        false,
                         !nativeExecution));
     }
 

--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -28,6 +28,8 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 message("Appending CMAKE_CXX_FLAGS with ${SCRIPT_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fsanitize=address -g -O0 ")
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 # Known warnings that are benign can be disabled.
 set(DISABLED_WARNINGS
@@ -120,9 +122,11 @@ if(PRESTO_ENABLE_CUDF)
   cmake_policy(SET CMP0104 NEW)
 endif()
 
+set(PRESTO_ENABLE_SPATIAL OFF)
 set(VELOX_ENABLE_GEO
     ${PRESTO_ENABLE_SPATIAL}
     CACHE BOOL "Enable Velox Geometry (aka spatial) support")
+message(STATUS "VELOX_ENABLE_GEO ${VELOX_ENABLE_GEO}")
 
 set(VELOX_BUILD_TESTING
     OFF

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -541,6 +541,14 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kUnnestSplitOutput,
       std::to_string(c.unnestSplitOutput()));
+
+  addSessionProperty(
+      kSkipIntegerUpCastsForHashJoin,
+      "kSkipIntegerUpCastsForHashJoin",
+      BOOLEAN(),
+      false,
+      QueryConfig::kSkipIntegerUpCastsForHashJoin,
+      boolToString(c.skipIntegerUpcastsForHashJoinEnabled()));
 }
 
 const std::string SessionProperties::toVeloxConfig(

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -340,6 +340,9 @@ class SessionProperties {
   static constexpr const char* kUnnestSplitOutput =
       "native_unnest_split_output";
 
+  static constexpr const char* kSkipIntegerUpCastsForHashJoin =
+      "native_skip_integer_upcasts_for_hash_join";
+
   static SessionProperties* instance();
 
   SessionProperties();

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextManagerTest.cpp
@@ -61,6 +61,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
           {"native_expression_max_array_size_in_reduce", "99999"},
           {"native_expression_max_compiled_regexes", "54321"},
           {"request_data_sizes_max_wait_sec", "20"},
+          {"native_skip_integer_upcasts_for_hash_join", "true"},
       }};
   protocol::TaskUpdateRequest updateRequest;
   updateRequest.session = session;
@@ -79,6 +80,7 @@ TEST_F(QueryContextManagerTest, nativeSessionProperties) {
   EXPECT_EQ(queryCtx->queryConfig().exprMaxArraySizeInReduce(), 99999);
   EXPECT_EQ(queryCtx->queryConfig().exprMaxCompiledRegexes(), 54321);
   EXPECT_EQ(queryCtx->queryConfig().requestDataSizesMaxWaitSec(), 20);
+  EXPECT_TRUE(queryCtx->queryConfig().skipIntegerUpcastsForHashJoinEnabled());
 }
 
 TEST_F(QueryContextManagerTest, nativeConnectorSessionProperties) {

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -125,7 +125,9 @@ TEST_F(SessionPropertiesTest, validateMapping) {
       {SessionProperties::kIndexLookupJoinSplitOutput,
        core::QueryConfig::kIndexLookupJoinSplitOutput},
       {SessionProperties::kUnnestSplitOutput,
-       core::QueryConfig::kUnnestSplitOutput}};
+       core::QueryConfig::kUnnestSplitOutput},
+      {SessionProperties::kSkipIntegerUpCastsForHashJoin,
+       core::QueryConfig::kSkipIntegerUpCastsForHashJoin}};
 
   const auto sessionProperties = SessionProperties::instance();
   for (const auto& [sessionProperty, expectedVeloxConfig] : expectedMappings) {


### PR DESCRIPTION
…hash_join

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

