### PR TITLE
refactor: Pass full file path to functionmetadatatest

### DIFF
--- a/presto-native-execution/presto_cpp/main/functions/tests/FunctionMetadataTest.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/tests/FunctionMetadataTest.cpp
@@ -46,7 +46,7 @@ class FunctionMetadataTest : public ::testing::Test {
       size_t expectedSize) {
     json metadataList = functionMetadata_.at(name);
     EXPECT_EQ(metadataList.size(), expectedSize);
-    std::string expectedStr = slurp(test::utils::getDataPath(expectedFile));
+    std::string expectedStr = slurp(test::utils::getDataPath("/github/presto-trunk/presto-native-execution/presto_cpp/main/functions/tests/data/", expectedFile));
     auto expected = json::parse(expectedStr);
     auto comparator = [](const json& a, const json& b) {
       return (a["outputType"] < b["outputType"]);

--- a/presto-native-execution/presto_cpp/main/types/tests/TestUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/TestUtils.cpp
@@ -14,11 +14,26 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 
+using namespace std;
+
 namespace facebook::presto::test::utils {
+
+namespace {
+  const std::string applyClionDirFix(std::string& currentPath, const std::string& fileName) {
+    // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
+    // directory. Hard-coded json files are not copied there and test fails with
+    // file not found. Fixing the path so that we can trigger these tests from
+    // CLion.
+    boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
+    boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
+
+    return currentPath + "/data/" + fileName;    
+  }
+}
 
 const std::string getDataPath(const std::string& fileName) {
   std::string currentPath = boost::filesystem::current_path().c_str();
-  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
+  if (boost::algorithm::ends_with(currentPath, "fbcode")) {  
     return currentPath +
         "/github/presto-trunk/presto-native-execution/presto_cpp/main/types/tests/data/" +
         fileName;
@@ -28,13 +43,16 @@ const std::string getDataPath(const std::string& fileName) {
         fileName;
   }
 
-  // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
-  // directory. Hard-coded json files are not copied there and test fails with
-  // file not found. Fixing the path so that we can trigger these tests from
-  // CLion.
-  boost::algorithm::replace_all(currentPath, "cmake-build-release/", "");
-  boost::algorithm::replace_all(currentPath, "cmake-build-debug/", "");
-
-  return currentPath + "/data/" + fileName;
+  return applyClionDirFix(currentPath, fileName);
 }
+
+const std::string getDataPath(const std::string& testDataDir, const std::string& fileName) {
+  std::string currentPath = boost::filesystem::current_path().c_str();
+  if (boost::algorithm::ends_with(currentPath, "fbcode")) {
+    return currentPath + testDataDir + fileName;
+  }
+
+  return applyClionDirFix(currentPath, fileName);
+}
+
 } // namespace facebook::presto::test::utils

--- a/presto-native-execution/presto_cpp/main/types/tests/TestUtils.h
+++ b/presto-native-execution/presto_cpp/main/types/tests/TestUtils.h
@@ -13,4 +13,5 @@
  */
 namespace facebook::presto::test::utils {
 const std::string getDataPath(const std::string& fileName);
+const std::string getDataPath(const std::string& testDataDir, const std::string& fileName);
 }


### PR DESCRIPTION
Passing full file path to Functonmetadatatest json files. This has no effect in OSS, however meta internal builds can benefit with this path as otherwise it can't run the tests.

