### PR TITLE
chore(plugin-iceberg): Reduce logging in REST servlet

### DIFF
--- a/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
+++ b/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
@@ -129,15 +129,6 @@ public class IcebergRestCatalogServlet
             }
         }
         catch (RESTException e) {
-            if ((context.route() == Route.LOAD_TABLE && e.getLocalizedMessage().contains("NoSuchTableException")) ||
-                    (context.route() == Route.LOAD_VIEW && e.getLocalizedMessage().contains("NoSuchViewException"))) {
-                // Suppress stack trace for load_table requests, most of which occur immediately
-                // preceding a create_table request
-                LOG.warn("Table at endpoint %s does not exist", context.path());
-            }
-            else {
-                LOG.error(e, "Error processing REST request at endpoint %s", context.path());
-            }
             response.setStatus(SC_INTERNAL_SERVER_ERROR);
         }
         catch (Exception e) {
@@ -149,7 +140,6 @@ public class IcebergRestCatalogServlet
     private Consumer<Map<String, String>> handleResponseHeader(HttpServletResponse response)
     {
         return (responseHeaders) -> {
-            LOG.error("Unexpected response header: %s", responseHeaders);
             throw new RuntimeException("Unexpected response header: " + responseHeaders);
         };
     }


### PR DESCRIPTION
## Description
The REST servlet is overly verbose for routine queries of existence.  It's not clear that we need such logs.

## Motivation and Context
When developing a feature that requires the REST catalog, I found that I needed to lower the logging to more easily understand test behavior.

## Impact
Less unnecessary logs in tests

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

