### PR TITLE
fix: Throw USER_ERROR instead of FUNCTION_IMPLEMENTATION_MISSING for unsupported parameters

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/ParametricScalar.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/ParametricScalar.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
 import static com.facebook.presto.spi.StandardErrorCode.AMBIGUOUS_FUNCTION_IMPLEMENTATION;
 import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_ERROR;
-import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_MISSING;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -119,6 +119,6 @@ public class ParametricScalar
             return selectedImplementation;
         }
 
-        throw new PrestoException(FUNCTION_IMPLEMENTATION_MISSING, format("Unsupported type parameters (%s) for %s", boundVariables, getSignature()));
+        throw new PrestoException(NOT_SUPPORTED, format("Unsupported type parameters (%s) for %s", boundVariables, getSignature()));
     }
 }


### PR DESCRIPTION
## Description
Throwing proper error code for better error classification.


## Motivation and Context
We see queries failing with `Unsupported type parameters (BoundVariables{typeVariables={T=array(varchar)}, longVariables={}}) for presto.default.approx_distinct<T>(T):bigint` where parmater isn't supported. This is simply user error (also the error message suggests so). Throwing user error code in this case reudce unnecessary retry, miscategorization and send proper signal to users.

## Impact
None

## Test Plan
Existing

```
== NO RELEASE NOTE ==
```

