### PR TITLE
build: Remove unused files to solve disk full problem for prestocpp-linux-build-engine job

### DIFF
--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -95,6 +95,10 @@ jobs:
           find . -name data | xargs rm -r
           find . -name tests | xargs rm -r
           find . -name test | xargs rm -rf
+          find . -name "*.md" -not -path "./.github/*" | xargs rm -f
+          find . -name "docs" | xargs rm -rf
+          find . -name "examples" | xargs rm -rf
+          find . -name ".git" -not -path "./.git*" | xargs rm -rf
 
       - name: Disk space consumption before build
         if: needs.changes.outputs.codechange == 'true'


### PR DESCRIPTION
## Description
Reduce disk consumption for prestocpp-linux-build-engine.
I have a PR https://github.com/prestodb/presto/pull/26218 which consistently fail due to disk full. Similar to https://github.com/prestodb/presto/pull/24331, this PR further remove files which are not used in the CI build.

## Motivation and Context
As in description.

## Impact
Fix failed CI test

## Test Plan
The CI test completes successfully https://github.com/prestodb/presto/actions/runs/18389979579/job/52397841783?pr=26270

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

