### PR TITLE
feat: Add max_split_preload_per_driver to java system config

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -191,6 +191,7 @@ public final class SystemSessionProperties
     public static final String IGNORE_STATS_CALCULATOR_FAILURES = "ignore_stats_calculator_failures";
     public static final String PRINT_STATS_FOR_NON_JOIN_QUERY = "print_stats_for_non_join_query";
     public static final String MAX_DRIVERS_PER_TASK = "max_drivers_per_task";
+    public static final String MAX_SPLIT_PRELOAD_PER_DRIVER = "max_split_preload_per_driver";
     public static final String MAX_TASKS_PER_STAGE = "max_tasks_per_stage";
     public static final String DEFAULT_FILTER_FACTOR_ENABLED = "default_filter_factor_enabled";
     public static final String CTE_MATERIALIZATION_STRATEGY = "cte_materialization_strategy";
@@ -1024,6 +1025,11 @@ public final class SystemSessionProperties
                         false,
                         value -> min(taskManagerConfig.getMaxDriversPerTask(), validateNullablePositiveIntegerValue(value, MAX_DRIVERS_PER_TASK)),
                         object -> object),
+                integerProperty(
+                        MAX_SPLIT_PRELOAD_PER_DRIVER,
+                        "Maximum number of splits to preload per driver. Set to 0 to disable preloading",
+                        0,
+                        false),
                 booleanProperty(
                         IGNORE_STATS_CALCULATOR_FAILURES,
                         "Ignore statistics calculator failures",
@@ -2582,6 +2588,11 @@ public final class SystemSessionProperties
             return OptionalInt.empty();
         }
         return OptionalInt.of(value);
+    }
+
+    public static int getMaxSplitPreloadPerDriver(Session session)
+    {
+        return session.getSystemProperty(MAX_SPLIT_PRELOAD_PER_DRIVER, Integer.class);
     }
 
     public static int getMaxTasksPerStage(Session session)


### PR DESCRIPTION
as titled

## Description
add java session property max_split_preload_per_driver with default value 0

## Motivation and Context
enable feature waitForPreloadSplitNanos

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
[e2e]
20251106_193157_00009_runst: waitForPreloadSplitNanos enabled when max_split_preload_per_driver = 2
20251105_230547_00023_gy8x9: waitForPreloadSplitNanos disabled when max_split_preload_per_driver = 0 (default)
## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

