### PR TITLE
fix(native): Fix inserting decimal type values precision and scale

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -20,6 +20,8 @@
 #include <folly/io/IOBuf.h>
 #include <velox/type/TypeUtil.h>
 #include <velox/type/Filter.h>
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/RoundRobinPartitionFunction.h"
@@ -118,6 +120,19 @@ RowTypePtr toRowType(
   return ROW(std::move(names), std::move(types));
 }
 
+RowTypePtr toRowType(
+    const std::vector<protocol::VariableReferenceExpression>& variables,
+    const std::vector<TypePtr>& types) {
+  VELOX_CHECK_EQ(types.size(), variables.size());
+  std::vector<std::string> names;
+  names.reserve(variables.size());
+  for (const auto& variable : variables) {
+    names.emplace_back(variable.name);
+  }
+
+  return ROW(std::move(names), std::move(types));
+}
+
 std::shared_ptr<connector::ColumnHandle> toColumnHandle(
     const protocol::ColumnHandle* column,
     const TypeParser& typeParser) {
@@ -156,6 +171,27 @@ std::vector<core::TypedExprPtr> getProjections(
   }
 
   return expressions;
+}
+
+std::vector<connector::hive::HiveColumnHandlePtr> extractInputColumnsFromHandle(
+    const std::shared_ptr<const connector::ConnectorInsertTableHandle>&
+        connectorHandle,
+    const std::string& connectorId) {
+  if (auto hiveHandle = std::dynamic_pointer_cast<
+          const connector::hive::HiveInsertTableHandle>(connectorHandle)) {
+    return hiveHandle->inputColumns();
+  }
+
+  if (auto icebergHandle = std::dynamic_pointer_cast<
+          const connector::hive::iceberg::IcebergInsertTableHandle>(
+          connectorHandle)) {
+    return icebergHandle->inputColumns();
+  }
+
+  VELOX_UNSUPPORTED(
+      "Table write with type casting is only supported for Hive and Iceberg"
+      " connectors. Connector: {}",
+      connectorId);
 }
 
 template <TypeKind KIND>
@@ -1619,16 +1655,79 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       sourceVeloxPlan,
       tableWriteInfo,
       taskId);
+
+  // For TableWriteNode, column types are not parsed but taken from the
+  // column definition for the table handle itself to ensure that the type
+  // used for the write matches the column type and not a possible derived type
+  // from a literal.
+  std::vector<TypePtr> tableTypes;
+  std::vector<connector::hive::HiveColumnHandlePtr> inputColumns;
+
+  inputColumns = extractInputColumnsFromHandle(
+      insertTableHandle->connectorInsertTableHandle(),
+      insertTableHandle->connectorId());
+
+  // Check if we need to insert a cast ProjectNode
+  core::PlanNodePtr finalSourcePlan = sourceVeloxPlan;
+  const auto& sourceOutputType = sourceVeloxPlan->outputType();
+  bool needsCast = false;
+  for (size_t i = 0; i < inputColumns.size(); i++) {
+    const auto& inputColumn = inputColumns[i];
+    tableTypes.emplace_back(inputColumn->dataType());
+    if (!needsCast && i < node->columns.size()) {
+      const auto& sourceColName = node->columns[i].name;
+      auto sourceColIdx = sourceOutputType->getChildIdxIfExists(sourceColName);
+      if (sourceColIdx.has_value()) {
+        const auto& sourceType =
+            sourceOutputType->childAt(sourceColIdx.value());
+        if (!sourceType->equivalent(*inputColumn->dataType())) {
+          needsCast = true;
+        }
+      }
+    }
+  }
+  if (needsCast) {
+    std::vector<std::string> projectionNames;
+    std::vector<core::TypedExprPtr> projectionExprs;
+    for (size_t i = 0; i < node->columns.size(); i++) {
+      const auto& sourceColName = node->columns[i].name;
+      auto sourceColIdx = sourceOutputType->getChildIdxIfExists(sourceColName);
+      VELOX_USER_CHECK(
+          sourceColIdx.has_value(),
+          "Column {} not found in source output: {}",
+          sourceColName,
+          sourceOutputType->toString());
+      const auto& sourceType = sourceOutputType->childAt(sourceColIdx.value());
+      const auto& tableType = tableTypes[i];
+      // Keep the source column name, not the table column name
+      projectionNames.push_back(sourceColName);
+      auto fieldExpr = std::make_shared<core::FieldAccessTypedExpr>(
+          sourceType, sourceColName);
+
+      if (!sourceType->equivalent(*tableType)) {
+        projectionExprs.push_back(
+            std::make_shared<core::CallTypedExpr>(
+                tableType, std::vector<core::TypedExprPtr>{fieldExpr}, "cast"));
+      } else {
+        projectionExprs.push_back(fieldExpr);
+      }
+    }
+    finalSourcePlan = std::make_shared<core::ProjectNode>(
+        node->id + "_cast",
+        std::move(projectionNames),
+        std::move(projectionExprs),
+        sourceVeloxPlan);
+  }
   return std::make_shared<core::TableWriteNode>(
       node->id,
-      toRowType(node->columns, typeParser_),
+      toRowType(node->columns, tableTypes),
       node->columnNames,
       columnStatsSpec,
       std::move(insertTableHandle),
       node->partitioningScheme != nullptr,
       outputType,
       getCommitStrategy(),
-      sourceVeloxPlan);
+      finalSourcePlan);
 }
 
 std::shared_ptr<const core::TableWriteNode>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeWriter.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeWriter.java
@@ -771,4 +771,50 @@ public class TestPrestoNativeWriter
                 .setCatalogSessionProperty("hive", "orc_compression_codec", "ZSTD")
                 .build();
     }
+
+    @Test
+    public void testDecimalTypeCastingOnInsert()
+    {
+        String sourceTable = "decimal_source";
+        String targetTable = "decimal_target";
+
+        try {
+            assertUpdate(String.format("CREATE TABLE %s (" +
+                    "id INTEGER, " +
+                    "short_decimal DECIMAL(10, 2), " +
+                    "long_decimal DECIMAL(30, 10)" +
+                    ") WITH (format = 'PARQUET')", sourceTable));
+
+            assertUpdate(String.format("INSERT INTO %s VALUES " +
+                    "(1, DECIMAL '12345.67', DECIMAL '12345678901234567890.1234567890'), " +
+                    "(2, DECIMAL '999.99', DECIMAL '999999999999999999.9999999999'), " +
+                    "(3, DECIMAL '-123.45', DECIMAL '-123456789012345.123456')", sourceTable), 3);
+
+            assertUpdate(String.format("CREATE TABLE %s (" +
+                    "id INTEGER, " +
+                    "short_decimal DECIMAL(15, 2), " +
+                    "long_decimal DECIMAL(38, 10)" +
+                    ") WITH (format = 'PARQUET')", targetTable));
+
+            assertUpdate(String.format("INSERT INTO %s SELECT * FROM %s", targetTable, sourceTable), 3);
+
+            assertQuery(String.format("SELECT COUNT(*) FROM %s", targetTable), "VALUES (BIGINT '3')");
+            assertQuery(String.format("SELECT id, short_decimal, long_decimal FROM %s WHERE id = 1", targetTable),
+                    "VALUES (1, CAST('12345.67' AS DECIMAL(15,2)), CAST('12345678901234567890.1234567890' AS DECIMAL(38,10)))");
+            assertQuery(String.format("SELECT id, short_decimal, long_decimal FROM %s WHERE id = 2", targetTable),
+                    "VALUES (2, CAST('999.99' AS DECIMAL(15,2)), CAST('999999999999999999.9999999999' AS DECIMAL(38,10)))");
+            assertQuery(String.format("SELECT id, short_decimal FROM %s WHERE id = 3", targetTable),
+                    "VALUES (3, CAST('-123.45' AS DECIMAL(15,2)))");
+
+            // Test direct INSERT with literal values that need casting
+            assertUpdate(String.format("INSERT INTO %s VALUES " +
+                    "(4, DECIMAL '1.23', DECIMAL '1.2345678901')", targetTable), 1);
+            assertQuery(String.format("SELECT short_decimal, long_decimal FROM %s WHERE id = 4", targetTable),
+                    "VALUES (CAST('1.23' AS DECIMAL(15,2)), CAST('1.2345678901' AS DECIMAL(38,10)))");
+        }
+        finally {
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", targetTable));
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", sourceTable));
+        }
+    }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestUnpartitionedWrite.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestUnpartitionedWrite.java
@@ -800,4 +800,50 @@ public class TestUnpartitionedWrite
             assertUpdate(String.format("DROP TABLE IF EXISTS %s", tableName));
         }
     }
+
+    @Test
+    public void testDecimalTypeCastingOnInsert()
+    {
+        String sourceTable = "decimal_source";
+        String targetTable = "decimal_target";
+
+        try {
+            assertUpdate(String.format("CREATE TABLE %s (" +
+                    "id INTEGER, " +
+                    "short_decimal DECIMAL(10, 2), " +
+                    "long_decimal DECIMAL(30, 10)" +
+                    ") WITH (format = 'PARQUET')", sourceTable));
+
+            assertUpdate(String.format("INSERT INTO %s VALUES " +
+                    "(1, DECIMAL '12345.67', DECIMAL '12345678901234567890.1234567890'), " +
+                    "(2, DECIMAL '999.99', DECIMAL '999999999999999999.9999999999'), " +
+                    "(3, DECIMAL '-123.45', DECIMAL '-123456789012345.123456')", sourceTable), 3);
+
+            assertUpdate(String.format("CREATE TABLE %s (" +
+                    "id INTEGER, " +
+                    "short_decimal DECIMAL(15, 2), " +
+                    "long_decimal DECIMAL(38, 10)" +
+                    ") WITH (format = 'PARQUET')", targetTable));
+
+            assertUpdate(String.format("INSERT INTO %s SELECT * FROM %s", targetTable, sourceTable), 3);
+
+            assertQuery(String.format("SELECT COUNT(*) FROM %s", targetTable), "VALUES (BIGINT '3')");
+            assertQuery(String.format("SELECT id, short_decimal, long_decimal FROM %s WHERE id = 1", targetTable),
+                    "VALUES (1, CAST('12345.67' AS DECIMAL(15,2)), CAST('12345678901234567890.1234567890' AS DECIMAL(38,10)))");
+            assertQuery(String.format("SELECT id, short_decimal, long_decimal FROM %s WHERE id = 2", targetTable),
+                    "VALUES (2, CAST('999.99' AS DECIMAL(15,2)), CAST('999999999999999999.9999999999' AS DECIMAL(38,10)))");
+            assertQuery(String.format("SELECT id, short_decimal FROM %s WHERE id = 3", targetTable),
+                    "VALUES (3, CAST('-123.45' AS DECIMAL(15,2)))");
+
+            // Test direct INSERT with literal values that need casting
+            assertUpdate(String.format("INSERT INTO %s VALUES " +
+                    "(4, DECIMAL '1.23', DECIMAL '1.2345678901')", targetTable), 1);
+            assertQuery(String.format("SELECT short_decimal, long_decimal FROM %s WHERE id = 4", targetTable),
+                    "VALUES (CAST('1.23' AS DECIMAL(15,2)), CAST('1.2345678901' AS DECIMAL(38,10)))");
+        }
+        finally {
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", targetTable));
+            assertUpdate(String.format("DROP TABLE IF EXISTS %s", sourceTable));
+        }
+    }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Prestissimo decimal type is incorrect when inserting values in Parquet. Decimal precision, scale are written incorrectly to Parquet. Need to change presto velox parquet-tools inspect output on parquet tools created by with decimal to be similar to presto java.

To Reproduce
```
create table decimaltest(col0 DECIMAL(10, 2));
CREATE TABLE
insert into decimaltest values(1200.00);
INSERT: 1 row

parquet meta file.parquet
```
Before the PR the output for prestissimo would be showing the `col0` type as `DECIMAL(6,2)` instead of `DECIMAL(10,2)`.
```
Created by: parquet-mr version 2.6.0 (build parquet-cpp-velox)
Properties: (none)
Schema:
message schema {
  optional int32 col0 (DECIMAL(6,2));
}
```
Expected behavior
Java writer does not have this issue. It uses the right precision, scale. AND with this PR we are getting the same output for the DECIMAL type and scale.

```
Created by: parquet-mr version 1.13.1 (build db4183109d5b734ec5930d870cdae161e408ddba)
Properties: (none)
Schema:
message hive_schema {
  optional fixed_len_byte_array(5) col0 (DECIMAL(10,2));
}
```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
#26113 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

