### PR TITLE
misc(optimizer): Move join prefilter optimization after connector optimization

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -723,8 +723,6 @@ public class PlanOptimizers
                                 .addAll(new InlineSqlFunctions(metadata).rules())
                                 .build()));
 
-        builder.add(new JoinPrefilter(metadata));
-
         builder.add(
                 new IterativeOptimizer(
                         metadata,
@@ -780,6 +778,8 @@ public class PlanOptimizers
         // Pass after connector optimizer, as it relies on connector optimizer to identify empty input tables and convert them to empty ValuesNode
         builder.add(new SimplifyPlanWithEmptyInput(),
                 new PruneUnreferencedOutputs());
+
+        builder.add(new JoinPrefilter(metadata));
 
         builder.add(new IterativeOptimizer(
                         metadata,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -322,9 +322,11 @@ public class PlannerUtils
         }
 
         return new ProjectNode(
+                projectNode.getSourceLocation(),
                 idAllocator.getNextId(),
                 newSource,
-                newAssignments.build());
+                newAssignments.build(),
+                projectNode.getLocality());
     }
 
     private static TableScanNode cloneTableScan(TableScanNode scanNode, Session session, Metadata metadata, PlanNodeIdAllocator planNodeIdAllocator, List<VariableReferenceExpression> fieldsToKeep, Map<VariableReferenceExpression, VariableReferenceExpression> varMap)


### PR DESCRIPTION
## Description
As title, so that join prefilter can be used for plans which are changed after connector optimizations.

## Motivation and Context
As in description

## Impact
As in description

## Test Plan
Existing unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

