### PR TITLE
fix(native): Enable CudfHiveConnector with PRESTO_ENABLE_CUDF

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/Registration.cpp
@@ -12,8 +12,8 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/connectors/Registration.h"
-#include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/HivePrestoToVeloxConnector.h"
+#include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/SystemConnector.h"
 
 #ifdef PRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR
@@ -91,6 +91,21 @@ void registerConnectorFactories() {
   facebook::presto::registerConnectorFactory(
       std::make_shared<facebook::velox::connector::hive::HiveConnectorFactory>(
           kHiveHadoop2ConnectorName));
+#ifdef PRESTO_ENABLE_CUDF
+  facebook::presto::unregisterConnectorFactory(
+      facebook::velox::connector::hive::HiveConnectorFactory::kHiveConnectorName);
+  facebook::presto::unregisterConnectorFactory(kHiveHadoop2ConnectorName);
+
+  // Register cuDF Hive connector factory
+  facebook::presto::registerConnectorFactory(
+      std::make_shared<facebook::velox::cudf_velox::connector::hive::
+                           CudfHiveConnectorFactory>());
+
+  // Register cudf Hive connector factory
+  facebook::presto::registerConnectorFactory(
+      std::make_shared<facebook::velox::cudf_velox::connector::hive::
+                           CudfHiveConnectorFactory>(kHiveHadoop2ConnectorName));
+#endif
 
   // Register TPC-DS connector factory
   facebook::presto::registerConnectorFactory(


### PR DESCRIPTION
## Description
The commit https://github.com/prestodb/presto/commit/3705024c70957c5f238053ad01541a8f764823d8 missed CudfHiveConnector during refactor. This PR adds it again.


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

