### PR TITLE
misc: Add lookup cast in standard function resolution

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -148,6 +148,12 @@ public final class FunctionResolution
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getOperatorType().equals(Optional.of(OperatorType.CAST));
     }
 
+    @Override
+    public FunctionHandle lookupCast(String castType, Type fromType, Type toType)
+    {
+        return functionAndTypeResolver.lookupCast(castType, fromType, toType);
+    }
+
     public boolean isTryCastFunction(FunctionHandle functionHandle)
     {
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "TRY_CAST"));

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestFunctionResolution.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/relational/TestFunctionResolution.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.spi.function.FunctionImplementationType.THRIFT;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
@@ -96,6 +97,9 @@ public class TestFunctionResolution
         // full qualified name
         assertEquals(standardFunctionResolution.notFunction(), standardFunctionResolution.lookupFunction("presto", "default", "not", ImmutableList.of(BOOLEAN)));
         assertEquals(standardFunctionResolution.countFunction(), standardFunctionResolution.lookupFunction("presto", "default", "count", ImmutableList.of()));
+
+        // lookup cast
+        assertTrue(standardFunctionResolution.isCastFunction(standardFunctionResolution.lookupCast("CAST", BIGINT, VARCHAR)));
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -60,6 +60,8 @@ public interface StandardFunctionResolution
 
     boolean isCastFunction(FunctionHandle functionHandle);
 
+    FunctionHandle lookupCast(String castType, Type fromType, Type toType);
+
     boolean isCountFunction(FunctionHandle functionHandle);
 
     boolean isCountIfFunction(FunctionHandle functionHandle);


### PR DESCRIPTION
## Description
cast function is special as it needs to specify both input and output types, hence cannot use the existing lookupBuiltInFunction API. Add the lookupCast API in this PR

## Motivation and Context
See description

## Impact
See description

## Test Plan
Unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

