### PR TITLE
[codemod][lowrisk] Enable `-Wunused-exception-parameter` in github/PACKAGE +1

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
@@ -222,7 +222,7 @@ std::string PrestoServerOperations::taskOperation(
         limit = limitStr == proxygen::empty_string
             ? std::numeric_limits<uint32_t>::max()
             : stoi(limitStr);
-      } catch (std::exception& ex) {
+      } catch (std::exception&) {
         VELOX_USER_FAIL("Invalid limit provided '{}'.", limitStr);
       }
       std::stringstream oss;

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -261,7 +261,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                     summarize,
                     startProcessCpuTimeNs,
                     receiveThrift);
-              } catch (const velox::VeloxException& e) {
+              } catch (const velox::VeloxException&) {
                 // Creating an empty task, putting errors inside so that next
                 // status fetch from coordinator will catch the error and well
                 // categorize it.
@@ -271,7 +271,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                       std::current_exception(),
                       summarize,
                       startProcessCpuTimeNs);
-                } catch (const velox::VeloxUserError& e) {
+                } catch (const velox::VeloxUserError&) {
                   throw;
                 }
               }

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -70,7 +70,7 @@ void sendResponse(
   std::string messageBody;
   try {
     messageBody = body.dump();
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     messageBody =
         body.dump(-1, ' ', false, nlohmann::detail::error_handler_t::replace);
     LOG(WARNING) << "Failed to serialize json to string. "

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -126,7 +126,7 @@ BroadcastExchangeSource::createExchangeSource(
   try {
     broadcastFileInfo =
         BroadcastFileInfo::deserialize(broadcastInfoJson.value());
-  } catch (const VeloxException& e) {
+  } catch (const VeloxException&) {
     throw;
   } catch (const std::exception& e) {
     VELOX_USER_FAIL("BroadcastInfo deserialization failed: {}", e.what());

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
@@ -23,7 +23,7 @@ namespace facebook::presto::operators {
 #define CALL_SHUFFLE(call, methodName)                                \
   try {                                                               \
     call;                                                             \
-  } catch (const velox::VeloxException& e) {                          \
+  } catch (const velox::VeloxException&) {                            \
     throw;                                                            \
   } catch (const std::exception& e) {                                 \
     VELOX_FAIL("ShuffleReader::{} failed: {}", methodName, e.what()); \

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
@@ -26,7 +26,7 @@ velox::core::PlanNodeId deserializePlanNodeId(const folly::dynamic& obj) {
 #define CALL_SHUFFLE(call, methodName)                                \
   try {                                                               \
     call;                                                             \
-  } catch (const VeloxException& e) {                                 \
+  } catch (const VeloxException&) {                                   \
     throw;                                                            \
   } catch (const std::exception& e) {                                 \
     VELOX_FAIL("ShuffleWriter::{} failed: {}", methodName, e.what()); \

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -209,7 +209,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
              try {
                expectedBytes =
                    toCapacity(expectedValue, config::CapacityUnit::BYTE);
-             } catch (const VeloxUserError& e) {
+             } catch (const VeloxUserError&) {
                expectedBytes = std::stoull(expectedValue);
              }
              EXPECT_EQ(expectedBytes, config.maxOutputBufferSize());
@@ -231,7 +231,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
              try {
                expectedBytes =
                    toCapacity(expectedValue, config::CapacityUnit::BYTE);
-             } catch (const VeloxUserError& e) {
+             } catch (const VeloxUserError&) {
                expectedBytes = std::stoull(expectedValue);
              }
              EXPECT_EQ(expectedBytes, config.maxPartitionedOutputBufferSize());
@@ -251,7 +251,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
              try {
                expectedBytes =
                    toCapacity(expectedValue, config::CapacityUnit::BYTE);
-             } catch (const VeloxUserError& e) {
+             } catch (const VeloxUserError&) {
                expectedBytes = std::stoull(expectedValue);
              }
              EXPECT_EQ(
@@ -270,7 +270,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
              try {
                expectedBytes =
                    toCapacity(expectedValue, config::CapacityUnit::BYTE);
-             } catch (const VeloxUserError& e) {
+             } catch (const VeloxUserError&) {
                expectedBytes = std::stoull(expectedValue);
              }
              EXPECT_EQ(expectedBytes, config.maxExchangeBufferSize());


### PR DESCRIPTION
Summary:
This diff enables compilation warning flags for the directory in question. Further details are in [this workplace post](https://fb.workplace.com/permalink.php?story_fbid=pfbid02XaWNiCVk69r1ghfvDVpujB8Hr9Y61uDvNakxiZFa2jwiPHscVdEQwCBHrmWZSyMRl&id=100051201402394).

This is a low-risk diff. There are **no run-time effects** and the diff has already been observed to compile locally. **If the code compiles, it work; test errors are spurious.**

Differential Revision: D87365532


