### PR TITLE
perf(function): Add map_int_keys_to_array and array_to_map_int_keys functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/map.rst
+++ b/presto-docs/src/main/sphinx/functions/map.rst
@@ -214,3 +214,14 @@ Map Functions
         SELECT transform_values(MAP(ARRAY ['a', 'b'], ARRAY [1, 2]), (k, v) -> k || CAST(v as VARCHAR)); -- {a -> a1, b -> b2}
         SELECT transform_values(MAP(ARRAY [1, 2], ARRAY [1.0, 1.4]), -- {1 -> one_1.0, 2 -> two_1.4}
                                 (k, v) -> MAP(ARRAY[1, 2], ARRAY['one', 'two'])[k] || '_' || CAST(v AS VARCHAR));
+
+.. function:: map_int_keys_to_array(map(int,V)) -> array(V)
+        Returns an ``array`` of values from the ``map`` with value at indexed by the original keys from ``map``::
+            SELECT MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[3, 5, 6, 9], ARRAY['a', 'b', 'c', 'd'])) -> ARRAY[null, null, 'a', null, 'b', 'c', null, null, 'd']
+            SELECT MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[3, 5, 6, 9], ARRAY['a', null, 'c', 'd'])) -> ARRAY[null, null, 'a', null, null, 'c', 'd']
+
+.. function:: array_to_map_int_keys(array(v)) -> map(int, v)
+        Returns an ``map`` with indices of all non-null values from the ``array`` as keys and element at the specified index as the value::
+            SELECT ARRAY_TO_MAP_INT_KEYS(CAST(ARRAY[3, 5, 6, 9] AS ARRAY<INT>)) -> MAP(ARRAY[1, 2, 3,4], ARRAY[3, 5, 6, 9])
+            SELECT ARRAY_TO_MAP_INT_KEYS(CAST(ARRAY[3, 5, null, 6, 9] AS ARRAY<INT>)) -> MAP(ARRAY[1, 2, 4, 5], ARRAY[3, 5, 6, 9])
+            SELECT ARRAY_TO_MAP_INT_KEYS(CAST(ARRAY[3, 5, null, 6, 9, null, null, 1] AS ARRAY<INT>)) -> MAP(ARRAY[1, 2, 4, 5, 8], ARRAY[3, 5, 6, 9, 1])

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapSqlFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestMapSqlFunctions.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.spi.StandardErrorCode;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.util.StructuralTestUtil.mapType;
+import static java.util.Arrays.asList;
+
+public class TestMapSqlFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testMapIntKeysToArray()
+    {
+        assertFunction("MAP_INT_KEYS_TO_ARRAY(CAST(MAP() AS MAP<INT, INT>))",
+                new ArrayType(INTEGER),
+                null);
+
+        assertFunction("MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[1, 3], ARRAY['a', 'b']))",
+                new ArrayType(createVarcharType(1)),
+                asList("a", null, "b"));
+
+        assertFunction("MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[3, 5, 6, 9], ARRAY['a', 'b', 'c', 'd']))",
+                new ArrayType(createVarcharType(1)),
+                asList(null, null, "a", null, "b", "c", null, null, "d"));
+
+        assertFunction("MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[3, 5, 6, 9], ARRAY['a', null, 'c', 'd']))",
+                new ArrayType(createVarcharType(1)),
+                asList(null, null, "a", null, null, "c", null, null, "d"));
+
+        assertFunction("MAP_INT_KEYS_TO_ARRAY(CAST(MAP() AS MAP<INT, INT>))",
+                new ArrayType(INTEGER),
+                null);
+
+        assertFunction("MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[2], ARRAY[MAP(ARRAY[3, 5, 6, 9], ARRAY['a', null, 'c', 'd'])]))",
+                new ArrayType(mapType(INTEGER, createVarcharType(1))),
+                asList(null, asMap(asList(3, 5, 6, 9), asList("a", null, "c", "d"))));
+
+        assertFunction("MAP_INT_KEYS_TO_ARRAY(CAST(MAP() AS MAP<INT, INT>))",
+                new ArrayType(INTEGER),
+                null);
+
+        assertInvalidFunction(
+                "MAP_INT_KEYS_TO_ARRAY(MAP(CAST(SEQUENCE(1,10000)||ARRAY[10001] AS ARRAY<INT>),SEQUENCE(1,10000)||ARRAY[10001]))",
+                StandardErrorCode.GENERIC_USER_ERROR,
+                "Max key value must be <= 10k for map_int_keys_to_array function");
+
+        assertInvalidFunction(
+                "MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[0],ARRAY[1]))",
+                StandardErrorCode.GENERIC_USER_ERROR,
+                "Only positive keys allowed in map_int_keys_to_array function, but got: 0");
+
+        assertInvalidFunction(
+                "MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[-1, 2], ARRAY['a', 'b']))",
+                StandardErrorCode.GENERIC_USER_ERROR,
+                "Only positive keys allowed in map_int_keys_to_array function, but got: -1");
+
+        assertInvalidFunction("MAP_INT_KEYS_TO_ARRAY(MAP(ARRAY[0, 2], ARRAY['a', 'b']))",
+                StandardErrorCode.GENERIC_USER_ERROR,
+                "Only positive keys allowed in map_int_keys_to_array function, but got: 0");
+    }
+
+    @Test
+    public void testArrayToMapIntKeys()
+    {
+        assertFunction("ARRAY_TO_MAP_INT_KEYS(CAST(ARRAY[3, 5, 6, 9] AS ARRAY<INT>))",
+                mapType(INTEGER, INTEGER),
+                ImmutableMap.of(1, 3, 2, 5, 3, 6, 4, 9));
+
+        assertFunction("ARRAY_TO_MAP_INT_KEYS(CAST(ARRAY[3, 5, null, 6, 9] AS ARRAY<INT>))",
+                mapType(INTEGER, INTEGER),
+                asMap(asList(1, 2, 4, 5), asList(3, 5, 6, 9)));
+
+        assertFunction("ARRAY_TO_MAP_INT_KEYS(CAST(ARRAY[3, 5, null, 6, 9, null, null, 1] AS ARRAY<INT>))",
+                mapType(INTEGER, INTEGER),
+                asMap(asList(1, 2, 4, 5, 8), asList(3, 5, 6, 9, 1)));
+
+        assertFunction("ARRAY_TO_MAP_INT_KEYS(CAST(NULL AS ARRAY<INT>))",
+                mapType(INTEGER, INTEGER),
+                null);
+
+        assertInvalidFunction(
+                "ARRAY_TO_MAP_INT_KEYS(SEQUENCE(1,10000)||ARRAY[10001])",
+                StandardErrorCode.GENERIC_USER_ERROR,
+                "Max number of elements must be <= 10k for array_to_map_int_keys function");
+    }
+}


### PR DESCRIPTION
## Description
We have use-cases where small maps with small ints as indices computed once and accessed trillions of times. In those case, we observed building arrays with nulls for missing keys makes the access very efficient - sometimes 30% latency/efficiency savings. So Added this function and it's converse that builds maps from arrays.

## Motivation and Context
Reduces map access overhead for fixed maps. Usually this is just done once so adding it as a inline SQL udf for now. If there is a need, we can add it as a builtin.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
*  Added map_int_keys_to_array
*  Added array_to_map_int_keys function

```

