### PR TITLE
fix: Fix ApplyConnectorOptimization when having optimizers supporting multiple connectors

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -159,12 +159,13 @@ public class ApplyConnectorOptimization
             }
             optimizersWithConnectorRange.put(currentConnectors, currentGroup.build());
 
-            ImmutableMap.Builder<PlanNode, ConnectorPlanNodeContext> contextMapBuilder = ImmutableMap.builder();
-            buildConnectorPlanNodeContext(plan, null, contextMapBuilder);
-            Map<PlanNode, ConnectorPlanNodeContext> contextMap = contextMapBuilder.build();
             for (Map.Entry<List<ConnectorId>, Set<ConnectorPlanOptimizer>> entry : optimizersWithConnectorRange.build().entrySet()) {
                 // keep track of changed nodes; the keys are original nodes and the values are the new nodes
                 Map<PlanNode, PlanNode> updates = new HashMap<>();
+
+                ImmutableMap.Builder<PlanNode, ConnectorPlanNodeContext> contextMapBuilder = ImmutableMap.builder();
+                buildConnectorPlanNodeContext(plan, null, contextMapBuilder);
+                Map<PlanNode, ConnectorPlanNodeContext> contextMap = contextMapBuilder.build();
 
                 // process connector optimizers
                 for (PlanNode node : contextMap.keySet()) {

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestConnectorOptimization.java
@@ -296,6 +296,28 @@ public class TestConnectorOptimization
                 union(
                         union(
                                 tableScan("cat1", "a", "b"),
+                                tableScan("cat2", "a", "b")),
+                        filter(tableScan("cat1", "a", "b"), TRUE_CONSTANT)),
+                "a");
+
+        actual = optimize(plan, ImmutableMap.of(
+                new ConnectorId("cat1"), ImmutableSet.of(multiConnectorOptimizer12, filterPushdown())));
+
+        assertPlanMatch(
+                actual,
+                PlanMatchPattern.output(
+                        PlanMatchPattern.union(
+                                PlanMatchPattern.union(
+                                        SimpleTableScanMatcher.tableScan("cat1", TRUE_CONSTANT),
+                                        PlanMatchPattern.filter(
+                                                "true",
+                                                SimpleTableScanMatcher.tableScan("cat2", "a", "b"))),
+                                SimpleTableScanMatcher.tableScan("cat1", TRUE_CONSTANT))));
+
+        plan = output(
+                union(
+                        union(
+                                tableScan("cat1", "a", "b"),
                                 tableScan("cat2", "a", "b")), // This union only contains supported connectors
                         tableScan("cat4", "a", "b")), // cat4 in separate part of plan
                 "a");


### PR DESCRIPTION
## Description
PR https://github.com/prestodb/presto/pull/26246 adds support for connector optimizers which process multiple connectors, this PR fix the case where optimizers which have different connector IDs support override the previous optimizers result.
The case which reproduce this case is added in the unit test.

## Motivation and Context

## Impact

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

