### PR TITLE
fix: Info and infoUnion should always be synced

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorInfoUnion.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorInfoUnion.java
@@ -257,7 +257,7 @@ public class OperatorInfoUnion
             return infoUnion.getTableWriterMergeInfo();
         }
         else {
-            throw new IllegalArgumentException("OperatorInfoUnion is of an unknown type: " + infoUnion.getClass().getName());
+            return null;
         }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -243,7 +243,7 @@ public class OperatorStats
         this.blockedReason = blockedReason;
 
         this.info = info;
-        this.infoUnion = null;
+        this.infoUnion = (info != null) ? OperatorInfoUnion.convertToOperatorInfoUnion(info) : null;
         this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
         this.joinBuildKeyCount = joinBuildKeyCount;
         this.nullJoinProbeKeyCount = nullJoinProbeKeyCount;
@@ -390,7 +390,7 @@ public class OperatorStats
         this.blockedReason = blockedReason;
 
         this.infoUnion = infoUnion;
-        this.info = null;
+        this.info = (infoUnion != null) ? OperatorInfoUnion.convertToOperatorInfo(infoUnion) : null;
         this.nullJoinBuildKeyCount = nullJoinBuildKeyCount;
         this.joinBuildKeyCount = joinBuildKeyCount;
         this.nullJoinProbeKeyCount = nullJoinProbeKeyCount;
@@ -668,6 +668,9 @@ public class OperatorStats
     @JsonProperty
     public OperatorInfo getInfo()
     {
+        if (info == null && infoUnion != null) {
+            return OperatorInfoUnion.convertToOperatorInfo(infoUnion);
+        }
         return info;
     }
 
@@ -675,6 +678,9 @@ public class OperatorStats
     @ThriftField(39)
     public OperatorInfoUnion getInfoUnion()
     {
+        if (infoUnion == null && info != null) {
+            return OperatorInfoUnion.convertToOperatorInfoUnion(info);
+        }
         return infoUnion;
     }
 


### PR DESCRIPTION
## Description
1. we saw a case when thrift is enabled, deserializer will only populate infounion but not info. And when the operatestats needs to be serialized to json for event logging, info will be empty while infounion, even though not empty, is not part of json serde.  So we should keep info and infounion always synced in case different serde is being used in the system.
2. S594718

## Motivation and Context
1. we need info and infounion to be synced

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
passed verifier run

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

