### PR TITLE
fix: Disable coordinator sidecar from being able to discover coordinator node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -643,20 +643,16 @@ public final class DiscoveryNodeManager
      * Resource Manager -> All Nodes
      * Catalog Server   -> All Nodes
      * Worker           -> Resource Managers or Catalog Servers
+     * Sidecar          -> Resource Managers or Catalog Servers
      *
      * @return Predicate to filter Service Descriptor for Nodes
      */
     private Predicate<ServiceDescriptor> filterRelevantNodes()
     {
-        if (currentNode.isCoordinator() || currentNode.isResourceManager() || currentNode.isCatalogServer() || currentNode.isCoordinatorSidecar()) {
-            // Allowing coordinator node in the list of services, even if it's not allowed by nodeStatusService with currentNode check
-            return service ->
-                    !nodeStatusService.isPresent()
-                            || nodeStatusService.get().isAllowed(service.getLocation())
-                            || isCatalogServer(service)
-                            || isCoordinatorSidecar(service);
+        if (currentNode.isCoordinator() || currentNode.isResourceManager() || currentNode.isCatalogServer()) {
+            return service -> !nodeStatusService.isPresent() || nodeStatusService.get().isAllowed(service.getLocation());
         }
 
-        return service -> isResourceManager(service) || isCatalogServer(service) || isCoordinatorSidecar(service);
+        return service -> isResourceManager(service) || isCatalogServer(service);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
@@ -169,7 +169,7 @@ public class TestDiscoveryNodeManager
             AllNodes allNodes = manager.getAllNodes();
 
             Set<InternalNode> activeNodes = allNodes.getActiveNodes();
-            assertEqualsIgnoreOrder(activeNodes, ImmutableSet.of(resourceManager, catalogServer, coordinatorSidecar));
+            assertEqualsIgnoreOrder(activeNodes, ImmutableSet.of(resourceManager, catalogServer));
 
             for (InternalNode actual : activeNodes) {
                 for (InternalNode expected : this.activeNodes) {
@@ -180,7 +180,7 @@ public class TestDiscoveryNodeManager
             assertEqualsIgnoreOrder(activeNodes, manager.getNodes(ACTIVE));
 
             Set<InternalNode> inactiveNodes = allNodes.getInactiveNodes();
-            assertEqualsIgnoreOrder(inactiveNodes, ImmutableSet.of(inActiveResourceManager, inActiveCatalogServer, inActiveCoordinatorSidecar));
+            assertEqualsIgnoreOrder(inactiveNodes, ImmutableSet.of(inActiveResourceManager, inActiveCatalogServer));
 
             for (InternalNode actual : inactiveNodes) {
                 for (InternalNode expected : this.inactiveNodes) {
@@ -271,7 +271,7 @@ public class TestDiscoveryNodeManager
             AllNodes allNodes = manager.getAllNodes();
 
             Set<InternalNode> activeNodes = allNodes.getActiveNodes();
-            assertEqualsIgnoreOrder(activeNodes, this.activeNodes);
+            assertEqualsIgnoreOrder(activeNodes, ImmutableSet.of(resourceManager, catalogServer));
 
             for (InternalNode actual : activeNodes) {
                 for (InternalNode expected : this.activeNodes) {
@@ -282,7 +282,7 @@ public class TestDiscoveryNodeManager
             assertEqualsIgnoreOrder(activeNodes, manager.getNodes(ACTIVE));
 
             Set<InternalNode> inactiveNodes = allNodes.getInactiveNodes();
-            assertEqualsIgnoreOrder(inactiveNodes, this.inactiveNodes);
+            assertEqualsIgnoreOrder(inactiveNodes, ImmutableSet.of(inActiveResourceManager, inActiveCatalogServer));
 
             for (InternalNode actual : inactiveNodes) {
                 for (InternalNode expected : this.inactiveNodes) {
@@ -298,11 +298,15 @@ public class TestDiscoveryNodeManager
     }
 
     @Test
-    public void testGetCurrentNode()
+    public void testNodesVisibleToWorkerNode()
     {
         DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, workerNodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             assertEquals(manager.getCurrentNode(), workerNode1);
+            assertEquals(manager.getCatalogServers(), ImmutableSet.of(catalogServer));
+            assertEquals(manager.getResourceManagers(), ImmutableSet.of(resourceManager));
+            assertEquals(manager.getCoordinatorSidecars(), ImmutableSet.of());
+            assertEquals(manager.getCoordinators(), ImmutableSet.of());
         }
         finally {
             manager.stop();
@@ -346,11 +350,14 @@ public class TestDiscoveryNodeManager
     }
 
     @Test
-    public void testGetCoordinatorSidecar()
+    public void testNodesVisibleToCoordinatorSidecar()
     {
         DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, coordinatorSidecarNodeInfo, new NoOpFailureDetector(), Optional.of(host -> false), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
-            assertEquals(manager.getCoordinatorSidecars(), ImmutableSet.of(coordinatorSidecar));
+            assertEquals(manager.getCatalogServers(), ImmutableSet.of(catalogServer));
+            assertEquals(manager.getResourceManagers(), ImmutableSet.of(resourceManager));
+            assertEquals(manager.getCoordinatorSidecars(), ImmutableSet.of());
+            assertEquals(manager.getCoordinators(), ImmutableSet.of());
         }
         finally {
             manager.stop();


### PR DESCRIPTION
Differential Revision: D84467840
## Description
<!---Describe your changes in detail-->
Currently, coordinator sidecar is allowed to discover all active nodes. This should not be allowed because currently, sidecar nodes are just a type of worker node. A non-sidecar worker node is currently only allowed to discover certain nodes, like catalog server and resource manager.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Coordinator sidecar should be treated no differently than worker node because they are just the same as a non-sidecar worker node, except that it have "sidecar" service descriptor.

Here is the docstring that outlines which nodes to should be visible to each type of node.

```
    /**
     * The predicate filters out the services to allow selecting relevant nodes
     * for discovery and sending heart beat.
     * Coordinator      -> All Nodes
     * Resource Manager -> All Nodes
     * Catalog Server   -> All Nodes
     * Worker           -> Resource Managers or Catalog Servers
     *
     * @return Predicate to filter Service Descriptor for Nodes
     */
```

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No impact and keeps existing behavior. It prevents a bug described in this issue:

https://github.com/prestodb/presto/issues/26280



## Test Plan
<!---Please fill in how you tested your change-->
Added unit tests to enforce the node visibility of each type.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```



