### PR TITLE
feat(function): Add Student's t distribution functions (t_cdf and inverse_t_cdf)

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -266,9 +266,14 @@ Probability Functions: cdf
     Compute the Poisson cdf with given lambda (mean) parameter:  P(N <= value; lambda).
     The lambda parameter must be a positive real number (of type DOUBLE) and value must be a non-negative integer.
 
+.. function:: t_cdf(df, value) -> double
+
+    Compute the Student's t cdf with given degrees of freedom:  P(N < value; df).
+    The degrees of freedom must be a positive real number and value must be a real value.
+
 .. function:: weibull_cdf(a, b, value) -> double
 
-    Compute the Weibull cdf with given parameters a, b: P(N <= value). The ``a``
+    Compute the Weibull cdf with given parameters a, b:  P(N <= value). The ``a``
     and ``b`` parameters must be positive doubles and ``value`` must also be a double.
 
 
@@ -331,6 +336,12 @@ Probability Functions: inverse_cdf
     probability (p). It returns the value of n so that: P(N <= n; lambda) = p.
     The lambda parameter must be a positive real number (of type DOUBLE).
     The probability p must lie on the interval [0, 1).
+
+.. function:: inverse_t_cdf(df, p) -> double
+
+    Compute the inverse of the Student's t cdf with given degrees of freedom for the cumulative
+    probability (p): P(N < n). The degrees of freedom must be a positive real value.
+    The probability p must lie on the interval [0, 1].
 
 .. function:: inverse_weibull_cdf(a, b, p) -> double
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -39,6 +39,7 @@ import org.apache.commons.math3.distribution.FDistribution;
 import org.apache.commons.math3.distribution.GammaDistribution;
 import org.apache.commons.math3.distribution.LaplaceDistribution;
 import org.apache.commons.math3.distribution.PoissonDistribution;
+import org.apache.commons.math3.distribution.TDistribution;
 import org.apache.commons.math3.distribution.WeibullDistribution;
 import org.apache.commons.math3.special.Erf;
 
@@ -979,6 +980,31 @@ public final class MathFunctions
         checkCondition(lambda > 0, INVALID_FUNCTION_ARGUMENT, "poissonCdf Function: lambda must be greater than 0");
         PoissonDistribution distribution = new PoissonDistribution(lambda);
         return distribution.cumulativeProbability((int) value);
+    }
+
+    @Description("inverse of Student's t cdf given degrees of freedom and probability")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double inverseTCdf(
+            @SqlType(StandardTypes.DOUBLE) double df,
+            @SqlType(StandardTypes.DOUBLE) double p)
+    {
+        checkCondition(df > 0, INVALID_FUNCTION_ARGUMENT, "df must be greater than 0");
+        checkCondition(p >= 0.0 && p <= 1.0, INVALID_FUNCTION_ARGUMENT, "p must be in the interval [0, 1]");
+        TDistribution distribution = new TDistribution(null, df, TDistribution.DEFAULT_INVERSE_ABSOLUTE_ACCURACY);
+        return distribution.inverseCumulativeProbability(p);
+    }
+
+    @Description("Student's t cdf given degrees of freedom and value")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double tCdf(
+            @SqlType(StandardTypes.DOUBLE) double df,
+            @SqlType(StandardTypes.DOUBLE) double value)
+    {
+        checkCondition(df > 0, INVALID_FUNCTION_ARGUMENT, "df must be greater than 0");
+        TDistribution distribution = new TDistribution(null, df, TDistribution.DEFAULT_INVERSE_ABSOLUTE_ACCURACY);
+        return distribution.cumulativeProbability(value);
     }
 
     @Description("Inverse of Weibull cdf given a, b parameters and probability")

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1810,6 +1810,31 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testInverseTCdf()
+    {
+        assertFunction("inverse_t_cdf(1000, 0.5)", DOUBLE, 0.0);
+        assertFunction("inverse_t_cdf(1000, 0.0)", DOUBLE, Double.NEGATIVE_INFINITY);
+        assertFunction("inverse_t_cdf(1000, 1.0)", DOUBLE, Double.POSITIVE_INFINITY);
+
+        assertInvalidFunction("inverse_t_cdf(0, 0.5)", "df must be greater than 0");
+        assertInvalidFunction("inverse_t_cdf(-1, 0.5)", "df must be greater than 0");
+        assertInvalidFunction("inverse_t_cdf(3, -0.1)", "p must be in the interval [0, 1]");
+        assertInvalidFunction("inverse_t_cdf(3, 1.1)", "p must be in the interval [0, 1]");
+    }
+
+    @Test
+    public void testTCdf()
+            throws Exception
+    {
+        assertFunction("t_cdf(1000, 0.0)", DOUBLE, 0.5);
+        assertFunction("t_cdf(1000, infinity())", DOUBLE, 1.0);
+        assertFunction("t_cdf(1000, -infinity())", DOUBLE, 0.0);
+
+        assertInvalidFunction("t_cdf(0, 0.5)", "df must be greater than 0");
+        assertInvalidFunction("t_cdf(-1, 0.5)", "df must be greater than 0");
+    }
+
+    @Test
     public void testInverseWeibullCdf()
     {
         assertFunction("inverse_weibull_cdf(1.0, 1.0, 0.0)", DOUBLE, 0.0);


### PR DESCRIPTION
Summary:
This change adds support for Student's t distribution statistical functions to Presto, allowing users to compute cumulative distribution function (CDF) and inverse CDF values for the t-distribution.

The t-distribution is commonly used in statistical hypothesis testing, particularly when dealing with small sample sizes or when the population standard deviation is unknown. These functions enable users to perform statistical analysis directly within SQL queries.
See: https://en.wikipedia.org/wiki/Student%27s_t-distribution#Occurrence_and_applications

**Functions Added:**
- `t_cdf(df, value)`: Computes the cumulative probability P(N < value) for a given degrees of freedom (df) and value
- `inverse_t_cdf(df, p)`: Computes the inverse CDF (quantile function) for a given degrees of freedom and probability p

Both functions use the Apache Commons Math3 TDistribution implementation and include proper validation for input parameters (df must be positive, probability must be in [0, 1]).

**Documentation:**
- Updated math.rst with function documentation in the appropriate sections (Probability Functions: cdf and Probability Functions: inverse_cdf)
- Documentation includes parameter descriptions and constraints

Differential Revision: D85004073


