### PR TITLE
feat: Add RemoveInsensitiveAggregateDistinct rule

### DIFF
--- a/presto-built-in-worker-function-tools/src/main/java/com/facebook/presto/builtin/tools/WorkerFunctionUtil.java
+++ b/presto-built-in-worker-function-tools/src/main/java/com/facebook/presto/builtin/tools/WorkerFunctionUtil.java
@@ -62,7 +62,7 @@ public class WorkerFunctionUtil
                 jsonBasedUdfFunctionMetaData.getAggregateMetadata()
                         .map(metadata -> new AggregationFunctionMetadata(
                                 convertApplicableTypeToVariable(metadata.getIntermediateType()),
-                                metadata.isOrderSensitive()));
+                                metadata.isOrderSensitive(), metadata.isDistinctSensitive()));
 
         return new SqlInvokedFunction(
                 qualifiedFunctionName,

--- a/presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -368,6 +368,7 @@ public abstract class AbstractSqlInvokedFunctionNamespaceManager
                         typeManager.getType(aggregationMetadata.getIntermediateType()),
                         typeManager.getType(function.getSignature().getReturnType()),
                         aggregationMetadata.isOrderSensitive(),
+                        aggregationMetadata.isDistinctSensitive(),
                         parameters);
             default:
                 throw new IllegalStateException(format("Unknown function implementation type: %s", implementationType));

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/aggregation/HiveAggregationFunctionDescription.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/aggregation/HiveAggregationFunctionDescription.java
@@ -29,6 +29,7 @@ public class HiveAggregationFunctionDescription
     private final Type finalType;
     private final boolean decomposable;
     private final boolean orderSensitive;
+    private final boolean distinctSensitive;
 
     public HiveAggregationFunctionDescription(
             QualifiedObjectName name,
@@ -36,7 +37,8 @@ public class HiveAggregationFunctionDescription
             List<Type> intermediateTypes,
             Type finalType,
             boolean decomposable,
-            boolean orderSensitive)
+            boolean orderSensitive,
+            boolean distinctSensitive)
     {
         this.name = requireNonNull(name);
         this.parameterTypes = requireNonNull(parameterTypes);
@@ -44,6 +46,7 @@ public class HiveAggregationFunctionDescription
         this.finalType = requireNonNull(finalType);
         this.decomposable = decomposable;
         this.orderSensitive = orderSensitive;
+        this.distinctSensitive = distinctSensitive;
     }
 
     public String getName()
@@ -74,5 +77,10 @@ public class HiveAggregationFunctionDescription
     public boolean isOrderSensitive()
     {
         return orderSensitive;
+    }
+
+    public boolean isDistinctSensitive()
+    {
+        return distinctSensitive;
     }
 }

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/aggregation/HiveAggregationFunctionImplementation.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/aggregation/HiveAggregationFunctionImplementation.java
@@ -107,6 +107,12 @@ public class HiveAggregationFunctionImplementation
         return aggregationFunctionDescription.isOrderSensitive();
     }
 
+    @Override
+    public boolean isDistinctSensitive()
+    {
+        return aggregationFunctionDescription.isDistinctSensitive();
+    }
+
     public AggregationMetadata getAggregationMetadata()
     {
         return aggregationMetadata;

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/aggregation/HiveAggregationFunctionImplementationFactory.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/aggregation/HiveAggregationFunctionImplementationFactory.java
@@ -76,7 +76,8 @@ public class HiveAggregationFunctionImplementationFactory
                 ImmutableList.of(intermediateType),
                 outputType,
                 true,
-                false);
+                false,
+                true);
 
         HiveAccumulatorInvoker invocationContext = new HiveAccumulatorInvoker(
                 partialEvaluatorSupplier,

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInSpecialFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInSpecialFunctionNamespaceManager.java
@@ -253,6 +253,7 @@ public abstract class BuiltInSpecialFunctionNamespaceManager
                 typeManager.getType(aggregationMetadata.getIntermediateType()),
                 typeManager.getType(function.getSignature().getReturnType()),
                 aggregationMetadata.isOrderSensitive(),
+                aggregationMetadata.isDistinctSensitive(),
                 parameters);
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
@@ -163,7 +163,7 @@ public abstract class AbstractMinMaxAggregationFunction
                 metadata,
                 classLoader);
         return new BuiltInAggregationFunctionImplementation(getSignature().getNameSuffix(), inputTypes, ImmutableList.of(intermediateType),
-                type, true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+                type, true, false, false, metadata, accumulatorClass, groupedAccumulatorClass);
     }
 
     protected AccumulatorStateSerializer<?> getStateSerializer(Class<? extends AccumulatorState> stateInterface, DynamicClassLoader classLoader)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -142,6 +142,7 @@ public class AggregationFromAnnotationsParser
                 parseDescription(aggregationDefinition),
                 aggregationAnnotation.decomposable(),
                 aggregationAnnotation.isOrderSensitive(),
+                aggregationAnnotation.isDistinctSensitive(),
                 aggregationAnnotation.visibility(),
                 aggregationAnnotation.isCalledOnNullInput());
     }
@@ -157,6 +158,7 @@ public class AggregationFromAnnotationsParser
                                 parseDescription(aggregationDefinition, toParse),
                                 aggregationAnnotation.decomposable(),
                                 aggregationAnnotation.isOrderSensitive(),
+                                aggregationAnnotation.isDistinctSensitive(),
                                 aggregationAnnotation.visibility(),
                                 aggregationAnnotation.isCalledOnNullInput()))
                 .collect(toImmutableList());

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AggregationHeader.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/AggregationHeader.java
@@ -25,15 +25,17 @@ public class AggregationHeader
     private final Optional<String> description;
     private final boolean decomposable;
     private final boolean orderSensitive;
+    private final boolean distinctSensitive;
     private final SqlFunctionVisibility visibility;
     private final boolean isCalledOnNullInput;
 
-    public AggregationHeader(String name, Optional<String> description, boolean decomposable, boolean orderSensitive, SqlFunctionVisibility visibility, boolean isCalledOnNullInput)
+    public AggregationHeader(String name, Optional<String> description, boolean decomposable, boolean orderSensitive, boolean distinctSensitive, SqlFunctionVisibility visibility, boolean isCalledOnNullInput)
     {
         this.name = requireNonNull(name, "name cannot be null");
         this.description = requireNonNull(description, "description cannot be null");
         this.decomposable = decomposable;
         this.orderSensitive = orderSensitive;
+        this.distinctSensitive = distinctSensitive;
         this.visibility = visibility;
         this.isCalledOnNullInput = isCalledOnNullInput;
     }
@@ -56,6 +58,11 @@ public class AggregationHeader
     public boolean isOrderSensitive()
     {
         return orderSensitive;
+    }
+
+    public boolean isDistinctSensitive()
+    {
+        return distinctSensitive;
     }
 
     public SqlFunctionVisibility getVisibility()

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ArbitraryAggregationFunction.java
@@ -169,7 +169,7 @@ public class ArbitraryAggregationFunction
                 metadata,
                 classLoader);
         return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), type,
-                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+                true, false, false, metadata, accumulatorClass, groupedAccumulatorClass);
     }
 
     protected Type overrideIntermediateType(Type inputType, Type defaultIntermediateType)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BitwiseAndAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BitwiseAndAggregation.java
@@ -24,7 +24,7 @@ import com.facebook.presto.spi.function.InputFunction;
 import com.facebook.presto.spi.function.OutputFunction;
 import com.facebook.presto.spi.function.SqlType;
 
-@AggregationFunction("bitwise_and_agg")
+@AggregationFunction(value = "bitwise_and_agg", isDistinctSensitive = false)
 public final class BitwiseAndAggregation
 {
     private BitwiseAndAggregation() {}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BitwiseOrAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BitwiseOrAggregation.java
@@ -24,7 +24,7 @@ import com.facebook.presto.spi.function.InputFunction;
 import com.facebook.presto.spi.function.OutputFunction;
 import com.facebook.presto.spi.function.SqlType;
 
-@AggregationFunction("bitwise_or_agg")
+@AggregationFunction(value = "bitwise_or_agg", isDistinctSensitive = false)
 public class BitwiseOrAggregation
 {
     private BitwiseOrAggregation() {}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BooleanAndAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BooleanAndAggregation.java
@@ -28,7 +28,7 @@ import static com.facebook.presto.operator.aggregation.state.TriStateBooleanStat
 import static com.facebook.presto.operator.aggregation.state.TriStateBooleanState.NULL_VALUE;
 import static com.facebook.presto.operator.aggregation.state.TriStateBooleanState.TRUE_VALUE;
 
-@AggregationFunction(value = "bool_and", alias = "every")
+@AggregationFunction(value = "bool_and", alias = "every", isDistinctSensitive = false)
 public final class BooleanAndAggregation
 {
     private BooleanAndAggregation() {}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BooleanOrAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BooleanOrAggregation.java
@@ -28,7 +28,7 @@ import static com.facebook.presto.operator.aggregation.state.TriStateBooleanStat
 import static com.facebook.presto.operator.aggregation.state.TriStateBooleanState.NULL_VALUE;
 import static com.facebook.presto.operator.aggregation.state.TriStateBooleanState.TRUE_VALUE;
 
-@AggregationFunction(value = "bool_or")
+@AggregationFunction(value = "bool_or", isDistinctSensitive = false)
 public final class BooleanOrAggregation
 {
     private BooleanOrAggregation() {}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BuiltInAggregationFunctionImplementation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/BuiltInAggregationFunctionImplementation.java
@@ -37,6 +37,7 @@ public final class BuiltInAggregationFunctionImplementation
     private final List<Class> lambdaInterfaces;
     private final boolean decomposable;
     private final boolean orderSensitive;
+    private final boolean distinctSensitive;
 
     private final AggregationMetadata aggregationMetadata;
 
@@ -62,6 +63,32 @@ public final class BuiltInAggregationFunctionImplementation
                 finalType,
                 decomposable,
                 orderSensitive,
+                true,
+                aggregationMetadata,
+                accumulatorClass,
+                groupedAccumulatorClass);
+    }
+
+    public BuiltInAggregationFunctionImplementation(
+            String name,
+            List<Type> parameterTypes,
+            List<Type> intermediateType,
+            Type finalType,
+            boolean decomposable,
+            boolean orderSensitive,
+            boolean distinctSensitive,
+            AggregationMetadata aggregationMetadata,
+            Class<? extends Accumulator> accumulatorClass,
+            Class<? extends GroupedAccumulator> groupedAccumulatorClass)
+    {
+        this(
+                name,
+                parameterTypes,
+                intermediateType,
+                finalType,
+                decomposable,
+                orderSensitive,
+                distinctSensitive,
                 aggregationMetadata,
                 accumulatorClass,
                 groupedAccumulatorClass,
@@ -75,6 +102,7 @@ public final class BuiltInAggregationFunctionImplementation
             Type finalType,
             boolean decomposable,
             boolean orderSensitive,
+            boolean distinctSensitive,
             AggregationMetadata aggregationMetadata,
             Class<? extends Accumulator> accumulatorClass,
             Class<? extends GroupedAccumulator> groupedAccumulatorClass,
@@ -87,6 +115,7 @@ public final class BuiltInAggregationFunctionImplementation
         this.finalType = requireNonNull(finalType, "finalType is null");
         this.decomposable = decomposable;
         this.orderSensitive = orderSensitive;
+        this.distinctSensitive = distinctSensitive;
         this.aggregationMetadata = aggregationMetadata;
         this.accumulatorClass = accumulatorClass;
         this.groupedAccumulatorClass = groupedAccumulatorClass;
@@ -137,6 +166,11 @@ public final class BuiltInAggregationFunctionImplementation
     public boolean isOrderSensitive()
     {
         return orderSensitive;
+    }
+
+    public boolean isDistinctSensitive()
+    {
+        return distinctSensitive;
     }
 
     public AggregationMetadata getAggregationMetadata()

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
@@ -127,6 +127,7 @@ public class ParametricAggregation
                 outputType,
                 details.isDecomposable(),
                 details.isOrderSensitive(),
+                details.isDistinctSensitive(),
                 metadata,
                 accumulatorClass,
                 groupedAccumulatorClass);

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ReduceAggregationFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ReduceAggregationFunction.java
@@ -143,6 +143,7 @@ public class ReduceAggregationFunction
                 stateType,
                 true,
                 false,
+                true,
                 metadata,
                 accumulatorClass,
                 groupedAccumulatorClass,

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationFunction.java
@@ -114,10 +114,8 @@ public class SetAggregationFunction
                 GroupedAccumulator.class,
                 metadata,
                 classLoader);
-        return new
-
-                BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), outputType,
-                true, true, metadata, accumulatorClass, groupedAccumulatorClass);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), outputType,
+                true, true, false, metadata, accumulatorClass, groupedAccumulatorClass);
     }
 
     private static List<AggregationMetadata.ParameterMetadata> createInputParameterMetadata(Type valueType)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetUnionFunction.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetUnionFunction.java
@@ -115,10 +115,8 @@ public class SetUnionFunction
                 GroupedAccumulator.class,
                 metadata,
                 classLoader);
-        return new
-
-                BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), outputType,
-                true, true, metadata, accumulatorClass, groupedAccumulatorClass);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), outputType,
+                true, true, false, metadata, accumulatorClass, groupedAccumulatorClass);
     }
 
     private static List<AggregationMetadata.ParameterMetadata> createInputParameterMetadata(Type valueType)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -117,6 +117,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveCrossJoinWithConstan
 import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveIdentityProjectionsBelowProjection;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveInsensitiveAggregateDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveMapCastRule;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantAggregateDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantCastToVarcharInJoinClause;
@@ -449,6 +450,7 @@ public class PlanOptimizers
                                         new PushLimitThroughUnion(),
                                         new RemoveTrivialFilters(),
                                         new ImplementFilteredAggregations(metadata.getFunctionAndTypeManager()),
+                                        new RemoveInsensitiveAggregateDistinct(metadata.getFunctionAndTypeManager()),
                                         new SingleDistinctAggregationToGroupBy(),
                                         new MultipleDistinctAggregationToMarkDistinct(),
                                         new ImplementBernoulliSampleAsFilter(metadata.getFunctionAndTypeManager()),
@@ -667,6 +669,7 @@ public class PlanOptimizers
                                 new RemoveRedundantSortColumns(),
                                 new RemoveRedundantLimit(),
                                 new RemoveRedundantDistinctLimit(),
+                                new RemoveInsensitiveAggregateDistinct(metadata.getFunctionAndTypeManager()),
                                 new RemoveRedundantAggregateDistinct(),
                                 new RemoveRedundantIdentityProjections(),
                                 new PushAggregationThroughOuterJoin(metadata.getFunctionAndTypeManager()))),
@@ -879,6 +882,7 @@ public class PlanOptimizers
                         new RemoveRedundantSort(),
                         new RemoveRedundantLimit(),
                         new RemoveRedundantDistinctLimit(),
+                        new RemoveInsensitiveAggregateDistinct(metadata.getFunctionAndTypeManager()),
                         new RemoveRedundantAggregateDistinct(),
                         new RemoveRedundantIdentityProjections(),
                         new PushAggregationThroughOuterJoin(metadata.getFunctionAndTypeManager()))));

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveInsensitiveAggregateDistinct.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveInsensitiveAggregateDistinct.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.function.AggregationFunctionImplementation;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static com.facebook.presto.spi.plan.AggregationNode.Aggregation.removeDistinct;
+import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static java.util.Objects.requireNonNull;
+
+public class RemoveInsensitiveAggregateDistinct
+        implements Rule<AggregationNode>
+{
+    private final Pattern<AggregationNode> pattern = aggregation()
+            .matching(this::canRemoveDistinct);
+
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public RemoveInsensitiveAggregateDistinct(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+    }
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        ImmutableMap.Builder<VariableReferenceExpression, Aggregation> aggregations = ImmutableMap.builder();
+        for (Map.Entry<VariableReferenceExpression, Aggregation> entry : node.getAggregations().entrySet()) {
+            Aggregation aggregation = entry.getValue();
+            if (canRemoveDistinct(aggregation)) {
+                aggregations.put(entry.getKey(), removeDistinct(entry.getValue()));
+            }
+            else {
+                aggregations.put(entry);
+            }
+        }
+        return Result.ofPlanNode(
+                new AggregationNode(
+                        node.getSourceLocation(),
+                        node.getId(),
+                        node.getSource(),
+                        aggregations.build(),
+                        node.getGroupingSets(),
+                        node.getPreGroupedVariables(),
+                        node.getStep(),
+                        node.getHashVariable(),
+                        node.getGroupIdVariable(),
+                        node.getAggregationId()));
+    }
+
+    private boolean canRemoveDistinct(AggregationNode aggregationNode)
+    {
+        return aggregationNode.getAggregations().values().stream()
+                .anyMatch(this::canRemoveDistinct);
+    }
+
+    private boolean canRemoveDistinct(Aggregation aggregation)
+    {
+        AggregationFunctionImplementation implementation = functionAndTypeManager
+                .getAggregateFunctionImplementation(aggregation.getFunctionHandle());
+        return aggregation.isDistinct()
+                && (!implementation.isDistinctSensitive())
+                && (!implementation.isOrderSensitive());
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/expressions/AbstractTestExpressionInterpreter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/expressions/AbstractTestExpressionInterpreter.java
@@ -118,7 +118,7 @@ public abstract class AbstractTestExpressionInterpreter
             "",
             notVersioned(),
             FunctionKind.AGGREGATE,
-            Optional.of(new AggregationFunctionMetadata(parseTypeSignature("ROW(double, int)"), false)));
+            Optional.of(new AggregationFunctionMetadata(parseTypeSignature("ROW(double, int)"), false, true)));
 
     public static final int TEST_VARCHAR_TYPE_LENGTH = 17;
     public static final TypeProvider SYMBOL_TYPES = TypeProvider.viewOf(ImmutableMap.<String, Type>builder()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveInsensitiveAggregateDistinct.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveInsensitiveAggregateDistinct.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.spi.plan.AggregationNode.Step;
+import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleAssert;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.globalAggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.symbol;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRemoveInsensitiveAggregateDistinct
+        extends BaseRuleTest
+{
+    @Test
+    public void testNoDistinct()
+    {
+        assertRuleApplication()
+                .on(p -> p.aggregation(builder -> builder
+                        .globalGrouping()
+                        .source(p.values(p.variable("input1"), p.variable("input2")))
+                        .addAggregation(p.variable("output"), p.rowExpression("max(input1)"))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSensitiveDistinct()
+    {
+        assertRuleApplication()
+                .on(p -> p.aggregation(builder -> builder
+                        .globalGrouping()
+                        .source(p.values(p.variable("input1"), p.variable("input2")))
+                        .addAggregation(p.variable("output"), p.rowExpression("count(input1)"), true)))
+                .doesNotFire();
+
+        assertRuleApplication()
+                .on(p -> p.aggregation(builder -> builder
+                        .globalGrouping()
+                        .source(p.values(p.variable("input1"), p.variable("input2")))
+                        .addAggregation(p.variable("output"), p.rowExpression("min(input1, 2)"), true)))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSensitiveOrder()
+    {
+        assertRuleApplication()
+                .on(p -> p.aggregation(builder -> builder
+                        .globalGrouping()
+                        .source(p.values(p.variable("input1"), p.variable("input2")))
+                        .addAggregation(p.variable("output"), p.rowExpression("set_agg(input1)"), true)))
+                .doesNotFire();
+
+        assertRuleApplication()
+                .on(p -> p.aggregation(builder -> builder
+                        .globalGrouping()
+                        .source(p.values(p.variable("input1", new ArrayType(BIGINT)), p.variable("input2")))
+                        .addAggregation(p.variable("output"), p.rowExpression("set_union(input1)"), true)))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testInsensitiveDistinct()
+    {
+        assertRuleApplication()
+                .on(p -> p.aggregation(builder -> builder
+                        .globalGrouping()
+                        .source(p.values(p.variable("input1"), p.variable("input2")))
+                        .addAggregation(p.variable("output"), p.rowExpression("max(input1)"), true)))
+                .matches(
+                        aggregation(
+                                globalAggregation(),
+                                ImmutableMap.of(
+                                        Optional.of("output"),
+                                        functionCall("max", false, ImmutableList.of(symbol("input1")))),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                Step.SINGLE,
+                                values("input1", "input2")));
+    }
+
+    @Test
+    public void testMultipleInsensitiveDistinct()
+    {
+        assertRuleApplication()
+                .on(p -> p.aggregation(builder -> builder
+                        .globalGrouping()
+                        .source(p.values(p.variable("input1"), p.variable("input2", BOOLEAN)))
+                        .addAggregation(p.variable("output1"), p.rowExpression("any_value(input1)"), true)
+                        .addAggregation(p.variable("output2"), p.rowExpression("arbitrary(input1)"), true)
+                        .addAggregation(p.variable("output3"), p.rowExpression("bitwise_and_agg(input1)"), true)
+                        .addAggregation(p.variable("output4"), p.rowExpression("bitwise_or_agg(input1)"), true)
+                        .addAggregation(p.variable("output5"), p.rowExpression("bool_and(input2)"), true)
+                        .addAggregation(p.variable("output6"), p.rowExpression("bool_or(input2)"), true)
+                        .addAggregation(p.variable("output7"), p.rowExpression("every(input2)"), true)
+                        .addAggregation(p.variable("output8"), p.rowExpression("max(input1)"), true)
+                        .addAggregation(p.variable("output9"), p.rowExpression("min(input1)"), true)))
+                .matches(
+                        aggregation(
+                                globalAggregation(),
+                                ImmutableMap.<Optional<String>, ExpectedValueProvider<FunctionCall>>builder()
+                                        .put(Optional.of("output1"), functionCall("any_value", false, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output2"), functionCall("arbitrary", false, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output3"), functionCall("bitwise_and_agg", false, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output4"), functionCall("bitwise_or_agg", false, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output5"), functionCall("bool_and", false, ImmutableList.of(symbol("input2"))))
+                                        .put(Optional.of("output6"), functionCall("bool_or", false, ImmutableList.of(symbol("input2"))))
+                                        .put(Optional.of("output7"), functionCall("every", false, ImmutableList.of(symbol("input2"))))
+                                        .put(Optional.of("output8"), functionCall("max", false, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output9"), functionCall("min", false, ImmutableList.of(symbol("input1"))))
+                                        .build(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                Step.SINGLE,
+                                values("input1", "input2")));
+    }
+
+    @Test
+    public void testMixedDistinct()
+    {
+        assertRuleApplication()
+                .on(p -> p.aggregation(builder -> builder
+                        .globalGrouping()
+                        .source(p.values(p.variable("input1"), p.variable("input2", BOOLEAN)))
+                        .addAggregation(p.variable("output1"), p.rowExpression("count(input1)"), true)
+                        .addAggregation(p.variable("output2"), p.rowExpression("sum(input1)"), true)
+                        .addAggregation(p.variable("output3"), p.rowExpression("avg(input1)"), true)
+                        .addAggregation(p.variable("output4"), p.rowExpression("max(input1)"), true)
+                        .addAggregation(p.variable("output5"), p.rowExpression("min(input1)"), true)))
+                .matches(
+                        aggregation(
+                                globalAggregation(),
+                                ImmutableMap.<Optional<String>, ExpectedValueProvider<FunctionCall>>builder()
+                                        .put(Optional.of("output1"), functionCall("count", true, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output2"), functionCall("sum", true, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output3"), functionCall("avg", true, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output4"), functionCall("max", false, ImmutableList.of(symbol("input1"))))
+                                        .put(Optional.of("output5"), functionCall("min", false, ImmutableList.of(symbol("input1"))))
+                                        .build(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                Step.SINGLE,
+                                values("input1", "input2")));
+    }
+
+    private RuleAssert assertRuleApplication()
+    {
+        return tester().assertThat(new RemoveInsensitiveAggregateDistinct(getFunctionManager()));
+    }
+}

--- a/presto-native-execution/presto_cpp/main/functions/FunctionMetadata.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/FunctionMetadata.cpp
@@ -51,6 +51,8 @@ const protocol::AggregationFunctionMetadata getAggregationFunctionMetadata(
       boost::algorithm::to_lower_copy(signature.intermediateType().toString());
   metadata.isOrderSensitive =
       getAggregateFunctionEntry(name)->metadata.orderSensitive;
+  metadata.isDistinctSensitive =
+      !getAggregateFunctionEntry(name)->metadata.ignoreDuplicates;
   return metadata;
 }
 

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/ApproxMostFrequent.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/ApproxMostFrequent.json
@@ -3,7 +3,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,bigint,array(boolean),array(bigint))",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
@@ -26,7 +27,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,bigint,array(tinyint),array(bigint))",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
@@ -49,7 +51,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,bigint,array(smallint),array(bigint))",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
@@ -72,7 +75,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,bigint,array(integer),array(bigint))",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
@@ -95,7 +99,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,bigint,array(bigint),array(bigint))",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
@@ -118,7 +123,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,bigint,array(varchar),array(bigint))",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",
@@ -141,7 +147,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,bigint,array(json),array(bigint))",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.approx_most_frequent",
       "functionKind": "AGGREGATE",

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/CovarSamp.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/CovarSamp.json
@@ -3,7 +3,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(double,bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.covar_samp",
       "functionKind": "AGGREGATE",
@@ -25,7 +26,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(double,bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.covar_samp",
       "functionKind": "AGGREGATE",

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/SetAgg.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/SetAgg.json
@@ -3,7 +3,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "array(t)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": false
       },
       "docString": "presto.default.set_agg",
       "functionKind": "AGGREGATE",

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/StddevSamp.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/StddevSamp.json
@@ -3,7 +3,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
@@ -24,7 +25,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
@@ -45,7 +47,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
@@ -66,7 +69,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",
@@ -87,7 +91,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.stddev_samp",
       "functionKind": "AGGREGATE",

--- a/presto-native-execution/presto_cpp/main/functions/tests/data/Variance.json
+++ b/presto-native-execution/presto_cpp/main/functions/tests/data/Variance.json
@@ -3,7 +3,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
@@ -24,7 +25,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
@@ -45,7 +47,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
@@ -66,7 +69,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",
@@ -87,7 +91,8 @@
     {
       "aggregateMetadata": {
         "intermediateType": "row(bigint,double,double)",
-        "isOrderSensitive": true
+        "isOrderSensitive": true,
+        "isDistinctSensitive": true
       },
       "docString": "presto.default.variance",
       "functionKind": "AGGREGATE",

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -537,6 +537,13 @@ void to_json(json& j, const AggregationFunctionMetadata& p) {
       "AggregationFunctionMetadata",
       "bool",
       "isOrderSensitive");
+  to_json_key(
+      j,
+      "isDistinctSensitive",
+      p.isDistinctSensitive,
+      "AggregationFunctionMetadata",
+      "bool",
+      "isDistinctSensitive");
 }
 
 void from_json(const json& j, AggregationFunctionMetadata& p) {
@@ -554,6 +561,13 @@ void from_json(const json& j, AggregationFunctionMetadata& p) {
       "AggregationFunctionMetadata",
       "bool",
       "isOrderSensitive");
+  from_json_key(
+      j,
+      "isDistinctSensitive",
+      p.isDistinctSensitive,
+      "AggregationFunctionMetadata",
+      "bool",
+      "isDistinctSensitive");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -421,6 +421,7 @@ namespace facebook::presto::protocol {
 struct AggregationFunctionMetadata {
   TypeSignature intermediateType = {};
   bool isOrderSensitive = {};
+  bool isDistinctSensitive = {};
 };
 void to_json(json& j, const AggregationFunctionMetadata& p);
 void from_json(const json& j, AggregationFunctionMetadata& p);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeBuiltInFunctions.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeBuiltInFunctions.java
@@ -125,7 +125,7 @@ public class TestPrestoNativeBuiltInFunctions
                 "default",
                 false,
                 new RoutineCharacteristics(RoutineCharacteristics.Language.CPP, RoutineCharacteristics.Determinism.DETERMINISTIC, RoutineCharacteristics.NullCallClause.CALLED_ON_NULL_INPUT),
-                Optional.of(new AggregationFunctionMetadata(new TypeSignature("varbinary"), true)),
+                Optional.of(new AggregationFunctionMetadata(new TypeSignature("varbinary"), true, true)),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(ImmutableList.of()),

--- a/presto-native-execution/src/test/resources/external_functions.json
+++ b/presto-native-execution/src/test/resources/external_functions.json
@@ -82,7 +82,8 @@
         },
         "aggregateMetadata": {
           "intermediateType": "BIGINT",
-          "isOrderSensitive": false
+          "isOrderSensitive": false,
+          "isDistinctSensitive": true
         }
       }
     ],
@@ -102,7 +103,8 @@
         },
         "aggregateMetadata": {
           "intermediateType": "ROW(DOUBLE, BIGINT)",
-          "isOrderSensitive": false
+          "isOrderSensitive": false,
+          "isDistinctSensitive": true
         }
       }
     ],
@@ -122,7 +124,8 @@
         },
         "aggregateMetadata": {
           "intermediateType": "ROW(DOUBLE, BIGINT)",
-          "isOrderSensitive": false
+          "isOrderSensitive": false,
+          "isDistinctSensitive": true
         }
       }
     ],
@@ -142,7 +145,8 @@
         },
         "aggregateMetadata": {
           "intermediateType": "ROW(DOUBLE, BIGINT)",
-          "isOrderSensitive": false
+          "isOrderSensitive": false,
+          "isDistinctSensitive": true
         }
       }
     ],

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionNamespaceManager.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/functionNamespace/NativeFunctionNamespaceManager.java
@@ -172,6 +172,7 @@ public class NativeFunctionNamespaceManager
                         typeManager.getType(resolvedIntermediateType),
                         typeManager.getType(signature.getReturnType()),
                         aggregationMetadata.isOrderSensitive(),
+                        aggregationMetadata.isDistinctSensitive(),
                         parameters));
         return aggregationImplementationByHandle.get(nativeFunctionHandle);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunction.java
@@ -35,6 +35,12 @@ public @interface AggregationFunction
      */
     boolean isOrderSensitive() default false;
 
+    /**
+     * Indicates whether the result of the function depends on the uniqueness of the input data,
+     * which allows the engine to optimize away DISTINCT in aggregation calls
+     */
+    boolean isDistinctSensitive() default true;
+
     SqlFunctionVisibility visibility() default PUBLIC;
 
     String[] alias() default {};

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionImplementation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionImplementation.java
@@ -27,4 +27,6 @@ public interface AggregationFunctionImplementation
     boolean isDecomposable();
 
     boolean isOrderSensitive();
+
+    boolean isDistinctSensitive();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionMetadata.java
@@ -36,13 +36,17 @@ public class AggregationFunctionMetadata
      */
     private final boolean isOrderSensitive;
 
+    private final boolean isDistinctSensitive;
+
     @JsonCreator
     public AggregationFunctionMetadata(
             @JsonProperty("intermediateType") TypeSignature intermediateType,
-            @JsonProperty("isOrderSensitive") boolean isOrderSensitive)
+            @JsonProperty("isOrderSensitive") boolean isOrderSensitive,
+            @JsonProperty("isDistinctSensitive") boolean isDistinctSensitive)
     {
         this.intermediateType = requireNonNull(intermediateType, "intermediateType is null");
         this.isOrderSensitive = isOrderSensitive;
+        this.isDistinctSensitive = isDistinctSensitive;
     }
 
     @JsonProperty
@@ -57,13 +61,20 @@ public class AggregationFunctionMetadata
         return isOrderSensitive;
     }
 
+    @JsonProperty
+    public boolean isDistinctSensitive()
+    {
+        return isDistinctSensitive;
+    }
+
     @Override
     public String toString()
     {
         return format(
-                "%s(%s,%s)",
+                "%s(%s,%s,%s)",
                 getClass().getSimpleName(),
                 getIntermediateType(),
-                isOrderSensitive());
+                isOrderSensitive(),
+                isDistinctSensitive());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedAggregationFunctionImplementation.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/SqlInvokedAggregationFunctionImplementation.java
@@ -35,17 +35,21 @@ public class SqlInvokedAggregationFunctionImplementation
 
     private final boolean isOrderSensitive;
 
+    private final boolean isDistinctSensitive;
+
     private final List<Type> parameterTypes;
 
     public SqlInvokedAggregationFunctionImplementation(
             Type intermediateType,
             Type finalType,
             boolean isOrderSensitive,
+            boolean isDistinctSensitive,
             List<Type> parameterTypes)
     {
         this.intermediateType = requireNonNull(intermediateType, "intermediateType is null");
         this.finalType = requireNonNull(finalType, "finalType is null");
         this.isOrderSensitive = isOrderSensitive;
+        this.isDistinctSensitive = isDistinctSensitive;
         this.parameterTypes = requireNonNull(parameterTypes, "parameterTypes is null");
     }
 
@@ -72,6 +76,12 @@ public class SqlInvokedAggregationFunctionImplementation
     public boolean isOrderSensitive()
     {
         return isOrderSensitive;
+    }
+
+    @Override
+    public boolean isDistinctSensitive()
+    {
+        return isDistinctSensitive;
     }
 
     @Override


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Added isDistinctSensitive() flag in AggregationFunction to indicate whether the function is sensitive to duplicate inputs, and an optimizer rule to remove distinct from aggregates which are insensitive to duplicates and orders.
Fixes https://github.com/prestodb/presto/issues/26075.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

