### PR TITLE
fix: Pass reasonForSelect to view identity for definer mode

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/connector/system/SystemConnectorSessionUtil.java
@@ -21,6 +21,10 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.facebook.presto.spi.security.Identity;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
 
@@ -35,7 +39,7 @@ public final class SystemConnectorSessionUtil
     {
         TransactionId transactionId = ((GlobalSystemTransactionHandle) transactionHandle).getTransactionId();
         ConnectorIdentity connectorIdentity = session.getIdentity();
-        Identity identity = new Identity(connectorIdentity.getUser(), connectorIdentity.getPrincipal(), connectorIdentity.getExtraCredentials());
+        Identity identity = new Identity(connectorIdentity.getUser(), connectorIdentity.getPrincipal(), ImmutableMap.of(), connectorIdentity.getExtraCredentials(), ImmutableMap.of(), Optional.empty(), connectorIdentity.getReasonForSelect(), ImmutableList.of());
         return Session.builder(createTestingSessionPropertyManager(SYSTEM_SESSION_PROPERTIES))
                 .setQueryId(new QueryId(session.getQueryId()))
                 .setTransactionId(transactionId)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -130,7 +130,7 @@ public final class MaterializedViewUtils
     public static Identity getOwnerIdentity(Optional<String> owner, Session session)
     {
         if (owner.isPresent() && !owner.get().equals(session.getIdentity().getUser())) {
-            return new Identity(owner.get(), Optional.empty(), session.getIdentity().getExtraCredentials());
+            return new Identity(owner.get(), Optional.empty(), ImmutableMap.of(), session.getIdentity().getExtraCredentials(), ImmutableMap.of(), Optional.empty(), session.getIdentity().getReasonForSelect(), ImmutableList.of());
         }
         return session.getIdentity();
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2337,6 +2337,7 @@ class StatementAnalyzer
             }
             throw new SemanticException(NOT_SUPPORTED, "Table version type %s not supported." + type);
         }
+
         private Optional<TableHandle> processTableVersion(Table table, QualifiedObjectName name, Optional<Scope> scope)
         {
             Expression stateExpr = table.getTableVersionExpression().get().getStateExpression();
@@ -2513,7 +2514,7 @@ class StatementAnalyzer
                     if (!owner.isPresent()) {
                         throw new SemanticException(NOT_SUPPORTED, "Owner must be present for DEFINER security mode");
                     }
-                    queryIdentity = new Identity(owner.get(), Optional.empty(), session.getIdentity().getExtraCredentials());
+                    queryIdentity = new Identity(owner.get(), Optional.empty(), emptyMap(), session.getIdentity().getExtraCredentials(), emptyMap(), Optional.empty(), session.getIdentity().getReasonForSelect(), emptyList());
                     // Use ViewAccessControl when the session user is not the owner, matching regular view behavior.
                     // This checks CREATE_VIEW_WITH_SELECT_COLUMNS permissions to prevent privilege escalation
                     // where a user with only SELECT could grant access to others via a DEFINER MV.
@@ -4303,7 +4304,7 @@ class StatementAnalyzer
                 AccessControl viewAccessControl;
                 if (owner.isPresent() && !owner.get().equals(session.getIdentity().getUser())) {
                     // definer mode
-                    identity = new Identity(owner.get(), Optional.empty(), session.getIdentity().getExtraCredentials());
+                    identity = new Identity(owner.get(), Optional.empty(), emptyMap(), session.getIdentity().getExtraCredentials(), emptyMap(), Optional.empty(), session.getIdentity().getReasonForSelect(), emptyList());
                     viewAccessControl = new ViewAccessControl(accessControl);
                 }
                 else {


### PR DESCRIPTION
## Description
When initialzing a view identity for definer mode permission checks, the reason for select is passed in as empty. This PR ensures that the same reason for select in the invoker's identity is used.

## Motivation and Context
When checking definer mode view permissions, the reason for select is always set to empty, which means that permissions checks for table will contain a reason for select but for the same query, the permission check of the underlying base tables for a definer mode view will always be empty, leading to a mismatch in reason for select.

## Impact
No impact on permissions checking behavior. The reason for select will now be made available for use in authorization checks for base tables of a definer mode view.

## Test Plan
<!---Please fill in how you tested your change-->
No impact, and existing tests pass.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```


Differential Revision: D88055399


