### PR TITLE
feat(native-pos): Add velox runtime metrics support for shuffle read

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
@@ -82,6 +82,15 @@ ShuffleExchangeSource::requestDataSizes(std::chrono::microseconds /*maxWait*/) {
   return folly::makeSemiFuture(Response{0, atEnd_, std::move(remainingBytes)});
 }
 
+bool ShuffleExchangeSource::supportsMetrics() const {
+  return shuffleReader_->supportsMetrics();
+}
+
+folly::F14FastMap<std::string, velox::RuntimeMetric>
+ShuffleExchangeSource::metrics() const {
+  return shuffleReader_->metrics();
+}
+
 folly::F14FastMap<std::string, int64_t> ShuffleExchangeSource::stats() const {
   return shuffleReader_->stats();
 }

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.h
@@ -68,6 +68,10 @@ class ShuffleExchangeSource : public velox::exec::ExchangeSource {
 
   folly::F14FastMap<std::string, int64_t> stats() const override;
 
+  bool supportsMetrics() const override;
+
+  folly::F14FastMap<std::string, velox::RuntimeMetric> metrics() const override;
+
   /// url needs to follow below format:
   /// batch://<taskid>?shuffleInfo=<serialized-shuffle-info>
   static std::shared_ptr<velox::exec::ExchangeSource> createExchangeSource(

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -57,6 +57,16 @@ class ShuffleReader {
 
   /// Runtime statistics.
   virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
+
+  /// Returns true if the shuffle reader supports Velox runtime metrics.
+  virtual bool supportsMetrics() const {
+    return false;
+  }
+
+  /// Returns statistics in the form of Velox runtime metrics.
+  virtual folly::F14FastMap<std::string, velox::RuntimeMetric> metrics() const {
+    VELOX_NYI();
+  }
 };
 
 class ShuffleInterfaceFactory {


### PR DESCRIPTION
Summary: Add velox runtime metrics API for shuffle read.

Reviewed By: xiaoxmeng

Differential Revision: D85281302

```
== NO RELEASE NOTE ==
