### PR TITLE
fix(native): Fix build failure on macos

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -97,7 +97,7 @@ RowVectorPtr ShuffleRead::getOutput() {
         (preferredOutputBatchBytes_ / estimatedRowSize_.value()),
         kInitialOutputRows);
   }
-  numOutputRows = std::min(numOutputRows, rows_.size() - nextRow_);
+  numOutputRows = std::min<uint64_t>(numOutputRows, rows_.size() - nextRow_);
 
   // Create a view of the rows to deserialize from nextRow_ to nextRow_ +
   // numOutputRows.


### PR DESCRIPTION
## Description

The following statement in `ShuffleReader.cpp` fails to compile on macOS:

```
numOutputRows = std::min(numOutputRows, rows_.size() - nextRow_);
```

due to conflicting types, the error message is as follows:

```
candidate template ignored: deduced conflicting types for parameter '_Tp' ('uint64_t' (aka 'unsigned long long') vs. 'size_t' (aka 'unsigned long'))
```

This PR fixes the issue by explicitly specifying the type for `std::min`.

## Motivation and Context

 - Fix CI failure

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

