### PR TITLE
feat: Add compression support for reactor-netty http2 client

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -475,6 +475,11 @@
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -152,6 +152,7 @@ import com.facebook.presto.resourcemanager.ResourceManagerClusterStatusSender;
 import com.facebook.presto.resourcemanager.ResourceManagerConfig;
 import com.facebook.presto.resourcemanager.ResourceManagerInconsistentException;
 import com.facebook.presto.resourcemanager.ResourceManagerResourceGroupService;
+import com.facebook.presto.server.remotetask.DecompressionFilter;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
 import com.facebook.presto.server.remotetask.ReactorNettyHttpClientConfig;
 import com.facebook.presto.server.thrift.FixedAddressSelector;
@@ -437,6 +438,7 @@ public class ServerMainModule
         // task execution
         jaxrsBinder(binder).bind(TaskResource.class);
         jaxrsBinder(binder).bind(ThriftTaskUpdateRequestBodyReader.class);
+        jaxrsBinder(binder).bind(DecompressionFilter.class);
 
         newExporter(binder).export(TaskResource.class).withGeneratedName();
         jaxrsBinder(binder).bind(TaskExecutorResource.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/DecompressionFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/DecompressionFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.remotetask;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.PrestoException;
+import com.github.luben.zstd.ZstdInputStream;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.lang.String.format;
+
+@Provider
+@Priority(Priorities.ENTITY_CODER)
+public class DecompressionFilter
+        implements ContainerRequestFilter
+{
+    private static final Logger log = Logger.get(DecompressionFilter.class);
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext)
+            throws IOException
+    {
+        String contentEncoding = containerRequestContext.getHeaderString("Content-Encoding");
+
+        if (contentEncoding != null && !contentEncoding.equalsIgnoreCase("identity")) {
+            InputStream originalStream = containerRequestContext.getEntityStream();
+            InputStream decompressedStream;
+
+            if (contentEncoding.equalsIgnoreCase("zstd")) {
+                decompressedStream = new ZstdInputStream(originalStream);
+            }
+            else {
+                throw new PrestoException(NOT_SUPPORTED, format("Unsupported Content-Encoding: '%s'. Only zstd compression is supported.", contentEncoding));
+            }
+
+            containerRequestContext.setEntityStream(decompressedStream);
+            containerRequestContext.getHeaders().remove("Content-Encoding");
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClientConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClientConfig.java
@@ -17,10 +17,12 @@ import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 import java.util.Optional;
 
+import static com.facebook.airlift.units.DataSize.Unit.KILOBYTE;
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -44,6 +46,94 @@ public class ReactorNettyHttpClientConfig
     private String keyStorePassword;
     private String trustStorePath;
     private Optional<String> cipherSuites = Optional.empty();
+
+    private boolean http2CompressionEnabled;
+    private DataSize payloadSizeThreshold = new DataSize(50, KILOBYTE);
+    private double compressionSavingThreshold = 0.1;
+    private DataSize tcpBufferSize = new DataSize(512, KILOBYTE);
+    private DataSize writeBufferWaterMarkLow = new DataSize(256, KILOBYTE);
+    private DataSize writeBufferWaterMarkHigh = new DataSize(512, KILOBYTE);
+
+    @Config("reactor.enable-http2-compression")
+    public ReactorNettyHttpClientConfig setHttp2CompressionEnabled(boolean http2CompressionEnabled)
+    {
+        this.http2CompressionEnabled = http2CompressionEnabled;
+        return this;
+    }
+
+    public boolean isHttp2CompressionEnabled()
+    {
+        return http2CompressionEnabled;
+    }
+
+    public double getCompressionSavingThreshold()
+    {
+        return compressionSavingThreshold;
+    }
+
+    @Config("reactor.compression-ratio-threshold")
+    @ConfigDescription("Use compressed data if the compression ratio is above the threshold")
+    public ReactorNettyHttpClientConfig setCompressionSavingThreshold(double compressionSavingThreshold)
+    {
+        this.compressionSavingThreshold = compressionSavingThreshold;
+        return this;
+    }
+
+    @Min(1024)
+    @Max(1024 * 1024)
+    public int getTcpBufferSize()
+    {
+        return (int) tcpBufferSize.toBytes();
+    }
+
+    @Config("reactor.tcp-buffer-size")
+    public ReactorNettyHttpClientConfig setTcpBufferSize(DataSize tcpBufferSize)
+    {
+        this.tcpBufferSize = tcpBufferSize;
+        return this;
+    }
+
+    @Min(1024)
+    @Max(1024 * 1024)
+    public int getWriteBufferWaterMarkLow()
+    {
+        return (int) writeBufferWaterMarkLow.toBytes();
+    }
+
+    @Config("reactor.tcp-write-buffer-water-mark-low")
+    public ReactorNettyHttpClientConfig setWriteBufferWaterMarkLow(DataSize writeBufferWaterMarkLow)
+    {
+        this.writeBufferWaterMarkLow = writeBufferWaterMarkLow;
+        return this;
+    }
+
+    @Min(1024)
+    @Max(1024 * 1024)
+    public int getWriteBufferWaterMarkHigh()
+    {
+        return (int) writeBufferWaterMarkHigh.toBytes();
+    }
+
+    @Config("reactor.tcp-write-buffer-water-mark-high")
+    public ReactorNettyHttpClientConfig setWriteBufferWaterMarkHigh(DataSize writeBufferWaterMarkHigh)
+    {
+        this.writeBufferWaterMarkHigh = writeBufferWaterMarkHigh;
+        return this;
+    }
+
+    @Min(1024)
+    @Max(512 * 1024)
+    public int getPayloadSizeThreshold()
+    {
+        return (int) payloadSizeThreshold.toBytes();
+    }
+
+    @Config("reactor.payload-compression-threshold")
+    public ReactorNettyHttpClientConfig setPayloadSizeThreshold(DataSize payloadSizeThreshold)
+    {
+        this.payloadSizeThreshold = payloadSizeThreshold;
+        return this;
+    }
 
     public boolean isReactorNettyHttpClientEnabled()
     {

--- a/presto-main/src/test/java/com/facebook/presto/remotetask/TestReactorNettyHttpClientConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/remotetask/TestReactorNettyHttpClientConfig.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static com.facebook.airlift.units.DataSize.Unit.KILOBYTE;
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -50,7 +51,13 @@ public class TestReactorNettyHttpClientConfig
                 .setKeyStorePath(null)
                 .setKeyStorePassword(null)
                 .setTrustStorePath(null)
-                .setCipherSuites(null));
+                .setCipherSuites(null)
+                .setHttp2CompressionEnabled(false)
+                .setPayloadSizeThreshold(new DataSize(50, KILOBYTE))
+                .setCompressionSavingThreshold(0.1)
+                .setTcpBufferSize(new DataSize(512, KILOBYTE))
+                .setWriteBufferWaterMarkHigh(new DataSize(512, KILOBYTE))
+                .setWriteBufferWaterMarkLow(new DataSize(256, KILOBYTE)));
     }
 
     @Test
@@ -75,6 +82,12 @@ public class TestReactorNettyHttpClientConfig
                 .put("reactor.truststore-path", "/var/abc/def/presto.jks")
                 .put("reactor.keystore-password", "password")
                 .put("reactor.cipher-suites", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
+                .put("reactor.enable-http2-compression", "true")
+                .put("reactor.payload-compression-threshold", "10kB")
+                .put("reactor.compression-ratio-threshold", "0.2")
+                .put("reactor.tcp-buffer-size", "256kB")
+                .put("reactor.tcp-write-buffer-water-mark-high", "256kB")
+                .put("reactor.tcp-write-buffer-water-mark-low", "128kB")
                 .build();
 
         ReactorNettyHttpClientConfig expected = new ReactorNettyHttpClientConfig()
@@ -95,7 +108,13 @@ public class TestReactorNettyHttpClientConfig
                 .setKeyStorePath("/var/abc/def/presto.jks")
                 .setTrustStorePath("/var/abc/def/presto.jks")
                 .setKeyStorePassword("password")
-                .setCipherSuites("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
+                .setCipherSuites("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
+                .setHttp2CompressionEnabled(true)
+                .setPayloadSizeThreshold(new DataSize(10, KILOBYTE))
+                .setCompressionSavingThreshold(0.2)
+                .setTcpBufferSize(new DataSize(256, KILOBYTE))
+                .setWriteBufferWaterMarkHigh(new DataSize(256, KILOBYTE))
+                .setWriteBufferWaterMarkLow(new DataSize(128, KILOBYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestCompression.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestCompression.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static org.testng.Assert.assertTrue;
+
+public class TestCompression
+{
+    @Test
+    public void testCompressionWithJson()
+            throws Exception
+    {
+        // Enable HTTP/2 and compression with minimal threshold to guarantee compression
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("reactor.netty-http-client-enabled", "true")         // Enable HTTP/2 client
+                .put("reactor.enable-http2-compression", "true")          // Enable compression
+                .put("reactor.payload-compression-threshold", "1kB")      // 1kB (minimum allowed by @Min(1024))
+                .put("reactor.compression-ratio-threshold", "0.01")        // 1% compression savings threshold
+                .build();
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties)) {
+            // Run multiple queries to test different data sizes and patterns
+            String[] queries = {
+                    "SELECT count(*) FROM tpch.tiny.nation",
+                    "SELECT * FROM tpch.tiny.region",
+                    "SELECT n.name, r.name FROM tpch.tiny.nation n JOIN tpch.tiny.region r ON n.regionkey = r.regionkey",
+                    "SELECT * FROM tpch.tiny.nation ORDER BY nationkey"
+            };
+
+            for (String query : queries) {
+                QueryId queryId = queryRunner.executeWithQueryId(queryRunner.getDefaultSession(), query).getQueryId();
+                assertTrue(queryRunner.getQueryInfo(queryId).getState().isDone());
+            }
+        }
+    }
+
+    @Test
+    public void testCompressionWithThrift()
+            throws Exception
+    {
+        // Enable HTTP/2 and compression with minimal threshold to guarantee compression
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("reactor.netty-http-client-enabled", "true")         // Enable HTTP/2 client
+                .put("reactor.enable-http2-compression", "true")          // Enable compression
+                .put("reactor.payload-compression-threshold", "1kB")      // 1kB (minimum allowed by @Min(1024))
+                .put("reactor.compression-ratio-threshold", "0.01")        // 1% compression savings threshold
+                .put("experimental.internal-communication.task-info-response-thrift-serde-enabled", "true")
+                .put("experimental.internal-communication.task-update-request-thrift-serde-enabled", "true")
+                .build();
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties)) {
+            // Run multiple queries to test different data sizes and patterns
+            String[] queries = {
+                    "SELECT count(*) FROM tpch.tiny.nation",
+                    "SELECT * FROM tpch.tiny.region",
+                    "SELECT n.name, r.name FROM tpch.tiny.nation n JOIN tpch.tiny.region r ON n.regionkey = r.regionkey",
+                    "SELECT * FROM tpch.tiny.nation ORDER BY nationkey"
+            };
+
+            for (String query : queries) {
+                QueryId queryId = queryRunner.executeWithQueryId(queryRunner.getDefaultSession(), query).getQueryId();
+                assertTrue(queryRunner.getQueryInfo(queryId).getState().isDone());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
1. add data compression support for http2. zstd only for better performance.
2. all parameters are configurable
3. will only be enabled if configured properly
4. work together with https://github.com/prestodb/presto/pull/26382

## Motivation and Context
1. when communicating with cpp worker via http2, coordinator will compress both the header and body and will also receive compressed response. We see great compression ratio for payload greater than 8 kB.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. passed verifier run

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add data compression support for http2 protocol
```

