### PR TITLE
refactor(native): Move function to extract function name parts to utilities

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -136,4 +136,14 @@ std::string decompressMessageBody(
         e.what());
   }
 }
+
+const std::vector<std::string> getFunctionNameParts(
+    const std::string& registeredFunction) {
+  std::vector<std::string> parts;
+  folly::split('.', registeredFunction, parts, true);
+  VELOX_USER_CHECK(
+      parts.size() == 3,
+      fmt::format("Prefix missing for function {}", registeredFunction));
+  return parts;
+}
 } // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/common/Utils.h
+++ b/presto-native-execution/presto_cpp/main/common/Utils.h
@@ -60,4 +60,10 @@ inline std::string addDefaultNamespacePrefix(
     const std::string& functionName) {
   return fmt::format("{}{}", prestoDefaultNamespacePrefix, functionName);
 }
+
+/// The keys in velox function maps are of the format
+/// `catalog.schema.function_name`. This utility function extracts the
+/// three parts, {catalog, schema, function_name}, from the registered function.
+const std::vector<std::string> getFunctionNameParts(
+    const std::string& registeredFunction);
 } // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -231,6 +231,32 @@ TEST(UtilsTest, extractMessageBody) {
   EXPECT_EQ(messageBody, "body1body2body3body4body5");
 }
 
+TEST(UtilsTest, getFunctionNameParts) {
+  {
+    auto parts = util::getFunctionNameParts("presto.default.my_function");
+    ASSERT_EQ(parts.size(), 3);
+    EXPECT_EQ(parts[0], "presto");
+    EXPECT_EQ(parts[1], "default");
+    EXPECT_EQ(parts[2], "my_function");
+  }
+
+  {
+    auto parts = util::getFunctionNameParts("remote.catalog.sum");
+    ASSERT_EQ(parts.size(), 3);
+    EXPECT_EQ(parts[0], "remote");
+    EXPECT_EQ(parts[1], "catalog");
+    EXPECT_EQ(parts[2], "sum");
+  }
+
+  EXPECT_THROW(util::getFunctionNameParts("catalog.function"), VeloxException);
+  EXPECT_THROW(util::getFunctionNameParts("function"), VeloxException);
+  EXPECT_THROW(
+      util::getFunctionNameParts("prefix.catalog.schema.function"),
+      VeloxException);
+  EXPECT_THROW(util::getFunctionNameParts(""), VeloxException);
+  EXPECT_THROW(util::getFunctionNameParts(".."), VeloxException);
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::SingletonVault::singleton()->registrationComplete();

--- a/presto-native-execution/presto_cpp/main/functions/FunctionMetadata.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/FunctionMetadata.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/functions/FunctionMetadata.h"
+#include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/WindowFunction.h"
@@ -40,19 +41,6 @@ bool isValidPrestoType(const TypeSignature& typeSignature) {
     }
   }
   return true;
-}
-
-// The keys in velox function maps are of the format
-// `catalog.schema.function_name`. This utility function extracts the
-// three parts, {catalog, schema, function_name}, from the registered function.
-const std::vector<std::string> getFunctionNameParts(
-    const std::string& registeredFunction) {
-  std::vector<std::string> parts;
-  folly::split('.', registeredFunction, parts, true);
-  VELOX_USER_CHECK(
-      parts.size() == 3,
-      fmt::format("Prefix missing for function {}", registeredFunction));
-  return parts;
 }
 
 const protocol::AggregationFunctionMetadata getAggregationFunctionMetadata(
@@ -289,7 +277,7 @@ json getFunctionsMetadata(const std::optional<std::string>& catalog) {
       continue;
     }
 
-    const auto parts = getFunctionNameParts(name);
+    const auto parts = util::getFunctionNameParts(name);
     if (skipCatalog(parts[0])) {
       continue;
     }
@@ -302,7 +290,7 @@ json getFunctionsMetadata(const std::optional<std::string>& catalog) {
   for (const auto& entry : aggregateFunctions) {
     if (!aggregateFunctions.at(entry.first).metadata.companionFunction) {
       const auto name = entry.first;
-      const auto parts = getFunctionNameParts(name);
+      const auto parts = util::getFunctionNameParts(name);
       if (skipCatalog(parts[0])) {
         continue;
       }
@@ -319,7 +307,7 @@ json getFunctionsMetadata(const std::optional<std::string>& catalog) {
   for (const auto& entry : functions) {
     if (aggregateFunctions.count(entry.first) == 0) {
       const auto name = entry.first;
-      const auto parts = getFunctionNameParts(entry.first);
+      const auto parts = util::getFunctionNameParts(entry.first);
       if (skipCatalog(parts[0])) {
         continue;
       }

--- a/presto-native-execution/presto_cpp/main/functions/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/functions/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_test(
 target_link_libraries(
   presto_function_metadata_test
   presto_function_metadata
+  presto_common
   presto_protocol
   presto_type_test_utils
   velox_aggregates


### PR DESCRIPTION
## Description
Move function to extract function name parts to utilities. 

## Motivation and Context
This function will be used in subsequent PR inside REST based remote functions outside the class FunctionMetadata.

## Impact
No Impact.

## Test Plan
UT added in this PR.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

