### PR TITLE
feat: Add findOrCreateBatchQueryCtx to query ctx manager

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -338,7 +338,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateBatchTask(
         }
 
         auto queryCtx =
-            taskManager_.getQueryContextManager()->findOrCreateQueryCtx(
+            taskManager_.getQueryContextManager()->findOrCreateBatchQueryCtx(
                 taskId, updateRequest);
 
         VeloxBatchQueryPlanConverter converter(

--- a/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/QueryContextCacheTest.cpp
@@ -95,7 +95,7 @@ TEST_F(QueryContextCacheTest, hasStartedTasks) {
     auto queryId = fmt::format("query-{}", i);
     EXPECT_FALSE(queryContextCache.hasStartedTasks(queryId));
     if (i % 2 == 0) {
-      queryContextCache.setHasStartedTasks(queryId);
+      queryContextCache.setTasksStarted(queryId);
     }
   }
 


### PR DESCRIPTION
Summary:
In Batch mode, only one query is running at a time. When tasks fail during memory arbitration, the query memory pool will be set aborted, failing any successive tasks immediately. Yet one task should not fail other newly admitted tasks because of task retries and server reuse. Failure control among tasks should be independent. So if query memory pool is aborted already, a cache clear is performed to allow successive tasks to create a new query context to continue execution.

This change also changes the folly::Synchronized lock to std::mutex for more flexible locking.

Differential Revision: D87006158


