### PR TITLE
fix: Fix http2 connect timeout config bug

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClient.java
@@ -176,7 +176,7 @@ public class ReactorNettyHttpClient
                     settings.initialWindowSize((int) (config.getMaxInitialWindowSize().toBytes()));
                     settings.maxFrameSize((int) (config.getMaxFrameSize().toBytes()));
                 })
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) config.getConnectTimeout().getValue())
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) config.getConnectTimeout().toMillis())
                 .option(ChannelOption.SO_KEEPALIVE, true)
                 .option(ChannelOption.TCP_NODELAY, true)
                 // Track HTTP client metrics


### PR DESCRIPTION
## Description
1. The timeout setting should be converted to millis instead of getting value directly which will return number of seconds


## Motivation and Context
1. See this error in coord's log "2025-11-04T19:19:07.792-0800 WARN task-event-loop-216 com.facebook.presto.server.RequestErrorTracker Error updating task 20251105_031903_00001_yzunb.3.0.16.0: connection timed out after 10 ms: db00:133c:5d23:face:0:61:0]:7778: https:db00:133c:5d23:face:0:61:0]:7778/v1/task/20251105_031903_00001_yzunb.3.0.16.0""

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
1. running verifier

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

