### PR TITLE
fix(native): Map more velox user errors to protocol user error codes

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Exception.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Exception.cpp
@@ -97,6 +97,14 @@ VeloxToPrestoExceptionTranslator::translateMap() {
             {velox::error_code::kArithmeticError,
              {0x00000000,
               "GENERIC_USER_ERROR",
+              protocol::ErrorType::USER_ERROR}},
+            {velox::error_code::kSchemaMismatch,
+             {0x00000000,
+              "GENERIC_USER_ERROR",
+              protocol::ErrorType::USER_ERROR}},
+            {velox::error_code::kInvalidArgument,
+             {0x00000000,
+              "GENERIC_USER_ERROR",
               protocol::ErrorType::USER_ERROR}}}},
 
           {velox::error_source::kErrorSourceSystem, {}}};


### PR DESCRIPTION
Updating user error with

kSchemaMismatch
https://github.com/facebookincubator/velox/blob/de0300697ddac129e921d13051b8755f2cfa9214/velox/common/base/Exceptions.h#L274

and
kInvalidArgument
https://github.com/facebookincubator/velox/blob/de0300697ddac129e921d13051b8755f2cfa9214/velox/common/base/VeloxException.h#L319

This allows proper classification for reporting error category, otherwise errors fall down to generic internal error.

```
== NO RELEASE NOTE ==
```
