### PR TITLE
fix(plugin-delta): Fix delta file path resolution by preserving full S3 URI

### DIFF
--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -178,6 +178,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-hive-metastore</artifactId>
         </dependency>

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaExpressionUtils.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaExpressionUtils.java
@@ -32,7 +32,6 @@ import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.utils.CloseableIterator;
 
 import java.io.IOException;
-import java.net.URI;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.Iterator;
@@ -240,7 +239,7 @@ public final class DeltaExpressionUtils
             for (DeltaColumnHandle partitionColumn : partitionColumns) {
                 String columnName = partitionColumn.getName();
                 String partitionValue = InternalScanFileUtils.getPartitionValues(row).get(columnName);
-                String filePath = URI.create(InternalScanFileUtils.getAddFileStatus(row).getPath()).getPath();
+                String filePath = DeltaFilePathUtils.normalizePath(InternalScanFileUtils.getAddFileStatus(row).getPath());
                 logger.debug("Obtaining domain of file: " + filePath);
                 Domain domain = getDomain(partitionColumn, partitionValue, typeManager, filePath);
                 Optional<Map<String, Domain>> domains = partitionPredicate.getDomains();

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaFilePathUtils.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaFilePathUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.delta;
+
+import org.apache.hadoop.fs.Path;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+public class DeltaFilePathUtils
+{
+    private DeltaFilePathUtils() {}
+
+    public static String normalizePath(String inputPath)
+    {
+        // Normalize partially encoded paths (for example, paths containing encoded spaces)
+        // before constructing Hadoop Path, to avoid double-encoding.
+        inputPath = getDecodedPath(inputPath);
+
+        // Construct Hadoop Path to ensure proper URI normalization and scheme handling.
+        Path path = new Path(inputPath);
+        URI uri = path.toUri();
+
+        // Local filesystem paths must be returned as OS-native paths.
+        if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        // Distributed filesystems and object stores (e.g., S3, HDFS):
+        // return a URI-safe string while preserving required encodings.
+        if (uri.getScheme() != null) {
+            return getDecodedPath(uri.toString());
+        }
+
+        // Relative paths (no scheme): return the normalized path component.
+        return uri.getPath();
+    }
+
+    /**
+     * Partially decodes an input path by decoding space encodings while preserving
+     * reserved URI characters such as colon (%3A).
+     * Full URI decoding is intentionally avoided, as decoding reserved characters
+     * can produce invalid URIs and break Hadoop Path or filesystem resolution.
+     */
+    private static String getDecodedPath(String inputPath)
+    {
+        String decoded = URLDecoder.decode(
+                inputPath.replaceAll("%3A", "__TEMP_COLON__"),
+                StandardCharsets.UTF_8);
+
+        decoded = decoded.replace("__TEMP_COLON__", "%3A");
+        return decoded;
+    }
+}

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaSplitManager.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaSplitManager.java
@@ -30,7 +30,6 @@ import jakarta.inject.Inject;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URI;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
@@ -98,7 +97,7 @@ public class DeltaSplitManager
                         connectorId,
                         deltaTable.getSchemaName(),
                         deltaTable.getTableName(),
-                        URI.create(addFileStatus.getPath()).getPath(),
+                        DeltaFilePathUtils.normalizePath(addFileStatus.getPath()),
                         0, /* start */
                         addFileStatus.getSize() /* split length - default is read the entire file in one split */,
                         addFileStatus.getSize(),

--- a/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaFilePathUtils.java
+++ b/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaFilePathUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.delta;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestDeltaFilePathUtils
+{
+    @DataProvider(name = "deltaFilePaths")
+    public static Object[][] deltaFilePaths()
+    {
+        return new Object[][] {
+                new Object[] {"/tmp/data/file.parquet", "/tmp/data/file.parquet"}, //TestLocalAbsolutePath
+                new Object[] {"/tmp/data/part date=2021-09-08/file.parquet", "/tmp/data/part date=2021-09-08/file.parquet"}, //TestLocalAbsolutePathWithSpaces
+                new Object[] {"file:/tmp/data/file.parquet", "/tmp/data/file.parquet"}, //TestFileSchemePathWithoutSpaces
+                new Object[] {"file:/tmp/data/part date=2021-09-08/file.parquet", "/tmp/data/part date=2021-09-08/file.parquet"}, //TestFileSchemePathWithSpaces
+                new Object[] {"file:/tmp/data/as_timestamp=2021-09-08%2011%253A11%253A11/file.parquet", "/tmp/data/as_timestamp=2021-09-08 11%3A11%3A11/file.parquet"}, //TestFileSchemePathWithSpacesAndSpecialCharacter
+                new Object[] {"s3a://my-bucket/data/file.parquet", "s3a://my-bucket/data/file.parquet"}, //TestS3PathWithoutSpaces
+                new Object[] {"s3a://my-bucket/data/part date=2021-09-08/file.parquet", "s3a://my-bucket/data/part date=2021-09-08/file.parquet"}, //TestS3PathWithSpaces
+                new Object[] {"s3a://my-bucket/data/as_timestamp=2021-09-08%2011%253A11%253A11/file.parquet", "s3a://my-bucket/data/as_timestamp=2021-09-08 11%3A11%3A11/file.parquet"}, //TestS3PathWithSpacesAndSpecialCharacter
+                new Object[] {"hdfs://namenode:8020/user/hive/warehouse/table/file.parquet", "hdfs://namenode:8020/user/hive/warehouse/table/file.parquet"}, //TestHdfsPath
+                new Object[] {"data/part=1/file.parquet", "data/part=1/file.parquet"} //TestRelativePath
+        };
+    }
+
+    @Test(dataProvider = "deltaFilePaths")
+    public void testDeltaNormalizeFilePath(String actualFilePath, String expectedFilePath)
+    {
+        assertEquals(DeltaFilePathUtils.normalizePath(actualFilePath), expectedFilePath);
+    }
+}


### PR DESCRIPTION
## Description
**Problem**
Presto Delta queries were failing with File does not exist exceptions even though the Parquet files were present in S3. The root cause was incorrect URI handling:
URI.create(...).getPath() stripped the scheme (s3a) and bucket name, resulting in invalid file paths.

```
2025-12-15T23:17:00.845Z	INFO	Query-20251215_231653_00890_tacwd-102561	io.delta.kernel.internal.snapshot.SnapshotManager	s3a://xpeng-ibm/admin_system/admin_system_city: Took 0ms to construct the snapshot (loading protocol and metadata) for 0 .
2025-12-15T23:17:00.948Z	ERROR	SplitRunner-1-134	com.facebook.presto.execution.executor.TaskExecutorError processing Split 20251215_231653_00890_tacwd.1.0.0.0-0 com.facebook.presto.delta.DeltaSplit@29bec417 (start = 1.701514336299152E9, wall = 1 ms, cpu = 0 ms, wait = 0 ms, calls = 1): DELTA_CANNOT_OPEN_SPLIT: File /admin_system/admin_system_city/part-00000-49dc75f4-b65f-4959-8b10-a97e594d5a42-c000.snappy.parquet does not exist
2025-12-15T23:17:00.950Z	ERROR	remote-task-callback-1410	com.facebook.presto.execution.StageExecutionStateMachine	Stage execution 20251215_231653_00890_tacwd.1.0 failed
com.facebook.presto.spi.PrestoException: File /admin_system/admin_system_city/part-00000-49dc75f4-b65f-4959-8b10-a97e594d5a42-c000.snappy.parquet does not exist
	at com.facebook.presto.delta.DeltaPageSourceProvider.createParquetPageSource(DeltaPageSourceProvider.java:352)
	at com.facebook.presto.delta.DeltaPageSourceProvider.createPageSource(DeltaPageSourceProvider.java:164)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider.createPageSource(ClassLoaderSafeConnectorPageSourceProvider.java:65)
	at com.facebook.presto.split.PageSourceManager.createPageSource(PageSourceManager.java:81)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:263)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:440)
	at com.facebook.presto.operator.Driver.lambda$processFor$10(Driver.java:323)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:749)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:316)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1078)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:619)
	at com.facebook.presto.$gen.Presto_0_296_SNAPSHOT_19bfd80__0_296_SNAPSHOT____20251202_065933_1.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.io.FileNotFoundException: File /admin_system/admin_system_city/part-00000-49dc75f4-b65f-4959-8b10-a97e594d5a42-c000.snappy.parquet does not exist
	at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:917)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:1238)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:907)
	at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:462)
	at org.apache.hadoop.fs.HadoopExtendedFileSystem.getFileStatus(HadoopExtendedFileSystem.java:388)
	at com.facebook.presto.delta.DeltaPageSourceProvider.createParquetPageSource(DeltaPageSourceProvider.java:226)
	... 15 more

```

**Root Cause**
Object-store URIs (S3) must retain their scheme and authority. Using **URI.getPath()** converts a fully qualified URI into a relative filesystem path, which is not valid for Presto’s S3 filesystem.

Root Cause OSS PR : https://github.com/prestodb/presto/pull/26397

**Fix**
The code now preserves the full URI by using URI.toString() (or by passing the original path directly), ensuring that the correct s3a://bucket/... path is passed to the filesystem layer and enabling support for reading tables with spaces in S3 locations or partition values.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

