### PR TITLE
feat: Add native session property native_max_split_preload_per_driver

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -511,6 +511,14 @@ This is used in global arbitration victim selection.
 Maximum number of splits to listen to by the SplitListener per table scan node per
 native worker.
 
+``native_max_split_preload_per_driver``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``0``
+
+Maximum number of splits to preload per driver. Set to 0 to disable preloading.
+
 ``native_index_lookup_join_max_prefetch_batches``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -351,6 +351,7 @@ public final class SystemSessionProperties
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
+    public static final String NATIVE_MAX_SPLIT_PRELOAD_PER_DRIVER = "native_max_split_preload_per_driver";
     public static final String NATIVE_EXECUTION_ENABLED = "native_execution_enabled";
     private static final String NATIVE_EXECUTION_EXECUTABLE_PATH = "native_execution_executable_path";
     private static final String NATIVE_EXECUTION_PROGRAM_ARGUMENTS = "native_execution_program_arguments";
@@ -1615,6 +1616,11 @@ public final class SystemSessionProperties
                                 "output processing. This is to simplify the aggregation query OOM prevention in " +
                                 "output processing stage.",
                         true,
+                        false),
+                integerProperty(
+                        NATIVE_MAX_SPLIT_PRELOAD_PER_DRIVER,
+                        "Native Execution only. Maximum number of splits to preload per driver. Set to 0 to disable preloading.",
+                        0,
                         false),
                 booleanProperty(
                         NATIVE_EXECUTION_ENABLED,
@@ -3361,6 +3367,11 @@ public final class SystemSessionProperties
     public static boolean isNativeExecutionScaleWritersThreadsEnabled(Session session)
     {
         return session.getSystemProperty(NATIVE_EXECUTION_SCALE_WRITER_THREADS_ENABLED, Boolean.class);
+    }
+
+    public static int getMaxSplitPreloadPerDriver(Session session)
+    {
+        return session.getSystemProperty(NATIVE_MAX_SPLIT_PRELOAD_PER_DRIVER, Integer.class);
     }
 
     public static boolean isNativeExecutionTypeRewriteEnabled(Session session)

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -509,6 +509,14 @@ SessionProperties::SessionProperties() {
       std::to_string(c.maxNumSplitsListenedTo()));
 
   addSessionProperty(
+      kMaxSplitPreloadPerDriver,
+      "Maximum number of splits to preload per driver. Set to 0 to disable preloading.",
+      INTEGER(),
+      false,
+      QueryConfig::kMaxSplitPreloadPerDriver,
+      std::to_string(c.maxSplitPreloadPerDriver()));
+
+  addSessionProperty(
       kIndexLookupJoinMaxPrefetchBatches,
       "Specifies the max number of input batches to prefetch to do index"
       "lookup ahead. If it is zero, then process one input batch at a time.",

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -327,6 +327,11 @@ class SessionProperties {
   static constexpr const char* kMaxNumSplitsListenedTo =
       "native_max_num_splits_listened_to";
 
+  /// Maximum number of splits to preload per driver. Set to 0 to disable
+  /// preloading.
+  static constexpr const char* kMaxSplitPreloadPerDriver =
+      "native_max_split_preload_per_driver";
+
   /// Specifies the max number of input batches to prefetch to do index lookup
   /// ahead. If it is zero, then process one input batch at a time.
   static constexpr const char* kIndexLookupJoinMaxPrefetchBatches =


### PR DESCRIPTION
## Description
This diff introduces a new native session property for Presto:
native_max_split_preload_per_driver
Type: integer
Default value: 0
Purpose:
Controls the maximum number of splits to preload per driver in native execution.
Setting it to 0 disables preloading.
Used to enable/disable the feature waitForPreloadSplitNanos.

property constant and registration for native_max_split_preload_per_driver: kMaxSplitPreloadPerDriver

## Motivation and Context
enable feature waitForPreloadSplitNanos


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
[e2e]
20251112_020913_00006_iqyde: waitForPreloadSplitNanos enabled when max_split_preload_per_driver = 2
20251112_022920_00009_iqyde: waitForPreloadSplitNanos disabled when max_split_preload_per_driver = 0 (default)
## Contributor checklist

## Release Notes
```
== RELEASE NOTES ==
General Changes
* Add support for scaling the maximum number of splits to preload per driver. Native execution only. See :ref:`presto_cpp/properties-session:\`\`native_max_split_preload_per_driver\`\``.

