### PR TITLE
fix(optimizer): Make groupby limit optimization functional again

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -6257,32 +6257,6 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
-    public void testGroupByLimitPartitionKeys()
-    {
-        Session prefilter = Session.builder(getSession())
-                .setSystemProperty("prefilter_for_groupby_limit", "true")
-                .build();
-
-        @Language("SQL") String createTable = "" +
-                "CREATE TABLE test_create_partitioned_table_as " +
-                "WITH (" +
-                "partitioned_by = ARRAY[ 'orderstatus' ]" +
-                ") " +
-                "AS " +
-                "SELECT custkey, orderkey, orderstatus FROM tpch.tiny.orders";
-
-        assertUpdate(prefilter, createTable, 15000);
-        prefilter = Session.builder(prefilter)
-                .setSystemProperty("prefilter_for_groupby_limit", "true")
-                .build();
-
-        MaterializedResult plan = computeActual(prefilter, "explain(type distributed) select count(custkey), orderstatus from test_create_partitioned_table_as group by orderstatus limit 1000");
-        assertFalse(((String) plan.getOnlyValue()).toUpperCase().indexOf("MAP_AGG") >= 0);
-        plan = computeActual(prefilter, "explain(type distributed) select count(custkey), orderkey from test_create_partitioned_table_as group by orderkey limit 1000");
-        assertTrue(((String) plan.getOnlyValue()).toUpperCase().indexOf("MAP_AGG") >= 0);
-    }
-
-    @Test
     public void testJoinPrefilterPartitionKeys()
     {
         Session prefilter = Session.builder(getSession())

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AggregationNodeUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AggregationNodeUtils.java
@@ -13,18 +13,11 @@
  */
 package com.facebook.presto.sql.planner.optimizations;
 
-import com.facebook.presto.Session;
-import com.facebook.presto.cost.CachingStatsProvider;
-import com.facebook.presto.cost.PlanNodeStatsEstimate;
-import com.facebook.presto.cost.StatsCalculator;
-import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.plan.AggregationNode;
-import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.VariablesExtractor;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
@@ -33,10 +26,8 @@ import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
-import static com.facebook.presto.spi.statistics.SourceInfo.ConfidenceLevel.LOW;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class AggregationNodeUtils
@@ -71,20 +62,6 @@ public class AggregationNodeUtils
         return VariablesExtractor.extractAll(expression)
                 .stream()
                 .collect(toImmutableList());
-    }
-
-    public static boolean isAllLowCardinalityGroupByKeys(AggregationNode aggregationNode, TableScanNode scanNode, Session session, StatsCalculator statsCalculator, TypeProvider types, long count)
-    {
-        List<VariableReferenceExpression> groupbyKeys = aggregationNode.getGroupingSets().getGroupingKeys().stream().collect(Collectors.toList());
-        StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
-        PlanNodeStatsEstimate estimate = statsProvider.getStats(scanNode);
-        if (estimate.confidenceLevel() == LOW) {
-            // For safety, we assume they are low card if not confident
-            // TODO(kaikalur) : maybe return low card only for partition keys if/when we can detect that
-            return true;
-        }
-
-        return groupbyKeys.stream().noneMatch(x -> estimate.getVariableStatistics(x).getDistinctValuesCount() >= count);
     }
 
     public static AggregationNode.Aggregation removeFilterAndMask(AggregationNode.Aggregation aggregation)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -60,7 +60,6 @@ import static com.facebook.presto.sql.planner.PlannerUtils.createMapType;
 import static com.facebook.presto.sql.planner.PlannerUtils.getHashExpression;
 import static com.facebook.presto.sql.planner.PlannerUtils.getTableScanNodeWithOnlyFilterAndProject;
 import static com.facebook.presto.sql.planner.PlannerUtils.projectExpressions;
-import static com.facebook.presto.sql.planner.optimizations.AggregationNodeUtils.isAllLowCardinalityGroupByKeys;
 import static com.facebook.presto.sql.planner.optimizations.JoinNodeUtils.typeConvert;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.facebook.presto.sql.relational.Expressions.call;
@@ -183,8 +182,7 @@ public class PrefilterForLimitingAggregation
                 Optional<TableScanNode> scanNode = getTableScanNodeWithOnlyFilterAndProject(aggregationNode.getSource());
                 // Since we duplicate the source of the aggregation - we want to restrict it to simple scan/filter/project
                 // so we can do this opportunistic optimization without too much latency/cpu overhead to support common BI usecases
-                if (scanNode.isPresent() &&
-                        !isAllLowCardinalityGroupByKeys(aggregationNode, scanNode.get(), session, statsCalculator, types, limitNode.getCount())) {
+                if (scanNode.isPresent()) {
                     PlanNode rewrittenAggregation = addPrefilter(aggregationNode, limitNode.getCount());
                     if (rewrittenAggregation != aggregationNode) {
                         planChanged = true;

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6690,19 +6690,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testPrefilterGroupByLimitNotFiredForLowCardinalityKeys()
-    {
-        Session prefilter = Session.builder(getSession())
-                .setSystemProperty("prefilter_for_groupby_limit", "true")
-                .build();
-
-        MaterializedResult plan = computeActual(prefilter, "explain(type distributed) select count(custkey), orderstatus from orders group by orderstatus limit 1000");
-        assertEquals(((String) plan.getOnlyValue()).toUpperCase().indexOf("MAP_AGG"), -1);
-        plan = computeActual(prefilter, "explain(type distributed) select count(custkey), orderkey from orders group by orderkey limit 100000");
-        assertEquals(((String) plan.getOnlyValue()).toUpperCase().indexOf("MAP_AGG"), -1);
-    }
-
-    @Test
     public void testNestedExpressions()
     {
         assertQuery(


### PR DESCRIPTION
## Description
Removing stats check for this opportunistic optimization.

## Motivation and Context
We have this awesone optimization prefilter_for_groupby_limit but it does stats check. But since this is just an opportunistic optimization, we can remove that check and let support team or user turn it on as needed/appropriate.

## Impact
Let people actually use this feature that's quite useful in exploratory aggregations.

## Test Plan
tests exist

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

