### PR TITLE
fix: Add checkQueryIntegrity permissions check from Presto spark

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -670,6 +670,7 @@ public class PrestoSparkQueryExecutionFactory
             Optional<QueryType> queryType = StatementUtils.getQueryType(preparedQuery.getStatement().getClass());
             if (queryType.isPresent() && (queryType.get() == QueryType.DATA_DEFINITION || queryType.get() == QueryType.CONTROL)) {
                 queryStateTimer.endAnalysis();
+                accessControl.checkQueryIntegrity(session.getIdentity(), session.getAccessControlContext(), sql, ImmutableMap.of(), ImmutableMap.of());
                 DDLDefinitionTask<?> task = (DDLDefinitionTask<?>) ddlTasks.get(preparedQuery.getStatement().getClass());
                 return new PrestoSparkDataDefinitionExecution(task, preparedQuery.getStatement(), transactionManager, accessControl, metadata, session, queryStateTimer, warningCollector, sql);
             }
@@ -677,6 +678,8 @@ public class PrestoSparkQueryExecutionFactory
                 return accessControlChecker.createExecution(session, preparedQuery, queryStateTimer, warningCollector, sql);
             }
             else {
+                accessControl.checkQueryIntegrity(session.getIdentity(), session.getAccessControlContext(), sql, ImmutableMap.of(), ImmutableMap.of());
+
                 VariableAllocator variableAllocator = new VariableAllocator();
                 PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator();
                 planAndMore = queryPlanner.createQueryPlan(session, preparedQuery, warningCollector, variableAllocator, planNodeIdAllocator, sparkContext, sql);


### PR DESCRIPTION
## Description
Add checkQueryIntegrity permission check validation for Presto spark queries to give it the same behavior as Presto queries.

## Motivation and Context
The query string is not validated currently for Presto spark queries, so this must be fixed in order to match the permissions checking behavior of Presto queries.

## Impact
No impact on open source code unless the default implementation of checkQueryIntegrity is overridden in the access control.

## Test Plan
<!---Please fill in how you tested your change-->
Existing behavior is maintained for permissions checking. The dedicated checkQueryIntegrity tests that check for at least one call to the check still pass.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```



Differential Revision: D87871753


