### PR TITLE
refactor: Avoid List and Array to track row number column in ORC format

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.getOrcMaxMergeDistance;
@@ -72,7 +73,6 @@ import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 
 public class OrcBatchPageSourceFactory
@@ -241,7 +241,6 @@ public class OrcBatchPageSourceFactory
             String rowGroupID = path.getName();
 
             // none of the columns are row numbers
-            List<Boolean> isRowNumberList = nCopies(physicalColumns.size(), false);
             return new OrcBatchPageSource(
                     recordReader,
                     reader.getOrcDataSource(),
@@ -250,7 +249,7 @@ public class OrcBatchPageSourceFactory
                     systemMemoryUsage,
                     stats,
                     hiveFileContext.getStats(),
-                    isRowNumberList,
+                    OptionalInt.empty(),
                     partitionID,
                     rowGroupID);
         }


### PR DESCRIPTION
## Description

Previously, the `OrcBatchPageSource` accept a `List<Boolean>` parameter to indicate which columns are row position columns, and converted it into a `boolean[]` for later use. This seems unnecessary; we can just use an `OptionalInt` for the row position column index, and use `OptionalInt.empty()` if there isn't one.

## Motivation and Context

Avoid the unnecessary logic of creating a list and converting it to an array

## Impact

N/A

## Test Plan

 - Make sure this refactoring do not affect any existing test cases

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```
