### PR TITLE
Enable case sensitivity support in the Pinot connector 

### DIFF
--- a/presto-docs/src/main/sphinx/connector/pinot.rst
+++ b/presto-docs/src/main/sphinx/connector/pinot.rst
@@ -84,6 +84,8 @@ Property Name                                               Description
 ``pinot.broker-authentication-user``                        Broker username for basic authentication method.
 ``pinot.broker-authentication-password``                    Broker password for basic authentication method.
 ``pinot.query-options``                                     Pinot query-related case-sensitive options. E.g. skipUpsert:true,enableNullHandling:true
+``case-sensitive-name-matching``                            Enable case-sensitive identifier support for schema, table, and column names for the connector. When disabled,
+                                                            names are matched case-insensitively using lowercase normalization. Default is ``false``.
 ==========================================================  =============================================================================================================
 
 If ``pinot.controller-authentication-type`` is set to ``PASSWORD`` then both ``pinot.controller-authentication-user`` and

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnMetadata.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnMetadata.java
@@ -19,8 +19,6 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Objects;
 
-import static java.util.Locale.ENGLISH;
-
 public class PinotColumnMetadata
         extends ColumnMetadata
 {
@@ -42,7 +40,7 @@ public class PinotColumnMetadata
     @Override
     public String getName()
     {
-        return name.toLowerCase(ENGLISH);
+        return name;
     }
 
     public String getPinotName()

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -114,6 +114,7 @@ public class PinotConfig
     private String brokerAuthenticationPassword;
 
     private String queryOptions;
+    private boolean caseSensitiveNameMatchingEnabled;
 
     @NotNull
     public Map<String, String> getExtraHttpHeaders()
@@ -664,6 +665,18 @@ public class PinotConfig
     public PinotConfig setQueryOptions(String options)
     {
         queryOptions = options;
+        return this;
+    }
+
+    public boolean isCaseSensitiveNameMatchingEnabled()
+    {
+        return caseSensitiveNameMatchingEnabled;
+    }
+
+    @Config("case-sensitive-name-matching")
+    public PinotConfig setCaseSensitiveNameMatchingEnabled(boolean caseSensitiveNameMatchingEnabled)
+    {
+        this.caseSensitiveNameMatchingEnabled = caseSensitiveNameMatchingEnabled;
         return this;
     }
 }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotMetadata.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotMetadata.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import static com.facebook.presto.pinot.PinotColumnHandle.PinotColumnType.REGULAR;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNCLASSIFIED_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Locale.ENGLISH;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 public class PinotMetadata
@@ -47,12 +47,14 @@ public class PinotMetadata
 {
     private final String connectorId;
     private final PinotConnection pinotPrestoConnection;
+    private final PinotConfig pinotConfig;
 
     @Inject
-    public PinotMetadata(ConnectorId connectorId, PinotConnection pinotPrestoConnection)
+    public PinotMetadata(ConnectorId connectorId, PinotConnection pinotPrestoConnection, PinotConfig pinotConfig)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
         this.pinotPrestoConnection = requireNonNull(pinotPrestoConnection, "pinotPrestoConnection is null");
+        this.pinotConfig = requireNonNull(pinotConfig, "pinotConfig is null");
     }
 
     @Override
@@ -131,7 +133,7 @@ public class PinotMetadata
         }
         ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
         for (ColumnMetadata column : table.getColumnsMetadata()) {
-            columnHandles.put(column.getName().toLowerCase(ENGLISH),
+            columnHandles.put(normalizeIdentifier(session, column.getName()),
                     new PinotColumnHandle(((PinotColumnMetadata) column).getPinotName(), column.getType(), REGULAR));
         }
         return columnHandles.build();
@@ -177,5 +179,11 @@ public class PinotMetadata
             ColumnHandle columnHandle)
     {
         return ((PinotColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier)
+    {
+        return pinotConfig.isCaseSensitiveNameMatchingEnabled() ? identifier : identifier.toLowerCase(ROOT);
     }
 }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
@@ -73,7 +73,8 @@ public class TestPinotConfig
                         .setBrokerAuthenticationType("NONE")
                         .setBrokerAuthenticationUser(null)
                         .setBrokerAuthenticationPassword(null)
-                        .setQueryOptions(null));
+                        .setQueryOptions(null)
+                        .setCaseSensitiveNameMatchingEnabled(false));
     }
 
     @Test
@@ -123,6 +124,7 @@ public class TestPinotConfig
                 .put("pinot.broker-authentication-user", "admin")
                 .put("pinot.broker-authentication-password", "verysecret")
                 .put("pinot.query-options", "enableNullHandling:true,skipUpsert:true")
+                .put("case-sensitive-name-matching", "true")
                 .build();
 
         PinotConfig expected = new PinotConfig()
@@ -169,7 +171,8 @@ public class TestPinotConfig
                 .setBrokerAuthenticationUser("admin")
                 .setBrokerAuthenticationPassword("verysecret")
                 .setUseSecureConnection(true)
-                .setQueryOptions("enableNullHandling:true,skipUpsert:true");
+                .setQueryOptions("enableNullHandling:true,skipUpsert:true")
+                .setCaseSensitiveNameMatchingEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotMetadata.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotMetadata.java
@@ -28,7 +28,7 @@ public class TestPinotMetadata
 {
     private final PinotConfig pinotConfig = new PinotConfig();
     private final PinotConnection pinotConnection = new PinotConnection(new MockPinotClusterInfoFetcher(pinotConfig), pinotConfig, Executors.newSingleThreadExecutor());
-    private final PinotMetadata metadata = new PinotMetadata(TestPinotSplitManager.pinotConnectorId, pinotConnection);
+    private final PinotMetadata metadata = new PinotMetadata(TestPinotSplitManager.pinotConnectorId, pinotConnection, pinotConfig);
 
     @Test
     public void testTables()


### PR DESCRIPTION
## Description
Enable case sensitivity support in the Pinot connector 

## Motivation and Context
Previously, the Pinot connector always converted schema, table, and column names to lowercase. This caused issues when working with identifiers that differ only by case.

This PR introduces a new catalog configuration, `case-sensitive-name-matching`, which enables exact case-sensitive matching of schema, table, and column names in the Pinot connector.

## Impact
Enable case sensitivity support in the Pinot connector

## Test Plan
Currently, there is no Pinot image/Server usage in the existing Pinot tests, so I have attached test results from my Pinot instance.

<img width="330" height="347" alt="image" src="https://github.com/user-attachments/assets/1b84f9ff-c719-4bab-8ee2-9581b23eac83" />

<img width="1865" height="167" alt="image" src="https://github.com/user-attachments/assets/ebb379ff-a955-477f-a342-91101ddcc858" />

<img width="607" height="176" alt="image" src="https://github.com/user-attachments/assets/50c0c7c0-e7a9-45a8-a2fa-626fd4a85255" />

Opened an issue to enhance Pinot test and add integration tests -  https://github.com/prestodb/presto/issues/26235

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Pinot Connector Changes
* Add support for case-sensitive identifiers in Pinot. It can be enabled by setting ``case-sensitive-name-matching=true`` configuration in the catalog configuration
```

