### PR TITLE
fix: Negative finishCpu causes stats reporting to fail

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -885,7 +885,9 @@ public class OperatorStats
             nullJoinProbeKeyCount += operator.getNullJoinProbeKeyCount();
             joinProbeKeyCount += operator.getJoinProbeKeyCount();
         }
-
+        if (finishCpu < 0) {
+            finishCpu = Long.MAX_VALUE;
+        }
         return Optional.of(new OperatorStats(
                 stageId,
                 stageExecutionId,


### PR DESCRIPTION
Summary:
finishCpu += operator.getFinishCpu().roundTo(NANOSECONDS);

getFinishCpu has underlying issue that causes finisheCpu to overflow thus resulting in a negative result. This causes exception while reporting query completion event leading to stats not being reported.
Fix it by setting finishCpu to max value when it overflows


# Release Note
```
== NO RELEASE NOTE ==
```
