### PR TITLE
feat(native): Add exchange.max-buffer-size to system config

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -115,64 +115,83 @@ void updateFromSystemConfigs(
   };
 
   static const std::vector<ConfigMapping> veloxToPrestoConfigMapping{
-      {std::string(SystemConfig::kQueryMaxMemoryPerNode),
-       velox::core::QueryConfig::kQueryMaxMemoryPerNode},
+      {.prestoSystemConfig = std::string(SystemConfig::kQueryMaxMemoryPerNode),
+       .veloxConfig = velox::core::QueryConfig::kQueryMaxMemoryPerNode},
 
       {
-          std::string(SystemConfig::kSpillerFileCreateConfig),
-          velox::core::QueryConfig::kSpillFileCreateConfig,
+          .prestoSystemConfig =
+              std::string(SystemConfig::kSpillerFileCreateConfig),
+          .veloxConfig = velox::core::QueryConfig::kSpillFileCreateConfig,
       },
 
-      {std::string(SystemConfig::kSpillEnabled),
-       velox::core::QueryConfig::kSpillEnabled},
+      {.prestoSystemConfig = std::string(SystemConfig::kSpillEnabled),
+       .veloxConfig = velox::core::QueryConfig::kSpillEnabled},
 
-      {std::string(SystemConfig::kJoinSpillEnabled),
-       velox::core::QueryConfig::kJoinSpillEnabled},
+      {.prestoSystemConfig = std::string(SystemConfig::kJoinSpillEnabled),
+       .veloxConfig = velox::core::QueryConfig::kJoinSpillEnabled},
 
-      {std::string(SystemConfig::kOrderBySpillEnabled),
-       velox::core::QueryConfig::kOrderBySpillEnabled},
+      {.prestoSystemConfig = std::string(SystemConfig::kOrderBySpillEnabled),
+       .veloxConfig = velox::core::QueryConfig::kOrderBySpillEnabled},
 
-      {std::string(SystemConfig::kAggregationSpillEnabled),
-       velox::core::QueryConfig::kAggregationSpillEnabled},
+      {.prestoSystemConfig =
+           std::string(SystemConfig::kAggregationSpillEnabled),
+       .veloxConfig = velox::core::QueryConfig::kAggregationSpillEnabled},
 
-      {std::string(SystemConfig::kRequestDataSizesMaxWaitSec),
-       velox::core::QueryConfig::kRequestDataSizesMaxWaitSec},
+      {.prestoSystemConfig =
+           std::string(SystemConfig::kRequestDataSizesMaxWaitSec),
+       .veloxConfig = velox::core::QueryConfig::kRequestDataSizesMaxWaitSec},
 
-      {std::string(SystemConfig::kDriverMaxSplitPreload),
-       velox::core::QueryConfig::kMaxSplitPreloadPerDriver},
+      {.prestoSystemConfig = std::string(SystemConfig::kDriverMaxSplitPreload),
+       .veloxConfig = velox::core::QueryConfig::kMaxSplitPreloadPerDriver},
 
-      {std::string(SystemConfig::kMaxLocalExchangePartitionBufferSize),
-       velox::core::QueryConfig::kMaxLocalExchangePartitionBufferSize},
+      {.prestoSystemConfig =
+           std::string(SystemConfig::kMaxLocalExchangePartitionBufferSize),
+       .veloxConfig =
+           velox::core::QueryConfig::kMaxLocalExchangePartitionBufferSize},
 
-      {std::string(SystemConfig::kUseLegacyArrayAgg),
-       velox::core::QueryConfig::kPrestoArrayAggIgnoreNulls},
+      {.prestoSystemConfig = std::string(SystemConfig::kUseLegacyArrayAgg),
+       .veloxConfig = velox::core::QueryConfig::kPrestoArrayAggIgnoreNulls},
 
-      {std::string{SystemConfig::kTaskWriterCount},
-       velox::core::QueryConfig::kTaskWriterCount},
+      {.prestoSystemConfig = std::string{SystemConfig::kTaskWriterCount},
+       .veloxConfig = velox::core::QueryConfig::kTaskWriterCount},
 
-      {std::string{SystemConfig::kTaskPartitionedWriterCount},
-       velox::core::QueryConfig::kTaskPartitionedWriterCount},
+      {.prestoSystemConfig =
+           std::string{SystemConfig::kTaskPartitionedWriterCount},
+       .veloxConfig = velox::core::QueryConfig::kTaskPartitionedWriterCount},
 
-      {std::string(SystemConfig::kSinkMaxBufferSize),
-       velox::core::QueryConfig::kMaxOutputBufferSize,
-       [](const auto& value) {
-         return folly::to<std::string>(velox::config::toCapacity(
-             value, velox::config::CapacityUnit::BYTE));
-       }},
+      {.prestoSystemConfig = std::string{SystemConfig::kExchangeMaxBufferSize},
+       .veloxConfig = velox::core::QueryConfig::kMaxExchangeBufferSize,
+       .toVeloxPropertyValueConverter =
+           [](const auto& value) {
+             return folly::to<std::string>(velox::config::toCapacity(
+                 value, velox::config::CapacityUnit::BYTE));
+           }},
 
-      {std::string(SystemConfig::kDriverMaxPagePartitioningBufferSize),
-       velox::core::QueryConfig::kMaxPartitionedOutputBufferSize,
-       [](const auto& value) {
-         return folly::to<std::string>(velox::config::toCapacity(
-             value, velox::config::CapacityUnit::BYTE));
-       }},
+      {.prestoSystemConfig = std::string(SystemConfig::kSinkMaxBufferSize),
+       .veloxConfig = velox::core::QueryConfig::kMaxOutputBufferSize,
+       .toVeloxPropertyValueConverter =
+           [](const auto& value) {
+             return folly::to<std::string>(velox::config::toCapacity(
+                 value, velox::config::CapacityUnit::BYTE));
+           }},
 
-      {std::string(SystemConfig::kTaskMaxPartialAggregationMemory),
-       velox::core::QueryConfig::kMaxPartialAggregationMemory,
-       [](const auto& value) {
-         return folly::to<std::string>(velox::config::toCapacity(
-             value, velox::config::CapacityUnit::BYTE));
-       }},
+      {.prestoSystemConfig =
+           std::string(SystemConfig::kDriverMaxPagePartitioningBufferSize),
+       .veloxConfig = velox::core::QueryConfig::kMaxPartitionedOutputBufferSize,
+       .toVeloxPropertyValueConverter =
+           [](const auto& value) {
+             return folly::to<std::string>(velox::config::toCapacity(
+                 value, velox::config::CapacityUnit::BYTE));
+           }},
+
+      {.prestoSystemConfig =
+           std::string(SystemConfig::kTaskMaxPartialAggregationMemory),
+       .veloxConfig = velox::core::QueryConfig::kMaxPartialAggregationMemory,
+       .toVeloxPropertyValueConverter =
+           [](const auto& value) {
+             return folly::to<std::string>(velox::config::toCapacity(
+                 value, velox::config::CapacityUnit::BYTE));
+           }},
   };
 
   for (const auto& configMapping : veloxToPrestoConfigMapping) {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -252,6 +252,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kExchangeEnableConnectionPool, true),
           BOOL_PROP(kExchangeEnableBufferCopy, true),
           BOOL_PROP(kExchangeImmediateBufferTransfer, true),
+          STR_PROP(kExchangeMaxBufferSize, "32MB"),
           NUM_PROP(kTaskRunTimeSliceMicros, 50'000),
           BOOL_PROP(kIncludeNodeInSpillPath, false),
           NUM_PROP(kOldTaskCleanUpMs, 60'000),
@@ -951,6 +952,12 @@ bool SystemConfig::exchangeEnableBufferCopy() const {
 
 bool SystemConfig::exchangeImmediateBufferTransfer() const {
   return optionalProperty<bool>(kExchangeImmediateBufferTransfer).value();
+}
+
+uint64_t SystemConfig::exchangeMaxBufferSize() const {
+  return velox::config::toCapacity(
+      optionalProperty(kExchangeMaxBufferSize).value(),
+      velox::config::CapacityUnit::BYTE);
 }
 
 int32_t SystemConfig::taskRunTimeSliceMicros() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -741,6 +741,11 @@ class SystemConfig : public ConfigBase {
       kExchangeHttpClientNumCpuThreadsHwMultiplier{
           "exchange.http-client.num-cpu-threads-hw-multiplier"};
 
+  /// Maximum size in bytes to accumulate in ExchangeQueue. Enforced
+  /// approximately, not strictly.
+  static constexpr std::string_view kExchangeMaxBufferSize{
+      "exchange.max-buffer-size"};
+
   /// The maximum timeslice for a task on thread if there are threads queued.
   static constexpr std::string_view kTaskRunTimeSliceMicros{
       "task-run-timeslice-micros"};
@@ -1117,6 +1122,8 @@ class SystemConfig : public ConfigBase {
   bool exchangeEnableBufferCopy() const;
 
   bool exchangeImmediateBufferTransfer() const;
+
+  uint64_t exchangeMaxBufferSize() const;
 
   int32_t taskRunTimeSliceMicros() const;
 

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -66,162 +66,221 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
   };
 
   std::vector<ConfigTestCase> testCases = {
-      {core::QueryConfig::kQueryMaxMemoryPerNode,
-       std::make_optional<std::string>("query_max_memory_per_node"),
-       std::string(SystemConfig::kQueryMaxMemoryPerNode),
-       "8GB",
-       "4GB",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(
-             config::toCapacity(expectedValue, config::CapacityUnit::BYTE),
-             config.queryMaxMemoryPerNode());
-       }},
+      {.veloxConfigKey = core::QueryConfig::kQueryMaxMemoryPerNode,
+       .sessionPropertyKey =
+           std::make_optional<std::string>("query_max_memory_per_node"),
+       .systemConfigKey = std::string(SystemConfig::kQueryMaxMemoryPerNode),
+       .sessionValue = "8GB",
+       .differentSessionValue = "4GB",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 config::toCapacity(expectedValue, config::CapacityUnit::BYTE),
+                 config.queryMaxMemoryPerNode());
+           }},
 
-      {core::QueryConfig::kSpillFileCreateConfig,
-       std::make_optional<std::string>(
+      {.veloxConfigKey = core::QueryConfig::kSpillFileCreateConfig,
+       .sessionPropertyKey = std::make_optional<std::string>(
            SessionProperties::kSpillFileCreateConfig),
-       std::string(SystemConfig::kSpillerFileCreateConfig),
-       "test_config_1",
-       "test_config_2",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(expectedValue, config.spillFileCreateConfig());
-       }},
+       .systemConfigKey = std::string(SystemConfig::kSpillerFileCreateConfig),
+       .sessionValue = "test_config_1",
+       .differentSessionValue = "test_config_2",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(expectedValue, config.spillFileCreateConfig());
+           }},
 
-      {core::QueryConfig::kSpillEnabled,
-       std::make_optional<std::string>(core::QueryConfig::kSpillEnabled),
-       std::string(SystemConfig::kSpillEnabled),
-       "false",
-       "true",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(expectedValue == "true", config.spillEnabled());
-       }},
+      {.veloxConfigKey = core::QueryConfig::kSpillEnabled,
+       .sessionPropertyKey =
+           std::make_optional<std::string>(core::QueryConfig::kSpillEnabled),
+       .systemConfigKey = std::string(SystemConfig::kSpillEnabled),
+       .sessionValue = "false",
+       .differentSessionValue = "true",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(expectedValue == "true", config.spillEnabled());
+           }},
 
-      {core::QueryConfig::kJoinSpillEnabled,
-       std::make_optional<std::string>(SessionProperties::kJoinSpillEnabled),
-       std::string(SystemConfig::kJoinSpillEnabled),
-       "false",
-       "true",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(expectedValue == "true", config.joinSpillEnabled());
-       }},
+      {.veloxConfigKey = core::QueryConfig::kJoinSpillEnabled,
+       .sessionPropertyKey = std::make_optional<std::string>(
+           SessionProperties::kJoinSpillEnabled),
+       .systemConfigKey = std::string(SystemConfig::kJoinSpillEnabled),
+       .sessionValue = "false",
+       .differentSessionValue = "true",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(expectedValue == "true", config.joinSpillEnabled());
+           }},
 
-      {core::QueryConfig::kOrderBySpillEnabled,
-       std::make_optional<std::string>("order_by_spill_enabled"),
-       std::string(SystemConfig::kOrderBySpillEnabled),
-       "false",
-       "true",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(expectedValue == "true", config.orderBySpillEnabled());
-       }},
+      {.veloxConfigKey = core::QueryConfig::kOrderBySpillEnabled,
+       .sessionPropertyKey =
+           std::make_optional<std::string>("order_by_spill_enabled"),
+       .systemConfigKey = std::string(SystemConfig::kOrderBySpillEnabled),
+       .sessionValue = "false",
+       .differentSessionValue = "true",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(expectedValue == "true", config.orderBySpillEnabled());
+           }},
 
-      {core::QueryConfig::kAggregationSpillEnabled,
-       std::make_optional<std::string>("aggregation_spill_enabled"),
-       std::string(SystemConfig::kAggregationSpillEnabled),
-       "false",
-       "true",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(expectedValue == "true", config.aggregationSpillEnabled());
-       }},
+      {.veloxConfigKey = core::QueryConfig::kAggregationSpillEnabled,
+       .sessionPropertyKey =
+           std::make_optional<std::string>("aggregation_spill_enabled"),
+       .systemConfigKey = std::string(SystemConfig::kAggregationSpillEnabled),
+       .sessionValue = "false",
+       .differentSessionValue = "true",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 expectedValue == "true", config.aggregationSpillEnabled());
+           }},
 
-      {core::QueryConfig::kRequestDataSizesMaxWaitSec,
-       std::make_optional<std::string>(
+      {.veloxConfigKey = core::QueryConfig::kRequestDataSizesMaxWaitSec,
+       .sessionPropertyKey = std::make_optional<std::string>(
            SessionProperties::kRequestDataSizesMaxWaitSec),
-       std::string(SystemConfig::kRequestDataSizesMaxWaitSec),
-       "30",
-       "15",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(
-             std::stoi(expectedValue), config.requestDataSizesMaxWaitSec());
-       }},
+       .systemConfigKey =
+           std::string(SystemConfig::kRequestDataSizesMaxWaitSec),
+       .sessionValue = "30",
+       .differentSessionValue = "15",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 std::stoi(expectedValue), config.requestDataSizesMaxWaitSec());
+           }},
 
-      {core::QueryConfig::kMaxSplitPreloadPerDriver,
-       std::nullopt,
-       std::string(SystemConfig::kDriverMaxSplitPreload),
-       "",
-       "",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(std::stoi(expectedValue), config.maxSplitPreloadPerDriver());
-       }},
+      {.veloxConfigKey = core::QueryConfig::kMaxSplitPreloadPerDriver,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey = std::string(SystemConfig::kDriverMaxSplitPreload),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 std::stoi(expectedValue), config.maxSplitPreloadPerDriver());
+           }},
 
-      {core::QueryConfig::kMaxLocalExchangePartitionBufferSize,
-       std::nullopt,
-       std::string(SystemConfig::kMaxLocalExchangePartitionBufferSize),
-       "",
-       "",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(
-             std::stoull(expectedValue),
-             config.maxLocalExchangePartitionBufferSize());
-       }},
+      {.veloxConfigKey =
+           core::QueryConfig::kMaxLocalExchangePartitionBufferSize,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey =
+           std::string(SystemConfig::kMaxLocalExchangePartitionBufferSize),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 std::stoull(expectedValue),
+                 config.maxLocalExchangePartitionBufferSize());
+           }},
 
-      {core::QueryConfig::kPrestoArrayAggIgnoreNulls,
-       std::nullopt,
-       std::string(SystemConfig::kUseLegacyArrayAgg),
-       "",
-       "",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         EXPECT_EQ(expectedValue == "true", config.prestoArrayAggIgnoreNulls());
-       }},
+      {.veloxConfigKey = core::QueryConfig::kPrestoArrayAggIgnoreNulls,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey = std::string(SystemConfig::kUseLegacyArrayAgg),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 expectedValue == "true", config.prestoArrayAggIgnoreNulls());
+           }},
 
-      {core::QueryConfig::kMaxOutputBufferSize,
-       std::make_optional<std::string>(SessionProperties::kMaxOutputBufferSize),
-       std::string(SystemConfig::kSinkMaxBufferSize),
-       "67108864",
-       "134217728",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         // System config and session is not same format, use try catch to
-         // handle the difference.
-         uint64_t expectedBytes;
-         try {
-           expectedBytes =
-               toCapacity(expectedValue, config::CapacityUnit::BYTE);
-         } catch (const VeloxUserError& e) {
-           expectedBytes = std::stoull(expectedValue);
-         }
-         EXPECT_EQ(expectedBytes, config.maxOutputBufferSize());
-       }},
+      {.veloxConfigKey = core::QueryConfig::kMaxOutputBufferSize,
+       .sessionPropertyKey = std::make_optional<std::string>(
+           SessionProperties::kMaxOutputBufferSize),
+       .systemConfigKey = std::string(SystemConfig::kSinkMaxBufferSize),
+       .sessionValue = "67108864",
+       .differentSessionValue = "134217728",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             // System config and session is not same format, use try catch to
+             // handle the difference.
+             uint64_t expectedBytes;
+             try {
+               expectedBytes =
+                   toCapacity(expectedValue, config::CapacityUnit::BYTE);
+             } catch (const VeloxUserError& e) {
+               expectedBytes = std::stoull(expectedValue);
+             }
+             EXPECT_EQ(expectedBytes, config.maxOutputBufferSize());
+           }},
 
-      {core::QueryConfig::kMaxPartitionedOutputBufferSize,
-       std::make_optional<std::string>(
+      {.veloxConfigKey = core::QueryConfig::kMaxPartitionedOutputBufferSize,
+       .sessionPropertyKey = std::make_optional<std::string>(
            SessionProperties::kMaxPartitionedOutputBufferSize),
-       std::string(SystemConfig::kDriverMaxPagePartitioningBufferSize),
-       "67108864",
-       "134217728",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         // System config and session is not same format, use try catch to
-         // handle the difference.
-         uint64_t expectedBytes;
-         try {
-           expectedBytes =
-               toCapacity(expectedValue, config::CapacityUnit::BYTE);
-         } catch (const VeloxUserError& e) {
-           expectedBytes = std::stoull(expectedValue);
-         }
-         EXPECT_EQ(expectedBytes, config.maxPartitionedOutputBufferSize());
-       }},
+       .systemConfigKey =
+           std::string(SystemConfig::kDriverMaxPagePartitioningBufferSize),
+       .sessionValue = "67108864",
+       .differentSessionValue = "134217728",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             // System config and session is not same format, use try catch to
+             // handle the difference.
+             uint64_t expectedBytes;
+             try {
+               expectedBytes =
+                   toCapacity(expectedValue, config::CapacityUnit::BYTE);
+             } catch (const VeloxUserError& e) {
+               expectedBytes = std::stoull(expectedValue);
+             }
+             EXPECT_EQ(expectedBytes, config.maxPartitionedOutputBufferSize());
+           }},
 
-      {core::QueryConfig::kMaxPartialAggregationMemory,
-       std::make_optional<std::string>(
+      {.veloxConfigKey = core::QueryConfig::kMaxPartialAggregationMemory,
+       .sessionPropertyKey = std::make_optional<std::string>(
            SessionProperties::kMaxPartialAggregationMemory),
-       std::string(SystemConfig::kTaskMaxPartialAggregationMemory),
-       "268435456",
-       "134217728",
-       [](const core::QueryConfig& config, const std::string& expectedValue) {
-         uint64_t expectedBytes;
-         try {
-           expectedBytes =
-               toCapacity(expectedValue, config::CapacityUnit::BYTE);
-         } catch (const VeloxUserError& e) {
-           expectedBytes = std::stoull(expectedValue);
-         }
-         EXPECT_EQ(expectedBytes, config.maxPartialAggregationMemoryUsage());
-       }},
+       .systemConfigKey =
+           std::string(SystemConfig::kTaskMaxPartialAggregationMemory),
+       .sessionValue = "268435456",
+       .differentSessionValue = "134217728",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             uint64_t expectedBytes;
+             try {
+               expectedBytes =
+                   toCapacity(expectedValue, config::CapacityUnit::BYTE);
+             } catch (const VeloxUserError& e) {
+               expectedBytes = std::stoull(expectedValue);
+             }
+             EXPECT_EQ(
+                 expectedBytes, config.maxPartialAggregationMemoryUsage());
+           }},
+
+      {.veloxConfigKey = core::QueryConfig::kMaxExchangeBufferSize,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey = std::string(SystemConfig::kExchangeMaxBufferSize),
+       .sessionValue = "64MB",
+       .differentSessionValue = "128MB",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             uint64_t expectedBytes;
+             try {
+               expectedBytes =
+                   toCapacity(expectedValue, config::CapacityUnit::BYTE);
+             } catch (const VeloxUserError& e) {
+               expectedBytes = std::stoull(expectedValue);
+             }
+             EXPECT_EQ(expectedBytes, config.maxExchangeBufferSize());
+           }},
   };
 
   // CRITICAL: This count MUST match the exact number of entries in
   // veloxToPrestoConfigMapping If this assertion fails, it means a new
   // mapping was added and this test needs to be updated
-  const size_t kExpectedMappingCount = 13;
+  const size_t kExpectedMappingCount = 14;
   EXPECT_EQ(kExpectedMappingCount, testCases.size());
 
   // Test each mapping to ensure session properties override system configs
@@ -570,4 +629,115 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionStartTimeConfiguration) {
 
   EXPECT_EQ(
       std::numeric_limits<int64_t>::max(), veloxConfig5.sessionStartTimeMs());
+}
+
+TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
+  // Verifies system configs are properly applied when no session properties
+  // override them. Uses exact count matching to catch any config additions or
+  // removals.
+
+  auto session = createBasicSession();
+  session.systemProperties.clear();
+  auto veloxConfigs = toVeloxConfigs(session);
+
+  struct SystemConfigMapping {
+    std::string veloxConfigKey;
+    std::string systemConfigKey;
+  };
+
+  // MUST match veloxToPrestoConfigMapping in PrestoToVeloxQueryConfig.cpp
+  std::vector<SystemConfigMapping> expectedMappings = {
+      {.veloxConfigKey = core::QueryConfig::kQueryMaxMemoryPerNode,
+       .systemConfigKey = std::string(SystemConfig::kQueryMaxMemoryPerNode)},
+      {.veloxConfigKey = core::QueryConfig::kSpillFileCreateConfig,
+       .systemConfigKey = std::string(SystemConfig::kSpillerFileCreateConfig)},
+      {.veloxConfigKey = core::QueryConfig::kSpillEnabled,
+       .systemConfigKey = std::string(SystemConfig::kSpillEnabled)},
+      {.veloxConfigKey = core::QueryConfig::kJoinSpillEnabled,
+       .systemConfigKey = std::string(SystemConfig::kJoinSpillEnabled)},
+      {.veloxConfigKey = core::QueryConfig::kOrderBySpillEnabled,
+       .systemConfigKey = std::string(SystemConfig::kOrderBySpillEnabled)},
+      {.veloxConfigKey = core::QueryConfig::kAggregationSpillEnabled,
+       .systemConfigKey = std::string(SystemConfig::kAggregationSpillEnabled)},
+      {.veloxConfigKey = core::QueryConfig::kRequestDataSizesMaxWaitSec,
+       .systemConfigKey =
+           std::string(SystemConfig::kRequestDataSizesMaxWaitSec)},
+      {.veloxConfigKey = core::QueryConfig::kMaxSplitPreloadPerDriver,
+       .systemConfigKey = std::string(SystemConfig::kDriverMaxSplitPreload)},
+      {.veloxConfigKey =
+           core::QueryConfig::kMaxLocalExchangePartitionBufferSize,
+       .systemConfigKey =
+           std::string(SystemConfig::kMaxLocalExchangePartitionBufferSize)},
+      {.veloxConfigKey = core::QueryConfig::kPrestoArrayAggIgnoreNulls,
+       .systemConfigKey = std::string(SystemConfig::kUseLegacyArrayAgg)},
+      {.veloxConfigKey = core::QueryConfig::kTaskWriterCount,
+       .systemConfigKey = std::string(SystemConfig::kTaskWriterCount)},
+      {.veloxConfigKey = core::QueryConfig::kTaskPartitionedWriterCount,
+       .systemConfigKey =
+           std::string(SystemConfig::kTaskPartitionedWriterCount)},
+      {.veloxConfigKey = core::QueryConfig::kMaxExchangeBufferSize,
+       .systemConfigKey = std::string(SystemConfig::kExchangeMaxBufferSize)},
+      {.veloxConfigKey = core::QueryConfig::kMaxOutputBufferSize,
+       .systemConfigKey = std::string(SystemConfig::kSinkMaxBufferSize)},
+      {.veloxConfigKey = core::QueryConfig::kMaxPartitionedOutputBufferSize,
+       .systemConfigKey =
+           std::string(SystemConfig::kDriverMaxPagePartitioningBufferSize)},
+      {.veloxConfigKey = core::QueryConfig::kMaxPartialAggregationMemory,
+       .systemConfigKey =
+           std::string(SystemConfig::kTaskMaxPartialAggregationMemory)},
+  };
+
+  const size_t kExpectedSystemConfigMappingCount = 16;
+  EXPECT_EQ(kExpectedSystemConfigMappingCount, expectedMappings.size())
+      << "Update expectedMappings to match veloxToPrestoConfigMapping";
+
+  // Verify each system config mapping is present when it has a value
+  auto* systemConfig = SystemConfig::instance();
+  for (const auto& mapping : expectedMappings) {
+    auto systemValue = systemConfig->optionalProperty(mapping.systemConfigKey);
+    if (systemValue.hasValue()) {
+      EXPECT_TRUE(veloxConfigs.count(mapping.veloxConfigKey) > 0)
+          << "Expected '" << mapping.veloxConfigKey << "' when system config '"
+          << mapping.systemConfigKey << "' = " << systemValue.value();
+    }
+  }
+
+  // Verify special case configs (always added)
+  EXPECT_TRUE(
+      veloxConfigs.count(core::QueryConfig::kAdjustTimestampToTimezone) > 0);
+  EXPECT_EQ(
+      "true", veloxConfigs.at(core::QueryConfig::kAdjustTimestampToTimezone));
+
+  EXPECT_TRUE(
+      veloxConfigs.count(core::QueryConfig::kDriverCpuTimeSliceLimitMs) > 0);
+  EXPECT_EQ(
+      "1000", veloxConfigs.at(core::QueryConfig::kDriverCpuTimeSliceLimitMs));
+
+  // Verify session-specific configs
+  EXPECT_TRUE(veloxConfigs.count(core::QueryConfig::kSessionStartTime) > 0);
+  EXPECT_EQ(
+      "1234567890", veloxConfigs.at(core::QueryConfig::kSessionStartTime));
+
+  // Calculate expected exact count
+  size_t expectedExactConfigs = 0;
+  for (const auto& mapping : expectedMappings) {
+    if (systemConfig->optionalProperty(mapping.systemConfigKey).hasValue()) {
+      expectedExactConfigs++;
+    }
+  }
+  expectedExactConfigs += 2; // kAdjustTimestampToTimezone,
+                             // kDriverCpuTimeSliceLimitMs
+  expectedExactConfigs += 1; // kSessionStartTime
+
+  // Use exact matching to catch any config additions/removals
+  EXPECT_EQ(veloxConfigs.size(), expectedExactConfigs)
+      << "Config count mismatch indicates mapping change. Expected "
+      << expectedExactConfigs << ", got " << veloxConfigs.size();
+
+  // Debug output
+  std::cout << "System configs (no session overrides):" << std::endl;
+  for (const auto& [key, value] : veloxConfigs) {
+    std::cout << "  " << key << " = " << value << std::endl;
+  }
+  std::cout << "Total: " << veloxConfigs.size() << std::endl;
 }


### PR DESCRIPTION
Summary: Expose the velox query config property to prestissimo system config

Differential Revision: D87194538

```
== NO RELEASE NOTE ==
```

