### PR TITLE
misc(native): Fix spelling in presto_protocol classes

### DIFF
--- a/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_flight/presto_protocol-json-cpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/arrow_flight/presto_protocol-json-cpp.mustache
@@ -76,7 +76,7 @@ namespace facebook::presto::protocol::arrow_flight {
 {{/struct}}
 {{#enum}}
 namespace facebook::presto::protocol::arrow_flight {
-    //Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+    //Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
     // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
     static const std::pair<{{&class_name}}, json>

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/hive/presto_protocol-json-cpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/hive/presto_protocol-json-cpp.mustache
@@ -61,7 +61,7 @@ namespace facebook::presto::protocol::hive {
 {{/struct}}
 {{#enum}}
 namespace facebook::presto::protocol::hive {
-    //Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+    //Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
     // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
     static const std::pair<{{&class_name}}, json>

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/hive/presto_protocol_hive.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/hive/presto_protocol_hive.cpp
@@ -23,7 +23,7 @@
 using namespace std::string_literals;
 
 namespace facebook::presto::protocol::hive {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ColumnType, json> ColumnType_enum_table[] =
@@ -366,7 +366,7 @@ void from_json(const json& j, HiveBucketHandle& p) {
 }
 } // namespace facebook::presto::protocol::hive
 namespace facebook::presto::protocol::hive {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<BucketFunctionType, json>
@@ -406,7 +406,7 @@ void from_json(const json& j, BucketFunctionType& e) {
 }
 } // namespace facebook::presto::protocol::hive
 namespace facebook::presto::protocol::hive {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<Order, json> Order_enum_table[] =
@@ -595,7 +595,7 @@ void from_json(const json& j, HiveFileSplit& p) {
 }
 } // namespace facebook::presto::protocol::hive
 namespace facebook::presto::protocol::hive {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<HiveCompressionCodec, json>
@@ -638,7 +638,7 @@ void from_json(const json& j, HiveCompressionCodec& e) {
 }
 } // namespace facebook::presto::protocol::hive
 namespace facebook::presto::protocol::hive {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<PrestoTableType, json> PrestoTableType_enum_table[] =
@@ -948,7 +948,7 @@ void from_json(const json& j, HiveStorageFormat& e) {
 }
 } // namespace facebook::presto::protocol::hive
 namespace facebook::presto::protocol::hive {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<TableType, json> TableType_enum_table[] =
@@ -984,7 +984,7 @@ void from_json(const json& j, TableType& e) {
 }
 } // namespace facebook::presto::protocol::hive
 namespace facebook::presto::protocol::hive {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<WriteMode, json> WriteMode_enum_table[] =

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol-json-cpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol-json-cpp.mustache
@@ -60,7 +60,7 @@ namespace facebook::presto::protocol::iceberg {
 {{/struct}}
 {{#enum}}
 namespace facebook::presto::protocol::iceberg {
-    //Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+    //Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
     // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
     static const std::pair<{{&class_name}}, json>

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -21,7 +21,7 @@
 using namespace std::string_literals;
 
 namespace facebook::presto::protocol::iceberg {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ChangelogOperation, json>
@@ -63,7 +63,7 @@ void from_json(const json& j, ChangelogOperation& e) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<TypeCategory, json> TypeCategory_enum_table[] =
@@ -260,7 +260,7 @@ void from_json(const json& j, ChangelogSplitInfo& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<FileContent, json> FileContent_enum_table[] =
@@ -298,7 +298,7 @@ void from_json(const json& j, FileContent& e) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<FileFormat, json> FileFormat_enum_table[] =
@@ -411,7 +411,7 @@ void from_json(const json& j, DeleteFile& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<IcebergTableType, json> IcebergTableType_enum_table[] =
@@ -505,17 +505,17 @@ void from_json(const json& j, IcebergTableName& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<PartitionTransformType, json>
     PartitionTransformType_enum_table[] =
         { // NOLINT: cert-err58-cpp
             {PartitionTransformType::IDENTITY, "IDENTITY"},
-            {PartitionTransformType::YEAR, "YEAR"},
-            {PartitionTransformType::MONTH, "MONTH"},
-            {PartitionTransformType::DAY, "DAY"},
             {PartitionTransformType::HOUR, "HOUR"},
+            {PartitionTransformType::DAY, "DAY"},
+            {PartitionTransformType::MONTH, "MONTH"},
+            {PartitionTransformType::YEAR, "YEAR"},
             {PartitionTransformType::BUCKET, "BUCKET"},
             {PartitionTransformType::TRUNCATE, "TRUNCATE"}};
 void to_json(json& j, const PartitionTransformType& e) {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/tpcds/presto_protocol-json-cpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/tpcds/presto_protocol-json-cpp.mustache
@@ -72,7 +72,7 @@ namespace facebook::presto::protocol::tpcds {
 {{/struct}}
 {{#enum}}
 namespace facebook::presto::protocol::tpcds {
-    //Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+    //Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
     // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
     static const std::pair<{{&class_name}}, json>

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/tpch/presto_protocol-json-cpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/tpch/presto_protocol-json-cpp.mustache
@@ -72,7 +72,7 @@ namespace facebook::presto::protocol::tpch {
 {{/struct}}
 {{#enum}}
 namespace facebook::presto::protocol::tpch {
-    //Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+    //Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
     // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
     static const std::pair<{{&class_name}}, json>

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol-json-cpp.mustache
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol-json-cpp.mustache
@@ -35,7 +35,7 @@ std::string json_map_key(std::string p) {
 } // namespace nlohmann
 
 namespace facebook::presto::protocol {
-    // Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+    // Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
     // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
     static const std::pair<NodeSelectionStrategy, json>
@@ -134,7 +134,7 @@ namespace facebook::presto::protocol {
 {{/struct}}
 {{#enum}}
 namespace facebook::presto::protocol {
-    //Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+    //Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
     // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
     static const std::pair<{{&class_name}}, json>

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -32,7 +32,7 @@ std::string json_map_key(std::string p) {
 } // namespace nlohmann
 
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<NodeSelectionStrategy, json>
@@ -343,7 +343,7 @@ void from_json(const json& j, CallExpression& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SortOrder, json> SortOrder_enum_table[] =
@@ -555,7 +555,7 @@ void from_json(const json& j, AggregationFunctionMetadata& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<AggregationNodeStep, json>
@@ -1119,6 +1119,7 @@ void from_json(const json& j, std::shared_ptr<ConnectorTableHandle>& p) {
 }
 } // namespace facebook::presto::protocol
 // dependency TpchTransactionHandle
+// dependency TpcdsTransactionHandle
 // dependency ArrowTransactionHandle
 
 namespace facebook::presto::protocol {
@@ -1317,7 +1318,7 @@ void from_json(const json& j, BaseInputDistribution& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<BufferType, json> BufferType_enum_table[] =
@@ -1481,7 +1482,7 @@ void from_json(const json& j, ResourceEstimates& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SelectedRoleType, json> SelectedRoleType_enum_table[] =
@@ -1547,7 +1548,7 @@ void from_json(const json& j, Parameter& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<Determinism, json> Determinism_enum_table[] = {
@@ -1598,7 +1599,7 @@ void from_json(const json& j, Language& p) {
 
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<NullCallClause, json> NullCallClause_enum_table[] =
@@ -1687,7 +1688,7 @@ void from_json(const json& j, RoutineCharacteristics& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<FunctionKind, json> FunctionKind_enum_table[] =
@@ -2806,7 +2807,7 @@ void from_json(const json& j, BufferInfo& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<BuiltInFunctionKind, json>
@@ -2889,7 +2890,7 @@ void from_json(const json& j, BuiltInFunctionHandle& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<CacheQuotaScope, json> CacheQuotaScope_enum_table[] =
@@ -3537,7 +3538,7 @@ void from_json(const json& j, Domain& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<BlockedReason, json> BlockedReason_enum_table[] =
@@ -4663,7 +4664,7 @@ void from_json(const json& j, EquiJoinClause& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ErrorType, json> ErrorType_enum_table[] =
@@ -4744,7 +4745,7 @@ void from_json(const json& j, ErrorLocation& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ExchangeNodeScope, json> ExchangeNodeScope_enum_table[] =
@@ -4784,7 +4785,7 @@ void from_json(const json& j, ExchangeNodeScope& e) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ExchangeNodeType, json> ExchangeNodeType_enum_table[] = {
@@ -4825,7 +4826,7 @@ void from_json(const json& j, ExchangeNodeType& e) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ExchangeEncoding, json> ExchangeEncoding_enum_table[] =
@@ -5172,7 +5173,7 @@ void from_json(const json& j, ExchangeNode& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ErrorCause, json> ErrorCause_enum_table[] =
@@ -5334,7 +5335,7 @@ void from_json(const json& j, FilterNode& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<BoundType, json> BoundType_enum_table[] =
@@ -5372,7 +5373,7 @@ void from_json(const json& j, BoundType& e) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<WindowType, json> WindowType_enum_table[] = {
@@ -5682,7 +5683,7 @@ void from_json(const json& j, IndexHandle& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<JoinType, json> JoinType_enum_table[] =
@@ -6143,7 +6144,7 @@ void from_json(const json& j, InsertHandle& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<JoinDistributionType, json>
@@ -6633,7 +6634,7 @@ void from_json(const json& j, LambdaDefinitionExpression& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<LimitNodeStep, json> LimitNodeStep_enum_table[] =
@@ -6764,7 +6765,7 @@ void from_json(const json& j, MarkDistinctNode& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<Bound, json> Bound_enum_table[] =
@@ -7127,7 +7128,7 @@ void from_json(const json& j, NodeLoadMetrics& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<NodeState, json> NodeState_enum_table[] =
@@ -7319,7 +7320,7 @@ void from_json(const json& j, NodeStatus& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<BufferState, json> BufferState_enum_table[] =
@@ -8211,7 +8212,7 @@ void from_json(const json& j, PlanCostEstimate& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<StageExecutionStrategy, json>
@@ -8309,7 +8310,7 @@ void from_json(const json& j, StageExecutionDescriptor& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<ConfidenceLevel, json> ConfidenceLevel_enum_table[] =
@@ -8694,7 +8695,7 @@ void from_json(const json& j, PlanFragment& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<Locality, json> Locality_enum_table[] =
@@ -9098,7 +9099,7 @@ void from_json(const json& j, RowNumberNode& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<RuntimeUnit, json> RuntimeUnit_enum_table[] =
@@ -9157,7 +9158,7 @@ void from_json(const json& j, RuntimeMetric& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SampleNodeType, json> SampleNodeType_enum_table[] =
@@ -9230,7 +9231,7 @@ void from_json(const json& j, SampleNode& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<DistributionType, json> DistributionType_enum_table[] =
@@ -9558,7 +9559,7 @@ void from_json(const json& j, SortedRangeSet& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SpatialJoinType, json> SpatialJoinType_enum_table[] =
@@ -9709,7 +9710,7 @@ void from_json(const json& j, SpatialJoinNode& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<Form, json> Form_enum_table[] =
@@ -9933,7 +9934,7 @@ void from_json(const json& j, SystemColumnHandle& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SystemPartitionFunction, json>
@@ -9976,7 +9977,7 @@ void from_json(const json& j, SystemPartitionFunction& e) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<SystemPartitioning, json>
@@ -11181,7 +11182,7 @@ void from_json(const json& j, TaskStats& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<TaskState, json> TaskState_enum_table[] =
@@ -11540,7 +11541,7 @@ void from_json(const json& j, TaskInfo& p) {
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-// Loosly copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
+// Loosely copied this here from NLOHMANN_JSON_SERIALIZE_ENUM()
 
 // NOLINTNEXTLINE: cppcoreguidelines-avoid-c-arrays
 static const std::pair<Step, json> Step_enum_table[] =


### PR DESCRIPTION
This was showing up in sourcery-ai review comments, so cleaning it.


```
== NO RELEASE NOTE ==
```

