### PR TITLE
docs(protocol): Add documentation about header size limits

### DIFF
--- a/presto-docs/src/main/sphinx/troubleshoot/query.rst
+++ b/presto-docs/src/main/sphinx/troubleshoot/query.rst
@@ -44,4 +44,7 @@ Edit ``config.properties`` for the Presto coordinator, and set the value of the
 
     http-server.max-request-header-size=5MB
 
-See :ref:`admin/properties:\`\`http-server.max-request-header-size\`\``. 
+See :ref:`admin/properties:\`\`http-server.max-request-header-size\`\``.
+
+Alternatively, avoid using prepared statements for large queries. Prepared statements
+place the SQL template in request headers, which can exceed the header size limit. 


### PR DESCRIPTION
## Description
Header limits are frequently tripped by using prepared statements.  Add doc that makes this clear to users and suggest a potential workaround.

## Motivation and Context
Clear documentation on how to avoid an error.

## Impact
More documentation.

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

