### PR TITLE
fix(ui): Handle incorrect duration format

### DIFF
--- a/presto-ui/src/utils.ts
+++ b/presto-ui/src/utils.ts
@@ -433,12 +433,13 @@ export function parseDataSize(value: string): number | null | undefined {
     }
 }
 
-export function parseDuration(value: string): number | null | undefined {
+export function parseDuration(value: string): number {
     const DURATION_PATTERN = /^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*$/;
 
     const match = DURATION_PATTERN.exec(value);
     if (match === null) {
-        return null;
+        console.error(`Invalid duration format: ${value}. Treat it as 0`);
+        return 0;
     }
     const number = parseFloat(match[1]);
     switch (match[2]) {
@@ -457,7 +458,8 @@ export function parseDuration(value: string): number | null | undefined {
         case "d":
             return number * 1000 * 60 * 60 * 24;
         default:
-            return null;
+            console.error(`Failed to convert to float: ${number}. Use 0 instead`);
+            return 0;
     }
 }
 


### PR DESCRIPTION
## Description
Treat the incorrect duration data as `0` and avoid parsing errors. Meanwhile, also generate an error log in the console to show the wrong value.

## Motivation and Context
fixed: #26588 

## Impact
An incorrect format, like a negative number, is treated as `0`.

## Test Plan
Verify the UI with negative numbers in the JSON payload

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

