### PR TITLE
fix(ci): Presto-function-server jar file is missing when building presto image

### DIFF
--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -255,6 +255,7 @@ jobs:
             presto-cli/target/presto-cli-*-executable.jar
             presto-benchmark-driver/target/presto-benchmark-driver-*-executable.jar
             presto-testing-server-launcher/target/presto-testing-server-launcher-*-executable.jar
+            presto-function-server/target/presto-function-server-*-executable.jar
 
   publish-github-release:
     needs: publish-maven-artifacts
@@ -290,6 +291,7 @@ jobs:
             ./presto-cli/target/presto-cli-*-executable.jar
             ./presto-benchmark-driver/target/presto-benchmark-driver-*-executable.jar
             ./presto-testing-server-launcher/target/presto-testing-server-launcher-*-executable.jar
+            ./presto-function-server/target/presto-function-server-*-executable.jar
 
   publish-docker-image:
     needs: publish-maven-artifacts
@@ -334,6 +336,7 @@ jobs:
         run: |
           mv ./presto-server/target/presto-server-*.tar.gz docker/
           mv ./presto-cli/target/presto-cli-*-executable.jar docker/
+          mv ./presto-function-server/target/presto-function-server-*-executable.jar docker/
 
       - name: Build docker image and publish
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/presto-function-server/pom.xml
+++ b/presto-function-server/pom.xml
@@ -212,6 +212,22 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.skife.maven</groupId>
+                        <artifactId>really-executable-jar-maven-plugin</artifactId>
+                        <configuration>
+                            <flags>-Xms128m</flags>
+                            <classifier>executable</classifier>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>really-executable-jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
## Description
There are 2 isssues, we have to merge this PR before cutting the 0.296 release.

1. When build presto java image, the presto-function-server-<version>-executable.jar is missing
2. The file presto-function-server-<version>-executable.jar is not in execuable format

## Motivation and Context
Copy or move the jar file to docker directory

## Impact
Release 

## Test Plan
https://github.com/unix280/presto/actions/runs/19716560849/job/56490069603

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

