### PR TITLE
fix(deps): Fix CVE-2025-48924: Replace commons-lang with commons-lang3:3.18.0

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -233,12 +233,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
@@ -46,7 +46,7 @@ import org.apache.accumulo.core.iterators.TypedValueCombiner;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
 

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
@@ -30,7 +30,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.FirstEntryInRowIterator;
 import org.apache.accumulo.core.iterators.user.WholeRowIterator;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.io.Text;
 
 import java.io.IOException;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Row.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/Row.java
@@ -21,7 +21,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.calcite.version>1.38.0</dep.calcite.version>
+        <dep.calcite.version>1.41.0</dep.calcite.version>
         <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <dep.jts.version>1.20.0</dep.jts.version>


### PR DESCRIPTION
## Description
- Fix CVE-2025-48924: Upgrade calcite-core in presto-pinot as calcite-core:1.38.0 brought in commons-lang:2.4 transitively.

- Replaced the vulnerable commons-lang dependency with commons-lang3 in presto-accumulo

## Motivation and Context
Commons-lang 2.x is end-of-life (last version 2.6, released 2011) and no longer receives security updates. It has been replaced by commons-lang3. This PR moves the project to use commons-lang3 instead.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade calcite-core to 1.41.0 in response to `CVE-2025-48924 <https://github.com/advisories/GHSA-j288-q9x7-2f5v>`_.
```


