### PR TITLE
fix(analyzer): MV stitching issue

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2491,10 +2491,9 @@ public class HiveMetadata
 
         for (MaterializedDataPredicates dataPredicates : partitionsFromBaseTables.values()) {
             if (!dataPredicates.getPredicateDisjuncts().isEmpty()) {
-                missingPartitions += dataPredicates.getPredicateDisjuncts().stream()
+                missingPartitions += (int) dataPredicates.getPredicateDisjuncts().stream()
                         .filter(baseQueryDomain::overlaps)
-                        .mapToInt(tupleDomain -> tupleDomain.getDomains().isPresent() ? tupleDomain.getDomains().get().size() : 0)
-                        .sum();
+                        .count();
             }
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2592,7 +2592,14 @@ class StatementAnalyzer
                     Map<String, Domain> rewrittenDomain = new HashMap<>();
 
                     for (Map.Entry<String, Domain> entry : viewQueryDomain.getDomains().orElse(ImmutableMap.of()).entrySet()) {
-                        Map<SchemaTableName, String> baseTableMapping = directColumnMappings.get(entry.getKey());
+                        Map<SchemaTableName, String> baseTableMapping = null;
+                        for (String columnName : directColumnMappings.keySet()) {
+                            if (columnName.equalsIgnoreCase(entry.getKey())) {
+                                baseTableMapping = directColumnMappings.get(columnName);
+                                break;
+                            }
+                        }
+
                         if (baseTableMapping == null || baseTableMapping.size() != 1) {
                             mappedToOneTable = false;
                             break;


### PR DESCRIPTION
Summary:
Two issues related to stitching:
1) the number of missingPartitions is mis calculated: it double counts when there are more partition columns
2) when calculating baseQueryDomain, it didn't consider letter case, thus it ignores columns if the column name in query had different case than the mv definition

Differential Revision: D87676370

```
== NO RELEASE NOTE ==
```

