### PR TITLE
fix(connector): Fix inconsistent case handling in UPDATE SET column resolution

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2630,6 +2630,26 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
+    public void testUpdateWithDifferentCaseColumnNames()
+    {
+        String tableName = "test_update_case_" + randomTableSuffix();
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (id INT, str1 VARCHAR)");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
+
+            assertUpdate("UPDATE " + tableName + " SET id = 11 WHERE id = 1", 1);
+            assertQuery("SELECT id FROM " + tableName, "VALUES 11");
+
+            assertUpdate("UPDATE " + tableName + " SET ID = 111 WHERE ID = 11", 1);
+            assertQuery("SELECT ID FROM " + tableName, "VALUES 111");
+            assertQuery("SELECT id FROM " + tableName, "VALUES 111");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testUpdateWithPredicates()
     {
         String tableName = "test_update_predicates_" + randomTableSuffix();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2913,14 +2913,14 @@ class StatementAnalyzer
                     .collect(toImmutableMap(ColumnMetadata::getName, Function.identity()));
 
             for (UpdateAssignment assignment : update.getAssignments()) {
-                String columnName = assignment.getName().getValue();
+                String columnName = metadata.normalizeIdentifier(session, tableName.getCatalogName(), assignment.getName().getValue());
                 if (!columns.containsKey(columnName)) {
                     throw new SemanticException(MISSING_COLUMN, assignment.getName(), "The UPDATE SET target column %s doesn't exist", columnName);
                 }
             }
 
             Set<String> assignmentTargets = update.getAssignments().stream()
-                    .map(assignment -> assignment.getName().getValue())
+                    .map(assignment -> metadata.normalizeIdentifier(session, tableName.getCatalogName(), assignment.getName().getValue()))
                     .collect(toImmutableSet());
             accessControl.checkCanUpdateTableColumns(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), tableName, assignmentTargets);
 
@@ -2954,7 +2954,7 @@ class StatementAnalyzer
             List<Type> expressionTypes = expressionTypesBuilder.build();
 
             List<Type> tableTypes = update.getAssignments().stream()
-                    .map(assignment -> requireNonNull(columns.get(assignment.getName().getValue())))
+                    .map(assignment -> requireNonNull(columns.get(metadata.normalizeIdentifier(session, tableName.getCatalogName(), assignment.getName().getValue()))))
                     .map(ColumnMetadata::getType)
                     .collect(toImmutableList());
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -511,7 +511,7 @@ public class LogicalPlanner
                 .filter(column -> !column.isHidden())
                 .collect(toImmutableList());
         List<String> targetColumnNames = node.getAssignments().stream()
-                .map(assignment -> assignment.getName().getValue())
+                .map(assignment -> metadata.normalizeIdentifier(session, handle.getConnectorId().getCatalogName(), assignment.getName().getValue()))
                 .collect(toImmutableList());
 
         for (ColumnMetadata columnMetadata : dataColumns) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -318,8 +318,9 @@ class QueryPlanner
                 .collect(toImmutableList());
         handle = metadata.beginUpdate(session, handle, updatedColumns);
 
+        String catalogName = handle.getConnectorId().getCatalogName();
         List<String> targetColumnNames = node.getAssignments().stream()
-                .map(assignment -> assignment.getName().getValue())
+                .map(assignment -> metadata.normalizeIdentifier(session, catalogName, assignment.getName().getValue()))
                 .collect(toImmutableList());
 
         // Create lists of columnnames and SET expressions, in table column order


### PR DESCRIPTION
## Description
Fix inconsistent case handling in UPDATE SET column resolution

## Motivation and Context
Fix inconsistent case handling in UPDATE SET column resolution

## Impact
Fixes - https://github.com/prestodb/presto/issues/26433 https://github.com/prestodb/presto/issues/26354

## Test Plan
Tests added in Iceberg connector

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

