### PR TITLE
feat(plugin-prometheus): Enable case-sensitive identifier support for Prometheus connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/prometheus.rst
+++ b/presto-docs/src/main/sphinx/connector/prometheus.rst
@@ -47,6 +47,7 @@ Property Name                                   Description
 ``prometheus.tls.truststore-path``       Path to the trust store containing the SSL certificates
 ``prometheus.tls.truststore-password``   Password to access the trust store for TLS verification
 ``verify-host-name``                     Enable or disable hostname verification in the SSL certificate
+``case-sensitive-name-matching``         Enable or disable case-sensitive matching for table names. The default is ``false``.
 ======================================== ============================================================================================
 
 Not Exhausting Your Presto Available Heap
@@ -79,3 +80,34 @@ Bearer Token Authentication
 Prometheus can be setup to require a Authorization header with every query. The value in
 ``prometheus.bearer-token-file`` allows for a bearer token to be read from the configured file. This file
 is optional and not required unless your Prometheus setup requires it.
+
+Case-Sensitive Name Matching
+----------------------------
+
+By default, Prometheus metric names (which appear as table names in Presto) are treated as case-insensitive. 
+This means that querying ``up`` or ``UP`` would refer to the same metric. However, since Prometheus itself 
+is case-sensitive, you can enable case-sensitive name matching to preserve the exact case of metric names.
+
+To enable case-sensitive name matching, add the following property to your ``prometheus.properties`` file:
+
+.. code-block:: none
+
+    case-sensitive-name-matching=true
+
+When case-sensitive name matching is enabled:
+
+* Table names must exactly match the case of the corresponding Prometheus metric name.
+* Queries using a different case than the actual metric name will fail with a ``Table not found`` error.
+
+This is useful when you have metrics with similar names that differ only by case.
+
+For example, with case-sensitive name matching enabled:
+
+.. code-block:: sql
+
+    -- This will work if the metric name is exactly "up"
+    SELECT * FROM prometheus.default.up;
+    
+    -- This will fail if the metric name is "up" (not "UP")
+    SELECT * FROM prometheus.default.UP;
+

--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusConnectorConfig.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusConnectorConfig.java
@@ -40,6 +40,7 @@ public class PrometheusConnectorConfig
     private String trustStorePath;
     private String truststorePassword;
     private boolean verifyHostName;
+    private boolean caseSensitiveNameMatchingEnabled;
 
     @NotNull
     public URI getPrometheusURI()
@@ -165,6 +166,19 @@ public class PrometheusConnectorConfig
     public PrometheusConnectorConfig setVerifyHostName(boolean val)
     {
         this.verifyHostName = val;
+        return this;
+    }
+
+    public boolean isCaseSensitiveNameMatchingEnabled()
+    {
+        return caseSensitiveNameMatchingEnabled;
+    }
+
+    @Config("case-sensitive-name-matching")
+    @ConfigDescription("Enable or disable case-sensitive matching for table names")
+    public PrometheusConnectorConfig setCaseSensitiveNameMatchingEnabled(boolean caseSensitiveNameMatchingEnabled)
+    {
+        this.caseSensitiveNameMatchingEnabled = caseSensitiveNameMatchingEnabled;
         return this;
     }
 }

--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusMetadata.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusMetadata.java
@@ -37,18 +37,22 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 public class PrometheusMetadata
         implements ConnectorMetadata
 {
     private final PrometheusClient prometheusClient;
+    private final boolean caseSensitiveNameMatchingEnabled;
 
     @Inject
-    public PrometheusMetadata(PrometheusClient prometheusClient)
+    public PrometheusMetadata(PrometheusClient prometheusClient, PrometheusConnectorConfig config)
     {
         requireNonNull(prometheusClient, "client is null");
+        requireNonNull(config, "config is null");
         this.prometheusClient = prometheusClient;
+        this.caseSensitiveNameMatchingEnabled = config.isCaseSensitiveNameMatchingEnabled();
     }
 
     private static List<String> listSchemaNames()
@@ -172,5 +176,11 @@ public class PrometheusMetadata
             return listTables(session, Optional.ofNullable(prefix.getSchemaName()));
         }
         return ImmutableList.of(prefix.toSchemaTableName());
+    }
+
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier)
+    {
+        return caseSensitiveNameMatchingEnabled ? identifier : identifier.toLowerCase(ROOT);
     }
 }

--- a/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/PrometheusQueryRunner.java
+++ b/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/PrometheusQueryRunner.java
@@ -34,13 +34,19 @@ public class PrometheusQueryRunner
     public static DistributedQueryRunner createPrometheusQueryRunner(PrometheusServer server)
             throws Exception
     {
+        Map<String, String> properties = ImmutableMap.of(
+                "prometheus.uri", server.getUri().toString());
+        return createPrometheusQueryRunner(properties);
+    }
+
+    public static DistributedQueryRunner createPrometheusQueryRunner(Map<String, String> properties)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession()).build();
 
             queryRunner.installPlugin(new PrometheusPlugin());
-            Map<String, String> properties = ImmutableMap.of(
-                    "prometheus.uri", server.getUri().toString());
             queryRunner.createCatalog("prometheus", "prometheus", properties);
             return queryRunner;
         }

--- a/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusCaseInsensitiveNameMatching.java
+++ b/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusCaseInsensitiveNameMatching.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.prometheus;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.plugin.prometheus.PrometheusQueryRunner.createPrometheusQueryRunner;
+import static org.testng.Assert.fail;
+
+/**
+ * Comprehensive test suite for the case-insensitive-name-matching configuration flag.
+ */
+@Test(singleThreaded = true)
+public class TestPrometheusCaseInsensitiveNameMatching
+        extends AbstractTestQueryFramework
+{
+    private static final String METRIC_NAME = "up";
+    private PrometheusServer server;
+    private Session session;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.server = new PrometheusServer();
+        // Default behavior: case-sensitive-name-matching = false (case-insensitive mode)
+        Map<String, String> properties = ImmutableMap.of(
+                "prometheus.uri", server.getUri().toString(),
+                "case-sensitive-name-matching", "false");
+        QueryRunner runner = createPrometheusQueryRunner(properties);
+        session = runner.getDefaultSession();
+        waitForPrometheusMetrics(runner);
+        return runner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    private void waitForPrometheusMetrics(QueryRunner runner)
+            throws Exception
+    {
+        int maxTries = 60;
+        int timeBetweenTriesMillis = 1000;
+        int tries = 0;
+
+        while (tries < maxTries) {
+            if (session != null && runner.tableExists(session, METRIC_NAME)) {
+                return;
+            }
+            Thread.sleep(timeBetweenTriesMillis);
+            tries++;
+        }
+        fail("Prometheus client not available for metrics query in " + maxTries * timeBetweenTriesMillis + " milliseconds.");
+    }
+
+    /**
+     * Provides various case variations of the "up" metric name for parameterized testing.
+     */
+    @DataProvider(name = "caseVariations")
+    public Object[][] caseVariations()
+    {
+        return new Object[][] {
+                {"up"},
+                {"UP"},
+                {"Up"},
+                {"uP"},
+        };
+    }
+
+    @Test(dataProvider = "caseVariations")
+    public void testSelectWithAnyCaseVariation(String metricVariation)
+    {
+        // All case variations should work in case-insensitive mode
+        assertQuerySucceeds(String.format("SELECT * FROM prometheus.default.%s LIMIT 1", metricVariation));
+    }
+
+    @Test(dataProvider = "caseVariations")
+    public void testShowColumnsWithAnyCaseVariation(String metricVariation)
+    {
+        assertQuerySucceeds(String.format("SHOW COLUMNS FROM prometheus.default.%s", metricVariation));
+    }
+
+    @Test(dataProvider = "caseVariations")
+    public void testDescribeWithAnyCaseVariation(String metricVariation)
+    {
+        assertQuerySucceeds(String.format("DESCRIBE prometheus.default.%s", metricVariation));
+    }
+
+    @Test(dataProvider = "caseVariations")
+    public void testCountWithAnyCaseVariation(String metricVariation)
+    {
+        assertQuerySucceeds(String.format("SELECT COUNT(*) FROM prometheus.default.%s", metricVariation));
+    }
+
+    protected void assertQuerySucceeds(String query)
+    {
+        try {
+            getQueryRunner().execute(session, query);
+        }
+        catch (Exception e) {
+            fail(String.format("Query should have succeeded but failed: %s. Error: %s", query, e.getMessage()), e);
+        }
+    }
+}

--- a/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusCaseSensitiveNameMatching.java
+++ b/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusCaseSensitiveNameMatching.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.prometheus;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.plugin.prometheus.PrometheusQueryRunner.createPrometheusQueryRunner;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Comprehensive test suite for case-sensitive name matching mode.
+ */
+@Test(singleThreaded = true)
+public class TestPrometheusCaseSensitiveNameMatching
+        extends AbstractTestQueryFramework
+{
+    private static final String METRIC_NAME = "up";
+    private PrometheusServer server;
+    private Session session;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.server = new PrometheusServer();
+        // Enable case-sensitive mode
+        Map<String, String> properties = ImmutableMap.of(
+                "prometheus.uri", server.getUri().toString(),
+                "case-sensitive-name-matching", "true");
+        QueryRunner runner = createPrometheusQueryRunner(properties);
+        session = runner.getDefaultSession();
+        waitForPrometheusMetrics(runner);
+        return runner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+    {
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    private void waitForPrometheusMetrics(QueryRunner runner)
+            throws Exception
+    {
+        int maxTries = 60;
+        int timeBetweenTriesMillis = 1000;
+        int tries = 0;
+
+        while (tries < maxTries) {
+            if (session != null && runner.tableExists(session, METRIC_NAME)) {
+                return;
+            }
+            Thread.sleep(timeBetweenTriesMillis);
+            tries++;
+        }
+        fail("Prometheus client not available for metrics query in " + maxTries * timeBetweenTriesMillis + " milliseconds.");
+    }
+
+    /**
+     * Provides case variations that should FAIL in case-sensitive mode.
+     */
+    @DataProvider(name = "invalidCaseVariations")
+    public Object[][] invalidCaseVariations()
+    {
+        return new Object[][] {
+                {"UP", "prometheus.default.UP"},
+                {"Up", "prometheus.default.Up"},
+                {"uP", "prometheus.default.uP"},
+        };
+    }
+
+    @Test
+    public void testTableExistsWithExactCase()
+    {
+        // The exact case "up" should work
+        assertTrue(getQueryRunner().tableExists(session, METRIC_NAME),
+                "Metric 'up' should be accessible with exact case match");
+    }
+
+    @Test
+    public void testSelectWithExactCase()
+    {
+        assertQuerySucceeds(String.format("SELECT * FROM prometheus.default.%s LIMIT 1", METRIC_NAME));
+    }
+
+    @Test
+    public void testShowColumnsWithExactCase()
+    {
+        assertQuerySucceeds(String.format("SHOW COLUMNS FROM prometheus.default.%s", METRIC_NAME));
+    }
+
+    @Test
+    public void testDescribeWithExactCase()
+    {
+        assertQuerySucceeds(String.format("DESCRIBE prometheus.default.%s", METRIC_NAME));
+    }
+
+    @Test(dataProvider = "invalidCaseVariations")
+    public void testSelectFailsWithWrongCase(String metricVariation, String expectedTableName)
+    {
+        assertQueryFails(
+                String.format("SELECT * FROM prometheus.default.%s LIMIT 1", metricVariation),
+                String.format(".*Table %s does not exist.*", expectedTableName));
+    }
+
+    @Test(dataProvider = "invalidCaseVariations")
+    public void testShowColumnsFailsWithWrongCase(String metricVariation, String expectedTableName)
+    {
+        assertQueryFails(
+                String.format("SHOW COLUMNS FROM prometheus.default.%s", metricVariation),
+                String.format(".*Table '%s' does not exist.*", expectedTableName));
+    }
+
+    @Test(dataProvider = "invalidCaseVariations")
+    public void testDescribeFailsWithWrongCase(String metricVariation, String expectedTableName)
+    {
+        assertQueryFails(
+                String.format("DESCRIBE prometheus.default.%s", metricVariation),
+                String.format(".*Table '%s' does not exist.*", expectedTableName));
+    }
+
+    @Test
+    public void testWrongCaseTablesDoNotExist()
+    {
+        assertQueryFails("SELECT * FROM prometheus.default.UP LIMIT 1",
+                ".*Table prometheus.default.UP does not exist.*");
+        assertQueryFails("SELECT * FROM prometheus.default.Up LIMIT 1",
+                ".*Table prometheus.default.Up does not exist.*");
+        assertQueryFails("SELECT * FROM prometheus.default.uP LIMIT 1",
+                ".*Table prometheus.default.uP does not exist.*");
+    }
+
+    @Test
+    public void testCountFailsWithWrongCase()
+    {
+        assertQueryFails("SELECT COUNT(*) FROM prometheus.default.UP",
+                ".*Table prometheus.default.UP does not exist.*");
+        assertQueryFails("SELECT COUNT(*) FROM prometheus.default.Up",
+                ".*Table prometheus.default.Up does not exist.*");
+    }
+
+    @Test
+    public void testAggregationFailsWithWrongCase()
+    {
+        assertQueryFails("SELECT MAX(value) FROM prometheus.default.UP",
+                ".*Table prometheus.default.UP does not exist.*");
+    }
+
+    protected void assertQuerySucceeds(String query)
+    {
+        try {
+            getQueryRunner().execute(session, query);
+        }
+        catch (Exception e) {
+            fail(String.format("Query should have succeeded but failed: %s. Error: %s", query, e.getMessage()), e);
+        }
+    }
+}

--- a/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusConnectorConfig.java
+++ b/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusConnectorConfig.java
@@ -43,7 +43,8 @@ public class TestPrometheusConnectorConfig
                 .setTlsEnabled(false)
                 .setTruststorePassword(null)
                 .setVerifyHostName(false)
-                .setTrustStorePath(null));
+                .setTrustStorePath(null)
+                .setCaseSensitiveNameMatchingEnabled(false));
     }
 
     @Test
@@ -59,6 +60,7 @@ public class TestPrometheusConnectorConfig
                 .put("prometheus.tls.truststore-password", "password")
                 .put("prometheus.tls.truststore-path", "/tmp/path/truststore")
                 .put("verify-host-name", "true")
+                .put("case-sensitive-name-matching", "true")
                 .build();
 
         URI uri = URI.create("file://test.json");
@@ -72,6 +74,7 @@ public class TestPrometheusConnectorConfig
         expected.setTruststorePassword("password");
         expected.setTrustStorePath("/tmp/path/truststore");
         expected.setVerifyHostName(true);
+        expected.setCaseSensitiveNameMatchingEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusRetrieveUpValueIntegrationTests.java
+++ b/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusRetrieveUpValueIntegrationTests.java
@@ -47,12 +47,14 @@ public class TestPrometheusRetrieveUpValueIntegrationTests
 
     private PrometheusServer server;
     private PrometheusClient client;
+    private PrometheusConnectorConfig config;
 
     @BeforeClass
     protected void createQueryRunner()
     {
         this.server = new PrometheusServer();
         this.client = createPrometheusClient(server);
+        this.config = new PrometheusConnectorConfig();
     }
 
     @AfterClass(alwaysRun = true)
@@ -84,14 +86,14 @@ public class TestPrometheusRetrieveUpValueIntegrationTests
     @Test(dependsOnMethods = "testRetrieveUpValue")
     public void testListSchemaNames()
     {
-        PrometheusMetadata metadata = new PrometheusMetadata(client);
+        PrometheusMetadata metadata = new PrometheusMetadata(client, config);
         assertEquals(metadata.listSchemaNames(SESSION), ImmutableSet.of("default"));
     }
 
     @Test(dependsOnMethods = "testRetrieveUpValue")
     public void testGetColumnMetadata()
     {
-        PrometheusMetadata metadata = new PrometheusMetadata(client);
+        PrometheusMetadata metadata = new PrometheusMetadata(client, config);
         assertEquals(metadata.getColumnMetadata(SESSION, RUNTIME_DETERMINED_TABLE_HANDLE, new PrometheusColumnHandle("text", createUnboundedVarcharType(), 0)),
                 ColumnMetadata.builder().setName("text").setType(createUnboundedVarcharType()).build());
 
@@ -105,7 +107,7 @@ public class TestPrometheusRetrieveUpValueIntegrationTests
     @Test(expectedExceptions = PrestoException.class, dependsOnMethods = "testRetrieveUpValue")
     public void testCreateTable()
     {
-        PrometheusMetadata metadata = new PrometheusMetadata(client);
+        PrometheusMetadata metadata = new PrometheusMetadata(client, config);
         metadata.createTable(
                 SESSION,
                 new ConnectorTableMetadata(
@@ -117,7 +119,7 @@ public class TestPrometheusRetrieveUpValueIntegrationTests
     @Test(expectedExceptions = PrestoException.class, dependsOnMethods = "testRetrieveUpValue")
     public void testDropTableTable()
     {
-        PrometheusMetadata metadata = new PrometheusMetadata(client);
+        PrometheusMetadata metadata = new PrometheusMetadata(client, config);
         metadata.dropTable(SESSION, RUNTIME_DETERMINED_TABLE_HANDLE);
     }
 


### PR DESCRIPTION
## Description
Added catalog-level config to support case-sensitive-name-matching

This PR implements case sensitivity handling for Prometheus metric (table) names:

    1. Added case-sensitive name matching support controlled by the case-sensitive-name-matching configuration property
    2. Implemented normalizeIdentifier in PrometheusMetadata to respect case sensitivity settings
    3. Modified PrometheusClient to preserve case when case-sensitive matching is enabled
When case-sensitive-name-matching is set to true:

    1. Metric (table) names will preserve their original case
    2. Queries must use the exact case as defined in Prometheus
When case-sensitive-name-matching is set to false (default for backward compatibility):

    1. All names are normalized to lowercase
    2. Queries are case-insensitive

**Note:** 

https://github.com/prestodb/presto/blob/76d8bf2f42476c36e429e7515797f452ca79aef3/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusClient.java#L148

https://github.com/prestodb/presto/blob/76d8bf2f42476c36e429e7515797f452ca79aef3/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusClient.java#L151

These three columns (labels, timestamp, value) are the fixed for all Prometheus metric tables. They represent:

_labels_: Map of label key-value pairs from Prometheus metrics
_timestamp_: Time when the metric was recorded
_value_: The numeric value of the metric

So the reason we have case-sensitive identifier support is extended to only tables but not to columns.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
Prometheus Connector Changes
* Add mixed case-sensitive identifier support for Prometheus connector.
