### PR TITLE
ci: Fix the issue where macos build gets stuck

### DIFF
--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -3,15 +3,33 @@ name: prestocpp-macos-build
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'presto-native-execution/**'
-      - '.github/workflows/prestocpp-macos-build.yml'
+
 jobs:
+  changes:
+    runs-on: macos-15
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+      # For pull requests it's not necessary to checkout the code
+      - name: Run changes check for PRs
+        uses: dorny/paths-filter@7267a8516b6f92bdb098633497bad573efdbf271
+        id: filter
+        with:
+          filters: |
+            codechange:
+              - 'presto-native-execution/**'
+              - '.github/workflows/prestocpp-macos-build.yml'
+
   prestocpp-macos-build-engine:
     strategy:
       matrix:
         os: [macos-13, macos-15]
     runs-on: ${{ matrix.os }}
+    needs: changes
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
       CMAKE_POLICY_VERSION_MINIMUM: "3.5"
@@ -24,18 +42,26 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+        if: |
+          needs.changes.outputs.codechange == 'true'
 
       - name: Fix git permissions
+        if: |
+          needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Update submodules
+        if: |
+          needs.changes.outputs.codechange == 'true'
         run: |
           cd presto-native-execution
           make submodules
 
       - name: "Setup MacOS"
+        if: |
+          needs.changes.outputs.codechange == 'true'
         run: |
           set -xu
           source presto-native-execution/scripts/setup-macos.sh
@@ -68,18 +94,26 @@ jobs:
           brew link --force protobuf@21
 
       - name: Install Github CLI for using apache/infrastructure-actions/stash
+        if: |
+          needs.changes.outputs.codechange == 'true'
         run: |
           brew install gh
 
       - uses: apache/infrastructure-actions/stash/restore@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
+        if: |
+          needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-macos-build-engine-${{ matrix.os }}
 
       - name: Zero ccache statistics
+        if: |
+          needs.changes.outputs.codechange == 'true'
         run: PATH=${INSTALL_PREFIX}/bin:${PATH} ccache -sz
 
       - name: "Build presto_cpp on MacOS"
+        if: |
+          needs.changes.outputs.codechange == 'true'
         run: |
           clang --version
           export PATH=$(brew --prefix m4)/bin:$(brew --prefix bison)/bin:${PATH}
@@ -99,9 +133,13 @@ jobs:
           ninja -C _build/${BUILD_TYPE} -j ${NJOBS}
 
       - name: Ccache after
+        if: |
+          needs.changes.outputs.codechange == 'true'
         run: PATH=${INSTALL_PREFIX}/bin:${PATH} ccache -s
 
       - uses: apache/infrastructure-actions/stash/save@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
+        if: |
+          needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-macos-build-engine-${{ matrix.os }}


### PR DESCRIPTION
## Description

We have changed the macos-15 job to be required,  but currently it will not be triggered by a PR without native code changes. This is causing the entire CI workflow to get stuck.

This PR fix the issue. The macos-15 job will now always be triggered, but only execute its build and test steps when native changes are present.

## Motivation and Context

 - Resolve the CI workflow stuck

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

