### PR TITLE
feat: Extend shuffle read interface to support read a batch of blocks

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalPersistentShuffle.h
@@ -131,7 +131,7 @@ class LocalPersistentShuffleReader : public ShuffleReader {
       std::vector<std::string> partitionIds,
       velox::memory::MemoryPool* pool);
 
-  folly::SemiFuture<std::unique_ptr<ReadBatch>> next() override;
+  folly::SemiFuture<std::vector<std::unique_ptr<ReadBatch>>> next(size_t numBatches) override;
 
   void noMoreData(bool success) override;
 

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
@@ -34,22 +34,24 @@ ShuffleExchangeSource::request(
     uint32_t /*maxBytes*/,
     std::chrono::microseconds /*maxWait*/) {
   auto nextBatch = [this]() {
-    return std::move(shuffleReader_->next())
-        .deferValue([this](std::unique_ptr<ReadBatch> batch) {
+    return std::move(shuffleReader_->next(1))
+        .deferValue([this](std::vector<std::unique_ptr<ReadBatch>>&& batches) {
           std::vector<velox::ContinuePromise> promises;
           int64_t totalBytes{0};
           {
             std::lock_guard<std::mutex> l(queue_->mutex());
-            if (batch == nullptr) {
+            if (batches.empty()) {
               atEnd_ = true;
               queue_->enqueueLocked(nullptr, promises);
             } else {
-              totalBytes = batch->data->size();
+              for (auto& batch : batches) {
+                totalBytes = batch->data->size();
               VELOX_CHECK_LE(totalBytes, std::numeric_limits<int32_t>::max());
               ++numBatches_;
               queue_->enqueueLocked(
                   std::make_unique<ShuffleRowBatch>(std::move(batch)),
                   promises);
+              }
             }
           }
 

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -46,9 +46,8 @@ class ShuffleReader {
  public:
   virtual ~ShuffleReader() = default;
 
-  /// Reads the next block of data. The function returns null if it has read all
-  /// the data. The function throws if run into any error.
-  virtual folly::SemiFuture<std::unique_ptr<ReadBatch>> next() = 0;
+  virtual folly::SemiFuture<std::vector<std::unique_ptr<ReadBatch>>> next(
+      size_t numBatches) = 0;
 
   /// Tell the shuffle system the reader is done. May be called with 'success'
   /// true before reading all the data. This happens when a query has a LIMIT or


### PR DESCRIPTION
Summary:
Extend ShuffleReader::next()` to support batch reading by accepting a `numBatches` parameter and returning a vector of `ReadBatch` objects instead of a single batch.

The changes enable more efficient shuffle reading by fetching multiple shuffle files in a single method call, reducing the overhead of repeated method invocations. The implementation reads up to `numBatches` files and returns all available batches if fewer files remain.

Differential Revision: D85124919


