### PR TITLE
fix: Add coordinator validation interface for Python UDF security

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/FunctionAndTypeResolver.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/FunctionAndTypeResolver.java
@@ -52,4 +52,13 @@ public interface FunctionAndTypeResolver
     FunctionHandle lookupCast(String castType, Type fromType, Type toType);
 
     QualifiedObjectName qualifyObjectName(QualifiedName name);
+
+    /**
+     * Validate a function call during analysis phase on the coordinator.
+     * Delegates to the FunctionNamespaceManager for custom validation logic.
+     *
+     * @param functionHandle The function handle being validated
+     * @param arguments Raw argument expressions (not yet evaluated)
+     */
+    void validateFunctionCall(FunctionHandle functionHandle, List<?> arguments);
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -319,6 +319,12 @@ public class FunctionAndTypeManager
                 return FunctionAndTypeManager.this.lookupCast(CastType.valueOf(castType), fromType, toType);
             }
 
+            @Override
+            public void validateFunctionCall(FunctionHandle functionHandle, List<?> arguments)
+            {
+                FunctionAndTypeManager.this.validateFunctionCall(functionHandle, arguments);
+            }
+
             public QualifiedObjectName qualifyObjectName(QualifiedName name)
             {
                 if (name.getSuffix().startsWith("$internal")) {
@@ -717,6 +723,19 @@ public class FunctionAndTypeManager
         Optional<FunctionNamespaceManager<?>> functionNamespaceManager = getServingFunctionNamespaceManager(functionHandle.getCatalogSchemaName());
         checkState(functionNamespaceManager.isPresent(), format("FunctionHandle %s should have a serving function namespace", functionHandle));
         return functionNamespaceManager.get().executeFunction(source, functionHandle, inputPage, channels, this);
+    }
+
+    public void validateFunctionCall(FunctionHandle functionHandle, List<?> arguments)
+    {
+        // Built-in functions don't need validation
+        if (functionHandle instanceof BuiltInFunctionHandle) {
+            return;
+        }
+
+        Optional<FunctionNamespaceManager<?>> functionNamespaceManager = getServingFunctionNamespaceManager(functionHandle.getCatalogSchemaName());
+        if (functionNamespaceManager.isPresent()) {
+            functionNamespaceManager.get().validateFunctionCall(functionHandle, arguments);
+        }
     }
 
     public WindowFunctionSupplier getWindowFunctionImplementation(FunctionHandle functionHandle)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1120,6 +1120,10 @@ public class ExpressionAnalyzer
             FunctionHandle function = resolveFunction(sessionFunctions, transactionId, node, argumentTypes, functionAndTypeResolver);
             FunctionMetadata functionMetadata = functionAndTypeResolver.getFunctionMetadata(function);
 
+            // Delegate function-specific validation to the FunctionNamespaceManager
+            // This allows function namespaces to perform custom validation
+            functionAndTypeResolver.validateFunctionCall(function, node.getArguments());
+
             if (node.getOrderBy().isPresent()) {
                 for (SortItem sortItem : node.getOrderBy().get().getSortItems()) {
                     Type sortKeyType = process(sortItem.getSortKey(), context);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -122,4 +122,18 @@ public interface FunctionNamespaceManager<F extends SqlFunction>
     {
         throw new UnsupportedOperationException("Does not support get aggregation function");
     }
+
+    /**
+     * Validate a function call during analysis phase on the coordinator.
+     * This allows function namespace managers to perform custom validation logic
+     * such as security checks, argument validation, etc.
+     *
+     * @param functionHandle The function handle being validated
+     * @param arguments Raw argument expressions (not yet evaluated) - type is Object to avoid SPI module dependencies
+     * @throws RuntimeException if validation fails
+     */
+    default void validateFunctionCall(FunctionHandle functionHandle, List<?> arguments)
+    {
+        // Default implementation: no validation
+    }
 }


### PR DESCRIPTION
Summary:
This is the first diff in a series to move Python UDF script validation from workers to the coordinator.

This OSS diff (presto-trunk) adds the infrastructure for coordinator-side validation:
- Adds `validateFunctionCall()` method to `FunctionNamespaceManager` SPI with a default no-op implementation
- Adds `validateFunctionCall()` to `FunctionAndTypeResolver` interface
- Calls validation from `ExpressionAnalyzer` during function resolution

This allows function namespace managers to perform custom validation logic (e.g., security checks for Python UDF scripts) during SQL analysis on the coordinator, before distributing work to workers.

The default implementation does nothing, maintaining backward compatibility. The actual validation logic for Python UDFs will be implemented in subsequent diffs in presto-facebook-trunk.

Follow-up diffs will:
1. Implement the actual Python UDF validation in the coordinator (presto-facebook-trunk)
2. Remove the validation from Java workers (presto-facebook-trunk)
3. Remove the validation from Velox/Prestissimo workers (velox/functions/facebook)

This is part of D84739785's plan to consolidate validation at the coordinator level for:
- Fail-fast error reporting
- Better error messages with full query context
- Single validation point instead of redundant checks
- Resource efficiency (reject invalid queries before allocating worker resources)

Differential Revision: D85081306



```
== NO RELEASE NOTE ==


```

