### PR TITLE
fix: Move Python UDF script validation from worker to coordinator

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/FunctionAndTypeResolver.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/FunctionAndTypeResolver.java
@@ -52,4 +52,13 @@ public interface FunctionAndTypeResolver
     FunctionHandle lookupCast(String castType, Type fromType, Type toType);
 
     QualifiedObjectName qualifyObjectName(QualifiedName name);
+
+    /**
+     * Validate a function call during analysis phase on the coordinator.
+     * Delegates to the FunctionNamespaceManager for custom validation logic.
+     *
+     * @param functionHandle The function handle being validated
+     * @param arguments Raw argument expressions (not yet evaluated)
+     */
+    void validateFunctionCall(FunctionHandle functionHandle, List<?> arguments);
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -319,6 +319,12 @@ public class FunctionAndTypeManager
                 return FunctionAndTypeManager.this.lookupCast(CastType.valueOf(castType), fromType, toType);
             }
 
+            @Override
+            public void validateFunctionCall(FunctionHandle functionHandle, List<?> arguments)
+            {
+                FunctionAndTypeManager.this.validateFunctionCall(functionHandle, arguments);
+            }
+
             public QualifiedObjectName qualifyObjectName(QualifiedName name)
             {
                 if (name.getSuffix().startsWith("$internal")) {
@@ -717,6 +723,19 @@ public class FunctionAndTypeManager
         Optional<FunctionNamespaceManager<?>> functionNamespaceManager = getServingFunctionNamespaceManager(functionHandle.getCatalogSchemaName());
         checkState(functionNamespaceManager.isPresent(), format("FunctionHandle %s should have a serving function namespace", functionHandle));
         return functionNamespaceManager.get().executeFunction(source, functionHandle, inputPage, channels, this);
+    }
+
+    public void validateFunctionCall(FunctionHandle functionHandle, List<?> arguments)
+    {
+        // Built-in functions don't need validation
+        if (isBuiltInPluginFunctionHandle(functionHandle) || isBuiltInWorkerFunctionHandle(functionHandle)) {
+            return;
+        }
+
+        Optional<FunctionNamespaceManager<?>> functionNamespaceManager = getServingFunctionNamespaceManager(functionHandle.getCatalogSchemaName());
+        if (functionNamespaceManager.isPresent()) {
+            functionNamespaceManager.get().validateFunctionCall(functionHandle, arguments);
+        }
     }
 
     public WindowFunctionSupplier getWindowFunctionImplementation(FunctionHandle functionHandle)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1120,6 +1120,10 @@ public class ExpressionAnalyzer
             FunctionHandle function = resolveFunction(sessionFunctions, transactionId, node, argumentTypes, functionAndTypeResolver);
             FunctionMetadata functionMetadata = functionAndTypeResolver.getFunctionMetadata(function);
 
+            // Delegate function-specific validation to the FunctionNamespaceManager
+            // This allows function namespaces to perform custom validation (e.g., Python UDF security checks)
+            functionAndTypeResolver.validateFunctionCall(function, node.getArguments());
+
             if (node.getOrderBy().isPresent()) {
                 for (SortItem sortItem : node.getOrderBy().get().getSortItems()) {
                     Type sortKeyType = process(sortItem.getSortKey(), context);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -122,4 +122,18 @@ public interface FunctionNamespaceManager<F extends SqlFunction>
     {
         throw new UnsupportedOperationException("Does not support get aggregation function");
     }
+
+    /**
+     * Validate a function call during analysis phase on the coordinator.
+     * This allows function namespace managers to perform custom validation logic
+     * such as security checks, argument validation, etc.
+     *
+     * @param functionHandle The function handle being validated
+     * @param arguments Raw argument expressions (not yet evaluated) - type is Object to avoid SPI module dependencies
+     * @throws RuntimeException if validation fails
+     */
+    default void validateFunctionCall(FunctionHandle functionHandle, List<?> arguments)
+    {
+        // Default implementation: no validation
+    }
 }


### PR DESCRIPTION
Summary:
This diff moves the unsupportedFunctionsRegex validation for Python UDF scripts from the worker side (C++ Velox and Java RemoteProjectOperator) to the coordinator side during SQL analysis.

Previously, validation happened in two places on workers:
1. PythonUdfSqlFunctionExecutor.java (Java worker execution)
2. FbPythonUdfClient.cpp (C++ Velox execution)

Now validation happens once at the coordinator during SQL analysis in ExpressionAnalyzer.validatePythonUdfScriptIfNeeded().

Benefits:
- Fail fast: Validation happens before task distribution to workers
- Better error messages: Full query context available during analysis
- Single validation point: No redundant checks on every worker
- Resource efficient: Invalid queries rejected before allocating worker resources

The validation still blocks the same dangerous functions:
- exec()
- eval()
- subprocess.call()
- os.environ
- sys.modules

Differential Revision: D84739785

```
== NO RELEASE NOTE ==


```
