### PR TITLE
feat(server): Add ability to disable the UI

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -43,6 +43,7 @@ public class ServerConfig
     private boolean nestedDataSerializationEnabled = true;
     private Duration clusterResourceGroupStateInfoExpirationDuration = new Duration(0, MILLISECONDS);
     private String clusterTag;
+    private boolean webUIEnabled = true;
 
     public boolean isResourceManager()
     {
@@ -113,6 +114,18 @@ public class ServerConfig
     public ServerConfig setCoordinator(boolean coordinator)
     {
         this.coordinator = coordinator;
+        return this;
+    }
+
+    public boolean isWebUIEnabled()
+    {
+        return webUIEnabled;
+    }
+
+    @Config("webui-enabled")
+    public ServerConfig setWebUIEnabled(boolean webUIEnabled)
+    {
+        this.webUIEnabled = webUIEnabled;
         return this;
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -35,6 +35,7 @@ public class TestServerConfig
     {
         assertRecordedDefaults(ConfigAssertions.recordDefaults(ServerConfig.class)
                 .setCoordinator(true)
+                .setWebUIEnabled(true)
                 .setPrestoVersion(null)
                 .setDataSources(null)
                 .setIncludeExceptionInResponse(true)
@@ -58,6 +59,7 @@ public class TestServerConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("coordinator", "false")
+                .put("webui-enabled", "false")
                 .put("presto.version", "test")
                 .put("datasources", "jmx")
                 .put("http.include-exception-in-response", "false")
@@ -78,6 +80,7 @@ public class TestServerConfig
 
         ServerConfig expected = new ServerConfig()
                 .setCoordinator(false)
+                .setWebUIEnabled(false)
                 .setPrestoVersion("test")
                 .setDataSources("jmx")
                 .setIncludeExceptionInResponse(false)

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -148,6 +148,13 @@ public class CoordinatorModule
             "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
                     "font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'; img-src 'self' data:; form-action 'self'";
 
+    private final boolean isWebUIEnabled;
+
+    public CoordinatorModule(boolean webUIEnabled)
+    {
+        this.isWebUIEnabled = webUIEnabled;
+    }
+
     public static HttpResourceBinding webUIBinder(Binder binder, String path, String classPathResourceBase)
     {
         return httpServerBinder(binder).bindResource(path, classPathResourceBase)
@@ -158,9 +165,14 @@ public class CoordinatorModule
     @Override
     protected void setup(Binder binder)
     {
-        webUIBinder(binder, "/ui/dev", "webapp/dev").withWelcomeFile("index.html");
-        webUIBinder(binder, "/ui", "webapp").withWelcomeFile("index.html");
-        webUIBinder(binder, "/tableau", "webapp/tableau");
+        if (isWebUIEnabled) {
+            webUIBinder(binder, "/ui/dev", "webapp/dev").withWelcomeFile("index.html");
+            webUIBinder(binder, "/ui", "webapp").withWelcomeFile("index.html");
+            webUIBinder(binder, "/tableau", "webapp/tableau");
+        }
+        else {
+            webUIBinder(binder, "/ui", "nowebapp").withWelcomeFile("index.html");
+        }
 
         // discovery server
         install(installModuleIf(EmbeddedDiscoveryConfig.class, EmbeddedDiscoveryConfig::isEnabled, new EmbeddedDiscoveryModule()));

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -336,7 +336,7 @@ public class ServerMainModule
             install(new CatalogServerModule());
         }
         else if (serverConfig.isCoordinator()) {
-            install(new CoordinatorModule());
+            install(new CoordinatorModule(serverConfig.isWebUIEnabled()));
         }
         else {
             install(new WorkerModule());

--- a/presto-main/src/main/resources/nowebapp/index.html
+++ b/presto-main/src/main/resources/nowebapp/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Presto UI Disabled</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+            background: #f7f7f9;
+            color: #222;
+        }
+
+        main {
+            text-align: center;
+            padding: 24px;
+        }
+
+        h1 {
+            font-size: 1.5rem;
+            margin: 0;
+        }
+    </style>
+</head>
+<body>
+<main>
+    <h1>The Presto UI has been disabled for this environment</h1>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Description
For controlled environments, users may want to disable the UI
The UI is enabled by default

## Impact
No impact

## Test Plan
- CI
- Manually test the UI page with the web-ui disabled
<img width="962" height="648" alt="image" src="https://github.com/user-attachments/assets/c6b82459-f577-4be6-b6b5-616b977a8a27" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add ability to disable the UI
```
