### PR TITLE
chore(native): Remove `mapTypeKindToName()` usage in PrestoCpp

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -13,9 +13,11 @@
  */
 
 #include "presto_cpp/main/types/PrestoToVeloxExpr.h"
-#include "presto_cpp/main/common/Utils.h"
+
 #include <boost/algorithm/string/case_conv.hpp>
+#include <fmt/format.h>
 #include "presto_cpp/main/common/Configs.h"
+#include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/presto_protocol/Base64Util.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/prestosql/types/JsonType.h"
@@ -175,7 +177,7 @@ velox::variant VeloxExprConverter::getConstantValue(
               0));
     default:
       throw std::invalid_argument(
-          "Unexpected Block type: " + mapTypeKindToName(typeKind));
+          fmt::format("Unexpected Block type: {}", typeKind));
   }
 }
 


### PR DESCRIPTION
Summary:
Removing the usage of `mapTypeKindToName()` which was deprecated in
Velox.

Differential Revision: D84874829


