### PR TITLE
refactor(native): Use new metadata structure for remote function

### DIFF
--- a/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.cpp
+++ b/presto-native-execution/presto_cpp/main/RemoteFunctionRegisterer.cpp
@@ -58,7 +58,7 @@ size_t processFile(
   std::stringstream buffer;
   buffer << stream.rdbuf();
 
-  velox::functions::RemoteVectorFunctionMetadata metadata;
+  velox::functions::RemoteThriftVectorFunctionMetadata metadata;
   metadata.location = location;
   metadata.serdeFormat = fromSerdeString(serde);
 


### PR DESCRIPTION
The remote function metadata structure in Velox has been renamed to RemoteThriftVectorFunctionMetadata in:

>https://github.com/facebookincubator/velox/pull/15001


