### PR TITLE
feat: Update timezone data to 2025b

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
         modules:
           - :presto-base-arrow-flight # Only run tests for the `presto-base-arrow-flight` module
 
@@ -201,7 +201,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17.0.15
+          java-version: 17.0.16
           cache: maven
       - name: Download nodejs to maven cache
         run: .github/bin/download_nodejs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17.0.15
+          java-version: 17.0.16
           cache: maven
       - name: Maven Install
         run: |

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 20

--- a/.github/workflows/jdbc-connector-tests.yml
+++ b/.github/workflows/jdbc-connector-tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     needs: changes
     timeout-minutes: 60

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     concurrency:

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -200,7 +200,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17.0.15
+          java-version: 17.0.16
           cache: maven
       - name: Download nodejs to maven cache
         if: |
@@ -332,7 +332,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17.0.15
+          java-version: 17.0.16
           cache: maven
       - name: Download nodejs to maven cache
         if: |
@@ -453,7 +453,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17.0.15
+          java-version: 17.0.16
           cache: maven
       - name: Download nodejs to maven cache
         if: |
@@ -568,7 +568,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17.0.15
+          java-version: 17.0.16
           cache: maven
       - name: Download nodejs to maven cache
         if: |
@@ -680,7 +680,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17.0.15
+          java-version: 17.0.16
           cache: maven
       - name: Download nodejs to maven cache
         if: |

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17.0.15]
+        java: [17.0.16]
         modules:
           - :presto-tests -P presto-tests-execution-memory
           - :presto-tests -P presto-tests-general

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dep.drift.version>${dep.airlift.version}</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
-        <dep.joda.version>2.13.1</dep.joda.version>
+        <dep.joda.version>2.14.0</dep.joda.version>
         <dep.tempto.version>1.55</dep.tempto.version>
         <dep.testng.version>7.5</dep.testng.version>
         <dep.lucene.version>9.12.0</dep.lucene.version>

--- a/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
+++ b/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
@@ -2240,3 +2240,4 @@
 2231 Pacific/Kanton
 2232 Europe/Kyiv
 2233 America/Ciudad_Juarez
+2234 America/Coyhaique

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
@@ -216,7 +216,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), 4825838578917475630L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), 3765670086753811806L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)


### PR DESCRIPTION
- Update Joda-Time from 2.13.1 to 2.14.0 (includes tzdata 2025b)
- Add America/Coyhaique timezone (new zone for Chile's Aysén Region)
- Update zone-index.properties checksum in test
- Update JDK version to 17.0.16 in CI config based on https://bugs.openjdk.org/browse/JDK-8352716

## Description
This PR updates the timezone data to 2025b by upgrading Joda-Time from 2.13.1 to 2.14.0. The update adds the new `America/Coyhaique` timezone (zone key 2234), which was introduced for Chile's Aysén Region. The zone-index.properties checksum in TestTimeZoneKey has been updated to reflect the new zone entry.

## Motivation and Context
Timezone databases are periodically updated to reflect changes in timezone rules around the world. The tzdata 2025b release includes the new America/Coyhaique zone for Chile's Aysén Region. Keeping Presto's timezone data current ensures accurate timestamp handling for users in affected regions.

## Impact
  - No breaking changes to public APIs
  - Users can now use America/Coyhaique as a valid timezone identifier
  - Existing timezone functionality remains unchanged

## Test Plan
  - Existing TestTimeZoneKey tests verify the zone-index.properties integrity via checksum validation
  - The checksum has been updated to account for the new timezone entry

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

  General Changes
  * Update timezone data to 2025b by upgrading to Joda-Time 2.14.0.
  * Add support for America/Coyhaique timezone (Chile's Aysén Region).
```
