### PR TITLE
fix: Set default kExchangeMaxErrorDuration to be > maxMemoryArbitrationTime

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -239,7 +239,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kHttpClientHttp2InitialStreamWindow, 1 << 23 /*8MB*/),
           NUM_PROP(kHttpClientHttp2StreamWindow, 1 << 23 /*8MB*/),
           NUM_PROP(kHttpClientHttp2SessionWindow, 1 << 26 /*64MB*/),
-          STR_PROP(kExchangeMaxErrorDuration, "3m"),
+          STR_PROP(kExchangeMaxErrorDuration, "6m"),
           STR_PROP(kExchangeRequestTimeout, "20s"),
           STR_PROP(kExchangeConnectTimeout, "20s"),
           BOOL_PROP(kExchangeEnableConnectionPool, true),


### PR DESCRIPTION
We have seen issues in production due to

 `Failed to fetch data from xxx /v1/task/20251016_061652_01883_is2sk.9.0.9.0/results/17/74 - Exhausted after 1 retries, duration 206279ms: proxygen::HTTPException: Shutdown transport: EOF, 10.154.225.18:8080 Operator: Exchange[3877] `

`206279ms` is roughly 3 min. Arbitrator timeout is 5m

Detailed investigation revealed that these errors occurred during high memory usage scenarios. Some stages were blocked waiting for memory arbitration, and while arbitration was pending, downstream tasks timed out when fetching data from upstream, resulting in the above exchange errors.

Fix

We increased the exchange error timeout to exceed the memory arbitrator’s activation duration. This prevents premature exchange failures caused by arbitration delays.

Note

This change does not address the underlying memory usage or query inefficiencies. It simply ensures that failures now correctly reflect memory pressure issues (e.g., lack of spilling or arbitration tuning) rather than misleading exchange errors.

There is also `kExchangeRequestTimeout` and `kExchangeConnectTimeout` but don't think they are respected in this case cause you can clearly see there was only 1 retry done in the error in 3 mins whereas we had values to set to 20sec


== RELEASE NOTES ==

Hive Connector Changes
* set default value of kExchangeMaxErrorDuration to 6m


