### PR TITLE
chore(native): Add window size configuration for http2 server

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -150,6 +150,9 @@ SystemConfig::SystemConfig() {
           NONE_PROP(kHttpServerHttpsPort),
           BOOL_PROP(kHttpServerHttpsEnabled, false),
           BOOL_PROP(kHttpServerHttp2Enabled, true),
+          NUM_PROP(kHttpServerHttp2InitialReceiveWindow, 1 << 20),
+          NUM_PROP(kHttpServerHttp2ReceiveStreamWindowSize, 1 << 20),
+          NUM_PROP(kHttpServerHttp2ReceiveSessionWindowSize, 10 * (1 << 20)),
           STR_PROP(
               kHttpsSupportedCiphers,
               "ECDHE-ECDSA-AES256-GCM-SHA384,AES256-GCM-SHA384"),
@@ -297,6 +300,21 @@ bool SystemConfig::httpServerHttpsEnabled() const {
 
 bool SystemConfig::httpServerHttp2Enabled() const {
   return optionalProperty<bool>(kHttpServerHttp2Enabled).value();
+}
+
+uint32_t SystemConfig::httpServerHttp2InitialReceiveWindow() const {
+  return optionalProperty<uint32_t>(kHttpServerHttp2InitialReceiveWindow)
+      .value();
+}
+
+uint32_t SystemConfig::httpServerHttp2ReceiveStreamWindowSize() const {
+  return optionalProperty<uint32_t>(kHttpServerHttp2ReceiveStreamWindowSize)
+      .value();
+}
+
+uint32_t SystemConfig::httpServerHttp2ReceiveSessionWindowSize() const {
+  return optionalProperty<uint32_t>(kHttpServerHttp2ReceiveSessionWindowSize)
+      .value();
 }
 
 std::string SystemConfig::httpsSupportedCiphers() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -209,6 +209,15 @@ class SystemConfig : public ConfigBase {
       "http-server.https.enabled"};
   static constexpr std::string_view kHttpServerHttp2Enabled{
       "http-server.http2.enabled"};
+  /// HTTP/2 initial receive window size in bytes (default 1MB).
+  static constexpr std::string_view kHttpServerHttp2InitialReceiveWindow{
+      "http-server.http2.initial-receive-window"};
+  /// HTTP/2 receive stream window size in bytes (default 1MB).
+  static constexpr std::string_view kHttpServerHttp2ReceiveStreamWindowSize{
+      "http-server.http2.receive-stream-window-size"};
+  /// HTTP/2 receive session window size in bytes (default 10MB).
+  static constexpr std::string_view kHttpServerHttp2ReceiveSessionWindowSize{
+      "http-server.http2.receive-session-window-size"};
   /// List of comma separated ciphers the client can use.
   ///
   /// NOTE: the client needs to have at least one cipher shared with server
@@ -801,6 +810,12 @@ class SystemConfig : public ConfigBase {
   int httpServerHttpsPort() const;
 
   bool httpServerHttp2Enabled() const;
+
+  uint32_t httpServerHttp2InitialReceiveWindow() const;
+
+  uint32_t httpServerHttp2ReceiveStreamWindowSize() const;
+
+  uint32_t httpServerHttp2ReceiveSessionWindowSize() const;
 
   /// A list of ciphers (comma separated) that are supported by
   /// server and client. Note Java and folly::SSLContext use different names to

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -288,10 +288,14 @@ void HttpServer::start(
   handlerFactories.addThen(std::move(handlerFactory_));
   options.handlerFactories = handlerFactories.build();
 
-  // Increase the default flow control to 1MB/10MB
-  options.initialReceiveWindow = static_cast<uint32_t>(1 << 20);
-  options.receiveStreamWindowSize = static_cast<uint32_t>(1 << 20);
-  options.receiveSessionWindowSize = 10 * (1 << 20);
+  // HTTP/2 flow control window sizes (configurable)
+  auto systemConfig = SystemConfig::instance();
+  options.initialReceiveWindow =
+      systemConfig->httpServerHttp2InitialReceiveWindow();
+  options.receiveStreamWindowSize =
+      systemConfig->httpServerHttp2ReceiveStreamWindowSize();
+  options.receiveSessionWindowSize =
+      systemConfig->httpServerHttp2ReceiveSessionWindowSize();
   options.h2cEnabled = true;
 
   server_ = std::make_unique<proxygen::HTTPServer>(std::move(options));


### PR DESCRIPTION
## Description
1. Make these three parameters configurable

## Motivation and Context
1. no hardcoding

Differential Revision: D85145751


## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

