### PR TITLE
feat(native-pos): Enforce per task storage broadcast join memory limit

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -20,6 +20,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <limits>
 #if __has_include("filesystem")
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -143,6 +144,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kMaxDriversPerTask, hardwareConcurrency()),
           NONE_PROP(kTaskWriterCount),
           NONE_PROP(kTaskPartitionedWriterCount),
+          NONE_PROP(kTaskMaxStorageBroadcastBytes),
           NUM_PROP(kConcurrentLifespansPerTask, 1),
           STR_PROP(kTaskMaxPartialAggregationMemory, "16MB"),
           NUM_PROP(kDriverMaxSplitPreload, 2),
@@ -167,7 +169,9 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kDriverStuckOperatorThresholdMs, 30 * 60 * 1000),
           NUM_PROP(
               kDriverCancelTasksWithStuckOperatorsThresholdMs, 40 * 60 * 1000),
-          NUM_PROP(kDriverNumStuckOperatorsToDetachWorker, std::round(0.5 * hardwareConcurrency())),
+          NUM_PROP(
+              kDriverNumStuckOperatorsToDetachWorker,
+              std::round(0.5 * hardwareConcurrency())),
           NUM_PROP(kSpillerNumCpuThreadsHwMultiplier, 1.0),
           STR_PROP(kSpillerFileCreateConfig, ""),
           STR_PROP(kSpillerDirectoryCreateConfig, ""),
@@ -425,6 +429,10 @@ folly::Optional<int32_t> SystemConfig::taskWriterCount() const {
 
 folly::Optional<int32_t> SystemConfig::taskPartitionedWriterCount() const {
   return optionalProperty<int32_t>(kTaskPartitionedWriterCount);
+}
+
+folly::Optional<uint64_t> SystemConfig::taskMaxStorageBroadcastBytes() const {
+  return optionalProperty<uint64_t>(kTaskMaxStorageBroadcastBytes);
 }
 
 int32_t SystemConfig::concurrentLifespansPerTask() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -179,6 +179,14 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kTaskWriterCount{"task.writer-count"};
   static constexpr std::string_view kTaskPartitionedWriterCount{
       "task.partitioned-writer-count"};
+
+  /// Maximum number of bytes per task that can be broadcast to storage for
+  /// storage-based broadcast joins. This property is only applicable to
+  /// storage-based broadcast join operations, currently used in the Presto on
+  /// Spark native stack. When the broadcast data size exceeds this limit, the
+  /// query fails.
+  static constexpr std::string_view kTaskMaxStorageBroadcastBytes{
+      "task.max-storage-broadcast-bytes"};
   static constexpr std::string_view kConcurrentLifespansPerTask{
       "task.concurrent-lifespans-per-task"};
   static constexpr std::string_view kTaskMaxPartialAggregationMemory{
@@ -842,6 +850,8 @@ class SystemConfig : public ConfigBase {
   folly::Optional<int32_t> taskWriterCount() const;
 
   folly::Optional<int32_t> taskPartitionedWriterCount() const;
+
+  folly::Optional<uint64_t> taskMaxStorageBroadcastBytes() const;
 
   int32_t concurrentLifespansPerTask() const;
 

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFactory.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFactory.h
@@ -40,6 +40,7 @@ class BroadcastFileWriter : velox::serializer::SerializedPageFileWriter {
  public:
   BroadcastFileWriter(
       const std::string& pathPrefix,
+      uint64_t maxBroadcastBytes,
       uint64_t writeBufferSize,
       std::unique_ptr<velox::VectorSerde::Options> serdeOptions,
       velox::memory::MemoryPool* pool);
@@ -58,6 +59,11 @@ class BroadcastFileWriter : velox::serializer::SerializedPageFileWriter {
   velox::RowVectorPtr fileStats();
 
  private:
+  void updateWriteStats(
+      uint64_t writtenBytes,
+      uint64_t /* flushTimeNs */,
+      uint64_t /* fileWriteTimeNs */) override;
+
   uint64_t flush() override;
 
   void closeFile() override;
@@ -70,6 +76,9 @@ class BroadcastFileWriter : velox::serializer::SerializedPageFileWriter {
   // [serialized-thrift-footer][footer_size(8)]
   void writeFooter();
 
+  const uint64_t maxBroadcastBytes_;
+
+  uint64_t writtenBytes_{0};
   int64_t numRows_{0};
   std::vector<int64_t> pageSizes_;
   velox::RowVectorPtr fileStats_{nullptr};
@@ -120,6 +129,7 @@ class BroadcastFactory {
 
   std::unique_ptr<BroadcastFileWriter> createWriter(
       uint64_t writeBufferSize,
+      uint64_t maxBroadcastBytes,
       velox::memory::MemoryPool* pool,
       std::unique_ptr<velox::VectorSerde::Options> serdeOptions);
 

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/operators/BroadcastWrite.h"
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/operators/BroadcastFactory.h"
 
 using namespace facebook::velox::exec;
@@ -55,10 +56,12 @@ class BroadcastWriteOperator : public Operator {
         serdeChannels_(calculateOutputChannels(
             planNode->inputType(),
             planNode->serdeRowType(),
-            planNode->serdeRowType())) {
+            planNode->serdeRowType())),
+        maxBroadcastBytes_(planNode->maxBroadcastBytes()) {
     auto fileBroadcast = BroadcastFactory(planNode->basePath());
     fileBroadcastWriter_ = fileBroadcast.createWriter(
         8 << 20,
+        planNode->maxBroadcastBytes(),
         operatorCtx_->pool(),
         getVectorSerdeOptions(ctx->queryConfig(), VectorSerde::Kind::kPresto));
   }
@@ -120,6 +123,7 @@ class BroadcastWriteOperator : public Operator {
   // Empty if column order in the serdeRowType_ is exactly the same as in input
   // or serdeRowType_ has no columns.
   const std::vector<column_index_t> serdeChannels_;
+  const uint64_t maxBroadcastBytes_;
   std::unique_ptr<BroadcastFileWriter> fileBroadcastWriter_;
   bool finished_{false};
 };
@@ -129,6 +133,7 @@ folly::dynamic BroadcastWriteNode::serialize() const {
   auto obj = PlanNode::serialize();
   obj["broadcastWriteBasePath"] =
       ISerializable::serialize<std::string>(basePath_);
+  obj["maxBroadcastBytes"] = maxBroadcastBytes_;
   obj["rowType"] = serdeRowType_->serialize();
   obj["sources"] = ISerializable::serialize(sources_);
   return obj;
@@ -141,6 +146,7 @@ velox::core::PlanNodePtr BroadcastWriteNode::create(
       deserializePlanNodeId(obj),
       ISerializable::deserialize<std::string>(
           obj["broadcastWriteBasePath"], context),
+      obj["maxBroadcastBytes"].asInt(),
       ISerializable::deserialize<RowType>(obj["rowType"]),
       ISerializable::deserialize<std::vector<velox::core::PlanNode>>(
           obj["sources"], context)[0]);

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.h
@@ -28,67 +28,14 @@ class BroadcastWriteNode : public velox::core::PlanNode {
   BroadcastWriteNode(
       const velox::core::PlanNodeId& id,
       const std::string& basePath,
+      uint64_t maxBroadcastBytes,
       velox::RowTypePtr serdeRowType,
       velox::core::PlanNodePtr source)
       : velox::core::PlanNode(id),
         basePath_{basePath},
-        serdeRowType_{serdeRowType},
+        maxBroadcastBytes_{maxBroadcastBytes},
+        serdeRowType_{std::move(serdeRowType)},
         sources_{std::move(source)} {}
-
-  class Builder {
-   public:
-    Builder() = default;
-
-    explicit Builder(const BroadcastWriteNode& other) {
-      id_ = other.id();
-      basePath_ = other.basePath();
-      serdeRowType_ = other.serdeRowType();
-      source_ = other.sources()[0];
-    }
-
-    Builder& id(velox::core::PlanNodeId id) {
-      id_ = std::move(id);
-      return *this;
-    }
-
-    Builder& basePath(std::string basePath) {
-      basePath_ = std::move(basePath);
-      return *this;
-    }
-
-    Builder& serdeRowType(velox::RowTypePtr serdeRowType) {
-      serdeRowType_ = std::move(serdeRowType);
-      return *this;
-    }
-
-    Builder& source(velox::core::PlanNodePtr source) {
-      source_ = std::move(source);
-      return *this;
-    }
-
-    std::shared_ptr<BroadcastWriteNode> build() const {
-      VELOX_USER_CHECK(id_.has_value(), "BroadcastWriteNode id is not set");
-      VELOX_USER_CHECK(
-          basePath_.has_value(), "BroadcastWriteNode basePath is not set");
-      VELOX_USER_CHECK(
-          serdeRowType_.has_value(),
-          "BroadcastWriteNode serdeRowType is not set");
-      VELOX_USER_CHECK(
-          source_.has_value(), "BroadcastWriteNode source is not set");
-
-      return std::make_shared<BroadcastWriteNode>(
-          id_.value(),
-          basePath_.value(),
-          serdeRowType_.value(),
-          source_.value());
-    }
-
-   private:
-    std::optional<velox::core::PlanNodeId> id_;
-    std::optional<std::string> basePath_;
-    std::optional<velox::RowTypePtr> serdeRowType_;
-    std::optional<velox::core::PlanNodePtr> source_;
-  };
 
   folly::dynamic serialize() const override;
 
@@ -113,6 +60,10 @@ class BroadcastWriteNode : public velox::core::PlanNode {
     return basePath_;
   }
 
+  uint64_t maxBroadcastBytes() const {
+    return maxBroadcastBytes_;
+  }
+
   /// The desired schema of the serialized data. May include a subset of input
   /// columns, some columns may be duplicated, some columns may be missing,
   /// columns may appear in different order.
@@ -128,6 +79,7 @@ class BroadcastWriteNode : public velox::core::PlanNode {
   void addDetails(std::stringstream& stream) const override {}
 
   const std::string basePath_;
+  const uint64_t maxBroadcastBytes_;
   const velox::RowTypePtr serdeRowType_;
   const std::vector<velox::core::PlanNodePtr> sources_;
 };

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
@@ -90,6 +90,7 @@ std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)> addShuffleWriteNode(
 
 std::function<PlanNodePtr(std::string, PlanNodePtr)> addBroadcastWriteNode(
     const std::string& basePath,
+    uint64_t maxBroadcastBytes,
     const std::optional<std::vector<std::string>>& outputLayout) {
   return [=](core::PlanNodeId nodeId,
              core::PlanNodePtr source) -> core::PlanNodePtr {
@@ -105,7 +106,7 @@ std::function<PlanNodePtr(std::string, PlanNodePtr)> addBroadcastWriteNode(
     }
 
     return std::make_shared<BroadcastWriteNode>(
-        nodeId, basePath, outputType, std::move(source));
+        nodeId, basePath, maxBroadcastBytes, outputType, std::move(source));
   };
 }
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
@@ -46,10 +46,12 @@ std::function<velox::core::PlanNodePtr(std::string, velox::core::PlanNodePtr)>
 
 /// Add BroadcastWriteNode for writing broadcast data to files under
 /// specified basePath
+/// @param maxBroadcastBytes Maximum size in bytes for broadcast data
 /// @param outputLayout Optional ordered list of input column names to use as
 /// serde layout. Input columns may appear in different order, some columns may
 /// be missing and other columns may be duplicated.
 addBroadcastWriteNode(
     const std::string& basePath,
+    uint64_t maxBroadcastBytes = std::numeric_limits<uint64_t>::max(),
     const std::optional<std::vector<std::string>>& outputLayout = std::nullopt);
 } // namespace facebook::presto::operators


### PR DESCRIPTION
Summary: Let broadcast join fail and throw "EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT" error when per node broadcast size exceeds the limit set by added config "task.max-storage-broadcast-bytes"

Differential Revision: D85024404

```
== NO RELEASE NOTES ==
```
