### PR TITLE
chore(build): Bump the release version for pos spark modules

### DIFF
--- a/presto-spark-classloader-spark3/pom.xml
+++ b/presto-spark-classloader-spark3/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>presto-root</artifactId>
     <groupId>com.facebook.presto</groupId>
-    <version>0.296-SNAPSHOT</version>
+    <version>0.297-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Summary:
presto-spark-classloader-spark3 release bump from 0.296 - 0.297 was missed due to module being conditionally included in the project.

```
== NO RELEASE NOTE ==
```

Differential Revision: D88866253


