### PR TITLE
fix(docs): Formatting in connector/mongodb.rst

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -60,7 +60,7 @@ Property Name                         Description                               
                                       table, and column names for the connector. When disabled,
                                       names are matched case-insensitively using lowercase
                                       normalization. Default is ``false``
-===================================== ==============================================================
+===================================== ============================================================== ===========
 
 ``mongodb.seeds``
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
The formatting of the table in [Configuration Properties](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/connector/mongodb.rst#configuration-properties) in connector/mongodb.rst was incorrect. 

## Motivation and Context
The formatting error causes the table in lines 37-63 of [Configuration Properties](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/connector/mongodb.rst#configuration-properties) to not be displayed in the documentation. 

## Impact
Documentation.

## Test Plan
Local doc build. 

Before, this error appears and the table is not visible in a local doc build. 

`ERROR: Malformed table.
Bottom/header table border does not match top border.`

After, the error does not appear and the table is visible in a local doc build. 
## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

