### PR TITLE
fix(planner): Fix materialized view planning when data table has hidden columns

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -325,10 +325,10 @@ class RelationPlanner
         List<VariableReferenceExpression> viewQueryVariables = viewQueryPlan.getFieldMappings();
 
         checkArgument(
-                dataTableVariables.size() == viewQueryVariables.size(),
-                "Materialized view %s has mismatched field counts: data table has %s fields but view query has %s fields",
+                dataTableDescriptor.getVisibleFieldCount() == viewQueryVariables.size(),
+                "Materialized view %s has mismatched field counts: data table has %s visible fields but view query has %s fields",
                 materializedViewName,
-                dataTableVariables.size(),
+                dataTableDescriptor.getVisibleFieldCount(),
                 viewQueryVariables.size());
 
         ImmutableList.Builder<VariableReferenceExpression> outputVariablesBuilder = ImmutableList.builder();


### PR DESCRIPTION
## Description

This PR fixes a bug when using the planning-oriented materialized view framework (introduced in PR #26492) in Hive connector. Unlike the tables in the Memory connector, the underlying hive tables of the materialized view contain hidden columns. Therefore, for the comparison with the number of output variables in the view query, we should use the underlying data table's visible field count instead of its total field count.

## Motivation and Context

 - Fix a bug when using the planning-oriented materialized view framework in Hive connector

## Impact

N/A

## Test Plans

 - New test case in `TestHiveMaterializedViewLogicalPlanner` which would fail without this change

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

