### PR TITLE
refactor: Remove unnecessary BroadcastFactory

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -14,7 +14,6 @@
 #include <fmt/format.h>
 #include <folly/Uri.h>
 
-#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/operators/BroadcastExchangeSource.h"
 
 using namespace facebook::velox;
@@ -133,12 +132,14 @@ BroadcastExchangeSource::createExchangeSource(
     VELOX_USER_FAIL("BroadcastInfo deserialization failed: {}", e.what());
   }
 
-  auto fileSystemBroadcast = BroadcastFactory(broadcastFileInfo->filePath_);
+  auto fileSystem =
+      velox::filesystems::getFileSystem(broadcastFileInfo->filePath_, nullptr);
   return std::make_shared<BroadcastExchangeSource>(
       uri.host(),
       destination,
       queue,
-      fileSystemBroadcast.createReader(std::move(broadcastFileInfo), pool),
+      std::make_shared<BroadcastFileReader>(
+          broadcastFileInfo, fileSystem, pool),
       pool);
 }
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.h
@@ -13,10 +13,9 @@
  */
 #pragma once
 
-#include "presto_cpp/main/operators/BroadcastFactory.h"
-#include "velox/core/PlanNode.h"
-#include "velox/exec/Exchange.h"
-#include "velox/exec/Operator.h"
+#include "presto_cpp/main/operators/BroadcastFile.h"
+#include "velox/exec/ExchangeQueue.h"
+#include "velox/exec/ExchangeSource.h"
 
 namespace facebook::presto::operators {
 

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFile.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFile.h
@@ -118,27 +118,4 @@ class BroadcastFileReader {
   uint32_t numPagesRead_{0};
   std::vector<int64_t> pageSizes_;
 };
-
-/// Factory to create Writers & Reader for file based broadcast.
-class BroadcastFactory {
- public:
-  /// Create FileBroadcast to write files under specified basePath.
-  BroadcastFactory(const std::string& basePath);
-
-  virtual ~BroadcastFactory() = default;
-
-  std::unique_ptr<BroadcastFileWriter> createWriter(
-      uint64_t writeBufferSize,
-      uint64_t maxBroadcastBytes,
-      velox::memory::MemoryPool* pool,
-      std::unique_ptr<velox::VectorSerde::Options> serdeOptions);
-
-  std::shared_ptr<BroadcastFileReader> createReader(
-      const std::unique_ptr<BroadcastFileInfo> fileInfo,
-      velox::memory::MemoryPool* pool);
-
- private:
-  const std::string basePath_;
-  std::shared_ptr<velox::filesystems::FileSystem> fileSystem_;
-};
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/operators/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(
   ShuffleWrite.cpp
   LocalShuffle.cpp
   BroadcastWrite.cpp
-  BroadcastFactory.cpp
+  BroadcastFile.cpp
   BroadcastExchangeSource.cpp
   BinarySortableSerializer.cpp
 )

--- a/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
@@ -15,6 +15,7 @@
 #include <folly/Uri.h>
 #include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/operators/BroadcastExchangeSource.h"
+#include "presto_cpp/main/operators/BroadcastFile.h"
 #include "presto_cpp/main/operators/BroadcastWrite.h"
 #include "presto_cpp/main/operators/tests/PlanBuilder.h"
 #include "velox/buffer/Buffer.h"
@@ -22,6 +23,8 @@
 #include "velox/common/compression/Compression.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/exec/Exchange.h"
+#include "velox/exec/ExchangeSource.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"


### PR DESCRIPTION
Summary: Broadcast reader/writer is not used in a factory framework so there is no need to have a factory class.

Differential Revision: D85187166

```
== NO RELEASE NOTE ==
```
