### PR TITLE
fix(native): Temporarily disable FunctionMetaDataTest.greatest

### DIFF
--- a/presto-native-execution/presto_cpp/main/functions/tests/FunctionMetadataTest.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/tests/FunctionMetadataTest.cpp
@@ -101,8 +101,9 @@ TEST_F(FunctionMetadataTest, covarSamp) {
 TEST_F(FunctionMetadataTest, elementAt) {
   testFunction("element_at", "ElementAt.json", 3);
 }
-
-TEST_F(FunctionMetadataTest, greatest) {
+// Disabled temporarily to avoid test failures due to
+// adding new signatures to the function.
+TEST_F(FunctionMetadataTest, DISABLED_greatest) {
   testFunction("greatest", "Greatest.json", 13);
 }
 


### PR DESCRIPTION
Summary: Test broke due to https://github.com/facebookincubator/velox/pull/15666 (D87961025) temporarily disable to add new signatures to `greatest`.

Differential Revision: D88359540

```
== NO RELEASE NOTE ==
```

