### PR TITLE
misc: Use protocol files from core directory

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.h
+++ b/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.h
@@ -13,7 +13,7 @@
  */
 
 #include "presto_cpp/external/json/nlohmann/json.hpp"
-#include "presto_cpp/presto_protocol/presto_protocol.h"
+#include "presto_cpp/presto_protocol/core/presto_protocol.h"
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/core/QueryCtx.h"
 

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include "presto_cpp/external/json/nlohmann/json.hpp"
-#include "presto_cpp/presto_protocol/presto_protocol.h"
+#include "presto_cpp/presto_protocol/core/presto_protocol.h"
 #include "velox/core/Expressions.h"
 #include "velox/serializers/PrestoSerializer.h"
 


### PR DESCRIPTION
The implementation file (e.g. https://github.com/prestodb/presto/blob/a2c2b4367010711ff16dd90d9c09d18e124fd87c/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.cpp#L22) uses the protocol from core directory. Keeping same for header as well.


```
== NO RELEASE NOTE ==
```