### PR TITLE
fix(native): Fix OS metrics to report cumulative values for AVG type

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.cpp
@@ -441,38 +441,26 @@ void PeriodicTaskManager::updateOperatingSystemStats() {
   const int64_t userCpuTimeUs{
       static_cast<int64_t>(usage.ru_utime.tv_sec) * 1'000'000 +
       static_cast<int64_t>(usage.ru_utime.tv_usec)};
-  RECORD_METRIC_VALUE(
-      kCounterOsUserCpuTimeMicros, userCpuTimeUs - lastUserCpuTimeUs_);
-  lastUserCpuTimeUs_ = userCpuTimeUs;
+  RECORD_METRIC_VALUE(kCounterOsUserCpuTimeMicros, userCpuTimeUs);
 
   const int64_t systemCpuTimeUs{
       static_cast<int64_t>(usage.ru_stime.tv_sec) * 1'000'000 +
       static_cast<int64_t>(usage.ru_stime.tv_usec)};
-  RECORD_METRIC_VALUE(
-      kCounterOsSystemCpuTimeMicros, systemCpuTimeUs - lastSystemCpuTimeUs_);
-  lastSystemCpuTimeUs_ = systemCpuTimeUs;
+  RECORD_METRIC_VALUE(kCounterOsSystemCpuTimeMicros, systemCpuTimeUs);
 
   const int64_t softPageFaults{usage.ru_minflt};
-  RECORD_METRIC_VALUE(
-      kCounterOsNumSoftPageFaults, softPageFaults - lastSoftPageFaults_);
-  lastSoftPageFaults_ = softPageFaults;
+  RECORD_METRIC_VALUE(kCounterOsNumSoftPageFaults, softPageFaults);
 
   const int64_t hardPageFaults{usage.ru_majflt};
-  RECORD_METRIC_VALUE(
-      kCounterOsNumHardPageFaults, hardPageFaults - lastHardPageFaults_);
-  lastHardPageFaults_ = hardPageFaults;
+  RECORD_METRIC_VALUE(kCounterOsNumHardPageFaults, hardPageFaults);
 
   const int64_t voluntaryContextSwitches{usage.ru_nvcsw};
   RECORD_METRIC_VALUE(
-      kCounterOsNumVoluntaryContextSwitches,
-      voluntaryContextSwitches - lastVoluntaryContextSwitches_);
-  lastVoluntaryContextSwitches_ = voluntaryContextSwitches;
+      kCounterOsNumVoluntaryContextSwitches, voluntaryContextSwitches);
 
   const int64_t forcedContextSwitches{usage.ru_nivcsw};
   RECORD_METRIC_VALUE(
-      kCounterOsNumForcedContextSwitches,
-      forcedContextSwitches - lastForcedContextSwitches_);
-  lastForcedContextSwitches_ = forcedContextSwitches;
+      kCounterOsNumForcedContextSwitches, forcedContextSwitches);
 }
 
 void PeriodicTaskManager::addOperatingSystemStatsUpdateTask() {

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -142,14 +142,6 @@ class PeriodicTaskManager {
       std::shared_ptr<velox::connector::Connector>>& connectors_;
   PrestoServer* server_;
 
-  // Operating system related stats.
-  int64_t lastUserCpuTimeUs_{0};
-  int64_t lastSystemCpuTimeUs_{0};
-  int64_t lastSoftPageFaults_{0};
-  int64_t lastHardPageFaults_{0};
-  int64_t lastVoluntaryContextSwitches_{0};
-  int64_t lastForcedContextSwitches_{0};
-
   int64_t lastHttpClientNumConnectionsCreated_{0};
 
   // NOTE: declare last since the threads access other members of `this`.


### PR DESCRIPTION
Fixes #26516 

All 6 OS-related metrics were defined as **AVG** type but reported as
**delta values**, causing incorrect averaging and potential data loss
in Prometheus monitoring.

Changed metrics to report **cumulative values** since process start:
- presto_cpp.os_user_cpu_time_micros
- presto_cpp.os_system_cpu_time_micros
- presto_cpp.os_num_soft_page_faults
- presto_cpp.os_num_hard_page_faults
- presto_cpp.os_num_voluntary_context_switches
- presto_cpp.os_num_forced_context_switches

This ensures:
1. Alignment with other AVG metrics in the system (task counts,
   cache sizes, etc.)
2. Proper rate calculations in monitoring systems and no data loss
   regardless of scraping intervals

```
== NO RELEASE NOTE ==
```