### PR TITLE
chore(ci): Add 'deps' to conventional commit check patterns

### DIFF
--- a/.github/workflows/conventional-commit-check.yml
+++ b/.github/workflows/conventional-commit-check.yml
@@ -59,6 +59,7 @@ jobs:
             build
             ci
             ui
+            deps
             plugin-[a-zA-Z][a-zA-Z0-9-]*
           subjectPattern: ^[A-Z].*[^.]$
           subjectPatternError: |


### PR DESCRIPTION
## Description
Dependabot opens the PR using the `deps` scope.  Add it so we can merge those PRs.

## Motivation and Context
Merge dependabot PRs.

## Impact
Merge dependabot PRs.

## Test Plan
N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

