### PR TITLE
perf(native): Fix incorrect initialization of empty 'folly::Promise' 

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -144,7 +144,7 @@ folly::SemiFuture<PrestoExchangeSource::Response> PrestoExchangeSource::request(
   VELOX_CHECK(requestPending_);
   // This call cannot be made concurrently from multiple threads, but other
   // calls that mutate promise_ can be called concurrently.
-  auto promise = VeloxPromise<Response>("PrestoExchangeSource::request");
+  VeloxPromise<Response> promise{"PrestoExchangeSource::request"};
   auto future = promise.getSemiFuture();
   velox::common::testutil::TestValue::adjust(
       "facebook::presto::PrestoExchangeSource::request", this);
@@ -355,7 +355,7 @@ void PrestoExchangeSource::processDataResponse(
   }
 
   const int64_t pageSize = empty ? 0 : page->size();
-  VeloxPromise<Response> requestPromise;
+  VeloxPromise<Response> requestPromise{VeloxPromise<Response>::makeEmpty()};
   std::vector<ContinuePromise> queuePromises;
   {
     std::lock_guard<std::mutex> l(queue_->mutex());


### PR DESCRIPTION
This is another follow-up for https://github.com/prestodb/presto/issues/26094

For an empty `folly::Promise` object that is expected to be overwritten,
we should use `folly::makeEmpty()` to initialize it (it is 'invalid')
instead of the default constructor (it will be 'valid' but
'not fulfilled', assigning to it will cause an exception. Creating an
exception triggers a stack unwind, which can saturate the CPU in
high-concurrency scenarios, **causing significant performance issues**.

```
== NO RELEASE NOTE ==
```

