### PR TITLE
fix(ci): Fix flaky test BroadcastTest.endToEndWithMultipleWriteNodes

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
@@ -66,6 +66,14 @@ class BroadcastTest : public exec::test::OperatorTestBase,
         BroadcastExchangeSource::createExchangeSource);
   }
 
+  void TearDown() override {
+    exec::test::waitForAllTasksToBeDeleted();
+    executor_.reset();
+    pool_.reset();
+    rootPool_.reset();
+    resetMemory();
+  }
+
   std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
       common::CompressionKind compressionKind) {
     std::unique_ptr<VectorSerde::Options> options = std::make_unique<


### PR DESCRIPTION
Summary:
X-link: https://github.com/prestodb/presto/pull/26461

Fix flaky stress test buck2 test //github/presto-trunk/presto-native-execution/presto_cpp/main/operators/tests:presto_operators_test -- 'BroadcastTest.endToEndWithMultipleWriteNodes/zstd' --stress-runs 100

BroadcastTestParam::TearDown() inherited from OperatorTestBase [https://www.internalfb.com/code/fbsource/[37f968940832]/fbcode/velox/exec/tests/utils/OperatorTestBase.cpp?lines=153](https://www.internalfb.com/code/fbsource/%5B37f968940832%5D/fbcode/velox/exec/tests/utils/OperatorTestBase.cpp?lines=153) ,

Added executor_.reset() to fix the flakness.

Task::addExchangeClientPool() creates leaf pool. BroadcastExchangeSource's async work on executor_ captures shared_ptr with buffers allocated from this pool. We need release the leaf pool before resetMemory to avoid arbitrary memory check failure.

The reference chain is: exchangeClient.0.0 [shared_ptr] → node.0 [shared_ptr] → query..2

Without the fix, the destructor of the leaf pool was handled asynchronously in another thread, so that exchangeClient.0.0 pool may be destroyed AFTER SharedArbitrator::shutdown(). executor_.reset() blocks and waits for all queued async work to complete, which includes the ExchangeSource cleanup that eventually destroys the exchangeClient.0.0 leaf pool. This ensures the pool hierarchy is fully cleaned up before OperatorTestBase::TearDown() runs SharedArbitrator::shutdown().

Reviewed By: xiaoxmeng

Differential Revision: D85685549
```
== NO RELEASE NOTE ==
```


Differential Revision: D85685549


