### PR TITLE
fix: Disable always active spark2 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3186,10 +3186,7 @@
             <id>spark2</id>
 
             <activation>
-                <activeByDefault>true</activeByDefault>
-                <property>
-                    <name>!spark-version</name>
-                </property>
+                <activeByDefault>false</activeByDefault>
             </activation>
 
             <properties>


### PR DESCRIPTION
## Description
Make the `spark2` profile inactive by default

## Motivation and Context
https://github.com/prestodb/presto/issues/26465

## Impact
CI will run maven enforcer checks which were accidentally disabled

## Test Plan
Ran `./mvnw help:active-profiles` and manually confirmed that `spark2` is inactive

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release notes
```
== NO RELEASE NOTE ==
```

