### PR TITLE
feat(client): Add serialized response format option to Presto client

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
@@ -111,6 +111,7 @@ public class BenchmarkDriverOptions
                 disableCompression,
                 ImmutableMap.of(),
                 ImmutableMap.of(),
+                false,
                 false);
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -162,6 +162,9 @@ public class ClientOptions
     @Option(name = "--disable-redirects", title = "disable redirects", description = "Disable client following redirects from server")
     public boolean disableRedirects;
 
+    @Option(name = "--serialized", title = "enabled serialized results", description = "Enable serialized response encoding from server")
+    public boolean serialized;
+
     public enum OutputFormat
     {
         ALIGNED,
@@ -197,7 +200,8 @@ public class ClientOptions
                 disableCompression,
                 emptyMap(),
                 emptyMap(),
-                validateNextUriSource);
+                validateNextUriSource,
+                serialized);
     }
 
     public static URI parseServer(String server)

--- a/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
@@ -85,6 +85,7 @@ public abstract class AbstractCliTest
                 true,
                 ImmutableMap.of(),
                 ImmutableMap.of(),
+                false,
                 false);
     }
 

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
@@ -192,4 +192,12 @@ public class TestClientOptions
         assertTrue(console.clientOptions.validateNextUriSource);
         assertTrue(console.clientOptions.toClientSession().validateNextUriSource());
     }
+
+    @Test
+    public void testSerializedFormat()
+    {
+        Console console = singleCommand(Console.class).parse("--serialized");
+        assertTrue(console.clientOptions.serialized);
+        assertTrue(console.clientOptions.toClientSession().isBinaryResults());
+    }
 }

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -29,6 +29,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
             <optional>true</optional>
@@ -117,6 +122,13 @@
         </dependency>
 
         <!-- for testing -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>concurrent</artifactId>

--- a/presto-client/src/main/java/com/facebook/presto/client/BinaryDataDeserializer.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/BinaryDataDeserializer.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.page.SerializedPage;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.page.PagesSerdeUtil.readSerializedPage;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class BinaryDataDeserializer
+{
+    private final PagesSerde pagesSerde;
+    private final TypeManager typeManager;
+    private final SqlFunctionProperties sqlFunctionProperties;
+
+    public BinaryDataDeserializer(
+            BlockEncodingSerde blockEncodingSerde,
+            TypeManager typeManager,
+            ClientSession session)
+    {
+        requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
+        requireNonNull(typeManager, "typeManager is null");
+        requireNonNull(session, "session is null");
+
+        this.pagesSerde = new PagesSerde(blockEncodingSerde, Optional.empty(), Optional.empty(), Optional.empty(), false);
+        this.typeManager = typeManager;
+        this.sqlFunctionProperties = createSqlFunctionPropertiesFromSession(session);
+    }
+
+    public Iterable<List<Object>> deserialize(List<Column> columns, Iterable<String> binaryData)
+    {
+        requireNonNull(columns, "columns is null");
+        requireNonNull(binaryData, "binaryData is null");
+
+        List<Type> columnTypes = extractTypesFromColumns(columns);
+        ImmutableList.Builder<List<Object>> allRows = ImmutableList.builder();
+
+        for (String encodedPage : binaryData) {
+            byte[] pageBytes = Base64.getDecoder().decode(encodedPage);
+            Slice slice = Slices.wrappedBuffer(pageBytes);
+
+            BasicSliceInput sliceInput = slice.getInput();
+            SerializedPage serializedPage = readSerializedPage(sliceInput);
+
+            Page page = pagesSerde.deserialize(serializedPage);
+
+            allRows.addAll(convertPageToRows(page, columnTypes));
+        }
+
+        return allRows.build();
+    }
+
+    private List<List<Object>> convertPageToRows(Page page, List<Type> columnTypes)
+    {
+        checkArgument(
+                page.getChannelCount() == columnTypes.size(),
+                "Expected %s columns in serialized page, found %s",
+                columnTypes.size(),
+                page.getChannelCount());
+
+        ImmutableList.Builder<List<Object>> rows = ImmutableList.builder();
+
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            List<Object> row = new ArrayList<>(page.getChannelCount());
+
+            for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                Type type = columnTypes.get(channel);
+                Block block = page.getBlock(channel);
+
+                Object value = type.getObjectValue(sqlFunctionProperties, block, position);
+                row.add(value);
+            }
+
+            rows.add(Collections.unmodifiableList(row));
+        }
+
+        return rows.build();
+    }
+
+    private List<Type> extractTypesFromColumns(List<Column> columns)
+    {
+        ImmutableList.Builder<Type> types = ImmutableList.builder();
+
+        for (Column column : columns) {
+            ClientTypeSignature clientTypeSignature = column.getTypeSignature();
+            TypeSignature typeSignature = convertClientTypeSignatureToTypeSignature(clientTypeSignature);
+            Type type = typeManager.getType(typeSignature);
+
+            if (type == null) {
+                throw new IllegalArgumentException("Unknown type: " + typeSignature);
+            }
+
+            types.add(type);
+        }
+
+        return types.build();
+    }
+
+    private TypeSignature convertClientTypeSignatureToTypeSignature(ClientTypeSignature clientTypeSignature)
+    {
+        List<TypeSignatureParameter> parameters = new ArrayList<>();
+
+        for (ClientTypeSignatureParameter argument : clientTypeSignature.getArguments()) {
+            parameters.add(convertClientTypeSignatureParameterToTypeSignatureParameter(argument));
+        }
+
+        return new TypeSignature(clientTypeSignature.getRawType(), parameters);
+    }
+
+    private TypeSignatureParameter convertClientTypeSignatureParameterToTypeSignatureParameter(
+            ClientTypeSignatureParameter parameter)
+    {
+        switch (parameter.getKind()) {
+            case TYPE:
+                return TypeSignatureParameter.of(
+                        convertClientTypeSignatureToTypeSignature(parameter.getTypeSignature()));
+            case LONG:
+                return TypeSignatureParameter.of(parameter.getLongLiteral());
+            case NAMED_TYPE:
+                return TypeSignatureParameter.of(parameter.getNamedTypeSignature());
+            default:
+                throw new UnsupportedOperationException("Unknown parameter kind: " + parameter.getKind());
+        }
+    }
+
+    private SqlFunctionProperties createSqlFunctionPropertiesFromSession(ClientSession session)
+    {
+        return SqlFunctionProperties.builder()
+                .setTimeZoneKey(session.getTimeZone())
+                .setSessionLocale(session.getLocale())
+                .setSessionUser(session.getUser())
+                .setSessionStartTime(System.currentTimeMillis())
+                .build();
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -55,6 +55,7 @@ public class ClientSession
     private final boolean compressionDisabled;
     private final Map<String, String> sessionFunctions;
     private final boolean validateNextUriSource;
+    private final boolean binaryResults;
 
     public static Builder builder(ClientSession clientSession)
     {
@@ -89,7 +90,8 @@ public class ClientSession
             boolean compressionDisabled,
             Map<String, String> sessionFunctions,
             Map<String, String> customHeaders,
-            boolean validateNextUriSource)
+            boolean validateNextUriSource,
+            boolean binaryResults)
     {
         this.server = requireNonNull(server, "server is null");
         this.user = user;
@@ -112,6 +114,7 @@ public class ClientSession
         this.compressionDisabled = compressionDisabled;
         this.sessionFunctions = ImmutableMap.copyOf(requireNonNull(sessionFunctions, "sessionFunctions is null"));
         this.validateNextUriSource = validateNextUriSource;
+        this.binaryResults = binaryResults;
 
         for (String clientTag : clientTags) {
             checkArgument(!clientTag.contains(","), "client tag cannot contain ','");
@@ -263,6 +266,11 @@ public class ClientSession
         return validateNextUriSource;
     }
 
+    public boolean isBinaryResults()
+    {
+        return binaryResults;
+    }
+
     @Override
     public String toString()
     {
@@ -305,6 +313,7 @@ public class ClientSession
         private boolean compressionDisabled;
         private Map<String, String> sessionFunctions;
         private boolean validateNextUriSource;
+        private boolean binaryResults;
 
         private Builder(ClientSession clientSession)
         {
@@ -330,6 +339,7 @@ public class ClientSession
             compressionDisabled = clientSession.isCompressionDisabled();
             sessionFunctions = clientSession.getSessionFunctions();
             validateNextUriSource = clientSession.validateNextUriSource();
+            binaryResults = clientSession.isBinaryResults();
         }
 
         public Builder withCatalog(String catalog)
@@ -404,6 +414,12 @@ public class ClientSession
             return this;
         }
 
+        public Builder withBinaryResults(boolean binaryResults)
+        {
+            this.binaryResults = binaryResults;
+            return this;
+        }
+
         public ClientSession build()
         {
             return new ClientSession(
@@ -427,7 +443,8 @@ public class ClientSession
                     compressionDisabled,
                     sessionFunctions,
                     customHeaders,
-                    validateNextUriSource);
+                    validateNextUriSource,
+                    binaryResults);
         }
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeManager.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeManager.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.common.type.DateType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.HyperLogLogType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.JsonType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.NamedTypeSignature;
+import com.facebook.presto.common.type.ParameterKind;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.RowFieldName;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TimeType;
+import com.facebook.presto.common.type.TimeWithTimeZoneType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
+import com.facebook.presto.common.type.TinyintType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.UuidType;
+import com.facebook.presto.common.type.VarbinaryType;
+import com.facebook.presto.common.type.VarcharType;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class ClientTypeManager
+        implements TypeManager
+{
+    private final Map<TypeSignature, Type> typeCache = new ConcurrentHashMap<>();
+
+    @Override
+    public Type getType(TypeSignature signature)
+    {
+        Type cachedType = typeCache.get(signature);
+        if (cachedType != null) {
+            return cachedType;
+        }
+
+        Type type = getTypeInternal(signature);
+        typeCache.put(signature, type);
+        return type;
+    }
+
+    private Type getTypeInternal(TypeSignature signature)
+    {
+        String baseType = signature.getBase();
+
+        switch (baseType) {
+            case StandardTypes.BOOLEAN:
+                return BooleanType.BOOLEAN;
+            case StandardTypes.TINYINT:
+                return TinyintType.TINYINT;
+            case StandardTypes.SMALLINT:
+                return SmallintType.SMALLINT;
+            case StandardTypes.INTEGER:
+                return IntegerType.INTEGER;
+            case StandardTypes.BIGINT:
+                return BigintType.BIGINT;
+            case StandardTypes.REAL:
+                return RealType.REAL;
+            case StandardTypes.DOUBLE:
+                return DoubleType.DOUBLE;
+            case StandardTypes.VARCHAR:
+                return createVarcharType(signature);
+            case StandardTypes.CHAR:
+                return createCharType(signature);
+            case StandardTypes.VARBINARY:
+                return VarbinaryType.VARBINARY;
+            case StandardTypes.DATE:
+                return DateType.DATE;
+            case StandardTypes.TIME:
+                return TimeType.TIME;
+            case StandardTypes.TIME_WITH_TIME_ZONE:
+                return TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+            case StandardTypes.TIMESTAMP:
+                return TimestampType.TIMESTAMP;
+            case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
+                return TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+            case StandardTypes.DECIMAL:
+                return createDecimalType(signature);
+            case StandardTypes.JSON:
+                return JsonType.JSON;
+            case StandardTypes.UUID:
+                return UuidType.UUID;
+            case StandardTypes.HYPER_LOG_LOG:
+                return HyperLogLogType.HYPER_LOG_LOG;
+            case StandardTypes.ARRAY:
+                return createArrayType(signature);
+            case StandardTypes.MAP:
+                return createMapType(signature);
+            case StandardTypes.ROW:
+                return createRowType(signature);
+            default:
+                throw new IllegalArgumentException("Unknown type: " + signature);
+        }
+    }
+
+    private Type createVarcharType(TypeSignature signature)
+    {
+        if (signature.getParameters().isEmpty()) {
+            return VarcharType.VARCHAR;
+        }
+        List<TypeSignatureParameter> parameters = signature.getParameters();
+        checkArgument(parameters.size() == 1, "VARCHAR type must have at most one parameter");
+        TypeSignatureParameter parameter = parameters.get(0);
+        checkArgument(parameter.getKind() == ParameterKind.LONG, "VARCHAR length must be a number");
+        long length = parameter.getLongLiteral();
+        if (length == Integer.MAX_VALUE) {
+            return VarcharType.createUnboundedVarcharType();
+        }
+        return VarcharType.createVarcharType((int) length);
+    }
+
+    private Type createCharType(TypeSignature signature)
+    {
+        if (signature.getParameters().isEmpty()) {
+            return CharType.createCharType(1);
+        }
+        List<TypeSignatureParameter> parameters = signature.getParameters();
+        checkArgument(parameters.size() == 1, "CHAR type must have at most one parameter");
+        TypeSignatureParameter parameter = parameters.get(0);
+        checkArgument(parameter.getKind() == ParameterKind.LONG, "CHAR length must be a number");
+        long length = parameter.getLongLiteral();
+        return CharType.createCharType((int) length);
+    }
+
+    private Type createDecimalType(TypeSignature signature)
+    {
+        List<TypeSignatureParameter> parameters = signature.getParameters();
+        checkArgument(parameters.size() == 2, "DECIMAL type must have exactly two parameters");
+
+        TypeSignatureParameter precisionParam = parameters.get(0);
+        TypeSignatureParameter scaleParam = parameters.get(1);
+
+        checkArgument(precisionParam.getKind() == ParameterKind.LONG, "DECIMAL precision must be a number");
+        checkArgument(scaleParam.getKind() == ParameterKind.LONG, "DECIMAL scale must be a number");
+
+        long precision = precisionParam.getLongLiteral();
+        long scale = scaleParam.getLongLiteral();
+
+        return DecimalType.createDecimalType((int) precision, (int) scale);
+    }
+
+    private Type createArrayType(TypeSignature signature)
+    {
+        List<TypeSignatureParameter> parameters = signature.getParameters();
+        checkArgument(parameters.size() == 1, "ARRAY type must have exactly one parameter");
+
+        TypeSignatureParameter elementParam = parameters.get(0);
+        checkArgument(elementParam.getKind() == ParameterKind.TYPE, "ARRAY element must be a type");
+
+        Type elementType = getType(elementParam.getTypeSignature());
+        return new ArrayType(elementType);
+    }
+
+    private Type createMapType(TypeSignature signature)
+    {
+        List<TypeSignatureParameter> parameters = signature.getParameters();
+        checkArgument(parameters.size() == 2, "MAP type must have exactly two parameters");
+
+        TypeSignatureParameter keyParam = parameters.get(0);
+        TypeSignatureParameter valueParam = parameters.get(1);
+
+        checkArgument(keyParam.getKind() == ParameterKind.TYPE, "MAP key must be a type");
+        checkArgument(valueParam.getKind() == ParameterKind.TYPE, "MAP value must be a type");
+
+        Type keyType = getType(keyParam.getTypeSignature());
+        Type valueType = getType(valueParam.getTypeSignature());
+
+        MethodHandle keyEquals = generateKeyEqualsHandle(keyType);
+        MethodHandle keyHashCode = generateKeyHashCodeHandle(keyType);
+
+        return new MapType(keyType, valueType, keyEquals, keyHashCode);
+    }
+
+    private Type createRowType(TypeSignature signature)
+    {
+        List<TypeSignatureParameter> parameters = signature.getParameters();
+        checkArgument(!parameters.isEmpty(), "ROW type must have at least one field");
+
+        List<RowType.Field> fields = new ArrayList<>();
+        for (TypeSignatureParameter param : parameters) {
+            checkArgument(param.getKind() == ParameterKind.NAMED_TYPE, "ROW parameters must be named types");
+
+            NamedTypeSignature namedType = param.getNamedTypeSignature();
+            Type fieldType = getType(namedType.getTypeSignature());
+
+            Optional<String> fieldName;
+            boolean isDelimited = false;
+
+            if (namedType.getFieldName().isPresent()) {
+                RowFieldName rowFieldName = namedType.getFieldName().get();
+                fieldName = Optional.of(rowFieldName.getName());
+                isDelimited = rowFieldName.isDelimited();
+            }
+            else {
+                fieldName = Optional.empty();
+            }
+
+            fields.add(new RowType.Field(fieldName, fieldType, isDelimited));
+        }
+
+        return RowType.from(fields);
+    }
+
+    private static class MapOperators
+    {
+        public static boolean blockEquals(Type keyType, Block leftBlock, int leftPos, Block rightBlock, int rightPos)
+        {
+            return keyType.equalTo(leftBlock, leftPos, rightBlock, rightPos);
+        }
+
+        public static long blockHashCode(Type keyType, Block block, int position)
+        {
+            return keyType.hash(block, position);
+        }
+    }
+
+    private MethodHandle generateKeyEqualsHandle(Type keyType)
+    {
+        try {
+            MethodHandle base = MethodHandles.lookup().findStatic(
+                    MapOperators.class,
+                    "blockEquals",
+                    MethodType.methodType(boolean.class, Type.class, Block.class, int.class, Block.class, int.class));
+            return MethodHandles.insertArguments(base, 0, keyType);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to create key equals handle for type: " + keyType, e);
+        }
+    }
+
+    private MethodHandle generateKeyHashCodeHandle(Type keyType)
+    {
+        try {
+            MethodHandle base = MethodHandles.lookup().findStatic(
+                    MapOperators.class,
+                    "blockHashCode",
+                    MethodType.methodType(long.class, Type.class, Block.class, int.class));
+            return MethodHandles.insertArguments(base, 0, keyType);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to create key hash code handle for type: " + keyType, e);
+        }
+    }
+
+    @Override
+    public Type getParameterizedType(String baseTypeName, List<TypeSignatureParameter> typeParameters)
+    {
+        return getType(new TypeSignature(baseTypeName, typeParameters));
+    }
+
+    @Override
+    public boolean canCoerce(Type actualType, Type expectedType)
+    {
+        return false;
+    }
+
+    @Override
+    public List<Type> getTypes()
+    {
+        throw new UnsupportedOperationException("getTypes not supported");
+    }
+
+    @Override
+    public boolean hasType(TypeSignature signature)
+    {
+        try {
+            return getType(signature) != null;
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryParameters.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryParameters.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+public final class QueryParameters
+{
+    public static final String BINARY_RESULTS = "binaryResults";
+
+    private QueryParameters() {}
+}

--- a/presto-client/src/test/java/com/facebook/presto/client/TestBinaryDataDeserializer.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestBinaryDataDeserializer.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.MethodHandleUtil;
+import com.facebook.presto.common.block.TestingBlockEncodingSerde;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.page.SerializedPage;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.page.PagesSerdeUtil.writeSerializedPage;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+@Test(singleThreaded = true)
+public class TestBinaryDataDeserializer
+{
+    private TestingBlockEncodingSerde blockEncodingSerde;
+    private ClientTypeManager typeManager;
+    private PagesSerde pagesSerde;
+    private BinaryDataDeserializer deserializer;
+    private ClientSession testSession;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        blockEncodingSerde = new TestingBlockEncodingSerde();
+        typeManager = new ClientTypeManager();
+        pagesSerde = new PagesSerde(blockEncodingSerde, Optional.empty(), Optional.empty(), Optional.empty(), false);
+        testSession = createTestClientSession();
+        deserializer = new BinaryDataDeserializer(blockEncodingSerde, typeManager, testSession);
+    }
+
+    private ClientSession createTestClientSession()
+    {
+        return new ClientSession(
+                URI.create("http://localhost:8080"),
+                "test-user",
+                "test-source",
+                Optional.empty(),
+                ImmutableSet.of(),
+                null,
+                null,
+                null,
+                "America/Los_Angeles",
+                java.util.Locale.US,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                null,
+                com.facebook.airlift.units.Duration.valueOf("2m"),
+                false,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                false,
+                false);
+    }
+
+    @Test
+    public void testDeserializePrimitiveTypes()
+    {
+        VarcharType varcharType = VarcharType.createVarcharType(100);
+        List<Column> columns = ImmutableList.of(
+                new Column("col1", BigintType.BIGINT),
+                new Column("col2", varcharType),
+                new Column("col3", BooleanType.BOOLEAN),
+                new Column("col4", IntegerType.INTEGER),
+                new Column("col5", DoubleType.DOUBLE));
+
+        BlockBuilder bigintBlockBuilder = BigintType.BIGINT.createBlockBuilder(null, 3);
+        bigintBlockBuilder.writeLong(123L);
+        bigintBlockBuilder.writeLong(456L);
+        bigintBlockBuilder.writeLong(789L);
+
+        BlockBuilder varcharBlockBuilder = varcharType.createBlockBuilder(null, 3);
+        varcharType.writeSlice(varcharBlockBuilder, utf8Slice("hello"));
+        varcharType.writeSlice(varcharBlockBuilder, utf8Slice("world"));
+        varcharType.writeSlice(varcharBlockBuilder, utf8Slice("test"));
+
+        BlockBuilder booleanBlockBuilder = BooleanType.BOOLEAN.createBlockBuilder(null, 3);
+        BooleanType.BOOLEAN.writeBoolean(booleanBlockBuilder, true);
+        BooleanType.BOOLEAN.writeBoolean(booleanBlockBuilder, false);
+        BooleanType.BOOLEAN.writeBoolean(booleanBlockBuilder, true);
+
+        BlockBuilder integerBlockBuilder = IntegerType.INTEGER.createBlockBuilder(null, 3);
+        IntegerType.INTEGER.writeLong(integerBlockBuilder, 10);
+        IntegerType.INTEGER.writeLong(integerBlockBuilder, 20);
+        IntegerType.INTEGER.writeLong(integerBlockBuilder, 30);
+
+        BlockBuilder doubleBlockBuilder = DoubleType.DOUBLE.createBlockBuilder(null, 3);
+        DoubleType.DOUBLE.writeDouble(doubleBlockBuilder, 1.5);
+        DoubleType.DOUBLE.writeDouble(doubleBlockBuilder, 2.5);
+        DoubleType.DOUBLE.writeDouble(doubleBlockBuilder, 3.5);
+
+        Page page = new Page(
+                bigintBlockBuilder.build(),
+                varcharBlockBuilder.build(),
+                booleanBlockBuilder.build(),
+                integerBlockBuilder.build(),
+                doubleBlockBuilder.build());
+
+        String encodedPage = serializePage(page);
+
+        Iterable<List<Object>> rows = deserializer.deserialize(columns, ImmutableList.of(encodedPage));
+
+        List<List<Object>> rowList = ImmutableList.copyOf(rows);
+        assertEquals(rowList.size(), 3);
+
+        assertEquals(rowList.get(0).get(0), 123L);
+        assertEquals(rowList.get(0).get(1), "hello");
+        assertEquals(rowList.get(0).get(2), true);
+        assertEquals(rowList.get(0).get(3), 10);
+        assertEquals(rowList.get(0).get(4), 1.5);
+
+        assertEquals(rowList.get(1).get(0), 456L);
+        assertEquals(rowList.get(1).get(1), "world");
+        assertEquals(rowList.get(1).get(2), false);
+        assertEquals(rowList.get(1).get(3), 20);
+        assertEquals(rowList.get(1).get(4), 2.5);
+
+        assertEquals(rowList.get(2).get(0), 789L);
+        assertEquals(rowList.get(2).get(1), "test");
+        assertEquals(rowList.get(2).get(2), true);
+        assertEquals(rowList.get(2).get(3), 30);
+        assertEquals(rowList.get(2).get(4), 3.5);
+    }
+
+    @Test
+    public void testDeserializeNullValues()
+    {
+        VarcharType varcharType = VarcharType.createVarcharType(100);
+        List<Column> columns = ImmutableList.of(
+                new Column("col1", BigintType.BIGINT),
+                new Column("col2", varcharType));
+
+        BlockBuilder bigintBlockBuilder = BigintType.BIGINT.createBlockBuilder(null, 2);
+        bigintBlockBuilder.writeLong(100L);
+        bigintBlockBuilder.appendNull();
+
+        BlockBuilder varcharBlockBuilder = varcharType.createBlockBuilder(null, 2);
+        varcharBlockBuilder.appendNull();
+        varcharType.writeSlice(varcharBlockBuilder, utf8Slice("text"));
+
+        Page page = new Page(bigintBlockBuilder.build(), varcharBlockBuilder.build());
+        String encodedPage = serializePage(page);
+
+        Iterable<List<Object>> rows = deserializer.deserialize(columns, ImmutableList.of(encodedPage));
+
+        List<List<Object>> rowList = ImmutableList.copyOf(rows);
+        assertEquals(rowList.size(), 2);
+
+        assertEquals(rowList.get(0).get(0), 100L);
+        assertNull(rowList.get(0).get(1));
+
+        assertNull(rowList.get(1).get(0));
+        assertEquals(rowList.get(1).get(1), "text");
+    }
+
+    @Test
+    public void testDeserializeArrayType()
+    {
+        ArrayType arrayType = new ArrayType(BigintType.BIGINT);
+
+        List<Column> columns = ImmutableList.of(
+                new Column("arr", arrayType));
+
+        BlockBuilder arrayBlockBuilder = arrayType.createBlockBuilder(null, 2);
+
+        BlockBuilder arrayElementBuilder1 = arrayBlockBuilder.beginBlockEntry();
+        BigintType.BIGINT.writeLong(arrayElementBuilder1, 1L);
+        BigintType.BIGINT.writeLong(arrayElementBuilder1, 2L);
+        BigintType.BIGINT.writeLong(arrayElementBuilder1, 3L);
+        arrayBlockBuilder.closeEntry();
+
+        BlockBuilder arrayElementBuilder2 = arrayBlockBuilder.beginBlockEntry();
+        BigintType.BIGINT.writeLong(arrayElementBuilder2, 4L);
+        BigintType.BIGINT.writeLong(arrayElementBuilder2, 5L);
+        arrayBlockBuilder.closeEntry();
+
+        Page page = new Page(arrayBlockBuilder.build());
+        String encodedPage = serializePage(page);
+
+        Iterable<List<Object>> rows = deserializer.deserialize(columns, ImmutableList.of(encodedPage));
+
+        List<List<Object>> rowList = ImmutableList.copyOf(rows);
+        assertEquals(rowList.size(), 2);
+
+        assertNotNull(rowList.get(0).get(0));
+        assertNotNull(rowList.get(1).get(0));
+    }
+
+    @Test
+    public void testDeserializeMapType()
+    {
+        VarcharType varcharType = VarcharType.createVarcharType(100);
+        MapType mapType = new MapType(
+                varcharType,
+                BigintType.BIGINT,
+                MethodHandleUtil.methodHandle(TestBinaryDataDeserializer.class, "blockEquals", Block.class, Block.class),
+                MethodHandleUtil.methodHandle(TestBinaryDataDeserializer.class, "blockHashCode", Block.class));
+
+        List<Column> columns = ImmutableList.of(
+                new Column("map", mapType));
+
+        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, 1);
+        BlockBuilder singleMapWriter = mapBlockBuilder.beginBlockEntry();
+        varcharType.writeSlice(singleMapWriter, utf8Slice("key1"));
+        BigintType.BIGINT.writeLong(singleMapWriter, 100L);
+        varcharType.writeSlice(singleMapWriter, utf8Slice("key2"));
+        BigintType.BIGINT.writeLong(singleMapWriter, 200L);
+        mapBlockBuilder.closeEntry();
+
+        Page page = new Page(mapBlockBuilder.build());
+        String encodedPage = serializePage(page);
+
+        Iterable<List<Object>> rows = deserializer.deserialize(columns, ImmutableList.of(encodedPage));
+
+        List<List<Object>> rowList = ImmutableList.copyOf(rows);
+        assertEquals(rowList.size(), 1);
+        assertNotNull(rowList.get(0).get(0));
+    }
+
+    @Test
+    public void testDeserializeRowType()
+    {
+        VarcharType varcharType = VarcharType.createVarcharType(100);
+        RowType rowType = RowType.from(ImmutableList.of(
+                new RowType.Field(Optional.of("field1"), BigintType.BIGINT, false),
+                new RowType.Field(Optional.of("field2"), varcharType, false)));
+
+        List<Column> columns = ImmutableList.of(
+                new Column("row", rowType));
+
+        BlockBuilder rowBlockBuilder = rowType.createBlockBuilder(null, 1);
+        BlockBuilder singleRowBuilder = rowBlockBuilder.beginBlockEntry();
+        BigintType.BIGINT.writeLong(singleRowBuilder, 42L);
+        varcharType.writeSlice(singleRowBuilder, utf8Slice("test"));
+        rowBlockBuilder.closeEntry();
+
+        Page page = new Page(rowBlockBuilder.build());
+        String encodedPage = serializePage(page);
+
+        Iterable<List<Object>> rows = deserializer.deserialize(columns, ImmutableList.of(encodedPage));
+
+        List<List<Object>> rowList = ImmutableList.copyOf(rows);
+        assertEquals(rowList.size(), 1);
+        assertNotNull(rowList.get(0).get(0));
+    }
+
+    @Test
+    public void testDeserializeMultiplePages()
+    {
+        List<Column> columns = ImmutableList.of(
+                new Column("col1", BigintType.BIGINT));
+
+        BlockBuilder builder1 = BigintType.BIGINT.createBlockBuilder(null, 2);
+        builder1.writeLong(1L);
+        builder1.writeLong(2L);
+        Page page1 = new Page(builder1.build());
+
+        BlockBuilder builder2 = BigintType.BIGINT.createBlockBuilder(null, 2);
+        builder2.writeLong(3L);
+        builder2.writeLong(4L);
+        Page page2 = new Page(builder2.build());
+
+        String encodedPage1 = serializePage(page1);
+        String encodedPage2 = serializePage(page2);
+
+        Iterable<List<Object>> rows = deserializer.deserialize(
+                columns,
+                ImmutableList.of(encodedPage1, encodedPage2));
+
+        List<List<Object>> rowList = ImmutableList.copyOf(rows);
+        assertEquals(rowList.size(), 4);
+        assertEquals(rowList.get(0).get(0), 1L);
+        assertEquals(rowList.get(1).get(0), 2L);
+        assertEquals(rowList.get(2).get(0), 3L);
+        assertEquals(rowList.get(3).get(0), 4L);
+    }
+
+    @Test
+    public void testDeserializeEmptyPage()
+    {
+        List<Column> columns = ImmutableList.of(
+                new Column("col1", BigintType.BIGINT));
+
+        BlockBuilder builder = BigintType.BIGINT.createBlockBuilder(null, 0);
+        Page page = new Page(builder.build());
+
+        String encodedPage = serializePage(page);
+
+        Iterable<List<Object>> rows = deserializer.deserialize(columns, ImmutableList.of(encodedPage));
+
+        List<List<Object>> rowList = ImmutableList.copyOf(rows);
+        assertEquals(rowList.size(), 0);
+    }
+
+    public static boolean blockEquals(Block left, Block right)
+    {
+        return left.equals(right);
+    }
+
+    public static long blockHashCode(Block block)
+    {
+        return block.hashCode();
+    }
+
+    private String serializePage(Page page)
+    {
+        SerializedPage serializedPage = pagesSerde.serialize(page);
+
+        DynamicSliceOutput output = new DynamicSliceOutput(serializedPage.getSizeInBytes());
+        writeSerializedPage(output, serializedPage);
+
+        Slice slice = output.slice();
+        byte[] bytes = slice.getBytes();
+
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+}

--- a/presto-client/src/test/java/com/facebook/presto/client/TestClientTypeManager.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestClientTypeManager.java
@@ -1,0 +1,478 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.common.type.DateType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.HyperLogLogType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.JsonType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.NamedTypeSignature;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.RowFieldName;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.TimeType;
+import com.facebook.presto.common.type.TimeWithTimeZoneType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
+import com.facebook.presto.common.type.TinyintType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.UuidType;
+import com.facebook.presto.common.type.VarbinaryType;
+import com.facebook.presto.common.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+@Test(singleThreaded = true)
+public class TestClientTypeManager
+{
+    private ClientTypeManager typeManager;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        typeManager = new ClientTypeManager();
+    }
+
+    @Test
+    public void testPrimitiveTypes()
+    {
+        assertEquals(typeManager.getType(new TypeSignature("boolean")), BooleanType.BOOLEAN);
+        assertEquals(typeManager.getType(new TypeSignature("tinyint")), TinyintType.TINYINT);
+        assertEquals(typeManager.getType(new TypeSignature("smallint")), SmallintType.SMALLINT);
+        assertEquals(typeManager.getType(new TypeSignature("integer")), IntegerType.INTEGER);
+        assertEquals(typeManager.getType(new TypeSignature("bigint")), BigintType.BIGINT);
+        assertEquals(typeManager.getType(new TypeSignature("real")), RealType.REAL);
+        assertEquals(typeManager.getType(new TypeSignature("double")), DoubleType.DOUBLE);
+        assertEquals(typeManager.getType(new TypeSignature("date")), DateType.DATE);
+        assertEquals(typeManager.getType(new TypeSignature("time")), TimeType.TIME);
+        assertEquals(typeManager.getType(new TypeSignature("time with time zone")), TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
+        assertEquals(typeManager.getType(new TypeSignature("timestamp")), TimestampType.TIMESTAMP);
+        assertEquals(typeManager.getType(new TypeSignature("timestamp with time zone")), TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
+        assertEquals(typeManager.getType(new TypeSignature("varbinary")), VarbinaryType.VARBINARY);
+        assertEquals(typeManager.getType(new TypeSignature("json")), JsonType.JSON);
+        assertEquals(typeManager.getType(new TypeSignature("uuid")), UuidType.UUID);
+        assertEquals(typeManager.getType(new TypeSignature("HyperLogLog")), HyperLogLogType.HYPER_LOG_LOG);
+    }
+
+    @Test
+    public void testVarcharType()
+    {
+        Type unboundedVarchar = typeManager.getType(new TypeSignature("varchar"));
+        assertEquals(unboundedVarchar, VarcharType.VARCHAR);
+
+        Type varchar10 = typeManager.getType(new TypeSignature(
+                "varchar",
+                ImmutableList.of(TypeSignatureParameter.of(10))));
+        assertTrue(varchar10 instanceof VarcharType);
+        assertEquals(varchar10, VarcharType.createVarcharType(10));
+
+        Type varchar255 = typeManager.getType(new TypeSignature(
+                "varchar",
+                ImmutableList.of(TypeSignatureParameter.of(255))));
+        assertTrue(varchar255 instanceof VarcharType);
+        assertEquals(varchar255, VarcharType.createVarcharType(255));
+    }
+
+    @Test
+    public void testCharType()
+    {
+        Type char1 = typeManager.getType(new TypeSignature("char"));
+        assertTrue(char1 instanceof CharType);
+        assertEquals(char1, CharType.createCharType(1));
+
+        Type char10 = typeManager.getType(new TypeSignature(
+                "char",
+                ImmutableList.of(TypeSignatureParameter.of(10))));
+        assertTrue(char10 instanceof CharType);
+        assertEquals(char10, CharType.createCharType(10));
+
+        Type char255 = typeManager.getType(new TypeSignature(
+                "char",
+                ImmutableList.of(TypeSignatureParameter.of(255))));
+        assertTrue(char255 instanceof CharType);
+        assertEquals(char255, CharType.createCharType(255));
+    }
+
+    @Test
+    public void testDecimalType()
+    {
+        Type decimalType1 = typeManager.getType(new TypeSignature(
+                "decimal",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(10),
+                        TypeSignatureParameter.of(2))));
+        assertTrue(decimalType1 instanceof DecimalType);
+        assertEquals(decimalType1, DecimalType.createDecimalType(10, 2));
+
+        Type decimalType2 = typeManager.getType(new TypeSignature(
+                "decimal",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(38),
+                        TypeSignatureParameter.of(10))));
+        assertTrue(decimalType2 instanceof DecimalType);
+        assertEquals(decimalType2, DecimalType.createDecimalType(38, 10));
+
+        try {
+            typeManager.getType(new TypeSignature(
+                    "decimal",
+                    ImmutableList.of(TypeSignatureParameter.of(10))));
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("DECIMAL type must have exactly two parameters"));
+        }
+    }
+
+    @Test
+    public void testArrayTypes()
+    {
+        Type arrayOfBigint = typeManager.getType(new TypeSignature(
+                "array",
+                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("bigint")))));
+        assertTrue(arrayOfBigint instanceof ArrayType);
+        ArrayType arrayType = (ArrayType) arrayOfBigint;
+        assertEquals(arrayType.getElementType(), BigintType.BIGINT);
+
+        Type arrayOfArrayOfInteger = typeManager.getType(new TypeSignature(
+                "array",
+                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature(
+                        "array",
+                        ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("integer"))))))));
+        assertTrue(arrayOfArrayOfInteger instanceof ArrayType);
+        ArrayType outerArray = (ArrayType) arrayOfArrayOfInteger;
+        assertTrue(outerArray.getElementType() instanceof ArrayType);
+        ArrayType innerArray = (ArrayType) outerArray.getElementType();
+        assertEquals(innerArray.getElementType(), IntegerType.INTEGER);
+
+        Type arrayOfVarchar = typeManager.getType(new TypeSignature(
+                "array",
+                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature(
+                        "varchar",
+                        ImmutableList.of(TypeSignatureParameter.of(100)))))));
+        assertTrue(arrayOfVarchar instanceof ArrayType);
+        ArrayType arrayOfVarcharType = (ArrayType) arrayOfVarchar;
+        assertEquals(arrayOfVarcharType.getElementType(), VarcharType.createVarcharType(100));
+
+        try {
+            typeManager.getType(new TypeSignature(
+                    "array",
+                    ImmutableList.of(
+                            TypeSignatureParameter.of(new TypeSignature("bigint")),
+                            TypeSignatureParameter.of(new TypeSignature("varchar")))));
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("ARRAY type must have exactly one parameter"));
+        }
+
+        try {
+            typeManager.getType(new TypeSignature(
+                    "array",
+                    ImmutableList.of(TypeSignatureParameter.of(42))));
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("ARRAY element must be a type"));
+        }
+    }
+
+    @Test
+    public void testMapTypes()
+    {
+        Type mapOfVarcharToBigint = typeManager.getType(new TypeSignature(
+                "map",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new TypeSignature("varchar")),
+                        TypeSignatureParameter.of(new TypeSignature("bigint")))));
+        assertTrue(mapOfVarcharToBigint instanceof MapType);
+        MapType mapType = (MapType) mapOfVarcharToBigint;
+        assertEquals(mapType.getKeyType(), VarcharType.VARCHAR);
+        assertEquals(mapType.getValueType(), BigintType.BIGINT);
+        assertNotNull(mapType.getKeyBlockEquals());
+        assertNotNull(mapType.getKeyBlockHashCode());
+
+        Type mapOfVarcharToMapOfIntegerToDouble = typeManager.getType(new TypeSignature(
+                "map",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new TypeSignature("varchar")),
+                        TypeSignatureParameter.of(new TypeSignature(
+                                "map",
+                                ImmutableList.of(
+                                        TypeSignatureParameter.of(new TypeSignature("integer")),
+                                        TypeSignatureParameter.of(new TypeSignature("double"))))))));
+        assertTrue(mapOfVarcharToMapOfIntegerToDouble instanceof MapType);
+        MapType outerMap = (MapType) mapOfVarcharToMapOfIntegerToDouble;
+        assertEquals(outerMap.getKeyType(), VarcharType.VARCHAR);
+        assertTrue(outerMap.getValueType() instanceof MapType);
+        MapType innerMap = (MapType) outerMap.getValueType();
+        assertEquals(innerMap.getKeyType(), IntegerType.INTEGER);
+        assertEquals(innerMap.getValueType(), DoubleType.DOUBLE);
+
+        Type mapOfVarcharToArrayOfBigint = typeManager.getType(new TypeSignature(
+                "map",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new TypeSignature("varchar")),
+                        TypeSignatureParameter.of(new TypeSignature(
+                                "array",
+                                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("bigint"))))))));
+        assertTrue(mapOfVarcharToArrayOfBigint instanceof MapType);
+        MapType mapWithArrayValue = (MapType) mapOfVarcharToArrayOfBigint;
+        assertEquals(mapWithArrayValue.getKeyType(), VarcharType.VARCHAR);
+        assertTrue(mapWithArrayValue.getValueType() instanceof ArrayType);
+        ArrayType arrayType = (ArrayType) mapWithArrayValue.getValueType();
+        assertEquals(arrayType.getElementType(), BigintType.BIGINT);
+
+        try {
+            typeManager.getType(new TypeSignature(
+                    "map",
+                    ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("bigint")))));
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("MAP type must have exactly two parameters"));
+        }
+
+        try {
+            typeManager.getType(new TypeSignature(
+                    "map",
+                    ImmutableList.of(
+                            TypeSignatureParameter.of(42),
+                            TypeSignatureParameter.of(new TypeSignature("bigint")))));
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("MAP key must be a type"));
+        }
+    }
+
+    @Test
+    public void testRowTypes()
+    {
+        Type row = typeManager.getType(new TypeSignature(
+                "row",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new NamedTypeSignature(
+                                Optional.of(new RowFieldName("field1", false)),
+                                new TypeSignature("bigint"))),
+                        TypeSignatureParameter.of(new NamedTypeSignature(
+                                Optional.of(new RowFieldName("field2", false)),
+                                new TypeSignature("varchar"))))));
+        assertTrue(row instanceof RowType);
+        RowType rowType = (RowType) row;
+        List<RowType.Field> fields = rowType.getFields();
+        assertEquals(fields.size(), 2);
+        assertEquals(fields.get(0).getName(), Optional.of("field1"));
+        assertEquals(fields.get(0).getType(), BigintType.BIGINT);
+        assertEquals(fields.get(1).getName(), Optional.of("field2"));
+        assertEquals(fields.get(1).getType(), VarcharType.VARCHAR);
+
+        Type anonymousRow = typeManager.getType(new TypeSignature(
+                "row",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new NamedTypeSignature(
+                                Optional.empty(),
+                                new TypeSignature("bigint"))),
+                        TypeSignatureParameter.of(new NamedTypeSignature(
+                                Optional.empty(),
+                                new TypeSignature("varchar"))))));
+        assertTrue(anonymousRow instanceof RowType);
+        RowType anonymousRowType = (RowType) anonymousRow;
+        List<RowType.Field> anonymousFields = anonymousRowType.getFields();
+        assertEquals(anonymousFields.size(), 2);
+        assertEquals(anonymousFields.get(0).getName(), Optional.empty());
+        assertEquals(anonymousFields.get(0).getType(), BigintType.BIGINT);
+        assertEquals(anonymousFields.get(1).getName(), Optional.empty());
+        assertEquals(anonymousFields.get(1).getType(), VarcharType.VARCHAR);
+
+        Type delimitedRow = typeManager.getType(new TypeSignature(
+                "row",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new NamedTypeSignature(
+                                Optional.of(new RowFieldName("field with spaces", true)),
+                                new TypeSignature("bigint"))))));
+        assertTrue(delimitedRow instanceof RowType);
+        RowType delimitedRowType = (RowType) delimitedRow;
+        List<RowType.Field> delimitedFields = delimitedRowType.getFields();
+        assertEquals(delimitedFields.size(), 1);
+        assertEquals(delimitedFields.get(0).getName(), Optional.of("field with spaces"));
+        assertTrue(delimitedFields.get(0).isDelimited());
+        assertEquals(delimitedFields.get(0).getType(), BigintType.BIGINT);
+
+        Type nestedRow = typeManager.getType(new TypeSignature(
+                "row",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new NamedTypeSignature(
+                                Optional.of(new RowFieldName("outer", false)),
+                                new TypeSignature(
+                                        "row",
+                                        ImmutableList.of(
+                                                TypeSignatureParameter.of(new NamedTypeSignature(
+                                                        Optional.of(new RowFieldName("inner", false)),
+                                                        new TypeSignature("bigint"))))))))));
+        assertTrue(nestedRow instanceof RowType);
+        RowType outerRow = (RowType) nestedRow;
+        assertEquals(outerRow.getFields().size(), 1);
+        assertEquals(outerRow.getFields().get(0).getName(), Optional.of("outer"));
+        assertTrue(outerRow.getFields().get(0).getType() instanceof RowType);
+        RowType innerRow = (RowType) outerRow.getFields().get(0).getType();
+        assertEquals(innerRow.getFields().size(), 1);
+        assertEquals(innerRow.getFields().get(0).getName(), Optional.of("inner"));
+        assertEquals(innerRow.getFields().get(0).getType(), BigintType.BIGINT);
+
+        Type complexRow = typeManager.getType(new TypeSignature(
+                "row",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new NamedTypeSignature(
+                                Optional.of(new RowFieldName("arr", false)),
+                                new TypeSignature(
+                                        "array",
+                                        ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("bigint")))))),
+                        TypeSignatureParameter.of(new NamedTypeSignature(
+                                Optional.of(new RowFieldName("map", false)),
+                                new TypeSignature(
+                                        "map",
+                                        ImmutableList.of(
+                                                TypeSignatureParameter.of(new TypeSignature("varchar")),
+                                                TypeSignatureParameter.of(new TypeSignature("integer")))))))));
+        assertTrue(complexRow instanceof RowType);
+        RowType complexRowType = (RowType) complexRow;
+        assertEquals(complexRowType.getFields().size(), 2);
+        assertTrue(complexRowType.getFields().get(0).getType() instanceof ArrayType);
+        assertTrue(complexRowType.getFields().get(1).getType() instanceof MapType);
+
+        try {
+            typeManager.getType(new TypeSignature("row", ImmutableList.of()));
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("ROW type must have at least one field"));
+        }
+
+        try {
+            typeManager.getType(new TypeSignature(
+                    "row",
+                    ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("bigint")))));
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("ROW parameters must be named types"));
+        }
+    }
+
+    @Test
+    public void testComplexType()
+    {
+        Type complexType = typeManager.getType(new TypeSignature(
+                "array",
+                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature(
+                        "map",
+                        ImmutableList.of(
+                                TypeSignatureParameter.of(new TypeSignature("varchar")),
+                                TypeSignatureParameter.of(new TypeSignature(
+                                        "row",
+                                        ImmutableList.of(
+                                                TypeSignatureParameter.of(new NamedTypeSignature(
+                                                        Optional.of(new RowFieldName("id", false)),
+                                                        new TypeSignature("bigint"))),
+                                                TypeSignatureParameter.of(new NamedTypeSignature(
+                                                        Optional.of(new RowFieldName("values", false)),
+                                                        new TypeSignature(
+                                                                "array",
+                                                                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("double")))))))))))))));
+        assertTrue(complexType instanceof ArrayType);
+        ArrayType arrayType = (ArrayType) complexType;
+        assertTrue(arrayType.getElementType() instanceof MapType);
+        MapType mapType = (MapType) arrayType.getElementType();
+        assertEquals(mapType.getKeyType(), VarcharType.VARCHAR);
+        assertTrue(mapType.getValueType() instanceof RowType);
+        RowType rowType = (RowType) mapType.getValueType();
+        assertEquals(rowType.getFields().size(), 2);
+        assertEquals(rowType.getFields().get(0).getType(), BigintType.BIGINT);
+        assertTrue(rowType.getFields().get(1).getType() instanceof ArrayType);
+        ArrayType innerArray = (ArrayType) rowType.getFields().get(1).getType();
+        assertEquals(innerArray.getElementType(), DoubleType.DOUBLE);
+    }
+
+    @Test
+    public void testTypeCaching()
+    {
+        TypeSignature bigintSignature = new TypeSignature("bigint");
+        Type type1 = typeManager.getType(bigintSignature);
+        Type type2 = typeManager.getType(bigintSignature);
+        assertSame(type1, type2);
+
+        TypeSignature arraySignature = new TypeSignature(
+                "array",
+                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("bigint"))));
+        Type arrayType1 = typeManager.getType(arraySignature);
+        Type arrayType2 = typeManager.getType(arraySignature);
+        assertSame(arrayType1, arrayType2);
+    }
+
+    @Test
+    public void testHasType()
+    {
+        assertTrue(typeManager.hasType(new TypeSignature("bigint")));
+        assertTrue(typeManager.hasType(new TypeSignature(
+                "array",
+                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("bigint"))))));
+        assertTrue(typeManager.hasType(new TypeSignature(
+                "map",
+                ImmutableList.of(
+                        TypeSignatureParameter.of(new TypeSignature("varchar")),
+                        TypeSignatureParameter.of(new TypeSignature("bigint"))))));
+    }
+
+    @Test
+    public void testGetParameterizedType()
+    {
+        Type arrayType = typeManager.getParameterizedType(
+                "array",
+                ImmutableList.of(TypeSignatureParameter.of(new TypeSignature("bigint"))));
+        assertTrue(arrayType instanceof ArrayType);
+        assertEquals(((ArrayType) arrayType).getElementType(), BigintType.BIGINT);
+    }
+
+    @Test
+    public void testUnknownTypeThrowsException()
+    {
+        try {
+            typeManager.getType(new TypeSignature("unknown_type"));
+            fail("Expected IllegalArgumentException");
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("Unknown type"));
+        }
+    }
+}

--- a/presto-client/src/test/java/com/facebook/presto/client/TestQueryResults.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestQueryResults.java
@@ -62,4 +62,52 @@ public class TestQueryResults
         QueryResults results = QUERY_RESULTS_CODEC.fromJson(goldenValue);
         assertEquals(results.getId(), "20160128_214710_00012_rk68b");
     }
+
+    @Test
+    public void testBinaryDataDeserialization()
+    {
+        String jsonWithBinaryData = "{\n" +
+                "  \"id\" : \"test_binary_query\",\n" +
+                "  \"infoUri\" : \"http://localhost:8080/query.html?test_binary_query\",\n" +
+                "  \"columns\" : [ {\n" +
+                "    \"name\" : \"_col0\",\n" +
+                "    \"type\" : \"varchar\",\n" +
+                "    \"typeSignature\" : {\n" +
+                "      \"rawType\" : \"varchar\",\n" +
+                "      \"typeArguments\" : [ ],\n" +
+                "      \"literalArguments\" : [ ],\n" +
+                "      \"arguments\" : [ ]\n" +
+                "    }\n" +
+                "  } ],\n" +
+                "  \"binaryData\" : [ \"YmluYXJ5X2RhdGFfMQ==\", \"YmluYXJ5X2RhdGFfMg==\" ],\n" +
+                "  \"stats\" : {\n" +
+                "    \"state\" : \"FINISHED\",\n" +
+                "    \"queued\" : false,\n" +
+                "    \"scheduled\" : false,\n" +
+                "    \"nodes\" : 0,\n" +
+                "    \"totalSplits\" : 0,\n" +
+                "    \"queuedSplits\" : 0,\n" +
+                "    \"runningSplits\" : 0,\n" +
+                "    \"completedSplits\" : 0,\n" +
+                "    \"cpuTimeMillis\" : 0,\n" +
+                "    \"wallTimeMillis\" : 0,\n" +
+                "    \"queuedTimeMillis\" : 0,\n" +
+                "    \"elapsedTimeMillis\" : 0,\n" +
+                "    \"processedRows\" : 0,\n" +
+                "    \"processedBytes\" : 0,\n" +
+                "    \"peakMemoryBytes\" : 0\n" +
+                "  }\n" +
+                "}";
+
+        QueryResults results = QUERY_RESULTS_CODEC.fromJson(jsonWithBinaryData);
+        assertEquals(results.getId(), "test_binary_query");
+        Iterable<String> binaryData = results.getBinaryData();
+        assertEquals(binaryData != null, true);
+        java.util.Iterator<String> iterator = binaryData.iterator();
+        assertEquals(iterator.hasNext(), true);
+        assertEquals(iterator.next(), "YmluYXJ5X2RhdGFfMQ==");
+        assertEquals(iterator.hasNext(), true);
+        assertEquals(iterator.next(), "YmluYXJ5X2RhdGFfMg==");
+        assertEquals(iterator.hasNext(), false);
+    }
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -796,7 +796,8 @@ public class PrestoConnection
                 compressionDisabled,
                 ImmutableMap.of(),
                 customHeaders,
-                validateNextUriSource);
+                validateNextUriSource,
+                false);
 
         return queryExecutor.startQuery(session, sql);
     }

--- a/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
+++ b/presto-plan-checker-router-plugin/src/main/java/com/facebook/presto/router/scheduler/PlanCheckerRouterPluginPrestoClient.java
@@ -279,7 +279,8 @@ public class PlanCheckerRouterPluginPrestoClient
                 true,
                 getSerializedSessionFunctions(sessionContext),
                 customHeaders,
-                true);
+                true,
+                false);
     }
 
     private URI getPlanCheckerClusterDestination()

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -182,6 +182,7 @@ public abstract class AbstractTestingPrestoClient<T>
                 true,
                 serializedSessionFunctions,
                 ImmutableMap.of(),
+                false,
                 false);
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
@@ -83,6 +83,7 @@ public class TestFinalQueryInfo
                     true,
                     ImmutableMap.of(),
                     ImmutableMap.of(),
+                    false,
                     false);
 
             // start query

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestPrestoClient.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestPrestoClient.java
@@ -1,0 +1,318 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.Session;
+import com.facebook.presto.client.ClientSession;
+import com.facebook.presto.client.Column;
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.client.StatementClient;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import okhttp3.OkHttpClient;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.client.StatementClientFactory.newStatementClient;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+@Test(singleThreaded = true)
+public class TestPrestoClient
+{
+    private DistributedQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        queryRunner = createQueryRunner(TEST_SESSION);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+
+    @Test
+    public void testNormalResultsWithPrimitiveTypes()
+    {
+        QueryResultData result = executeQuery(
+                "SELECT * FROM (VALUES (CAST(123 AS BIGINT), 'hello', true, CAST(42 AS INTEGER), CAST(3.14 AS DOUBLE))) AS t(col1, col2, col3, col4, col5)",
+                false);
+
+        assertEquals(result.rows.size(), 1);
+        assertEquals(result.columns.size(), 5);
+        assertEquals(result.columns.get(0).getType(), "bigint");
+        assertEquals(result.columns.get(1).getType(), "varchar(5)");
+        assertEquals(result.columns.get(2).getType(), "boolean");
+        assertEquals(result.columns.get(3).getType(), "integer");
+        assertEquals(result.columns.get(4).getType(), "double");
+
+        List<Object> row = result.rows.get(0);
+        assertEquals(row.get(0), 123L);
+        assertEquals(row.get(1), "hello");
+        assertEquals(row.get(2), true);
+        assertEquals(row.get(3), 42);
+        assertEquals(row.get(4), 3.14);
+    }
+
+    @Test
+    public void testBinaryResultsWithPrimitiveTypes()
+    {
+        QueryResultData result = executeQuery(
+                "SELECT * FROM (VALUES (CAST(123 AS BIGINT), 'hello', true, CAST(42 AS INTEGER), CAST(3.14 AS DOUBLE))) AS t(col1, col2, col3, col4, col5)",
+                true);
+
+        assertEquals(result.rows.size(), 1);
+        assertEquals(result.columns.size(), 5);
+        assertEquals(result.columns.get(0).getType(), "bigint");
+        assertEquals(result.columns.get(1).getType(), "varchar(5)");
+        assertEquals(result.columns.get(2).getType(), "boolean");
+        assertEquals(result.columns.get(3).getType(), "integer");
+        assertEquals(result.columns.get(4).getType(), "double");
+
+        List<Object> row = result.rows.get(0);
+        assertEquals(row.get(0), 123L);
+        assertEquals(row.get(1), "hello");
+        assertEquals(row.get(2), true);
+        assertEquals(row.get(3), 42);
+        assertEquals(row.get(4), 3.14);
+    }
+
+    @Test
+    public void testNormalResultsWithMultipleRows()
+    {
+        QueryResultData result = executeQuery(
+                "SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name)",
+                false);
+
+        assertEquals(result.rows.size(), 3);
+        assertEquals(result.columns.size(), 2);
+
+        assertEquals(result.rows.get(0).get(0), 1);
+        assertEquals(result.rows.get(0).get(1), "a");
+        assertEquals(result.rows.get(1).get(0), 2);
+        assertEquals(result.rows.get(1).get(1), "b");
+        assertEquals(result.rows.get(2).get(0), 3);
+        assertEquals(result.rows.get(2).get(1), "c");
+    }
+
+    @Test
+    public void testBinaryResultsWithMultipleRows()
+    {
+        QueryResultData result = executeQuery(
+                "SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, name)",
+                true);
+
+        assertEquals(result.rows.size(), 3);
+        assertEquals(result.columns.size(), 2);
+
+        assertEquals(result.rows.get(0).get(0), 1);
+        assertEquals(result.rows.get(0).get(1), "a");
+        assertEquals(result.rows.get(1).get(0), 2);
+        assertEquals(result.rows.get(1).get(1), "b");
+        assertEquals(result.rows.get(2).get(0), 3);
+        assertEquals(result.rows.get(2).get(1), "c");
+    }
+
+    @Test
+    public void testNormalResultsWithNullValues()
+    {
+        QueryResultData result = executeQuery(
+                "SELECT CAST(NULL AS BIGINT), VARCHAR 'test', CAST(NULL AS BOOLEAN)",
+                false);
+
+        assertEquals(result.rows.size(), 1);
+        assertEquals(result.columns.size(), 3);
+
+        List<Object> row = result.rows.get(0);
+        assertNull(row.get(0));
+        assertEquals(row.get(1), "test");
+        assertNull(row.get(2));
+    }
+
+    @Test
+    public void testBinaryResultsWithNullValues()
+    {
+        QueryResultData result = executeQuery(
+                "SELECT CAST(NULL AS BIGINT), VARCHAR 'test', CAST(NULL AS BOOLEAN)",
+                true);
+
+        assertEquals(result.rows.size(), 1);
+        assertEquals(result.columns.size(), 3);
+
+        List<Object> row = result.rows.get(0);
+        assertNull(row.get(0));
+        assertEquals(row.get(1), "test");
+        assertNull(row.get(2));
+    }
+
+    @Test
+    public void testBinaryAndNormalResultsMatch()
+    {
+        String query = "SELECT * FROM (VALUES (CAST(999 AS BIGINT), 'world', false, CAST(88 AS INTEGER), CAST(2.718 AS DOUBLE))) AS t(col1, col2, col3, col4, col5)";
+
+        QueryResultData normalResult = executeQuery(query, false);
+        QueryResultData binaryResult = executeQuery(query, true);
+
+        assertEquals(normalResult.rows.size(), binaryResult.rows.size());
+        assertEquals(normalResult.columns.size(), binaryResult.columns.size());
+
+        for (int i = 0; i < normalResult.rows.size(); i++) {
+            List<Object> normalRow = normalResult.rows.get(i);
+            List<Object> binaryRow = binaryResult.rows.get(i);
+
+            assertEquals(normalRow.size(), binaryRow.size());
+            for (int j = 0; j < normalRow.size(); j++) {
+                Object normalValue = normalRow.get(j);
+                Object binaryValue = binaryRow.get(j);
+                if (normalValue instanceof Double && binaryValue instanceof Double) {
+                    assertEquals((Double) normalValue, (Double) binaryValue, 0.0001);
+                }
+                else {
+                    assertEquals(normalValue, binaryValue);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testBinaryResultsWithTpchQuery()
+    {
+        QueryResultData result = executeQuery("SELECT COUNT(*) FROM tpch.tiny.nation", true);
+
+        assertEquals(result.rows.size(), 1);
+        assertEquals(result.columns.get(0).getType(), "bigint");
+        assertEquals(result.rows.get(0).get(0), 25L);
+    }
+
+    @Test
+    public void testNormalResultsWithTpchQuery()
+    {
+        QueryResultData result = executeQuery("SELECT COUNT(*) FROM tpch.tiny.nation", false);
+
+        assertEquals(result.rows.size(), 1);
+        assertEquals(result.columns.get(0).getType(), "bigint");
+        assertEquals(result.rows.get(0).get(0), 25L);
+    }
+
+    private QueryResultData executeQuery(String sql, boolean binaryResults)
+    {
+        OkHttpClient httpClient = new OkHttpClient();
+        try {
+            ClientSession clientSession = new ClientSession(
+                    queryRunner.getCoordinator().getBaseUrl(),
+                    "test-user",
+                    "test-source",
+                    Optional.empty(),
+                    ImmutableSet.of(),
+                    null,
+                    null,
+                    null,
+                    "America/Los_Angeles",
+                    Locale.ENGLISH,
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    null,
+                    new Duration(2, MINUTES),
+                    false,
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    false,
+                    binaryResults);
+
+            StatementClient client = newStatementClient(httpClient, clientSession, sql);
+
+            List<Column> columns = null;
+            ImmutableList.Builder<List<Object>> rowsBuilder = ImmutableList.builder();
+
+            while (client.isRunning()) {
+                Iterable<List<Object>> data = client.currentData().getData();
+                if (data != null) {
+                    for (List<Object> row : data) {
+                        rowsBuilder.add(row);
+                    }
+                }
+
+                if (columns == null) {
+                    QueryResults results = (QueryResults) client.currentStatusInfo();
+                    if (results.getColumns() != null) {
+                        columns = results.getColumns();
+                    }
+                }
+
+                client.advance();
+            }
+
+            assertNotNull(columns, "Columns should not be null");
+
+            ImmutableList<List<Object>> rows = rowsBuilder.build();
+            return new QueryResultData(columns, rows);
+        }
+        finally {
+            httpClient.dispatcher().executorService().shutdown();
+            httpClient.connectionPool().evictAll();
+        }
+    }
+
+    private static class QueryResultData
+    {
+        public final List<Column> columns;
+        public final List<List<Object>> rows;
+
+        public QueryResultData(List<Column> columns, List<List<Object>> rows)
+        {
+            this.columns = columns;
+            this.rows = rows;
+        }
+    }
+
+    private static DistributedQueryRunner createQueryRunner(Session session)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setNodeCount(2)
+                .build();
+
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
## Description
The capability exists for Presto server to return serialized responses, but is currently not enabled in the client nor piped through to the CLI. This change adds support for the client to request and process serialized responses via the `--serialized` flag

NOTE: right now I only handle the types located in presto-common on the serialized path; there are some additional types declared in presto-main-base which the client does not have access to. Those could either be moved or redefined in presto-client, but since serialized APIs are opt-in and fails fast, it seemed acceptable to defer support for those types

## Motivation and Context
As far as I know, there is no OSS client which can read using the serialized interface. This can make it difficult to test changes which may affect serialized query responses. 

## Impact
Callers can now read from the server using the binary serialized interface using the Presto CLI.

## Test Plan
Test manually against tpch:
```
$ ./target/presto-cli-0.296-SNAPSHOT-executable.jar --server localhost:8081 --catalog tpch --schema tiny --serialized
presto:tiny> select * from lineitem limit 10;
 l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate |  l_shipinstruct   | l_shipmode >
------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------>
          1 |    155190 |      7706 |            1 |       17.0 |        21168.23 |       0.04 |  0.02 | N            | O            | 1996-03-13 | 1996-02-12   | 1996-03-22    | DELIVER IN PERSON | TRUCK      >
          1 |     67310 |      7311 |            2 |       36.0 |        45983.16 |       0.09 |  0.06 | N            | O            | 1996-04-12 | 1996-02-28   | 1996-04-20    | TAKE BACK RETURN  | MAIL       >
          1 |     63700 |      3701 |            3 |        8.0 |         13309.6 |        0.1 |  0.02 | N            | O            | 1996-01-29 | 1996-03-05   | 1996-01-31    | TAKE BACK RETURN  | REG AIR    >
          1 |      2132 |      4633 |            4 |       28.0 |        28955.64 |       0.09 |  0.06 | N            | O            | 1996-04-21 | 1996-03-30   | 1996-05-16    | NONE              | AIR        >
          1 |     24027 |      1534 |            5 |       24.0 |        22824.48 |        0.1 |  0.04 | N            | O            | 1996-03-30 | 1996-03-14   | 1996-04-01    | NONE              | FOB        >
          1 |     15635 |       638 |            6 |       32.0 |        49620.16 |       0.07 |  0.02 | N            | O            | 1996-01-30 | 1996-02-07   | 1996-02-03    | DELIVER IN PERSON | MAIL       >
          2 |    106170 |      1191 |            1 |       38.0 |        44694.46 |        0.0 |  0.05 | N            | O            | 1997-01-28 | 1997-01-14   | 1997-02-02    | TAKE BACK RETURN  | RAIL       >
          3 |      4297 |      1798 |            1 |       45.0 |        54058.05 |       0.06 |   0.0 | R            | F            | 1994-02-02 | 1994-01-04   | 1994-02-23    | NONE              | AIR        >
          3 |     19036 |      6540 |            2 |       49.0 |        46796.47 |        0.1 |   0.0 | R            | F            | 1993-11-09 | 1993-12-20   | 1993-11-24    | TAKE BACK RETURN  | RAIL       >
          3 |    128449 |      3474 |            3 |       27.0 |        39890.88 |       0.06 |  0.07 | A            | F            | 1994-01-16 | 1993-11-22   | 1994-01-23    | DELIVER IN PERSON | SHIP       >
(10 rows)
Query 20251119_002325_00013_gdtfy, FINISHED, 1 node
Splits: 1 total, 0 done (0.00%)
[Latency: client-side: 120ms, server-side: 49ms] [1.01K rows, 398KB] [20.6K rows/s, 7.94MB/s]
```
I also added test coverage to the following components:

- ClientTypeManager
- BinaryResultDeserializer

And some E2E test coverage using both the binary serialized and JSON-serialized response formats

## Contributor checklist
- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [] CI passed.

## Release Notes
```
General changes
* Add client support for binary serialized responses
```

Differential Revision: D87268210


