### PR TITLE
feat: Make table info JSON length configurable

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -711,3 +711,14 @@ The corresponding configuration property is :ref:`admin/properties:\`\`materiali
 
 Enable optimization to combine multiple :func:`!approx_distinct` function calls on expressions
 of the same type into a single aggregation using ``set_agg`` with array operations (``array_constructor``, ``array_transpose``).
+
+``table_finish_info_json_length_limit``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``int``
+* **Default value:** ``10,000,000``
+
+The maximum length of the JSON-serialized ConnectorOutputMetadata string in
+TableFinishInfo. If the length is exceeded, then the Metadata is omitted.
+
+When set to a non-positive value, the length limit is not enforced.

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -27,6 +27,7 @@ import com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAware
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
+import com.facebook.presto.operator.OperatorFeaturesConfig;
 import com.facebook.presto.spi.MaterializedViewStaleReadBehavior;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.eventlistener.CTEInformation;
@@ -137,6 +138,7 @@ public final class SystemSessionProperties
     public static final String SCALE_WRITERS = "scale_writers";
     public static final String WRITER_MIN_SIZE = "writer_min_size";
     public static final String OPTIMIZED_SCALE_WRITER_PRODUCER_BUFFER = "optimized_scale_writer_producer_buffer";
+    public static final String TABLE_FINISH_INFO_JSON_LENGTH_LIMIT = "table_finish_info_json_length_limit";
     public static final String PUSH_TABLE_WRITE_THROUGH_UNION = "push_table_write_through_union";
     public static final String EXECUTION_POLICY = "execution_policy";
     public static final String DICTIONARY_AGGREGATION = "dictionary_aggregation";
@@ -397,7 +399,8 @@ public final class SystemSessionProperties
                 new NodeSpillConfig(),
                 new TracingConfig(),
                 new CompilerConfig(),
-                new HistoryBasedOptimizationConfig());
+                new HistoryBasedOptimizationConfig(),
+                new OperatorFeaturesConfig());
     }
 
     @Inject
@@ -413,7 +416,8 @@ public final class SystemSessionProperties
             NodeSpillConfig nodeSpillConfig,
             TracingConfig tracingConfig,
             CompilerConfig compilerConfig,
-            HistoryBasedOptimizationConfig historyBasedOptimizationConfig)
+            HistoryBasedOptimizationConfig historyBasedOptimizationConfig,
+            OperatorFeaturesConfig tableFinishConfig)
     {
         sessionProperties = ImmutableList.of(
                 integerProperty(
@@ -575,6 +579,11 @@ public final class SystemSessionProperties
                         "Optimize scale writer creation based on producer buffer",
                         featuresConfig.isOptimizedScaleWriterProducerBuffer(),
                         true),
+                integerProperty(
+                        TABLE_FINISH_INFO_JSON_LENGTH_LIMIT,
+                        "Maximum number of characters in connector output metadata JSON in table finish info",
+                        tableFinishConfig.getTableFinishInfoJsonLengthLimit(),
+                        false),
                 booleanProperty(
                         PUSH_TABLE_WRITE_THROUGH_UNION,
                         "Parallelize writes when using UNION ALL in queries that write data",

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorFeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorFeaturesConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+
+public class OperatorFeaturesConfig
+{
+    private int tableFinishInfoJsonLengthLimit = 10_000_000;
+
+    @NotNull
+    public int getTableFinishInfoJsonLengthLimit()
+    {
+        return tableFinishInfoJsonLengthLimit;
+    }
+
+    @Config("table-finish-info-json-length-limit")
+    @ConfigDescription("Maximum number of characters in connector output metadata JSON in table finish info")
+    public OperatorFeaturesConfig setTableFinishInfoJsonLengthLimit(int tableFinishInfoJsonLengthLimit)
+    {
+        this.tableFinishInfoJsonLengthLimit = tableFinishInfoJsonLengthLimit;
+        return this;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -120,6 +120,7 @@ import com.facebook.presto.operator.DriverFactory;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
 import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.OperatorFeaturesConfig;
 import com.facebook.presto.operator.OutputFactory;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.SourceOperatorFactory;
@@ -458,7 +459,8 @@ public class LocalQueryRunner
                                 new NodeSpillConfig(),
                                 new TracingConfig(),
                                 new CompilerConfig(),
-                                new HistoryBasedOptimizationConfig()).getSessionProperties(),
+                                new HistoryBasedOptimizationConfig(),
+                                new OperatorFeaturesConfig()).getSessionProperties(),
                         new JavaFeaturesConfig(),
                         nodeSpillConfig),
                 new SchemaPropertyManager(),

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestCreateMaterializedViewTask.java
@@ -33,6 +33,7 @@ import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MaterializedViewPropertyManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.metadata.TablePropertyManager;
+import com.facebook.presto.operator.OperatorFeaturesConfig;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
@@ -402,7 +403,8 @@ public class TestCreateMaterializedViewTask
                         new NodeSpillConfig(),
                         new TracingConfig(),
                         new CompilerConfig(),
-                        new HistoryBasedOptimizationConfig()).getSessionProperties(),
+                        new HistoryBasedOptimizationConfig(),
+                        new OperatorFeaturesConfig()).getSessionProperties(),
                 featuresConfig,
                 new JavaFeaturesConfig(),
                 new NodeSpillConfig());

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
@@ -28,6 +28,7 @@ import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.failureDetector.NoOpFailureDetector;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
+import com.facebook.presto.operator.OperatorFeaturesConfig;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.TableHandle;
@@ -106,7 +107,8 @@ public class TestAdaptivePhasedExecutionPolicy
                 new NodeSpillConfig(),
                 new TracingConfig(),
                 new CompilerConfig(),
-                new HistoryBasedOptimizationConfig()))).build();
+                new HistoryBasedOptimizationConfig(),
+                new OperatorFeaturesConfig()))).build();
         AdaptivePhasedExecutionPolicy policy = new AdaptivePhasedExecutionPolicy();
         Collection<StageExecutionAndScheduler> schedulers = getStageExecutionAndSchedulers(4);
         assertTrue(policy.createExecutionSchedule(session, schedulers) instanceof AllAtOnceExecutionSchedule);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestOperatorFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestOperatorFeaturesConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestOperatorFeaturesConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(OperatorFeaturesConfig.class)
+                .setTableFinishInfoJsonLengthLimit(10_000_000));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("table-finish-info-json-length-limit", "5000000")
+                .build();
+
+        OperatorFeaturesConfig expected = new OperatorFeaturesConfig()
+                .setTableFinishInfoJsonLengthLimit(5_000_000);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -22,6 +22,7 @@ import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
+import com.facebook.presto.operator.OperatorFeaturesConfig;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.StandardWarningCode;
 import com.facebook.presto.spi.WarningCollector;
@@ -245,7 +246,8 @@ public class TestAnalyzer
                 new NodeSpillConfig(),
                 new TracingConfig(),
                 new CompilerConfig(),
-                new HistoryBasedOptimizationConfig()))).build();
+                new HistoryBasedOptimizationConfig(),
+                new OperatorFeaturesConfig()))).build();
         assertFails(session, WINDOW_FUNCTION_ORDERBY_LITERAL,
                 "SELECT SUM(x) OVER (PARTITION BY y ORDER BY 1) AS s\n" +
                         "FROM (values (1,10), (2, 10)) AS T(x, y)");
@@ -655,7 +657,8 @@ public class TestAnalyzer
                 new NodeSpillConfig(),
                 new TracingConfig(),
                 new CompilerConfig(),
-                new HistoryBasedOptimizationConfig()))).build();
+                new HistoryBasedOptimizationConfig(),
+                new OperatorFeaturesConfig()))).build();
         analyze(session, "SELECT a, b, c, d, e, f, g, h, i, j, k, SUM(l)" +
                 "FROM (VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))\n" +
                 "t (a, b, c, d, e, f, g, h, i, j, k, l)\n" +

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestOperatorFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestOperatorFeaturesConfig.java
@@ -55,7 +55,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrate
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class TestFeaturesConfig
+public class TestOperatorFeaturesConfig
 {
     @Test
     public void testDefaults()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingJoins.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingJoins.java
@@ -24,6 +24,7 @@ import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.operator.OperatorFeaturesConfig;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
@@ -89,7 +90,8 @@ public class TestValidateStreamingJoins
                         new NodeSpillConfig(),
                         new TracingConfig(),
                         new CompilerConfig(),
-                        new HistoryBasedOptimizationConfig())))
+                        new HistoryBasedOptimizationConfig(),
+                        new OperatorFeaturesConfig())))
                 .setCatalog("local")
                 .setSchema("tiny")
                 .setSystemProperty("spill_enabled", "true")

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -136,6 +136,7 @@ import com.facebook.presto.operator.HttpAndThriftRpcShuffleClientProvider;
 import com.facebook.presto.operator.HttpShuffleClientProvider;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
+import com.facebook.presto.operator.OperatorFeaturesConfig;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.RpcShuffleClientProvider;
@@ -634,6 +635,7 @@ public class ServerMainModule
                         addressSelectorBinder.bind(AddressSelector.class).annotatedWith(annotation).to(FixedAddressSelector.class)));
 
         configBinder(binder).bindConfig(ExchangeClientConfig.class);
+        configBinder(binder).bindConfig(OperatorFeaturesConfig.class);
         binder.bind(ExchangeExecutionMBean.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ExchangeExecutionMBean.class).withGeneratedName();
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -95,6 +95,7 @@ import com.facebook.presto.operator.FragmentCacheStats;
 import com.facebook.presto.operator.FragmentResultCacheManager;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
+import com.facebook.presto.operator.OperatorFeaturesConfig;
 import com.facebook.presto.operator.OperatorInfo;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PagesIndex;
@@ -290,6 +291,7 @@ public class PrestoSparkModule
         configBinder(binder).bindConfig(TracingConfig.class);
         configBinder(binder).bindConfig(PlanCheckerProviderManagerConfig.class);
         configBinder(binder).bindConfig(SecurityConfig.class);
+        configBinder(binder).bindConfig(OperatorFeaturesConfig.class);
 
         // json codecs
         jsonCodecBinder(binder).bindJsonCodec(ViewDefinition.class);


### PR DESCRIPTION
Differential Revision: D87825974

## Problem

Currently, `TableFinishInfo` hard-codes a 10 MB limit for serialized metadata info. If that size limit is exceeded, data is dropped. This cannot be configured, and is problematic for users who rely upon `TableFinishInfo` containing complete information

## Solution

- Make the length limit configurable via a Session Property.
- Make the default value of the session property configurable at the cluster-level.
- When the length limit is set to a non-positive value, entirely bypass enforcing a size limit. 

## Reviewer Notes

I couldn't find a good config file to put the default Table Finish JSON length limit, so I created a new config file: `TableFinishConfig`.

This *slightly* increased the scope of this change, because I needed to pass this config in all tests which explicitly construct `SystemSessionProperties`.

```
== RELEASE NOTES ==

General Changes
* Add System Session Property `table_finish_info_json_length_limit`, making the `TableFinishInfo` length limit configurable. Disables length limit enforcement when set to a non-positive value. Defaults to `10MB` (current hard-coded limit).
```