### PR TITLE
feat: Implement Iceberg Avro page source for timestamp logical types

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAvroPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAvroPageSource.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.SeekableInput;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
+import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_CANNOT_OPEN_SPLIT;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Page source for reading Avro files in Iceberg tables.
+ * Supports Avro logical types including:
+ * - timestamp-micros with adjust-to-utc (maps to TIMESTAMP_WITH_TIME_ZONE)
+ * - timestamp-nanos without adjust-to-utc (maps to TIMESTAMP)
+ */
+public class IcebergAvroPageSource
+        implements ConnectorPageSource
+{
+    private static final int ROWS_PER_REQUEST = 8192;
+
+    private final List<IcebergColumnHandle> columns;
+    private final List<Type> types;
+    private final DataFileReader<GenericRecord> dataFileReader;
+    private final PageBuilder pageBuilder;
+    private final RuntimeStats runtimeStats;
+    private boolean closed;
+    private long completedBytes;
+    private long readTimeNanos;
+
+    public IcebergAvroPageSource(
+            FSDataInputStream inputStream,
+            Path path,
+            long start,
+            long length,
+            Schema fileSchema,
+            List<IcebergColumnHandle> columns,
+            RuntimeStats runtimeStats)
+    {
+        this.columns = requireNonNull(columns, "columns is null");
+        this.types = columns.stream()
+                .map(IcebergColumnHandle::getType)
+                .collect(ImmutableList.toImmutableList());
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+        this.pageBuilder = new PageBuilder(types);
+
+        try {
+            SeekableInput seekableInput = new HdfsSeekableInput(inputStream, path.toString());
+            DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(fileSchema);
+            this.dataFileReader = new DataFileReader<>(seekableInput, datumReader);
+
+            // Seek to the start position if needed
+            if (start > 0) {
+                dataFileReader.sync(start);
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, "Failed to open Avro file: " + path, e);
+        }
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return completedBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed || !dataFileReader.hasNext();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (isFinished()) {
+            return null;
+        }
+
+        long start = System.nanoTime();
+        try {
+            pageBuilder.reset();
+
+            int rowCount = 0;
+            while (rowCount < ROWS_PER_REQUEST && dataFileReader.hasNext()) {
+                GenericRecord record = dataFileReader.next();
+                pageBuilder.declarePosition();
+
+                for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+                    IcebergColumnHandle column = columns.get(columnIndex);
+                    BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(columnIndex);
+                    Type type = types.get(columnIndex);
+
+                    Object value = record.get(column.getName());
+                    writeValue(blockBuilder, type, value, column);
+                }
+
+                rowCount++;
+                completedBytes = dataFileReader.tell();
+            }
+
+            Page page = pageBuilder.build();
+            readTimeNanos += System.nanoTime() - start;
+            return page;
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_BAD_DATA, "Failed to read Avro data", e);
+        }
+    }
+
+    private void writeValue(BlockBuilder blockBuilder, Type type, Object value, IcebergColumnHandle column)
+    {
+        if (value == null) {
+            blockBuilder.appendNull();
+            return;
+        }
+
+        // Handle timestamp logical types
+        if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+            // timestamp-micros with adjust-to-utc: true
+            // Value is in microseconds from epoch UTC
+            long micros = (Long) value;
+            long millis = TimeUnit.MICROSECONDS.toMillis(micros);
+            type.writeLong(blockBuilder, millis);
+        }
+        else if (type.equals(TIMESTAMP)) {
+            // timestamp-nanos without adjust-to-utc: false
+            // Value is in nanoseconds from epoch (local time)
+            long nanos = (Long) value;
+            long micros = TimeUnit.NANOSECONDS.toMicros(nanos);
+            type.writeLong(blockBuilder, micros);
+        }
+        else if (value instanceof Long) {
+            type.writeLong(blockBuilder, (Long) value);
+        }
+        else if (value instanceof Integer) {
+            type.writeLong(blockBuilder, ((Integer) value).longValue());
+        }
+        else if (value instanceof Double) {
+            type.writeDouble(blockBuilder, (Double) value);
+        }
+        else if (value instanceof Float) {
+            type.writeLong(blockBuilder, Float.floatToIntBits((Float) value));
+        }
+        else if (value instanceof Boolean) {
+            type.writeBoolean(blockBuilder, (Boolean) value);
+        }
+        else if (value instanceof CharSequence) {
+            type.writeSlice(blockBuilder, io.airlift.slice.Slices.utf8Slice(value.toString()));
+        }
+        else if (value instanceof java.nio.ByteBuffer) {
+            type.writeSlice(blockBuilder, io.airlift.slice.Slices.wrappedBuffer((java.nio.ByteBuffer) value));
+        }
+        else {
+            throw new PrestoException(ICEBERG_BAD_DATA, "Unsupported Avro type: " + value.getClass());
+        }
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        try {
+            dataFileReader.close();
+        }
+        catch (IOException e) {
+            throw new PrestoException(ICEBERG_CANNOT_OPEN_SPLIT, "Failed to close Avro reader", e);
+        }
+    }
+
+    /**
+     * Adapter to make FSDataInputStream work with Avro's SeekableInput interface
+     */
+    private static class HdfsSeekableInput
+            implements SeekableInput
+    {
+        private final FSDataInputStream inputStream;
+        private final String path;
+
+        public HdfsSeekableInput(FSDataInputStream inputStream, String path)
+        {
+            this.inputStream = requireNonNull(inputStream, "inputStream is null");
+            this.path = requireNonNull(path, "path is null");
+        }
+
+        @Override
+        public void seek(long position)
+                throws IOException
+        {
+            inputStream.seek(position);
+        }
+
+        @Override
+        public long tell()
+                throws IOException
+        {
+            return inputStream.getPos();
+        }
+
+        @Override
+        public long length()
+                throws IOException
+        {
+            return inputStream.available();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len)
+                throws IOException
+        {
+            return inputStream.read(b, off, len);
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            inputStream.close();
+        }
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergAvroTimestampTypes.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergAvroTimestampTypes.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
+import com.facebook.presto.common.type.Type;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for Avro timestamp logical types in Iceberg connector.
+ * Tests the mapping of:
+ * - timestamp-micros with adjust-to-utc: true -> TIMESTAMP_WITH_TIME_ZONE
+ * - timestamp-nanos without adjust-to-utc: false -> TIMESTAMP
+ */
+public class TestIcebergAvroTimestampTypes
+{
+    @Test
+    public void testTimestampMicrosWithAdjustToUtc()
+    {
+        // timestamp-micros with adjust-to-utc: true should map to TIMESTAMP_WITH_TIME_ZONE
+        Types.TimestampType icebergType = Types.TimestampType.withZone();
+
+        Type prestoType = toPrestoType(icebergType, null);
+
+        assertTrue(prestoType instanceof TimestampWithTimeZoneType,
+                "timestamp-micros with adjust-to-utc should map to TIMESTAMP_WITH_TIME_ZONE");
+        assertEquals(prestoType, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
+    }
+
+    @Test
+    public void testTimestampNanosWithoutAdjustToUtc()
+    {
+        // timestamp-nanos without adjust-to-utc: false should map to TIMESTAMP
+        Types.TimestampType icebergType = Types.TimestampType.withoutZone();
+
+        Type prestoType = toPrestoType(icebergType, null);
+
+        assertTrue(prestoType instanceof TimestampType,
+                "timestamp-nanos without adjust-to-utc should map to TIMESTAMP");
+        assertEquals(prestoType, TimestampType.TIMESTAMP);
+    }
+
+    @Test
+    public void testMixedTimestampTypes()
+    {
+        // Test schema with both timestamp types
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "ts_with_tz", Types.TimestampType.withZone()),
+                Types.NestedField.required(2, "ts_without_tz", Types.TimestampType.withoutZone()));
+
+        Type typeWithTz = toPrestoType(schema.findField(1).type(), null);
+        Type typeWithoutTz = toPrestoType(schema.findField(2).type(), null);
+
+        assertEquals(typeWithTz, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE,
+                "Field with timezone should map to TIMESTAMP_WITH_TIME_ZONE");
+        assertEquals(typeWithoutTz, TimestampType.TIMESTAMP,
+                "Field without timezone should map to TIMESTAMP");
+    }
+
+    @Test
+    public void testTimestampTypeConversion()
+    {
+        // Test that Iceberg timestamp types correctly identify their UTC adjustment
+        Types.TimestampType withZone = Types.TimestampType.withZone();
+        Types.TimestampType withoutZone = Types.TimestampType.withoutZone();
+
+        assertTrue(withZone.shouldAdjustToUTC(),
+                "TimestampType.withZone() should adjust to UTC");
+        assertFalse(withoutZone.shouldAdjustToUTC(), "TimestampType.withoutZone() should not adjust to UTC");
+    }
+}


### PR DESCRIPTION
## Description
- Implement Iceberg Avro page source for timestamp logical types
- Update iceberg to 1.10.0

## Motivation and Context
Add support for timestamp with nanosecond precision

## Impact
No Impact

## Test Plan
UT Added
## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

