### PR TITLE
chore(deps): Upgrade org.codehaus.mojo:extra-enforcer-rules version to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2824,7 +2824,7 @@
                         <dependency>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>extra-enforcer-rules</artifactId>
-                            <version>1.6.2</version>
+                            <version>1.11.0</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -3236,7 +3236,7 @@
                                 <dependency>
                                     <groupId>org.codehaus.mojo</groupId>
                                     <artifactId>extra-enforcer-rules</artifactId>
-                                    <version>1.6.2</version>
+                                    <version>1.11.0</version>
                                 </dependency>
                             </dependencies>
                             <configuration>
@@ -3308,7 +3308,7 @@
                                 <dependency>
                                     <groupId>org.codehaus.mojo</groupId>
                                     <artifactId>extra-enforcer-rules</artifactId>
-                                    <version>1.6.2</version>
+                                    <version>1.11.0</version>
                                 </dependency>
                             </dependencies>
                             <configuration>


### PR DESCRIPTION
## Description
Upgrade org.codehaus.mojo:extra-enforcer-rules version to 1.11.0

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

