### PR TITLE
feat(plugin-iceberg): Add $snapshot_sequence_number as hidden column in iceberg table

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -800,9 +800,9 @@ Details about the table snapshots. For more information see `Snapshots <https://
 
 .. code-block:: text
 
-                 committed_at             |     snapshot_id     | parent_id | operation |                                                  manifest_list                                           |                                                                                 summary
-    --------------------------------------+---------------------+-----------+-----------+----------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    2022-11-25 20:56:31.784 Asia/Kolkata  | 7606232158543069775 | NULL      | append    | s3://my-bucket/ctas_nation/metadata/snap-7606232158543069775-1-395a2cad-b244-409b-b030-cc44949e5a4e.avro | {changed-partition-count=1, added-data-files=1, total-equality-deletes=0, added-records=25, total-position-deletes=0, added-files-size=1648, total-delete-files=0, total-files-size=1648, total-records=25, total-data-files=1}
+                 committed_at             |     snapshot_id     | snapshot_sequence_number | parent_id | operation |                                                  manifest_list                                           |                                                                                 summary
+    --------------------------------------+---------------------+--------------------------+-----------+----------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    2022-11-25 20:56:31.784 Asia/Kolkata  | 7606232158543069775 | 1                        | NULL      | append    | s3://my-bucket/ctas_nation/metadata/snap-7606232158543069775-1-395a2cad-b244-409b-b030-cc44949e5a4e.avro | {changed-partition-count=1, added-data-files=1, total-equality-deletes=0, added-records=25, total-position-deletes=0, added-files-size=1648, total-delete-files=0, total-files-size=1648, total-records=25, total-data-files=1}
 
 ``$manifests`` Table
 ^^^^^^^^^^^^^^^^^^^^

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -100,6 +100,7 @@ import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -150,6 +151,8 @@ import static com.facebook.presto.iceberg.IcebergColumnHandle.IS_DELETED_COLUMN_
 import static com.facebook.presto.iceberg.IcebergColumnHandle.IS_DELETED_COLUMN_METADATA;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_METADATA;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.SNAPSHOT_SEQUENCE_NUMBER_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.SNAPSHOT_SEQUENCE_NUMBER_COLUMN_METADATA;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_MATERIALIZED_VIEW;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
@@ -157,6 +160,7 @@ import static com.facebook.presto.iceberg.IcebergMetadataColumn.DATA_SEQUENCE_NU
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.DELETE_FILE_PATH;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.FILE_PATH;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.IS_DELETED;
+import static com.facebook.presto.iceberg.IcebergMetadataColumn.SNAPSHOT_SEQUENCE_NUMBER;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.UPDATE_ROW_DATA;
 import static com.facebook.presto.iceberg.IcebergPartitionType.ALL;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressionCodec;
@@ -183,7 +187,9 @@ import static com.facebook.presto.iceberg.IcebergUtil.getSnapshotIdTimeOperator;
 import static com.facebook.presto.iceberg.IcebergUtil.getSortFields;
 import static com.facebook.presto.iceberg.IcebergUtil.getTableComment;
 import static com.facebook.presto.iceberg.IcebergUtil.getViewComment;
+import static com.facebook.presto.iceberg.IcebergUtil.removeSnapshotSequenceDomain;
 import static com.facebook.presto.iceberg.IcebergUtil.resolveSnapshotIdByName;
+import static com.facebook.presto.iceberg.IcebergUtil.rewriteSnapshotSequencePredicate;
 import static com.facebook.presto.iceberg.IcebergUtil.toHiveColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetLocation;
 import static com.facebook.presto.iceberg.IcebergUtil.tryGetProperties;
@@ -351,9 +357,14 @@ public abstract class IcebergAbstractMetadata
 
         IcebergTableHandle handle = (IcebergTableHandle) table;
         Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
+        IcebergTableName name = IcebergTableName.from(handle.getTableName());
+        Snapshot latestSnapshot = icebergTable.currentSnapshot();
+
+        handle = rewriteSnapshotSequencePredicate(handle, icebergTable, name, constraint, latestSnapshot);
+        TupleDomain<ColumnHandle> newDomainPredicate = removeSnapshotSequenceDomain(constraint);
 
         List<IcebergColumnHandle> partitionColumns = getPartitionKeyColumnHandles(handle, icebergTable, typeManager);
-        TupleDomain<ColumnHandle> partitionColumnPredicate = TupleDomain.withColumnDomains(Maps.filterKeys(constraint.getSummary().getDomains().orElse(ImmutableMap.of()), Predicates.in(partitionColumns)));
+        TupleDomain<ColumnHandle> partitionColumnPredicate = TupleDomain.withColumnDomains(Maps.filterKeys(newDomainPredicate.getDomains().orElse(ImmutableMap.of()), Predicates.in(partitionColumns)));
         Optional<Set<IcebergColumnHandle>> requestedColumns = desiredColumns.map(columns -> columns.stream().map(column -> (IcebergColumnHandle) column).collect(toImmutableSet()));
 
         List<HivePartition> partitions;
@@ -377,7 +388,7 @@ public abstract class IcebergAbstractMetadata
                 new IcebergTableLayoutHandle.Builder()
                         .setPartitionColumns(ImmutableList.copyOf(partitionColumns))
                         .setDataColumns(toHiveColumns(icebergTable.schema().columns()))
-                        .setDomainPredicate(constraint.getSummary().simplify().transform(IcebergAbstractMetadata::toSubfield))
+                        .setDomainPredicate(newDomainPredicate.simplify().transform(IcebergAbstractMetadata::toSubfield))
                         .setRemainingPredicate(TRUE_CONSTANT)
                         .setPredicateColumns(predicateColumns)
                         .setRequestedColumns(requestedColumns)
@@ -386,7 +397,7 @@ public abstract class IcebergAbstractMetadata
                         .setPartitions(Optional.ofNullable(partitions.size() == 0 ? null : partitions))
                         .setTable(handle)
                         .build());
-        return new ConnectorTableLayoutResult(layout, constraint.getSummary());
+        return new ConnectorTableLayoutResult(layout, newDomainPredicate);
     }
 
     public static Subfield toSubfield(ColumnHandle columnHandle)
@@ -513,6 +524,7 @@ public abstract class IcebergAbstractMetadata
                 columns.add(DATA_SEQUENCE_NUMBER_COLUMN_METADATA);
                 columns.add(IS_DELETED_COLUMN_METADATA);
                 columns.add(DELETE_FILE_PATH_COLUMN_METADATA);
+                columns.add(SNAPSHOT_SEQUENCE_NUMBER_COLUMN_METADATA);
             }
             return new ConnectorTableMetadata(table, columns.build(), createMetadataProperties(icebergTable, session), getTableComment(icebergTable));
         }
@@ -1057,6 +1069,7 @@ public abstract class IcebergAbstractMetadata
             columnHandles.put(DATA_SEQUENCE_NUMBER.getColumnName(), DATA_SEQUENCE_NUMBER_COLUMN_HANDLE);
             columnHandles.put(IS_DELETED.getColumnName(), IS_DELETED_COLUMN_HANDLE);
             columnHandles.put(DELETE_FILE_PATH.getColumnName(), DELETE_FILE_PATH_COLUMN_HANDLE);
+            columnHandles.put(SNAPSHOT_SEQUENCE_NUMBER.getColumnName(), SNAPSHOT_SEQUENCE_NUMBER_COLUMN_HANDLE);
         }
         return columnHandles.build();
     }
@@ -1093,7 +1106,7 @@ public abstract class IcebergAbstractMetadata
 
                 return new IcebergTableHandle(
                         storageTableName.getSchemaName(),
-                        new IcebergTableName(storageTableName.getTableName(), name.getTableType(), Optional.empty(), Optional.empty()),
+                        new IcebergTableName(storageTableName.getTableName(), name.getTableType(), Optional.empty(), Optional.empty(), false),
                         name.getSnapshotId().isPresent(),
                         tryGetLocation(storageTable),
                         tryGetProperties(storageTable),
@@ -1126,7 +1139,7 @@ public abstract class IcebergAbstractMetadata
 
         return new IcebergTableHandle(
                 tableNameToLoad.getSchemaName(),
-                new IcebergTableName(tableNameToLoad.getTableName(), name.getTableType(), tableSnapshotId, name.getChangelogEndSnapshot()),
+                new IcebergTableName(tableNameToLoad.getTableName(), name.getTableType(), tableSnapshotId, name.getChangelogEndSnapshot(), false),
                 name.getSnapshotId().isPresent(),
                 tryGetLocation(table),
                 tryGetProperties(table),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.iceberg.IcebergMetadataColumn.DATA_SEQUENCE_NU
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.DELETE_FILE_PATH;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.FILE_PATH;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.IS_DELETED;
+import static com.facebook.presto.iceberg.IcebergMetadataColumn.SNAPSHOT_SEQUENCE_NUMBER;
 import static com.facebook.presto.iceberg.IcebergMetadataColumn.UPDATE_ROW_DATA;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -56,6 +57,8 @@ public class IcebergColumnHandle
     public static final ColumnMetadata IS_DELETED_COLUMN_METADATA = getColumnMetadata(IS_DELETED);
     public static final IcebergColumnHandle DELETE_FILE_PATH_COLUMN_HANDLE = getIcebergColumnHandle(DELETE_FILE_PATH);
     public static final ColumnMetadata DELETE_FILE_PATH_COLUMN_METADATA = getColumnMetadata(DELETE_FILE_PATH);
+    public static final IcebergColumnHandle SNAPSHOT_SEQUENCE_NUMBER_COLUMN_HANDLE = getIcebergColumnHandle(SNAPSHOT_SEQUENCE_NUMBER);
+    public static final ColumnMetadata SNAPSHOT_SEQUENCE_NUMBER_COLUMN_METADATA = getColumnMetadata(SNAPSHOT_SEQUENCE_NUMBER);
 
     private final ColumnIdentity columnIdentity;
     private final Type type;
@@ -194,6 +197,10 @@ public class IcebergColumnHandle
     public boolean isDeleteFilePathColumn()
     {
         return getColumnIdentity().getId() == DELETE_FILE_PATH.getId();
+    }
+    public boolean isSnapshotSequenceNumberColumn()
+    {
+        return getColumnIdentity().getId() == SNAPSHOT_SEQUENCE_NUMBER.getId();
     }
 
     public static IcebergColumnHandle primitiveIcebergColumnHandle(int id, String name, Type type, Optional<String> comment)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -394,7 +394,7 @@ public class IcebergHiveMetadata
 
         return new IcebergOutputTableHandle(
                 schemaName,
-                new IcebergTableName(tableName, DATA, Optional.empty(), Optional.empty()),
+                new IcebergTableName(tableName, DATA, Optional.empty(), Optional.empty(), false),
                 toPrestoSchema(metadata.schema(), typeManager),
                 toPrestoPartitionSpec(metadata.spec(), typeManager),
                 getColumnsForWrite(metadata.schema(), metadata.spec(), typeManager),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataColumn.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataColumn.java
@@ -35,6 +35,7 @@ public enum IcebergMetadataColumn
     DATA_SEQUENCE_NUMBER(Integer.MAX_VALUE - 1001, "$data_sequence_number", BIGINT, PRIMITIVE),
     IS_DELETED(MetadataColumns.IS_DELETED.fieldId(), "$deleted", BOOLEAN, PRIMITIVE),
     DELETE_FILE_PATH(MetadataColumns.DELETE_FILE_PATH.fieldId(), "$delete_file_path", VARCHAR, PRIMITIVE),
+    SNAPSHOT_SEQUENCE_NUMBER(Integer.MAX_VALUE - 1002, "$snapshot_sequence_number", BIGINT, PRIMITIVE),
     /**
      * Iceberg reserved row ids begin at INTEGER.MAX_VALUE and count down. Starting with MIN_VALUE here to avoid conflicts.
      * Inner type for row is not known until runtime.

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -444,7 +444,7 @@ public class IcebergNativeMetadata
 
         return new IcebergOutputTableHandle(
                 schemaName,
-                new IcebergTableName(tableName, DATA, Optional.empty(), Optional.empty()),
+                new IcebergTableName(tableName, DATA, Optional.empty(), Optional.empty(), false),
                 toPrestoSchema(icebergTable.schema(), typeManager),
                 toPrestoPartitionSpec(icebergTable.spec(), typeManager),
                 getColumnsForWrite(icebergTable.schema(), icebergTable.spec(), typeManager),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableHandle.java
@@ -147,6 +147,22 @@ public class IcebergTableHandle
                 materializedViewName);
     }
 
+    public IcebergTableHandle withUpdatedIcebergTableName(IcebergTableName icebergTableName)
+    {
+        return new IcebergTableHandle(
+                getSchemaName(),
+                icebergTableName,
+                snapshotSpecified,
+                outputPath,
+                storageProperties,
+                tableSchemaJson,
+                partitionFieldIds,
+                equalityFieldIds,
+                sortOrder,
+                updatedColumns,
+                materializedViewName);
+    }
+
     @Override
     public boolean equals(Object o)
     {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableName.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableName.java
@@ -50,6 +50,7 @@ public class IcebergTableName
     private final Optional<Long> snapshotId;
 
     private final Optional<Long> changelogEndSnapshot;
+    private final boolean fromInclusive;
 
     private static final Set<IcebergTableType> SYSTEM_TABLES = Sets.immutableEnumSet(FILES, MANIFESTS, PARTITIONS, HISTORY, SNAPSHOTS, PROPERTIES, REFS);
 
@@ -58,12 +59,14 @@ public class IcebergTableName
             @JsonProperty("tableName") String tableName,
             @JsonProperty("tableType") IcebergTableType icebergTableType,
             @JsonProperty("snapshotId") Optional<Long> snapshotId,
-            @JsonProperty("changelogEndSnapshot") Optional<Long> changelogEndSnapshot)
+            @JsonProperty("changelogEndSnapshot") Optional<Long> changelogEndSnapshot,
+            @JsonProperty("fromInclusive") boolean fromInclusive)
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.icebergTableType = requireNonNull(icebergTableType, "tableType is null");
         this.snapshotId = requireNonNull(snapshotId, "snapshotId is null");
         this.changelogEndSnapshot = requireNonNull(changelogEndSnapshot, "changelogEndSnapshot is null");
+        this.fromInclusive = fromInclusive;
     }
 
     @JsonProperty
@@ -82,6 +85,12 @@ public class IcebergTableName
     public Optional<Long> getChangelogEndSnapshot()
     {
         return changelogEndSnapshot;
+    }
+
+    @JsonProperty
+    public boolean isFromInclusive()
+    {
+        return fromInclusive;
     }
 
     public boolean isSystemTable()
@@ -153,6 +162,16 @@ public class IcebergTableName
             throw new PrestoException(NOT_SUPPORTED, format("Invalid Iceberg table name (cannot use @ version with table type '%s'): %s", type, name));
         }
 
-        return new IcebergTableName(table, type, version, changelogEndVersion);
+        return new IcebergTableName(table, type, version, changelogEndVersion, false);
+    }
+
+    public IcebergTableName withUpdatedInclusion(boolean fromInclusive)
+    {
+        return new IcebergTableName(
+                tableName,
+                icebergTableType,
+                snapshotId,
+                changelogEndSnapshot,
+                fromInclusive);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableType.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableType.java
@@ -24,6 +24,7 @@ public enum IcebergTableType
     REFS(true),
     PROPERTIES(true),
     CHANGELOG(true),
+    INCREMENTAL(true),
     EQUALITY_DELETES(true),
     DATA_WITHOUT_EQUALITY_DELETES(false);
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.GenericInternalException;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.NullableValue;
+import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.Decimals;
@@ -84,7 +85,6 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.util.LocationUtil;
-import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.view.View;
 
 import java.io.IOException;
@@ -107,6 +107,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static com.facebook.airlift.units.DataSize.succinctBytes;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -147,6 +148,7 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.getCompressio
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isMergeOnReadModeEnabled;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getWriteDataLocation;
 import static com.facebook.presto.iceberg.IcebergTableProperties.isHiveLocksEnabled;
+import static com.facebook.presto.iceberg.IcebergTableType.INCREMENTAL;
 import static com.facebook.presto.iceberg.TypeConverter.toIcebergType;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
@@ -213,6 +215,7 @@ import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
 import static org.apache.iceberg.TableProperties.WRITE_METADATA_LOCATION;
 import static org.apache.iceberg.types.Type.TypeID.BINARY;
 import static org.apache.iceberg.types.Type.TypeID.FIXED;
+import static org.apache.iceberg.util.SnapshotUtil.oldestAncestor;
 
 public final class IcebergUtil
 {
@@ -316,7 +319,7 @@ public final class IcebergUtil
         }
 
         if (name.getTableType() == IcebergTableType.CHANGELOG) {
-            return Optional.ofNullable(SnapshotUtil.oldestAncestor(table)).map(Snapshot::snapshotId);
+            return Optional.ofNullable(oldestAncestor(table)).map(Snapshot::snapshotId);
         }
 
         return tryGetCurrentSnapshot(table).map(Snapshot::snapshotId);
@@ -492,6 +495,157 @@ public final class IcebergUtil
         return mapWithIndex(schema.columns().stream(),
                 (column, position) -> immutableEntry(column.name(), toIntExact(position)))
                 .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+    }
+
+    public static IcebergTableHandle rewriteSnapshotSequencePredicate(
+            IcebergTableHandle handle,
+            Table icebergTable,
+            IcebergTableName name,
+            Constraint<ColumnHandle> constraint,
+            Snapshot latestSnapshot)
+    {
+        Optional<Map<ColumnHandle, Domain>> optionalDomains = constraint.getSummary().getDomains();
+        if (optionalDomains.isEmpty()) {
+            return handle;
+        }
+
+        Map<ColumnHandle, Domain> domains = optionalDomains.get();
+        for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+            IcebergColumnHandle column = (IcebergColumnHandle) entry.getKey();
+
+            if (!column.getName().equalsIgnoreCase("$snapshot_sequence_number")) {
+                continue;
+            }
+
+            Domain domain = entry.getValue();
+            if (domain.isSingleValue()) {
+                long sequenceNumber = ((Number) domain.getSingleValue()).longValue();
+                Snapshot endSnapshot = validateAndFetchSnapshot(icebergTable, sequenceNumber);
+                handle = handle.withUpdatedIcebergTableName(prepareIncrementalScan(icebergTable, endSnapshot, name.withUpdatedInclusion(true), endSnapshot, true));
+                continue;
+            }
+
+            List<Range> ranges = domain.getValues().getRanges().getOrderedRanges();
+            if (ranges.size() != 1) {
+                throw unsupportedPredicate();
+            }
+
+            Range range = ranges.get(0);
+            if (!range.isLowUnbounded() && range.isLowInclusive() && range.isHighUnbounded()) {
+                // WHERE $snapshot_sequence_number >= X (delta from x to latest)
+                long lowerSequenceNumber = ((Number) range.getLowBoundedValue()).longValue();
+                Snapshot start = validateAndFetchSnapshot(icebergTable, lowerSequenceNumber);
+                handle = handle.withUpdatedIcebergTableName(prepareIncrementalScan(icebergTable, start, name.withUpdatedInclusion(true), latestSnapshot, true));
+            }
+            else if (!range.isLowUnbounded() && !range.isLowInclusive() && range.isHighUnbounded()) {
+                // WHERE $snapshot_sequence_number > X, excludes lower bound
+                long lowerSequenceNumber = ((Number) range.getLowBoundedValue()).longValue();
+                Snapshot start = validateAndFetchSnapshot(icebergTable, lowerSequenceNumber);
+                handle = handle.withUpdatedIcebergTableName(prepareIncrementalScan(icebergTable, start, name.withUpdatedInclusion(false), latestSnapshot, false));
+            }
+            else if (range.isLowInclusive() && range.isHighInclusive()) {
+                // WHERE $snapshot_sequence_number BETWEEN X AND Y
+                handle = handle.withUpdatedIcebergTableName(prepareBetweenScan(icebergTable, name.withUpdatedInclusion(true), range, true));
+            }
+            else {
+                throw unsupportedPredicate();
+            }
+        }
+        return handle;
+    }
+
+    public static TupleDomain<ColumnHandle> removeSnapshotSequenceDomain(Constraint<ColumnHandle> constraint)
+    {
+        Optional<Map<ColumnHandle, Domain>> optionalDomains = constraint.getSummary().getDomains();
+        if (optionalDomains.isEmpty()) {
+            return TupleDomain.none();
+        }
+
+        ImmutableMap.Builder<ColumnHandle, Domain> filtered = ImmutableMap.builder();
+
+        for (Map.Entry<ColumnHandle, Domain> entry : optionalDomains.get().entrySet()) {
+            IcebergColumnHandle column = (IcebergColumnHandle) entry.getKey();
+            if (!column.getName().equalsIgnoreCase("$snapshot_sequence_number")) {
+                filtered.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return TupleDomain.withColumnDomains(filtered.build());
+    }
+
+    private static Snapshot getSnapshotBySequenceNumber(Table icebergTable, long sequenceNumber)
+    {
+        if (icebergTable == null) {
+            throw new IllegalArgumentException("icebergTable is null");
+        }
+        return StreamSupport.stream(icebergTable.snapshots().spliterator(), false)
+                .filter(s -> s.sequenceNumber() == sequenceNumber)
+                .findFirst().orElse(null);
+    }
+
+    private static void validateEndSnapshotId(Table table, long sequenceNumber)
+    {
+        Snapshot current = table.currentSnapshot();
+        if (!(current != null && current.sequenceNumber() >= sequenceNumber)) {
+            throw new PrestoException(ICEBERG_INVALID_SNAPSHOT_ID, format("Invalid snapshot sequence number %s for table: %s. Current snapshot sequence number is %s",
+                    sequenceNumber, table, current != null ? current.sequenceNumber() : "null"));
+        }
+    }
+
+    private static void hasOnlyAppendOperations(Table table, Snapshot startSnapshot, Snapshot endSnapshot, boolean fromInclusive)
+    {
+        requireNonNull(endSnapshot, "EndSnapshot must not be null for incremental scan.");
+        long startSequenceNumber = (startSnapshot == null) ? -1 : startSnapshot.sequenceNumber();
+        long endSequenceNumber = endSnapshot.sequenceNumber();
+
+        for (Snapshot snapshot : table.snapshots()) {
+            long seqNumber = snapshot.sequenceNumber();
+            boolean inRange = fromInclusive ? (seqNumber >= startSequenceNumber && seqNumber <= endSequenceNumber)
+                    : (seqNumber > startSequenceNumber && seqNumber <= endSequenceNumber);
+            if (inRange && !"append".equals(snapshot.operation())) {
+                throw new PrestoException(NOT_SUPPORTED, format("Only append operations are supported in incremental scans. Found %s operation in snapshot %s", snapshot.operation(), snapshot.snapshotId()));
+            }
+        }
+    }
+
+    /**
+     * Validates that a snapshot with the given sequence number exists
+     * and returns it. Throws if not found.
+     */
+    private static Snapshot validateAndFetchSnapshot(Table table, long seqNum)
+    {
+        validateEndSnapshotId(table, seqNum);
+        Snapshot snapshot = getSnapshotBySequenceNumber(table, seqNum);
+        if (snapshot == null) {
+            throw new PrestoException(ICEBERG_INVALID_SNAPSHOT_ID, format("Snapshot with sequence number %s does not exist for table %s.", seqNum, table.name()));
+        }
+        return snapshot;
+    }
+
+    private static IcebergTableName prepareIncrementalScan(Table table, Snapshot start, IcebergTableName name, Snapshot end, boolean fromInclusive)
+    {
+        hasOnlyAppendOperations(table, start, end, fromInclusive);
+        Optional<Long> startSnapshotId = (start == null) ? Optional.empty() : Optional.of(start.snapshotId());
+        return new IcebergTableName(name.getTableName(), INCREMENTAL, startSnapshotId, Optional.of(end.snapshotId()), fromInclusive);
+    }
+
+    private static IcebergTableName prepareBetweenScan(Table table, IcebergTableName name, Range range, boolean fromInclusive)
+    {
+        long lowerSequenceNumber = ((Number) range.getLowBoundedValue()).longValue();
+        long upperSequenceNumber = ((Number) range.getHighBoundedValue()).longValue();
+
+        Snapshot lower = validateAndFetchSnapshot(table, lowerSequenceNumber);
+        Snapshot upper = validateAndFetchSnapshot(table, upperSequenceNumber);
+
+        hasOnlyAppendOperations(table, lower, upper, fromInclusive);
+
+        return new IcebergTableName(name.getTableName(), INCREMENTAL, Optional.of(lower.snapshotId()), Optional.of(upper.snapshotId()), fromInclusive);
+    }
+
+    private static PrestoException unsupportedPredicate()
+    {
+        return new PrestoException(NOT_SUPPORTED,
+                "Unsupported predicate for $snapshot_sequence_number; only >= constant or BETWEEN are allowed");
     }
 
     public static void validateTableMode(ConnectorSession session, org.apache.iceberg.Table table)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergEqualityDeleteAsJoin.java
@@ -351,7 +351,7 @@ public class IcebergEqualityDeleteAsJoin
                     new IcebergTableName(tableName.getTableName(),
                             IcebergTableType.EQUALITY_DELETES, // Read equality deletes instead of data
                             tableName.getSnapshotId(),
-                            Optional.empty()),
+                            Optional.empty(), false),
                     icebergTableHandle.isSnapshotSpecified(),
                     icebergTableHandle.getOutputPath(),
                     icebergTableHandle.getStorageProperties(),
@@ -382,7 +382,7 @@ public class IcebergEqualityDeleteAsJoin
                     new IcebergTableName(tableName.getTableName(),
                             IcebergTableType.DATA_WITHOUT_EQUALITY_DELETES, // Don't apply equality deletes in the split
                             tableName.getSnapshotId(),
-                            tableName.getChangelogEndSnapshot()),
+                            tableName.getChangelogEndSnapshot(), false),
                     icebergTableHandle.isSnapshotSpecified(),
                     icebergTableHandle.getOutputPath(),
                     icebergTableHandle.getStorageProperties(),

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2397,6 +2397,82 @@ public abstract class IcebergDistributedTestBase
                 "VALUES (true, 1, 'a'), (false, 1, 'b'), (false, 2, 'a'), (false, 3, 'a')");
     }
 
+    @Test
+    public void testSnapshotSequenceNumberHiddenColumnSimple()
+    {
+        String tableName = "test_snapshot_seq_num_hidden_" + randomTableSuffix();
+
+        try {
+            assertUpdate("CREATE TABLE " + tableName + "(id int, data varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (100, 'a')", 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (200, 'b')", 1);
+            Table iceberTable = loadTable(tableName);
+            long sequenceNumber = iceberTable.currentSnapshot().sequenceNumber();
+            iceberTable.refresh();
+
+            assertQueryFails("SELECT COUNT(\"$snapshot_sequence_number\") FROM " + tableName, "The column \\$snapshot_sequence_number is internal and cannot be selected directly");
+            assertQueryFails("SELECT \"$snapshot_sequence_number\" FROM " + tableName, "The column \\$snapshot_sequence_number is internal and cannot be selected directly");
+
+            assertQuery("SELECT * FROM " + tableName + " WHERE \"$snapshot_sequence_number\" = " + sequenceNumber, "VALUES " +
+                    "(200, 'b')");
+        }
+        finally {
+            assertQuerySucceeds("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
+    public void testSnapshotSequenceNumberPredicatePushdown()
+    {
+        String tableName = "test_snapshot_seq_num_pred_pushdown_" + randomTableSuffix();
+
+        try {
+            assertUpdate("CREATE TABLE " + tableName + "(id int, data varchar)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (100, 'a')", 1);
+            long snapshotSequenceNumber1 = loadTable(tableName).currentSnapshot().sequenceNumber();
+            assertUpdate("INSERT INTO " + tableName + " VALUES (200, 'b')", 1);
+            long snapshotSequenceNumber2 = loadTable(tableName).currentSnapshot().sequenceNumber();
+            assertUpdate("INSERT INTO " + tableName + " VALUES (300, 'c')", 1);
+            Long currentSnapshotSequenceNumber = loadTable(tableName).currentSnapshot().sequenceNumber();
+            loadTable(tableName).refresh();
+
+            // current table values
+            assertQuery("SELECT * FROM " + tableName, "VALUES (100, 'a'), (200, 'b'), (300, 'c')");
+            assertQuery("SELECT COUNT(*) FROM " + tableName, "VALUES 3");
+
+            // Single value predicate
+            assertQuery("SELECT COUNT(*) FROM " + tableName + " WHERE \"$snapshot_sequence_number\" = " + snapshotSequenceNumber1, "VALUES 1");
+            assertQuery("SELECT COUNT(*) FROM " + tableName + " WHERE \"$snapshot_sequence_number\" = " + currentSnapshotSequenceNumber, "VALUES 1");
+
+            // Range predicate >=
+            assertQuery("SELECT COUNT(*) FROM " + tableName + " WHERE \"$snapshot_sequence_number\" >= " + snapshotSequenceNumber1, "VALUES 3");
+
+            // Range predicate >
+            assertQuery("SELECT COUNT(*) FROM " + tableName + " WHERE \"$snapshot_sequence_number\" > " + snapshotSequenceNumber1, "VALUES 2");
+            assertQuery("SELECT * FROM " + tableName + " WHERE \"$snapshot_sequence_number\" > " + snapshotSequenceNumber1,
+                    "VALUES (200, 'b'), (300, 'c')");
+
+            // BETWEEN different value
+            assertQuery("SELECT COUNT(*) FROM " + tableName + " WHERE \"$snapshot_sequence_number\" BETWEEN " + snapshotSequenceNumber1 +
+                    " AND " + snapshotSequenceNumber2, "VALUES 2");
+            assertQuery("SELECT * FROM " + tableName + " WHERE \"$snapshot_sequence_number\" BETWEEN " + snapshotSequenceNumber1 +
+                    " AND " + snapshotSequenceNumber2, "VALUES (100, 'a'), (200, 'b')");
+
+            // Unsupported predicate
+            assertQueryFails("SELECT * FROM " + tableName + " WHERE \"$snapshot_sequence_number\" < " + currentSnapshotSequenceNumber,
+                    "Unsupported predicate for \\$snapshot_sequence_number; only >= constant or BETWEEN are allowed");
+            assertQueryFails("SELECT * FROM " + tableName + " WHERE \"$snapshot_sequence_number\" <= " + snapshotSequenceNumber1,
+                    "Unsupported predicate for \\$snapshot_sequence_number; only >= constant or BETWEEN are allowed");
+            assertQueryFails("SELECT * FROM " + tableName + " WHERE \"$snapshot_sequence_number\" <> " + snapshotSequenceNumber1,
+                    "Unsupported predicate for \\$snapshot_sequence_number; only >= constant or BETWEEN are allowed");
+            assertQueryFails("SELECT * FROM " + tableName + " WHERE \"$snapshot_sequence_number\" IN (" + snapshotSequenceNumber1 + ", " + snapshotSequenceNumber2 + ")",
+                    "Unsupported predicate for \\$snapshot_sequence_number; only >= constant or BETWEEN are allowed");
+        }
+        finally {
+            assertQuerySucceeds("DROP TABLE " + tableName);
+        }
+    }
+
     @DataProvider(name = "pushdownFilterEnabled")
     public Object[][] pushdownFilterEnabledProvider()
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -160,6 +160,7 @@ public class TestIcebergSystemTables
         assertQuery("SHOW COLUMNS FROM test_schema.\"test_table$snapshots\"",
                 "VALUES ('committed_at', 'timestamp with time zone', '', '', null, null, null)," +
                         "('snapshot_id', 'bigint', '', '', 19L, null, null)," +
+                        "('snapshot_sequence_number', 'bigint', '', '', 19L, null, null)," +
                         "('parent_id', 'bigint', '', '', 19L, null, null)," +
                         "('operation', 'varchar', '', '', null, null, 2147483647L)," +
                         "('manifest_list', 'varchar', '', '', null, null, 2147483647L)," +

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
@@ -202,7 +202,7 @@ public class TestRenameTableOnFragileFileSystem
     private static final String newTablePermissionFilePath = String.format("%s/%s/%s/%s/%s", catalogDirectory, newSchemaName, newTableName, ".prestoPermissions", "testFile");
 
     IcebergTableHandle icebergTableHandle = new IcebergTableHandle(originSchemaName,
-            new IcebergTableName(originTableName, IcebergTableType.DATA, Optional.empty(), Optional.empty()),
+            new IcebergTableName(originTableName, IcebergTableType.DATA, Optional.empty(), Optional.empty(), false),
             false,
             Optional.empty(),
             Optional.empty(),


### PR DESCRIPTION
## Description
Add `$snapshot_sequence_number` as a hidden column in the iceberg table

## Motivation and Context
- Add `$snapshot_sequence_number` extra column in `$snapshots` metadata table
- Add `$snapshot_sequence_number` as a hidden column in the iceberg table

As `$snapshot_id` is not incremental so while calculating Delta between 2 snapshots (With query like `WHERE $snapshot_id BETWEEN snap1 AND snap2`) would return wrong results since comparison is not valid.

## Impact
Get the delta between 2 snapshots using `$snapshot_sequence_number` as column.

Here these are the covered options -
1. `WHERE "$snapshot_sequence_number" >= X` (Get delta from start snapshot to X)
2. `WHERE "$snapshot_sequence_number" BETWEEN X AND Y` (Get delta from start snapshot to X)
3. `WHERE "$snapshot_sequence_number" = X`
4. `WHERE "$snapshot_sequence_number" > X`

**Limitation -** 
Above are using `newIncrementalAppendScan()` Iceberg API which is append-only snapshot operation mode. Also `IncrementalChangelogScan` has limitation and doesn't support delta for snapshots with operation modes `delete` & `overwrite` and fails [here](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java#L110).

## Test Plan
Tests Added

- Get `$snapshot_sequence_number `from `$snapshots` metadata table
- Now we can use `$snapshot_sequence_number `column for filter to find delta on a table

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add ``$snapshot_sequence_number`` as a hidden column in the Iceberg table.
```
