### PR TITLE
fix: Add P4HyperLogLog to NativeTypeManager

### DIFF
--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.common.type.StandardTypes.IPADDRESS;
 import static com.facebook.presto.common.type.StandardTypes.IPPREFIX;
 import static com.facebook.presto.common.type.StandardTypes.JSON;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.P4_HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.StandardTypes.QDIGEST;
 import static com.facebook.presto.common.type.StandardTypes.REAL;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
@@ -90,6 +91,7 @@ public class NativeTypeManager
                     DOUBLE,
                     SMALLINT,
                     HYPER_LOG_LOG,
+                    P4_HYPER_LOG_LOG,
                     JSON,
                     TIMESTAMP_WITH_TIME_ZONE,
                     UUID,

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sidecar;
 
 import com.facebook.airlift.units.DataSize;
 import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
 import com.facebook.presto.scalar.sql.NativeSqlInvokedFunctionsPlugin;
 import com.facebook.presto.scalar.sql.SqlInvokedFunctionsPlugin;
@@ -42,6 +43,7 @@ import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -52,12 +54,15 @@ import static com.facebook.presto.SystemSessionProperties.KEY_BASED_SAMPLING_ENA
 import static com.facebook.presto.SystemSessionProperties.REMOVE_MAP_CAST;
 import static com.facebook.presto.common.Utils.checkArgument;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createCustomer;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersEx;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createRegion;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -620,6 +625,25 @@ public class TestNativeSidecarPlugin
         assertQueryFails(session,
                 "select count(1) FROM lineitem l left JOIN orders o ON l.orderkey = o.orderkey JOIN customer c ON o.custkey = c.custkey",
                 ".*Scalar function name not registered: native.default.key_sampling_percent.*");
+    }
+
+    @Test
+    public void testP4HyperLogLogWithApproxSet()
+    {
+        // Map each SQL type to its expected NDV.
+        Map<Type, Long> typeToNdvMap = ImmutableMap.of(
+                BIGINT, 1002L,
+                VARCHAR, 1024L,
+                DOUBLE, 1014L);
+        for (Map.Entry<Type, Long> entry : typeToNdvMap.entrySet()) {
+            Type type = entry.getKey();
+            Long expectedNdv = entry.getValue();
+            MaterializedResult actual = computeActual(String.format("SELECT cardinality(cast(approx_set(cast(custkey AS %s)) AS P4HYPERLOGLOG)) FROM orders", type.getTypeSignature().toString()));
+            MaterializedResult expectedResult = resultBuilder(getSession(), BIGINT)
+                    .row(expectedNdv)
+                    .build();
+            assertEquals(actual.getMaterializedRows(), expectedResult.getMaterializedRows());
+        }
     }
 
     private String generateRandomTableName()


### PR DESCRIPTION
## Description
P4HyperLogLog type was added to Velox recently in https://github.com/facebookincubator/velox/pull/14626/commits/75ec5ba6141e08622874b207e01797f1f851b64a, and this type should be supported by `NativeTypeManager`.

## Motivation and Context
Support P4HLL type in `NativeTypeManager`, uncovered by `native-tests` in #23671.

## Impact
Support P4HLL in Presto C++ clusters with sidecar.

## Test Plan
Added tests.

```
== NO RELEASE NOTE ==
```

