### PR TITLE
fix(native): Change content type of endpoint /v1/info/metrics based on accept header

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpConstants.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpConstants.h
@@ -30,6 +30,7 @@ constexpr uint16_t kHttpInternalServerError = 500;
 
 constexpr char kMimeTypeApplicationJson[] = "application/json";
 constexpr char kMimeTypeApplicationThrift[] = "application/x-thrift+binary";
+constexpr char kMimeTypeTextPlain[] = "text/plain";
 constexpr char kShuttingDown[] = "\"SHUTTING_DOWN\"";
 constexpr char kPrestoInternalBearer[] = "X-Presto-Internal-Bearer";
 

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -39,6 +39,16 @@ void sendOkResponse(
       .sendWithEOM();
 }
 
+void sendOkTextResponse(
+    proxygen::ResponseHandler* downstream,
+    const std::string& body) {
+  proxygen::ResponseBuilder(downstream)
+      .status(http::kHttpOk, "")
+      .header(proxygen::HTTP_HEADER_CONTENT_TYPE, http::kMimeTypeTextPlain)
+      .body(body)
+      .sendWithEOM();
+}
+
 void sendOkThriftResponse(
     proxygen::ResponseHandler* downstream,
     const std::string& body) {

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -33,6 +33,10 @@ void sendOkResponse(
     proxygen::ResponseHandler* downstream,
     const std::string& body);
 
+void sendOkTextResponse(
+    proxygen::ResponseHandler* downstream,
+    const std::string& body);
+
 void sendOkThriftResponse(
     proxygen::ResponseHandler* downstream,
     const std::string& body);


### PR DESCRIPTION
## Description
Modifies the Content-Type of endpoint `/v1/info/metrics` to `application/json` or `text/plain` based on the request's ACCEPT header.

## Motivation and Context
Earlier Prometheus versions were not strict about Content-Type header in the response for this endpoint which is currently `application/json`. Latest version requires it to be set correctly to what's expected by Prometheus while scraping the metrics which is `text/plain`

## Impact
Changes the Content-Type of endpoint `/v1/info/metrics` from `application/json` to `text/plain`.

## Test Plan
Tested manually running Prometheus in Docker and reproduced the error when Content-Type was set to json. Issue is fixed as shown in 2nd image below.

1) Failing case
<img width="1728" height="570" alt="Screenshot 2025-11-17 at 3 43 10 PM" src="https://github.com/user-attachments/assets/25e22579-ea04-4141-8c45-cfa08f86fb95" />

2) Passing case
<img width="1728" height="598" alt="Screenshot 2025-11-17 at 3 49 58 PM" src="https://github.com/user-attachments/assets/3dc9a057-ff86-4f5f-9821-76f0fca092a3" />

```
== RELEASE NOTES ==

General Changes
*  Fix to modify the Content-Type of endpoint /v1/info/metrics to application/json or text/plain based on the request's ACCEPT header
```

