### PR TITLE
feat(native-pos): Add shuffle read splits postprocessing hook in task executor

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/shuffle/PrestoSparkShuffleInfoTranslator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/shuffle/PrestoSparkShuffleInfoTranslator.java
@@ -14,8 +14,11 @@
 package com.facebook.presto.spark.execution.shuffle;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.ScheduledSplit;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleReadDescriptor;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleWriteDescriptor;
+
+import java.util.Set;
 
 /**
  * PrestoSparkShuffleInfoTranslator is used to translate the {@link PrestoSparkShuffleWriteDescriptor} and
@@ -32,4 +35,20 @@ public interface PrestoSparkShuffleInfoTranslator
     String createSerializedWriteInfo(PrestoSparkShuffleWriteInfo writeInfo);
 
     String createSerializedReadInfo(PrestoSparkShuffleReadInfo readInfo);
+
+    /**
+     * Post-processes shuffle read splits.
+     * For shuffle implementations that support multi-driver parallelism (like Cosco),
+     * this method can expand splits to include sub-partition information.
+     * The default implementation returns the input splits unchanged.
+     *
+     * @param splits The input set of shuffle read splits
+     * @param session The session to get configuration from
+     * @return Post-processed set of ScheduledSplits
+     */
+    default Set<ScheduledSplit> postProcessSplits(Set<ScheduledSplit> splits, Session session)
+    {
+        // Default: return splits unchanged
+        return splits;
+    }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/task/PrestoSparkNativeTaskExecutorFactory.java
@@ -478,7 +478,8 @@ public class PrestoSparkNativeTaskExecutorFactory
                                     shuffleInfoTranslator.createSerializedReadInfo(
                                             shuffleInfoTranslator.createShuffleReadInfo(session, shuffleReadDescriptor)))),
                             DUMMY_TASK_ID)));
-                    TaskSource source = new TaskSource(remoteSource.getId(), ImmutableSet.of(split), ImmutableSet.of(Lifespan.taskWide()), true);
+                    Set<ScheduledSplit> shuffleSplits = shuffleInfoTranslator.postProcessSplits(ImmutableSet.of(split), session);
+                    TaskSource source = new TaskSource(remoteSource.getId(), shuffleSplits, ImmutableSet.of(Lifespan.taskWide()), true);
                     shuffleTaskSources.add(source);
                 }
 


### PR DESCRIPTION
### Summary
This PR adds a new postProcessSplits hook to Shuffle Read splits generation

This can be used by various ShuffleSystems to update split info with extra information
needed. In the internal use-case at Meta, this can be used to create multiple splits (per sub-partition) for a single shuffle read partition, which helps with efficiency

### Test
- Unit tests. No logic change. Trivial 

Differential Revision: D89343659

```
== NO RELEASE NOTE ==
```




