### PR TITLE
fix: Fix the total_split_wall_time as TotalScheduledTime

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -430,7 +430,7 @@ public class QueryMonitor
         return new QueryStatistics(
                 ofMillis(queryStats.getTotalCpuTime().toMillis()),
                 ofMillis(queryStats.getRetriedCpuTime().toMillis()),
-                ofMillis(queryStats.getElapsedTime().toMillis()),
+                ofMillis(queryStats.getTotalScheduledTime().toMillis()),
                 ofMillis(queryStats.getWaitingForPrerequisitesTime().toMillis()),
                 ofMillis(queryStats.getQueuedTime().toMillis()),
                 ofMillis(queryStats.getResourceWaitingTime().toMillis()),
@@ -470,7 +470,7 @@ public class QueryMonitor
         return new QueryStatistics(
                 ofMillis(queryStats.getTotalCpuTime().toMillis()),
                 ofMillis(0),
-                ofMillis(queryStats.getElapsedTime().toMillis()),
+                ofMillis(queryStats.getTotalScheduledTime().toMillis()),
                 ofMillis(queryStats.getWaitingForPrerequisitesTime().toMillis()),
                 ofMillis(queryStats.getQueuedTime().toMillis()),
                 ofMillis(0),


### PR DESCRIPTION
Summary:
Currently in Scuba, the "Total Split Wall Time" metric is very close to the "Query Execution Time."
 {F1982478498}
However, it should technically be no less than "Total Split CPU Time," since it is essentially the sum of the total split CPU time and the total split I/O time.

We currently have three wall time concepts QueryStats:
1. QueryStateTimer::ElapsedTime : the e2e total query time, measured from query creation to completion.
2. QueryStateTimer::ExecutionTime: time spent in actual execution phases only.
 `getDuration(executionTime, beginPlanningNanos)`
3. [QueryStats::totalScheduledTime](https://www.internalfb.com/code/fbsource/[d3a398f0040808641ede7ac4c564695e65726e9d]/fbcode/github/presto-trunk/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java?lines=473)
Sum of wall time across all threads of all tasks/stages that were actually scheduled for execution.

In the event pipeline:

Currently [QueryStatistics.wallTime is read from QueryStateTimer::ElapsedTime ](https://www.internalfb.com/code/fbsource/[d3a398f0040808641ede7ac4c564695e65726e9d]/fbcode/github/presto-trunk/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java?lines=473)

QueryStateTimer::ElapsedTime → 
QueryStatistics.wallTime →  
PrismQueryCompletedEvent.totalSplitWallTime → PrismScubaPrestoQueryEvent.totalSplitWallTimeMs

PrismScubaPrestoQueryEvent.totalSplitWallTimeMs should use QueryStats::totalScheduledTime instead of QueryStateTimer::ElapsedTime.
This change makes sense because we care about the aggregation of total wall time—specifically, the sum of wall time across all threads/tasks/stages that were actually scheduled for execution.

Differential Revision: D83854612

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```
