### PR TITLE
refactor(native): Remove assignments argument from toVeloxTableHandle API

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
@@ -335,8 +335,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle>
 HivePrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser,
-    const velox::connector::ColumnHandleMap& assignments) const {
+    const TypeParser& typeParser) const {
   auto hiveLayout =
       std::dynamic_pointer_cast<const protocol::hive::HiveTableLayoutHandle>(
           tableHandle.connectorTableLayout);

--- a/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.h
@@ -41,8 +41,7 @@ class HivePrestoToVeloxConnector final : public PrestoToVeloxConnector {
   std::unique_ptr<velox::connector::ConnectorTableHandle> toVeloxTableHandle(
       const protocol::TableHandle& tableHandle,
       const VeloxExprConverter& exprConverter,
-      const TypeParser& typeParser,
-      const velox::connector::ColumnHandleMap& assignments) const final;
+      const TypeParser& typeParser) const final;
 
   std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
   toVeloxInsertTableHandle(

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -247,8 +247,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle>
 IcebergPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser,
-    const velox::connector::ColumnHandleMap& assignments) const {
+    const TypeParser& typeParser) const {
   auto icebergLayout = std::dynamic_pointer_cast<
       const protocol::iceberg::IcebergTableLayoutHandle>(
       tableHandle.connectorTableLayout);

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
@@ -36,8 +36,7 @@ class IcebergPrestoToVeloxConnector final : public PrestoToVeloxConnector {
   std::unique_ptr<velox::connector::ConnectorTableHandle> toVeloxTableHandle(
       const protocol::TableHandle& tableHandle,
       const VeloxExprConverter& exprConverter,
-      const TypeParser& typeParser,
-      const velox::connector::ColumnHandleMap& assignments) const final;
+      const TypeParser& typeParser) const final;
 
   std::unique_ptr<protocol::ConnectorProtocol> createConnectorProtocol()
       const final;

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.cpp
@@ -101,8 +101,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle>
 TpchPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser,
-    const velox::connector::ColumnHandleMap& assignments) const {
+    const TypeParser& typeParser) const {
   auto tpchLayout =
       std::dynamic_pointer_cast<const protocol::tpch::TpchTableLayoutHandle>(
           tableHandle.connectorTableLayout);
@@ -153,8 +152,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle>
 TpcdsPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser,
-    const velox::connector::ColumnHandleMap& assignments) const {
+    const TypeParser& typeParser) const {
   auto tpcdsLayout =
       std::dynamic_pointer_cast<const protocol::tpcds::TpcdsTableLayoutHandle>(
           tableHandle.connectorTableLayout);

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.h
@@ -58,8 +58,7 @@ class PrestoToVeloxConnector {
   toVeloxTableHandle(
       const protocol::TableHandle& tableHandle,
       const VeloxExprConverter& exprConverter,
-      const TypeParser& typeParser,
-      const velox::connector::ColumnHandleMap& assignments) const = 0;
+      const TypeParser& typeParser) const = 0;
 
   [[nodiscard]] virtual std::unique_ptr<
       velox::connector::ConnectorInsertTableHandle>
@@ -132,8 +131,7 @@ class TpchPrestoToVeloxConnector final : public PrestoToVeloxConnector {
   std::unique_ptr<velox::connector::ConnectorTableHandle> toVeloxTableHandle(
       const protocol::TableHandle& tableHandle,
       const VeloxExprConverter& exprConverter,
-      const TypeParser& typeParser,
-      const velox::connector::ColumnHandleMap& assignments) const final;
+      const TypeParser& typeParser) const final;
 
   std::unique_ptr<protocol::ConnectorProtocol> createConnectorProtocol()
       const final;
@@ -156,8 +154,7 @@ class TpcdsPrestoToVeloxConnector final : public PrestoToVeloxConnector {
   std::unique_ptr<velox::connector::ConnectorTableHandle> toVeloxTableHandle(
       const protocol::TableHandle& tableHandle,
       const VeloxExprConverter& exprConverter,
-      const TypeParser& typeParser,
-      const velox::connector::ColumnHandleMap& assignments) const final;
+      const TypeParser& typeParser) const final;
 
   std::unique_ptr<protocol::ConnectorProtocol> createConnectorProtocol()
       const final;

--- a/presto-native-execution/presto_cpp/main/connectors/SystemConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/SystemConnector.cpp
@@ -376,8 +376,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle>
 SystemPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser,
-    const velox::connector::ColumnHandleMap& assignments) const {
+    const TypeParser& typeParser) const {
   auto systemLayout =
       std::dynamic_pointer_cast<const protocol::SystemTableLayoutHandle>(
           tableHandle.connectorTableLayout);

--- a/presto-native-execution/presto_cpp/main/connectors/SystemConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/SystemConnector.h
@@ -191,8 +191,7 @@ class SystemPrestoToVeloxConnector final : public PrestoToVeloxConnector {
   std::unique_ptr<velox::connector::ConnectorTableHandle> toVeloxTableHandle(
       const protocol::TableHandle& tableHandle,
       const VeloxExprConverter& exprConverter,
-      const TypeParser& typeParser,
-      const velox::connector::ColumnHandleMap& assignments) const final;
+      const TypeParser& typeParser) const final;
 
   std::unique_ptr<protocol::ConnectorProtocol> createConnectorProtocol()
       const final;

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowPrestoToVeloxConnector.cpp
@@ -47,8 +47,7 @@ std::unique_ptr<velox::connector::ConnectorTableHandle>
 ArrowPrestoToVeloxConnector::toVeloxTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& /*exprConverter*/,
-    const TypeParser& /*typeParser*/,
-    const velox::connector::ColumnHandleMap& /*assignments*/) const {
+    const TypeParser& /*typeParser*/) const {
   return std::make_unique<presto::ArrowFlightTableHandle>(
       tableHandle.connectorId);
 }

--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowPrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/ArrowPrestoToVeloxConnector.h
@@ -34,8 +34,7 @@ class ArrowPrestoToVeloxConnector final : public PrestoToVeloxConnector {
   std::unique_ptr<velox::connector::ConnectorTableHandle> toVeloxTableHandle(
       const protocol::TableHandle& tableHandle,
       const VeloxExprConverter& exprConverter,
-      const TypeParser& typeParser,
-      const velox::connector::ColumnHandleMap& assignments) const final;
+      const TypeParser& typeParser) const final;
 
   std::unique_ptr<protocol::ConnectorProtocol> createConnectorProtocol()
       const final;

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -85,12 +85,10 @@ std::shared_ptr<connector::ColumnHandle> toColumnHandle(
 std::shared_ptr<connector::ConnectorTableHandle> toConnectorTableHandle(
     const protocol::TableHandle& tableHandle,
     const VeloxExprConverter& exprConverter,
-    const TypeParser& typeParser,
-    connector::ColumnHandleMap& assignments) {
+    const TypeParser& typeParser) {
   const auto& connector =
       getPrestoToVeloxConnector(tableHandle.connectorHandle->_type);
-  return connector.toVeloxTableHandle(
-      tableHandle, exprConverter, typeParser, assignments);
+  return connector.toVeloxTableHandle(tableHandle, exprConverter, typeParser);
 }
 
 std::vector<core::TypedExprPtr> getProjections(
@@ -1007,8 +1005,8 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     assignments.emplace(
         variable.name, toColumnHandle(columnHandle.get(), typeParser_));
   }
-  auto connectorTableHandle = toConnectorTableHandle(
-      node->table, exprConverter_, typeParser_, assignments);
+  auto connectorTableHandle =
+      toConnectorTableHandle(node->table, exprConverter_, typeParser_);
   return std::make_shared<core::TableScanNode>(
       node->id, rowType, connectorTableHandle, assignments);
 }
@@ -1376,8 +1374,8 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     assignments.emplace(
         variable.name, toColumnHandle(columnHandle.get(), typeParser_));
   }
-  auto connectorTableHandle = toConnectorTableHandle(
-      node->tableHandle, exprConverter_, typeParser_, assignments);
+  auto connectorTableHandle =
+      toConnectorTableHandle(node->tableHandle, exprConverter_, typeParser_);
   return std::make_shared<core::TableScanNode>(
       node->id, rowType, connectorTableHandle, assignments);
 }

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -138,9 +138,8 @@ TEST_F(PrestoToVeloxConnectorTest, icebergPreservesColumnNameCase) {
   tableHandle.connectorTableLayout = layout;
 
   IcebergPrestoToVeloxConnector icebergConnector("iceberg");
-  connector::ColumnHandleMap assignments;
   auto result = icebergConnector.toVeloxTableHandle(
-      tableHandle, *exprConverter_, *typeParser_, assignments);
+      tableHandle, *exprConverter_, *typeParser_);
 
   ASSERT_NE(result, nullptr);
   auto* handle = dynamic_cast<connector::hive::HiveTableHandle*>(result.get());
@@ -172,9 +171,8 @@ TEST_F(PrestoToVeloxConnectorTest, hiveLowercasesColumnNames) {
   tableHandle.connectorTableLayout = layout;
 
   HivePrestoToVeloxConnector hiveConnector("hive");
-  connector::ColumnHandleMap assignments;
   auto result = hiveConnector.toVeloxTableHandle(
-      tableHandle, *exprConverter_, *typeParser_, assignments);
+      tableHandle, *exprConverter_, *typeParser_);
 
   ASSERT_NE(result, nullptr);
   auto* handle = dynamic_cast<connector::hive::HiveTableHandle*>(result.get());


### PR DESCRIPTION
Summary: Connector-specific toVeloxTableHandle conversion logic should not depend on assignments.

Differential Revision: D86342058

## Release Notes
```
== NO RELEASE NOTE ==
```
