### PR TITLE
feat: Enhance connector optimizer to work on plan with multiple connectors

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPlanOptimizer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPlanOptimizer.java
@@ -16,6 +16,9 @@ package com.facebook.presto.spi;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Given a PlanNode, return a transformed PlanNode.
  * <p/>
@@ -34,4 +37,20 @@ public interface ConnectorPlanOptimizer
             ConnectorSession session,
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator);
+
+    /**
+     * Returns the list of connector IDs that this optimizer can run on when operating on
+     * subplans that span multiple connectors.
+     * <p>
+     * If this method returns an empty list (the default), the optimizer will only be applied
+     * to subplans that belong exclusively to the connector that registered this optimizer.
+     * <p>
+     * If this method returns a non-empty list, the optimizer will be applied to subplans
+     * that contain table scans from exactly the connectors specified in the returned list.
+     * This allows cross-connector optimizations for federated queries.
+     */
+    default List<ConnectorId> getSupportedConnectorIds()
+    {
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
## Description

Previously, connector optimizers in Presto were limited to optimizing subplans containing tables from only a single connector. For example, a Hive connector optimizer could only process subplans that exclusively contained Hive table scans, preventing optimization opportunities for federated queries that span multiple data sources.

This PR extends the connector optimization framework to support cross-connector optimizations for federated queries. A new method `getSupportedConnectorIds()` has been added to the `ConnectorPlanOptimizer` interface that allows optimizers to declare which combinations of connectors they can optimize together.

*   When `getSupportedConnectorIds()` returns an empty list, the optimizer maintains the existing behavior - only processing subplans from the connector it's registered with.
    
*   When `getSupportedConnectorIds()` returns a non-empty list, the optimizer will be applied to subplans that contain table scans from **exactly** the specified set of connectors. For example, if an optimizer specifies `[hive, thrift]`, it will: process subplans with both Hive and Thrift tables, not subplans with only Hive tables, nor subplans with Hive, Thrift, and MySQL tables

## Motivation and Context
To have connector optimizer to work for sub plans with multiple connectors involved.

## Impact
To have connector optimizer to work for sub plans with multiple connectors involved.

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add new feature to connector optimizer so that it can work for sub plans with multiple connectors
```


