### PR TITLE
fix(ci): Use merge base for OWASP plugin

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -27,28 +27,21 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 100 # Fetch enough history to find merge base
 
       - name: Find merge base
         id: merge-base
         env:
+          GH_TOKEN: ${{ github.token }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
         run: |
-          # Fetch the base branch with same depth
-          git fetch origin "$BASE_REF" --depth=100
+          merge_base=$(gh api -q '.merge_base_commit.sha' \
+            "/repos/$REPO/compare/$BASE_REF...$HEAD_SHA")
+          echo "sha=$merge_base" >> $GITHUB_OUTPUT
+          echo "Using merge base: $merge_base"
 
-          # Try to find merge base
-          if merge_base=$(git merge-base HEAD "origin/$BASE_REF" 2>/dev/null); then
-            echo "sha=$merge_base" >> $GITHUB_OUTPUT
-            echo "Using merge base: $merge_base"
-          else
-            # Fallback to base.sha if merge base not found (very old PRs)
-            echo "sha=$BASE_SHA" >> $GITHUB_OUTPUT
-            echo "Could not find merge base, using base branch head instead.  This should not happen for recent PRs."
-          fi
-
-      - name: Checkout base branch (merge base)
+      - name: Checkout base branch
         uses: actions/checkout@v4
         with:
           persist-credentials: false


### PR DESCRIPTION
## Description
Don't use trunk, because if a vulnerability fix has been merged, this requires PRs to rebase.  Instead, try to find a merge base where possible and use that as the reference point to ensure no new vulnerabilities are being introduced by a PR.

## Motivation and Context
Recent OWASP job failures

## Impact
Less false positives from the OWASP job

## Test Plan
Old commit without newer security vulnerability fixes doesn't trigger OWASP failure anymore: https://github.com/tdcmeehan/presto/pull/12
Previous vulnerability detection continues to work: https://github.com/tdcmeehan/presto/pull/13

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

