### PR TITLE
feat: Add array_transpose SQL function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -258,6 +258,17 @@ Array Functions
         SELECT array_top_n(ARRAY [1, 100], 5); -- [100, 1]
         SELECT array_top_n(ARRAY ['a', 'zzz', 'zz', 'b', 'g', 'f'], 3); -- ['zzz', 'zz', 'g']
 
+.. function:: array_transpose(array(array(T))) -> array(array(T))
+
+    Returns a transpose of a 2D array (matrix), where rows become columns and columns become rows.
+    Converts ``a[x][y]`` to ``transpose(a)[y][x]``. All rows in the input array must have the same length, otherwise the function will fail with an error.
+    Returns an empty array if the input is empty or if all rows are empty. ::
+
+        SELECT array_transpose(ARRAY [ARRAY [1, 2, 3], ARRAY [4, 5, 6]]) -- [[1, 4], [2, 5], [3, 6]]
+        SELECT array_transpose(ARRAY [ARRAY ['a', 'b'], ARRAY ['c', 'd'], ARRAY ['e', 'f']]) -- [['a', 'c', 'e'], ['b', 'd', 'f']]
+        SELECT array_transpose(ARRAY [ARRAY [1]]) -- [[1]]
+        SELECT array_transpose(ARRAY []) -- []
+
 .. function:: arrays_overlap(x, y) -> boolean
 
     Tests if arrays ``x`` and ``y`` have any non-null elements in common.

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
@@ -401,4 +401,17 @@ public class TestArraySqlFunctions
         assertFunction("ARRAY_TOP_N(ARRAY [], 3)", new ArrayType(UNKNOWN), emptyList());
         assertFunction("ARRAY_TOP_N(ARRAY [1, 4], 3)", new ArrayType(INTEGER), ImmutableList.of(4, 1));
     }
+
+    @Test
+    public void testArrayTranspose()
+    {
+        assertFunction("ARRAY_TRANSPOSE(ARRAY[ARRAY[1, 2, 3], ARRAY[4, 5, 6]])", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(1, 4), ImmutableList.of(2, 5), ImmutableList.of(3, 6)));
+        assertFunction("ARRAY_TRANSPOSE(ARRAY[ARRAY[1]])", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(1)));
+        assertFunction("ARRAY_TRANSPOSE(ARRAY[])", new ArrayType(new ArrayType(UNKNOWN)), emptyList());
+        assertFunction("ARRAY_TRANSPOSE(ARRAY[ARRAY[VARCHAR 'a', VARCHAR 'b'], ARRAY[VARCHAR 'c', VARCHAR 'd'], ARRAY[VARCHAR 'e', VARCHAR 'f']])", new ArrayType(new ArrayType(VARCHAR)), ImmutableList.of(ImmutableList.of("a", "c", "e"), ImmutableList.of("b", "d", "f")));
+        assertFunction("array_transpose(array[array[1, null, 3], array[4, 5, null]])", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(1, 4), asList(null, 5), asList(3, null)));
+        assertFunction("array_transpose(array_transpose(array[array[1, 2, 3], array[4, 5, 6]]))", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(1, 2, 3), ImmutableList.of(4, 5, 6)));
+
+        assertInvalidFunction("array_transpose(array[array[1, 2, 3], array[4, 5]])", StandardErrorCode.GENERIC_USER_ERROR, "All rows must have the same length for matrix transpose");
+    }
 }

--- a/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/ArraySqlFunctions.java
+++ b/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/ArraySqlFunctions.java
@@ -174,4 +174,17 @@ public class ArraySqlFunctions
     {
         return "RETURN IF(n < 0, fail('Parameter n: ' || cast(n as varchar) || ' to ARRAY_TOP_N is negative'), SLICE(REVERSE(ARRAY_SORT(input, f)), 1, n))";
     }
+
+    @SqlInvokedScalarFunction(value = "array_transpose", deterministic = true, calledOnNullInput = false)
+    @Description("Transposes a 2D array (matrix) such that a[x][y] = transpose(a)[y][x]. All rows must have the same length.")
+    @TypeParameter("T")
+    @SqlParameter(name = "input", type = "array(array(T))")
+    @SqlType("array(array(T))")
+    public static String arrayTranspose()
+    {
+        return "RETURN IF(cardinality(input) = 0, input, " +
+                "IF(any_match(input, row -> cardinality(row) != cardinality(input[1])), " +
+                "fail('All rows must have the same length for matrix transpose'), " +
+                "transform(sequence(1, cardinality(input[1])), x -> transform(input, y -> y[x]))))";
+    }
 }


### PR DESCRIPTION
## Description
Adds a new SQL-invoked function `array_transpose` that transposes 2D arrays (matrices). Transforms a 2D array such that `a[x][y]` becomes `transpose(a)[y][x]`

## Motivation and Context
Matrix transposition is a common operation in data analysis and transformations. This function provides a convenient SQL builtin for transposing 2D arrays without requiring complex nested queries or external processing.

## Test Plan
Test are passing

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* add :func:`array_transpose` to return a transpose of an array.

