### PR TITLE
docs(native): Update documentation for Hive Connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -1041,7 +1041,7 @@ Invalidate Directory List Cache
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Invalidating directory list cache is useful when the files are added or deleted in the cache directory path and you want to make the changes visible to Presto immediately.
-There are a couple of ways for invalidating this cache and are listed below -
+There are a couple of ways for invalidating this cache:
 
 * The Hive connector exposes a procedure over JMX (``com.facebook.presto.hive.CachingDirectoryLister#flushCache``) to invalidate the directory list cache. You can call this procedure to invalidate the directory list cache by connecting via jconsole or jmxterm. This procedure flushes all the cache entries.
 


### PR DESCRIPTION
## Description
Remove the topic **How to invalidate directory list cache?** from the documentation, and consolidate the content from the removed topic into **Invalidate Directory ListCache**

## Motivation and Context
To remove duplicate documentation for invalidate directory list cache in Hive Connector
[Issue Reference Link](https://github.com/prestodb/presto/issues/26101)

## Impact
1) Consolidated contents from **How to invalidate directory list cache?** block to **Invalidate Directory List Cache** block in hive.rst file
2) Removed  **How to invalidate directory list cache?** block from hive.rst file

## Test Plan
Tested locally. Attaching the screenshots.

<img width="1353" height="1032" alt="image" src="https://github.com/user-attachments/assets/249e41be-8d90-4eb6-990f-63e228431184" />
<img width="1353" height="1032" alt="image" src="https://github.com/user-attachments/assets/962f549c-a24f-442b-a6e6-84f757604e42" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
== NO RELEASE NOTE ==
