### PR TITLE
refactor: Pass exception type to calls to Try::tryGetExceptionObject

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -121,8 +121,8 @@ TEST_P(HttpTestSuite, basic) {
 
     auto tryResponse = sendGet(client.get(), "/blackhole").getTry();
     ASSERT_TRUE(tryResponse.hasException());
-    auto httpException = dynamic_cast<proxygen::HTTPException*>(
-        tryResponse.tryGetExceptionObject());
+    auto httpException =
+        tryResponse.tryGetExceptionObject<proxygen::HTTPException>();
     ASSERT_EQ(httpException->getProxygenError(), proxygen::kErrorTimeout);
 
     response = sendGet(client.get(), "/ping").get();
@@ -133,8 +133,8 @@ TEST_P(HttpTestSuite, basic) {
   auto tryResponse = sendGet(client.get(), "/ping").getTry();
   ASSERT_TRUE(tryResponse.hasException());
 
-  auto socketException = dynamic_cast<folly::AsyncSocketException*>(
-      tryResponse.tryGetExceptionObject());
+  auto socketException =
+      tryResponse.tryGetExceptionObject<folly::AsyncSocketException>();
   ASSERT_EQ(socketException->getType(), folly::AsyncSocketException::NOT_OPEN);
 }
 


### PR DESCRIPTION
Summary: Instead of asking `Try::tryGetExceptionObject` internally to do a `dynamic_cast` to `std::exception` and then doing another `dynamic_cast` after that, just ask for the desired type up-front.

```
== NO RELEASE NOTE ==
```
