### PR TITLE
docs(native): Update documentation for Hive Connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -1040,13 +1040,15 @@ Sync Partition Metadata
 Invalidate Directory List Cache
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``system.invalidate_directory_list_cache()``
+Invalidating directory list cache is useful when the files are added or deleted in the cache directory path and you want to make the changes visible to Presto immediately.
+There are a couple of ways for invalidating this cache and are listed below -
 
-  Flush full directory list cache.
+* The Hive connector exposes a procedure over JMX (``com.facebook.presto.hive.CachingDirectoryLister#flushCache``) to invalidate the directory list cache. You can call this procedure to invalidate the directory list cache by connecting via jconsole or jmxterm. This procedure flushes all the cache entries.
 
-* ``system.invalidate_directory_list_cache(directory_path)``
+* The Hive connector exposes ``system.invalidate_directory_list_cache`` procedure which gives the flexibility to invalidate the list cache completely or partially as per the requirement and can be invoked in various ways.
 
-  Invalidate directory list cache for specified directory_path.
+  * ``system.invalidate_directory_list_cache()`` : Flush full directory list cache.
+  * ``system.invalidate_directory_list_cache(directory_path)`` : Invalidate directory list cache for specified directory_path.
 
 Invalidate Metastore Cache
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1091,16 +1093,6 @@ There are a couple of ways for invalidating this cache and are listed below -
 * The Hive connector exposes a procedure over JMX (``com.facebook.presto.hive.metastore.InMemoryCachingHiveMetastore#invalidateAll``) to invalidate the metastore cache. You can call this procedure to invalidate the metastore cache by connecting via jconsole or jmxterm. However, this procedure flushes the cache for all the tables in all the schemas.
 
 * The Hive connector exposes ``system.invalidate_metastore_cache`` procedure which enables users to invalidate the metastore cache completely or partially as per the requirement and can be invoked with various arguments. See `Invalidate Metastore Cache`_ for more information.
-
-How to invalidate directory list cache?
----------------------------------------
-
-Invalidating directory list cache is useful when the files are added or deleted in the cache directory path and you want to make the changes visible to Presto immediately.
-There are a couple of ways for invalidating this cache and are listed below -
-
-* The Hive connector exposes a procedure over JMX (``com.facebook.presto.hive.CachingDirectoryLister#flushCache``) to invalidate the directory list cache. You can call this procedure to invalidate the directory list cache by connecting via jconsole or jmxterm. This procedure flushes all the cache entries.
-
-* The Hive connector exposes ``system.invalidate_directory_list_cache`` procedure which gives the flexibility to invalidate the list cache completely or partially as per the requirement and can be invoked in various ways. See `Invalidate Directory List Cache`_ for more information.
 
 Examples
 --------


### PR DESCRIPTION
## Description
Remove the topic **How to invalidate directory list cache?** from the documentation, and consolidate the content from the removed topic into **Invalidate Directory ListCache**

## Motivation and Context
To remove duplicate documentation for invalidate directory list cache in Hive Connector
[Issue Reference Link](https://github.com/prestodb/presto/issues/26101)

## Impact
1) Consolidated contents from **How to invalidate directory list cache?** block to **Invalidate Directory List Cache** block in hive.rst file
2) Consolidated content from 

## Test Plan
Tested locally. Attaching the screenshots
<img width="1353" height="997" alt="image" src="https://github.com/user-attachments/assets/f38a20a4-3ab9-42b9-8d73-a3bf26074e46" />
<img width="1353" height="997" alt="image" src="https://github.com/user-attachments/assets/22d3e5ec-8358-4565-a689-7feef8ce6adc" />



## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
== NO RELEASE NOTE ==
