### PR TITLE
chore: Upgrade org.scala-lang:scala-library versio to 2.13.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <dep.mariadb.version>3.5.4</dep.mariadb.version>
         <dep.spark.version>2.0.2-6</dep.spark.version>
         <dep.hadoop.version>3.4.1-1</dep.hadoop.version>
+        <scala.version>2.13.17</scala.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -2725,6 +2726,12 @@
                         <artifactId>asm</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>${scala.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.13.17</version>
         </dependency>
 
         <dependency>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <scala.version>2.13.16</scala.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 
@@ -324,7 +323,6 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-product-tests/pom.xml
+++ b/presto-product-tests/pom.xml
@@ -15,7 +15,6 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <main-class>com.facebook.presto.tests.TemptoProductTestRunner</main-class>
         <air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>
-        <scala.version>2.13.16</scala.version>
         <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
@@ -214,7 +213,6 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -607,7 +607,6 @@
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>
-                    <version>2.13.17</version>
                     <scope>provided</scope>
                 </dependency>
 

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -72,7 +72,6 @@
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>
-                    <version>2.13.17</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/presto-spark-classloader-spark3/pom.xml
+++ b/presto-spark-classloader-spark3/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.13.17</version>
       <scope>provided</scope>
     </dependency>
 

--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -73,7 +73,6 @@
                 <dependency>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-library</artifactId>
-                    <version>2.13.17</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
## Description
Upgrade org.scala-lang:scala-library versio to 2.13.17

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```

== RELEASE NOTES ==

Security Changes
* Upgrade org.apache.calcite to 1.38.0 in response to `CVE-2022-36944<https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36944>`_. 

