### PR TITLE
build(native): Add dependency on Apache DataSketches CPP for Sketch Theta functions

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -1,3 +1,21 @@
 The code for the t-digest was originally authored by Ted Dunning
 
 Adrien Grand contributed the heart of the AVLTreeDigest (https://github.com/jpountz)
+
+This product includes software from the Apache DataSketches C++ project.
+* https://github.com/apache/datasketches-cpp/tree/master/theta
+which contains the following NOTICE file:
+-------
+Apache DataSketches C++
+Copyright 2025 The Apache Software Foundation
+
+Copyright 2015-2018 Yahoo Inc.
+Copyright 2019-2020 Verizon Media
+Copyright 2021- Yahoo Inc.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+Prior to moving to ASF, the software for this project was developed at
+Yahoo Inc. (https://developer.yahoo.com).
+-------

--- a/presto-native-execution/scripts/setup-centos.sh
+++ b/presto-native-execution/scripts/setup-centos.sh
@@ -18,6 +18,7 @@ export CC=/opt/rh/gcc-toolset-12/root/bin/gcc
 export CXX=/opt/rh/gcc-toolset-12/root/bin/g++
 
 GPERF_VERSION="3.1"
+DATASKETCHES_VERSION="5.2.0"
 
 CPU_TARGET="${CPU_TARGET:-avx}"
 SCRIPT_DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
@@ -59,10 +60,16 @@ function install_proxygen {
   cmake_install_dir proxygen -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON
 }
 
+function install_datasketches {
+  wget_and_untar https://github.com/apache/datasketches-cpp/archive/refs/tags/${DATASKETCHES_VERSION}.tar.gz datasketches-cpp
+  cmake_install_dir datasketches-cpp -DBUILD_TESTS=OFF
+}
+
 function install_presto_deps {
   run_and_time install_presto_deps_from_package_managers
   run_and_time install_gperf
   run_and_time install_proxygen
+  run_and_time install_datasketches
 }
 
 if [[ $# -ne 0 ]]; then

--- a/presto-native-execution/scripts/setup-macos.sh
+++ b/presto-native-execution/scripts/setup-macos.sh
@@ -24,6 +24,7 @@ PYTHON_VENV=${PYTHON_VENV:-"${SCRIPTDIR}/../.venv"}
 BUILD_DUCKDB="${BUILD_DUCKDB:-false}"
 source "$(dirname "${BASH_SOURCE[0]}")/../velox/scripts/setup-macos.sh"
 GPERF_VERSION="3.1"
+DATASKETCHES_VERSION="5.2.0"
 
 function install_proxygen {
   wget_and_untar https://github.com/facebook/proxygen/archive/refs/tags/${FB_OS_VERSION}.tar.gz proxygen
@@ -42,9 +43,15 @@ function install_gperf {
   )
 }
 
+function install_datasketches {
+  wget_and_untar https://github.com/apache/datasketches-cpp/archive/refs/tags/${DATASKETCHES_VERSION}.tar.gz datasketches-cpp
+  cmake_install_dir datasketches-cpp -DBUILD_TESTS=OFF
+}
+
 function install_presto_deps {
   run_and_time install_gperf
   run_and_time install_proxygen
+  run_and_time install_datasketches
 }
 
 (return 2>/dev/null) && return # If script was sourced, don't run commands.

--- a/presto-native-execution/scripts/setup-ubuntu.sh
+++ b/presto-native-execution/scripts/setup-ubuntu.sh
@@ -19,6 +19,7 @@ set -eufx -o pipefail
 # Run the velox setup script first.
 source "$(dirname "${BASH_SOURCE[0]}")/../velox/scripts/setup-ubuntu.sh"
 SUDO="${SUDO:-"sudo --preserve-env"}"
+DATASKETCHES_VERSION="5.2.0"
 
 function install_proxygen {
   # proxygen requires python and gperf
@@ -31,8 +32,14 @@ function install_proxygen {
   cmake_install_dir proxygen -DBUILD_TESTS=OFF
 }
 
+function install_datasketches {
+  wget_and_untar https://github.com/apache/datasketches-cpp/archive/refs/tags/${DATASKETCHES_VERSION}.tar.gz datasketches-cpp
+  cmake_install_dir datasketches-cpp -DBUILD_TESTS=OFF
+}
+
 function install_presto_deps {
   run_and_time install_proxygen
+  run_and_time install_datasketches
 }
 
 if [[ $# -ne 0 ]]; then


### PR DESCRIPTION

## Description
This change adds a Apache DataSketches CPP package to the setup scripts

## Motivation and Context
This package is required to implement Theta sketch aggregate and scalar functions required for Iceberg statistics. The functions will be implemented in a different PR https://github.com/prestodb/presto/pull/25685 .

## Impact
No impact

## Test Plan
<!---Please fill in how you tested your change-->


```
== NO RELEASE NOTE ==
```

