### PR TITLE
chore(deps): Update jedis-mock test dependency

### DIFF
--- a/redis-hbo-provider/pom.xml
+++ b/redis-hbo-provider/pom.xml
@@ -202,7 +202,7 @@
         <dependency>
             <groupId>com.github.fppt</groupId>
             <artifactId>jedis-mock</artifactId>
-            <version>1.0.9</version>
+            <version>1.1.12</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
## Description
This PR updates the test dependency `jedis-mock` from version 1.0.9 to 1.1.12.

There are no production code changes — this affects test scope only.

## Motivation and Context

As the maintainer of jedis-mock, I am submitting this update so that Presto relies on the most accurate and up-to-date version of the library during Redis-related tests.

Since version 1.0.9, jedis-mock has received a large number of bug fixes, behavioral corrections, and parity improvements with real Redis. Version 1.1.12 more faithfully mimics Redis semantics, improving the correctness and reliability of tests that depend on Redis-like behavior.

This change keeps Presto aligned with upstream improvements and maintains test accuracy.

## Impact

No user-facing or public API impact, no performance impact, test-only dependency upgrade.

## Test Plan

* Presto test suite successfully passes with the upgraded dependency.
* No changes to existing tests were necessary.
* Verified that updated jedis-mock behaves consistently with expected Redis semantics in the Redis test paths.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```
