### PR TITLE
perf: Change shuffle read API to return a row batch instead if io buffer

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -39,7 +39,7 @@
 #include "presto_cpp/main/operators/LocalPersistentShuffle.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleRead.h"
-#include "presto_cpp/main/operators/UnsafeRowExchangeSource.h"
+#include "presto_cpp/main/operators/CompactRowExchangeSource.h"
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include "presto_cpp/main/types/VeloxPlanConversion.h"
 #include "velox/common/base/Counters.h"
@@ -451,7 +451,7 @@ void PrestoServer::run() {
       });
 
   velox::exec::ExchangeSource::registerFactory(
-      operators::UnsafeRowExchangeSource::createExchangeSource);
+      operators::CompactRowExchangeSource::createExchangeSource);
 
   // Batch broadcast exchange source.
   velox::exec::ExchangeSource::registerFactory(

--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
   PartitionAndSerialize.cpp
   ShuffleRead.cpp
   ShuffleWrite.cpp
-  UnsafeRowExchangeSource.cpp
+  CompactRowExchangeSource.cpp
   LocalPersistentShuffle.cpp
   BroadcastWrite.cpp
   BroadcastFactory.cpp

--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -77,7 +77,7 @@ class LocalPersistentShuffleWriter : public ShuffleWriter {
       uint32_t shuffleId,
       uint32_t numPartitions,
       uint64_t maxBytesPerPartition,
-      velox::memory::MemoryPool* FOLLY_NONNULL pool);
+      velox::memory::MemoryPool* pool);
 
   void collect(
       int32_t partition,
@@ -109,7 +109,7 @@ class LocalPersistentShuffleWriter : public ShuffleWriter {
 
   // Used to make sure files created by this thread have unique names.
   const std::thread::id threadId_;
-  velox::memory::MemoryPool* FOLLY_NONNULL pool_;
+  velox::memory::MemoryPool* pool_;
   const uint32_t numPartitions_;
   const uint64_t maxBytesPerPartition_;
   // The top directory of the shuffle files and its file system.
@@ -129,9 +129,9 @@ class LocalPersistentShuffleReader : public ShuffleReader {
       const std::string& rootPath,
       const std::string& queryId,
       std::vector<std::string> partitionIds,
-      velox::memory::MemoryPool* FOLLY_NONNULL pool);
+      velox::memory::MemoryPool* pool);
 
-  folly::SemiFuture<velox::BufferPtr> next() override;
+  folly::SemiFuture<std::unique_ptr<ReadBatch>> next() override;
 
   void noMoreData(bool success) override;
 
@@ -147,7 +147,7 @@ class LocalPersistentShuffleReader : public ShuffleReader {
   const std::string rootPath_;
   const std::string queryId_;
   const std::vector<std::string> partitionIds_;
-  velox::memory::MemoryPool* FOLLY_NONNULL pool_;
+  velox::memory::MemoryPool* pool_;
 
   // Latest read block (file) index in 'readPartitionFiles_' for 'partition_'.
   size_t readPartitionFileIndex_{0};
@@ -165,11 +165,11 @@ class LocalPersistentShuffleFactory : public ShuffleInterfaceFactory {
   std::shared_ptr<ShuffleReader> createReader(
       const std::string& serializedStr,
       const int32_t partition,
-      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
+      velox::memory::MemoryPool* pool) override;
 
   std::shared_ptr<ShuffleWriter> createWriter(
       const std::string& serializedStr,
-      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
+      velox::memory::MemoryPool* pool) override;
 };
 
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(presto_operators_plan_builder velox_core)
 
 add_executable(
   presto_operators_test
-  PlanNodeSerdeTest.cpp UnsafeRowShuffleTest.cpp BroadcastTest.cpp
+  PlanNodeSerdeTest.cpp CompactRowShuffleTest.cpp BroadcastTest.cpp
   BinarySortableSerializerTest.cpp PlanNodeBuilderTest.cpp)
 
 add_test(presto_operators_test presto_operators_test)

--- a/presto-native-execution/presto_cpp/main/operators/tests/CompactRowShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/CompactRowShuffleTest.cpp
@@ -14,11 +14,11 @@
 #include <folly/Uri.h>
 #include "folly/init/Init.h"
 #include "presto_cpp/external/json/nlohmann/json.hpp"
+#include "presto_cpp/main/operators/CompactRowExchangeSource.h"
 #include "presto_cpp/main/operators/LocalPersistentShuffle.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleRead.h"
 #include "presto_cpp/main/operators/ShuffleWrite.h"
-#include "presto_cpp/main/operators/UnsafeRowExchangeSource.h"
 #include "presto_cpp/main/operators/tests/PlanBuilder.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
@@ -94,18 +94,13 @@ class TestShuffleWriter : public ShuffleWriter {
         maxKeyBytes_(maxKeyBytes),
         inProgressSizes_(numPartitions, 0),
         readyPartitions_(
-            std::make_shared<std::vector<std::vector<BufferPtr>>>()),
+            std::make_shared<
+                std::vector<std::vector<std::unique_ptr<ReadBatch>>>>()),
         serializedSortKeys_(
             std::make_shared<std::vector<std::vector<std::string>>>()) {
     inProgressPartitions_.resize(numPartitions_);
     readyPartitions_->resize(numPartitions_);
     serializedSortKeys_->resize(numPartitions_);
-  }
-
-  void initialize(velox::memory::MemoryPool* pool) {
-    if (pool_ == nullptr) {
-      pool_ = pool;
-    }
   }
 
   void collect(int32_t partition, std::string_view key, std::string_view data)
@@ -115,32 +110,35 @@ class TestShuffleWriter : public ShuffleWriter {
     TestValue::adjust(
         "facebook::presto::operators::test::TestShuffleWriter::collect", this);
 
-    auto& buffer = inProgressPartitions_[partition];
+    auto& readBatch = inProgressPartitions_[partition];
     TRowSize rowSize = data.size();
     auto size = sizeof(TRowSize) + rowSize;
 
     // Check if there is enough space in the buffer.
-    if (buffer && inProgressSizes_[partition] + size >= maxBytesPerPartition_) {
-      buffer->setSize(inProgressSizes_[partition]);
-      (*readyPartitions_)[partition].emplace_back(std::move(buffer));
+    if (readBatch &&
+        inProgressSizes_[partition] + size >= maxBytesPerPartition_) {
+      readBatch->data->setSize(inProgressSizes_[partition]);
+      (*readyPartitions_)[partition].emplace_back(std::move(readBatch));
       inProgressPartitions_[partition].reset();
     }
 
     // Allocate buffer if needed.
-    if (buffer == nullptr) {
-      buffer = AlignedBuffer::allocate<char>(maxBytesPerPartition_, pool_);
-      assert(buffer != nullptr);
-      inProgressPartitions_[partition] = buffer;
+    if (readBatch == nullptr) {
+      auto buffer = AlignedBuffer::allocate<char>(maxBytesPerPartition_, pool_);
+      VELOX_CHECK_NOT_NULL(buffer);
+      readBatch = std::make_unique<ReadBatch>(
+          std::vector<std::string_view>{}, std::move(buffer));
+      inProgressPartitions_[partition] = std::move(readBatch);
       inProgressSizes_[partition] = 0;
     }
 
     // Copy data.
     auto offset = inProgressSizes_[partition];
-    auto rawBuffer = buffer->asMutable<char>() + offset;
+    auto* rawBuffer = readBatch->data->asMutable<char>() + offset;
 
     *(TRowSize*)(rawBuffer) = folly::Endian::big(rowSize);
     ::memcpy(rawBuffer + sizeof(TRowSize), data.data(), rowSize);
-
+    readBatch->rows.push_back(data);
     inProgressSizes_[partition] += size;
 
     if (!key.empty()) {
@@ -153,9 +151,9 @@ class TestShuffleWriter : public ShuffleWriter {
     // Flush in-progress buffers.
     for (auto i = 0; i < numPartitions_; ++i) {
       if (inProgressSizes_[i] > 0) {
-        auto& buffer = inProgressPartitions_[i];
-        buffer->setSize(inProgressSizes_[i]);
-        (*readyPartitions_)[i].emplace_back(std::move(buffer));
+        auto& readBatch = inProgressPartitions_[i];
+        readBatch->data->setSize(inProgressSizes_[i]);
+        (*readyPartitions_)[i].emplace_back(std::move(readBatch));
         inProgressPartitions_[i].reset();
       }
     }
@@ -167,7 +165,8 @@ class TestShuffleWriter : public ShuffleWriter {
         {exec::ExchangeClient::kBackgroundCpuTimeMs, kFakeBackgroundCpuTimeMs}};
   }
 
-  std::shared_ptr<std::vector<std::vector<BufferPtr>>>& readyPartitions() {
+  std::shared_ptr<std::vector<std::vector<std::unique_ptr<ReadBatch>>>>&
+  readyPartitions() {
     return readyPartitions_;
   }
 
@@ -176,7 +175,9 @@ class TestShuffleWriter : public ShuffleWriter {
   }
 
   static void reset() {
+    LOG(ERROR) << "instance " << getInstance().use_count();
     getInstance().reset();
+    LOG(ERROR) << getInstance();
   }
 
   /// Maintains a single shuffle write interface for testing purpose.
@@ -187,9 +188,9 @@ class TestShuffleWriter : public ShuffleWriter {
 
   static std::shared_ptr<TestShuffleWriter> createWriter(
       const std::string& serializedShuffleInfo,
-      velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+      velox::memory::MemoryPool* pool) {
     std::shared_ptr<TestShuffleWriter>& instance = getInstance();
-    if (instance) {
+    if (instance != nullptr) {
       return instance;
     }
     TestShuffleInfo writeInfo =
@@ -209,12 +210,13 @@ class TestShuffleWriter : public ShuffleWriter {
   /// Indexed by partition number. Each element represents currently being
   /// accumulated buffer by shuffler for a certain partition. Internal layout:
   /// | row-size | ..row-payload.. | row-size | ..row-payload.. | ..
-  std::vector<BufferPtr> inProgressPartitions_;
+  std::vector<std::unique_ptr<ReadBatch>> inProgressPartitions_;
 
   /// Tracks the total size of each in-progress partition in
   /// inProgressPartitions_
   std::vector<size_t> inProgressSizes_;
-  std::shared_ptr<std::vector<std::vector<BufferPtr>>> readyPartitions_;
+  std::shared_ptr<std::vector<std::vector<std::unique_ptr<ReadBatch>>>>
+      readyPartitions_;
   std::shared_ptr<std::vector<std::vector<std::string>>> serializedSortKeys_;
 };
 
@@ -222,21 +224,22 @@ class TestShuffleReader : public ShuffleReader {
  public:
   TestShuffleReader(
       const int32_t partition,
-      const std::shared_ptr<std::vector<std::vector<BufferPtr>>>&
+      const std::shared_ptr<
+          std::vector<std::vector<std::unique_ptr<ReadBatch>>>>&
           readyPartitions)
       : partition_(partition), readyPartitions_(readyPartitions) {}
 
-  folly::SemiFuture<BufferPtr> next() override {
+  folly::SemiFuture<std::unique_ptr<ReadBatch>> next() override {
     TestValue::adjust(
         "facebook::presto::operators::test::TestShuffleReader::next", this);
     if ((*readyPartitions_)[partition_].empty()) {
-      BufferPtr buffer = nullptr;
-      return folly::makeSemiFuture<BufferPtr>(std::move(buffer));
+      return folly::makeSemiFuture(std::unique_ptr<ReadBatch>(nullptr));
     }
 
-    auto buffer = (*readyPartitions_)[partition_].back();
+    auto readBatch = std::move((*readyPartitions_)[partition_].back());
     (*readyPartitions_)[partition_].pop_back();
-    return folly::makeSemiFuture<BufferPtr>(std::move(buffer));
+    return folly::makeSemiFuture<std::unique_ptr<ReadBatch>>(
+        std::move(readBatch));
   }
 
   void noMoreData(bool success) override {
@@ -250,8 +253,9 @@ class TestShuffleReader : public ShuffleReader {
   }
 
  private:
-  int32_t partition_;
-  const std::shared_ptr<std::vector<std::vector<BufferPtr>>>& readyPartitions_;
+  const int32_t partition_;
+  const std::shared_ptr<std::vector<std::vector<std::unique_ptr<ReadBatch>>>>&
+      readyPartitions_;
 };
 
 class TestShuffleFactory : public ShuffleInterfaceFactory {
@@ -261,14 +265,14 @@ class TestShuffleFactory : public ShuffleInterfaceFactory {
   std::shared_ptr<ShuffleReader> createReader(
       const std::string& /* serializedShuffleInfo */,
       const int partition,
-      velox::memory::MemoryPool* FOLLY_NONNULL pool) override {
+      velox::memory::MemoryPool* pool) override {
     return std::make_shared<TestShuffleReader>(
         partition, TestShuffleWriter::getInstance()->readyPartitions());
   }
 
   std::shared_ptr<ShuffleWriter> createWriter(
       const std::string& serializedShuffleInfo,
-      velox::memory::MemoryPool* FOLLY_NONNULL pool) override {
+      velox::memory::MemoryPool* pool) override {
     return TestShuffleWriter::createWriter(serializedShuffleInfo, pool);
   }
 };
@@ -280,13 +284,12 @@ void registerExchangeSource(const std::string& shuffleName) {
           const std::string& taskId,
           int destination,
           const std::shared_ptr<exec::ExchangeQueue>& queue,
-          memory::MemoryPool* FOLLY_NONNULL pool)
-          -> std::shared_ptr<exec::ExchangeSource> {
+          memory::MemoryPool* pool) -> std::shared_ptr<exec::ExchangeSource> {
         if (strncmp(taskId.c_str(), "batch://", 8) == 0) {
           auto uri = folly::Uri(taskId);
           for (auto& pair : uri.getQueryParams()) {
             if (pair.first == "shuffleInfo") {
-              return std::make_shared<UnsafeRowExchangeSource>(
+              return std::make_shared<CompactRowExchangeSource>(
                   taskId,
                   destination,
                   queue,
@@ -303,7 +306,7 @@ void registerExchangeSource(const std::string& shuffleName) {
 }
 } // namespace
 
-class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
+class CompactRowShuffleTest : public exec::test::OperatorTestBase {
  public:
   std::string testShuffleInfo(
       uint32_t numPartitions,
@@ -345,6 +348,8 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
  protected:
   void SetUp() override {
     exec::test::OperatorTestBase::SetUp();
+    // Make sure all previously registered exchange factory are gone.
+    velox::exec::ExchangeSource::factories().clear();
     ShuffleInterfaceFactory::registerFactory(
         std::string(TestShuffleFactory::kShuffleName),
         std::make_unique<TestShuffleFactory>());
@@ -821,7 +826,7 @@ class UnsafeRowShuffleTest : public exec::test::OperatorTestBase {
   }
 };
 
-TEST_F(UnsafeRowShuffleTest, operators) {
+TEST_F(CompactRowShuffleTest, operators) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>({1, 2, 3, 4}),
       makeFlatVector<int64_t>({10, 20, 30, 40}),
@@ -844,7 +849,7 @@ TEST_F(UnsafeRowShuffleTest, operators) {
   TestShuffleWriter::reset();
 }
 
-DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleWriterExceptions) {
+DEBUG_ONLY_TEST_F(CompactRowShuffleTest, shuffleWriterExceptions) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>({1, 2, 3, 4}),
       makeFlatVector<int64_t>({10, 20, 30, 40}),
@@ -876,7 +881,7 @@ DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleWriterExceptions) {
   exec::test::waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleReaderExceptions) {
+DEBUG_ONLY_TEST_F(CompactRowShuffleTest, shuffleReaderExceptions) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>({1, 2, 3, 4}),
       makeFlatVector<int64_t>({10, 20, 30, 40}),
@@ -922,7 +927,7 @@ DEBUG_ONLY_TEST_F(UnsafeRowShuffleTest, shuffleReaderExceptions) {
   exec::test::waitForAllTasksToBeDeleted();
 }
 
-TEST_F(UnsafeRowShuffleTest, endToEnd) {
+TEST_F(CompactRowShuffleTest, endToEnd) {
   size_t numPartitions = 5;
   size_t numMapDrivers = 2;
 
@@ -931,9 +936,7 @@ TEST_F(UnsafeRowShuffleTest, endToEnd) {
       makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60}),
   });
 
-  // Make sure all previously registered exchange factory are gone.
-  velox::exec::ExchangeSource::factories().clear();
-  auto shuffleInfo = testShuffleInfo(numPartitions, 1 << 20);
+  const auto shuffleInfo = testShuffleInfo(numPartitions, 1 << 20);
   TestShuffleWriter::createWriter(shuffleInfo, pool());
   registerExchangeSource(std::string(TestShuffleFactory::kShuffleName));
   runShuffleTest(
@@ -946,9 +949,10 @@ TEST_F(UnsafeRowShuffleTest, endToEnd) {
       {data},
       kFakeBackgroundCpuTimeMs * Timestamp::kNanosecondsInMillisecond);
   TestShuffleWriter::reset();
+  EXPECT_FALSE(true);
 }
 
-TEST_F(UnsafeRowShuffleTest, endToEndWithSortedShuffle) {
+TEST_F(CompactRowShuffleTest, endToEndWithSortedShuffle) {
   size_t numPartitions = 2;
   size_t numMapDrivers = 1;
 
@@ -992,7 +996,7 @@ TEST_F(UnsafeRowShuffleTest, endToEndWithSortedShuffle) {
   TestShuffleWriter::reset();
 }
 
-TEST_F(UnsafeRowShuffleTest, endToEndWithSortedShuffleRowLimit) {
+TEST_F(CompactRowShuffleTest, endToEndWithSortedShuffleRowLimit) {
   size_t numPartitions = 3;
   size_t numMapDrivers = 1;
 
@@ -1050,7 +1054,7 @@ TEST_F(UnsafeRowShuffleTest, endToEndWithSortedShuffleRowLimit) {
   TestShuffleWriter::reset();
 }
 
-TEST_F(UnsafeRowShuffleTest, endToEndWithReplicateNullAndAny) {
+TEST_F(CompactRowShuffleTest, endToEndWithReplicateNullAndAny) {
   size_t numPartitions = 9;
   size_t numMapDrivers = 2;
 
@@ -1076,7 +1080,7 @@ TEST_F(UnsafeRowShuffleTest, endToEndWithReplicateNullAndAny) {
   TestShuffleWriter::reset();
 }
 
-TEST_F(UnsafeRowShuffleTest, replicateNullsAndAny) {
+TEST_F(CompactRowShuffleTest, replicateNullsAndAny) {
   // No nulls. Expect to replicate first row.
   auto data = makeRowVector({
       makeFlatVector<int32_t>({1, 2, 3, 4}),
@@ -1106,7 +1110,7 @@ TEST_F(UnsafeRowShuffleTest, replicateNullsAndAny) {
       data, makeFlatVector<bool>({true, false, true, true, false}));
 }
 
-TEST_F(UnsafeRowShuffleTest, persistentShuffleDeser) {
+TEST_F(CompactRowShuffleTest, persistentShuffleDeser) {
   std::string serializedWriteInfo =
       "{\n"
       "  \"rootPath\": \"abc\",\n"
@@ -1168,7 +1172,7 @@ TEST_F(UnsafeRowShuffleTest, persistentShuffleDeser) {
       nlohmann::detail::type_error);
 }
 
-TEST_F(UnsafeRowShuffleTest, persistentShuffle) {
+TEST_F(CompactRowShuffleTest, persistentShuffle) {
   uint32_t numPartitions = 1;
   uint32_t numMapDrivers = 1;
 
@@ -1201,43 +1205,43 @@ TEST_F(UnsafeRowShuffleTest, persistentShuffle) {
   cleanupDirectory(rootPath);
 }
 
-TEST_F(UnsafeRowShuffleTest, persistentShuffleFuzz) {
+TEST_F(CompactRowShuffleTest, persistentShuffleFuzz) {
   fuzzerTest(false, 1);
   fuzzerTest(false, 3);
   fuzzerTest(false, 7);
 }
 
-TEST_F(UnsafeRowShuffleTest, persistentShuffleFuzzWithReplicateNullsAndAny) {
+TEST_F(CompactRowShuffleTest, persistentShuffleFuzzWithReplicateNullsAndAny) {
   fuzzerTest(true, 1);
   fuzzerTest(true, 3);
   fuzzerTest(true, 7);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOutputByteLimit) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeOutputByteLimit) {
   partitionAndSerializeWithThresholds(10'000, 1, 10, 10);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOutputRowLimit) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeOutputRowLimit) {
   partitionAndSerializeWithThresholds(5, 1'000'000'000, 10, 2);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOutputRowLimitWithSort) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeOutputRowLimitWithSort) {
   partitionAndSerializeWithThresholds(5, 1'000'000'000, 10, 2, true);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOutputByteLimitWithSort) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeOutputByteLimitWithSort) {
   partitionAndSerializeWithThresholds(10'000, 100, 10, 10, true);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeNoLimit) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeNoLimit) {
   partitionAndSerializeWithThresholds(1'000, 1'000'000'000, 5, 1);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeBothLimited) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeBothLimited) {
   partitionAndSerializeWithThresholds(1, 1'000'000, 5, 5);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperator) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeOperator) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
@@ -1251,7 +1255,7 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperator) {
   testPartitionAndSerialize(plan, data);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeWithLargeInput) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeWithLargeInput) {
   auto data = makeRowVector(
       {makeFlatVector<int32_t>(20'000, [](auto row) { return row; })});
 
@@ -1263,7 +1267,7 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeWithLargeInput) {
   testPartitionAndSerialize(plan, data);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeWithDifferentColumnOrder) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeWithDifferentColumnOrder) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
@@ -1298,7 +1302,9 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeWithDifferentColumnOrder) {
   testPartitionAndSerialize(plan, expected);
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperatorWhenSinglePartition) {
+TEST_F(
+    CompactRowShuffleTest,
+    partitionAndSerializeOperatorWhenSinglePartition) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
@@ -1312,7 +1318,7 @@ TEST_F(UnsafeRowShuffleTest, partitionAndSerializeOperatorWhenSinglePartition) {
   testPartitionAndSerialize(plan, data);
 }
 
-TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
+TEST_F(CompactRowShuffleTest, shuffleWriterToString) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
@@ -1335,7 +1341,7 @@ TEST_F(UnsafeRowShuffleTest, shuffleWriterToString) {
       " -> partition:INTEGER, key:VARBINARY, data:VARBINARY\n");
 }
 
-TEST_F(UnsafeRowShuffleTest, partitionAndSerializeToString) {
+TEST_F(CompactRowShuffleTest, partitionAndSerializeToString) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
       makeFlatVector<int64_t>(1'000, [](auto row) { return row * 10; }),
@@ -1379,7 +1385,7 @@ class DummyShuffleInterfaceFactory : public ShuffleInterfaceFactory {
   }
 };
 
-TEST_F(UnsafeRowShuffleTest, shuffleInterfaceRegistration) {
+TEST_F(CompactRowShuffleTest, shuffleInterfaceRegistration) {
   const std::string kShuffleName = "dummy-shuffle";
   EXPECT_TRUE(ShuffleInterfaceFactory::registerFactory(
       kShuffleName, std::make_unique<DummyShuffleInterfaceFactory>()));


### PR DESCRIPTION
Summary: Extend shuffle read API to return a row batch instead of a iobuf so that we can avoid redundant parsing

```
== NO RELEASE NOTE ==
```


