### PR TITLE
misc(native): Remove the force restriction on function name prefix

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -141,9 +141,6 @@ const std::vector<std::string> getFunctionNameParts(
     const std::string& registeredFunction) {
   std::vector<std::string> parts;
   folly::split('.', registeredFunction, parts, true);
-  VELOX_USER_CHECK(
-      parts.size() == 3,
-      fmt::format("Prefix missing for function {}", registeredFunction));
   return parts;
 }
 } // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/CommonTest.cpp
@@ -247,14 +247,6 @@ TEST(UtilsTest, getFunctionNameParts) {
     EXPECT_EQ(parts[1], "catalog");
     EXPECT_EQ(parts[2], "sum");
   }
-
-  EXPECT_THROW(util::getFunctionNameParts("catalog.function"), VeloxException);
-  EXPECT_THROW(util::getFunctionNameParts("function"), VeloxException);
-  EXPECT_THROW(
-      util::getFunctionNameParts("prefix.catalog.schema.function"),
-      VeloxException);
-  EXPECT_THROW(util::getFunctionNameParts(""), VeloxException);
-  EXPECT_THROW(util::getFunctionNameParts(".."), VeloxException);
 }
 
 int main(int argc, char** argv) {

--- a/presto-native-execution/presto_cpp/main/functions/FunctionMetadata.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/FunctionMetadata.cpp
@@ -256,9 +256,13 @@ json buildWindowMetadata(
 json getFunctionsMetadata(const std::optional<std::string>& catalog) {
   json j;
 
-  // Lambda to check if a function should be skipped based on catalog filter
-  auto skipCatalog = [&catalog](const std::string& functionCatalog) {
-    return catalog.has_value() && functionCatalog != catalog.value();
+  // Lambda to check if a function should be skipped based on function prefix
+  // and catalog filter.
+  auto skipFunction = [&catalog](const std::vector<std::string>& parts) {
+    if (parts.size() < 3) {
+      return true;
+    }
+    return catalog.has_value() && parts[0] != catalog.value();
   };
 
   // Get metadata for all registered scalar functions in velox.
@@ -278,7 +282,7 @@ json getFunctionsMetadata(const std::optional<std::string>& catalog) {
     }
 
     const auto parts = util::getFunctionNameParts(name);
-    if (skipCatalog(parts[0])) {
+    if (skipFunction(parts)) {
       continue;
     }
     const auto schema = parts[1];
@@ -291,7 +295,7 @@ json getFunctionsMetadata(const std::optional<std::string>& catalog) {
     if (!aggregateFunctions.at(entry.first).metadata.companionFunction) {
       const auto name = entry.first;
       const auto parts = util::getFunctionNameParts(name);
-      if (skipCatalog(parts[0])) {
+      if (skipFunction(parts)) {
         continue;
       }
       const auto schema = parts[1];
@@ -308,7 +312,7 @@ json getFunctionsMetadata(const std::optional<std::string>& catalog) {
     if (aggregateFunctions.count(entry.first) == 0) {
       const auto name = entry.first;
       const auto parts = util::getFunctionNameParts(entry.first);
-      if (skipCatalog(parts[0])) {
+      if (skipFunction(parts)) {
         continue;
       }
       const auto schema = parts[1];


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

There is a force restriction on Velox function name such as `catalog.schema.function_name`. If the function name does consist of three parts it leads to failure check immediately.
This can causes worker node to crash etc.  See discussion from https://github.com/prestodb/presto/pull/26584.
But we should not impose this rules from Prestissimo to Velox functions. Velox might register some functions that does not follow the Prestissimo rules. From Prestissimo point of view, it can just ignore those functions that do not have 3 part name.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

