### PR TITLE
fix(security): Upgrade druid version to 35.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dep.slf4j.version>2.0.16</dep.slf4j.version>
         <dep.kafka.version>3.9.1</dep.kafka.version>
         <dep.pinot.version>1.3.0</dep.pinot.version>
-        <dep.druid.version>30.0.1</dep.druid.version>
+        <dep.druid.version>35.0.1</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
         <dep.jaxb.runtime.version>4.0.6</dep.jaxb.runtime.version>
         <dep.hudi.version>0.14.0</dep.hudi.version>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -32,7 +32,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>8.0.3.Final</version>
             </dependency>
@@ -40,6 +40,16 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.el</artifactId>
                 <version>4.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mozilla</groupId>
+                <artifactId>rhino</artifactId>
+                <version>1.8.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-druid/src/main/java/com/facebook/presto/druid/segment/PrestoQueryableIndex.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/segment/PrestoQueryableIndex.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.segment;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.query.OrderBy;
+import org.apache.druid.segment.DimensionHandler;
+import org.apache.druid.segment.Metadata;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.column.BaseColumnHolder;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.data.Indexed;
+import org.joda.time.Interval;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class PrestoQueryableIndex
+        implements QueryableIndex
+{
+    private final Interval dataInterval;
+    private final List<String> columnNames;
+    private final Indexed<String> availableDimensions;
+    private final BitmapFactory bitmapFactory;
+    private final Map<String, Supplier<ColumnHolder>> columns;
+    private final SmooshedFileMapper fileMapper;
+    @Nullable
+    private final Metadata metadata;
+    private final Supplier<Map<String, DimensionHandler>> dimensionHandlers;
+
+    public PrestoQueryableIndex(
+            Interval dataInterval,
+            Indexed<String> dimNames,
+            BitmapFactory bitmapFactory,
+            Map<String, Supplier<ColumnHolder>> columns,
+            SmooshedFileMapper fileMapper,
+            @Nullable Metadata metadata,
+            boolean lazy)
+    {
+        Preconditions.checkNotNull(columns.get(ColumnHolder.TIME_COLUMN_NAME));
+        this.dataInterval = Preconditions.checkNotNull(dataInterval, "dataInterval");
+        ImmutableList.Builder<String> columnNamesBuilder = ImmutableList.builder();
+        for (String column : columns.keySet()) {
+            if (!ColumnHolder.TIME_COLUMN_NAME.equals(column)) {
+                columnNamesBuilder.add(column);
+            }
+        }
+        this.columnNames = columnNamesBuilder.build();
+        this.availableDimensions = dimNames;
+        this.bitmapFactory = bitmapFactory;
+        this.columns = columns;
+        this.fileMapper = fileMapper;
+        this.metadata = metadata;
+
+        if (lazy) {
+            this.dimensionHandlers = Suppliers.memoize(() -> initDimensionHandlers(availableDimensions));
+        }
+        else {
+            this.dimensionHandlers = () -> initDimensionHandlers(availableDimensions);
+        }
+    }
+
+    @Override
+    public Interval getDataInterval()
+    {
+        return dataInterval;
+    }
+
+    @Override
+    public int getNumRows()
+    {
+        return columns.get(ColumnHolder.TIME_COLUMN_NAME).get().getLength();
+    }
+
+    @Override
+    public List<String> getColumnNames()
+    {
+        return columnNames;
+    }
+
+    @Override
+    public Indexed<String> getAvailableDimensions()
+    {
+        return availableDimensions;
+    }
+
+    @Override
+    public BitmapFactory getBitmapFactoryForDimensions()
+    {
+        return bitmapFactory;
+    }
+
+    @Nullable
+    @Override
+    public BaseColumnHolder getColumnHolder(String columnName)
+    {
+        Supplier<BaseColumnHolder> columnHolderSupplier = (Supplier) this.columns.get(columnName);
+        return columnHolderSupplier == null ? null : (BaseColumnHolder) columnHolderSupplier.get();
+    }
+
+    @VisibleForTesting
+    public Map<String, Supplier<ColumnHolder>> getColumns()
+    {
+        return columns;
+    }
+
+    @VisibleForTesting
+    public SmooshedFileMapper getFileMapper()
+    {
+        return fileMapper;
+    }
+
+    @Override
+    public void close()
+    {
+        if (fileMapper != null) {
+            fileMapper.close();
+        }
+    }
+
+    @Override
+    public Metadata getMetadata()
+    {
+        return metadata;
+    }
+
+    @Override
+    public List<OrderBy> getOrdering()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Map<String, DimensionHandler> getDimensionHandlers()
+    {
+        return dimensionHandlers.get();
+    }
+
+    private Map<String, DimensionHandler> initDimensionHandlers(Indexed<String> availableDimensions)
+    {
+        Map<String, DimensionHandler> dimensionHandlerMap = Maps.newLinkedHashMap();
+        for (String dim : availableDimensions) {
+            final ColumnHolder columnHolder = getColumnHolder(dim);
+            final DimensionHandler handler = columnHolder.getColumnFormat().getColumnHandler(dim);
+            dimensionHandlerMap.put(dim, handler);
+        }
+        return dimensionHandlerMap;
+    }
+}


### PR DESCRIPTION
## Description
Upgrade **druid** to version 35.0.1 to address CVE-2024-53990 and CVE-2025-12183

Since the CVE fixes for lz4-java and Rhino are not included in Druid 35.0.1, we resolved the vulnerabilities by upgrading the corresponding transitive dependencies.

Upgrade **lz4-java** to version 1.10.2 to address CVE-2025-66566
Upgrade **rhino** to version 1.8.1 to address CVE-2025-66453

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Tested in Local : 

```
presto> show tables from druid.wikipedia;

Query 20260101_125243_00001_dkgk2, RUNNING, 1 node, 19 splits

Query 20260101_125243_00001_dkgk2, RUNNING, 1 node, 19 splits

Query 20260101_125243_00001_dkgk2, RUNNING, 1 node, 19 splits
      Table      
-----------------
 car_details     
 employee        
 employee_data   
 employee_druid2 
 inline_data     
 kttm1           
 order_details   
 product_table   
 sales_report    
 student_details 
 wikipedia       
(11 rows)

Query 20260101_125243_00001_dkgk2, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:07, server-side: 0:07] [11 rows, 334B] [1 rows/s, 49B/s]

presto> select * from druid.wikipedia.employee_data limit 10;
         __time          | employee_id |      name       | department  | salary 
-------------------------+-------------+-----------------+-------------+--------
 2010-01-01 05:30:00.000 |         101 | John Doe        | Marketing   |  60000 
 2010-01-01 05:30:00.000 |         102 | Jane Smith      | Sales       |  70000 
 2010-01-01 05:30:00.000 |         103 | Michael Johnson | Engineering |  80000 
 2010-01-01 05:30:00.000 |         104 | Emily Davis     | Finance     |  75000 
(4 rows)

Query 20260101_125342_00002_dkgk2, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:03, server-side: 0:03] [4 rows, 224B] [1 rows/s, 85B/s]

presto> select * from druid.wikipedia.employee_data limit 3;
         __time          | employee_id |      name       | department  | salary 
-------------------------+-------------+-----------------+-------------+--------
 2010-01-01 05:30:00.000 |         101 | John Doe        | Marketing   |  60000 
 2010-01-01 05:30:00.000 |         102 | Jane Smith      | Sales       |  70000 
 2010-01-01 05:30:00.000 |         103 | Michael Johnson | Engineering |  80000 
(3 rows)

Query 20260101_125409_00003_dkgk2, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:02, server-side: 0:02] [3 rows, 169B] [1 rows/s, 78B/s]
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade Druid to version 35.0.1 to address `CVE-2024-53990 <https://github.com/advisories/GHSA-mfj5-cf8g-g2fv>`_ and `CVE-2025-12183 <https://github.com/advisories/GHSA-vqf4-7m7x-wgfc>`_.
* Upgrade lz4-java to version 1.10.2 to address `CVE-2025-66566 <https://github.com/advisories/GHSA-cmp6-m4wj-q63q>`_.
* Upgrade Rhino to version 1.8.1 to address `CVE-2025-66453 <https://github.com/advisories/GHSA-3w8q-xq97-5j7x>`_.
```