### PR TITLE
fix: Fix duplicate join criteria

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/TestJoinStatsRule.java
@@ -128,8 +128,9 @@ public class TestJoinStatsRule
     @Test
     public void testStatsForInnerJoinWithRepeatedClause()
     {
-        double innerJoinRowCount = LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS // driver join clause
-                * UNKNOWN_FILTER_COEFFICIENT; // auxiliary join clause
+        // When duplicate join clauses are passed, JoinNode deduplicates them,
+        // so we only have a single join clause and no auxiliary filter coefficient is applied.
+        double innerJoinRowCount = LEFT_ROWS_COUNT * RIGHT_ROWS_COUNT / LEFT_JOIN_COLUMN_NDV * LEFT_JOIN_COLUMN_NON_NULLS * RIGHT_JOIN_COLUMN_NON_NULLS;
         PlanNodeStatsEstimate innerJoinStats = planNodeStats(innerJoinRowCount,
                 variableStatistics(LEFT_JOIN_COLUMN, 5.0, 20.0, 0.0, RIGHT_JOIN_COLUMN_NDV),
                 variableStatistics(RIGHT_JOIN_COLUMN, 5.0, 20.0, 0.0, RIGHT_JOIN_COLUMN_NDV),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestFullOuterJoinWithCoalesce.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestFullOuterJoinWithCoalesce.java
@@ -91,7 +91,7 @@ public class TestFullOuterJoinWithCoalesce
                                                         ImmutableMap.of("ts", expression("coalesce(t, s)")),
                                                         join(
                                                                 FULL,
-                                                                ImmutableList.of(equiJoinClause("t", "s"), equiJoinClause("t", "s")),
+                                                                ImmutableList.of(equiJoinClause("t", "s")),
                                                                 exchange(REMOTE_STREAMING, REPARTITION, anyTree(values(ImmutableList.of("t")))),
                                                                 exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("s"))))))),
                                         exchange(LOCAL, GATHER, anyTree(values(ImmutableList.of("r"))))))));

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/JoinNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/JoinNode.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -107,7 +108,10 @@ public final class JoinNode
         this.type = type;
         this.left = left;
         this.right = right;
-        this.criteria = unmodifiableList(new ArrayList<>(criteria));
+        LinkedHashSet<EquiJoinClause> distinct = new LinkedHashSet<>(criteria);
+        this.criteria = (distinct.size() == criteria.size())
+                ? unmodifiableList(new ArrayList<>(criteria))
+                : unmodifiableList(new ArrayList<>(distinct));
         this.outputVariables = unmodifiableList(new ArrayList<>(outputVariables));
         this.filter = filter;
         this.leftHashVariable = leftHashVariable;


### PR DESCRIPTION
## Description
So for queries like the example below, two join keys both have filter which have the same value, and the UnAliasSymbol optimizer will canonicalize the two variables as the same variable when optimizing the join node and create duplicate join critieria, which will lead to error in Presto CPP. This PR fix the duplicate join criteria problem.

Before fix:
```
presto:tpch> explain (type distributed) select * from lineitem l full outer join partsupp ps on l.partkey = ps.partkey and l.suppkey = ps.suppkey where l.partkey=1 and l.suppkey=1;
                                                                                                                                                             >
------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                         >
     Output layout: [orderkey, partkey, partkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdat>
     Output partitioning: SINGLE []                                                                                                                          >
     Output encoding: COLUMNAR                                                                                                                               >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                           >
     - Output[PlanNodeId 10][orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, re>
             Estimates: {source: CostBasedSourceInfo, rows: 1 (372B), cpu: 20,974,967.02, memory: 161.07, network: 664.61}                                   >
             suppkey := partkey (1:28)                                                                                                                       >
             partkey := partkey_0 (1:28)                                                                                                                     >
             suppkey := partkey_0 (1:28)                                                                                                                     >
             comment := comment_2 (1:28)                                                                                                                     >
         - RemoteSource[1]  => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:double, retu>
                                                                                                                                                             >
 Fragment 1 [HASH]                                                                                                                                           >
     Output layout: [orderkey, partkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdate, shipin>
     Output partitioning: SINGLE []                                                                                                                          >
     Output encoding: COLUMNAR                                                                                                                               >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                           >
     - Project[PlanNodeId 327][projectLocality = LOCAL] => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:double, disco>
             Estimates: {source: CostBasedSourceInfo, rows: 1 (350B), cpu: 20,974,967.02, memory: 161.07, network: 313.92}                                   >
             partkey := BIGINT'1'                                                                                                                            >
         - LeftJoin[PlanNodeId 4][("partkey" = "partkey_0") AND ("partkey" = "partkey_0")][$hashvalue, $hashvalue_95] => [orderkey:bigint, linenumber:integer>
                 Estimates: {source: CostBasedSourceInfo, rows: 1 (350B), cpu: 20,974,616.33, memory: 161.07, network: 313.92}                               >
                 Distribution: PARTITIONED                                                                                                                   >
             - RemoteSource[2]  => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:double, >
             - LocalExchange[PlanNodeId 676][HASH][$hashvalue_95] (partkey_0, partkey_0) => [partkey_0:bigint, availqty:integer, supplycost:double, comment_2>
                     Estimates: {source: CostBasedSourceInfo, rows: 1 (501B), cpu: 2,577,695.27, memory: 0.00, network: 161.07}                              >
                 - RemoteSource[3]  => [partkey_0:bigint, availqty:integer, supplycost:double, comment_2:varchar(199), $hashvalue_96:bigint]                 >
                                                                                                                                                             >
 Fragment 2 [SOURCE]                                                                                                                                         >
     Output layout: [orderkey, partkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdate, shipin>
     Output partitioning: HASH [partkey, partkey][$hashvalue_94]                                                                                             >
     Output encoding: COLUMNAR                                                                                                                               >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                           >
     - Project[PlanNodeId 749][projectLocality = LOCAL] => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:double, disco>
             Estimates: {source: CostBasedSourceInfo, rows: 1 (152B), cpu: 18,396,116.71, memory: 0.00, network: 0.00}                                       >
             $hashvalue_94 := combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(partkey), BIGINT'0')), COALESCE($operator$hash_code(partkey),>
         - ScanFilterProject[PlanNodeId 0,614,324][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=linei>
                 Estimates: {source: CostBasedSourceInfo, rows: 60,175 (8.77MB), cpu: 9,197,910.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo>
                 partkey := BIGINT'1' (1:42)                                                                                                                 >
                 LAYOUT: tpch.lineitem{domains={partkey=[ [["1"]] ], suppkey=[ [["1"]] ]}}                                                                   >
                 extendedprice := extendedprice:double:5:REGULAR (1:42)                                                                                      >
                 shipdate := shipdate:date:10:REGULAR (1:42)                                                                                                 >
                 orderkey := orderkey:bigint:0:REGULAR (1:42)                                                                                                >
                 commitdate := commitdate:date:11:REGULAR (1:42)                                                                                             >
                 partkey := partkey:bigint:1:REGULAR (1:42)                                                                                                  >
                 tax := tax:double:7:REGULAR (1:42)                                                                                                          >
                 shipinstruct := shipinstruct:varchar(25):13:REGULAR (1:42)                                                                                  >
                 linenumber := linenumber:int:3:REGULAR (1:42)                                                                                               >
                 discount := discount:double:6:REGULAR (1:42)                                                                                                >
                 returnflag := returnflag:varchar(1):8:REGULAR (1:42)                                                                                        >
                 receiptdate := receiptdate:date:12:REGULAR (1:42)                                                                                           >
                 shipmode := shipmode:varchar(10):14:REGULAR (1:42)                                                                                          >
                 quantity := quantity:double:4:REGULAR (1:42)                                                                                                >
                 suppkey := suppkey:bigint:2:REGULAR (1:42)                                                                                                  >
                 comment := comment:varchar(44):15:REGULAR (1:42)                                                                                            >
                 linestatus := linestatus:varchar(1):9:REGULAR (1:42)                                                                                        >
                                                                                                                                                             >
 Fragment 3 [SOURCE]                                                                                                                                         >
     Output layout: [partkey_0, availqty, supplycost, comment_2, $hashvalue_97]                                                                              >
     Output partitioning: HASH [partkey_0, partkey_0][$hashvalue_97]                                                                                         >
     Output encoding: COLUMNAR                                                                                                                               >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                           >
     - Project[PlanNodeId 750][projectLocality = LOCAL] => [partkey_0:bigint, availqty:integer, supplycost:double, comment_2:varchar(199), $hashvalue_97:bigi>
             Estimates: {source: CostBasedSourceInfo, rows: 1 (161B), cpu: 2,577,373.13, memory: 0.00, network: 0.00}                                        >
             $hashvalue_97 := combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(partkey_0), BIGINT'0')), COALESCE($operator$hash_code(partkey>
         - ScanFilterProject[PlanNodeId 1,615,325][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=parts>
                 Estimates: {source: CostBasedSourceInfo, rows: 8,000 (1.23MB), cpu: 1,288,530.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo,>
                 partkey_0 := BIGINT'1' (1:69)                                                                                                               >
                 LAYOUT: tpch.partsupp{domains={partkey=[ [["1"]] ], suppkey=[ [["1"]] ]}}                                                                   >
                 partkey_0 := partkey:bigint:0:REGULAR (1:69)                                                                                                >
                 availqty := availqty:int:2:REGULAR (1:69)                                                                                                   >
                 comment_2 := comment:varchar(199):4:REGULAR (1:69)                                                                                          >
                 suppkey_1 := suppkey:bigint:1:REGULAR (1:69)                                                                                                >
                 supplycost := supplycost:double:3:REGULAR (1:69)                                                                                            >
                                                                                                                                                             >
                                                                                                                                                             >
(1 row)
```
After fix:
```
presto:tpch> explain (type distributed) select * from lineitem l full outer join partsupp ps on l.partkey = ps.partkey and l.suppkey = ps.suppkey where l.partkey=1 and l.suppkey=1;
                                                                                                                                                             >
------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Fragment 0 [SINGLE]                                                                                                                                         >
     Output layout: [orderkey, partkey, partkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdat>
     Output partitioning: SINGLE []                                                                                                                          >
     Output encoding: COLUMNAR                                                                                                                               >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                           >
     - Output[PlanNodeId 10][orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, re>
             Estimates: {source: CostBasedSourceInfo, rows: 2 (394B), cpu: 20,975,358.85, memory: 161.07, network: 703.76}                                   >
             suppkey := partkey (1:28)                                                                                                                       >
             partkey := partkey_0 (1:28)                                                                                                                     >
             suppkey := partkey_0 (1:28)                                                                                                                     >
             comment := comment_2 (1:28)                                                                                                                     >
         - RemoteSource[1]  => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:double, retu>
                                                                                                                                                             >
 Fragment 1 [HASH]                                                                                                                                           >
     Output layout: [orderkey, partkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdate, shipin>
     Output partitioning: SINGLE []                                                                                                                          >
     Output encoding: COLUMNAR                                                                                                                               >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                           >
     - Project[PlanNodeId 327][projectLocality = LOCAL] => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:double, disco>
             Estimates: {source: CostBasedSourceInfo, rows: 2 (371B), cpu: 20,975,358.85, memory: 161.07, network: 331.92}                                   >
             partkey := BIGINT'1'                                                                                                                            >
         - LeftJoin[PlanNodeId 4][("partkey" = "partkey_0")][$hashvalue, $hashvalue_97] => [orderkey:bigint, linenumber:integer, quantity:double, extendedpri>
                 Estimates: {source: CostBasedSourceInfo, rows: 2 (371B), cpu: 20,974,987.01, memory: 161.07, network: 331.92}                               >
                 Distribution: PARTITIONED                                                                                                                   >
             - Project[PlanNodeId 750][projectLocality = LOCAL] => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:doubl>
                     Estimates: {source: CostBasedSourceInfo, rows: 1 (221B), cpu: 18,396,440.41, memory: 0.00, network: 161.85}                             >
                 - RemoteSource[2]  => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:double, discount:double, tax:doub>
             - LocalExchange[PlanNodeId 676][HASH][$hashvalue_97] (partkey_0) => [partkey_0:bigint, availqty:integer, supplycost:double, comment_2:varchar(19>
                     Estimates: {source: CostBasedSourceInfo, rows: 1 (501B), cpu: 2,577,874.33, memory: 0.00, network: 170.07}                              >
                 - Project[PlanNodeId 752][projectLocality = LOCAL] => [partkey_0:bigint, availqty:integer, supplycost:double, comment_2:varchar(199), $hashv>
                         Estimates: {source: CostBasedSourceInfo, rows: 1 (501B), cpu: 2,577,713.27, memory: 0.00, network: 170.07}                          >
                     - RemoteSource[3]  => [partkey_0:bigint, availqty:integer, supplycost:double, comment_2:varchar(199), $hashvalue_98:bigint, $hashvalue_9>
                                                                                                                                                             >
 Fragment 2 [SOURCE]                                                                                                                                         >
     Output layout: [orderkey, partkey, linenumber, quantity, extendedprice, discount, tax, returnflag, linestatus, shipdate, commitdate, receiptdate, shipin>
     Output partitioning: HASH [partkey, partkey][$hashvalue_96]                                                                                             >
     Output encoding: COLUMNAR                                                                                                                               >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                           >
     - Project[PlanNodeId 749][projectLocality = LOCAL] => [orderkey:bigint, partkey:bigint, linenumber:integer, quantity:double, extendedprice:double, disco>
             Estimates: {source: CostBasedSourceInfo, rows: 1 (161B), cpu: 18,396,125.71, memory: 0.00, network: 0.00}                                       >
             $hashvalue_95 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(partkey), BIGINT'0')) (1:42)                                              >
             $hashvalue_96 := combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(partkey), BIGINT'0')), COALESCE($operator$hash_code(partkey),>
         - ScanFilterProject[PlanNodeId 0,614,324][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=linei>
                 Estimates: {source: CostBasedSourceInfo, rows: 60,175 (9.29MB), cpu: 9,197,910.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo>
                 partkey := BIGINT'1' (1:42)                                                                                                                 >
                 LAYOUT: tpch.lineitem{domains={suppkey=[ [["1"]] ], partkey=[ [["1"]] ]}}                                                                   >
                 extendedprice := extendedprice:double:5:REGULAR (1:42)                                                                                      >
                 shipdate := shipdate:date:10:REGULAR (1:42)                                                                                                 >
                 orderkey := orderkey:bigint:0:REGULAR (1:42)                                                                                                >
                 commitdate := commitdate:date:11:REGULAR (1:42)                                                                                             >
                 partkey := partkey:bigint:1:REGULAR (1:42)                                                                                                  >
                 tax := tax:double:7:REGULAR (1:42)                                                                                                          >
                 shipinstruct := shipinstruct:varchar(25):13:REGULAR (1:42)                                                                                  >
                 linenumber := linenumber:int:3:REGULAR (1:42)                                                                                               >
                 discount := discount:double:6:REGULAR (1:42)                                                                                                >
                 returnflag := returnflag:varchar(1):8:REGULAR (1:42)                                                                                        >
                 receiptdate := receiptdate:date:12:REGULAR (1:42)                                                                                           >
                 shipmode := shipmode:varchar(10):14:REGULAR (1:42)                                                                                          >
                 quantity := quantity:double:4:REGULAR (1:42)                                                                                                >
                 suppkey := suppkey:bigint:2:REGULAR (1:42)                                                                                                  >
                 comment := comment:varchar(44):15:REGULAR (1:42)                                                                                            >
                 linestatus := linestatus:varchar(1):9:REGULAR (1:42)                                                                                        >
                                                                                                                                                             >
 Fragment 3 [SOURCE]                                                                                                                                         >
     Output layout: [partkey_0, availqty, supplycost, comment_2, $hashvalue_100, $hashvalue_101]                                                             >
     Output partitioning: HASH [partkey_0, partkey_0][$hashvalue_101]                                                                                        >
     Output encoding: COLUMNAR                                                                                                                               >
     Stage Execution Strategy: UNGROUPED_EXECUTION                                                                                                           >
     - Project[PlanNodeId 751][projectLocality = LOCAL] => [partkey_0:bigint, availqty:integer, supplycost:double, comment_2:varchar(199), $hashvalue_100:big>
             Estimates: {source: CostBasedSourceInfo, rows: 1 (170B), cpu: 2,577,382.13, memory: 0.00, network: 0.00}                                        >
             $hashvalue_100 := combine_hash(BIGINT'0', COALESCE($operator$hash_code(partkey_0), BIGINT'0')) (1:69)                                           >
             $hashvalue_101 := combine_hash(combine_hash(BIGINT'0', COALESCE($operator$hash_code(partkey_0), BIGINT'0')), COALESCE($operator$hash_code(partke>
         - ScanFilterProject[PlanNodeId 1,615,325][table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=parts>
                 Estimates: {source: CostBasedSourceInfo, rows: 8,000 (1.30MB), cpu: 1,288,530.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo,>
                 partkey_0 := BIGINT'1' (1:69)                                                                                                               >
                 LAYOUT: tpch.partsupp{domains={partkey=[ [["1"]] ], suppkey=[ [["1"]] ]}}                                                                   >
                 partkey_0 := partkey:bigint:0:REGULAR (1:69)                                                                                                >
                 availqty := availqty:int:2:REGULAR (1:69)                                                                                                   >
                 comment_2 := comment:varchar(199):4:REGULAR (1:69)                                                                                          >
                 suppkey_1 := suppkey:bigint:1:REGULAR (1:69)                                                                                                >
                 supplycost := supplycost:double:3:REGULAR (1:69)                                                                                            >
                                                                                                                                                             >
                                                                                                                                                             >
(1 row)
```

## Motivation and Context
As in description.

## Impact
As in description.

## Test Plan
As in description.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

