### PR TITLE
fix(native): Incorrect session property hidden attribute

### DIFF
--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -488,7 +488,7 @@ SessionProperties::SessionProperties() {
       kRequestDataSizesMaxWaitSec,
       "Maximum wait time for exchange long poll requests in seconds.",
       INTEGER(),
-      10,
+      false,
       QueryConfig::kRequestDataSizesMaxWaitSec,
       std::to_string(c.requestDataSizesMaxWaitSec()));
 
@@ -496,7 +496,7 @@ SessionProperties::SessionProperties() {
       kNativeQueryMemoryReclaimerPriority,
       "Memory pool reclaimer priority.",
       INTEGER(),
-      2147483647,
+      false,
       QueryConfig::kQueryMemoryReclaimerPriority,
       std::to_string(c.queryMemoryReclaimerPriority()));
 
@@ -504,7 +504,7 @@ SessionProperties::SessionProperties() {
       kMaxNumSplitsListenedTo,
       "Maximum number of splits to listen to by SplitListener on native workers.",
       INTEGER(),
-      0,
+      true,
       QueryConfig::kMaxNumSplitsListenedTo,
       std::to_string(c.maxNumSplitsListenedTo()));
 
@@ -547,9 +547,9 @@ SessionProperties::SessionProperties() {
 
   addSessionProperty(
       kPreferredOutputBatchBytes,
-      "Prefered memory budget for operator output batches. Used in tandem with average row size estimates when available.",
+      "Preferred memory budget for operator output batches. Used in tandem with average row size estimates when available.",
       BIGINT(),
-      10UL * 1048576,
+      true,
       QueryConfig::kPreferredOutputBatchBytes,
       std::to_string(c.preferredOutputBatchBytes()));
 
@@ -557,7 +557,7 @@ SessionProperties::SessionProperties() {
       kPreferredOutputBatchRows,
       "Preferred row count per operator output batch. Used when average row size estimates are unknown.",
       INTEGER(),
-      1024,
+      true,
       QueryConfig::kPreferredOutputBatchRows,
       std::to_string(c.preferredOutputBatchRows()));
 
@@ -565,7 +565,7 @@ SessionProperties::SessionProperties() {
       kMaxOutputBatchRows,
       "Upperbound for row count per output batch, used together with preferred_output_batch_bytes and average row size estimates.",
       INTEGER(),
-      10'000,
+      true,
       QueryConfig::kMaxOutputBatchRows,
       std::to_string(c.maxOutputBatchRows()));
 


### PR DESCRIPTION
A session property can be declared hidden.
Some session property additions set a default value instead of the hidden property. The integers were
interpreted as true.

This change fixes the attribute to true or false.
It is set to false for documented session properties and true for undocumented properties at the time of addition.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

