### PR TITLE
feat: Allow InPredicate in MV refresh where clause

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -6065,9 +6065,34 @@ public class TestHiveIntegrationSmokeTest
                 "SELECT COUNT(*) FROM ( " + expectedInsertQuery + " )",
                 false, true);
 
+        // Test InPredicate
+        refreshSql = "REFRESH MATERIALIZED VIEW test_customer_view_5 WHERE regionkey IN (1, 2)";
+        expectedInsertQuery = "SELECT nation.name AS nationname, customer.custkey, customer.name AS customername, UPPER(customer.mktsegment) AS marketsegment, customer.nationkey, regionkey " +
+                "FROM test_nation_base_5 nation JOIN test_customer_base_5 customer ON (nation.nationkey = customer.nationkey) " +
+                "WHERE regionkey IN (1, 2)";
+        QueryAssertions.assertQuery(
+                queryRunner,
+                session,
+                refreshSql,
+                queryRunner,
+                "SELECT COUNT(*) FROM ( " + expectedInsertQuery + " )",
+                false, true);
+
+        refreshSql = "REFRESH MATERIALIZED VIEW test_customer_view_5 WHERE nationkey IN (1, 5, 10) AND regionkey = 1";
+        expectedInsertQuery = "SELECT nation.name AS nationname, customer.custkey, customer.name AS customername, UPPER(customer.mktsegment) AS marketsegment, customer.nationkey, regionkey " +
+                "FROM test_nation_base_5 nation JOIN test_customer_base_5 customer ON (nation.nationkey = customer.nationkey) " +
+                "WHERE nation.nationkey IN (1, 5, 10) AND regionkey = 1";
+        QueryAssertions.assertQuery(
+                queryRunner,
+                session,
+                refreshSql,
+                queryRunner,
+                "SELECT COUNT(*) FROM ( " + expectedInsertQuery + " )",
+                false, true);
+
         // Test invalid predicates
         assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5 WHERE nationname = 'UNITED STATES'", ".*Refresh materialized view by column nationname is not supported.*");
-        assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5 WHERE regionkey + nationkey = 25", ".*Only columns specified on literals are supported in WHERE clause.*");
+        assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5 WHERE regionkey + nationkey = 25", ".*Only column references are supported on the left side of comparison expressions in WHERE clause.*");
         assertQueryFails("REFRESH MATERIALIZED VIEW test_customer_view_5", ".*Refresh Materialized View without predicates is not supported.");
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RefreshMaterializedViewPredicateAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/RefreshMaterializedViewPredicateAnalyzer.java
@@ -24,6 +24,8 @@ import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.InListExpression;
+import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Literal;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.Node;
@@ -35,7 +37,6 @@ import jakarta.annotation.Nullable;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
@@ -104,7 +105,7 @@ public class RefreshMaterializedViewPredicateAnalyzer
         @Override
         public Void process(Node node, @Nullable Void context)
         {
-            if (!(node instanceof ComparisonExpression || node instanceof LogicalBinaryExpression)) {
+            if (!(node instanceof ComparisonExpression || node instanceof LogicalBinaryExpression || node instanceof InPredicate)) {
                 throw new SemanticException(NOT_SUPPORTED, node, "Only column specifications connected by logical AND are supported in WHERE clause.");
             }
 
@@ -126,10 +127,10 @@ public class RefreshMaterializedViewPredicateAnalyzer
                 return null;
             }
 
-            if (!(node.getLeft() instanceof ComparisonExpression || node.getLeft() instanceof LogicalBinaryExpression)) {
+            if (!(node.getLeft() instanceof ComparisonExpression || node.getLeft() instanceof LogicalBinaryExpression || node.getLeft() instanceof InPredicate)) {
                 throw new SemanticException(NOT_SUPPORTED, node.getLeft(), "Only column specifications connected by logical AND are supported in WHERE clause.");
             }
-            if (!(node.getRight() instanceof ComparisonExpression || node.getRight() instanceof LogicalBinaryExpression)) {
+            if (!(node.getRight() instanceof ComparisonExpression || node.getRight() instanceof LogicalBinaryExpression || node.getRight() instanceof InPredicate)) {
                 throw new SemanticException(NOT_SUPPORTED, node.getRight(), "Only column specifications connected by logical AND are supported in WHERE clause.");
             }
 
@@ -137,23 +138,100 @@ public class RefreshMaterializedViewPredicateAnalyzer
         }
 
         @Override
+        protected Void visitInPredicate(InPredicate node, Void context)
+        {
+            Expression value = node.getValue();
+            Expression valueList = node.getValueList();
+
+            if (!(value instanceof Identifier || value instanceof DereferenceExpression)) {
+                throw new SemanticException(NOT_SUPPORTED, value, "Only column references are supported on the left side of IN predicates in WHERE clause.");
+            }
+            if (!(valueList instanceof InListExpression)) {
+                throw new SemanticException(NOT_SUPPORTED, valueList, "Only IN list expressions are supported in WHERE clause's IN predicates.");
+            }
+
+            InListExpression inListExpression = (InListExpression) valueList;
+            for (Expression inValue : inListExpression.getValues()) {
+                if (!(inValue instanceof Literal)) {
+                    throw new SemanticException(NOT_SUPPORTED, inValue, "Only literal values are supported in WHERE clause's IN lists.");
+                }
+            }
+
+            QualifiedName qualifiedName = value instanceof DereferenceExpression
+                    ? DereferenceExpression.getQualifiedName((DereferenceExpression) value)
+                    : QualifiedName.of(((Identifier) value).getValue());
+
+            ResolvedField resolvedField = viewScope.tryResolveField(value).orElseThrow(() -> missingAttributeException(value, qualifiedName));
+            String column = resolvedField.getField().getOriginColumnName().orElseThrow(() -> missingAttributeException(value, qualifiedName));
+
+            if (!viewDefinition.getValidRefreshColumns().orElse(emptyList()).contains(column)) {
+                throw new SemanticException(NOT_SUPPORTED, value, "Refresh materialized view by column %s is not supported.", value.toString());
+            }
+
+            Map<SchemaTableName, String> baseTableColumns = viewDefinition.getColumnMappingsAsMap().get(column);
+
+            // Convert IN predicate to OR'd equality comparisons
+            boolean mappedToSingleBaseTablePartition = true;
+            for (Expression inValue : inListExpression.getValues()) {
+                if (baseTableColumns != null && inValue instanceof NullLiteral) {
+                    if (viewDefinition.getBaseTablesOnOuterJoinSide().stream().anyMatch(t -> baseTableColumns.containsKey(t))) {
+                        mappedToSingleBaseTablePartition = false;
+                        break;
+                    }
+                }
+            }
+
+            if (mappedToSingleBaseTablePartition && baseTableColumns != null) {
+                for (SchemaTableName baseTable : baseTableColumns.keySet()) {
+                    Expression orExpression = null;
+                    for (Expression inValue : inListExpression.getValues()) {
+                        ComparisonExpression comparison = new ComparisonExpression(
+                                ComparisonExpression.Operator.EQUAL,
+                                new Identifier(baseTableColumns.get(baseTable)),
+                                inValue);
+                        if (orExpression == null) {
+                            orExpression = comparison;
+                        }
+                        else {
+                            orExpression = new LogicalBinaryExpression(LogicalBinaryExpression.Operator.OR, orExpression, comparison);
+                        }
+                    }
+                    tablePredicatesBuilder.put(baseTable, orExpression);
+                }
+            }
+            else {
+                SchemaTableName viewName = new SchemaTableName(viewDefinition.getSchema(), viewDefinition.getTable());
+                Expression orExpression = null;
+                for (Expression inValue : inListExpression.getValues()) {
+                    ComparisonExpression comparison = new ComparisonExpression(ComparisonExpression.Operator.EQUAL, value, inValue);
+                    if (orExpression == null) {
+                        orExpression = comparison;
+                    }
+                    else {
+                        orExpression = new LogicalBinaryExpression(LogicalBinaryExpression.Operator.OR, orExpression, comparison);
+                    }
+                }
+                tablePredicatesBuilder.put(viewName, orExpression);
+            }
+
+            return null;
+        }
+
+        @Override
         protected Void visitComparisonExpression(ComparisonExpression node, Void context)
         {
             if (!(node.getLeft() instanceof Identifier || node.getLeft() instanceof DereferenceExpression)) {
-                throw new SemanticException(NOT_SUPPORTED, node.getLeft(), "Only columns specified on literals are supported in WHERE clause.");
+                throw new SemanticException(NOT_SUPPORTED, node.getLeft(), "Only column references are supported on the left side of comparison expressions in WHERE clause.");
             }
             if (!(node.getRight() instanceof Literal)) {
-                throw new SemanticException(NOT_SUPPORTED, node.getRight(), "Only columns specified on literals are supported in WHERE clause.");
+                throw new SemanticException(NOT_SUPPORTED, node.getRight(), "Only literal values are supported on the right side of comparison expressions in WHERE clause.");
             }
-            Supplier<QualifiedName> qualifiedName = () -> {
-                if (node.getLeft() instanceof DereferenceExpression) {
-                    return DereferenceExpression.getQualifiedName((DereferenceExpression) node.getLeft());
-                }
-                return QualifiedName.of(((Identifier) node.getLeft()).getValue());
-            };
+            QualifiedName qualifiedName = node.getLeft() instanceof DereferenceExpression
+                    ? DereferenceExpression.getQualifiedName((DereferenceExpression) node.getLeft())
+                    : QualifiedName.of(((Identifier) node.getLeft()).getValue());
 
-            ResolvedField resolvedField = viewScope.tryResolveField(node.getLeft()).orElseThrow(() -> missingAttributeException(node.getLeft(), qualifiedName.get()));
-            String column = resolvedField.getField().getOriginColumnName().orElseThrow(() -> missingAttributeException(node.getLeft(), qualifiedName.get()));
+            ResolvedField resolvedField = viewScope.tryResolveField(node.getLeft()).orElseThrow(() -> missingAttributeException(node.getLeft(), qualifiedName));
+            String column = resolvedField.getField().getOriginColumnName().orElseThrow(() -> missingAttributeException(node.getLeft(), qualifiedName));
 
             if (!viewDefinition.getValidRefreshColumns().orElse(emptyList()).contains(column)) {
                 throw new SemanticException(NOT_SUPPORTED, node.getLeft(), "Refresh materialized view by column %s is not supported.", node.getLeft().toString());


### PR DESCRIPTION
Summary:
MV refresh needs IN to better support automated refresh.

This PR supports InPredicate by transforming to multiple comparisonExpression connected with OR. Note that we cannot just decompose to comparisonExpressions because they will be connected with AND in getTablePredicates().

Differential Revision: D85317105

```
== RELEASE NOTES ==

Materialized View
* Allow using IN predicates for MV refresh 
```

