### PR TITLE
[velox] refactor: Rename velox casting utilities to camelCase convention

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalShuffle.cpp
@@ -463,7 +463,7 @@ std::vector<std::unique_ptr<ReadBatch>> LocalShuffleReader::nextSorted(
   uint64_t bufferUsed = 0;
 
   while (auto* stream = merge_->next()) {
-    auto* reader = velox::checked_pointer_cast<SortedFileInputStream>(stream);
+    auto* reader = velox::checkedPointerCast<SortedFileInputStream>(stream);
     const auto data = reader->currentValue();
 
     if (bufferUsed + data.size() > maxBytes) {

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -83,7 +83,7 @@ RowVectorPtr ShuffleRead::getOutput() {
     }
     rows_.reserve(numRows);
     for (const auto& page : currentPages_) {
-      auto* batch = checked_pointer_cast<ShuffleRowBatch>(page.get());
+      auto* batch = checkedPointerCast<ShuffleRowBatch>(page.get());
       const auto& rows = batch->rows();
       for (const auto& row : rows) {
         rows_.emplace_back(row);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/15614

X-link: https://github.com/facebookincubator/nimble/pull/333

Renamed three function templates in velox's casting utilities to follow the camelCase naming convention:
- `checked_pointer_cast` → `checkedPointerCast`
- `static_unique_pointer_cast` → `staticUniquePointerCast`
- `is_instance_of` → `isInstanceOf`

This change affects the function definitions in `/data/users/ericjjj/fbsource/fbcode/velox/common/Casts.h` and all call sites within the velox codebase and related projects that use velox namespaced functions.

Files updated:
- Function definitions in `velox/common/Casts.h`
- Velox core files: `core/PlanNode.cpp`, `exec/Exchange.cpp`, `exec/Task.cpp`, `common/memory/MemoryPool.cpp`, `tool/trace/TopNRowNumberReplayer.cpp`
- Test file: `velox/common/testutil/tests/CastsTest.cpp` - updated all test cases
- DataInfra/Sequence files that use `facebook::velox::` namespace prefix (8 files)

This refactoring improves consistency with velox's naming conventions while maintaining backward compatibility with external codebases that use their own implementations.

Differential Revision: D87806227


