### PR TITLE
fix(security): Prestoui restrict img-src wildcard in CSP

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -146,7 +146,7 @@ public class CoordinatorModule
 {
     private static final String DEFAULT_WEBUI_CSP =
             "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-                    "font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'; img-src 'self' http: https: data:; form-action 'self'";
+                    "font-src 'self' https://fonts.gstatic.com; frame-ancestors 'self'; img-src 'self' data:; form-action 'self'";
 
     public static HttpResourceBinding webUIBinder(Binder binder, String path, String classPathResourceBase)
     {


### PR DESCRIPTION
## Description

Medium Dynamic scan CSV's issues flagged by ZAP.

1. CSP: Wildcard Directive

- [CWE-693](https://cwe.mitre.org/data/definitions/693.html)
- [OWASP_2021_A05](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/)
- [OWASP_2017_A06](https://owasp.org/www-project-top-ten/2017/A6_2017-Security_Misconfiguration.html)

## Motivation and Context

(1) CSP: Wildcard Directive

**Issue**: CSP has a very broad `img-src:`

Removing `http: https:` eliminates scheme-wide allowances that permitted any external image host, closing the “wildcard/broad img-src” finding. Only images served from the UI origin or inline data URIs will load; everything else is blocked by the browser.
This directly addresses the reported CSP issue because the Content-Security-Policy header sent by the coordinator UI is the enforcement point; tightening the directive stops untrusted external image sources.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Fix CSP by removing `img-src 'http: https:'` in response to `CWE-693 <https://cwe.mitre.org/data/definitions/693.html>`_. :pr:`25910`

```

