### PR TITLE
Draft

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -340,6 +340,7 @@ public final class SystemSessionProperties
     public static final String WARN_ON_COMMON_NAN_PATTERNS = "warn_on_common_nan_patterns";
     public static final String INLINE_PROJECTIONS_ON_VALUES = "inline_projections_on_values";
     public static final String INCLUDE_VALUES_NODE_IN_CONNECTOR_OPTIMIZER = "include_values_node_in_connector_optimizer";
+    public static final String ENABLE_EMPTY_CONNECTOR_OPTIMIZER = "enable_empty_connector_optimizer";
     public static final String SINGLE_NODE_EXECUTION_ENABLED = "single_node_execution_enabled";
     public static final String BROADCAST_SEMI_JOIN_FOR_DELETE = "broadcast_semi_join_for_delete";
     public static final String EXPRESSION_OPTIMIZER_NAME = "expression_optimizer_name";
@@ -1961,6 +1962,10 @@ public final class SystemSessionProperties
                         "Include values node for connector optimizer",
                         featuresConfig.isIncludeValuesNodeInConnectorOptimizer(),
                         false),
+                booleanProperty(ENABLE_EMPTY_CONNECTOR_OPTIMIZER,
+                    "Run optimizers which optimize queries with values node",
+                    false,
+                    false),
                 booleanProperty(
                         INNER_JOIN_PUSHDOWN_ENABLED,
                         "Enable Join Predicate Pushdown",
@@ -3381,6 +3386,11 @@ public final class SystemSessionProperties
     public static boolean isIncludeValuesNodeInConnectorOptimizer(Session session)
     {
         return session.getSystemProperty(INCLUDE_VALUES_NODE_IN_CONNECTOR_OPTIMIZER, Boolean.class);
+    }
+
+    public static boolean isEmptyConnectorOptimizerEnabled(Session session)
+    {
+        return session.getSystemProperty(ENABLE_EMPTY_CONNECTOR_OPTIMIZER, Boolean.class);
     }
 
     public static Boolean isInnerJoinPushdownEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -63,6 +63,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isEmptyConnectorOptimizerEnabled;
 import static com.facebook.presto.SystemSessionProperties.isIncludeValuesNodeInConnectorOptimizer;
 import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static com.facebook.presto.sql.OptimizerRuntimeTrackUtil.getOptimizerNameForLog;
@@ -103,7 +104,7 @@ public class ApplyConnectorOptimization
             DeleteNode.class);
 
     // for a leaf node that does not belong to any connector (e.g., ValuesNode)
-    private static final ConnectorId EMPTY_CONNECTOR_ID = new ConnectorId("$internal$" + ApplyConnectorOptimization.class + "_CONNECTOR");
+    private static final ConnectorId EMPTY_CONNECTOR_ID = new ConnectorId("$internal$ApplyConnectorOptimization_EMPTY_CONNECTOR");
 
     private final Supplier<Map<ConnectorId, Set<ConnectorPlanOptimizer>>> connectorOptimizersSupplier;
 
@@ -130,6 +131,7 @@ public class ApplyConnectorOptimization
         // retrieve all the connectors
         ImmutableSet.Builder<ConnectorId> connectorIds = ImmutableSet.builder();
         getAllConnectorIds(plan, connectorIds);
+        Set<ConnectorId> connectorIdSet = connectorIds.build();
 
         // for each connector, retrieve the set of subplans to optimize
         // TODO: what if a new connector is added by an existing one
@@ -137,8 +139,20 @@ public class ApplyConnectorOptimization
         // create a UNION_ALL to federate data sources from both C1 and C2 (regardless of the classloader issue).
         // For such case, it is dangerous to re-calculate the "max closure" given the fixpoint property will be broken.
         // In order to preserve the fixpoint, we will "pretend" the newly added C2 table scan is part of C1's job to maintain.
-        for (ConnectorId connectorId : connectorIds.build()) {
-            Set<ConnectorPlanOptimizer> optimizers = connectorOptimizers.get(connectorId);
+        for (ConnectorId connectorId : connectorIdSet) {
+            Set<ConnectorPlanOptimizer> optimizers;
+            if (isEmptyConnectorOptimizerEnabled(session) && connectorIdSet.stream()
+                .allMatch(x -> x.equals(EMPTY_CONNECTOR_ID)) && session.getCatalog().isPresent()) {
+                ConnectorId queryConnectorId = new ConnectorId(session.getCatalog().get());
+                optimizers = connectorOptimizers.get(queryConnectorId) == null ? null
+                    : connectorOptimizers.get(queryConnectorId).stream()
+                        .filter(x -> x.getSupportedConnectorIds().size() == 1
+                            && x.getSupportedConnectorIds().get(0).equals(EMPTY_CONNECTOR_ID))
+                        .collect(
+                            toImmutableSet());
+            } else {
+                optimizers = connectorOptimizers.get(connectorId);
+            }
             if (optimizers == null || optimizers.isEmpty()) {
                 continue;
             }
@@ -188,6 +202,9 @@ public class ApplyConnectorOptimization
                     for (ConnectorPlanOptimizer optimizer : entry.getValue()) {
                         long start = System.nanoTime();
                         ConnectorSession connectorSession = session.toConnectorSession(connectorId);
+                        if (isEmptyConnectorOptimizerEnabled(session) && connectorId.equals(EMPTY_CONNECTOR_ID) && session.getCatalog().isPresent()) {
+                            connectorSession = session.toConnectorSession(new ConnectorId(session.getCatalog().get()));
+                        }
                         checkState(connectorSession.getConnectorId().isPresent());
                         newNode = optimizer.optimize(newNode, connectorSession, variableAllocator, idAllocator);
                         if (enableVerboseRuntimeStats || trackOptimizerRuntime(session, optimizer)) {
@@ -337,6 +354,9 @@ public class ApplyConnectorOptimization
 
         boolean isClosure(ConnectorId connectorId, Session session, List<ConnectorId> supportedConnectorId)
         {
+            if (isEmptyConnectorOptimizerEnabled(session) && reachableConnectors.stream().allMatch(x -> x.equals(EMPTY_CONNECTOR_ID)) && supportedConnectorId.size() == 1 && supportedConnectorId.get(0).equals(EMPTY_CONNECTOR_ID)) {
+                return containsAll(CONNECTOR_ACCESSIBLE_PLAN_NODES, reachablePlanNodeTypes);
+            }
             // check if all children can reach the only connector
             boolean includeValuesNode = isIncludeValuesNodeInConnectorOptimizer(session);
             Set<ConnectorId> connectorIds = includeValuesNode ? reachableConnectors.stream().filter(x -> !x.equals(EMPTY_CONNECTOR_ID)).collect(toImmutableSet()) : reachableConnectors;


### PR DESCRIPTION
We have an internal connector optimizer, which we want to apply to queries which have values node only. Add a session property to control it.

## Description
We have an internal connector optimizer, which we want to apply to queries which have values node only. Add a session property to control it.

## Motivation and Context
as in description

## Impact
as in description

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```



