### PR TITLE
fix(ci): Free disk space for some CI test workflows

### DIFF
--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -43,11 +43,10 @@ jobs:
     steps:
       - name: Free Disk Space
         if: needs.changes.outputs.codechange == 'true'
-        run: |
-          df -h
-          sudo apt-get clean
-          rm -rf /opt/hostedtoolcache
-          df -h
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          swap-storage: false
       - uses: actions/checkout@v4
         if: needs.changes.outputs.codechange == 'true'
         with:

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -42,6 +42,12 @@ jobs:
       group: ${{ github.workflow }}-spark-integration-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
+      - name: Free Disk Space
+        if: needs.changes.outputs.codechange == 'true'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          swap-storage: false
       - uses: actions/checkout@v4
         if: needs.changes.outputs.codechange == 'true'
         with:


### PR DESCRIPTION
## Description

This change free disk space for `product-tests-basic-environment` and `spark-integration` which are failing frequently due to disk space issues.

## Motivation and Context

Stable CI

## Impact

Stable CI

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

