### PR TITLE
refactor(native): Modify `PlanConversionFailureInfo` to `NativeSidecarFailureInfo`

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Exception.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Exception.cpp
@@ -204,4 +204,14 @@ protocol::ExecutionFailureInfo VeloxToPrestoExceptionTranslator::translate(
   error.message = e.what();
   return error;
 }
+
+protocol::NativeSidecarFailureInfo toNativeSidecarFailureInfo(
+    const protocol::ExecutionFailureInfo& failure) {
+  facebook::presto::protocol::NativeSidecarFailureInfo nativeSidecarFailureInfo;
+  nativeSidecarFailureInfo.type = failure.type;
+  nativeSidecarFailureInfo.message = failure.message;
+  nativeSidecarFailureInfo.stack = failure.stack;
+  nativeSidecarFailureInfo.errorCode = failure.errorCode;
+  return nativeSidecarFailureInfo;
+}
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/common/Exception.h
+++ b/presto-native-execution/presto_cpp/main/common/Exception.h
@@ -95,4 +95,7 @@ inline protocol::ExecutionFailureInfo translateToPrestoException(
       "VeloxToPrestoExceptionTranslator singleton must be registered");
   return translator->translate(e);
 }
+
+protocol::NativeSidecarFailureInfo toNativeSidecarFailureInfo(
+    const protocol::ExecutionFailureInfo& failure);
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/types/VeloxPlanConversion.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxPlanConversion.cpp
@@ -18,19 +18,6 @@
 
 using namespace facebook::velox;
 
-namespace {
-
-facebook::presto::protocol::PlanConversionFailureInfo copyFailureInfo(
-    const facebook::presto::protocol::ExecutionFailureInfo& failure) {
-  facebook::presto::protocol::PlanConversionFailureInfo failureCopy;
-  failureCopy.type = failure.type;
-  failureCopy.message = failure.message;
-  failureCopy.stack = failure.stack;
-  failureCopy.errorCode = failure.errorCode;
-  return failureCopy;
-}
-} // namespace
-
 namespace facebook::presto {
 
 protocol::PlanConversionResponse prestoToVeloxPlanConversion(
@@ -55,10 +42,10 @@ protocol::PlanConversionResponse prestoToVeloxPlanConversion(
     planValidator->validatePlanFragment(veloxPlan);
   } catch (const VeloxException& e) {
     response.failures.emplace_back(
-        copyFailureInfo(translateToPrestoException(e)));
+        toNativeSidecarFailureInfo(translateToPrestoException(e)));
   } catch (const std::exception& e) {
     response.failures.emplace_back(
-        copyFailureInfo(translateToPrestoException(e)));
+        toNativeSidecarFailureInfo(translateToPrestoException(e)));
   }
 
   return response;

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -7557,6 +7557,68 @@ void from_json(const json& j, MergeTarget& p) {
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
+void to_json(json& j, const NativeSidecarFailureInfo& p) {
+  j = json::object();
+  to_json_key(j, "type", p.type, "NativeSidecarFailureInfo", "String", "type");
+  to_json_key(
+      j, "message", p.message, "NativeSidecarFailureInfo", "String", "message");
+  to_json_key(
+      j,
+      "cause",
+      p.cause,
+      "NativeSidecarFailureInfo",
+      "NativeSidecarFailureInfo",
+      "cause");
+  to_json_key(
+      j,
+      "suppressed",
+      p.suppressed,
+      "NativeSidecarFailureInfo",
+      "List<NativeSidecarFailureInfo>",
+      "suppressed");
+  to_json_key(
+      j, "stack", p.stack, "NativeSidecarFailureInfo", "List<String>", "stack");
+  to_json_key(
+      j,
+      "errorCode",
+      p.errorCode,
+      "NativeSidecarFailureInfo",
+      "ErrorCode",
+      "errorCode");
+}
+
+void from_json(const json& j, NativeSidecarFailureInfo& p) {
+  from_json_key(
+      j, "type", p.type, "NativeSidecarFailureInfo", "String", "type");
+  from_json_key(
+      j, "message", p.message, "NativeSidecarFailureInfo", "String", "message");
+  from_json_key(
+      j,
+      "cause",
+      p.cause,
+      "NativeSidecarFailureInfo",
+      "NativeSidecarFailureInfo",
+      "cause");
+  from_json_key(
+      j,
+      "suppressed",
+      p.suppressed,
+      "NativeSidecarFailureInfo",
+      "List<NativeSidecarFailureInfo>",
+      "suppressed");
+  from_json_key(
+      j, "stack", p.stack, "NativeSidecarFailureInfo", "List<String>", "stack");
+  from_json_key(
+      j,
+      "errorCode",
+      p.errorCode,
+      "NativeSidecarFailureInfo",
+      "ErrorCode",
+      "errorCode");
+}
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
+
 void to_json(json& j, const NodeLoadMetrics& p) {
   j = json::object();
   to_json_key(
@@ -8571,88 +8633,6 @@ void from_json(const json& j, PipelineStats& p) {
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
 
-void to_json(json& j, const PlanConversionFailureInfo& p) {
-  j = json::object();
-  to_json_key(j, "type", p.type, "PlanConversionFailureInfo", "String", "type");
-  to_json_key(
-      j,
-      "message",
-      p.message,
-      "PlanConversionFailureInfo",
-      "String",
-      "message");
-  to_json_key(
-      j,
-      "cause",
-      p.cause,
-      "PlanConversionFailureInfo",
-      "PlanConversionFailureInfo",
-      "cause");
-  to_json_key(
-      j,
-      "suppressed",
-      p.suppressed,
-      "PlanConversionFailureInfo",
-      "List<PlanConversionFailureInfo>",
-      "suppressed");
-  to_json_key(
-      j,
-      "stack",
-      p.stack,
-      "PlanConversionFailureInfo",
-      "List<String>",
-      "stack");
-  to_json_key(
-      j,
-      "errorCode",
-      p.errorCode,
-      "PlanConversionFailureInfo",
-      "ErrorCode",
-      "errorCode");
-}
-
-void from_json(const json& j, PlanConversionFailureInfo& p) {
-  from_json_key(
-      j, "type", p.type, "PlanConversionFailureInfo", "String", "type");
-  from_json_key(
-      j,
-      "message",
-      p.message,
-      "PlanConversionFailureInfo",
-      "String",
-      "message");
-  from_json_key(
-      j,
-      "cause",
-      p.cause,
-      "PlanConversionFailureInfo",
-      "PlanConversionFailureInfo",
-      "cause");
-  from_json_key(
-      j,
-      "suppressed",
-      p.suppressed,
-      "PlanConversionFailureInfo",
-      "List<PlanConversionFailureInfo>",
-      "suppressed");
-  from_json_key(
-      j,
-      "stack",
-      p.stack,
-      "PlanConversionFailureInfo",
-      "List<String>",
-      "stack");
-  from_json_key(
-      j,
-      "errorCode",
-      p.errorCode,
-      "PlanConversionFailureInfo",
-      "ErrorCode",
-      "errorCode");
-}
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
-
 void to_json(json& j, const PlanConversionResponse& p) {
   j = json::object();
   to_json_key(
@@ -8660,7 +8640,7 @@ void to_json(json& j, const PlanConversionResponse& p) {
       "failures",
       p.failures,
       "PlanConversionResponse",
-      "List<PlanConversionFailureInfo>",
+      "List<NativeSidecarFailureInfo>",
       "failures");
 }
 
@@ -8670,7 +8650,7 @@ void from_json(const json& j, PlanConversionResponse& p) {
       "failures",
       p.failures,
       "PlanConversionResponse",
-      "List<PlanConversionFailureInfo>",
+      "List<NativeSidecarFailureInfo>",
       "failures");
 }
 } // namespace facebook::presto::protocol

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1848,6 +1848,18 @@ void to_json(json& j, const MergeTarget& p);
 void from_json(const json& j, MergeTarget& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
+struct NativeSidecarFailureInfo {
+  String type = {};
+  String message = {};
+  std::shared_ptr<NativeSidecarFailureInfo> cause = {};
+  List<NativeSidecarFailureInfo> suppressed = {};
+  List<String> stack = {};
+  ErrorCode errorCode = {};
+};
+void to_json(json& j, const NativeSidecarFailureInfo& p);
+void from_json(const json& j, NativeSidecarFailureInfo& p);
+} // namespace facebook::presto::protocol
+namespace facebook::presto::protocol {
 struct NodeLoadMetrics {
   double cpuUsedPercent = {};
   double memoryUsedInBytes = {};
@@ -1988,20 +2000,8 @@ void to_json(json& j, const PipelineStats& p);
 void from_json(const json& j, PipelineStats& p);
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {
-struct PlanConversionFailureInfo {
-  String type = {};
-  String message = {};
-  std::shared_ptr<PlanConversionFailureInfo> cause = {};
-  List<PlanConversionFailureInfo> suppressed = {};
-  List<String> stack = {};
-  ErrorCode errorCode = {};
-};
-void to_json(json& j, const PlanConversionFailureInfo& p);
-void from_json(const json& j, PlanConversionFailureInfo& p);
-} // namespace facebook::presto::protocol
-namespace facebook::presto::protocol {
 struct PlanConversionResponse {
-  List<PlanConversionFailureInfo> failures = {};
+  List<NativeSidecarFailureInfo> failures = {};
 };
 void to_json(json& j, const PlanConversionResponse& p);
 void from_json(const json& j, PlanConversionResponse& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -352,7 +352,7 @@ JavaClasses:
   - presto-main-base/src/main/java/com/facebook/presto/connector/system/SystemTransactionHandle.java
   - presto-spi/src/main/java/com/facebook/presto/spi/function/AggregationFunctionMetadata.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/ExchangeEncoding.java
-  - presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/PlanConversionFailureInfo.java
+  - presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/NativeSidecarFailureInfo.java
   - presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/PlanConversionResponse.java
   - presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/JsonBasedUdfFunctionMetadata.java
   - presto-spi/src/main/java/com/facebook/presto/spi/plan/DeleteNode.java

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/NativeSidecarFailureInfo.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/NativeSidecarFailureInfo.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.sidecar.nativechecker;
+package com.facebook.presto.sidecar;
 
 import com.facebook.presto.common.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -27,27 +27,27 @@ import java.util.regex.Pattern;
 import static java.util.Objects.requireNonNull;
 
 /**
- * This class provides failure information in the response from the native plan checker.
+ * This class provides failure information in the response from sidecar.
  * It is derived from {@link com.facebook.presto.client.FailureInfo}.
  */
 @Immutable
-public class PlanConversionFailureInfo
+public class NativeSidecarFailureInfo
 {
     private static final Pattern STACK_TRACE_PATTERN = Pattern.compile("(.*)\\.(.*)\\(([^:]*)(?::(.*))?\\)");
 
     private final String type;
     private final String message;
-    private final PlanConversionFailureInfo cause;
-    private final List<PlanConversionFailureInfo> suppressed;
+    private final NativeSidecarFailureInfo cause;
+    private final List<NativeSidecarFailureInfo> suppressed;
     private final List<String> stack;
     private final ErrorCode errorCode;
 
     @JsonCreator
-    public PlanConversionFailureInfo(
+    public NativeSidecarFailureInfo(
             @JsonProperty("type") String type,
             @JsonProperty("message") String message,
-            @JsonProperty("cause") PlanConversionFailureInfo cause,
-            @JsonProperty("suppressed") List<PlanConversionFailureInfo> suppressed,
+            @JsonProperty("cause") NativeSidecarFailureInfo cause,
+            @JsonProperty("suppressed") List<NativeSidecarFailureInfo> suppressed,
             @JsonProperty("stack") List<String> stack,
             @JsonProperty("errorCode") ErrorCode errorCode)
     {
@@ -78,13 +78,13 @@ public class PlanConversionFailureInfo
 
     @Nullable
     @JsonProperty
-    public PlanConversionFailureInfo getCause()
+    public NativeSidecarFailureInfo getCause()
     {
         return cause;
     }
 
     @JsonProperty
-    public List<PlanConversionFailureInfo> getSuppressed()
+    public List<NativeSidecarFailureInfo> getSuppressed()
     {
         return suppressed;
     }
@@ -107,17 +107,17 @@ public class PlanConversionFailureInfo
         return toException(this);
     }
 
-    private static FailureException toException(PlanConversionFailureInfo failureInfo)
+    private static FailureException toException(NativeSidecarFailureInfo failureInfo)
     {
         if (failureInfo == null) {
             return null;
         }
         FailureException failure = new FailureException(failureInfo.getType(), failureInfo.getMessage(), toException(failureInfo.getCause()));
-        for (PlanConversionFailureInfo suppressed : failureInfo.getSuppressed()) {
+        for (NativeSidecarFailureInfo suppressed : failureInfo.getSuppressed()) {
             failure.addSuppressed(toException(suppressed));
         }
         StackTraceElement[] stackTrace =
-                failureInfo.getStack().stream().map(PlanConversionFailureInfo::toStackTraceElement).toArray(StackTraceElement[]::new);
+                failureInfo.getStack().stream().map(NativeSidecarFailureInfo::toStackTraceElement).toArray(StackTraceElement[]::new);
         failure.setStackTrace(stackTrace);
         return failure;
     }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sidecar.nativechecker;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.sidecar.NativeSidecarFailureInfo;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.NodeManager;
@@ -126,7 +127,7 @@ public final class NativePlanChecker
 
         try (Response response = httpClient.newCall(request).execute()) {
             if (!response.isSuccessful()) {
-                PlanConversionFailureInfo failure = processResponseFailure(response);
+                NativeSidecarFailureInfo failure = processResponseFailure(response);
                 String message = String.format("Error from native plan checker: %s", firstNonNull(failure.getMessage(), "Internal error"));
                 throw new PrestoException(failure::getErrorCode, message, failure.toException());
             }
@@ -152,7 +153,7 @@ public final class NativePlanChecker
         return builder.build();
     }
 
-    private PlanConversionFailureInfo processResponseFailure(Response response) throws IOException
+    private NativeSidecarFailureInfo processResponseFailure(Response response) throws IOException
     {
         if (response.body() == null) {
             throw new PrestoException(NATIVEPLANCHECKER_UNKNOWN_CONVERSION_FAILURE, "Error response without failure from native plan checker with code: " + response.code());

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/PlanConversionResponse.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/PlanConversionResponse.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sidecar.nativechecker;
 
+import com.facebook.presto.sidecar.NativeSidecarFailureInfo;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -23,17 +24,17 @@ import static java.util.Objects.requireNonNull;
 
 public class PlanConversionResponse
 {
-    private final List<PlanConversionFailureInfo> failures;
+    private final List<NativeSidecarFailureInfo> failures;
 
     @JsonCreator
     public PlanConversionResponse(
-            @JsonProperty("failures") List<PlanConversionFailureInfo> failures)
+            @JsonProperty("failures") List<NativeSidecarFailureInfo> failures)
     {
         this.failures = ImmutableList.copyOf(requireNonNull(failures, "failures is null"));
     }
 
     @JsonProperty
-    public List<PlanConversionFailureInfo> getFailures()
+    public List<NativeSidecarFailureInfo> getFailures()
     {
         return failures;
     }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestPlanCheckerProvider.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestPlanCheckerProvider.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.ErrorCode;
 import com.facebook.presto.sidecar.nativechecker.NativePlanChecker;
 import com.facebook.presto.sidecar.nativechecker.NativePlanCheckerConfig;
 import com.facebook.presto.sidecar.nativechecker.NativePlanCheckerProvider;
-import com.facebook.presto.sidecar.nativechecker.PlanConversionFailureInfo;
 import com.facebook.presto.sidecar.nativechecker.PlanConversionResponse;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.Node;
@@ -92,7 +91,7 @@ public class TestPlanCheckerProvider
 
             String errorMessage = "native conversion error";
             ErrorCode errorCode = StandardErrorCode.NOT_SUPPORTED.toErrorCode();
-            PlanConversionResponse responseError = new PlanConversionResponse(ImmutableList.of(new PlanConversionFailureInfo("MockError", errorMessage, null, ImmutableList.of(), ImmutableList.of(), errorCode)));
+            PlanConversionResponse responseError = new PlanConversionResponse(ImmutableList.of(new NativeSidecarFailureInfo("MockError", errorMessage, null, ImmutableList.of(), ImmutableList.of(), errorCode)));
             String responseErrorString = PLAN_CONVERSION_RESPONSE_JSON_CODEC.toJson(responseError);
             server.enqueue(new MockResponse().setResponseCode(500).setBody(responseErrorString));
             PrestoException error = expectThrows(PrestoException.class,


### PR DESCRIPTION
## Description
Refactors `PlanConversionFailureInfo` to `NativeSidecarFailureInfo` in order to externalize its uses beyond the `NativePlanChecker` (and for use in the `NativeExpressionOptimizer`). 
Also exposes the helper method that converts `protocol::ExecutionFailureInfo` to `protocol::NativeSidecarFailureInfo` for use in native expression optimization endpoint, `v1/expressions` (to be added).

## Motivation and Context
Needed for https://github.com/prestodb/presto/pull/26475.

## Impact
N/A.

## Test Plan
Existing tests for `NativePlanChecker`.


```
== NO RELEASE NOTE ==
```

