### PR TITLE
feat: TVF Part 6/X Final SQL parsing changes

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -270,7 +270,11 @@ public final class SqlFormatter
         protected Void visitTableArgument(TableFunctionTableArgument node, Integer indent)
         {
             Relation relation = node.getTable();
-            Relation unaliased = relation instanceof AliasedRelation ? ((AliasedRelation) relation).getRelation() : relation;
+            Node unaliased = relation instanceof AliasedRelation ? ((AliasedRelation) relation).getRelation() : relation;
+            if (unaliased instanceof TableSubquery) {
+                // unpack the relation from TableSubquery to avoid adding another pair of parentheses
+                unaliased = ((TableSubquery) unaliased).getQuery();
+            }
             builder.append("TABLE(");
             process(unaliased, indent);
             builder.append(")");


### PR DESCRIPTION
Final SQL Parsing changes for TVF. Includes changes for unaliasing as well as a change to prevent COPARTITION ambiguity. 

Please check https://github.com/trinodb/trino/pull/15734 for more details.

Contains all changes under `presto-parser/src/main/java/com/facebook/presto/sql`

New complete PR:
https://github.com/prestodb/presto/pull/26188

## Description
<!---Describe your changes in detail-->
Changes adapted from trino/PR#16014, 14175

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
The keyword COPARTITION is specific to table function invocation. It is not a reserved keyword. In some cases, the word COPARTITION can be ambiguously interpreted: either as table argument alias, or as part of the COPARTITION clause.
To solve the ambiguity, we decided to fail queries using the word "copartition" as table argument alias, while keeping the word non-reserved and available to be used as identifier in other contexts.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
testCopartitionInTableArgumentAlias in TestSqlParser.java

Tests ran to check for regressions:
TestSqlParser
TestSqlParserErrorHandling
TestAnalyzer
TestTableFunctionInvocation
TestTableFunctionRegistry


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

