### PR TITLE
fix(native): Fix executor name in PrestoExchangeSource

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -284,7 +284,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   // applies if 'enableBufferCopy_' is true
   const bool immediateBufferTransfer_;
 
-  folly::CPUThreadPoolExecutor* const driverExecutor_;
+  folly::CPUThreadPoolExecutor* const exchangeHttpCpuExecutor_;
 
   std::shared_ptr<http::HttpClient> httpClient_;
   RetryState dataRequestRetryState_;


### PR DESCRIPTION
In commit 74fb8cee62, a separate thread pool(See
`TaskServer::exchangeHttpCpuExecutor_`) was introduced, replacing the
driver thread pool to process exchange requests. However, the name
`driverExecutor_` is still being used in `PrestoExchangeSource`,
which is misleading.

This PR fixes this issue.

```
== NO RELEASE NOTE ==
```

