### PR TITLE
fix: Add type check for ReplaceConstantVariableReferencesWithConstants

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ReplaceConstantVariableReferencesWithConstants.java
@@ -202,7 +202,7 @@ public class ReplaceConstantVariableReferencesWithConstants
                             if (newConstantMap.containsKey(variable) && !newConstantMap.get(variable).equals(constant)) {
                                 return new PlanNodeWithConstant(replaceChildren(node, ImmutableList.of(rewrittenChild.getPlanNode())), ImmutableMap.of());
                             }
-                            if (!constant.isNull()) {
+                            if (!constant.isNull() && variable.getType().equals(constant.getType())) {
                                 planChanged = true;
                                 newConstantMap.put(variable, constant);
                             }
@@ -235,7 +235,7 @@ public class ReplaceConstantVariableReferencesWithConstants
             for (Map.Entry<VariableReferenceExpression, RowExpression> entry : newProjectNode.getAssignments().getMap().entrySet()) {
                 if (entry.getValue() instanceof ConstantExpression && isSupportedType(entry.getKey()) && isSupportedType(entry.getValue())) {
                     ConstantExpression constantExpression = (ConstantExpression) entry.getValue();
-                    if (!constantExpression.isNull()) {
+                    if (!constantExpression.isNull() && entry.getKey().getType().equals(constantExpression.getType())) {
                         planChanged = true;
                         newConstantMap.put(entry.getKey(), constantExpression);
                     }


### PR DESCRIPTION
## Description
As title. 
So this optimizer is trying to connect variables and its value if the variable will be a constant due to filter/project assignment etc.
In production, we see query which have this optimizer failing because the variable is of type varchar but the constant is of type varchar(4), and it fails when we do the assert that the constant and variable are of the same type in the end of the optimization. To avoid query failure, this PR adds a check before adding the varchar and constant mapping.

## Motivation and Context

## Impact

## Test Plan
I tried to reproduce this with open source dataset, but not easy as it is due to some internal function related stuff. Anyway this change is a safe change without any adverse impact.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

