### PR TITLE
fix(optimizer): Fix local exchange for merge join

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -558,8 +558,7 @@ public class TestLogicalPlanner
                 preferSortMergeJoin,
                 anyTree(
                         mergeJoin(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_PK")), Optional.empty(),
-                                exchange(LOCAL, GATHER, ImmutableList.of(),
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
                                 sort(
                                         ImmutableList.of(sort("LINEITEM_PK", ASCENDING, FIRST)),
                                         exchange(LOCAL, GATHER, ImmutableList.of(),
@@ -574,18 +573,15 @@ public class TestLogicalPlanner
                                         ImmutableList.of(sort("ORDERS_CK", ASCENDING, FIRST)),
                                         exchange(LOCAL, GATHER, ImmutableList.of(),
                                                 tableScan("orders", ImmutableMap.of("ORDERS_CK", "custkey")))),
-                                exchange(LOCAL, GATHER, ImmutableList.of(),
-                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
+                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))));
 
         // Both sides are sorted.
         assertPlan("SELECT o.orderkey FROM orders o INNER JOIN lineitem l ON o.orderkey = l.orderkey",
                 preferSortMergeJoin,
                 anyTree(
                         mergeJoin(INNER, ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")), Optional.empty(),
-                                exchange(LOCAL, GATHER, ImmutableList.of(),
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
-                                exchange(LOCAL, GATHER, ImmutableList.of(),
-                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
+                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))));
     }
 
     @Test


### PR DESCRIPTION
## Description
Current code will try to add a round robin local exchange below the merge join node, which will break the sorted property of the input. In this PR, we fixed it.

## Motivation and Context
Bug fix

## Impact
Bug fix

## Test Plan
Unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

