### PR TITLE
revert: Do not block scheduler if there are stages ready for scheduling

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -27,7 +27,6 @@ import com.facebook.presto.execution.QueryStateMachine;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.RemoteTaskFactory;
 import com.facebook.presto.execution.SqlStageExecution;
-import com.facebook.presto.execution.StageExecutionId;
 import com.facebook.presto.execution.StageExecutionInfo;
 import com.facebook.presto.execution.StageExecutionState;
 import com.facebook.presto.execution.StageId;
@@ -424,7 +423,6 @@ public class SqlQueryScheduler
             Set<StageId> completedStages = new HashSet<>();
 
             List<ExecutionSchedule> sectionExecutionSchedules = new LinkedList<>();
-            Map<StageExecutionId, ListenableFuture<?>> blockedStages = new HashMap<>();
 
             while (!Thread.currentThread().isInterrupted()) {
                 // remove finished section
@@ -447,23 +445,18 @@ public class SqlQueryScheduler
                         .forEach(sectionExecutionSchedules::add);
 
                 while (sectionExecutionSchedules.stream().noneMatch(ExecutionSchedule::isFinished)) {
+                    List<ListenableFuture<?>> blockedStages = new ArrayList<>();
+
                     List<StageExecutionAndScheduler> executionsToSchedule = sectionExecutionSchedules.stream()
                             .flatMap(schedule -> schedule.getStagesToSchedule().stream())
                             .collect(toImmutableList());
 
-                    boolean allBlocked = true;
                     for (StageExecutionAndScheduler stageExecutionAndScheduler : executionsToSchedule) {
                         long startCpuNanos = THREAD_MX_BEAN.getCurrentThreadCpuTime();
                         long startWallNanos = System.nanoTime();
 
                         SqlStageExecution stageExecution = stageExecutionAndScheduler.getStageExecution();
                         stageExecution.beginScheduling();
-
-                        ListenableFuture<?> stillBlocked = blockedStages.get(stageExecution.getStageExecutionId());
-                        if (stillBlocked != null && !stillBlocked.isDone()) {
-                            continue;
-                        }
-                        blockedStages.remove(stageExecution.getStageExecutionId());
 
                         // perform some scheduling work
                         ScheduleResult result = stageExecutionAndScheduler.getStageScheduler()
@@ -482,10 +475,7 @@ public class SqlQueryScheduler
                             stageExecution.schedulingComplete();
                         }
                         else if (!result.getBlocked().isDone()) {
-                            blockedStages.put(stageExecution.getStageExecutionId(), result.getBlocked());
-                        }
-                        else {
-                            allBlocked = false;
+                            blockedStages.add(result.getBlocked());
                         }
                         stageExecutionAndScheduler.getStageLinkage()
                                 .processScheduleResults(stageExecution.getState(), result.getNewTasks());
@@ -545,11 +535,11 @@ public class SqlQueryScheduler
                     }
 
                     // wait for a state change and then schedule again
-                    if (allBlocked && !blockedStages.isEmpty()) {
+                    if (!blockedStages.isEmpty()) {
                         try (TimeStat.BlockTimer timer = schedulerStats.getSleepTime().time()) {
-                            tryGetFutureValue(whenAnyComplete(blockedStages.values()), 1, SECONDS);
+                            tryGetFutureValue(whenAnyComplete(blockedStages), 1, SECONDS);
                         }
-                        for (ListenableFuture<?> blockedStage : blockedStages.values()) {
+                        for (ListenableFuture<?> blockedStage : blockedStages) {
                             blockedStage.cancel(true);
                         }
                     }


### PR DESCRIPTION
…eduling (#26268)"

This reverts commit fc29b742b7039c823a08dfa847e4e860a1f0e655.

## Description
Causing query failures
```
java.util.concurrent.CancellationException: Task was cancelled.
	at com.google.common.util.concurrent.AbstractFuture.cancellationExceptionWithCause(AbstractFuture.java:1560)
	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:590)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:551)
	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:111)
	at com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:247)
	at com.google.common.util.concurrent.Futures.getDone(Futures.java:1176)
	at com.facebook.airlift.concurrent.ExtendedSettableFuture.lambda$setAsync$0(ExtendedSettableFuture.java:54)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1286)
	at com.google.common.util.concurrent.AbstractFuture.addListener(AbstractFuture.java:760)
	at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.addListener(AbstractFuture.java:134)
	at com.facebook.airlift.concurrent.ExtendedSettableFuture.setAsync(ExtendedSettableFuture.java:44)
	at com.facebook.airlift.concurrent.MoreFutures.whenAnyComplete(MoreFutures.java:283)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler.schedule(SqlQueryScheduler.java:550)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

## Test Plan
Confirmed with author @arhimondr 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

