### PR TITLE
[presto] ensure txn hasn't detached before attempting to use

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -212,12 +212,12 @@ class ResponseHandler : public proxygen::HTTPTransactionHandler {
   }
 
   void setTransaction(proxygen::HTTPTransaction* txn) noexcept override {
-    if (txn) {
-      protocol_ = txn->getTransport().getCodec().getProtocol();
-    }
+    txn_ = CHECK_NOTNULL(txn);
+    protocol_ = txn_->getTransport().getCodec().getProtocol();
   }
 
   void detachTransaction() noexcept override {
+    txn_ = nullptr;
     self_.reset();
   }
 
@@ -269,12 +269,14 @@ class ResponseHandler : public proxygen::HTTPTransactionHandler {
     self_.reset();
   }
 
-  void sendRequest(proxygen::HTTPTransaction* txn) {
-    txn->sendHeaders(request_);
-    if (!body_.empty()) {
-      txn->sendBody(folly::IOBuf::wrapBuffer(body_.c_str(), body_.size()));
+  void sendRequest() {
+    if (txn_) {
+      txn_->sendHeaders(request_);
+      if (!body_.empty()) {
+        txn_->sendBody(folly::IOBuf::wrapBuffer(body_.c_str(), body_.size()));
+      }
+      txn_->sendEOM();
     }
-    txn->sendEOM();
   }
 
  private:
@@ -288,6 +290,7 @@ class ResponseHandler : public proxygen::HTTPTransactionHandler {
   std::shared_ptr<ResponseHandler> self_;
   std::shared_ptr<HttpClient> client_;
   std::optional<proxygen::CodecProtocol> protocol_;
+  proxygen::HTTPTransaction* txn_{nullptr};
 };
 
 // Responsible for making an HTTP request. The request will be made in 2
@@ -354,10 +357,8 @@ class ConnectionHandler : public proxygen::HTTPConnector::Callback {
           http2InitialStreamWindow_, http2StreamWindow_, http2SessionWindow_);
       session->setMaxConcurrentOutgoingStreams(maxConcurrentStreams_);
     }
-    auto txn = session->newTransaction(responseHandler_.get());
-    if (txn) {
-      responseHandler_->sendRequest(txn);
-    }
+    session->newTransaction(responseHandler_.get());
+    responseHandler_->sendRequest();
 
     sessionPool_->putSession(session);
     delete this;
@@ -532,10 +533,9 @@ folly::SemiFuture<proxygen::HTTPTransaction*> HttpClient::createTransaction(
 void HttpClient::sendRequest(std::shared_ptr<ResponseHandler> responseHandler) {
   initSessionPool();
   auto txnFuture = createTransaction(responseHandler.get());
-  auto doSend = [this, responseHandler = std::move(responseHandler)](
-                    proxygen::HTTPTransaction* txn) {
-    if (txn) {
-      responseHandler->sendRequest(txn);
+  auto doSend = [this, responseHandler = std::move(responseHandler)](proxygen::HTTPTransaction* txn) {
+    if (txn) { // txn may no longer be valid, ::sendRequest will no-op in such cases
+      responseHandler->sendRequest();
       return;
     }
     VLOG(2) << "Create new connection to " << address_.describe();


### PR DESCRIPTION
Summary: context in https://fb.workplace.com/groups/httpproxygen/posts/822181263882364

Differential Revision: D86889401


