### PR TITLE
fix(plugin-pinot): Normalize mixed-case Pinot table/column name handling when case-sensitive flag is disabled

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
@@ -33,6 +33,7 @@ import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNSUPPORTED_COLUMN_TYPE;
@@ -52,15 +53,20 @@ public class PinotColumnUtils
 
     public static List<PinotColumn> getPinotColumnsForPinotSchema(Schema pinotTableSchema, boolean inferDateType, boolean inferTimestampType)
     {
-        return getPinotColumnsForPinotSchema(pinotTableSchema, inferDateType, inferTimestampType, false);
+        return getPinotColumnsForPinotSchema(pinotTableSchema, inferDateType, inferTimestampType, false, false);
     }
 
-    public static List<PinotColumn> getPinotColumnsForPinotSchema(Schema pinotTableSchema, boolean inferDateType, boolean inferTimestampType, boolean nullHandlingEnabled)
+    public static List<PinotColumn> getPinotColumnsForPinotSchema(
+            Schema pinotTableSchema,
+            boolean inferDateType,
+            boolean inferTimestampType,
+            boolean nullHandlingEnabled,
+            boolean isCaseSensitiveNameMatchingEnabled)
     {
         return pinotTableSchema.getColumnNames().stream()
                 .filter(columnName -> !columnName.startsWith("$")) // Hidden columns starts with "$", ignore them as we can't use them in SQL
                 .map(columnName -> new PinotColumn(
-                        columnName,
+                        isCaseSensitiveNameMatchingEnabled ? columnName : columnName.toLowerCase(Locale.ROOT),
                         getPrestoTypeFromPinotType(pinotTableSchema.getFieldSpecFor(columnName), inferDateType, inferTimestampType),
                         isNullableColumnFromPinotType(pinotTableSchema.getFieldSpecFor(columnName), nullHandlingEnabled),
                         getCommentFromPinotType(pinotTableSchema.getFieldSpecFor(columnName))))

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnection.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConnection.java
@@ -64,7 +64,10 @@ public class PinotConnection
                                     throws Exception
                             {
                                 Schema tablePinotSchema = pinotClusterInfoFetcher.getTableSchema(tableName);
-                                return PinotColumnUtils.getPinotColumnsForPinotSchema(tablePinotSchema, pinotConfig.isInferDateTypeInSchema(), pinotConfig.isInferTimestampTypeInSchema(), nullHandlingEnabled);
+                                return PinotColumnUtils.getPinotColumnsForPinotSchema(tablePinotSchema, pinotConfig.isInferDateTypeInSchema(),
+                                        pinotConfig.isInferTimestampTypeInSchema(),
+                                        nullHandlingEnabled,
+                                        pinotConfig.isCaseSensitiveNameMatchingEnabled());
                             }
                         }, executor));
 


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

This bug fix normalizes identifiers for tables and columns when the case-sensitive flag is **disabled**. As a result, mixed case table/column names no longer cause query failures when using the Pinot connector in Presto.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
to fix failing queries when the flag is disabled 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->


## Test Plan
<!---Please fill in how you tested your change-->

Tested using a Pinot connector instance from IBM QA. Also tested with the flag enabled to ensure behavior remains unchanged.

Flag disabled;

<img width="1023" height="76" alt="Screenshot 2025-11-20 at 2 06 20 PM" src="https://github.com/user-attachments/assets/ce244686-ffd4-4c98-ba6c-d0cfa79dc5d3" />
<img width="1023" height="106" alt="Screenshot 2025-11-20 at 2 07 08 PM" src="https://github.com/user-attachments/assets/9f4ff94d-0bb8-4b2f-b60a-46274ac1d678" />

Flag enabled; 
<img width="1023" height="163" alt="Screenshot 2025-11-20 at 2 19 45 PM" src="https://github.com/user-attachments/assets/1ff4372e-ce1f-4898-869a-b2c8253f738e" />

<img width="1023" height="403" alt="Screenshot 2025-11-20 at 2 19 19 PM" src="https://github.com/user-attachments/assets/abf3f87b-f37d-4e49-9a61-36aac30fbd8c" />


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Fix table and column normalization when the case-sensitive flag is disabled to prevent query failures when using Pinot connector.