### PR TITLE
refactor: Rename local persistent shuffle to local shuffle

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -36,7 +36,7 @@
 #include "presto_cpp/main/http/filters/StatsFilter.h"
 #include "presto_cpp/main/operators/BroadcastExchangeSource.h"
 #include "presto_cpp/main/operators/BroadcastWrite.h"
-#include "presto_cpp/main/operators/LocalPersistentShuffle.h"
+#include "presto_cpp/main/operators/LocalShuffle.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleExchangeSource.h"
 #include "presto_cpp/main/operators/ShuffleRead.h"

--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(
   ShuffleExchangeSource.cpp
   ShuffleRead.cpp
   ShuffleWrite.cpp
-  LocalPersistentShuffle.cpp
+  LocalShuffle.cpp
   BroadcastWrite.cpp
   BroadcastFactory.cpp
   BroadcastExchangeSource.cpp

--- a/presto-native-execution/presto_cpp/main/operators/LocalShuffle.h
+++ b/presto-native-execution/presto_cpp/main/operators/LocalShuffle.h
@@ -69,9 +69,9 @@ struct LocalShuffleReadInfo {
 /// multi-process use scenarios as long as each producer or consumer is assigned
 /// to a distinct group of partition IDs. Each of them can create an instance of
 /// this class (pointing to the same root path) to read and write shuffle data.
-class LocalPersistentShuffleWriter : public ShuffleWriter {
+class LocalShuffleWriter : public ShuffleWriter {
  public:
-  LocalPersistentShuffleWriter(
+  LocalShuffleWriter(
       const std::string& rootPath,
       const std::string& queryId,
       uint32_t shuffleId,
@@ -123,15 +123,16 @@ class LocalPersistentShuffleWriter : public ShuffleWriter {
   std::shared_ptr<velox::filesystems::FileSystem> fileSystem_;
 };
 
-class LocalPersistentShuffleReader : public ShuffleReader {
+class LocalShuffleReader : public ShuffleReader {
  public:
-  LocalPersistentShuffleReader(
+  LocalShuffleReader(
       const std::string& rootPath,
       const std::string& queryId,
       std::vector<std::string> partitionIds,
       velox::memory::MemoryPool* pool);
 
-  folly::SemiFuture<std::vector<std::unique_ptr<ReadBatch>>> next(size_t numBatches) override;
+  folly::SemiFuture<std::vector<std::unique_ptr<ReadBatch>>> next(
+      size_t numBatches) override;
 
   void noMoreData(bool success) override;
 

--- a/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
@@ -14,7 +14,7 @@
 #include <folly/Uri.h>
 #include "folly/init/Init.h"
 #include "presto_cpp/external/json/nlohmann/json.hpp"
-#include "presto_cpp/main/operators/LocalPersistentShuffle.h"
+#include "presto_cpp/main/operators/LocalShuffle.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleExchangeSource.h"
 #include "presto_cpp/main/operators/ShuffleRead.h"

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -15,7 +15,7 @@
 
 #include "presto_cpp/main/common/tests/test_json.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnector.h"
-#include "presto_cpp/main/operators/LocalPersistentShuffle.h"
+#include "presto_cpp/main/operators/LocalShuffle.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleRead.h"
 #include "presto_cpp/main/operators/ShuffleWrite.h"


### PR DESCRIPTION
Summary: The followup will add sort function to local shuffle and replace test shuffle in all tests

Differential Revision: D85212498
