### PR TITLE
facebook-single-target- clang-tidy checks causing crash

### DIFF
--- a/presto-native-execution/.clang-tidy
+++ b/presto-native-execution/.clang-tidy
@@ -16,6 +16,8 @@ Checks: >
   -cppcoreguidelines-pro-type-vararg,
   -cppcoreguidelines-pro-type-vararg,
   -cppcoreguidelines-special-member-functions,
+  -facebook-single-target-typedef-spreader,
+  -facebook-single-target-map-usage-validator,
   -fuchsia-*,
   -google-*,
   -hicpp-avoid-c-arrays,


### PR DESCRIPTION
Summary:
D85480482 added a new .clang-tidy file under fbcode/github/presto-trunk/presto-native-execution/.clang-tidy which is causing C++ extension to crash when open files under this folder e.g. fbcode/github/presto-trunk/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.cpp

From clangd log, it shows "LLVM ERROR: No target typedef name provided"

The offending clang-tidy rules should be:
  -facebook-single-target-typedef-spreader,
  -facebook-single-target-map-usage-validator,

I'm temporarily excluding these two checks to unblock the user. 

Also add DenisYaroshevskiy who recently made changes to these two checks for fixing the rules, clang-tidy checks are not intended to fail with fatal errors

Reviewed By: DenisYaroshevskiy, duxiao1212

Differential Revision: D85637495


