### PR TITLE
misc: Add feature to control function namespace managers to list functions

### DIFF
--- a/presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers-common/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -252,7 +252,8 @@ public abstract class AbstractSqlInvokedFunctionNamespaceManager
         return new PrestoException(GENERIC_INTERNAL_ERROR, failureMessage, cause);
     }
 
-    protected String getCatalogName()
+    @Override
+    public String getCatalogName()
     {
         return catalogName;
     }

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespaceManager.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespaceManager.java
@@ -233,6 +233,12 @@ public class HiveFunctionNamespaceManager
         return ((HiveAggregationFunction) function).getImplementation();
     }
 
+    @Override
+    public String getCatalogName()
+    {
+        return catalogName;
+    }
+
     private static class DummyHiveFunction
             extends HiveFunction
     {

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -59,6 +59,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -81,6 +82,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregation
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.parseQueryTypesFromString;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Math.min;
 import static java.lang.String.format;
@@ -207,6 +209,7 @@ public final class SystemSessionProperties
     public static final String OPTIMIZED_REPARTITIONING_ENABLED = "optimized_repartitioning";
     public static final String AGGREGATION_PARTITIONING_MERGING_STRATEGY = "aggregation_partitioning_merging_strategy";
     public static final String LIST_BUILT_IN_FUNCTIONS_ONLY = "list_built_in_functions_only";
+    public static final String NON_BUILT_IN_FUNCTION_NAMESPACES_TO_LIST_FUNCTIONS = "non_built_in_function_namespaces_to_list_functions";
     public static final String PARTITIONING_PRECISION_STRATEGY = "partitioning_precision_strategy";
     public static final String EXPERIMENTAL_FUNCTIONS_ENABLED = "experimental_functions_enabled";
     public static final String OPTIMIZE_COMMON_SUB_EXPRESSIONS = "optimize_common_sub_expressions";
@@ -1144,6 +1147,11 @@ public final class SystemSessionProperties
                         LIST_BUILT_IN_FUNCTIONS_ONLY,
                         "Only List built-in functions in SHOW FUNCTIONS",
                         featuresConfig.isListBuiltInFunctionsOnly(),
+                        false),
+                stringProperty(
+                        NON_BUILT_IN_FUNCTION_NAMESPACES_TO_LIST_FUNCTIONS,
+                        "Comma-separated list of function namespace names from which to list non-built-in functions. Only takes effect when LIST_BUILT_IN_FUNCTIONS_ONLY is false. If empty, functions from all available function namespaces will be listed.",
+                        "",
                         false),
                 new PropertyMetadata<>(
                         PARTITIONING_PRECISION_STRATEGY,
@@ -2764,6 +2772,11 @@ public final class SystemSessionProperties
     public static boolean isListBuiltInFunctionsOnly(Session session)
     {
         return session.getSystemProperty(LIST_BUILT_IN_FUNCTIONS_ONLY, Boolean.class);
+    }
+
+    public static Set<String> getNonBuiltInFunctionNamespacesToListFunctions(Session session)
+    {
+        return Splitter.on(",").trimResults().splitToList(session.getSystemProperty(NON_BUILT_IN_FUNCTION_NAMESPACES_TO_LIST_FUNCTIONS, String.class)).stream().filter(x -> !x.isEmpty()).collect(toImmutableSet());
     }
 
     public static boolean isExactPartitioningPreferred(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -94,6 +94,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
+import static com.facebook.presto.SystemSessionProperties.getNonBuiltInFunctionNamespacesToListFunctions;
 import static com.facebook.presto.SystemSessionProperties.isExperimentalFunctionsEnabled;
 import static com.facebook.presto.SystemSessionProperties.isListBuiltInFunctionsOnly;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
@@ -544,8 +545,10 @@ public class FunctionAndTypeManager
             functions.addAll(builtInWorkerFunctionNamespaceManager.listFunctions(likePattern, escape).stream().collect(toImmutableList()));
         }
         else {
+            Set<String> catalogsToListFunction = getNonBuiltInFunctionNamespacesToListFunctions(session);
             functions.addAll(SessionFunctionUtils.listFunctions(session.getSessionFunctions()));
             functions.addAll(functionNamespaceManagers.values().stream()
+                    .filter(x -> x instanceof BuiltInTypeAndFunctionNamespaceManager || catalogsToListFunction.isEmpty() || catalogsToListFunction.contains(x.getCatalogName()))
                     .flatMap(manager -> manager.listFunctions(likePattern, escape).stream())
                     .collect(toImmutableList()));
             functions.addAll(builtInPluginFunctionNamespaceManager.listFunctions(likePattern, escape).stream().collect(toImmutableList()));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -136,4 +136,9 @@ public interface FunctionNamespaceManager<F extends SqlFunction>
     {
         // Default implementation: no validation
     }
+
+    default String getCatalogName()
+    {
+        throw new UnsupportedOperationException("getCatalogName not supported");
+    }
 }


### PR DESCRIPTION
## Description
Currently when run `show functions`, it has configurations, either session list_built_in_functions_only is true which only list built in functions, or list_built_in_functions_only is false, which list all functions.
This PR adds one more session property, `non_built_in_function_namespaces_to_list_functions` which specify a list of non builtin function catalogs which will list functions.

## Motivation and Context
Gives flexibility on which functions to show.

## Impact
Gives flexibility on which functions to show.

## Test Plan
Unit test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

