### PR TITLE
fix(native): Fix a flaky test in FunctionMetadataTest

### DIFF
--- a/presto-native-execution/presto_cpp/main/functions/tests/FunctionMetadataTest.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/tests/FunctionMetadataTest.cpp
@@ -57,11 +57,25 @@ class FunctionMetadataTest : public ::testing::Test {
     json::array_t expectedList = expected[name];
     std::sort(expectedList.begin(), expectedList.end(), comparator);
     std::sort(metadataList.begin(), metadataList.end(), comparator);
+    auto sortVariableConstraints = [](json& obj) {
+      for (auto& [key, value] : obj.items()) {
+        if (key == "typeVariableConstraints" ||
+            key == "longVariableConstraints") {
+          std::sort(
+              value.begin(), value.end(), [](const json& a, const json& b) {
+                return a["name"] < b["name"];
+              });
+        }
+      }
+    };
     for (auto i = 0; i < expectedSize; i++) {
+      sortVariableConstraints(expectedList[i]);
+      sortVariableConstraints(metadataList[i]);
       EXPECT_EQ(expectedList[i], metadataList[i]) << "Position: " << i;
     }
   }
 
+ private:
   json functionMetadata_;
 };
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

This PR fixes a flaky test FunctionMetadataTest.mod(https://github.com/prestodb/presto/issues/26527).
```
presto-native-execution/presto_cpp/main/functions/tests/FunctionMetadataTest.cpp:74: Failure
Expected equality of these values:
   expectedList[i]
     Which is: {"docString":"presto.default.mod","functionKind":"SCALAR","longVariableConstraints":[{"expression":"max(i5, i6)","name":"i7"},{"expression":"min(i2 - i6, i1 - i5) + max(i5, i6)","name":"i3"}],"outputType":"decimal(i3,i7)","paramTypes":["decimal(i1,i5)","decimal(i2,i6)"],"routineCharacteristics":{"determinism":"DETERMINISTIC","language":"CPP","nullCallClause":"RETURNS_NULL_ON_NULL_INPUT"},"schema":"default","typeVariableConstraints":[],"variableArity":false}
   metadataList[i]
     Which is: {"docString":"presto.default.mod","functionKind":"SCALAR","longVariableConstraints":[{"expression":"min(i2 - i6, i1 - i5) + max(i5, i6)","name":"i3"},{"expression":"max(i5, i6)","name":"i7"}],"outputType":"decimal(i3,i7)","paramTypes":["decimal(i1,i5)","decimal(i2,i6)"],"routineCharacteristics":{"determinism":"DETERMINISTIC","language":"CPP","nullCallClause":"RETURNS_NULL_ON_NULL_INPUT"},"schema":"default","typeVariableConstraints":[],"variableArity":false}
 Position: 1
```
`longVariableConstraints` is built in `getLongVariableConstraints`, and its element order depends on the iterating of functionSignature.variables(), which is an unordered_map and therefore not guaranteed. 
This PR adds a sort operation before the result comparison. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

