### PR TITLE
refactor(native): Remove redundant VeloxException error handlers

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -189,11 +189,6 @@ proxygen::RequestHandler* TaskResource::acknowledgeResults(
               }
             })
             .thenError(
-                folly::tag_t<velox::VeloxException>{},
-                [downstream](auto&& e) {
-                  http::sendErrorResponse(downstream, e.what());
-                })
-            .thenError(
                 folly::tag_t<std::exception>{},
                 [downstream, handlerState](auto&& e) {
                   if (!handlerState->requestExpired()) {
@@ -290,13 +285,6 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                 }
               }
             })
-            .thenError(
-                folly::tag_t<velox::VeloxException>{},
-                [downstream, handlerState](auto&& e) {
-                  if (!handlerState->requestExpired()) {
-                    http::sendErrorResponse(downstream, e.what());
-                  }
-                })
             .thenError(
                 folly::tag_t<std::exception>{},
                 [downstream, handlerState](auto&& e) {
@@ -456,13 +444,6 @@ proxygen::RequestHandler* TaskResource::deleteTask(
               }
             })
             .thenError(
-                folly::tag_t<velox::VeloxException>{},
-                [downstream, handlerState](auto&& e) {
-                  if (!handlerState->requestExpired()) {
-                    http::sendErrorResponse(downstream, e.what());
-                  }
-                })
-            .thenError(
                 folly::tag_t<std::exception>{},
                 [downstream, handlerState](auto&& e) {
                   if (!handlerState->requestExpired()) {
@@ -553,14 +534,6 @@ proxygen::RequestHandler* TaskResource::getResults(
                     builder.body(std::move(result->data)).sendWithEOM();
                   })
                   .thenError(
-                      folly::tag_t<velox::VeloxException>{},
-                      [downstream,
-                       handlerState](const velox::VeloxException& e) {
-                        if (!handlerState->requestExpired()) {
-                          http::sendErrorResponse(downstream, e.what());
-                        }
-                      })
-                  .thenError(
                       folly::tag_t<std::exception>{},
                       [downstream, handlerState](const std::exception& e) {
                         if (!handlerState->requestExpired()) {
@@ -617,14 +590,6 @@ proxygen::RequestHandler* TaskResource::getTaskStatus(
                             json taskStatusJson = *taskStatus;
                             http::sendOkResponse(downstream, taskStatusJson);
                           }
-                        }
-                      })
-                  .thenError(
-                      folly::tag_t<velox::VeloxException>{},
-                      [downstream,
-                       handlerState](const velox::VeloxException& e) {
-                        if (!handlerState->requestExpired()) {
-                          http::sendErrorResponse(downstream, e.what());
                         }
                       })
                   .thenError(
@@ -691,14 +656,6 @@ proxygen::RequestHandler* TaskResource::getTaskInfo(
                     }
                   })
                   .thenError(
-                      folly::tag_t<velox::VeloxException>{},
-                      [downstream,
-                       handlerState](const velox::VeloxException& e) {
-                        if (!handlerState->requestExpired()) {
-                          http::sendErrorResponse(downstream, e.what());
-                        }
-                      })
-                  .thenError(
                       folly::tag_t<std::exception>{},
                       [downstream, handlerState](const std::exception& e) {
                         if (!handlerState->requestExpired()) {
@@ -735,13 +692,6 @@ proxygen::RequestHandler* TaskResource::removeRemoteSource(
                 http::sendOkResponse(downstream);
               }
             })
-            .thenError(
-                folly::tag_t<velox::VeloxException>{},
-                [downstream, handlerState](const velox::VeloxException& e) {
-                  if (!handlerState->requestExpired()) {
-                    http::sendErrorResponse(downstream, e.what());
-                  }
-                })
             .thenError(
                 folly::tag_t<std::exception>{},
                 [downstream, handlerState](const std::exception& e) {


### PR DESCRIPTION
Summary: velox::VeloxException inherits from std::exception, making the separate VeloxException error handlers redundant. Removed duplicate handlers while keeping std::exception handlers that catch both exception types.

To confirm that we don't need 2 handlers I wrote a small test (facebook engs can find it in D88794923 diff):
<details>
<summary>Test</summary>

```c++
// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

#include <folly/futures/Future.h>
#include <gtest/gtest.h>
#include <velox/common/base/Exceptions.h>

namespace facebook::detail {

struct MockDownstream {
  std::string lastErrorMessage;
};

void sendErrorResponse(
    std::shared_ptr<MockDownstream> downstream,
    const std::string& message) {
  downstream->lastErrorMessage = message;
}

TEST(ErrorHandlingTest, SingleHandlerCatchesAllExceptions) {
  auto downstream1 = std::make_shared<MockDownstream>();
  auto downstream2 = std::make_shared<MockDownstream>();

  auto futureWithBothHandlers =
      folly::makeFuture()
          .thenValue(
              [](auto&&) -> folly::Unit { VELOX_USER_FAIL("Test message"); })
          .thenError(
              folly::tag_t<velox::VeloxException>{},
              [downstream1](auto&& e) {
                sendErrorResponse(downstream1, e.what());
              })
          .thenError(folly::tag_t<std::exception>{}, [downstream1](auto&& e) {
            sendErrorResponse(downstream1, e.what());
          });

  auto futureWithSingleHandler =
      folly::makeFuture()
          .thenValue(
              [](auto&&) -> folly::Unit { VELOX_USER_FAIL("Test message"); })
          .thenError(folly::tag_t<std::exception>{}, [downstream2](auto&& e) {
            sendErrorResponse(downstream2, e.what());
          });

  futureWithBothHandlers.wait();
  futureWithSingleHandler.wait();

  EXPECT_NE(
      downstream1->lastErrorMessage.find("Test message"), std::string::npos);
  EXPECT_NE(
      downstream2->lastErrorMessage.find("Test message"), std::string::npos);

  LOG(WARNING) << "downstream1->lastErrorMessage: "
               << downstream1->lastErrorMessage;
  LOG(WARNING) << "downstream2->lastErrorMessage: "
               << downstream2->lastErrorMessage;
}

} // namespace facebook::detail
``` 
The output:
```
BUILD SUCCEEDED - starting your binary
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ErrorHandlingTest
[ RUN      ] ErrorHandlingTest.SingleHandlerCatchesAllExceptions
--------------------------------------------------------------------------------
downstream1->lastErrorMessage: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Test message
Retriable: False
Function: operator()
File: fbcode/scripts/timaou/main.cpp
Line: 26
Stack trace:
Stack trace has been disabled. Use --velox_exception_user_stacktrace_enabled=true to enable it.
--------------------------------------------------------------------------------
downstream2->lastErrorMessage: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Test message
Retriable: False
Function: operator()
File: fbcode/scripts/timaou/main.cpp
Line: 39
Stack trace:
Stack trace has been disabled. Use --velox_exception_user_stacktrace_enabled=true to enable it.
--------------------------------------------------------------------------------
[       OK ] ErrorHandlingTest.SingleHandlerCatchesAllExceptions (0 ms)
[----------] 1 test from ErrorHandlingTest (0 ms total)
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.
```
The exception messages are identical.
</details>

== NO RELEASE NOTE ==

Differential Revision: D88794817




