### PR TITLE
fix(build): Alternative gperf link not working

### DIFF
--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -34,11 +34,21 @@ function install_proxygen {
 }
 
 function install_gperf {
-  wget_and_untar https://ftp.gnu.org/pub/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz gperf
-  test -e ${DEPENDENCY_DIR}/gperf/configure ||
-  wget_and_untar https://mirrors.ocf.berkeley.edu/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz gperf
-  cd ${DEPENDENCY_DIR}/gperf
-  ./configure --prefix=${INSTALL_PREFIX}
+  mkdir -p "${DEPENDENCY_DIR}"
+  cd "${DEPENDENCY_DIR}"
+  if [ -d gperf ]; then
+      if prompt "gperf already exists. Delete?"; then
+        ${SUDO} rm -rf gperf
+      else
+        return
+      fi
+  fi
+  (curl ${CURL_OPTIONS:+${CURL_OPTIONS}} -L https://ftp.gnu.org/pub/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz -o gperf-${GPERF_VERSION}.tar.gz ||
+   curl ${CURL_OPTIONS:+${CURL_OPTIONS}} -L https://mirrors.ocf.berkeley.edu/gnu/gperf/gperf-${GPERF_VERSION}.tar.gz -o gperf-${GPERF_VERSION}.tar.gz) &&
+  mkdir -p gperf &&
+  tar -xz --strip-components=1 --no-same-owner -f gperf-${GPERF_VERSION}.tar.gz -C gperf &&
+  cd gperf &&
+  ./configure --prefix=${INSTALL_PREFIX} &&
   make install
 }
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

See error https://github.com/prestodb/presto/actions/runs/18566575985/job/52929180036?pr=26338.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

