### PR TITLE
fix(native): Init system used memory cache at the beginning of PeriodicMemoryChecker callback

### DIFF
--- a/presto-native-execution/presto_cpp/main/LinuxMemoryChecker.cpp
+++ b/presto-native-execution/presto_cpp/main/LinuxMemoryChecker.cpp
@@ -63,7 +63,7 @@ class LinuxMemoryChecker : public PeriodicMemoryChecker {
   ~LinuxMemoryChecker() override {}
 
   int64_t getUsedMemory() {
-    return systemUsedMemoryBytes();
+    return systemUsedMemoryBytes(/*fetchFresh=*/true);
   }
 
   void setStatFile(std::string statFile) {
@@ -180,7 +180,7 @@ class LinuxMemoryChecker : public PeriodicMemoryChecker {
   // value. It may be better than what we currently use. For
   // consistency we will match cgroup V1 and change if
   // necessary.
-  int64_t systemUsedMemoryBytes() override {
+  void loadSystemMemoryUsage() override {
     size_t memAvailable = 0;
     size_t memTotal = 0;
     size_t inactiveAnon = 0;
@@ -207,7 +207,7 @@ class LinuxMemoryChecker : public PeriodicMemoryChecker {
       // Unit is in bytes.
       const auto memBytes = inactiveAnon + activeAnon;
       cachedSystemUsedMemoryBytes_ = memBytes;
-      return memBytes;
+      return;
     }
 
     // Last resort use host machine info.
@@ -231,7 +231,6 @@ class LinuxMemoryChecker : public PeriodicMemoryChecker {
     const auto memBytes =
         (memAvailable && memTotal) ? memTotal - memAvailable : 0;
     cachedSystemUsedMemoryBytes_ = memBytes;
-    return memBytes;
   }
 
   int64_t mallocBytes() const override {

--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
@@ -76,15 +76,14 @@ class PeriodicMemoryChecker {
   /// Stops the 'PeriodicMemoryChecker'.
   virtual void stop();
 
-  /// Returns the last known cached 'current' system memory usage in bytes.
-  int64_t cachedSystemUsedMemoryBytes() const {
-    return cachedSystemUsedMemoryBytes_;
-  }
+  /// Returns the last known cached 'current' system memory usage in bytes.  If
+  /// 'fetchFresh' is true, retrieves and returns the current system memory usage.
+  /// The returned value is used to compare with 'Config::systemMemLimitBytes'.
+  int64_t systemUsedMemoryBytes(bool fetchFresh = false);
 
  protected:
-  /// Fetches and returns current system memory usage in bytes.
-  /// The returned value is used to compare with 'Config::systemMemLimitBytes'.
-  virtual int64_t systemUsedMemoryBytes() = 0;
+  /// Fetches current system memory usage in bytes and stores it in the cache.
+  virtual void loadSystemMemoryUsage() = 0;
 
   /// Returns current bytes allocated by malloc. The returned value is used to
   /// compare with 'Config::mallocBytesUsageDumpThreshold'

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1530,7 +1530,7 @@ void PrestoServer::checkOverload() {
       systemConfig->workerOverloadedThresholdMemGb() * 1024 * 1024 * 1024;
   if (overloadedThresholdMemBytes > 0) {
     const auto currentUsedMemoryBytes = (memoryChecker_ != nullptr)
-        ? memoryChecker_->cachedSystemUsedMemoryBytes()
+        ? memoryChecker_->systemUsedMemoryBytes()
         : 0;
     const bool memOverloaded =
         (currentUsedMemoryBytes > overloadedThresholdMemBytes);

--- a/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PeriodicMemoryCheckerTest.cpp
@@ -34,10 +34,11 @@ class PeriodicMemoryCheckerTest : public testing::Test {
         std::function<void()>&& periodicCb = nullptr,
         std::function<bool(const std::string&)>&& heapDumpCb = nullptr)
         : PeriodicMemoryChecker(config),
-          systemUsedMemoryBytes_(systemUsedMemoryBytes),
           mallocBytes_(mallocBytes),
           periodicCb_(std::move(periodicCb)),
-          heapDumpCb_(std::move(heapDumpCb)) {}
+          heapDumpCb_(std::move(heapDumpCb)) {
+            cachedSystemUsedMemoryBytes_ = systemUsedMemoryBytes;
+          }
 
     ~TestPeriodicMemoryChecker() override {}
 
@@ -46,9 +47,7 @@ class PeriodicMemoryCheckerTest : public testing::Test {
     }
 
    protected:
-    int64_t systemUsedMemoryBytes() override {
-      return systemUsedMemoryBytes_;
-    }
+    void loadSystemMemoryUsage() override {}
 
     int64_t mallocBytes() const override {
       return mallocBytes_;
@@ -70,7 +69,6 @@ class PeriodicMemoryCheckerTest : public testing::Test {
     void removeDumpFile(const std::string& filePath) const override {}
 
    private:
-    int64_t systemUsedMemoryBytes_{0};
     int64_t mallocBytes_{0};
     std::function<void()> periodicCb_;
     std::function<bool(const std::string&)> heapDumpCb_;


### PR DESCRIPTION
## Description
The initial idea behind this change was to preload SystemMemoryUsage at the beginning of the `PeriodicMemoryChecker` callback. If the memory is preloaded, in the subsequent `periodicCb()` and `pushbackMemory()` implementation calls, we can decide whether to use the preloaded value or refetch it from the system.

For our use case, we want to report the value obtained to the monitoring system. This will help in understanding the exact memory value used in the pushback mechanism.

This PR was imported from Meta Phabricator: D83218739
The discussion there led to a desire to change the API to make it clearer for users.

So in this diff I'm changing the API from:
```c++
  int64_t cachedSystemUsedMemoryBytes() const {
    return cachedSystemUsedMemoryBytes_;
  }

  virtual int64_t systemUsedMemoryBytes() = 0;
```
to:
```c++
  int64_t systemUsedMemoryBytes(bool fetchFresh = false);

  virtual void loadSystemMemoryUsage() = 0;
```
With the new API, we can clearly specify whether we want to preload the value, retrieve it from the cache, or fetch the current one.

The API change only affects `PeriodicMemoryChecker` descendants. If this PR broke your build, follow this guide to fix the code:
1) Replace `systemUsedMemoryBytes()` calls with `systemUsedMemoryBytes(/*fetchFresh=*/true)`
2) Replace `cachedSystemUsedMemoryBytes()` calls with `systemUsedMemoryBytes()`
3) Put `systemUsedMemoryBytes()` impl to `loadSystemMemoryUsage()` impl

## Test Plan
This PR is more like a refactoring, but I tested it in prod-like environment in Meta.

```
== NO RELEASE NOTE ==
```

