### PR TITLE
feat: Support runtime stats inside shuffle read operator for perf monitoring

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -41,9 +41,13 @@ class ShuffleRead : public Exchange {
                 shuffleReadNode->outputType(),
                 VectorSerde::Kind::kCompactRow),
             exchangeClient,
-            "ShuffleRead") {}
+            "ShuffleRead") {
+    initStats();
+  }
 
   RowVectorPtr getOutput() override;
+
+  void close() override;
 
  protected:
   VectorSerde* getSerde() override {
@@ -51,10 +55,40 @@ class ShuffleRead : public Exchange {
   }
 
  private:
+  static inline const std::string kShuffleDecodeTime{"shuffleDecodeWallNanos"};
+  static inline const std::string kShuffleNumBatchesPerRead{
+      "shuffleNumBatchesPerRead"};
+  static inline const std::string kShuffleNumBatches{"shuffleNumBatches"};
+
+  void initStats();
+
+  void resetOutputState();
+
+  int64_t numBatches_{0};
+  std::unordered_map<std::string, velox::RuntimeMetric> runtimeStats_;
+
   size_t nextRow_{0};
+  size_t nextPage_{0};
   // Reusable buffers.
   std::vector<std::string_view> rows_;
+  std::vector<size_t> pageRows_;
 };
+
+void ShuffleRead::initStats() {
+  VELOX_CHECK(runtimeStats_.empty());
+  runtimeStats_.insert(
+      std::pair{kShuffleDecodeTime, velox::RuntimeCounter::Unit::kNanos});
+  runtimeStats_.insert(
+      std::pair{kShuffleNumBatchesPerRead, velox::RuntimeCounter::Unit::kNone});
+}
+
+void ShuffleRead::resetOutputState() {
+  currentPages_.clear();
+  rows_.clear();
+  pageRows_.clear();
+  nextRow_ = 0;
+  nextPage_ = 0;
+}
 
 RowVectorPtr ShuffleRead::getOutput() {
   if (currentPages_.empty()) {
@@ -63,9 +97,8 @@ RowVectorPtr ShuffleRead::getOutput() {
 
   SCOPE_EXIT {
     if (nextRow_ == rows_.size()) {
-      currentPages_.clear();
-      rows_.clear();
-      nextRow_ = 0;
+      VELOX_CHECK_EQ(nextPage_, currentPages_.size());
+      resetOutputState();
     }
   };
 
@@ -75,7 +108,10 @@ RowVectorPtr ShuffleRead::getOutput() {
     size_t numRows{0};
     for (const auto& page : currentPages_) {
       rawInputBytes += page->size();
-      numRows += page->numRows().value();
+      const auto pageRows = page->numRows().value();
+      pageRows_.emplace_back(
+          (pageRows_.empty() ? 0 : pageRows_.back()) + pageRows);
+      numRows += pageRows;
     }
     rows_.reserve(numRows);
     for (const auto& page : currentPages_) {
@@ -84,6 +120,10 @@ RowVectorPtr ShuffleRead::getOutput() {
       for (const auto& row : rows) {
         rows_.emplace_back(row);
       }
+    }
+    if (!currentPages_.empty()) {
+      runtimeStats_[kShuffleNumBatchesPerRead].addValue(currentPages_.size());
+      numBatches_ += currentPages_.size();
     }
   }
   VELOX_CHECK_LE(nextRow_, rows_.size());
@@ -99,21 +139,48 @@ RowVectorPtr ShuffleRead::getOutput() {
   }
   numOutputRows = std::min<uint64_t>(numOutputRows, rows_.size() - nextRow_);
 
-  // Create a view of the rows to deserialize from nextRow_ to nextRow_ +
-  // numOutputRows.
-  if (numOutputRows == rows_.size()) {
-    result_ = row::CompactRow::deserialize(rows_, outputType_, pool());
-  } else {
-    std::vector<std::string_view> outputRows(
-        rows_.begin() + nextRow_, rows_.begin() + nextRow_ + numOutputRows);
-    result_ = row::CompactRow::deserialize(outputRows, outputType_, pool());
+  uint64_t decodeTimeNs{0};
+  {
+    velox::NanosecondTimer timer(&decodeTimeNs);
+    // Create a view of the rows to deserialize from nextRow_ to nextRow_ +
+    // numOutputRows.
+    if (numOutputRows == rows_.size()) {
+      result_ = row::CompactRow::deserialize(rows_, outputType_, pool());
+    } else {
+      std::vector<std::string_view> outputRows(
+          rows_.begin() + nextRow_, rows_.begin() + nextRow_ + numOutputRows);
+      result_ = row::CompactRow::deserialize(outputRows, outputType_, pool());
+    }
   }
+  runtimeStats_[kShuffleDecodeTime].addValue(decodeTimeNs);
+
   nextRow_ += numOutputRows;
+  for (; nextPage_ < currentPages_.size(); ++nextPage_) {
+    if (pageRows_[nextPage_] > nextRow_) {
+      break;
+    }
+    currentPages_[nextPage_].reset();
+  }
   estimatedRowSize_ = std::max(
       result_->estimateFlatSize() / numOutputRows,
       estimatedRowSize_.value_or(1L));
   recordInputStats(rawInputBytes);
   return result_;
+}
+
+void ShuffleRead::close() {
+  Exchange::close();
+  auto lockedStats = stats_.wlock();
+  for (const auto& [name, metric] : runtimeStats_) {
+    if (metric.count == 0) {
+      continue;
+    }
+    lockedStats->runtimeStats[name] = metric;
+  }
+  if (numBatches_ != 0) {
+    lockedStats->addRuntimeStat(
+        kShuffleNumBatches, RuntimeCounter(numBatches_));
+  }
 }
 } // namespace
 


### PR DESCRIPTION
Summary: Add runtime stats with unit test

Differential Revision: D85360881
