### PR TITLE
perf(native-pos): Broadcast join: Improve broadcast files read performance

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -77,14 +77,11 @@ BroadcastExchangeSource::request(
   });
 }
 
-folly::F14FastMap<std::string, int64_t> BroadcastExchangeSource::stats() const {
-  return reader_->stats();
-}
-
 folly::SemiFuture<BroadcastExchangeSource::Response>
 BroadcastExchangeSource::requestDataSizes(
     std::chrono::microseconds /*maxWait*/) {
-  return folly::makeTryWith([&]() -> Response {
+  // Deferred execution to avoid blocking the caller thread.
+  return folly::makeSemiFuture().deferValue([this](auto&&) -> Response {
     auto remainingPageSizes = reader_->remainingPageSizes();
 
     // If the source is empty from the start, signal completion to ExchangeQueue

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.h
@@ -45,7 +45,14 @@ class BroadcastExchangeSource : public velox::exec::ExchangeSource {
 
   void close() override {}
 
-  folly::F14FastMap<std::string, int64_t> stats() const override;
+  bool supportsMetrics() const override {
+    return true;
+  }
+
+  folly::F14FastMap<std::string, velox::RuntimeMetric> metrics()
+      const override {
+    return reader_->metrics();
+  }
 
   /// Url format for this exchange source:
   /// batch://<taskid>?broadcastInfo={fileInfos:[<fileInfo>]}.


### PR DESCRIPTION
Differential Revision: D88238987

We make 3 main changes in this diff to improve performance of broadcast join file reads in native pos stack

- The footer read call for broadcast file has been moved out of constructor and into a standalone function which is called once by the first caller (`request`, `requestDataSizes`). This solves the issue of ExchangeClient::addRemoteTaskId calling  requestDataSize on each source sequentially in a loop, which is causing performance regression, when the number of files / sources are large , say 4096

- Make the `requestDataSizes` implementation async so that the `addRemoteTaskId` calling `request` does not result in blocking I/O call. This is currently resulting in a performance regression

- Add 2 new RuntimeMetrics to Exchange operator - `broadcastExchangeSource.openFileAndReadFooterTime` and `broadcastExchangeSource.fileReadWallTime` which measures the time to read footer and the time to read the pages in the broadcast file


```
== NO RELEASE NOTE ==
```


