### PR TITLE
fix: Update presto-native-dependencies image and TestCustomFunctions test

### DIFF
--- a/.github/workflows/prestocpp-linux-adapters-build.yml
+++ b/.github/workflows/prestocpp-linux-adapters-build.yml
@@ -12,7 +12,7 @@ jobs:
   prestocpp-linux-adapters-build:
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+      image: prestodb/presto-native-dependency:0.296-20251021214746-7eb2686
     concurrency:
       group: ${{ github.workflow }}-prestocpp-linux-adapters-build-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+      image: prestodb/presto-native-dependency:0.296-20251021214746-7eb2686
     concurrency:
       group: ${{ github.workflow }}-prestocpp-linux-build-test-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -79,8 +79,6 @@ jobs:
           github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           source /opt/rh/gcc-toolset-12/enable
-          cp -r presto-native-tests/presto_cpp/tests presto-native-execution/presto_cpp/main/functions/dynamic_registry
-          echo "add_subdirectory(tests)" >> presto-native-execution/presto_cpp/main/functions/dynamic_registry/CMakeLists.txt
           cd presto-native-execution
           cmake \
             -B _build/release \
@@ -128,13 +126,12 @@ jobs:
           path: |
             presto-native-execution/_build/release/presto_cpp/main/presto_server
             presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
-            presto-native-execution/_build/release/presto_cpp/main/functions/dynamic_registry/tests/
 
   prestocpp-linux-presto-e2e-tests:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+      image: prestodb/presto-native-dependency:0.296-20251021214746-7eb2686
     env:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
@@ -230,7 +227,7 @@ jobs:
         storage-format: [ "PARQUET", "DWRF" ]
         enable-sidecar: [ "true", "false" ]
     container:
-      image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+      image: prestodb/presto-native-dependency:0.296-20251021214746-7eb2686
     env:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
@@ -254,6 +251,13 @@ jobs:
         with:
           name: presto-native-build
           path: presto-native-execution/_build/release
+
+      - name: Update velox
+        if: |
+          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
+        run: |
+          cd presto-native-execution
+          make velox-submodule
 
       # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
       - name: Restore execute permissions and library path
@@ -324,7 +328,7 @@ jobs:
         storage-format: [ "PARQUET", "DWRF" ]
         enable-sidecar: [ "true", "false" ]
     container:
-      image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+      image: prestodb/presto-native-dependency:0.296-20251021214746-7eb2686
     env:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
@@ -413,7 +417,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+      image: prestodb/presto-native-dependency:0.296-20251021214746-7eb2686
     env:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"
@@ -498,7 +502,7 @@ jobs:
     needs: [changes, prestocpp-linux-build-for-test]
     runs-on: ubuntu-22.04
     container:
-      image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+      image: prestodb/presto-native-dependency:0.296-20251021214746-7eb2686
     env:
       MAVEN_OPTS: "-Xmx4G -XX:+ExitOnOutOfMemoryError"
       MAVEN_FAST_INSTALL: "-B -V --quiet -T 1C -DskipTests -Dair.check.skip-all -Dmaven.javadoc.skip=true"

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.293-20250522140509-484b00e
+      image: prestodb/presto-native-dependency:0.296-20251021214746-7eb2686
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/presto-native-tests/CMakeLists.txt
+++ b/presto-native-tests/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_minimum_required(VERSION 3.10)
 # set the project name
 project(PrestoCpp)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 message("Appending CMAKE_CXX_FLAGS with ${SCRIPT_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")

--- a/presto-native-tests/presto_cpp/tests/custom_functions/CMakeLists.txt
+++ b/presto-native-tests/presto_cpp/tests/custom_functions/CMakeLists.txt
@@ -14,10 +14,16 @@ set(PRESTO_AND_VELOX_INCLUDE_DIRS
   ${CMAKE_SOURCE_DIR}/../presto-native-execution/velox
 )
 
-add_library(presto_cpp_custom_functions_test SHARED CustomFunctions.cpp)
-
+find_package(xsimd)
 set(CMAKE_DYLIB_TEST_LINK_LIBRARIES fmt::fmt
                                     xsimd)
+
+if(APPLE)
+    message(STATUS "APPLE compilation requires gflags library. Appending.")
+    list(APPEND CMAKE_DYLIB_TEST_LINK_LIBRARIES "gflags::gflags")
+endif()
+
+add_library(presto_cpp_custom_functions_test SHARED CustomFunctions.cpp)
 
 target_include_directories(presto_cpp_custom_functions_test
   PRIVATE

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/NativeTestsUtils.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/NativeTestsUtils.java
@@ -31,7 +31,7 @@ public class NativeTestsUtils
 {
     private NativeTestsUtils() {}
 
-    public static QueryRunner createNativeQueryRunner(String storageFormat, boolean charNToVarcharImplicitCast, boolean sidecarEnabled)
+    public static QueryRunner createNativeQueryRunner(String storageFormat, boolean charNToVarcharImplicitCast, boolean sidecarEnabled, boolean customFunctionsEnabled)
             throws Exception
     {
         QueryRunner queryRunner = nativeHiveQueryRunnerBuilder()
@@ -40,12 +40,18 @@ public class NativeTestsUtils
                 .setUseThrift(true)
                 .setImplicitCastCharNToVarchar(charNToVarcharImplicitCast)
                 .setCoordinatorSidecarEnabled(sidecarEnabled)
-                .setPluginDirectory(sidecarEnabled ? Optional.of(getCustomFunctionsPluginDirectory().toString()) : Optional.empty())
+                .setPluginDirectory(customFunctionsEnabled ? Optional.of(getCustomFunctionsPluginDirectory().toString()) : Optional.empty())
                 .build();
         if (sidecarEnabled) {
             setupNativeSidecarPlugin(queryRunner);
         }
         return queryRunner;
+    }
+
+    public static QueryRunner createNativeQueryRunner(String storageFormat, boolean charNToVarcharImplicitCast, boolean sidecarEnabled)
+            throws Exception
+    {
+        return createNativeQueryRunner(storageFormat, false, sidecarEnabled, false);
     }
 
     public static QueryRunner createNativeQueryRunner(String storageFormat, boolean sidecarEnabled)
@@ -89,9 +95,7 @@ public class NativeTestsUtils
         // All candidate paths relative to prestoRoot
         List<Path> candidates = ImmutableList.of(
                 prestoRoot.resolve("presto-native-tests/_build/debug/presto_cpp/tests/custom_functions"),
-                prestoRoot.resolve("presto-native-tests/_build/release/presto_cpp/tests/custom_functions"),
-                prestoRoot.resolve("presto-native-execution/_build/debug/presto_cpp/main/functions/dynamic_registry/tests/custom_functions"),
-                prestoRoot.resolve("presto-native-execution/_build/release/presto_cpp/main/functions/dynamic_registry/tests/custom_functions"));
+                prestoRoot.resolve("presto-native-tests/_build/release/presto_cpp/tests/custom_functions"));
 
         return candidates.stream()
                 .filter(Files::exists)

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestCustomFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestCustomFunctions.java
@@ -87,7 +87,7 @@ public class TestCustomFunctions
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
-        return NativeTestsUtils.createNativeQueryRunner(storageFormat, sidecarEnabled);
+        return NativeTestsUtils.createNativeQueryRunner(storageFormat, false, sidecarEnabled, true);
     }
 
     @Override


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Update dynamic custom functions test to build from presto-native-tests. Also fix issue where BUNDLED xsimd was required to build. 

Updated presto-native-dependencies image to pull the latest dependencies.

Main changes are,
1. set(CMAKE_CXX_STANDARD 20) . This was causing compilation issues when building under presto-native-tests.
2. Add new `boolean customFunctionsEnabled`. This is because not all sidecar tests require the custom functions directory. Just the custom functions test.
3. Update CMakeLists for custom functions. This is because pipeline uses BUNDLED xsimd.
4. Update pipeline to no longer build the custom functions, as we now build as part of the e2e test. This requires presto-native-execution and its dependencies. But does not require a presto-native-execution build. 
5. Update TestCustomFunctions test to add a path when sidecar is disabled. This is because we still expect it to fail with function not found when sidecar is disabled and there are custom functions loaded. 
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Was not building when using system's xsimd. 
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Ran TestCustomFunctions with BUNDLED and with SYSTEM. 
## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

