### PR TITLE
feat(native-pos): Use HashTable caching in Broadcast joins

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -206,6 +206,10 @@ void updateFromSystemConfigs(
              return folly::to<std::string>(velox::config::toCapacity(
                  value, velox::config::CapacityUnit::BYTE));
            }},
+
+      {.prestoSystemConfig =
+           std::string(SystemConfig::kExchangeLazyFetchingEnabled),
+       .veloxConfig = velox::core::QueryConfig::kExchangeLazyFetchingEnabled},
   };
 
   for (const auto& configMapping : veloxToPrestoConfigMapping) {

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -275,6 +275,8 @@ SystemConfig::SystemConfig() {
           BOOL_PROP(kAggregationSpillEnabled, true),
           BOOL_PROP(kOrderBySpillEnabled, true),
           NUM_PROP(kMaxSpillBytes, 100UL << 30), // 100GB
+          BOOL_PROP(kBroadcastJoinTableCachingEnabled, false),
+          BOOL_PROP(kExchangeLazyFetchingEnabled, false),
           NUM_PROP(kRequestDataSizesMaxWaitSec, 10),
           STR_PROP(kPluginDir, ""),
           NUM_PROP(kExchangeIoEvbViolationThresholdMs, 1000),
@@ -423,6 +425,14 @@ bool SystemConfig::aggregationSpillEnabled() const {
 
 bool SystemConfig::orderBySpillEnabled() const {
   return optionalProperty<bool>(kOrderBySpillEnabled).value();
+}
+
+bool SystemConfig::broadcastJoinTableCachingEnabled() const {
+  return optionalProperty<bool>(kBroadcastJoinTableCachingEnabled).value();
+}
+
+bool SystemConfig::exchangeLazyFetchingEnabled() const {
+  return optionalProperty<bool>(kExchangeLazyFetchingEnabled).value();
 }
 
 uint64_t SystemConfig::maxSpillBytes() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -825,6 +825,17 @@ class SystemConfig : public ConfigBase {
       "order-by-spill-enabled"};
   static constexpr std::string_view kMaxSpillBytes{"max-spill-bytes"};
 
+  /// When enabled, hash tables built for broadcast joins are cached and reused
+  /// across tasks within the same query and stage.
+  static constexpr std::string_view kBroadcastJoinTableCachingEnabled{
+      "broadcast-join-table-caching-enabled"};
+
+  /// If true, data fetching is deferred until next() is called on the exchange
+  /// client. If false (default), exchange clients will start fetching data
+  /// immediately when remote tasks are added.
+  static constexpr std::string_view kExchangeLazyFetchingEnabled{
+      "exchange-lazy-fetching-enabled"};
+
   // Max wait time for exchange request in seconds.
   static constexpr std::string_view kRequestDataSizesMaxWaitSec{
       "exchange.http-client.request-data-sizes-max-wait-sec"};
@@ -1187,6 +1198,10 @@ class SystemConfig : public ConfigBase {
   bool aggregationSpillEnabled() const;
 
   bool orderBySpillEnabled() const;
+
+  bool broadcastJoinTableCachingEnabled() const;
+
+  bool exchangeLazyFetchingEnabled() const;
 
   uint64_t maxSpillBytes() const;
 

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -695,9 +695,12 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
       {.veloxConfigKey = core::QueryConfig::kMaxPartialAggregationMemory,
        .systemConfigKey =
            std::string(SystemConfig::kTaskMaxPartialAggregationMemory)},
+      {.veloxConfigKey = core::QueryConfig::kExchangeLazyFetchingEnabled,
+       .systemConfigKey =
+           std::string(SystemConfig::kExchangeLazyFetchingEnabled)},
   };
 
-  const size_t kExpectedSystemConfigMappingCount = 19;
+  const size_t kExpectedSystemConfigMappingCount = 20;
   EXPECT_EQ(kExpectedSystemConfigMappingCount, expectedMappings.size())
       << "Update expectedMappings to match veloxToPrestoConfigMapping";
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -15,6 +15,7 @@
 // clang-format off
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/connectors/PrestoToVeloxConnector.h"
+#include "presto_cpp/main/types/PrestoTaskId.h"
 #include "presto_cpp/main/types/PrestoToVeloxQueryPlan.h"
 #include <velox/type/TypeUtil.h>
 #include <velox/type/Filter.h>
@@ -43,6 +44,26 @@ using namespace facebook::velox::exec;
 namespace facebook::presto {
 
 namespace {
+
+// Check if this is a broadcast join with cached hash table enabled.
+// Works with both JoinNode and SemiJoinNode.
+bool useCachedHashTable(const protocol::PlanNode& node) {
+  if (!SystemConfig::instance()->broadcastJoinTableCachingEnabled()) {
+    return false;
+  }
+  if (const auto* joinNode = dynamic_cast<const protocol::JoinNode*>(&node)) {
+    return joinNode->distributionType &&
+        *joinNode->distributionType ==
+        protocol::JoinDistributionType::REPLICATED;
+  } else if (
+      const auto* semiJoinNode =
+          dynamic_cast<const protocol::SemiJoinNode*>(&node)) {
+    return semiJoinNode->distributionType &&
+        *semiJoinNode->distributionType ==
+        protocol::DistributionType::REPLICATED;
+  }
+  return false;
+}
 
 std::vector<std::string> getNames(const protocol::Assignments& assignments) {
   std::vector<std::string> names;
@@ -668,20 +689,20 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     projections.emplace_back(
         std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), constantValue));
 
+    auto hashJoinNode = std::make_shared<core::HashJoinNode>(
+        semiJoin->id,
+        joinType.value(),
+        joinType == core::JoinType::kAnti ? true : false,
+        leftKeys,
+        rightKeys,
+        nullptr,
+        left,
+        right,
+        left->outputType(),
+        useCachedHashTable(*semiJoin));
+
     return std::make_shared<core::ProjectNode>(
-        node->id,
-        std::move(names),
-        std::move(projections),
-        std::make_shared<core::HashJoinNode>(
-            semiJoin->id,
-            joinType.value(),
-            joinType == core::JoinType::kAnti ? true : false,
-            leftKeys,
-            rightKeys,
-            nullptr, // filter
-            left,
-            right,
-            left->outputType()));
+        node->id, std::move(names), std::move(projections), hashJoinNode);
   }
 
   return std::make_shared<core::FilterNode>(
@@ -1238,7 +1259,8 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       node->filter ? exprConverter_.toVeloxExpr(*node->filter) : nullptr,
       toVeloxQueryPlan(node->left, tableWriteInfo, taskId),
       toVeloxQueryPlan(node->right, tableWriteInfo, taskId),
-      toRowType(node->outputVariables, typeParser_));
+      toRowType(node->outputVariables, typeParser_),
+      useCachedHashTable(*node));
 }
 
 core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
@@ -1269,7 +1291,8 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
       /*filter=*/nullptr,
       left,
       right,
-      ROW(std::move(outputNames), std::move(outputTypes)));
+      ROW(std::move(outputNames), std::move(outputTypes)),
+      useCachedHashTable(*node));
 }
 
 core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(


### PR DESCRIPTION
Summary:
Velox introduced ability to Cache Hash Tables in the HashBuild operator.
This is useful in Broadcast joins as we can built the HashTable once per worker
and re-use it for all the join tasks that land on that worker.

Velox PRs: https://github.com/facebookincubator/velox/pull/15754
and https://github.com/facebookincubator/velox/pull/15768

This diff enables setting the `useCachedHashTable=true` during
velox `HashBuild` node construction in the cases that it is a 
broadcast join

Differential Revision: D88900941

```
== NO RELEASE NOTE ==
```


