### PR TITLE
misc: Expose TotalRunningTaskCount on Coordinator

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -529,7 +529,8 @@ public final class InternalResourceGroupManager<C>
         return taskLimitExceeded.get() ? 1 : 0;
     }
 
-    private int getTotalRunningTaskCount()
+    @Managed
+    public int getTotalRunningTaskCount()
     {
         int taskCount = 0;
         for (RootInternalResourceGroup rootGroup : rootGroups) {


### PR DESCRIPTION
Summary: Expose running task count so we can use it to track how many in flight tasks a coordinator is handling. Due to recent coordinator overloads/crashes, we want to use this metric to do load testing on the coordinator.

Differential Revision: D88803334


== NO RELEASE NOTE ==
