### PR TITLE
fix(analyzer): Materialized view with logical view and cte

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -221,6 +221,9 @@ public class Analysis
     // Keeps track of the subquery we are visiting, so we have access to base query information when processing materialized view status
     private Optional<QuerySpecification> currentQuerySpecification = Optional.empty();
 
+    // Track WHERE clause from the query accessing a view for subquery analysis such as materialized view
+    private Optional<Expression> viewAccessorWhereClause = Optional.empty();
+
     // Maps each output Field to its originating SourceColumn(s) for column-level lineage tracking.
     private final Multimap<Field, SourceColumn> originColumnDetails = ArrayListMultimap.create();
 
@@ -1112,9 +1115,25 @@ public class Analysis
     {
         this.currentQuerySpecification = Optional.of(currentSubQuery);
     }
+
     public Optional<QuerySpecification> getCurrentQuerySpecification()
     {
         return currentQuerySpecification;
+    }
+
+    public void setViewAccessorWhereClause(Expression whereClause)
+    {
+        this.viewAccessorWhereClause = Optional.of(whereClause);
+    }
+
+    public void clearViewAccessorWhereClause()
+    {
+        this.viewAccessorWhereClause = Optional.empty();
+    }
+
+    public Optional<Expression> getViewAccessorWhereClause()
+    {
+        return viewAccessorWhereClause;
     }
 
     public void setTargetQuery(QuerySpecification targetQuery)


### PR DESCRIPTION
Summary:
If a materialized view is a part of a logical view, the logical view's where predicate is not pushed down to materialized view so that it doesn't check the overlap correctly. It caused the comparison between mv's data and ALL base table data instead of the ones specified in the query.

This diff fixes it by storing the where predicate when processing a logical view. So mv can combine the where predicate in logical view as well when getting mv status. It also fixes the issue during with using the logical view/mv in cte.

Differential Revision: D87928199


