### PR TITLE
fix: Negative finishCpu causes stats reporting to fail (#26587)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -885,7 +885,9 @@ public class OperatorStats
             nullJoinProbeKeyCount += operator.getNullJoinProbeKeyCount();
             joinProbeKeyCount += operator.getJoinProbeKeyCount();
         }
-
+        if (finishCpu < 0) {
+            finishCpu = Long.MAX_VALUE;
+        }
         return Optional.of(new OperatorStats(
                 stageId,
                 stageExecutionId,


### PR DESCRIPTION
Summary:
finishCpu += operator.getFinishCpu().roundTo(NANOSECONDS);

getFinishCpu has underlying issue that causes finisheCpu to overflow thus resulting in a negative result. This causes exception while reporting query completion event leading to stats not being reported. Fix it by setting finishCpu to max value when it overflows


# Release Note
```
== NO RELEASE NOTE ==
```

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

