### PR TITLE
fix: Make http2 param configurable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClientConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/ReactorNettyHttpClientConfig.java
@@ -37,11 +37,11 @@ public class ReactorNettyHttpClientConfig
     private int eventLoopThreadCount = Runtime.getRuntime().availableProcessors();
     private Duration connectTimeout = new Duration(10, SECONDS);
     private Duration requestTimeout = new Duration(10, SECONDS);
-    private Duration maxIdleTime = new Duration(45, SECONDS);
-    private Duration evictBackgroundTime = new Duration(15, SECONDS);
-    private Duration pendingAcquireTimeout = new Duration(2, SECONDS);
-    private DataSize maxInitialWindowSize = new DataSize(25, MEGABYTE);
-    private DataSize maxFrameSize = new DataSize(8, MEGABYTE);
+    private Duration maxIdleTime = new Duration(0, SECONDS);
+    private Duration evictBackgroundTime = new Duration(0, SECONDS);
+    private Duration pendingAcquireTimeout = new Duration(0, SECONDS);
+    private DataSize maxInitialWindowSize = new DataSize(0, MEGABYTE);
+    private DataSize maxFrameSize = new DataSize(0, MEGABYTE);
     private String keyStorePath;
     private String keyStorePassword;
     private String trustStorePath;
@@ -53,6 +53,59 @@ public class ReactorNettyHttpClientConfig
     private DataSize tcpBufferSize = new DataSize(512, KILOBYTE);
     private DataSize writeBufferWaterMarkLow = new DataSize(256, KILOBYTE);
     private DataSize writeBufferWaterMarkHigh = new DataSize(512, KILOBYTE);
+
+    private boolean isHttp2ConnectionPoolStatsTrackingEnabled;
+    private boolean isHttp2ClientStatsTrackingEnabled;
+    private boolean isChannelOptionSoKeepAliveEnabled = true;
+    private boolean isChannelOptionTcpNoDelayEnabled = true;
+
+    public boolean isHttp2ClientStatsTrackingEnabled()
+    {
+        return isHttp2ClientStatsTrackingEnabled;
+    }
+
+    @Config("reactor.enable-http2-client-stats-tracking")
+    public ReactorNettyHttpClientConfig setHttp2ClientStatsTrackingEnabled(boolean isHttp2ClientStatsTrackingEnabled)
+    {
+        this.isHttp2ClientStatsTrackingEnabled = isHttp2ClientStatsTrackingEnabled;
+        return this;
+    }
+
+    public boolean isHttp2ConnectionPoolStatsTrackingEnabled()
+    {
+        return isHttp2ConnectionPoolStatsTrackingEnabled;
+    }
+
+    @Config("reactor.enable-http2-connection-pool-stats-tracking")
+    public ReactorNettyHttpClientConfig setHttp2ConnectionPoolStatsTrackingEnabled(boolean isHttp2ConnectionPoolStatsTrackingEnabled)
+    {
+        this.isHttp2ConnectionPoolStatsTrackingEnabled = isHttp2ConnectionPoolStatsTrackingEnabled;
+        return this;
+    }
+
+    public boolean isChannelOptionSoKeepAliveEnabled()
+    {
+        return isChannelOptionSoKeepAliveEnabled;
+    }
+
+    @Config("reactor.channel-option-so-keep-alive")
+    public ReactorNettyHttpClientConfig setChannelOptionSoKeepAliveEnabled(boolean isChannelOptionSoKeepAliveEnabled)
+    {
+        this.isChannelOptionSoKeepAliveEnabled = isChannelOptionSoKeepAliveEnabled;
+        return this;
+    }
+
+    public boolean isChannelOptionTcpNoDelayEnabled()
+    {
+        return isChannelOptionTcpNoDelayEnabled;
+    }
+
+    @Config("reactor.channel-option-tcp-no-delay")
+    public ReactorNettyHttpClientConfig setChannelOptionTcpNoDelayEnabled(boolean isChannelOptionTcpNoDelayEnabled)
+    {
+        this.isChannelOptionTcpNoDelayEnabled = isChannelOptionTcpNoDelayEnabled;
+        return this;
+    }
 
     @Config("reactor.enable-http2-compression")
     public ReactorNettyHttpClientConfig setHttp2CompressionEnabled(boolean http2CompressionEnabled)

--- a/presto-main/src/test/java/com/facebook/presto/remotetask/TestReactorNettyHttpClientConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/remotetask/TestReactorNettyHttpClientConfig.java
@@ -43,11 +43,11 @@ public class TestReactorNettyHttpClientConfig
                 .setEventLoopThreadCount(Runtime.getRuntime().availableProcessors())
                 .setConnectTimeout(new Duration(10, SECONDS))
                 .setRequestTimeout(new Duration(10, SECONDS))
-                .setMaxIdleTime(new Duration(45, SECONDS))
-                .setEvictBackgroundTime(new Duration(15, SECONDS))
-                .setPendingAcquireTimeout(new Duration(2, SECONDS))
-                .setMaxInitialWindowSize(new DataSize(25, MEGABYTE)) // 25MB
-                .setMaxFrameSize(new DataSize(8, MEGABYTE)) // 8MB
+                .setMaxIdleTime(new Duration(0, SECONDS))
+                .setEvictBackgroundTime(new Duration(0, SECONDS))
+                .setPendingAcquireTimeout(new Duration(0, SECONDS))
+                .setMaxInitialWindowSize(new DataSize(0, MEGABYTE))
+                .setMaxFrameSize(new DataSize(0, MEGABYTE))
                 .setKeyStorePath(null)
                 .setKeyStorePassword(null)
                 .setTrustStorePath(null)
@@ -57,7 +57,11 @@ public class TestReactorNettyHttpClientConfig
                 .setCompressionSavingThreshold(0.1)
                 .setTcpBufferSize(new DataSize(512, KILOBYTE))
                 .setWriteBufferWaterMarkHigh(new DataSize(512, KILOBYTE))
-                .setWriteBufferWaterMarkLow(new DataSize(256, KILOBYTE)));
+                .setWriteBufferWaterMarkLow(new DataSize(256, KILOBYTE))
+                .setHttp2ConnectionPoolStatsTrackingEnabled(false)
+                .setHttp2ClientStatsTrackingEnabled(false)
+                .setChannelOptionSoKeepAliveEnabled(true)
+                .setChannelOptionTcpNoDelayEnabled(true));
     }
 
     @Test
@@ -88,6 +92,10 @@ public class TestReactorNettyHttpClientConfig
                 .put("reactor.tcp-buffer-size", "256kB")
                 .put("reactor.tcp-write-buffer-water-mark-high", "256kB")
                 .put("reactor.tcp-write-buffer-water-mark-low", "128kB")
+                .put("reactor.enable-http2-connection-pool-stats-tracking", "true")
+                .put("reactor.enable-http2-client-stats-tracking", "true")
+                .put("reactor.channel-option-so-keep-alive", "false")
+                .put("reactor.channel-option-tcp-no-delay", "false")
                 .build();
 
         ReactorNettyHttpClientConfig expected = new ReactorNettyHttpClientConfig()
@@ -114,7 +122,11 @@ public class TestReactorNettyHttpClientConfig
                 .setCompressionSavingThreshold(0.2)
                 .setTcpBufferSize(new DataSize(256, KILOBYTE))
                 .setWriteBufferWaterMarkHigh(new DataSize(256, KILOBYTE))
-                .setWriteBufferWaterMarkLow(new DataSize(128, KILOBYTE));
+                .setWriteBufferWaterMarkLow(new DataSize(128, KILOBYTE))
+                .setHttp2ConnectionPoolStatsTrackingEnabled(true)
+                .setHttp2ClientStatsTrackingEnabled(true)
+                .setChannelOptionSoKeepAliveEnabled(false)
+                .setChannelOptionTcpNoDelayEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
1. Make http2 param configurable
2. 
## Motivation and Context
1. make them configurable which is easy for debugging

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
passed verifier

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

