### PR TITLE
fix!: Remove trailing uninitialized bytes in the binary result array

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -52,6 +52,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.ThreadSafe;
@@ -521,7 +522,8 @@ class Query
                     DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
                     writeSerializedPage(sliceOutput, serializedPage);
 
-                    String encodedPage = BASE64_ENCODER.encodeToString(sliceOutput.slice().byteArray());
+                    byte[] binaryResultArray = sliceOutput.slice().byteArray();
+                    String encodedPage = BaseEncoding.base64().encode(binaryResultArray, 0, sliceOutput.size());
                     pages.add(encodedPage);
                 }
                 if (rows > 0) {


### PR DESCRIPTION
Summary:
Remove the uninitialized bytes in binaryData, so we can reduce the binary response size.

 {F1983340076}

Differential Revision: D85720910
### RELEASE NOTES ###
```
== RELEASE NOTES ==
General Changes
* Replace the java standard base64 encoder with BaseEncoding from Guava 
```
