### PR TITLE
fix(native): Generation of thrift protocol

### DIFF
--- a/presto-native-execution/presto_cpp/main/thrift/thrift2json.py
+++ b/presto-native-execution/presto_cpp/main/thrift/thrift2json.py
@@ -38,7 +38,9 @@ def preprocess(file_path, output_temp_path):
         lines = file.readlines()
     modified_lines = []
     for line in lines:
-        modified_line = re.sub(r"\s*,*\s*drift\.recursive_reference=true\s*", "", line)
+        modified_line = re.sub(
+            r"\s*,*\s*drift\.recursive_reference\s*=\s*true\s*,*\s*", "", line
+        )
         modified_line = re.sub(r"\(\s*\)$", "", modified_line)
         modified_lines.append(modified_line)
     with open(output_temp_path, "w") as file:

--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -33,7 +33,7 @@ export NPROC=${NPROC:-$(getconf _NPROCESSORS_ONLN)}
 function install_presto_deps_from_package_managers {
   dnf install -y maven java clang-tools-extra jq perl-XML-XPath
   # This python version is installed by the Velox setup scripts
-  pip install regex pyyaml chevron black
+  pip install regex pyyaml chevron black ptsd-jbroll
 }
 
 function install_gperf {


### PR DESCRIPTION
The thrift generation was broken because a line
that was expected to be removed was not and caused a thrift parse error.

That line is "drift.recursive_reference = true,” which was not caught by the regex attempting to remove it.

This PR also adds the required thrift parser to the python installation of the dependency to use it in the CI.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

