### PR TITLE
fix(scheduler): Provide blocked future when scheduler is blocked on placement

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SourcePartitionedScheduler.java
@@ -258,6 +258,7 @@ public class SourcePartitionedScheduler
             Multimap<InternalNode, Split> splitAssignment = ImmutableMultimap.of();
             if (!scheduleGroup.pendingSplits.isEmpty()) {
                 if (!scheduleGroup.placementFuture.isDone()) {
+                    overallBlockedFutures.add(scheduleGroup.placementFuture);
                     anyBlockedOnPlacements = true;
                     continue;
                 }
@@ -374,6 +375,8 @@ public class SourcePartitionedScheduler
         else {
             blockedReason = anyBlockedOnPlacements ? SPLIT_QUEUES_FULL : NO_ACTIVE_DRIVER_GROUP;
         }
+
+        verify(!overallBlockedFutures.isEmpty() || blockedReason == NO_ACTIVE_DRIVER_GROUP, "overallBlockedFutures is expected to be not empty when blocked on placement or splits");
 
         overallBlockedFutures.add(whenFinishedOrNewLifespanAdded);
         return ScheduleResult.blocked(


### PR DESCRIPTION
## Description

Provide blocked future when scheduler is blocked on placement

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

To avoid unnecessary scheduling delays

When scheduler is blocked on placement but the placement future is not provided the query scheduler ends up waiting for 1s unnecessarily. 

## Impact

Improved scheduling latency for bucketed execution and single node execution modes for queries with more than a single TableScan

## Test Plan

Assertion + CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

