### PR TITLE
fix(native): Fix crash in proxygen::ResponseHandler::onEOM callback

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -248,13 +248,17 @@ class ResponseHandler : public proxygen::HTTPTransactionHandler {
   }
 
   void onEOM() noexcept override {
-    promise_.setValue(std::move(response_));
+    if (!promise_.isFulfilled()) {
+      promise_.setValue(std::move(response_));
+    }
   }
 
   void onUpgrade(proxygen::UpgradeProtocol /* protocol*/) noexcept override {}
 
   void onError(const proxygen::HTTPException& error) noexcept override {
-    promise_.setException(error);
+    if (!promise_.isFulfilled()) {
+      promise_.setException(error);
+    }
   }
 
   void onEgressPaused() noexcept override {}


### PR DESCRIPTION
Summary:
`folly::PromiseAlreadySatisfie` exception in `proxygen::ResponseHandler::onEOM` callback causes an abort and crash:
```
terminate called after throwing an instance of 'folly::PromiseAlreadySatisfied'
  what():  Promise already satisfied
*** Aborted at 1765239333 (Unix time, try 'date -d 1765239333') ***
*** Signal 6 (SIGABRT) (0x75830000006d) received by PID 109 (pthread TID 0x7ff32fe9f000) (linux TID 755) (maybe from PID 109, UID 30083) (code: -6), stack trace: ***
    @ 0000000016f8bfaa folly::symbolizer::(anonymous namespace)::innerSignalHandler(int, siginfo_t*, void*) [clone .__uniq.302291754384189453301783370447166124111]
                       ./fbcode/folly/debugging/symbolizer/SignalHandler.cpp:526
    @ 0000000016f8bf17 folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*) [clone .__uniq.302291754384189453301783370447166124111] [clone .llvm.1795421822937876201]
                       ./fbcode/folly/debugging/symbolizer/SignalHandler.cpp:547
    @ 000000000004455f (unknown)
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/unix/sysv/linux/libc_sigaction.c:8
                       -> /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c
    @ 000000000009c993 pthread_kill
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_kill.c:46
    @ 00000000000444ac raise
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/posix/raise.c:26
    @ 000000000002c432 abort
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/stdlib/abort.c:79
    @ 00000000000a3fc4 __gnu_cxx::__verbose_terminate_handler()
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/vterminate.cc:95
    @ 00000000000a1b29 __cxxabiv1::__terminate(void (*)())
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_terminate.cc:48
    @ 00000000000a1b94 std::terminate()
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_terminate.cc:58
    @ 0000000012f0858d __clang_call_terminate
    @ 000000003dd318d3 facebook::presto::http::ResponseHandler::onEOM()
                       ./fbcode/github/presto-trunk/presto-native-execution/presto_cpp/main/http/HttpClient.cpp:251
    @ 0000000040564eaa proxygen::HTTPTransaction::onIngressEOM()
                       ./fbcode/proxygen/lib/http/session/HTTPTransaction.cpp:583
    @ 0000000040564c86 non-virtual thunk to proxygen::PassThroughHTTPCodecFilter::onMessageComplete(unsigned long, bool)
                       fbcode/proxygen/lib/http/session/HTTPSession.cpp:1039
    @ 000000004055dfba proxygen::HTTP2Codec::parseDataFrameData(folly::io::Cursor&, unsigned long, unsigned long&)
                       ./fbcode/proxygen/lib/http/codec/HTTP2Codec.cpp:284
    @ 000000004055db3b proxygen::HTTP2Codec::onIngress(folly::IOBuf const&)
                       ./fbcode/proxygen/lib/http/codec/HTTP2Codec.cpp:129
    @ 00000000405626a0 proxygen::HTTPSession::readDataAvailable(unsigned long)
                       ./fbcode/proxygen/lib/http/session/HTTPSession.cpp:575
    @ 00000000404108ce folly::AsyncSocket::processNormalRead()
                       ./fbcode/folly/io/async/AsyncSocket.cpp:3327
    @ 0000000040410299 folly::AsyncSocket::handleRead()
                       ./fbcode/folly/io/async/AsyncSocket.cpp:3400
    @ 0000000040410210 folly::AsyncSSLSocket::handleRead()
                       ./fbcode/folly/io/async/AsyncSSLSocket.cpp:0
    @ 000000004045861a folly::EventHandler::libeventCallback(int, short, void*)
                       fbcode/folly/io/async/AsyncSocket.cpp:0
    @ 00000000404583bd event_process_active
                       /home/engshare/third-party2/libevent/1.4.14b_hphp/src/libevent-1.4.14b-stable/event.c:390
    @ 00000000404581ef event_base_loop
                       /home/engshare/third-party2/libevent/1.4.14b_hphp/src/libevent-1.4.14b-stable/event.c:532
    @ 00000000404595ce folly::EventBase::loopMain(int, folly::EventBase::LoopOptions)
                       ./fbcode/folly/io/async/EventBase.cpp:0
    @ 00000000143b5065 folly::EventBase::loopBody(int, folly::EventBase::LoopOptions)
                       ./fbcode/folly/io/async/EventBase.cpp:539
    @ 00000000143b4fef folly::EventBase::loop()
                       ./fbcode/folly/io/async/EventBase.cpp:500
    @ 00000000143b5e36 folly::EventBase::loopForever()
                       ./fbcode/folly/io/async/EventBase.cpp:810
    @ 00000000143e8936 folly::IOThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
                       ./fbcode/folly/executors/IOThreadPoolExecutor.cpp:252
    @ 0000000040c1311b void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
                       fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/invoke.h:74
    @ 00000000000df5b4 execute_native_thread_routine
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/src/c++11/../../../.././libstdc++-v3/src/c++11/thread.cc:82
    @ 000000000009abc8 start_thread
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_create.c:434
    @ 000000000012ce4b __clone3
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```
For Facebook engs. Here are other crashes with this stacktrace for the last 3 months: https://fburl.com/scuba/coredumper/ebhl67rp

## Root cause
The current implementation of ResponseHandler is based on the assumption that only one of the`onEOM()` and `onError()` calbacks may be called at the end. But it's not correct. This is what we have in proxygen documentation:
https://github.com/facebook/proxygen/blob/main/proxygen/lib/http/session/HTTPTransaction.h
```
  /**
   * Can be called once per transaction. If you had previously called
   * pauseIngress(), this callback will be delayed until you call
   * resumeIngress(). After this callback is received, there will be no
   * more normal ingress callbacks received (onEgress*() and onError()
   * may still be invoked). The Handler should consider
   * ingress complete after receiving this message. This Transaction is
   * still valid, and work may still occur on it until detachTransaction
   * is called.
   */
  virtual void onEOM() noexcept = 0;
...
  /**
   * Can be called at any time before detachTransaction(). This callback
   * implies that an error has occurred. To determine if ingress or egress
   * is affected, check the direciont on the HTTPException. If the
   * direction is INGRESS, it MAY still be possible to send egress.
   */
  virtual void onError(const HTTPException& error) noexcept = 0;
```
Basically the both callbacks may be called without strict order.

## Fix
For the fix, we check if the promise is already fulfilled. The first callback should be sufficient for us to continue the client code.

== NO RELEASE NOTE ==

Differential Revision: D88708402
