### PR TITLE
fix: Misleading error message caused by unsupported compresssion codec

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1106,6 +1106,41 @@ public abstract class IcebergDistributedSmokeTestBase
         assertUpdate("CALL system.unregister_table('" + schemaName + "', '" + newTableName + "')");
     }
 
+    @DataProvider
+    public Object[][] compressionCodecTestData()
+    {
+        return new Object[][] {
+                // codec, format, shouldSucceed, expectedErrorMessage
+                {"ZSTD", "PARQUET", false, "Compression codec ZSTD is not supported for Parquet format"},
+                {"LZ4", "PARQUET", false, "Compression codec LZ4 is not supported for Parquet format"},
+                {"LZ4", "ORC", false, "Compression codec LZ4 is not supported for ORC format"},
+                {"ZSTD", "ORC", true, null},
+                {"SNAPPY", "ORC", true, null},
+                {"SNAPPY", "PARQUET", true, null},
+                {"GZIP", "PARQUET", true, null},
+                {"NONE", "PARQUET", true, null},
+        };
+    }
+
+    @Test(dataProvider = "compressionCodecTestData")
+    public void testCompressionCodecValidation(String codec, String format, boolean shouldSucceed, String expectedErrorMessage)
+    {
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "compression_codec", codec)
+                .build();
+
+        String tableName = "test_compression_" + codec.toLowerCase() + "_" + format.toLowerCase();
+        String createTableSql = "CREATE TABLE " + tableName + " (x int) WITH (format = '" + format + "')";
+
+        if (shouldSucceed) {
+            assertUpdate(session, createTableSql);
+            dropTable(session, tableName);
+        }
+        else {
+            assertQueryFails(session, createTableSql, expectedErrorMessage);
+        }
+    }
+
     @Test
     public void testCreateNestedPartitionedTable()
     {


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Problem:
When setting `iceberg.compression-codec=ZSTD` (or LZ4) in iceberg.properties
and attempt to create a iceberg table with default file format, the system throws a cryptic error:
"NoSuchElementException: No value present" at IcebergUtil.populateTableProperties().

`13:55:39  {"level":"error","benchmark_stage_id":"cleanup_sf100","query_file":"create-table/customer.sql","query_index":0,"cold_run":true,"sequence_no":0,"info_url":"https://xxxxxx.prestodb.dev/ui/query.html?20251009_125539_00038_24pui","query_id":"20251009_125539_00038_24pui","query_error":{"message":"No value present","error_code":65536,"error_name":"GENERIC_INTERNAL_ERROR","error_type":"INTERNAL_ERROR","retriable":false,"failure_info":{"type":"java.util.NoSuchElementException","message":"No value present","suppressed":[],"stack":["java.base/java.util.Optional.get(Optional.java:143)","com.facebook.presto.iceberg.IcebergUtil.populateTableProperties(IcebergUtil.java:1178)","com.facebook.presto.iceberg.IcebergHiveMetadata.beginCreateTable(IcebergHiveMetadata.java:385)","com.facebook.presto.iceberg.IcebergAbstractMetadata.createTable(IcebergAbstractMetadata.java:503)","com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.createTable(ClassLoaderSafeConnectorMetadata.java:374)","com.facebook.presto.metadata.MetadataManager.createTable(MetadataManager.java:675)","com.facebook.presto.execution.CreateTableTask.internalExecute(CreateTableTask.java:229)","com.facebook.presto.execution.CreateTableTask.execute(CreateTableTask.java:96)","com.facebook.presto.execution.CreateTableTask.execute(CreateTableTask.java:78)","com.facebook.presto.execution.DDLDefinitionExecution.executeTask(DDLDefinitionExecution.java:67)","com.facebook.presto.execution.DataDefinitionExecution.start(DataDefinitionExecution.java:217)","com.facebook.presto.$gen.Presto_0_296_0d532be__0_296_202510071020_0d532be3____20251009_124343_1.run(Unknown Source)","com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:326)","com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:210)","java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)","..."]}},"expected_row_count":1,"start_time":"2025-10-09T12:55:39Z","finish_time":"2025-10-09T12:55:39Z","duration_in_seconds":0.112960251,"time":"2025-10-09T12:55:39Z","message":"execution failed"}`

The root case of this error message is `ZSTD` is a unsupported compression codec, and when executing this line 

`propertiesBuilder.put(PARQUET_COMPRESSION, getCompressionCodec(session).getParquetCompressionCodec().get().toString());`, 

For ZSTD and LZ4, getParquetCompressionCodec() returns Optional.empty() and calling .get() on empty Optional throws the confusing exception

Solution:
Added validation in IcebergUtil.populateTableProperties() to check codec
compatibility before calling .get() on Optional.

And also add unit tests to validate the compression codec.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

