### PR TITLE
fix(docs): Fix typo in connector description in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -342,7 +342,7 @@ Note: Each PR/commit should have a single primary type. If your changes span mul
 * `spi` - Service Provider Interface changes
 * `scheduler` - Task scheduling and execution
 * `protocol` - Wire protocol and serialization
-* `connector` - Changes to broader connector functionality or conector SPI
+* `connector` - Changes to broader connector functionality or connector SPI
 * `resource` - Resource management (memory manager, resource groups)
 * `security` - Authentication and authorization
 * `function` - Built-in functions and operators


### PR DESCRIPTION
## Description
Fix a small typo

## Motivation and Context
N/A

## Impact
N/A

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

