### PR TITLE
fix(plugin-iceberg): Fix special characters in MV base table name

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -78,6 +78,7 @@ import com.facebook.presto.parquet.cache.ParquetCacheConfig;
 import com.facebook.presto.parquet.cache.ParquetFileMetadata;
 import com.facebook.presto.parquet.cache.ParquetMetadataSource;
 import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
@@ -169,6 +170,7 @@ public class IcebergCommonModule
 
         jsonCodecBinder(binder).bindJsonCodec(CommitTaskData.class);
         jsonCodecBinder(binder).bindListJsonCodec(MaterializedViewDefinition.ColumnMapping.class);
+        jsonCodecBinder(binder).bindListJsonCodec(SchemaTableName.class);
 
         binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -181,6 +181,7 @@ public class IcebergHiveMetadata
             RowExpressionService rowExpressionService,
             JsonCodec<CommitTaskData> commitTaskCodec,
             JsonCodec<List<MaterializedViewDefinition.ColumnMapping>> columnMappingsCodec,
+            JsonCodec<List<SchemaTableName>> schemaTableNamesCodec,
             NodeVersion nodeVersion,
             FilterStatsCalculatorService filterStatsCalculatorService,
             IcebergHiveTableOperationsConfig hiveTableOperationsConfig,
@@ -189,7 +190,7 @@ public class IcebergHiveMetadata
             IcebergTableProperties tableProperties,
             ConnectorSystemConfig connectorSystemConfig)
     {
-        super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
+        super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadataFactory.java
@@ -20,6 +20,7 @@ import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
 import com.facebook.presto.spi.ConnectorSystemConfig;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
@@ -40,6 +41,7 @@ public class IcebergHiveMetadataFactory
     final TypeManager typeManager;
     final JsonCodec<CommitTaskData> commitTaskCodec;
     final JsonCodec<List<ColumnMapping>> columnMappingsCodec;
+    final JsonCodec<List<SchemaTableName>> schemaTableNamesCodec;
     final StandardFunctionResolution functionResolution;
     final RowExpressionService rowExpressionService;
     final NodeVersion nodeVersion;
@@ -60,6 +62,7 @@ public class IcebergHiveMetadataFactory
             RowExpressionService rowExpressionService,
             JsonCodec<CommitTaskData> commitTaskCodec,
             JsonCodec<List<ColumnMapping>> columnMappingsCodec,
+            JsonCodec<List<SchemaTableName>> schemaTableNamesCodec,
             NodeVersion nodeVersion,
             FilterStatsCalculatorService filterStatsCalculatorService,
             IcebergHiveTableOperationsConfig operationsConfig,
@@ -76,6 +79,7 @@ public class IcebergHiveMetadataFactory
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
         this.columnMappingsCodec = requireNonNull(columnMappingsCodec, "columnMappingsCodec is null");
+        this.schemaTableNamesCodec = requireNonNull(schemaTableNamesCodec, "schemaTableNamesCodec is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.operationsConfig = requireNonNull(operationsConfig, "operationsConfig is null");
@@ -96,6 +100,7 @@ public class IcebergHiveMetadataFactory
                 rowExpressionService,
                 commitTaskCodec,
                 columnMappingsCodec,
+                schemaTableNamesCodec,
                 nodeVersion,
                 filterStatsCalculatorService,
                 operationsConfig,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -113,13 +113,14 @@ public class IcebergNativeMetadata
             RowExpressionService rowExpressionService,
             JsonCodec<CommitTaskData> commitTaskCodec,
             JsonCodec<List<MaterializedViewDefinition.ColumnMapping>> columnMappingsCodec,
+            JsonCodec<List<SchemaTableName>> schemaTableNamesCodec,
             CatalogType catalogType,
             NodeVersion nodeVersion,
             FilterStatsCalculatorService filterStatsCalculatorService,
             StatisticsFileCache statisticsFileCache,
             IcebergTableProperties tableProperties)
     {
-        super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
+        super(typeManager, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
         this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
         this.catalogType = requireNonNull(catalogType, "catalogType is null");
         this.warehouseDataDir = Optional.ofNullable(catalogFactory.getCatalogWarehouseDataDir());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
 import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.spi.plan.FilterStatsCalculatorService;
@@ -34,6 +35,7 @@ public class IcebergNativeMetadataFactory
     final TypeManager typeManager;
     final JsonCodec<CommitTaskData> commitTaskCodec;
     final JsonCodec<List<MaterializedViewDefinition.ColumnMapping>> columnMappingsCodec;
+    final JsonCodec<List<SchemaTableName>> schemaTableNamesCodec;
     final IcebergNativeCatalogFactory catalogFactory;
     final CatalogType catalogType;
     final StandardFunctionResolution functionResolution;
@@ -52,6 +54,7 @@ public class IcebergNativeMetadataFactory
             RowExpressionService rowExpressionService,
             JsonCodec<CommitTaskData> commitTaskCodec,
             JsonCodec<List<MaterializedViewDefinition.ColumnMapping>> columnMappingsCodec,
+            JsonCodec<List<SchemaTableName>> schemaTableNamesCodec,
             NodeVersion nodeVersion,
             FilterStatsCalculatorService filterStatsCalculatorService,
             StatisticsFileCache statisticsFileCache,
@@ -63,6 +66,7 @@ public class IcebergNativeMetadataFactory
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
         this.columnMappingsCodec = requireNonNull(columnMappingsCodec, "columnMappingsCodec is null");
+        this.schemaTableNamesCodec = requireNonNull(schemaTableNamesCodec, "schemaTableNamesCodec is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.catalogType = config.getCatalogType();
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
@@ -72,6 +76,6 @@ public class IcebergNativeMetadataFactory
 
     public ConnectorMetadata create()
     {
-        return new IcebergNativeMetadata(catalogFactory, typeManager, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, catalogType, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
+        return new IcebergNativeMetadata(catalogFactory, typeManager, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec, catalogType, nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
@@ -329,7 +329,7 @@ public class TestIcebergMaterializedViewMetadata
             properties2.put(PRESTO_MATERIALIZED_VIEW_ORIGINAL_SQL, "SELECT id FROM test_other_validation_base");
             properties2.put(PRESTO_MATERIALIZED_VIEW_STORAGE_SCHEMA, "test_schema");
             properties2.put(PRESTO_MATERIALIZED_VIEW_STORAGE_TABLE_NAME, "storage_invalid_json");
-            properties2.put(PRESTO_MATERIALIZED_VIEW_BASE_TABLES, "test_schema.test_other_validation_base");
+            properties2.put(PRESTO_MATERIALIZED_VIEW_BASE_TABLES, "[{\"schema\":\"test_schema\", \"table\": \"test_other_validation_base\"}]");
             properties2.put(PRESTO_MATERIALIZED_VIEW_COLUMN_MAPPINGS, "{invalid json here");
             properties2.put(PRESTO_MATERIALIZED_VIEW_OWNER, "test_user");
             properties2.put(PRESTO_MATERIALIZED_VIEW_SECURITY_MODE, "DEFINER");
@@ -356,7 +356,7 @@ public class TestIcebergMaterializedViewMetadata
             properties3.put(PRESTO_MATERIALIZED_VIEW_ORIGINAL_SQL, "SELECT id FROM nonexistent_table");
             properties3.put(PRESTO_MATERIALIZED_VIEW_STORAGE_SCHEMA, "test_schema");
             properties3.put(PRESTO_MATERIALIZED_VIEW_STORAGE_TABLE_NAME, "storage_nonexistent_base");
-            properties3.put(PRESTO_MATERIALIZED_VIEW_BASE_TABLES, "test_schema.nonexistent_table");
+            properties3.put(PRESTO_MATERIALIZED_VIEW_BASE_TABLES, "[{\"schema\":\"test_schema\", \"table\": \"nonexistent_table\"}]");
             properties3.put(PRESTO_MATERIALIZED_VIEW_COLUMN_MAPPINGS, "[]");
             properties3.put(PRESTO_MATERIALIZED_VIEW_OWNER, "test_user");
             properties3.put(PRESTO_MATERIALIZED_VIEW_SECURITY_MODE, "DEFINER");
@@ -565,7 +565,7 @@ public class TestIcebergMaterializedViewMetadata
             properties2.put("presto.materialized_view.original_sql", "SELECT id, name FROM test_validation_base");
             properties2.put("presto.materialized_view.storage_schema", "test_schema");
             properties2.put("presto.materialized_view.storage_table_name", "storage2");
-            properties2.put("presto.materialized_view.base_tables", "test_schema.test_validation_base");
+            properties2.put("presto.materialized_view.base_tables", "[{\"schema\":\"test_schema\", \"table\": \"test_validation_base\"}]");
 
             catalog.buildView(viewId2)
                     .withSchema(new org.apache.iceberg.Schema(
@@ -586,7 +586,7 @@ public class TestIcebergMaterializedViewMetadata
             properties3.put("presto.materialized_view.format_version", CURRENT_MATERIALIZED_VIEW_FORMAT_VERSION + "");
             properties3.put("presto.materialized_view.original_sql", "SELECT id, name FROM test_validation_base");
             properties3.put("presto.materialized_view.storage_table_name", "storage3");
-            properties3.put("presto.materialized_view.base_tables", "test_schema.test_validation_base");
+            properties3.put("presto.materialized_view.base_tables", "[{\"schema\":\"test_schema\", \"table\": \"test_validation_base\"}]");
             properties3.put("presto.materialized_view.column_mappings", "[]");
 
             catalog.buildView(viewId3)
@@ -608,7 +608,7 @@ public class TestIcebergMaterializedViewMetadata
             properties4.put("presto.materialized_view.format_version", CURRENT_MATERIALIZED_VIEW_FORMAT_VERSION + "");
             properties4.put("presto.materialized_view.original_sql", "SELECT id, name FROM test_validation_base");
             properties4.put("presto.materialized_view.storage_schema", "test_schema");
-            properties4.put("presto.materialized_view.base_tables", "test_schema.test_validation_base");
+            properties4.put("presto.materialized_view.base_tables", "[{\"schema\":\"test_schema\", \"table\": \"test_validation_base\"}]");
             properties4.put("presto.materialized_view.column_mappings", "[]");
 
             catalog.buildView(viewId4)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestRenameTableOnFragileFileSystem.java
@@ -416,6 +416,7 @@ public class TestRenameTableOnFragileFileSystem
                 ROW_EXPRESSION_SERVICE,
                 jsonCodec(CommitTaskData.class),
                 jsonCodec(new TypeToken<>() {}),
+                jsonCodec(new TypeToken<>() {}),
                 new NodeVersion("test_node_v1"),
                 FILTER_STATS_CALCULATOR_SERVICE,
                 new IcebergHiveTableOperationsConfig(),


### PR DESCRIPTION
## Description

Since Presto allows special characters (e.g., ".", ",") in double quoted table names, using them as delimiters in MV's `PRESTO_MATERIALIZED_VIEW_BASE_TABLES` can lead to parsing problems. For example, the base tables' names could be "tt.3", "tt,4.5", or "tt\"\"tt,123\"\".123".

This PR addresses the issue by serializing the list of table names into a JSON string using `JsonCodec<List<SchemaTableName>>`. This ensures proper handling of special characters.

## Motivation and Context

 - Fix the issue caused by special characters in the base table name of MV

## Impact

N/A

## Test Plan

 - Add test cases to cover the scenarios mentioned above

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

