### PR TITLE
fix: Cli debug print for prestissimo only queries

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -179,9 +179,6 @@ Spilled: 20GB
         Duration serverSideWallTime = succinctDuration(stats.getElapsedTimeMillis(), MILLISECONDS);
 
         int nodes = stats.getNodes();
-        if ((nodes == 0) || (stats.getTotalSplits() == 0)) {
-            return;
-        }
 
         // blank line
         out.println();


### PR DESCRIPTION
Summary:
For coordinator only queries on prestissimo we don't print anything due to nodes and stats check. It looks it should be ok to remove this check given we will just print 0 for splits and node in `printFinalInfo`

There is another place in `printQueryInfo` which is used to show in progress query which also has similar check. Given these are coordinator only queries, I have not updated it since most of the stats would be 0

https://github.com/prestodb/presto/issues/25960

Differential Revision: D84577466

== NO RELEASE NOTE ==

