### PR TITLE
feat!: Allow connectors to pass through richer representations of commit metadata for query event listeners

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveCommitHandle.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveCommitHandle.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -24,6 +25,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
+@JsonIgnoreProperties({ "lastDataCommitTimesForRead", "lastDataCommitTimesForWrite" })
 public class HiveCommitHandle
         implements ConnectorCommitHandle
 {

--- a/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -596,7 +596,7 @@ public class QueryMonitor
                             .collect(Collectors.toList()),
                     input.getConnectorInfo(),
                     input.getStatistics(),
-                    input.getSerializedCommitOutput()));
+                    input.getCommitOutput()));
         }
 
         Optional<QueryOutputMetadata> output = Optional.empty();
@@ -622,8 +622,8 @@ public class QueryMonitor
                             queryInfo.getOutput().get().getTable(),
                             tableFinishInfo.map(TableFinishInfo::getSerializedConnectorOutputMetadata),
                             tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded),
-                            queryInfo.getOutput().get().getSerializedCommitOutput(),
-                            outputColumnsMetadata));
+                            outputColumnsMetadata,
+                            queryInfo.getOutput().get().getCommitOutput()));
         }
 
         return new QueryIOMetadata(inputs.build(), output);

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/Input.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/Input.java
@@ -37,9 +37,9 @@ public final class Input
     private final Optional<Object> connectorInfo;
     private final Optional<TableStatistics> statistics;
 
-    // This field records the metastore commit info about this input.
+    // This field stores any connector specific metadata about the commit
     // E.g., the last data commit time for the input partitions.
-    private final String serializedCommitOutput;
+    private final Optional<Object> commitOutput;
 
     @JsonCreator
     public Input(
@@ -49,7 +49,7 @@ public final class Input
             @JsonProperty("connectorInfo") Optional<Object> connectorInfo,
             @JsonProperty("columns") List<Column> columns,
             @JsonProperty("statistics") Optional<TableStatistics> statistics,
-            @JsonProperty("serializedCommitOutput") String serializedCommitOutput)
+            @JsonProperty("commitOutput") Optional<Object> commitOutput)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -57,7 +57,7 @@ public final class Input
         this.connectorInfo = requireNonNull(connectorInfo, "connectorInfo is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.statistics = requireNonNull(statistics, "table statistics is null");
-        this.serializedCommitOutput = requireNonNull(serializedCommitOutput, "serializedCommitOutput is null");
+        this.commitOutput = requireNonNull(commitOutput, "commitOutput is null");
     }
 
     @JsonProperty
@@ -97,9 +97,9 @@ public final class Input
     }
 
     @JsonProperty
-    public String getSerializedCommitOutput()
+    public Optional<Object> getCommitOutput()
     {
-        return serializedCommitOutput;
+        return commitOutput;
     }
 
     @Override
@@ -118,13 +118,13 @@ public final class Input
                 Objects.equals(columns, input.columns) &&
                 Objects.equals(connectorInfo, input.connectorInfo) &&
                 Objects.equals(statistics, input.statistics) &&
-                Objects.equals(serializedCommitOutput, input.serializedCommitOutput);
+                Objects.equals(commitOutput, input.commitOutput);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schema, table, columns, connectorInfo, statistics, serializedCommitOutput);
+        return Objects.hash(connectorId, schema, table, columns, connectorInfo, statistics, commitOutput);
     }
 
     @Override
@@ -136,7 +136,7 @@ public final class Input
                 .addValue(table)
                 .addValue(columns)
                 .addValue(statistics)
-                .addValue(serializedCommitOutput)
+                .addValue(commitOutput)
                 .toString();
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/Output.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/Output.java
@@ -32,22 +32,22 @@ public final class Output
     private final ConnectorId connectorId;
     private final String schema;
     private final String table;
-    private final String serializedCommitOutput;
     private final Optional<List<OutputColumnMetadata>> columns;
+    private final Optional<Object> commitOutput;
 
     @JsonCreator
     public Output(
             @JsonProperty("connectorId") ConnectorId connectorId,
             @JsonProperty("schema") String schema,
             @JsonProperty("table") String table,
-            @JsonProperty("serializedCommitOutput") String serializedCommitOutput,
-            @JsonProperty("columns") Optional<List<OutputColumnMetadata>> columns)
+            @JsonProperty("columns") Optional<List<OutputColumnMetadata>> columns,
+            @JsonProperty("commitOutput") Optional<Object> commitOutput)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
-        this.serializedCommitOutput = requireNonNull(serializedCommitOutput, "connectorCommitOutput is null");
         this.columns = columns.map(ImmutableList::copyOf);
+        this.commitOutput = requireNonNull(commitOutput, "commitOutput is null");
     }
 
     @JsonProperty
@@ -69,15 +69,15 @@ public final class Output
     }
 
     @JsonProperty
-    public String getSerializedCommitOutput()
-    {
-        return serializedCommitOutput;
-    }
-
-    @JsonProperty
     public Optional<List<OutputColumnMetadata>> getColumns()
     {
         return columns;
+    }
+
+    @JsonProperty
+    public Optional<Object> getCommitOutput()
+    {
+        return commitOutput;
     }
 
     @Override
@@ -93,13 +93,13 @@ public final class Output
         return Objects.equals(connectorId, output.connectorId) &&
                 Objects.equals(schema, output.schema) &&
                 Objects.equals(table, output.table) &&
-                Objects.equals(serializedCommitOutput, output.serializedCommitOutput) &&
-                Objects.equals(columns, output.columns);
+                Objects.equals(columns, output.columns) &&
+                Objects.equals(commitOutput, output.commitOutput);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schema, table, serializedCommitOutput, columns);
+        return Objects.hash(connectorId, schema, table, columns, commitOutput);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -617,8 +617,8 @@ public class QueryStateMachine
                 outputInfo.getConnectorId(),
                 outputInfo.getSchema(),
                 outputInfo.getTable(),
-                commitHandle.getSerializedCommitOutputForWrite(table),
-                outputInfo.getColumns())));
+                outputInfo.getColumns(),
+                Optional.of(commitHandle.getCommitOutputForWrite(table)))));
     }
 
     private void addSerializedCommitOutputToInputs(List<?> commitHandles)
@@ -649,7 +649,7 @@ public class QueryStateMachine
                         input.getConnectorInfo(),
                         input.getColumns(),
                         input.getStatistics(),
-                        commitHandle.getSerializedCommitOutputForRead(table));
+                        Optional.of(commitHandle.getCommitOutputForRead(table)));
             }
         }
         return input;
@@ -1177,7 +1177,7 @@ public class QueryStateMachine
                                                         .setHistogram(Optional.empty())
                                                         .build())))
                                 .build()),
-                        input.getSerializedCommitOutput()))
+                        input.getCommitOutput()))
                 .collect(toImmutableSet());
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/InputExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/InputExtractor.java
@@ -69,7 +69,7 @@ public class InputExtractor
     {
         SchemaTableName schemaTable = table.getTable();
         Optional<Object> inputMetadata = metadata.getInfo(session, tableHandle);
-        return new Input(table.getConnectorId(), schemaTable.getSchemaName(), schemaTable.getTableName(), inputMetadata, ImmutableList.copyOf(columns), statistics, "");
+        return new Input(table.getConnectorId(), schemaTable.getSchemaName(), schemaTable.getTableName(), inputMetadata, ImmutableList.copyOf(columns), statistics, Optional.empty());
     }
 
     private class Visitor

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
@@ -27,7 +27,6 @@ import com.google.common.base.VerifyException;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.spi.connector.ConnectorCommitHandle.EMPTY_COMMIT_OUTPUT;
 import static com.google.common.base.Preconditions.checkState;
 
 public class OutputExtractor
@@ -44,8 +43,8 @@ public class OutputExtractor
                 visitor.getConnectorId(),
                 visitor.getSchemaTableName().getSchemaName(),
                 visitor.getSchemaTableName().getTableName(),
-                EMPTY_COMMIT_OUTPUT,
-                visitor.getOutputColumns()));
+                visitor.getOutputColumns(),
+                Optional.empty()));
     }
 
     private class Visitor

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestInput.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestInput.java
@@ -34,7 +34,7 @@ public class TestInput
                 new Column("column2", "string"),
                 new Column("column3", "string")),
                 Optional.empty(),
-                "");
+                Optional.empty());
 
         String json = codec.toJson(expected);
         Input actual = codec.fromJson(json);

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestOutput.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestOutput.java
@@ -24,7 +24,6 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static com.facebook.presto.spi.connector.ConnectorCommitHandle.EMPTY_COMMIT_OUTPUT;
 import static org.testng.Assert.assertEquals;
 
 public class TestOutput
@@ -38,13 +37,13 @@ public class TestOutput
                 new ConnectorId("connectorId"),
                 "schema",
                 "table",
-                EMPTY_COMMIT_OUTPUT,
                 Optional.of(
                         ImmutableList.of(
                                 new OutputColumnMetadata(
                                         "column", "type",
                                         ImmutableSet.of(
-                                                new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column"))))));
+                                                new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column"))))),
+                Optional.empty());
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
@@ -188,7 +188,7 @@ public class TestQueryInfo
                 null,
                 null,
                 ImmutableList.of(new PrestoWarning(new WarningCode(1, "name"), "message")),
-                ImmutableSet.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("name", "type")), Optional.empty(), "")),
+                ImmutableSet.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("name", "type")), Optional.empty(), Optional.empty())),
                 Optional.empty(),
                 true,
                 Optional.empty(),

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -83,7 +83,7 @@ public class TestQueryStateMachine
     private static final String QUERY = "sql";
     private static final URI LOCATION = URI.create("fake://fake-query");
     private static final SQLException FAILED_CAUSE = new SQLException("FAILED");
-    private static final List<Input> INPUTS = ImmutableList.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("a", "varchar")), Optional.empty(), ""));
+    private static final List<Input> INPUTS = ImmutableList.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("a", "varchar")), Optional.empty(), Optional.empty()));
     private static final Optional<Output> OUTPUT = Optional.empty();
     private static final List<String> OUTPUT_FIELD_NAMES = ImmutableList.of("a", "b", "c");
     private static final List<Type> OUTPUT_FIELD_TYPES = ImmutableList.of(BIGINT, BIGINT, BIGINT);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitHandle.java
@@ -19,14 +19,36 @@ public interface ConnectorCommitHandle
 {
     String EMPTY_COMMIT_OUTPUT = "";
 
+    /**
+     * This has been superseded by {@code getCommitOutputForRead(SchemaTableName)}, which allows
+     * connectors to supply metadata representing the query inputs.
+     *
+     * @deprecated replaced by {@link #getCommitOutputForRead(SchemaTableName)}
+     */
     default String getSerializedCommitOutputForRead(SchemaTableName table)
     {
         return EMPTY_COMMIT_OUTPUT;
     }
 
+    /**
+     * This has been superseded by {@code getCommitOutputForWrite(SchemaTableName)}, which allows
+     * connectors to supply metadata representing the query output.
+     *
+     * @deprecated replaced by {@link #getCommitOutputForWrite(SchemaTableName)}
+     */
     default String getSerializedCommitOutputForWrite(SchemaTableName table)
     {
         return EMPTY_COMMIT_OUTPUT;
+    }
+
+    default Object getCommitOutputForRead(SchemaTableName table)
+    {
+        return getSerializedCommitOutputForRead(table);
+    }
+
+    default Object getCommitOutputForWrite(SchemaTableName table)
+    {
+        return getSerializedCommitOutputForWrite(table);
     }
 
     default boolean hasCommitOutput(SchemaTableName table)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryInputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryInputMetadata.java
@@ -31,9 +31,9 @@ public class QueryInputMetadata
     private final List<Column> columnObjects;
     private final Optional<Object> connectorInfo;
     private final Optional<TableStatistics> statistics;
-    private final String serializedCommitOutput;
+    private final Optional<Object> commitOutput;
 
-    public QueryInputMetadata(String catalogName, String schema, String table, List<Column> columnObjects, Optional<Object> connectorInfo, Optional<TableStatistics> statistics, String serializedCommitOutput)
+    public QueryInputMetadata(String catalogName, String schema, String table, List<Column> columnObjects, Optional<Object> connectorInfo, Optional<TableStatistics> statistics, Optional<Object> commitOutput)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -41,7 +41,7 @@ public class QueryInputMetadata
         this.columnObjects = requireNonNull(columnObjects, "columns is null");
         this.connectorInfo = requireNonNull(connectorInfo, "connectorInfo is null");
         this.statistics = requireNonNull(statistics, "table statistics is null");
-        this.serializedCommitOutput = requireNonNull(serializedCommitOutput, "serializedCommitOutput is null");
+        this.commitOutput = requireNonNull(commitOutput, "commitOutput is null");
     }
 
     @JsonProperty
@@ -86,9 +86,17 @@ public class QueryInputMetadata
         return statistics;
     }
 
-    @JsonProperty
+    /**
+     * Provides a {@code String} representation of the commit metadata.  For richer type support use {@link #getCommitOutput()}
+     */
     public String getSerializedCommitOutput()
     {
-        return serializedCommitOutput;
+        return commitOutput.map(Object::toString).orElse("");
+    }
+
+    @JsonProperty
+    public Optional<Object> getCommitOutput()
+    {
+        return commitOutput;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
@@ -29,8 +29,8 @@ public class QueryOutputMetadata
     private final Optional<String> connectorOutputMetadata;
     private final Optional<Boolean> jsonLengthLimitExceeded;
 
-    private final String serializedCommitOutput;
     private final Optional<List<OutputColumnMetadata>> columns;
+    private final Optional<Object> commitOutput;
 
     public QueryOutputMetadata(
             String catalogName,
@@ -38,16 +38,16 @@ public class QueryOutputMetadata
             String table,
             Optional<String> connectorOutputMetadata,
             Optional<Boolean> jsonLengthLimitExceeded,
-            String serializedCommitOutput,
-            Optional<List<OutputColumnMetadata>> columns)
+            Optional<List<OutputColumnMetadata>> columns,
+            Optional<Object> commitOutput)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.connectorOutputMetadata = requireNonNull(connectorOutputMetadata, "connectorOutputMetadata is null");
         this.jsonLengthLimitExceeded = requireNonNull(jsonLengthLimitExceeded, "jsonLengthLimitExceeded is null");
-        this.serializedCommitOutput = requireNonNull(serializedCommitOutput, "connectorCommitHandle is null");
         this.columns = requireNonNull(columns, "columns is null");
+        this.commitOutput = requireNonNull(commitOutput, "commitOutput is null");
     }
 
     @JsonProperty
@@ -80,15 +80,23 @@ public class QueryOutputMetadata
         return jsonLengthLimitExceeded;
     }
 
-    @JsonProperty
+    /**
+     * Provides a {@code String} representation of the commit metadata.  For richer type support use {@link #getCommitOutput()}
+     */
     public String getSerializedCommitOutput()
     {
-        return serializedCommitOutput;
+        return commitOutput.map(Object::toString).orElse("");
     }
 
     @JsonProperty
     public Optional<List<OutputColumnMetadata>> getColumns()
     {
         return columns;
+    }
+
+    @JsonProperty
+    public Optional<Object> getCommitOutput()
+    {
+        return commitOutput;
     }
 }


### PR DESCRIPTION
Summary:
Currently, the `Input` and `Output` query metadata classes retain two source of connector-specific information that can be useful for reporting via an `EventListener`:
```
Optional<Object> connectorInfo;
String serializedCommitOutput;
```
* `connectorInfo` can be cast back to the correct type in an `EventListener` implementation, allowing rich access to the underlying data
* `serializedCommitOutput` however, is serialized in a given format by the `ConnectorCommitHandle` implementation, which makes it difficult to correctly represent the reporting requirements in an EventListener (which may need correlation with data in the `connectorInfo` result).

For example, `HiveCommitHandle` retains the lastDataCommitTime for each partition in a simple array associated with the table name, where the partition names are retained in the `HiveInputInfo` instance carried through in connectorInfo.  For these times to be mapped back to individual partitions, the entries must be in the exact same order as the entries in HiveInputInfo.

This change simply replaces the `serializedCommitOutput` property with an `Optional<Object>` instance, providing parity with the `connectorInfo`, and allowing `EventListener` implementations to cast the commit handle back to the correct type for richer access to the underlying data.

Differential Revision: D84382446

## Release Notes
```
== RELEASE NOTES ==

SPI Changes
* Replaces the ``String serializedCommitOutput`` argument with ``Optional<Object> commitOutput`` in the ``com.facebook.presto.spi.eventlistener.QueryInputMetadata`` and ``com.facebook.presto.spi.eventlistener.QueryOutputMetadata`` constructors
* Adds ``getCommitOutputForRead()`` and ``getCommitOutputForWrite()`` methods to ``ConnectorCommitHandle``, and deprecates the existing ``getSerializedCommitOutputForRead()`` and ``getSerializedCommitOutputForWrite()`` methods
```
