### PR TITLE
feat: Add support for LZ4 and ZSTD compression codecs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -347,9 +347,9 @@ Property Name                                           Description             
 
 ``iceberg.compression-codec``                           The compression codec to use when writing files. The          ``GZIP``                           Yes                 No, write is not supported yet
                                                         available values are ``NONE``, ``SNAPPY``, ``GZIP``,
-                                                        and ``ZSTD``.
+                                                        ``LZ4``, and ``ZSTD``.
                                                         
-                                                        Note: ``ZSTD`` is only available when 
+                                                        Note: ``LZ4`` is only available when
                                                         ``iceberg.file-format=ORC``.
 
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCompressionCodec.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCompressionCodec.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.GzipCodec;
+import org.apache.hadoop.io.compress.Lz4Codec;
 import org.apache.hadoop.io.compress.SnappyCodec;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
@@ -25,6 +26,7 @@ import java.util.function.Predicate;
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
 import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
+import static com.facebook.presto.hive.HiveStorageFormat.PARQUET;
 import static java.util.Objects.requireNonNull;
 
 public enum HiveCompressionCodec
@@ -32,12 +34,12 @@ public enum HiveCompressionCodec
     NONE(null, CompressionKind.NONE, CompressionCodecName.UNCOMPRESSED, f -> true),
     SNAPPY(SnappyCodec.class, CompressionKind.SNAPPY, CompressionCodecName.SNAPPY, f -> true),
     GZIP(GzipCodec.class, CompressionKind.ZLIB, CompressionCodecName.GZIP, f -> true),
-    LZ4(null, CompressionKind.NONE, null, f -> f == PAGEFILE),
-    ZSTD(null, CompressionKind.ZSTD, null, f -> f == ORC || f == DWRF || f == PAGEFILE);
+    LZ4(Lz4Codec.class, CompressionKind.LZ4, CompressionCodecName.UNCOMPRESSED, f -> f == PAGEFILE || f == ORC),
+    ZSTD(null, CompressionKind.ZSTD, CompressionCodecName.ZSTD, f -> f == ORC || f == DWRF || f == PAGEFILE || f == PARQUET);
 
     private final Optional<Class<? extends CompressionCodec>> codec;
     private final CompressionKind orcCompressionKind;
-    private final Optional<CompressionCodecName> parquetCompressionCodec;
+    private final CompressionCodecName parquetCompressionCodec;
     private final Predicate<HiveStorageFormat> supportedStorageFormats;
 
     HiveCompressionCodec(
@@ -48,7 +50,7 @@ public enum HiveCompressionCodec
     {
         this.codec = Optional.ofNullable(codec);
         this.orcCompressionKind = requireNonNull(orcCompressionKind, "orcCompressionKind is null");
-        this.parquetCompressionCodec = Optional.ofNullable(parquetCompressionCodec);
+        this.parquetCompressionCodec = requireNonNull(parquetCompressionCodec, "parquetCompressionCodec is null");
         this.supportedStorageFormats = requireNonNull(supportedStorageFormats, "supportedStorageFormats is null");
     }
 
@@ -62,7 +64,7 @@ public enum HiveCompressionCodec
         return orcCompressionKind;
     }
 
-    public Optional<CompressionCodecName> getParquetCompressionCodec()
+    public CompressionCodecName getParquetCompressionCodec()
     {
         return parquetCompressionCodec;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -59,7 +59,7 @@ public final class HiveSessionProperties
     private static final String ORC_OPTIMIZED_WRITER_COMPRESSION_LEVEL = "orc_optimized_writer_compression_level";
     private static final String PAGEFILE_WRITER_MAX_STRIPE_SIZE = "pagefile_writer_max_stripe_size";
     public static final String HIVE_STORAGE_FORMAT = "hive_storage_format";
-    private static final String COMPRESSION_CODEC = "compression_codec";
+    static final String COMPRESSION_CODEC = "compression_codec";
     private static final String ORC_COMPRESSION_CODEC = "orc_compression_codec";
     public static final String RESPECT_TABLE_FORMAT = "respect_table_format";
     private static final String CREATE_EMPTY_BUCKET_FILES = "create_empty_bucket_files";

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/ConfigurationUtils.java
@@ -120,7 +120,7 @@ public final class ConfigurationUtils
             config.unset(FileOutputFormat.COMPRESS_CODEC);
         }
         // For Parquet
-        compression.getParquetCompressionCodec().ifPresent(codec -> config.set(ParquetOutputFormat.COMPRESSION, codec.name()));
+        config.set(ParquetOutputFormat.COMPRESSION, compression.getParquetCompressionCodec().name());
         // For SequenceFile
         config.set(FileOutputFormat.COMPRESS_TYPE, BLOCK.toString());
         // For PageFile

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -74,6 +74,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.SystemSessionProperties.COLOCATED_JOIN;
@@ -106,6 +107,7 @@ import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
 import static com.facebook.presto.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static com.facebook.presto.hive.HiveQueryRunner.createBucketedSession;
 import static com.facebook.presto.hive.HiveQueryRunner.createMaterializeExchangesSession;
+import static com.facebook.presto.hive.HiveSessionProperties.COMPRESSION_CODEC;
 import static com.facebook.presto.hive.HiveSessionProperties.FILE_RENAMING_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.MANIFEST_VERIFICATION_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED;
@@ -159,6 +161,7 @@ import static io.airlift.tpch.TpchTable.ORDERS;
 import static io.airlift.tpch.TpchTable.PART_SUPPLIER;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -5268,17 +5271,6 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
-    public void testPageFileCompression()
-    {
-        for (HiveCompressionCodec compression : HiveCompressionCodec.values()) {
-            if (!compression.isSupportedStorageFormat(PAGEFILE)) {
-                continue;
-            }
-            testPageFileCompression(compression.name());
-        }
-    }
-
-    @Test
     public void testPartialAggregatePushdownORC()
     {
         @Language("SQL") String createTable = "" +
@@ -5703,31 +5695,35 @@ public class TestHiveIntegrationSmokeTest
         assertQueryFails(parquetFilterPushdownSession, "SELECT a FROM test_parquet_filter_pushdoown WHERE b = false", "Parquet reader doesn't support filter pushdown yet");
     }
 
-    private void testPageFileCompression(String compression)
+    @DataProvider(name = "testFormatAndCompressionCodecs")
+    public Object[][] compressionCodecs()
     {
-        Session testSession = Session.builder(getQueryRunner().getDefaultSession())
-                .setCatalogSessionProperty(catalog, "compression_codec", compression)
-                .setCatalogSessionProperty(catalog, "pagefile_writer_max_stripe_size", "100B")
-                .setCatalogSessionProperty(catalog, "max_split_size", "1kB")
-                .setCatalogSessionProperty(catalog, "max_initial_split_size", "1kB")
-                .build();
+        return Stream.of(PARQUET, ORC, PAGEFILE)
+                .flatMap(format -> Arrays.stream(HiveCompressionCodec.values())
+                        .map(codec -> new Object[] {codec, format}))
+                .toArray(Object[][]::new);
+    }
 
-        assertUpdate(
-                testSession,
-                "CREATE TABLE test_pagefile_compression\n" +
-                        "WITH (\n" +
-                        "format = 'PAGEFILE'\n" +
-                        ") AS\n" +
-                        "SELECT\n" +
-                        "*\n" +
-                        "FROM tpch.orders",
-                "SELECT count(*) FROM orders");
-
-        assertQuery(testSession, "SELECT count(*) FROM test_pagefile_compression", "SELECT count(*) FROM orders");
-
-        assertQuery(testSession, "SELECT sum(custkey) FROM test_pagefile_compression", "SELECT sum(custkey) FROM orders");
-
-        assertUpdate("DROP TABLE test_pagefile_compression");
+    @Test(dataProvider = "testFormatAndCompressionCodecs")
+    public void testFormatAndCompressionCodecs(HiveCompressionCodec codec, HiveStorageFormat format)
+    {
+        String tableName = "test_" + format.name().toLowerCase(ROOT) + "_compression_codec_" + codec.name().toLowerCase(ROOT);
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("hive", COMPRESSION_CODEC, codec.name()).build();
+        if (codec.isSupportedStorageFormat(format == PARQUET ? HiveStorageFormat.PARQUET : HiveStorageFormat.ORC)) {
+            assertUpdate(session,
+                    format("CREATE TABLE %s WITH (format = '%s') AS SELECT * FROM orders",
+                            tableName, format.name()),
+                    "SELECT count(*) FROM orders");
+            assertQuery(format("SELECT count(*) FROM %s", tableName), "SELECT count(*) FROM orders");
+            assertQuery(format("SELECT sum(custkey) FROM %s", tableName), "SELECT sum(custkey) FROM orders");
+            assertQuerySucceeds(format("DROP TABLE %s", tableName));
+        }
+        else {
+            assertQueryFails(session, format("CREATE TABLE %s WITH (format = '%s') AS SELECT * FROM orders",
+                            tableName, format.name()),
+                    format("%s compression is not supported with %s", codec, format));
+        }
     }
 
     private static Consumer<Plan> assertTableWriterMergeNodeIsPresent()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -83,7 +83,6 @@ import java.util.Properties;
 
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
-import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
 import static com.facebook.presto.hive.HiveStorageFormat.PAGEFILE;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_RESOLUTION;
@@ -246,9 +245,6 @@ public enum FileFormat
                 HiveCompressionCodec compressionCodec)
                 throws IOException
         {
-            if (!compressionCodec.isSupportedStorageFormat(PAGEFILE)) {
-                compressionCodec = NONE;
-            }
             return new PrestoPageFormatWriter(targetFile, compressionCodec);
         }
     },
@@ -696,7 +692,7 @@ public enum FileFormat
                     columnNames,
                     types,
                     ParquetWriterOptions.builder().build(),
-                    compressionCodec.getParquetCompressionCodec().get().getHadoopCompressionCodecClassName());
+                    compressionCodec.getParquetCompressionCodec().getHadoopCompressionCodecClassName());
         }
 
         @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -160,7 +160,7 @@ public class IcebergFileWriterFactory
                     makeTypeMap(fileColumnTypes, fileColumnNames),
                     parquetWriterOptions,
                     IntStream.range(0, fileColumnNames.size()).toArray(),
-                    getCompressionCodec(session).getParquetCompressionCodec().get(),
+                    getCompressionCodec(session).getParquetCompressionCodec(),
                     outputPath,
                     hdfsEnvironment,
                     hdfsContext,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -48,7 +48,6 @@ import static java.lang.String.format;
 
 public final class IcebergSessionProperties
 {
-    private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
@@ -61,6 +60,7 @@ public final class IcebergSessionProperties
     private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
     private static final String NESSIE_REFERENCE_NAME = "nessie_reference_name";
     private static final String NESSIE_REFERENCE_HASH = "nessie_reference_hash";
+    static final String COMPRESSION_CODEC = "compression_codec";
     public static final String PARQUET_DEREFERENCE_PUSHDOWN_ENABLED = "parquet_dereference_pushdown_enabled";
     public static final String MERGE_ON_READ_MODE_ENABLED = "merge_on_read_enabled";
     public static final String PUSHDOWN_FILTER_ENABLED = "pushdown_filter_enabled";

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -1171,7 +1171,7 @@ public final class IcebergUtil
                 if (!compressionCodec.isSupportedStorageFormat(HiveStorageFormat.PARQUET)) {
                     throw new PrestoException(NOT_SUPPORTED, format("Compression codec %s is not supported for Parquet format", compressionCodec));
                 }
-                propertiesBuilder.put(PARQUET_COMPRESSION, compressionCodec.getParquetCompressionCodec().get().toString());
+                propertiesBuilder.put(PARQUET_COMPRESSION, compressionCodec.getParquetCompressionCodec().name());
                 break;
             case ORC:
                 if (!compressionCodec.isSupportedStorageFormat(HiveStorageFormat.ORC)) {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1111,9 +1111,9 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         return new Object[][] {
                 // codec, format, shouldSucceed, expectedErrorMessage
-                {"ZSTD", "PARQUET", false, "Compression codec ZSTD is not supported for Parquet format"},
+                {"ZSTD", "PARQUET", true, null},
                 {"LZ4", "PARQUET", false, "Compression codec LZ4 is not supported for Parquet format"},
-                {"LZ4", "ORC", false, "Compression codec LZ4 is not supported for ORC format"},
+                {"LZ4", "ORC", true, null},
                 {"ZSTD", "ORC", true, null},
                 {"SNAPPY", "ORC", true, null},
                 {"SNAPPY", "PARQUET", true, null},

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergUtil.java
@@ -390,12 +390,12 @@ public class TestIcebergUtil
                 {HiveStorageFormat.PARQUET, HiveCompressionCodec.SNAPPY, true},
                 {HiveStorageFormat.PARQUET, HiveCompressionCodec.GZIP, true},
                 {HiveStorageFormat.PARQUET, HiveCompressionCodec.LZ4, false},
-                {HiveStorageFormat.PARQUET, HiveCompressionCodec.ZSTD, false},
+                {HiveStorageFormat.PARQUET, HiveCompressionCodec.ZSTD, true},
                 {HiveStorageFormat.ORC, HiveCompressionCodec.NONE, true},
                 {HiveStorageFormat.ORC, HiveCompressionCodec.SNAPPY, true},
                 {HiveStorageFormat.ORC, HiveCompressionCodec.GZIP, true},
                 {HiveStorageFormat.ORC, HiveCompressionCodec.ZSTD, true},
-                {HiveStorageFormat.ORC, HiveCompressionCodec.LZ4, false},
+                {HiveStorageFormat.ORC, HiveCompressionCodec.LZ4, true},
         };
     }
 
@@ -410,11 +410,11 @@ public class TestIcebergUtil
     @Test
     public void testParquetCompressionCodecAvailability()
     {
-        assertThat(HiveCompressionCodec.NONE.getParquetCompressionCodec().isPresent()).isTrue();
-        assertThat(HiveCompressionCodec.SNAPPY.getParquetCompressionCodec().isPresent()).isTrue();
-        assertThat(HiveCompressionCodec.GZIP.getParquetCompressionCodec().isPresent()).isTrue();
+        assertThat(HiveCompressionCodec.NONE.getParquetCompressionCodec()).isNotNull();
+        assertThat(HiveCompressionCodec.SNAPPY.getParquetCompressionCodec()).isNotNull();
+        assertThat(HiveCompressionCodec.GZIP.getParquetCompressionCodec()).isNotNull();
 
-        assertThat(HiveCompressionCodec.LZ4.getParquetCompressionCodec().isPresent()).isFalse();
-        assertThat(HiveCompressionCodec.ZSTD.getParquetCompressionCodec().isPresent()).isFalse();
+        assertThat(HiveCompressionCodec.LZ4.getParquetCompressionCodec()).isNotNull();
+        assertThat(HiveCompressionCodec.ZSTD.getParquetCompressionCodec()).isNotNull();
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -89,12 +89,12 @@ public class ParquetWriter
     public static final Slice MAGIC = wrappedBuffer("PAR1".getBytes(US_ASCII));
 
     public ParquetWriter(OutputStream outputStream,
-                         MessageType messageType,
-                         Map<List<String>, Type> primitiveTypes,
-                         List<String> columnNames,
-                         List<Type> types,
-                         ParquetWriterOptions writerOption,
-                         String compressionCodecClass)
+            MessageType messageType,
+            Map<List<String>, Type> primitiveTypes,
+            List<String> columnNames,
+            List<Type> types,
+            ParquetWriterOptions writerOption,
+            String compressionCodecClass)
     {
         this.outputStream = new OutputStreamSliceOutput(requireNonNull(outputStream, "outputstream is null"));
         this.names = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
@@ -335,7 +335,8 @@ public class ParquetWriter
         else if (compressionCodecClass.equals("org.apache.hadoop.io.compress.Lz4Codec")) {
             return LZ4;
         }
-        else if (compressionCodecClass.equals("org.apache.hadoop.io.compress.ZStandardCodec")) {
+        else if (compressionCodecClass.equals("org.apache.hadoop.io.compress.ZStandardCodec") ||
+                compressionCodecClass.equals("org.apache.parquet.hadoop.codec.ZstandardCodec")) {
             return ZSTD;
         }
         throw new IllegalArgumentException("Invalid compressionCodec: " + compressionCodecClass);


### PR DESCRIPTION
Co-authored-by: Zac Blanco <zac@ibm.com>

## Description

These codecs are available in the writers, but don't seem to have been configured correctly. Trying to write tables with these formats previously threw errors. This change enables LZ4 on ORC and ZSTD on Parquet for data writers in Hive and Iceberg

Address issue #26334 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
 * Add support for ``ZSTD`` compression codec in Parquet format
 * Add support for ``LZ4`` compression codec in ORC format

 Hive Connector Changes
 * Add support for`` ZSTD`` compression codec in Parquet format
 * Add support for ``LZ4`` compression codec in ORC format
```
