### PR TITLE
fix(native-pos): Enable shuffle stats

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -596,7 +596,7 @@ public class QueryStats
                 for (OperatorStats operatorStats : stageExecutionStats.getOperatorSummaries()) {
                     // NOTE: we need to literally check each operator type to tell if the source is from table input or shuffled input. A stage can have input from both types of source.
                     String operatorType = operatorStats.getOperatorType();
-                    if (operatorType.equals(ExchangeOperator.class.getSimpleName()) || operatorType.equals(MergeOperator.class.getSimpleName())) {
+                    if (operatorType.equals(ExchangeOperator.class.getSimpleName()) || operatorType.equals(MergeOperator.class.getSimpleName()) || operatorType.equals("PrestoSparkRemoteSourceOperator") || operatorType.equals("ShuffleRead")) {
                         shuffledPositions += operatorStats.getRawInputPositions();
                         shuffledDataSize += operatorStats.getRawInputDataSizeInBytes();
                     }


### PR DESCRIPTION
Summary:
currently shuffle stats are missing in query performance tab
This diff enabels this stats for queries running on sapphire velox engine

# Release Notes
```
== NO RELEASE NOTE ==
```

Differential Revision: D85287726


