### PR TITLE
feat(Prestissimo): Make Broadcast writes directories configurable

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -184,6 +184,7 @@ SystemConfig::SystemConfig() {
           STR_PROP(kSpillerFileCreateConfig, ""),
           STR_PROP(kSpillerDirectoryCreateConfig, ""),
           NONE_PROP(kSpillerSpillPath),
+          STR_PROP(kBroadcasterDirectoryCreateConfig, ""),
           NUM_PROP(kShutdownOnsetSec, 10),
           NUM_PROP(kSystemMemoryGb, 57),
           BOOL_PROP(kSystemMemPushbackEnabled, false),
@@ -567,6 +568,11 @@ std::string SystemConfig::spillerFileCreateConfig() const {
 
 std::string SystemConfig::spillerDirectoryCreateConfig() const {
   return optionalProperty<std::string>(kSpillerDirectoryCreateConfig).value();
+}
+
+std::string SystemConfig::broadcasterDirectoryCreateConfig() const {
+  return optionalProperty<std::string>(kBroadcasterDirectoryCreateConfig)
+      .value();
 }
 
 folly::Optional<std::string> SystemConfig::spillerSpillPath() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -328,6 +328,13 @@ class SystemConfig : public ConfigBase {
 
   static constexpr std::string_view kSpillerSpillPath{
       "experimental.spiller-spill-path"};
+
+  /// Config used to create broadcast directories. This config is provided to
+  /// underlying file system and the config is free form. The form should be
+  /// defined by the underlying file system.
+  static constexpr std::string_view kBroadcasterDirectoryCreateConfig{
+      "broadcaster.directory-create-config"};
+
   static constexpr std::string_view kShutdownOnsetSec{"shutdown-onset-sec"};
 
   /// Memory allocation limit enforced via internal memory allocator.
@@ -974,6 +981,8 @@ class SystemConfig : public ConfigBase {
   std::string spillerFileCreateConfig() const;
 
   std::string spillerDirectoryCreateConfig() const;
+
+  std::string broadcasterDirectoryCreateConfig() const;
 
   folly::Optional<std::string> spillerSpillPath() const;
 


### PR DESCRIPTION
Summary:
Adds support for configuring the directory used for Storage-based Broadcasts in Velox.

The "config" is a transparent string, which is expected to be interpreted by the Filesystem.

Differential Revision: D87552571
