### PR TITLE
misc: Enable function resolution to resolve functions with full qualified name

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -438,4 +438,10 @@ public final class FunctionResolution
     {
         return functionAndTypeResolver.lookupFunction(functionName, fromTypes(inputTypes));
     }
+
+    @Override
+    public FunctionHandle lookupFunction(String catalog, String schema, String functionName, List<Type> inputTypes)
+    {
+        return functionAndTypeResolver.resolveFunction(Optional.empty(), Optional.empty(), QualifiedObjectName.valueOf(catalog, schema, functionName), fromTypes(inputTypes));
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -91,4 +91,6 @@ public interface StandardFunctionResolution
     FunctionHandle approximateSetFunction(Type valueType);
 
     FunctionHandle lookupBuiltInFunction(String functionName, List<Type> inputTypes);
+
+    FunctionHandle lookupFunction(String catalog, String schema, String functionName, List<Type> inputTypes);
 }


### PR DESCRIPTION
## Description
Current FunctionResolution only has `lookupBuiltInFunction` which works for built in function in default namespace, this PR will enable it to look up functions in non-default namespace too.

## Motivation and Context
In description

## Impact
In description

## Test Plan
Unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

