### PR TITLE
fix: Add missing name field in presto-sql-helper plugins

### DIFF
--- a/presto-sql-helpers/presto-native-sql-invoked-functions-plugin/pom.xml
+++ b/presto-sql-helpers/presto-native-sql-invoked-functions-plugin/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-native-sql-invoked-functions-plugin</artifactId>
+    <name>presto-native-sql-invoked-functions-plugin</name>
     <description>Presto Native - Sql invoked functions plugin</description>
     <packaging>presto-plugin</packaging>
 

--- a/presto-sql-helpers/presto-sql-invoked-functions-plugin/pom.xml
+++ b/presto-sql-helpers/presto-sql-invoked-functions-plugin/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>presto-sql-invoked-functions-plugin</artifactId>
+    <name>presto-sql-invoked-functions-plugin</name>
     <description>Presto - Sql invoked functions plugin</description>
     <packaging>presto-plugin</packaging>
 


### PR DESCRIPTION
## Description

Error when publishing maven plugins, logs:

```log
Deployment 1a2273ac-3e3d-4502-aeca-72658dda57f6 failed
pkg:maven/com.facebook.presto/presto-native-sql-invoked-functions-plugin@0.295:
 - Project name is missing

pkg:maven/com.facebook.presto/presto-sql-invoked-functions-plugin@0.295:
 - Project name is missing
 ```
## Motivation and Context

## Impact
0.295-release

## Test Plan
Release

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
```
== NO RELEASE NOTE ==
```

