### PR TITLE
feat: Expose Velox kMaxLocalExchangeBufferSize, kParallelOutputJoinBuildRow…

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -145,9 +145,23 @@ void updateFromSystemConfigs(
        .veloxConfig = velox::core::QueryConfig::kMaxSplitPreloadPerDriver},
 
       {.prestoSystemConfig =
+           std::string(SystemConfig::kMaxLocalExchangeBufferSize),
+       .veloxConfig = velox::core::QueryConfig::kMaxLocalExchangeBufferSize},
+
+      {.prestoSystemConfig =
            std::string(SystemConfig::kMaxLocalExchangePartitionBufferSize),
        .veloxConfig =
            velox::core::QueryConfig::kMaxLocalExchangePartitionBufferSize},
+
+      {.prestoSystemConfig =
+           std::string(SystemConfig::kParallelOutputJoinBuildRowsEnabled),
+       .veloxConfig =
+           velox::core::QueryConfig::kParallelOutputJoinBuildRowsEnabled},
+
+      {.prestoSystemConfig =
+           std::string(SystemConfig::kHashProbeBloomFilterPushdownMaxSize),
+       .veloxConfig =
+           velox::core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize},
 
       {.prestoSystemConfig = std::string(SystemConfig::kUseLegacyArrayAgg),
        .veloxConfig = velox::core::QueryConfig::kPrestoArrayAggIgnoreNulls},

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -279,7 +279,10 @@ SystemConfig::SystemConfig() {
           STR_PROP(kPluginDir, ""),
           NUM_PROP(kExchangeIoEvbViolationThresholdMs, 1000),
           NUM_PROP(kHttpSrvIoEvbViolationThresholdMs, 1000),
-          NUM_PROP(kMaxLocalExchangePartitionBufferSize, 65536),
+          NUM_PROP(kMaxLocalExchangeBufferSize, 32UL << 20), // 32MB
+          NUM_PROP(kMaxLocalExchangePartitionBufferSize, 65536), // 64KB
+          BOOL_PROP(kParallelOutputJoinBuildRowsEnabled, false),
+          NUM_PROP(kHashProbeBloomFilterPushdownMaxSize, 0),
           BOOL_PROP(kTextWriterEnabled, true),
           BOOL_PROP(kTextReaderEnabled, true),
           BOOL_PROP(kCharNToVarcharImplicitCast, false),
@@ -1039,8 +1042,21 @@ int32_t SystemConfig::httpSrvIoEvbViolationThresholdMs() const {
   return optionalProperty<int32_t>(kHttpSrvIoEvbViolationThresholdMs).value();
 }
 
+uint64_t SystemConfig::maxLocalExchangeBufferSize() const {
+  return optionalProperty<uint64_t>(kMaxLocalExchangeBufferSize).value();
+}
+
 uint64_t SystemConfig::maxLocalExchangePartitionBufferSize() const {
   return optionalProperty<uint64_t>(kMaxLocalExchangePartitionBufferSize)
+      .value();
+}
+
+bool SystemConfig::parallelOutputJoinBuildRowsEnabled() const {
+  return optionalProperty<bool>(kParallelOutputJoinBuildRowsEnabled).value();
+}
+
+uint64_t SystemConfig::hashProbeBloomFilterPushdownMaxSize() const {
+  return optionalProperty<uint64_t>(kHashProbeBloomFilterPushdownMaxSize)
       .value();
 }
 

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -834,8 +834,17 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kHttpSrvIoEvbViolationThresholdMs{
       "http-server.io-evb-violation-threshold-ms"};
 
+  static constexpr std::string_view kMaxLocalExchangeBufferSize{
+      "local-exchange.max-buffer-size"};
+
   static constexpr std::string_view kMaxLocalExchangePartitionBufferSize{
       "local-exchange.max-partition-buffer-size"};
+
+  static constexpr std::string_view kParallelOutputJoinBuildRowsEnabled{
+      "join.parallel-output-build-rows-enabled"};
+
+  static constexpr std::string_view kHashProbeBloomFilterPushdownMaxSize{
+      "join.hash-probe-bloom-filter-pushdown-max-size"};
 
   // Add to temporarily help with gradual rollout for text writer
   // TODO: remove once text writer is fully rolled out
@@ -1189,7 +1198,13 @@ class SystemConfig : public ConfigBase {
 
   int32_t httpSrvIoEvbViolationThresholdMs() const;
 
+  uint64_t maxLocalExchangeBufferSize() const;
+
   uint64_t maxLocalExchangePartitionBufferSize() const;
+
+  bool parallelOutputJoinBuildRowsEnabled() const;
+
+  uint64_t hashProbeBloomFilterPushdownMaxSize() const;
 
   bool textWriterEnabled() const;
 

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -664,10 +664,20 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
            std::string(SystemConfig::kRequestDataSizesMaxWaitSec)},
       {.veloxConfigKey = core::QueryConfig::kMaxSplitPreloadPerDriver,
        .systemConfigKey = std::string(SystemConfig::kDriverMaxSplitPreload)},
+      {.veloxConfigKey = core::QueryConfig::kMaxLocalExchangeBufferSize,
+       .systemConfigKey =
+           std::string(SystemConfig::kMaxLocalExchangeBufferSize)},
       {.veloxConfigKey =
            core::QueryConfig::kMaxLocalExchangePartitionBufferSize,
        .systemConfigKey =
            std::string(SystemConfig::kMaxLocalExchangePartitionBufferSize)},
+      {.veloxConfigKey = core::QueryConfig::kParallelOutputJoinBuildRowsEnabled,
+       .systemConfigKey =
+           std::string(SystemConfig::kParallelOutputJoinBuildRowsEnabled)},
+      {.veloxConfigKey =
+           core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize,
+       .systemConfigKey =
+           std::string(SystemConfig::kHashProbeBloomFilterPushdownMaxSize)},
       {.veloxConfigKey = core::QueryConfig::kPrestoArrayAggIgnoreNulls,
        .systemConfigKey = std::string(SystemConfig::kUseLegacyArrayAgg)},
       {.veloxConfigKey = core::QueryConfig::kTaskWriterCount,
@@ -687,7 +697,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
            std::string(SystemConfig::kTaskMaxPartialAggregationMemory)},
   };
 
-  const size_t kExpectedSystemConfigMappingCount = 16;
+  const size_t kExpectedSystemConfigMappingCount = 19;
   EXPECT_EQ(kExpectedSystemConfigMappingCount, expectedMappings.size())
       << "Update expectedMappings to match veloxToPrestoConfigMapping";
 


### PR DESCRIPTION
…sEnabled, and kHashProbeBloomFilterPushdownMaxSize as system configs

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

