### PR TITLE
feat(plugin-delta): Upgrade io.delta.delta-kernel libraries to 3.3.2

### DIFF
--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <enforcer.skip>true</enforcer.skip>
-        <io.delta.delta-kernel-api.version>3.2.0</io.delta.delta-kernel-api.version>
+        <io.delta.delta-kernel-api.version>3.3.2</io.delta.delta-kernel-api.version>
         <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaExpressionUtils.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaExpressionUtils.java
@@ -32,7 +32,6 @@ import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.utils.CloseableIterator;
 
 import java.io.IOException;
-import java.net.URI;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.Iterator;
@@ -240,7 +239,7 @@ public final class DeltaExpressionUtils
             for (DeltaColumnHandle partitionColumn : partitionColumns) {
                 String columnName = partitionColumn.getName();
                 String partitionValue = InternalScanFileUtils.getPartitionValues(row).get(columnName);
-                String filePath = URI.create(InternalScanFileUtils.getAddFileStatus(row).getPath()).getPath();
+                String filePath = InternalScanFileUtils.getAddFileStatus(row).getPath();
                 logger.debug("Obtaining domain of file: " + filePath);
                 Domain domain = getDomain(partitionColumn, partitionValue, typeManager, filePath);
                 Optional<Map<String, Domain>> domains = partitionPredicate.getDomains();

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaSplitManager.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaSplitManager.java
@@ -30,7 +30,6 @@ import jakarta.inject.Inject;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URI;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
@@ -98,7 +97,7 @@ public class DeltaSplitManager
                         connectorId,
                         deltaTable.getSchemaName(),
                         deltaTable.getTableName(),
-                        URI.create(addFileStatus.getPath()).getPath(),
+                        addFileStatus.getPath(),
                         0, /* start */
                         addFileStatus.getSize() /* split length - default is read the entire file in one split */,
                         addFileStatus.getSize(),


### PR DESCRIPTION
## Description
Upgrade delta-kernel-api and delta-kernel-defaults library to version 3.3.2

## Motivation and Context
Upgrading those libraries will make us able to support future improvements in the connector, like support for deletion vectors, type widening, variant type... .

## Impact
Library bug fixes from 3.2.0 and ability to support new features. In the 3.2.1 version, this bug was fixed:
https://github.com/delta-io/delta/pull/3291
so this previous bugfix has been undone as it is not needed anymore: https://github.com/prestodb/presto/pull/26397

## Test Plan
There already exist unit tests. Since this is only a library version upgrade, passing the unit tests should be our target.

## Release Notes
```
== NO RELEASE NOTE ==
```