### PR TITLE
feat: Relax grammar for refresh materialized view

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -6061,7 +6061,7 @@ public class TestHiveIntegrationSmokeTest
         assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5 WHERE nationname = 'UNITED STATES'", ".*Refresh materialized view by column nationname is not supported.*");
         assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5 WHERE regionkey = 1 OR nationkey = 24", ".*Only logical AND is supported in WHERE clause.*");
         assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5 WHERE regionkey + nationkey = 25", ".*Only columns specified on literals are supported in WHERE clause.*");
-        assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5", ".*mismatched input '<EOF>'\\. Expecting: '\\.', 'WHERE'.*");
+        assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5", ".*Refresh Materialized View without predicates is not supported.");
     }
 
     @Test

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/DefaultTreeRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/DefaultTreeRewriter.java
@@ -480,12 +480,12 @@ public class DefaultTreeRewriter<C>
     protected Node visitRefreshMaterializedView(RefreshMaterializedView node, C context)
     {
         Node table = process(node.getTarget(), context);
-        Node where = process(node.getWhere(), context);
-        if (node.getTarget() == table && node.getWhere() == where) {
+        Optional<Expression> where = process(node.getWhere(), context);
+        if (node.getTarget() == table && sameElement(node.getWhere(), where)) {
             return node;
         }
 
-        return new RefreshMaterializedView((Table) table, (Expression) where);
+        return new RefreshMaterializedView((Table) table, where);
     }
 
     @Override

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -81,7 +81,8 @@ statement
         (COMMENT string)?
         (WITH properties)? AS (query | '('query')')                    #createMaterializedView
     | DROP MATERIALIZED VIEW (IF EXISTS)? qualifiedName                #dropMaterializedView
-    | REFRESH MATERIALIZED VIEW qualifiedName WHERE booleanExpression  #refreshMaterializedView
+    | REFRESH MATERIALIZED VIEW qualifiedName
+        (WHERE where=booleanExpression)?                               #refreshMaterializedView
     | CREATE (OR REPLACE)? TEMPORARY? FUNCTION functionName=qualifiedName
         '(' (sqlParameterDeclaration (',' sqlParameterDeclaration)*)? ')'
         RETURNS returnType=type

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -914,9 +914,12 @@ public final class SqlFormatter
         protected Void visitRefreshMaterializedView(RefreshMaterializedView node, Integer context)
         {
             builder.append("REFRESH MATERIALIZED VIEW ")
-                    .append(formatName(node.getTarget().getName()))
-                    .append(" WHERE ")
-                    .append(formatExpression(node.getWhere(), parameters));
+                    .append(formatName(node.getTarget().getName()));
+
+            if (node.getWhere().isPresent()) {
+                builder.append(" WHERE ")
+                        .append(formatExpression(node.getWhere().get(), parameters));
+            }
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -425,7 +425,7 @@ class AstBuilder
         return new RefreshMaterializedView(
                 getLocation(context),
                 new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
-                (Expression) visit(context.booleanExpression()));
+                visitIfPresent(context.booleanExpression(), Expression.class));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DefaultTraversalVisitor.java
@@ -560,7 +560,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitRefreshMaterializedView(RefreshMaterializedView node, C context)
     {
         process(node.getTarget(), context);
-        process(node.getWhere(), context);
+        node.getWhere().ifPresent(where -> process(where, context));
 
         return null;
     }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RefreshMaterializedView.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RefreshMaterializedView.java
@@ -26,19 +26,19 @@ public class RefreshMaterializedView
         extends Statement
 {
     private final Table target;
-    private final Expression where;
+    private final Optional<Expression> where;
 
-    public RefreshMaterializedView(Table target, Expression where)
+    public RefreshMaterializedView(Table target, Optional<Expression> where)
     {
         this(Optional.empty(), target, where);
     }
 
-    public RefreshMaterializedView(NodeLocation location, Table target, Expression where)
+    public RefreshMaterializedView(NodeLocation location, Table target, Optional<Expression> where)
     {
         this(Optional.of(location), target, where);
     }
 
-    private RefreshMaterializedView(Optional<NodeLocation> location, Table target, Expression where)
+    private RefreshMaterializedView(Optional<NodeLocation> location, Table target, Optional<Expression> where)
     {
         super(location);
         this.target = requireNonNull(target, "target is null");
@@ -50,7 +50,7 @@ public class RefreshMaterializedView
         return target;
     }
 
-    public Expression getWhere()
+    public Optional<Expression> getWhere()
     {
         return where;
     }
@@ -64,7 +64,10 @@ public class RefreshMaterializedView
     @Override
     public List<Node> getChildren()
     {
-        return ImmutableList.of(where);
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.add(target);
+        where.ifPresent(nodes::add);
+        return nodes.build();
     }
 
     @Override

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1569,13 +1569,21 @@ public class TestSqlParser
         assertStatement(
                 "REFRESH MATERIALIZED VIEW a WHERE p = 'x'",
                 new RefreshMaterializedView(
-                        table(QualifiedName.of("a")),
-                        new ComparisonExpression(ComparisonExpression.Operator.EQUAL, new Identifier("p"), new StringLiteral("x"))));
+                        table(QualifiedName.of("a")), Optional.of(
+                        new ComparisonExpression(ComparisonExpression.Operator.EQUAL,
+                                new Identifier("p"),
+                                new StringLiteral("x")))));
         assertStatement(
                 "REFRESH MATERIALIZED VIEW a.b WHERE p = 'x'",
                 new RefreshMaterializedView(
-                        table(QualifiedName.of("a", "b")),
-                        new ComparisonExpression(ComparisonExpression.Operator.EQUAL, new Identifier("p"), new StringLiteral("x"))));
+                        table(QualifiedName.of("a", "b")), Optional.of(
+                        new ComparisonExpression(ComparisonExpression.Operator.EQUAL,
+                                new Identifier("p"),
+                                new StringLiteral("x")))));
+
+        assertStatement(
+                "REFRESH MATERIALIZED VIEW mv",
+                new RefreshMaterializedView(table(QualifiedName.of("mv")), Optional.empty()));
     }
 
     @Test

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/DefaultTreeRewriter.java
@@ -465,12 +465,12 @@ public class DefaultTreeRewriter<C>
     protected Node visitRefreshMaterializedView(RefreshMaterializedView node, C context)
     {
         Node table = process(node.getTarget(), context);
-        Node where = process(node.getWhere(), context);
-        if (node.getTarget() == table && node.getWhere() == where) {
+        Optional<Expression> where = process(node.getWhere(), context);
+        if (node.getTarget() == table && sameElement(node.getWhere(), where)) {
             return node;
         }
 
-        return new RefreshMaterializedView((Table) table, (Expression) where);
+        return new RefreshMaterializedView((Table) table, where);
     }
 
     @Override


### PR DESCRIPTION
Remove the need of WHERE predicates in REFRESH MATERIALIZED VIEW.

ONLY relax grammar.  Analysis logic change will be added in the next pr.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Unit test. e2e test with refresh materialized view query

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

