### PR TITLE
fix: False-positive MAP_SUBSET performance warnings

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -168,30 +168,27 @@ public class TestAnalyzer
     @Test
     public void testMapFilterWarnings()
     {
+        assertNoWarning(analyzeWithWarnings("SELECT map_filter(user_features, (k, v) -> v > 1) FROM (VALUES (map(ARRAY[1,2], ARRAY[2,3]))) AS t(user_features)"));
+
         assertHasWarning(
-                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> v > 1) FROM (VALUES (map(ARRAY[1,2], ARRAY[2,3]))) AS t(x)"),
+                analyzeWithWarnings("SELECT map_filter(user_features, (k, v) -> k = 2) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(user_features)"),
                 PERFORMANCE_WARNING,
                 "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
 
         assertHasWarning(
-                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> k = 2) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"),
+                analyzeWithWarnings("SELECT map_filter(user_features, (k, v) -> k IN (1, 3)) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(user_features)"),
                 PERFORMANCE_WARNING,
                 "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
 
-        assertHasWarning(
-                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> k IN (1, 3)) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"),
-                PERFORMANCE_WARNING,
-                "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
+        assertNoWarning(analyzeWithWarnings("SELECT map_filter(user_features, (k, v) -> v IN (20, 30)) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(user_features)"));
 
-        assertHasWarning(
-                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> v IN (20, 30)) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"),
-                PERFORMANCE_WARNING,
-                "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
+        assertNoWarning(analyzeWithWarnings("SELECT map_filter(user_features, (k, v) -> k + v > 25) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(user_features)"));
 
-        assertHasWarning(
-                analyzeWithWarnings("SELECT map_filter(x, (k, v) -> k + v > 25) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"),
-                PERFORMANCE_WARNING,
-                "Function 'presto.default.map_filter' uses a lambda on large maps which is expensive. Consider using map_subset");
+        assertNoWarning(analyzeWithWarnings("SELECT map_filter(user_features, (k, v) -> k > 2) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(user_features)"));
+
+        assertNoWarning(analyzeWithWarnings("SELECT transform_values(user_features, (k, v) -> v * 2) FROM (VALUES (map(ARRAY[1,2], ARRAY[2,3]))) AS t(user_features)"));
+
+        assertNoWarning(analyzeWithWarnings("SELECT map_filter(x, (k, v) -> k = 2) FROM (VALUES (map(ARRAY[1,2,3], ARRAY[10,20,30]))) AS t(x)"));
     }
 
     @Test

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestWarnings.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestWarnings.java
@@ -180,7 +180,7 @@ public class TestWarnings
         assertWarnings(queryRunner, TEST_SESSION, query, ImmutableSet.of(SEMANTIC_WARNING.toWarningCode()));
 
         query = "select transform_keys(map(ARRAY [25.5E0, 26.5E0, 27.5E0], ARRAY [25.5E0, 26.5E0, 27.5E0]), (k, v) -> k + v)";
-        assertWarnings(queryRunner, TEST_SESSION, query, ImmutableSet.of(SEMANTIC_WARNING.toWarningCode(), PERFORMANCE_WARNING.toWarningCode()));
+        assertWarnings(queryRunner, TEST_SESSION, query, ImmutableSet.of(SEMANTIC_WARNING.toWarningCode()));
 
         query = "SELECT histogram(RETAILPRICE) FROM tpch.tiny.part";
         assertWarnings(queryRunner, TEST_SESSION, query, ImmutableSet.of(SEMANTIC_WARNING.toWarningCode()));


### PR DESCRIPTION
Summary:
The MAP_SUBSET performance warning was triggering incorrectly in many cases:
1. Warning on transform_values (which transforms values, not filters keys)
2. Warning on map_filter when lambda uses values (e.g., v > 2)
3. Warning on map_filter with non-membership key comparisons (e.g., k > 0)
4. Warning on all map columns, even when not related to features

This diff tightens the detection logic to only warn when ALL conditions are met:
- Function is map_filter (not transform_values or other map functions)
- Lambda does NOT reference the value argument
- Lambda uses simple key membership tests (k = c, k IN (...), OR combinations, CONTAINS)
- Column name contains "features" (the main motivation for this rule)

This eliminates false positives while focusing on the intended use case of optimizing feature map filtering operations.

Implementation details:
- Added isKeyOnlyMembershipFilter() to validate lambda only uses keys
- Added expressionReferencesName() to detect value argument usage
- Added isSimpleKeyEquality() to validate membership-only comparisons
- Added containsFeatures() to limit warnings to feature-related columns
- Updated test cases to reflect correct warning behavior

Differential Revision: D84627028

```
== NO RELEASE NOTE ==


```
