### PR TITLE
feat(plugin-cassandra): Add support for Astra DB

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -192,6 +192,20 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.20.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <!-- dependencyManagement is to fix the Require upper bound dependencies error for slf4j -->

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -32,6 +32,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import jakarta.inject.Singleton;
 
+import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -77,18 +78,44 @@ public class CassandraClientModule
             CassandraClientConfig config,
             JsonCodec<List<ExtraColumnMetadata>> extraColumnMetadataCodec)
     {
+        return createCassandraSession(Cluster.builder(),
+                connectorId,
+                config,
+                extraColumnMetadataCodec);
+    }
+    public static CassandraSession createCassandraSession(
+            Cluster.Builder clusterBuilder,
+            CassandraConnectorId connectorId,
+            CassandraClientConfig config,
+            JsonCodec<List<ExtraColumnMetadata>> extraColumnMetadataCodec)
+    {
         requireNonNull(config, "config is null");
         requireNonNull(extraColumnMetadataCodec, "extraColumnMetadataCodec is null");
 
-        Cluster.Builder clusterBuilder = Cluster.builder()
-                .withProtocolVersion(config.getProtocolVersion());
+        clusterBuilder.withProtocolVersion(config.getProtocolVersion());
+        checkArgument(!(config.getAstraSecureConnectBundlePath().isPresent() &&
+                config.getContactPoints().isPresent()),
+                "Contact points and Astra Secure Connect Bundle cannot both be specified!");
 
-        List<String> contactPoints = requireNonNull(config.getContactPoints(), "contactPoints is null");
-        checkArgument(!contactPoints.isEmpty(), "empty contactPoints");
+        checkArgument(config.getAstraSecureConnectBundlePath().isPresent()
+                || config.getContactPoints().isPresent(),
+                "contactPoints or astraSecureConnectBundlePath are not provided");
+
+        if (config.getAstraSecureConnectBundlePath().isPresent()) {
+            clusterBuilder.withCloudSecureConnectBundle(new File(config.getAstraSecureConnectBundlePath().get()));
+        }
+        else {
+            checkArgument(config.getContactPoints().isPresent()
+                    && config.getContactPoints().get().isEmpty() == false,
+                    "contactPoints is not provided");
+            List<String> contactPoints = config.getContactPoints().get();
+            checkArgument(!contactPoints.isEmpty(), "empty contactPoints");
+            contactPoints.forEach(clusterBuilder::addContactPoint);
+        }
+
         clusterBuilder.withPort(config.getNativeProtocolPort());
         clusterBuilder.withReconnectionPolicy(new ExponentialReconnectionPolicy(500, 10000));
         clusterBuilder.withRetryPolicy(config.getRetryPolicy().getPolicy());
-
         LoadBalancingPolicy loadPolicy = new RoundRobinPolicy();
 
         if (config.isUseDCAware()) {
@@ -147,14 +174,10 @@ public class CassandraClientModule
                     config.getSpeculativeExecutionDelay().toMillis(), // delay before a new execution is launched
                     config.getSpeculativeExecutionLimit())); // maximum number of executions
         }
-
         return new NativeCassandraSession(
                 connectorId.toString(),
                 extraColumnMetadataCodec,
-                new ReopeningCluster(() -> {
-                    contactPoints.forEach(clusterBuilder::addContactPoint);
-                    return clusterBuilder.build();
-                }),
+                new ReopeningCluster(() -> { return clusterBuilder.build(); }),
                 config.getNoHostAvailableRetryTimeout(), config.isCaseSensitiveNameMatchingEnabled());
     }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraClientModuleTest.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraClientModuleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.facebook.airlift.json.JsonCodec;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CassandraClientModuleTest
+{
+    private CassandraConnectorId ccId;
+
+    private Cluster.Builder mockClusterBuilder;
+
+    private CassandraClientConfig ccConfig;
+
+    private JsonCodec<List<ExtraColumnMetadata>> mockExtraColumnMetadataCodec;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        ccId = new CassandraConnectorId("test");
+        mockClusterBuilder = Mockito.mock(Cluster.Builder.class, Answers.RETURNS_SELF);
+        when(mockClusterBuilder.build()).thenReturn(mock(Cluster.class));
+        ccConfig = new CassandraClientConfig();
+        mockExtraColumnMetadataCodec = Mockito.mock(JsonCodec.class);
+    }
+
+    @Test
+    public void testContactPointsOnly()
+    {
+        ccConfig.setContactPoints("127.0.0.1", "127.0.0.2", "127.0.0.3");
+        CassandraClientModule.createCassandraSession(mockClusterBuilder, ccId, ccConfig, mockExtraColumnMetadataCodec);
+        verify(mockClusterBuilder, times(3)).addContactPoint(anyString());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testContactPointsAndAstraBundleThrowError()
+    {
+        ccConfig.setContactPoints("127.0.0.1", "127.0.0.2", "127.0.0.3");
+        String testData = "Astra secure connect bundle data..";
+        ccConfig.setAstraSecureConnectBundlePath("/tmp/my_astra.csb");
+        CassandraClientModule.createCassandraSession(mockClusterBuilder, ccId, ccConfig, mockExtraColumnMetadataCodec);
+    }
+
+    @Test
+    public void astraBundleOnly()
+    {
+        String testData = "Astra secure connect bundle data..";
+        ccConfig.setAstraSecureConnectBundlePath("/tmp/my_astra.csb");
+        CassandraClientModule.createCassandraSession(mockClusterBuilder, ccId, ccConfig, mockExtraColumnMetadataCodec);
+        verify(mockClusterBuilder).withCloudSecureConnectBundle(any(File.class));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNoContactPointsOrAstraBundle()
+    {
+        CassandraClientModule.createCassandraSession(mockClusterBuilder, ccId, ccConfig, mockExtraColumnMetadataCodec);
+    }
+}

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraServer.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraServer.java
@@ -66,7 +66,7 @@ public class CassandraServer
     {
         log.info("Starting cassandra...");
 
-        this.dockerContainer = new GenericContainer<>("cassandra:2.1.16")
+        this.dockerContainer = new GenericContainer<>("cassandra:3.11.19")
                 .withExposedPorts(PORT)
                 .withCopyFileToContainer(forHostPath(prepareCassandraYaml()), "/etc/cassandra/cassandra.yaml");
         this.dockerContainer.start();

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraClientConfig.java
@@ -38,6 +38,7 @@ public class TestCassandraClientConfig
                 .setFetchSize(5_000)
                 .setConsistencyLevel(ConsistencyLevel.ONE)
                 .setContactPoints("")
+                .setAstraSecureConnectBundlePath(null)
                 .setNativeProtocolPort(9042)
                 .setPartitionSizeForBatchSelect(100)
                 .setSplitSize(1_024)
@@ -74,6 +75,7 @@ public class TestCassandraClientConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("cassandra.contact-points", "host1,host2")
+                .put("cassandra.astra-secure-connect-bundle-path", "/tmp/scb.zip")
                 .put("cassandra.native-protocol-port", "9999")
                 .put("cassandra.fetch-size", "10000")
                 .put("cassandra.consistency-level", "TWO")
@@ -109,6 +111,7 @@ public class TestCassandraClientConfig
 
         CassandraClientConfig expected = new CassandraClientConfig()
                 .setContactPoints("host1", "host2")
+                .setAstraSecureConnectBundlePath("/tmp/scb.zip")
                 .setNativeProtocolPort(9999)
                 .setFetchSize(10_000)
                 .setConsistencyLevel(ConsistencyLevel.TWO)

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -38,6 +38,15 @@ with a different name (making sure it ends in ``.properties``). For
 example, if you name the property file ``sales.properties``, Presto
 will create a catalog named ``sales`` using the configured connector.
 
+
+Astra
+^^^^^
+
+To connect to an `Astra DB`_ specify ``cassandra.astra-secure-connect-bundle-path`` instead of ``cassandra.contact-points``.
+
+
+.. _Astra DB: https://docs.datastax.com/en/astra-db-serverless/index.html
+
 Configuration Properties
 ------------------------
 
@@ -48,7 +57,13 @@ Property Name                                      Description
 ================================================== ======================================================================
 ``cassandra.contact-points``                       Comma-separated list of hosts in a Cassandra cluster. The Cassandra
                                                    driver will use these contact points to discover cluster topology.
-                                                   At least one Cassandra host is required.
+                                                   Must be specified unless ``cassandra.astra-secure-connect-bundle-path``
+                                                   is provided. When specified, at least one Cassandra host is required.
+
+``cassandra.astra-secure-connect-bundle-path``     Absolute physical path to the `Astra Secure Connect Bundle (SCB)`_ file.
+                                                   The Cassandra driver will use this file for cluster discovery and
+                                                   channel encryption. When specifying this property do not provide
+                                                   ``cassandra.contact-points``.
 
 ``cassandra.native-protocol-port``                 The Cassandra server port running the native client protocol
                                                    (defaults to ``9042``).
@@ -86,6 +101,8 @@ Property Name                                      Description
         the ``system.size_estimates`` table.
 
 .. _Cassandra consistency: https://docs.datastax.com/en/cassandra-oss/2.2/cassandra/dml/dmlConfigConsistency.html
+
+.. _Astra Secure Connect Bundle (SCB): https://docs.datastax.com/en/astra-db-serverless/databases/secure-connect-bundle.html
 
 The following advanced configuration properties are available:
 


### PR DESCRIPTION
## Description
adds a new parameter to facilitate connecting to Astra DB

## Motivation and Context
Ability to query data in Astra DB

## Impact
none

## Test Plan
Unit test: used mocked Cluster.Builder to verify parameter is handled properly.
Functional test (manual): verified ability to query data in Astra DB via presto-cli 

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Cassandra Connector Changes
* adds support for Astra DB (through new configuration property ``cassandra.astra-secure-connect-bundle-path``)
```

