### PR TITLE
feat(httpserver): Add support for clientCA file on proxygen HTTP server

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -335,13 +335,16 @@ void PrestoServer::run() {
 
     const bool http2Enabled =
         SystemConfig::instance()->httpServerHttp2Enabled();
+    const std::string clientCaFile =
+        SystemConfig::instance()->httpsClientCaFile().value_or("");
     httpsConfig = std::make_unique<http::HttpsConfig>(
         httpsSocketAddress,
         certPath,
         keyPath,
         ciphers,
         reusePort,
-        http2Enabled);
+        http2Enabled,
+        clientCaFile);
   }
 
   httpServer_ = std::make_unique<http::HttpServer>(

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -157,6 +157,7 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kHttpsCertPath),
           NONE_PROP(kHttpsKeyPath),
           NONE_PROP(kHttpsClientCertAndKeyPath),
+          NONE_PROP(kHttpsClientCaFile),
           NUM_PROP(kExchangeHttpClientNumIoThreadsHwMultiplier, 1.0),
           NUM_PROP(kExchangeHttpClientNumCpuThreadsHwMultiplier, 1.0),
           NUM_PROP(kConnectorNumCpuThreadsHwMultiplier, 0.0),
@@ -311,6 +312,10 @@ folly::Optional<std::string> SystemConfig::httpsKeyPath() const {
 
 folly::Optional<std::string> SystemConfig::httpsClientCertAndKeyPath() const {
   return optionalProperty(kHttpsClientCertAndKeyPath);
+}
+
+folly::Optional<std::string> SystemConfig::httpsClientCaFile() const {
+  return optionalProperty(kHttpsClientCaFile);
 }
 
 std::string SystemConfig::prestoVersion() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -211,6 +211,8 @@ class SystemConfig : public ConfigBase {
   /// Path to a .PEM file with certificate and key concatenated together.
   static constexpr std::string_view kHttpsClientCertAndKeyPath{
       "https-client-cert-key-path"};
+  /// Path to client CA file for SSL client certificate verification.
+  static constexpr std::string_view kHttpsClientCaFile{"https-client-ca-file"};
 
   /// Floating point number used in calculating how many threads we would use
   /// for CPU executor for connectors mainly for async operators:
@@ -815,6 +817,9 @@ class SystemConfig : public ConfigBase {
   /// required, break this down to 3 configs one for cert,key and password
   /// later.
   folly::Optional<std::string> httpsClientCertAndKeyPath() const;
+
+  /// Path to client CA file for SSL client certificate verification.
+  folly::Optional<std::string> httpsClientCaFile() const;
 
   bool mutableConfig() const;
 

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -107,11 +107,13 @@ HttpsConfig::HttpsConfig(
     const std::string& keyPath,
     const std::string& supportedCiphers,
     bool reusePort,
-    bool http2Enabled)
+    bool http2Enabled,
+    const std::string& clientCaFile)
     : address_(address),
       certPath_(certPath),
       keyPath_(keyPath),
       supportedCiphers_(supportedCiphers),
+      clientCaFile_(clientCaFile),
       reusePort_(reusePort),
       http2Enabled_(http2Enabled) {
   // Wangle separates ciphers by ":" where in the config it's separated with ","
@@ -128,6 +130,12 @@ proxygen::HTTPServer::IPConfig HttpsConfig::ipConfig() const {
       folly::SSLContext::VerifyClientCertificate::DO_NOT_REQUEST;
   sslCfg.setCertificate(certPath_, keyPath_, "");
   sslCfg.sslCiphers = supportedCiphers_;
+  if (!clientCaFile_.empty()) {
+    sslCfg.clientCAFiles = {clientCaFile_};
+    sslCfg.clientVerification = 
+      folly::SSLContext::VerifyClientCertificate::ALWAYS;
+  }
+
   if (http2Enabled_) {
     sslCfg.setNextProtocols({"h2", "http/1.1"});
   }

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -260,7 +260,8 @@ class HttpsConfig {
       const std::string& keyPath,
       const std::string& supportedCiphers,
       bool reusePort = false,
-      bool http2Enabled = true);
+      bool http2Enabled = true,
+      const std::string& clientCaFile = "");
 
   proxygen::HTTPServer::IPConfig ipConfig() const;
 
@@ -269,6 +270,7 @@ class HttpsConfig {
   const std::string certPath_;
   const std::string keyPath_;
   std::string supportedCiphers_;
+  const std::string clientCaFile_;
   const bool reusePort_;
   const bool http2Enabled_;
 };


### PR DESCRIPTION
Summary:
Add support for clientCA file on proxygen HTTP server.
Also change DO_NOT_REQUEST to ALWAYS when client CA is present

```
== NO RELEASE NOTE ==
```


