### PR TITLE
fix(plugin-prometheus): Use appendPath to build URI in Prometheus connector

### DIFF
--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusClient.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusClient.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.prometheus;
 
+import com.facebook.airlift.http.client.HttpUriBuilder;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.type.DoubleType;
@@ -38,7 +39,6 @@ import javax.net.ssl.X509TrustManager;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.security.KeyManagementException;
@@ -92,13 +92,8 @@ public class PrometheusClient
 
     private static URI getPrometheusMetricsURI(URI prometheusUri)
     {
-        try {
-            // endpoint to retrieve metric names from Prometheus
-            return new URI(prometheusUri.getScheme(), prometheusUri.getAuthority(), prometheusUri.getPath() + METRICS_ENDPOINT, null, null);
-        }
-        catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
+        // endpoint to retrieve metric names from Prometheus
+        return HttpUriBuilder.uriBuilderFrom(prometheusUri).appendPath(METRICS_ENDPOINT).build();
     }
 
     public Set<String> getTableNames(String schema)

--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusSplitManager.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusSplitManager.java
@@ -160,13 +160,13 @@ public class PrometheusSplitManager
         return new BigDecimal(Long.toString(millis)).divide(new BigDecimal(1000L)).toPlainString();
     }
 
-    // URIBuilder handles URI encode
+    // HttpUriBuilder handles URI encode
     private static URI buildQuery(URI baseURI, String time, String metricName, Duration queryChunkSizeDuration)
             throws URISyntaxException
     {
         return HttpUriBuilder
                 .uriBuilderFrom(baseURI)
-                .replacePath("api/v1/query")
+                .appendPath("api/v1/query")
                 .addParameter("query", metricName + "[" + queryChunkSizeDuration.roundTo(queryChunkSizeDuration.getUnit()) +
                         Duration.timeUnitToString(queryChunkSizeDuration.getUnit()) + "]")
                 .addParameter("time", time)


### PR DESCRIPTION
## Description
In case of a prometheus server behind proxy or a prometheus compatible API (e.g. VictoriaMetrics), prometheus API URI should be appended. Similar to what has been done in: https://github.com/trinodb/trino/commit/55c008bb8783b41aa38808671dc30ec57e96773f

## Motivation and Context
With replacePath, query will return 404 on VictoriaMetrics (we are using its prometheus API and configured as: http://ip:port/select/1:1/prometheus) as current code base will build the URI as http://ip:port/api/v1/query

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Release Notes
```
== NO RELEASE NOTE ==
```
