### PR TITLE
chore: Fix executable name pattern of presto-function-server in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ presto-native-execution/deps-install
 # Compiled executables used for docker build
 /docker/presto-cli-*-executable.jar
 /docker/presto-server-*.tar.gz
-/docker/presto-function-server-executable.jar
+/docker/presto-function-server-*-executable.jar


### PR DESCRIPTION
## Description
fix executable name pattern of presto-function-server

## Impact
No Impact 

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

