### PR TITLE
misc: Make eventloop the default implementation for httpRemoteTask

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -99,7 +99,7 @@ public class TaskManagerConfig
     private double highMemoryTaskKillerGCReclaimMemoryThreshold = 0.01;
     private Duration highMemoryTaskKillerFrequentFullGCDurationThreshold = new Duration(1, SECONDS);
     private double highMemoryTaskKillerHeapMemoryThreshold = 0.9;
-    private boolean enableEventLoop;
+    private boolean enableEventLoop = true;
     private Duration slowMethodThresholdOnEventLoop = new Duration(0, SECONDS);
 
     public long getSlowMethodThresholdOnEventLoop()

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -81,7 +81,7 @@ public class TestTaskManagerConfig
                 .setHighMemoryTaskKillerHeapMemoryThreshold(0.9)
                 .setTaskUpdateSizeTrackingEnabled(true)
                 .setSlowMethodThresholdOnEventLoop(new Duration(0, SECONDS))
-                .setEventLoopEnabled(false));
+                .setEventLoopEnabled(true));
     }
 
     @Test
@@ -130,7 +130,7 @@ public class TestTaskManagerConfig
                 .put("experimental.task.high-memory-task-killer-frequent-full-gc-duration-threshold", "2s")
                 .put("experimental.task.high-memory-task-killer-heap-memory-threshold", "0.8")
                 .put("task.update-size-tracking-enabled", "false")
-                .put("task.enable-event-loop", "true")
+                .put("task.enable-event-loop", "false")
                 .put("task.event-loop-slow-method-threshold", "10m")
                 .build();
 
@@ -177,7 +177,7 @@ public class TestTaskManagerConfig
                 .setHighMemoryTaskKillerFrequentFullGCDurationThreshold(new Duration(2, SECONDS))
                 .setHighMemoryTaskKillerHeapMemoryThreshold(0.8)
                 .setTaskUpdateSizeTrackingEnabled(false)
-                .setEventLoopEnabled(true)
+                .setEventLoopEnabled(false)
                 .setSlowMethodThresholdOnEventLoop(new Duration(10, MINUTES));
 
         assertFullMapping(properties, expected);

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -155,7 +155,8 @@ public class TestHttpRemoteTask
     private static final TaskManagerConfig TASK_MANAGER_CONFIG = new TaskManagerConfig()
             // Shorten status refresh wait and info update interval so that we can have a shorter test timeout
             .setStatusRefreshMaxWait(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 100, MILLISECONDS))
-            .setInfoUpdateInterval(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 10, MILLISECONDS));
+            .setInfoUpdateInterval(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 10, MILLISECONDS))
+            .setEventLoopEnabled(false);
 
     private static final boolean TRACE_HTTP = false;
 


### PR DESCRIPTION
## Description
1. event loop based http remote task, task status fetcher and task info fetcher has been reliably running in production for many months now. This pr makes event loop as the default implementation for those three classes and remove the old code.
2. I also tried to replay production queries with only 5 threads for the event loop attempting to catch any potential issues but no issue has been found.
3. heapdump analysis also showed that the failTask call is heavy containing a recursive toFailure call. This is something we can optimize.

## Motivation and Context
eventloop is faster

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
passed verifier

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

