### PR TITLE
feat(spi): Expose new QueryStatistic for totalScheduledTime

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -223,6 +223,7 @@ public class QueryMonitor
                         ofMillis(0),
                         ofMillis(0),
                         ofMillis(0),
+                        ofMillis(0),
                         ofMillis(queryInfo.getQueryStats().getWaitingForPrerequisitesTime().toMillis()),
                         ofMillis(queryInfo.getQueryStats().getQueuedTime().toMillis()),
                         ofMillis(0),
@@ -430,6 +431,7 @@ public class QueryMonitor
         return new QueryStatistics(
                 ofMillis(queryStats.getTotalCpuTime().toMillis()),
                 ofMillis(queryStats.getRetriedCpuTime().toMillis()),
+                ofMillis(queryStats.getElapsedTime().toMillis()),
                 ofMillis(queryStats.getTotalScheduledTime().toMillis()),
                 ofMillis(queryStats.getWaitingForPrerequisitesTime().toMillis()),
                 ofMillis(queryStats.getQueuedTime().toMillis()),
@@ -470,6 +472,7 @@ public class QueryMonitor
         return new QueryStatistics(
                 ofMillis(queryStats.getTotalCpuTime().toMillis()),
                 ofMillis(0),
+                ofMillis(queryStats.getElapsedTime().toMillis()),
                 ofMillis(queryStats.getTotalScheduledTime().toMillis()),
                 ofMillis(queryStats.getWaitingForPrerequisitesTime().toMillis()),
                 ofMillis(queryStats.getQueuedTime().toMillis()),

--- a/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/eventlistener/TestEventListenerManager.java
@@ -222,6 +222,7 @@ public class TestEventListenerManager
         Duration cpuTime = Duration.ofMillis(1000);
         Duration retriedCpuTime = Duration.ofMillis(500);
         Duration wallTime = Duration.ofMillis(2000);
+        Duration totalScheduledTime = Duration.ofMillis(2000);
         Duration waitingForPrerequisitesTime = Duration.ofMillis(300);
         Duration queuedTime = Duration.ofMillis(1500);
         Duration waitingForResourcesTime = Duration.ofMillis(600);
@@ -257,6 +258,7 @@ public class TestEventListenerManager
                 cpuTime,
                 retriedCpuTime,
                 wallTime,
+                totalScheduledTime,
                 waitingForPrerequisitesTime,
                 queuedTime,
                 waitingForResourcesTime,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
@@ -25,6 +25,7 @@ public class QueryStatistics
     private final Duration cpuTime;
     private final Duration retriedCpuTime;
     private final Duration wallTime;
+    private final Duration totalScheduledTime;
     private final Duration waitingForPrerequisitesTime;
     private final Duration queuedTime;
     private final Duration waitingForResourcesTime;
@@ -64,6 +65,7 @@ public class QueryStatistics
             Duration cpuTime,
             Duration retriedCpuTime,
             Duration wallTime,
+            Duration totalScheduledTime,
             Duration waitingForPrerequisitesTime,
             Duration queuedTime,
             Duration waitingForResourcesTime,
@@ -98,6 +100,7 @@ public class QueryStatistics
         this.cpuTime = requireNonNull(cpuTime, "cpuTime is null");
         this.retriedCpuTime = requireNonNull(retriedCpuTime, "retriedCpuTime is null");
         this.wallTime = requireNonNull(wallTime, "wallTime is null");
+        this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
         this.waitingForPrerequisitesTime = requireNonNull(waitingForPrerequisitesTime, "waitingForPrerequisitesTime is null");
         this.queuedTime = requireNonNull(queuedTime, "queuedTime is null");
         this.waitingForResourcesTime = requireNonNull(waitingForResourcesTime, "waitingForResourcesTime is null");
@@ -143,6 +146,11 @@ public class QueryStatistics
     public Duration getWallTime()
     {
         return wallTime;
+    }
+
+    public Duration getTotalScheduledTime()
+    {
+        return totalScheduledTime;
     }
 
     public Duration getWaitingForPrerequisitesTime()


### PR DESCRIPTION
https://github.com/prestodb/presto/pull/26244 previously changed the semantics of the wallTime from the QueryStatistics to be the totalScheduledTime (Sum of wall time across all threads of all tasks/stages that were actually scheduled for execution). This breaks non-Meta tooling.

This change exposes a new statistic for totalScheduledTime retaining the old wallTime. This is a backwards compatible way to keep both stats.

Note to Meta : Please use the new getTotalScheduledTime() SPI from QueryStatistics for your tools.

## Impact
New QueryStatistics.getTotalScheduledTime() method added to QueryStatistics SPI.


```
== RELEASE NOTES ==

SPI Changes
* Adds new metric getTotalScheduledTime() to QueryStatistics SPI. This value is the sum of wall time across all threads of all tasks/stages of a query that were actually scheduled for execution.
