### PR TITLE
feat(function): Add array_union_sum aggregation function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -71,6 +71,22 @@ General Aggregate Functions
         ) AS t(name, age, gender);
         --['Alice','Bob','Charlie','Lucy']
 
+.. function:: array_union_sum(array(T)) -> array(T)
+
+    Returns the element-wise sum of all input arrays. Arrays of different lengths
+    are padded with zeros for missing positions. All null values in the original
+    arrays are coalesced to 0.
+    ::
+
+        SELECT array_union_sum(arrays) AS merged_sum_array
+        FROM (
+        VALUES
+            (ARRAY[1, 2, 3]),
+            (ARRAY[10, 5, 4, 1]),
+            (ARRAY[9, 0, 5, 4])
+        ) AS t(arrays);
+        --[20, 7, 12, 5]
+
 .. function:: avg(x) -> double
 
     Returns the average (arithmetic mean) of all input values.

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -345,6 +345,7 @@ import static com.facebook.presto.operator.aggregation.AlternativeMaxAggregation
 import static com.facebook.presto.operator.aggregation.AlternativeMinAggregationFunction.ALTERNATIVE_MIN;
 import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ANY_VALUE_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ARBITRARY_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.ArrayUnionSumAggregation.ARRAY_UNION_SUM;
 import static com.facebook.presto.operator.aggregation.ChecksumAggregationFunction.CHECKSUM_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
 import static com.facebook.presto.operator.aggregation.DecimalAverageAggregation.DECIMAL_AVERAGE_AGGREGATION;
@@ -942,7 +943,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .function(new ArrayAggregationFunction(functionsConfig.isLegacyArrayAgg(), functionsConfig.getArrayAggGroupImplementation()))
                 .functions(new MapSubscriptOperator(functionsConfig.isLegacyMapSubscript()))
                 .functions(MAP_CONSTRUCTOR, MAP_TO_JSON, JSON_TO_MAP, JSON_STRING_TO_MAP)
-                .functions(MAP_AGG, MAP_UNION, MAP_UNION_SUM)
+                .functions(MAP_AGG, MAP_UNION, MAP_UNION_SUM, ARRAY_UNION_SUM)
                 .function(new ReduceAggregationFunction(functionsConfig.isReduceAggForComplexTypesEnabled()))
                 .functions(DECIMAL_TO_VARCHAR_CAST, DECIMAL_TO_INTEGER_CAST, DECIMAL_TO_BIGINT_CAST, DECIMAL_TO_DOUBLE_CAST, DECIMAL_TO_REAL_CAST, DECIMAL_TO_BOOLEAN_CAST, DECIMAL_TO_TINYINT_CAST, DECIMAL_TO_SMALLINT_CAST)
                 .functions(VARCHAR_TO_DECIMAL_CAST, INTEGER_TO_DECIMAL_CAST, BIGINT_TO_DECIMAL_CAST, DOUBLE_TO_DECIMAL_CAST, REAL_TO_DECIMAL_CAST, BOOLEAN_TO_DECIMAL_CAST, TINYINT_TO_DECIMAL_CAST, SMALLINT_TO_DECIMAL_CAST)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ArrayUnionSumAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ArrayUnionSumAggregation.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.state.ArrayUnionSumState;
+import com.facebook.presto.operator.aggregation.state.ArrayUnionSumStateFactory;
+import com.facebook.presto.operator.aggregation.state.ArrayUnionSumStateSerializer;
+import com.facebook.presto.spi.function.aggregation.Accumulator;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata;
+import com.facebook.presto.spi.function.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import com.facebook.presto.spi.function.aggregation.GroupedAccumulator;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.common.type.StandardTypes.ARRAY;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.function.Signature.nonDecimalNumericTypeParameter;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.spi.function.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class ArrayUnionSumAggregation
+        extends SqlAggregationFunction
+{
+    public static final String NAME = "array_union_sum";
+    public static final ArrayUnionSumAggregation ARRAY_UNION_SUM = new ArrayUnionSumAggregation();
+
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(ArrayUnionSumAggregation.class, "input", Type.class, ArrayUnionSumState.class, Block.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(ArrayUnionSumAggregation.class, "combine", ArrayUnionSumState.class, ArrayUnionSumState.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(ArrayUnionSumAggregation.class, "output", ArrayUnionSumState.class, BlockBuilder.class);
+
+    public ArrayUnionSumAggregation()
+    {
+        super(NAME,
+                ImmutableList.of(nonDecimalNumericTypeParameter("T")),
+                ImmutableList.of(),
+                parseTypeSignature("array<T>"),
+                ImmutableList.of(parseTypeSignature("array<T>")));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Aggregate all the arrays into a single array summing the values at each index";
+    }
+
+    @Override
+    public BuiltInAggregationFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        Type elementType = boundVariables.getTypeVariable("T");
+        ArrayType outputType = (ArrayType) functionAndTypeManager.getParameterizedType(ARRAY, ImmutableList.of(
+                TypeSignatureParameter.of(elementType.getTypeSignature())));
+
+        return generateAggregation(elementType, outputType);
+    }
+
+    private static BuiltInAggregationFunctionImplementation generateAggregation(Type elementType, ArrayType outputType)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(ArrayUnionSumAggregation.class.getClassLoader());
+        List<Type> inputTypes = ImmutableList.of(outputType);
+        ArrayUnionSumStateSerializer stateSerializer = new ArrayUnionSumStateSerializer(outputType);
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                createInputParameterMetadata(outputType),
+                INPUT_FUNCTION.bindTo(elementType),
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                        ArrayUnionSumState.class,
+                        stateSerializer,
+                        new ArrayUnionSumStateFactory(elementType))),
+                outputType);
+
+        Class<? extends Accumulator> accumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                Accumulator.class,
+                metadata,
+                classLoader);
+        Class<? extends GroupedAccumulator> groupedAccumulatorClass = AccumulatorCompiler.generateAccumulatorClass(
+                GroupedAccumulator.class,
+                metadata,
+                classLoader);
+        return new BuiltInAggregationFunctionImplementation(NAME, inputTypes, ImmutableList.of(intermediateType), outputType,
+                true, false, metadata, accumulatorClass, groupedAccumulatorClass);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type inputType)
+    {
+        return ImmutableList.of(
+                new ParameterMetadata(STATE),
+                new ParameterMetadata(INPUT_CHANNEL, inputType));
+    }
+
+    public static void input(Type elementType, ArrayUnionSumState state, Block arrayBlock)
+    {
+        ArrayUnionSumResult arrayUnionSumResult = state.get();
+        long startSize;
+
+        if (arrayUnionSumResult == null) {
+            startSize = 0;
+            arrayUnionSumResult = ArrayUnionSumResult.create(elementType, state.getAdder(), arrayBlock);
+            state.set(arrayUnionSumResult);
+        }
+        else {
+            startSize = arrayUnionSumResult.getRetainedSizeInBytes();
+            state.set(state.get().unionSum(arrayBlock));
+        }
+
+        state.addMemoryUsage(arrayUnionSumResult.getRetainedSizeInBytes() - startSize);
+    }
+
+    public static void combine(ArrayUnionSumState state, ArrayUnionSumState otherState)
+    {
+        if (state.get() == null) {
+            state.set(otherState.get());
+            return;
+        }
+
+        long startSize = state.get().getRetainedSizeInBytes();
+        state.set(state.get().unionSum(otherState.get()));
+        state.addMemoryUsage(state.get().getRetainedSizeInBytes() - startSize);
+    }
+
+    public static void output(ArrayUnionSumState state, BlockBuilder out)
+    {
+        ArrayUnionSumResult arrayUnionSumResult = state.get();
+        if (arrayUnionSumResult == null) {
+            out.appendNull();
+        }
+        else {
+            arrayUnionSumResult.serialize(out);
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ArrayUnionSumResult.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/ArrayUnionSumResult.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.Type;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.facebook.presto.common.type.TypeUtils.isExactNumericType;
+import static com.facebook.presto.type.TypeUtils.expectedValueSize;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+
+public abstract class ArrayUnionSumResult
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ArrayUnionSumResult.class).instanceSize();
+    private static final int EXPECTED_ENTRY_SIZE = 16;
+
+    protected final Type elementType;
+    protected final Adder adder;
+
+    public ArrayUnionSumResult(Type elementType, Adder adder)
+    {
+        this.elementType = requireNonNull(elementType, "elementType is null");
+        this.adder = requireNonNull(adder, "adder is null");
+    }
+
+    abstract int size();
+    abstract void appendValue(int i, BlockBuilder blockBuilder);
+    abstract boolean isValueNull(int i);
+    public abstract long getRetainedSizeInBytes();
+    abstract Block getValueBlock();
+    abstract int getValueBlockIndex(int i);
+
+    public static ArrayUnionSumResult create(Type elementType, Adder adder, Block arrayBlock)
+    {
+        return new SingleArrayBlock(elementType, adder, arrayBlock);
+    }
+
+    public Type getElementType()
+    {
+        return elementType;
+    }
+
+    public void serialize(BlockBuilder out)
+    {
+        BlockBuilder arrayBlockBuilder = out.beginBlockEntry();
+        for (int i = 0; i < size(); i++) {
+            appendValue(i, arrayBlockBuilder);
+        }
+        out.closeEntry();
+    }
+
+    static void appendValue(Type elementType, Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            if (isExactNumericType(elementType) || elementType instanceof RealType) {
+                elementType.writeLong(blockBuilder, 0L);
+            }
+            else {
+                elementType.writeDouble(blockBuilder, 0);
+            }
+        }
+        else {
+            elementType.appendTo(block, position, blockBuilder);
+        }
+    }
+
+    /**
+     * Add the values for corresponding indices from other to this.
+     * The result array length is the maximum of the two input array lengths.
+     * Missing elements are treated as 0, and null values are coalesced to 0.
+     */
+    public ArrayUnionSumResult unionSum(ArrayUnionSumResult other)
+    {
+        int thisSize = size();
+        int otherSize = other.size();
+        int resultSize = max(thisSize, otherSize);
+
+        BlockBuilder resultValueBlockBuilder = elementType.createBlockBuilder(null, resultSize, expectedValueSize(elementType, EXPECTED_ENTRY_SIZE));
+
+        for (int i = 0; i < resultSize; i++) {
+            boolean thisHasValue = i < thisSize;
+            boolean otherHasValue = i < otherSize;
+
+            if (thisHasValue && otherHasValue) {
+                boolean thisIsNull = isValueNull(i);
+                boolean otherIsNull = other.isValueNull(i);
+
+                if (!thisIsNull && !otherIsNull) {
+                    // Both have non-null values, sum them
+                    adder.writeSum(
+                            elementType,
+                            getValueBlock(),
+                            getValueBlockIndex(i),
+                            other.getValueBlock(),
+                            other.getValueBlockIndex(i),
+                            resultValueBlockBuilder);
+                }
+                else if (!thisIsNull) {
+                    this.appendValue(i, resultValueBlockBuilder);
+                }
+                else {
+                    other.appendValue(i, resultValueBlockBuilder);
+                }
+            }
+            else if (thisHasValue) {
+                this.appendValue(i, resultValueBlockBuilder);
+            }
+            else {
+                other.appendValue(i, resultValueBlockBuilder);
+            }
+        }
+
+        return new AccumulatedValues(elementType, adder, resultValueBlockBuilder.build());
+    }
+
+    public ArrayUnionSumResult unionSum(Block arrayBlock)
+    {
+        ArrayUnionSumResult arrayUnionSumResult = new SingleArrayBlock(elementType, adder, arrayBlock);
+        return unionSum(arrayUnionSumResult);
+    }
+
+    /**
+     * Holds the input array block to avoid unnecessary copy for the first array.
+     */
+    private static class SingleArrayBlock
+            extends ArrayUnionSumResult
+    {
+        private final Block arrayBlock;
+
+        public SingleArrayBlock(Type elementType, Adder adder, Block arrayBlock)
+        {
+            super(elementType, adder);
+            this.arrayBlock = arrayBlock;
+        }
+
+        @Override
+        int size()
+        {
+            return arrayBlock.getPositionCount();
+        }
+
+        @Override
+        void appendValue(int i, BlockBuilder blockBuilder)
+        {
+            appendValue(elementType, arrayBlock, i, blockBuilder);
+        }
+
+        @Override
+        boolean isValueNull(int i)
+        {
+            return arrayBlock.isNull(i);
+        }
+
+        @Override
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE;
+        }
+
+        @Override
+        Block getValueBlock()
+        {
+            return arrayBlock;
+        }
+
+        @Override
+        int getValueBlockIndex(int i)
+        {
+            return i;
+        }
+    }
+
+    /**
+     * Holds the result of aggregating two or more arrays.
+     */
+    private static class AccumulatedValues
+            extends ArrayUnionSumResult
+    {
+        private final Block valueBlock;
+
+        AccumulatedValues(Type elementType, Adder adder, Block valueBlock)
+        {
+            super(elementType, adder);
+            this.valueBlock = valueBlock;
+        }
+
+        @Override
+        int size()
+        {
+            return valueBlock.getPositionCount();
+        }
+
+        @Override
+        void appendValue(int i, BlockBuilder blockBuilder)
+        {
+            appendValue(elementType, valueBlock, i, blockBuilder);
+        }
+
+        @Override
+        boolean isValueNull(int i)
+        {
+            return valueBlock.isNull(i);
+        }
+
+        @Override
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE + valueBlock.getRetainedSizeInBytes();
+        }
+
+        @Override
+        Block getValueBlock()
+        {
+            return valueBlock;
+        }
+
+        @Override
+        int getValueBlockIndex(int i)
+        {
+            return i;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayUnionSumState.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayUnionSumState.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.Adder;
+import com.facebook.presto.operator.aggregation.ArrayUnionSumResult;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+@AccumulatorStateMetadata(stateFactoryClass = ArrayUnionSumStateFactory.class, stateSerializerClass = ArrayUnionSumStateSerializer.class)
+public interface ArrayUnionSumState
+        extends AccumulatorState
+{
+    ArrayUnionSumResult get();
+
+    void set(ArrayUnionSumResult value);
+
+    void addMemoryUsage(long memory);
+
+    Type getElementType();
+
+    Adder getAdder();
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayUnionSumStateFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayUnionSumStateFactory.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.array.ObjectBigArray;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.Adder;
+import com.facebook.presto.operator.aggregation.ArrayUnionSumResult;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.type.BigintOperators;
+import com.facebook.presto.type.DoubleOperators;
+import com.facebook.presto.type.RealOperators;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.TypeUtils.isExactNumericType;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public final class ArrayUnionSumStateFactory
+        implements AccumulatorStateFactory<ArrayUnionSumState>
+{
+    private final Type elementType;
+    private final Adder adder;
+
+    public ArrayUnionSumStateFactory(Type elementType)
+    {
+        this.elementType = requireNonNull(elementType, "elementType is null");
+        this.adder = getAdder(elementType);
+    }
+
+    @Override
+    public ArrayUnionSumState createSingleState()
+    {
+        return new SingleState(elementType, adder);
+    }
+
+    @Override
+    public Class<? extends ArrayUnionSumState> getSingleStateClass()
+    {
+        return SingleState.class;
+    }
+
+    @Override
+    public ArrayUnionSumState createGroupedState()
+    {
+        return new GroupedState(elementType, adder);
+    }
+
+    @Override
+    public Class<? extends ArrayUnionSumState> getGroupedStateClass()
+    {
+        return GroupedState.class;
+    }
+
+    public static class GroupedState
+            extends AbstractGroupedAccumulatorState
+            implements ArrayUnionSumState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedState.class).instanceSize();
+        private final Type elementType;
+        private final Adder adder;
+        private final ObjectBigArray<ArrayUnionSumResult> results = new ObjectBigArray<>();
+        private long size;
+
+        public GroupedState(Type elementType, Adder adder)
+        {
+            this.elementType = elementType;
+            this.adder = adder;
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            results.ensureCapacity(size);
+        }
+
+        @Override
+        public ArrayUnionSumResult get()
+        {
+            return results.get(getGroupId());
+        }
+
+        @Override
+        public void set(ArrayUnionSumResult value)
+        {
+            requireNonNull(value, "value is null");
+
+            ArrayUnionSumResult previous = get();
+            if (previous != null) {
+                size -= previous.getRetainedSizeInBytes();
+            }
+
+            results.set(getGroupId(), value);
+            size += value.getRetainedSizeInBytes();
+        }
+
+        @Override
+        public void addMemoryUsage(long memory)
+        {
+            size += memory;
+        }
+
+        @Override
+        public Type getElementType()
+        {
+            return elementType;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return INSTANCE_SIZE + size + results.sizeOf();
+        }
+
+        @Override
+        public Adder getAdder()
+        {
+            return adder;
+        }
+    }
+
+    public static class SingleState
+            implements ArrayUnionSumState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleState.class).instanceSize();
+        private final Type elementType;
+        private final Adder adder;
+        private ArrayUnionSumResult result;
+
+        public SingleState(Type elementType, Adder adder)
+        {
+            this.elementType = elementType;
+            this.adder = adder;
+        }
+
+        @Override
+        public ArrayUnionSumResult get()
+        {
+            return result;
+        }
+
+        @Override
+        public void set(ArrayUnionSumResult value)
+        {
+            result = value;
+        }
+
+        @Override
+        public void addMemoryUsage(long memory)
+        {
+        }
+
+        @Override
+        public Type getElementType()
+        {
+            return elementType;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            long estimatedSize = INSTANCE_SIZE;
+            if (result != null) {
+                estimatedSize += result.getRetainedSizeInBytes();
+            }
+            return estimatedSize;
+        }
+
+        @Override
+        public Adder getAdder()
+        {
+            return adder;
+        }
+    }
+
+    private static final Adder LONG_ADDER = new Adder() {
+        @Override
+        public void writeSum(Type type, Block block1, int position1, Block block2, int position2, BlockBuilder blockBuilder)
+        {
+            type.writeLong(blockBuilder, BigintOperators.add(type.getLong(block1, position1), type.getLong(block2, position2)));
+        }
+    };
+
+    private static final Adder DOUBLE_ADDER = new Adder() {
+        @Override
+        public void writeSum(Type type, Block block1, int position1, Block block2, int position2, BlockBuilder blockBuilder)
+        {
+            type.writeDouble(blockBuilder, DoubleOperators.add(type.getDouble(block1, position1), type.getDouble(block2, position2)));
+        }
+    };
+
+    private static final Adder FLOAT_ADDER = new Adder() {
+        @Override
+        public void writeSum(Type type, Block block1, int position1, Block block2, int position2, BlockBuilder blockBuilder)
+        {
+            type.writeLong(blockBuilder, RealOperators.add(type.getLong(block1, position1), type.getLong(block2, position2)));
+        }
+    };
+
+    private static Adder getAdder(Type type)
+    {
+        if (isExactNumericType(type)) {
+            return LONG_ADDER;
+        }
+
+        if (DOUBLE.equals(type)) {
+            return DOUBLE_ADDER;
+        }
+
+        if (REAL.equals(type)) {
+            return FLOAT_ADDER;
+        }
+
+        checkState(false);
+        return null;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayUnionSumStateSerializer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/state/ArrayUnionSumStateSerializer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.ArrayUnionSumResult;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ArrayUnionSumStateSerializer
+        implements AccumulatorStateSerializer<ArrayUnionSumState>
+{
+    private final ArrayType arrayType;
+
+    public ArrayUnionSumStateSerializer(ArrayType arrayType)
+    {
+        this.arrayType = requireNonNull(arrayType, "arrayType is null");
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return arrayType;
+    }
+
+    @Override
+    public void serialize(ArrayUnionSumState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            state.get().serialize(out);
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ArrayUnionSumState state)
+    {
+        ArrayUnionSumResult arrayUnionSumResult = ArrayUnionSumResult.create(state.getElementType(), state.getAdder(), arrayType.getObject(block, index));
+        state.set(arrayUnionSumResult);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/aggregation/TestArrayUnionSumResult.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/aggregation/TestArrayUnionSumResult.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.state.ArrayUnionSumState;
+import com.facebook.presto.operator.aggregation.state.ArrayUnionSumStateFactory;
+import com.facebook.presto.operator.aggregation.state.ArrayUnionSumStateSerializer;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static java.lang.Float.floatToRawIntBits;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestArrayUnionSumResult
+{
+    private static final ArrayType ARRAY_BIGINT = new ArrayType(BIGINT);
+    private static final ArrayType ARRAY_DOUBLE = new ArrayType(DOUBLE);
+    private static final ArrayType ARRAY_REAL = new ArrayType(REAL);
+
+    @Test
+    public void testBasicUnionSum()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(BIGINT).createSingleState();
+
+        // Create array [1, 2, 3]
+        Block array1 = createLongsBlock(BIGINT, 1L, 2L, 3L);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array1);
+        assertEquals(result1.size(), 3);
+
+        // Create array [10, 5, 4, 1]
+        Block array2 = createLongsBlock(BIGINT, 10L, 5L, 4L, 1L);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+        assertEquals(result2.size(), 4);
+
+        // Create array [9, 0, 5, 4]
+        Block array3 = createLongsBlock(BIGINT, 9L, 0L, 5L, 4L);
+        ArrayUnionSumResult result3 = result2.unionSum(array3);
+        assertEquals(result3.size(), 4);
+
+        // Verify the result: [20, 7, 12, 5]
+        BlockBuilder out = ARRAY_BIGINT.createBlockBuilder(null, 1);
+        result3.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_BIGINT.getObject(resultBlock, 0);
+
+        assertEquals(BIGINT.getLong(arrayBlock, 0), 20L);
+        assertEquals(BIGINT.getLong(arrayBlock, 1), 7L);
+        assertEquals(BIGINT.getLong(arrayBlock, 2), 12L);
+        assertEquals(BIGINT.getLong(arrayBlock, 3), 5L);
+    }
+
+    @Test
+    public void testNullHandling()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(BIGINT).createSingleState();
+
+        // Create array [1, null, 3]
+        Block array1 = createLongsBlock(BIGINT, 1L, null, 3L);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array1);
+
+        // Create array [10, 5]
+        Block array2 = createLongsBlock(BIGINT, 10L, 5L);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+
+        // Verify the result: [11, 5, 3] - null treated as 0
+        BlockBuilder out = ARRAY_BIGINT.createBlockBuilder(null, 1);
+        result2.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_BIGINT.getObject(resultBlock, 0);
+
+        assertEquals(BIGINT.getLong(arrayBlock, 0), 11L);
+        assertEquals(BIGINT.getLong(arrayBlock, 1), 5L);
+        assertEquals(BIGINT.getLong(arrayBlock, 2), 3L);
+    }
+
+    @Test
+    public void testBothNullsAtSamePosition()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(BIGINT).createSingleState();
+
+        // Create array [1, null, 3]
+        Block array1 = createLongsBlock(BIGINT, 1L, null, 3L);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array1);
+
+        // Create array [10, null, 5]
+        Block array2 = createLongsBlock(BIGINT, 10L, null, 5L);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+
+        // Verify the result: [11, 0, 8] - both nulls treated as 0
+        BlockBuilder out = ARRAY_BIGINT.createBlockBuilder(null, 1);
+        result2.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_BIGINT.getObject(resultBlock, 0);
+
+        assertEquals(BIGINT.getLong(arrayBlock, 0), 11L);
+        assertEquals(BIGINT.getLong(arrayBlock, 1), 0L);
+        assertEquals(BIGINT.getLong(arrayBlock, 2), 8L);
+    }
+
+    @Test
+    public void testDifferentLengthArrays()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(BIGINT).createSingleState();
+
+        // Create array [1, 2]
+        Block array1 = createLongsBlock(BIGINT, 1L, 2L);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array1);
+
+        // Create array [10, 5, 100, 200]
+        Block array2 = createLongsBlock(BIGINT, 10L, 5L, 100L, 200L);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+
+        // Verify result: [11, 7, 100, 200]
+        BlockBuilder out = ARRAY_BIGINT.createBlockBuilder(null, 1);
+        result2.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_BIGINT.getObject(resultBlock, 0);
+
+        assertEquals(arrayBlock.getPositionCount(), 4);
+        assertEquals(BIGINT.getLong(arrayBlock, 0), 11L);
+        assertEquals(BIGINT.getLong(arrayBlock, 1), 7L);
+        assertEquals(BIGINT.getLong(arrayBlock, 2), 100L);
+        assertEquals(BIGINT.getLong(arrayBlock, 3), 200L);
+    }
+
+    @Test
+    public void testDoubleAdder()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(DOUBLE).createSingleState();
+
+        // Create array [1.5, 2.5]
+        Block array1 = createDoublesBlock(1.5, 2.5);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(DOUBLE, state.getAdder(), array1);
+
+        // Create array [10.5, 5.5, 100.0]
+        Block array2 = createDoublesBlock(10.5, 5.5, 100.0);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+
+        // Verify result: [12.0, 8.0, 100.0]
+        BlockBuilder out = ARRAY_DOUBLE.createBlockBuilder(null, 1);
+        result2.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_DOUBLE.getObject(resultBlock, 0);
+
+        assertEquals(arrayBlock.getPositionCount(), 3);
+        assertEquals(DOUBLE.getDouble(arrayBlock, 0), 12.0, 0.001);
+        assertEquals(DOUBLE.getDouble(arrayBlock, 1), 8.0, 0.001);
+        assertEquals(DOUBLE.getDouble(arrayBlock, 2), 100.0, 0.001);
+    }
+
+    @Test
+    public void testDoubleWithNulls()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(DOUBLE).createSingleState();
+
+        // Create array [1.5, null]
+        Block array1 = createDoublesBlock(1.5, null);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(DOUBLE, state.getAdder(), array1);
+
+        // Create array [10.5, 5.5]
+        Block array2 = createDoublesBlock(10.5, 5.5);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+
+        // Verify result: [12.0, 5.5] - null treated as 0
+        BlockBuilder out = ARRAY_DOUBLE.createBlockBuilder(null, 1);
+        result2.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_DOUBLE.getObject(resultBlock, 0);
+
+        assertEquals(DOUBLE.getDouble(arrayBlock, 0), 12.0, 0.001);
+        assertEquals(DOUBLE.getDouble(arrayBlock, 1), 5.5, 0.001);
+    }
+
+    @Test
+    public void testRealAdder()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(REAL).createSingleState();
+
+        // Create array [1.5f, 2.5f]
+        Block array1 = createRealsBlock(1.5f, 2.5f);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(REAL, state.getAdder(), array1);
+
+        // Create array [10.5f, 5.5f]
+        Block array2 = createRealsBlock(10.5f, 5.5f);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+
+        // Verify result: [12.0f, 8.0f]
+        BlockBuilder out = ARRAY_REAL.createBlockBuilder(null, 1);
+        result2.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_REAL.getObject(resultBlock, 0);
+
+        assertEquals(arrayBlock.getPositionCount(), 2);
+        assertEquals(Float.intBitsToFloat((int) REAL.getLong(arrayBlock, 0)), 12.0f, 0.001f);
+        assertEquals(Float.intBitsToFloat((int) REAL.getLong(arrayBlock, 1)), 8.0f, 0.001f);
+    }
+
+    @Test
+    public void testRealWithNulls()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(REAL).createSingleState();
+
+        // Create array [1.5f, null]
+        Block array1 = createRealsBlock(1.5f, null);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(REAL, state.getAdder(), array1);
+
+        // Create array [10.5f, 5.5f]
+        Block array2 = createRealsBlock(10.5f, 5.5f);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+
+        // Verify result: [12.0f, 5.5f]
+        BlockBuilder out = ARRAY_REAL.createBlockBuilder(null, 1);
+        result2.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_REAL.getObject(resultBlock, 0);
+
+        assertEquals(Float.intBitsToFloat((int) REAL.getLong(arrayBlock, 0)), 12.0f, 0.001f);
+        assertEquals(Float.intBitsToFloat((int) REAL.getLong(arrayBlock, 1)), 5.5f, 0.001f);
+    }
+
+    @Test
+    public void testSingleStateFactory()
+    {
+        ArrayUnionSumStateFactory factory = new ArrayUnionSumStateFactory(BIGINT);
+        ArrayUnionSumState state = factory.createSingleState();
+
+        assertNotNull(state);
+        assertNull(state.get());
+        assertEquals(state.getElementType(), BIGINT);
+        assertNotNull(state.getAdder());
+
+        // Test set and get
+        Block array = createLongsBlock(BIGINT, 1L, 2L, 3L);
+        ArrayUnionSumResult result = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array);
+        state.set(result);
+        assertNotNull(state.get());
+        assertEquals(state.get().size(), 3);
+
+        // Test estimated size
+        assertTrue(state.getEstimatedSize() > 0);
+    }
+
+    @Test
+    public void testGroupedStateFactory()
+    {
+        ArrayUnionSumStateFactory factory = new ArrayUnionSumStateFactory(BIGINT);
+        ArrayUnionSumState state = factory.createGroupedState();
+
+        assertNotNull(state);
+        assertNull(state.get());
+        assertEquals(state.getElementType(), BIGINT);
+        assertNotNull(state.getAdder());
+
+        // Test estimated size
+        assertTrue(state.getEstimatedSize() > 0);
+    }
+
+    @Test
+    public void testStateSerializer()
+    {
+        ArrayUnionSumStateFactory factory = new ArrayUnionSumStateFactory(BIGINT);
+        ArrayUnionSumState state = factory.createSingleState();
+        ArrayUnionSumStateSerializer serializer = new ArrayUnionSumStateSerializer(ARRAY_BIGINT);
+
+        assertEquals(serializer.getSerializedType(), ARRAY_BIGINT);
+
+        // Test serialize null state
+        BlockBuilder out = ARRAY_BIGINT.createBlockBuilder(null, 1);
+        serializer.serialize(state, out);
+        Block serialized = out.build();
+        assertTrue(serialized.isNull(0));
+
+        // Test serialize with value
+        Block array = createLongsBlock(BIGINT, 1L, 2L, 3L);
+        ArrayUnionSumResult result = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array);
+        state.set(result);
+
+        BlockBuilder out2 = ARRAY_BIGINT.createBlockBuilder(null, 1);
+        serializer.serialize(state, out2);
+        Block serialized2 = out2.build();
+
+        // Test deserialize
+        ArrayUnionSumState newState = factory.createSingleState();
+        serializer.deserialize(serialized2, 0, newState);
+        assertNotNull(newState.get());
+        assertEquals(newState.get().size(), 3);
+    }
+
+    @Test
+    public void testRetainedSizeInBytes()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(BIGINT).createSingleState();
+
+        Block array1 = createLongsBlock(BIGINT, 1L, 2L, 3L);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array1);
+        assertTrue(result1.getRetainedSizeInBytes() > 0);
+
+        Block array2 = createLongsBlock(BIGINT, 10L, 5L, 4L, 1L);
+        ArrayUnionSumResult result2 = result1.unionSum(array2);
+        assertTrue(result2.getRetainedSizeInBytes() > 0);
+    }
+
+    @Test
+    public void testGetElementType()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(BIGINT).createSingleState();
+        Block array = createLongsBlock(BIGINT, 1L, 2L, 3L);
+        ArrayUnionSumResult result = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array);
+        assertEquals(result.getElementType(), BIGINT);
+    }
+
+    @Test
+    public void testUnionSumWithResult()
+    {
+        ArrayUnionSumState state = new ArrayUnionSumStateFactory(BIGINT).createSingleState();
+
+        Block array1 = createLongsBlock(BIGINT, 1L, 2L);
+        ArrayUnionSumResult result1 = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array1);
+
+        Block array2 = createLongsBlock(BIGINT, 10L, 5L);
+        ArrayUnionSumResult result2 = ArrayUnionSumResult.create(BIGINT, state.getAdder(), array2);
+
+        // Test unionSum with another result (not a block)
+        ArrayUnionSumResult combined = result1.unionSum(result2);
+        assertEquals(combined.size(), 2);
+
+        BlockBuilder out = ARRAY_BIGINT.createBlockBuilder(null, 1);
+        combined.serialize(out);
+        Block resultBlock = out.build();
+        Block arrayBlock = ARRAY_BIGINT.getObject(resultBlock, 0);
+
+        assertEquals(BIGINT.getLong(arrayBlock, 0), 11L);
+        assertEquals(BIGINT.getLong(arrayBlock, 1), 7L);
+    }
+
+    private static Block createLongsBlock(Type type, Long... values)
+    {
+        BlockBuilder builder = type.createBlockBuilder(null, values.length);
+        for (Long value : values) {
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                type.writeLong(builder, value);
+            }
+        }
+        return builder.build();
+    }
+
+    private static Block createDoublesBlock(Double... values)
+    {
+        BlockBuilder builder = DOUBLE.createBlockBuilder(null, values.length);
+        for (Double value : values) {
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                DOUBLE.writeDouble(builder, value);
+            }
+        }
+        return builder.build();
+    }
+
+    private static Block createRealsBlock(Float... values)
+    {
+        BlockBuilder builder = REAL.createBlockBuilder(null, values.length);
+        for (Float value : values) {
+            if (value == null) {
+                builder.appendNull();
+            }
+            else {
+                REAL.writeLong(builder, floatToRawIntBits(value));
+            }
+        }
+        return builder.build();
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6339,6 +6339,97 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testArrayUnionSum()
+    {
+        // Basic aggregation with real values
+        MaterializedResult actual = computeActual("select array_union_sum(x) from (select cast(array[1.1, 2] as array<real>) x union all select cast(array[10, 20] as array<real>))");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(0), ImmutableList.of(11.1f, 22.0f));
+
+        // Basic aggregation with double values
+        actual = computeActual("select array_union_sum(x) from (select cast(array[1.1, 2.58] as array<double>) x union all select cast(array[10.1, 20.1] as array<double>))");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(0), ImmutableList.of(11.2, 22.68));
+
+        // Basic aggregation with bigint values
+        actual = computeActual("select array_union_sum(x) from (select cast(array[1, 2] as array<bigint>) x union all select cast(array[10, 20] as array<bigint>))");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(0), ImmutableList.of(11L, 22L));
+
+        // Arrays of different lengths - shorter array padded with 0
+        actual = computeActual("select array_union_sum(x) from (select cast(array[1, 2, 3] as array<bigint>) x union all select cast(array[10, 5, 4, 1] as array<bigint>) union all select cast(array[9, 0, 5, 4] as array<bigint>))");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(0), ImmutableList.of(20L, 7L, 12L, 5L));
+
+        // Grouped aggregation
+        actual = computeActual("select y, array_union_sum(x) from (select 1 y, cast(array[1, 2] as array<bigint>) x union all select 1 y, cast(array[10, 30, 20] as array<bigint>)) group by y");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableList.of(11L, 32L, 20L));
+
+        // Null handling - null values treated as 0
+        actual = computeActual("select y, array_union_sum(x) from (select 1 y, cast(array[1, null] as array<bigint>) x) group by y");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableList.of(1L, 0L));
+
+        // Null values with multiple arrays
+        actual = computeActual("select y, array_union_sum(x) from (select 1 y, cast(array[null, 30, 20] as array<integer>) x " +
+                "union all select 1 y, cast(array[1, null] as array<integer>) x) group by y");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableList.of(1, 30, 20));
+
+        // smallint type
+        actual = computeActual("select y, array_union_sum(x) from (select 1 y, cast(array[null, 30, 20] as array<smallint>) x " +
+                "union all select 1 y, cast(array[1, null] as array<smallint>) x) group by y");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableList.of((short) 1, (short) 30, (short) 20));
+
+        // tinyint type
+        actual = computeActual("select y, array_union_sum(x) from (select 1 y, cast(array[null, 30, 20] as array<tinyint>) x " +
+                "union all select 1 y, cast(array[1, null] as array<tinyint>) x) group by y");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableList.of((byte) 1, (byte) 30, (byte) 20));
+
+        // real type with nulls
+        actual = computeActual("select y, array_union_sum(x) from (select 1 y, cast(array[null, 30, 20] as array<real>) x union all select 1 y, cast(array[1, null] as array<real>) x) group by y");
+        assertEquals(actual.getRowCount(), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableList.of(1.0f, 30.0f, 20.0f));
+
+        // Multiple groups
+        actual = computeActual("select y, array_union_sum(x) from (select 1 y, cast(array[1, null] as array<bigint>) x " +
+                "union all select 1 y, cast(array[null, 30, 20] as array<bigint>) " +
+                "union all select 1 y, cast(array[100, 400, 200] as array<bigint>) " +
+                "union all select 3 y, cast(array[-1, 2, -3] as array<bigint>) " +
+                ") group by y order by y");
+        assertEquals(actual.getRowCount(), 2);
+        assertEquals(actual.getMaterializedRows().get(0).getField(0), 1);
+        assertEquals(actual.getMaterializedRows().get(0).getField(1), ImmutableList.of(101L, 430L, 220L));
+        assertEquals(actual.getMaterializedRows().get(1).getField(0), 3);
+        assertEquals(actual.getMaterializedRows().get(1).getField(1), ImmutableList.of(-1L, 2L, -3L));
+    }
+
+    @Test
+    public void testInvalidArrayUnionSum()
+    {
+        assertQueryFails(
+                "SELECT array_union_sum(x) from (select cast(array[] as array<varchar>) x)",
+                "(?s).*line 1:8: Unexpected parameters \\(array\\(varchar\\)\\) for function (?:native.default.)?array_union_sum. Expected: (?:native.default.)?array_union_sum\\(array\\((T|t)\\)\\) (T|t):nonDecimalNumeric.*");
+        assertQueryFails(
+                "SELECT array_union_sum(x) from (select cast(array[] as array<decimal(10,2)>) x)",
+                "(?s).*line 1:8: Unexpected parameters \\(array\\(decimal\\(10,2\\)\\)\\) for function (?:native.default.)?array_union_sum. Expected: (?:native.default.)?array_union_sum\\(array\\((T|t)\\)\\) (T|t):nonDecimalNumeric.*");
+    }
+
+    @Test
+    public void testArrayUnionSumOverflow()
+    {
+        assertQueryFails(
+                "select y, array_union_sum(x) from (select 1 y, cast(array[null, 30, 100] as array<tinyint>) x " +
+                        "union all select 1 y, cast(array[1, 100] as array<tinyint>) x) group by y", "(?s).*Value 130 exceeds.*");
+        assertQueryFails(
+                "select y, array_union_sum(x) from (select 1 y, cast(array[null, 30, 32760] as array<smallint>) x " +
+                        "union all select 1 y, cast(array[1, 100, 100] as array<smallint>) x) group by y", "(?s).*Value 32860 exceeds.*");
+    }
+
+    @Test
     public void testMultipleOrderingOnSameCanonicalVariables()
     {
         assertQuerySucceeds("SELECT ARRAY_AGG( x ORDER BY x ASC, x DESC ) FROM ( SELECT 0 as x, 0 AS y)");


### PR DESCRIPTION
## Description                                          
  Adds a new SQL aggregation function `array_union_sum` that combines multiple arrays by summing values at corresponding indices. This function is analogous to `map_union_sum` but operates on arrays instead of maps.
                                                          
  **Example usage:**                                      
  ```sql                                                  
  -- Basic usage                                          
  SELECT array_union_sum(arr) FROM (                      
      VALUES (ARRAY[1, 2, 3]),                            
             (ARRAY[4, 5, 6]),                            
             (ARRAY[10, 20, 30])                          
  ) AS t(arr);                                            
  -- Returns: [15, 27, 39]                                
                                                          
  -- With GROUP BY                                        
  SELECT category, array_union_sum(values)                
  FROM metrics                                            
  GROUP BY category;   

```                                   
                                                          
  ## Implementation details:                                 
  - ArrayUnionSumAggregation.java - Main aggregation function registration and input/combine/output methods
  - ArrayUnionSumResult.java - Result container with efficient union-sum logic using lazy evaluation
  - ArrayUnionSumState.java - State interface for accumulator
  - ArrayUnionSumStateFactory.java - Creates single and grouped states with type-specific adders
  - ArrayUnionSumStateSerializer.java - Handles serialization for distributed execution
                                                          
 ## Motivation and Context                                  
                                                          
  Users often need to aggregate arrays element-wise, such as:
  - Combining metric arrays across time periods           
  - Aggregating feature vectors                           
  - Summing histogram buckets stored as arrays            
                                                          
  Currently, this requires complex workarounds using unnest, zip, and manual reconstruction. The array_union_sum function provides a clean, efficient solution similar to the existing map_union_sum function.
                                                          
  ## Impact                                                  
                                                          
  Public API changes:                                     
  - Adds new SQL function: array_union_sum(array<T>) -> array<T> where T is a non-decimal numeric type
                                                          
  ## Behavior:                                               
  - Result array length is the maximum length across all input arrays
  - Missing elements (shorter arrays) are treated as 0    
  - NULL values within arrays are coalesced to 0          
  - NULL arrays are skipped                               
  - Empty arrays are handled correctly                    
                                                          
 ## Supported types:                                        
  - BIGINT, INTEGER, SMALLINT, TINYINT (exact numeric)    
  - DOUBLE, REAL (floating point)                         
                                                          
  ## Performance:                                            
  - Uses lazy evaluation to avoid copying the first input array
  - Memory-efficient state management with proper size tracking
  - Follows the same patterns as map_union_sum for consistency
                                                          
  ## Test Plan                                               
                                                          
  - Unit tests in TestArrayUnionSumResult.java (14 test cases):
    - Basic union sum with multiple arrays                
    - NULL value handling (single NULL, both NULLs at same position)
    - Different length arrays                             
    - DOUBLE type with precision verification             
    - REAL type with precision verification               
    - NULL handling for DOUBLE and REAL types             
    - State factory tests (single and grouped)            
    - State serializer tests (serialize/deserialize round-trip)
    - Retained size tracking                              
    - Element type verification                           
  - Integration tests in AbstractTestQueries.java:        
    - Basic aggregation queries                           
    - GROUP BY queries                                    
    - Edge cases (empty arrays, NULL arrays)              
  - Manual testing with Presto CLI against memory connector
  - All existing tests pass                               
                                                          
  ## Contributor checklist                                   
                                                          
  - Please make sure your submission complies with our https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md, in particular https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style and https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards.
  - PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
  - Documented new properties (with its default value), SQL syntax, functions, or other functionality.
  - If release notes are required, they follow the https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines.
  - Adequate tests were added if applicable.              
  - CI passed.                                            
  - If adding new dependencies, verified they have an https://securityscorecards.dev/#the-checks score of 5.0 or higher (or obtained explicit TSC approval for lower scores).
                                                          
  ## Release Notes                                           
                                                          
  == RELEASE NOTES ==                                     
                                                          
  General Changes                                         
  * Add ``array_union_sum`` aggregation function that combines arrays by summing values at corresponding indices. Supports all non-decimal numeric types (BIGINT, INTEGER, SMALLINT, TINYINT, DOUBLE, REAL). The result array length is the maximum of all input arrays, with missing elements treated as 0 and NULL values coalesced to 0.