### PR TITLE
feat(plugin-iceberg): Enable Nessie with S3 access via Iceberg REST Catalog

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -349,6 +349,49 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-aws</artifactId>
+            <version>${dep.iceberg.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-parquet</artifactId>
             <version>${dep.iceberg.version}</version>
             <exclusions>
@@ -522,36 +565,6 @@
         </dependency>
 
         <!-- for testing -->
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>regions</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sdk-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>auth</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>aws-core</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/container/IcebergMinIODataLake.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/container/IcebergMinIODataLake.java
@@ -48,9 +48,14 @@ public class IcebergMinIODataLake
 
     public IcebergMinIODataLake(String bucketName, String warehouseDir)
     {
+        this(bucketName, warehouseDir, newNetwork());
+    }
+
+    public IcebergMinIODataLake(String bucketName, String warehouseDir, Network network)
+    {
         this.bucketName = requireNonNull(bucketName, "bucketName is null");
         this.warehouseDir = requireNonNull(warehouseDir, "warehouseDir is null");
-        Network network = closer.register(newNetwork());
+        closer.register(network);
         this.minIOContainer = closer.register(
                 MinIOContainer.builder()
                         .withNetwork(network)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieRestCatalogDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergNessieRestCatalogDistributedQueries.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.nessie;
+
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.container.IcebergMinIODataLake;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.containers.MinIOContainer;
+import com.facebook.presto.testing.containers.NessieContainer;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+import org.testcontainers.containers.Network;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import software.amazon.awssdk.regions.Region;
+
+import java.net.URI;
+import java.util.Map;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.container.IcebergMinIODataLake.ACCESS_KEY;
+import static com.facebook.presto.iceberg.container.IcebergMinIODataLake.SECRET_KEY;
+import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+
+public class TestIcebergNessieRestCatalogDistributedQueries
+        extends TestIcebergNessieCatalogDistributedQueries
+{
+    static final String WAREHOUSE_DATA_DIR = "warehouse_data/";
+    private NessieContainer nessieContainer;
+    private IcebergMinIODataLake dockerizedS3DataLake;
+    private String bucketName;
+    HostAndPort minioApiEndpoint;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        Network network = Network.newNetwork();
+
+        bucketName = "fornessie-" + randomTableSuffix();
+        dockerizedS3DataLake = new IcebergMinIODataLake(bucketName, WAREHOUSE_DATA_DIR, network);
+        dockerizedS3DataLake.start();
+        minioApiEndpoint = dockerizedS3DataLake.getMinio().getMinioApiEndpoint();
+
+        Map<String, String> envVars = ImmutableMap.<String, String>builder()
+                .putAll(NessieContainer.DEFAULT_ENV_VARS)
+                .put("NESSIE_CATALOG_SERVICE_S3_DEFAULT-OPTIONS_ACCESS-KEY", "urn:nessie-secret:quarkus:nessie.catalog.secrets.access-key")
+                .put("NESSIE_CATALOG_SECRETS_ACCESS-KEY_NAME", ACCESS_KEY)
+                .put("NESSIE_CATALOG_SECRETS_ACCESS-KEY_SECRET", SECRET_KEY)
+                .put("NESSIE_CATALOG_SERVICE_S3_DEFAULT-OPTIONS_PATH_STYLE_ACCESS", "true")
+                .put("NESSIE_CATALOG_SERVICE_S3_DEFAULT-OPTIONS_ENDPOINT", format("http://%s:%s", MinIOContainer.DEFAULT_HOST_NAME, MinIOContainer.MINIO_API_PORT))
+                .put("NESSIE_CATALOG_SERVICE_S3_DEFAULT-OPTIONS_REGION", Region.US_EAST_1.toString())
+                .put("NESSIE_CATALOG_WAREHOUSES_WAREHOUSE_LOCATION", getCatalogDataDirectory().toString())
+                .put("NESSIE_CATALOG_DEFAULT-WAREHOUSE", "warehouse")
+                .put("NESSIE_CATALOG_SERVICE_S3.DEFAULT-OPTIONS_EXTERNAL-ENDPOINT", format("http://%s:%s", minioApiEndpoint.getHost(), minioApiEndpoint.getPort()))
+                .buildOrThrow();
+        nessieContainer = NessieContainer.builder().withEnvVars(envVars).withNetwork(network).build();
+        nessieContainer.start();
+
+        super.init();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void tearDown()
+    {
+        super.tearDown();
+        if (nessieContainer != null) {
+            nessieContainer.stop();
+        }
+        if (dockerizedS3DataLake != null) {
+            dockerizedS3DataLake.stop();
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .put("iceberg.rest.uri", nessieContainer.getIcebergRestUri())
+                .put("iceberg.catalog.warehouse", getCatalogDataDirectory().toString())
+                .put("hive.s3.aws-access-key", ACCESS_KEY)
+                .put("hive.s3.aws-secret-key", SECRET_KEY)
+                .put("hive.s3.endpoint", format("http://%s:%s", minioApiEndpoint.getHost(), minioApiEndpoint.getPort()))
+                .put("hive.s3.path-style-access", "true")
+                .build();
+
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setExtraConnectorProperties(icebergProperties)
+                .build().getQueryRunner();
+    }
+
+    protected org.apache.hadoop.fs.Path getCatalogDataDirectory()
+    {
+        return new org.apache.hadoop.fs.Path(URI.create(format("s3a://%s/%s", bucketName, WAREHOUSE_DATA_DIR)));
+    }
+}

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/MinIOContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/MinIOContainer.java
@@ -30,7 +30,7 @@ public class MinIOContainer
 {
     private static final Logger log = Logger.get(MinIOContainer.class);
 
-    public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2021-07-15T22-27-34Z";
+    public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z";
     public static final String DEFAULT_HOST_NAME = "minio";
 
     public static final int MINIO_API_PORT = 4566;

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
@@ -27,7 +27,7 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "ghcr.io/projectnessie/nessie:0.77.1";
+    public static final String DEFAULT_IMAGE = "ghcr.io/projectnessie/nessie:0.105.7";
     public static final String DEFAULT_HOST_NAME = "nessie";
     public static final String VERSION_STORE_TYPE = "IN_MEMORY";
 
@@ -57,6 +57,11 @@ public class NessieContainer
     public String getRestApiUri()
     {
         return "http://" + getMappedHostAndPortForExposedPort(PORT) + "/api/v1";
+    }
+
+    public String getIcebergRestUri()
+    {
+        return "http://" + getMappedHostAndPortForExposedPort(PORT) + "/iceberg";
     }
 
     public static class Builder


### PR DESCRIPTION
## Description
Enables support for accessing the Nessie catalog and S3 storage when using the Iceberg REST Catalog API.

This PR solves the `ClassNotFoundException` by adding the `iceberg-aws` dependency and its transitive `AWS SDK V2` dependencies.


## Motivation and Context

Currently, attempting to use the Iceberg REST API with Nessie and S3 storage fails when creating tables due to a missing dependency:

```
 Query failed: Cannot initialize FileIO implementation org.apache.iceberg.aws.s3.S3FileIO: Cannot find constructor for interface org.apache.iceberg.io.FileIO
    Missing org.apache.iceberg.aws.s3.S3FileIO [java.lang.ClassNotFoundException: org.apache.iceberg.aws.s3.S3FileIO]
```

The motivation for enabling this is to take advantage of the OAuth 2.0 authentication provided by the Iceberg REST catalog, specifically using the `iceberg.rest.auth.oauth2.credential` property to avoid manual token handling.


## Test Plan
- Run same tests as in `TestIcebergNessieCatalogDistributedQueries` with Nessie configured as an Iceberg REST catalog:
```
iceberg.catalog.type=rest
iceberg.rest.uri=http://HOST:PORT/iceberg   # Nessie Iceberg REST endpoint
```

- Upgrade the Nessie image in `NessieContainer`  to a version that has available the Iceberg REST spec endpoint.
- Upgrade the MinIO image in `MinIOContainer` to prevent [ChecksumAlgorithm.SHA256 PutObjectRequest support #17662](https://github.com/minio/minio/issues/17662)

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add support to access Nessie with S3 using Iceberg REST catalog

```

