### PR TITLE
fix: Default to utilizing all columns for UPDATE, DELETE and ANALYZE queries

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/UtilizedColumnsAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/UtilizedColumnsAnalyzer.java
@@ -14,14 +14,17 @@
 package com.facebook.presto.sql.analyzer;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.NotSupportedException;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.AccessControlInfo;
 import com.facebook.presto.sql.tree.AliasedRelation;
+import com.facebook.presto.sql.tree.Analyze;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Delete;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Except;
 import com.facebook.presto.sql.tree.ExistsPredicate;
@@ -51,6 +54,7 @@ import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
 import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.Unnest;
+import com.facebook.presto.sql.tree.Update;
 import com.facebook.presto.sql.tree.Values;
 import com.facebook.presto.sql.tree.With;
 import com.facebook.presto.sql.tree.WithQuery;
@@ -475,6 +479,30 @@ public class UtilizedColumnsAnalyzer
             handleExpression(fieldReference, context);
 
             return null;
+        }
+
+        //TODO : Add actual fixes for these nodes https://github.com/prestodb/presto/issues/26466
+        @Override
+        protected Void visitUpdate(Update node, Context context)
+        {
+            return notSupportedNode(node);
+        }
+
+        @Override
+        protected Void visitDelete(Delete node, Context context)
+        {
+            return notSupportedNode(node);
+        }
+
+        @Override
+        protected Void visitAnalyze(Analyze node, Context context)
+        {
+            return notSupportedNode(node);
+        }
+
+        public Void notSupportedNode(Node node)
+        {
+            throw new NotSupportedException(String.format("Utilized Column check not implemented for : %s", node));
         }
 
         private void handleRelation(Relation relation, Context context, Relation... children)


### PR DESCRIPTION
for access control checks

## Motivation and Context
This is a partial fix for https://github.com/prestodb/presto/issues/26466

## Impact
UPDATE, DELETE and ANALYZE queries will have their relevant columns passed to the SAC APIs
Without this, empty column lists were being passed

## Test Plan
New unit test added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

