### PR TITLE
feat: Make SSD cache maxEntries limit configurable

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties.rst
@@ -532,6 +532,17 @@ The configuration properties of AsyncDataCache and SSD cache are described here.
   When enabled, a CRC-based checksum is calculated for each cache entry written to SSD.
   The checksum is stored in the next checkpoint file.
 
+``ssd-cache-max-entries``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``integer``
+* **Default value:** ``10000000``
+
+  Maximum number of entries allowed in the SSD cache. A value of 0 means no limit.
+  When the limit is reached, new entry writes will be skipped.
+
+  The default of 10 million entries keeps metadata memory usage around 500MB, as each
+  cache entry uses approximately 50-60 bytes for the key, value, and hash overhead.
+
 ``ssd-cache-read-verification-enabled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * **Type:** ``bool``

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -980,7 +980,8 @@ std::unique_ptr<velox::cache::SsdCache> PrestoServer::setupSsdCache() {
       systemConfig->asyncCacheSsdCheckpointGb() << 30,
       systemConfig->asyncCacheSsdDisableFileCow(),
       systemConfig->ssdCacheChecksumEnabled(),
-      systemConfig->ssdCacheReadVerificationEnabled());
+      systemConfig->ssdCacheReadVerificationEnabled(),
+      systemConfig->ssdCacheMaxEntries());
   PRESTO_STARTUP_LOG(INFO) << "Initializing SSD cache with "
                            << cacheConfig.toString();
   return std::make_unique<velox::cache::SsdCache>(cacheConfig);

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -212,6 +212,7 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kAsyncCacheSsdDisableFileCow, false),
           BOOL_PROP(kSsdCacheChecksumEnabled, false),
           BOOL_PROP(kSsdCacheReadVerificationEnabled, false),
+          NUM_PROP(kSsdCacheMaxEntries, 10'000'000),
           BOOL_PROP(kEnableSerializedPageChecksum, true),
           BOOL_PROP(kUseMmapAllocator, true),
           STR_PROP(kMemoryArbitratorKind, ""),
@@ -698,6 +699,10 @@ bool SystemConfig::ssdCacheChecksumEnabled() const {
 
 bool SystemConfig::ssdCacheReadVerificationEnabled() const {
   return optionalProperty<bool>(kSsdCacheReadVerificationEnabled).value();
+}
+
+uint64_t SystemConfig::ssdCacheMaxEntries() const {
+  return optionalProperty<uint64_t>(kSsdCacheMaxEntries).value();
 }
 
 std::string SystemConfig::shuffleName() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -447,6 +447,12 @@ class SystemConfig : public ConfigBase {
   /// value when cache data is loaded from the SSD.
   static constexpr std::string_view kSsdCacheReadVerificationEnabled{
       "ssd-cache-read-verification-enabled"};
+  /// Maximum number of entries allowed in the SSD cache. A value of 0 means no
+  /// limit. When the limit is reached, new entry writes will be skipped.
+  /// Default is 10 million entries, which keeps metadata memory usage around
+  /// 500MB (each entry uses ~50-60 bytes for key, value, and hash overhead).
+  static constexpr std::string_view kSsdCacheMaxEntries{
+      "ssd-cache-max-entries"};
   static constexpr std::string_view kEnableSerializedPageChecksum{
       "enable-serialized-page-checksum"};
 
@@ -1051,6 +1057,8 @@ class SystemConfig : public ConfigBase {
   bool ssdCacheChecksumEnabled() const;
 
   bool ssdCacheReadVerificationEnabled() const;
+
+  uint64_t ssdCacheMaxEntries() const;
 
   std::string shuffleName() const;
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

Prestissimo
* Add ``ssd-cache-max-entries`` config to limit SSD cache entries and prevent unbounded metadata memory growth (default value: 10M entries, ~500MB metadata).  :pr:`26795`
```

