### PR TITLE
fix(security): Fix Ranger plugin deserialisation to ignore unknown fields

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/security/ranger/RangerBasedAccessControl.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/security/ranger/RangerBasedAccessControl.java
@@ -66,6 +66,7 @@ import static com.facebook.presto.spi.security.AccessDeniedException.denyRenameT
 import static com.facebook.presto.spi.security.AccessDeniedException.denySelectColumns;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowColumnsMetadata;
 import static com.facebook.presto.spi.security.AccessDeniedException.denyShowCreateTable;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
@@ -80,7 +81,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class RangerBasedAccessControl
         implements ConnectorAccessControl
 {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
     private static final JsonCodec<Users> USER_INFO_CODEC = jsonCodec(Users.class);
     private static final JsonCodec<List<String>> ROLES_INFO_CODEC = listJsonCodec(String.class);
 
@@ -133,7 +135,7 @@ public class RangerBasedAccessControl
             return OBJECT_MAPPER.readValue(httpClient.execute(request, createStringResponseHandler()).getBody(), ServicePolicies.class);
         }
         catch (IOException e) {
-            throw new PrestoException(HIVE_RANGER_SERVER_ERROR, format("Unable to fetch policies from %s hive service end point", config.getRangerHiveServiceName()));
+            throw new PrestoException(HIVE_RANGER_SERVER_ERROR, format("Unable to fetch policies from %s hive service end point", config.getRangerHiveServiceName()), e);
         }
     }
 

--- a/presto-hive/src/test/resources/com.facebook.presto.hive.security.ranger/default-allow-all.json
+++ b/presto-hive/src/test/resources/com.facebook.presto.hive.security.ranger/default-allow-all.json
@@ -94,7 +94,8 @@
         "impliedGrants": [],
         "itemId": 1,
         "label": "select",
-        "name": "select"
+        "name": "select",
+        "category": "data"
       },
       {
         "impliedGrants": [],


### PR DESCRIPTION
## Description
Fix Ranger plugin deserialisation to ignore unknown fields.

The Hive Ranger plugin was failing to fetch policies from Ranger servers with versions newer than 2.1.0. The failure was due to Jackson throwing -

> UnrecognizedPropertyException for fields like category
> in RangerServiceDef$RangerAccessTypeDef.

This change configures the ObjectMapper to ignore unknown properties during deserialization, allowing the plugin to work with newer Ranger servers without failing.

## Motivation and Context
Support current client features even with upgraded Ranger instance version > 2.1.0

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Modified the test policy file to include an extra field, which would cause deserialization to fail. Updated ObjectMapper to ignore unknown properties to prevent exceptions.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

