### PR TITLE
fix: Add TIME_WITH_TIME_ZONE type to NativeTypeManager

### DIFF
--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
@@ -63,6 +63,7 @@ import static com.facebook.presto.common.type.StandardTypes.TDIGEST;
 import static com.facebook.presto.common.type.StandardTypes.TIME;
 import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
 import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.StandardTypes.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.StandardTypes.TINYINT;
 import static com.facebook.presto.common.type.StandardTypes.UNKNOWN;
 import static com.facebook.presto.common.type.StandardTypes.UUID;
@@ -93,6 +94,7 @@ public class NativeTypeManager
                     HYPER_LOG_LOG,
                     P4_HYPER_LOG_LOG,
                     JSON,
+                    TIME_WITH_TIME_ZONE,
                     TIMESTAMP_WITH_TIME_ZONE,
                     UUID,
                     IPADDRESS,


### PR DESCRIPTION
## Description
Adds type `TIME_WITH_TIME_ZONE` to list of supported Presto C++ types in `NativeTypeManager`.

## Motivation and Context
`TIME_WITH_TIME_ZONE` type is now supported in Velox.

## Impact
Queries with `TIME_WITH_TIME_ZONE` type will not fail with `Unsupported type` error in Presto C++ with sidecar.

## Test Plan
Verified with aggregation tests in https://github.com/prestodb/presto/pull/26154.


```
== NO RELEASE NOTE ==
```

