### PR TITLE
feat(plugin-hive): Add support for skip_header_line_count and skip_footer_line_count table properties

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -253,6 +253,14 @@ Property Name                                            Description            
                                                          reading an Avro-formatted table. If specified, Presto will fetch                override schema)
                                                          and use this schema instead of relying on any schema in the
                                                          Metastore.
+
+``skip_header_line_count``                               Number of header lines to skip when reading CSV or TEXTFILE tables.             None (ignored if not set). Must be non-negative. Only valid for
+                                                         When set to ``1``, a header row will be written when creating new               CSV and TEXTFILE formats. Values greater than ``1`` are not
+                                                         CSV or TEXTFILE tables.                                                         supported for ``CREATE TABLE AS`` or ``INSERT`` operations.
+
+``skip_footer_line_count``                               Number of footer lines to skip when reading CSV or TEXTFILE tables.             None (ignored if not set). Must be non-negative. Only valid for
+                                                         Cannot be used when inserting into a table.                                     CSV and TEXTFILE formats. This property is not
+                                                                                                                                         supported for ``CREATE TABLE AS`` or ``INSERT`` operations.
 ======================================================== ============================================================================== ======================================================================================
 
 Hive Metastore Configuration for Avro

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
@@ -57,6 +57,8 @@ public class HiveTableProperties
     public static final String CSV_SEPARATOR = "csv_separator";
     public static final String CSV_QUOTE = "csv_quote";
     public static final String CSV_ESCAPE = "csv_escape";
+    public static final String SKIP_HEADER_LINE_COUNT = "skip_header_line_count";
+    public static final String SKIP_FOOTER_LINE_COUNT = "skip_footer_line_count";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -155,6 +157,8 @@ public class HiveTableProperties
                 stringProperty(CSV_SEPARATOR, "CSV separator character", null, false),
                 stringProperty(CSV_QUOTE, "CSV quote character", null, false),
                 stringProperty(CSV_ESCAPE, "CSV escape character", null, false),
+                integerProperty(SKIP_HEADER_LINE_COUNT, "Number of header lines", null, false),
+                integerProperty(SKIP_FOOTER_LINE_COUNT, "Number of footer lines", null, false),
                 new PropertyMetadata<>(
                         ENCRYPT_COLUMNS,
                         "List of key references and columns being encrypted. Example: ARRAY['key1:col1,col2', 'key2:col3,col4']",
@@ -289,5 +293,15 @@ public class HiveTableProperties
     {
         return tableProperties.containsKey(ENCRYPT_COLUMNS) ? (ColumnEncryptionInformation) tableProperties.get(ENCRYPT_COLUMNS) :
                 ColumnEncryptionInformation.fromMap(ImmutableMap.of());
+    }
+
+    public static Optional<Integer> getHeaderSkipCount(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((Integer) tableProperties.get(SKIP_HEADER_LINE_COUNT));
+    }
+
+    public static Optional<Integer> getFooterSkipCount(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((Integer) tableProperties.get(SKIP_FOOTER_LINE_COUNT));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/RecordFileWriter.java
@@ -26,6 +26,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
+import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.Serializer;
 import org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe;
@@ -100,10 +101,17 @@ public class RecordFileWriter
             serDe = OptimizedLazyBinaryColumnarSerde.class.getName();
         }
         serializer = initializeSerializer(conf, schema, serDe);
-        recordWriter = createRecordWriter(path, conf, schema, storageFormat.getOutputFormat(), session);
 
         List<ObjectInspector> objectInspectors = getRowColumnInspectors(fileColumnTypes);
         tableInspector = getStandardStructObjectInspector(fileColumnNames, objectInspectors);
+
+        if (storageFormat.getOutputFormat().equals(HiveIgnoreKeyTextOutputFormat.class.getName())) {
+            Optional<TextCSVHeaderWriter> textHeaderWriter = Optional.of(new TextCSVHeaderWriter(serializer, typeManager, session, fileColumnNames));
+            recordWriter = createRecordWriter(path, conf, schema, storageFormat.getOutputFormat(), session, textHeaderWriter);
+        }
+        else {
+            recordWriter = createRecordWriter(path, conf, schema, storageFormat.getOutputFormat(), session, Optional.empty());
+        }
 
         // reorder (and possibly reduce) struct fields to match input
         structFields = ImmutableList.copyOf(inputColumnNames.stream()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/TextCSVHeaderWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/TextCSVHeaderWriter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.ConnectorSession;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.Serializer;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
+import org.apache.hadoop.io.BinaryComparable;
+import org.apache.hadoop.io.Text;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.hive.HiveWriteUtils.getRowColumnInspector;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TextCSVHeaderWriter
+{
+    private final Serializer serializer;
+    private final Type headerType;
+    private final List<String> fileColumnNames;
+    public TextCSVHeaderWriter(Serializer serializer, TypeManager typeManager, ConnectorSession session, List<String> fileColumnNames)
+    {
+        this.serializer = serializer;
+        this.fileColumnNames = fileColumnNames;
+        this.headerType = HiveType.valueOf("string").getType(typeManager);
+    }
+
+    public void write(OutputStream compressedOutput, int rowSeparator)
+            throws IOException
+    {
+        try {
+            ObjectInspector stringObjectInspector = getRowColumnInspector(headerType);
+            List<Text> headers = fileColumnNames.stream().map(Text::new).collect(toImmutableList());
+            List<ObjectInspector> inspectors = IntStream.range(0, fileColumnNames.size()).mapToObj(ignored -> stringObjectInspector).collect(toImmutableList());
+            StandardStructObjectInspector headerStructObjectInspectors = ObjectInspectorFactory.getStandardStructObjectInspector(fileColumnNames, inspectors);
+            BinaryComparable binary = (BinaryComparable) serializer.serialize(headers, headerStructObjectInspectors);
+            compressedOutput.write(binary.getBytes(), 0, binary.getLength());
+            compressedOutput.write(rowSeparator);
+        }
+        catch (SerDeException e) {
+            throw new IOException(e);
+        }
+    }
+}


### PR DESCRIPTION
…hive

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
Hive Connector Changes
* Add support for skip_header_line_count and skip_footer_line_count
```
