### PR TITLE
docs: Fix minor documentation issues

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2379,7 +2379,7 @@ Property Name                                              Description
 The storage table inherits standard Iceberg table properties for partitioning, sorting, and file format.
 
 Freshness and Refresh
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 Materialized views track the snapshot IDs of their base tables to determine staleness. When base tables are modified, the materialized view becomes stale and returns results by querying the base tables directly. After running ``REFRESH MATERIALIZED VIEW``, queries read from the pre-computed storage table.
 
@@ -2388,7 +2388,7 @@ The refresh operation uses a full refresh strategy, replacing all data in the st
 .. _iceberg-stale-data-handling:
 
 Stale Data Handling
-"""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^
 
 By default, when no staleness properties are configured, queries against a stale materialized
 view will fall back to executing the underlying view query against the base tables. You can

--- a/presto-docs/src/main/sphinx/develop/procedures.rst
+++ b/presto-docs/src/main/sphinx/develop/procedures.rst
@@ -152,7 +152,7 @@ During startup, the PrestoDB engine collects the procedure providers exposed by 
 respective namespaces (for example, ``hive.system`` or ``iceberg.system``). Once startup is complete, users can invoke these procedures by specifying
 the corresponding connector namespace, for example:
 
-.. code-block:: java
+.. code-block:: sql
 
     call iceberg.system.expire_snapshots('default', 'test_table');
     call hive.system.invalidate_directory_list_cache();

--- a/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst
+++ b/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst
@@ -107,7 +107,7 @@ Property Name                                Description                        
 ============================================ ===================================================================== ==============================
 
 Expression optimizer
------------------
+--------------------
 
 These properties must be configured in ``etc/expression-manager/native.properties`` to use the native expression optimizer of the ``NativeSidecarPlugin``.
 

--- a/presto-docs/src/main/sphinx/presto_cpp/features.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/features.rst
@@ -55,7 +55,7 @@ The request/response flow of Presto C++ is identical to Java workers. The tasks 
 
 * GET: /v1/operation/server/clearCache?type=memory: It clears the memory cache on worker node. Here is an example:
 
-  .. sourcecode:: http
+  .. code-block:: shell
 
    curl -X GET "http://localhost:7777/v1/operation/server/clearCache?type=memory"
 
@@ -63,7 +63,7 @@ The request/response flow of Presto C++ is identical to Java workers. The tasks 
 
 * GET: /v1/operation/server/clearCache?type=ssd: It clears the ssd cache on worker node. Here is an example:
 
-  .. sourcecode:: http
+  .. code-block:: shell
 
    curl -X GET "http://localhost:7777/v1/operation/server/clearCache?type=ssd"
 
@@ -71,7 +71,7 @@ The request/response flow of Presto C++ is identical to Java workers. The tasks 
 
 * GET: /v1/operation/server/writeSsd: It writes data from memory cache to the ssd cache on worker node. Here is an example:
 
-  .. sourcecode:: http
+  .. code-block:: shell
 
    curl -X GET "http://localhost:7777/v1/operation/server/writeSsd"
 


### PR DESCRIPTION
## Description
The PR fixes some minor issues in the documentation.

## Motivation and Context
The following issues have been fixed:
1. Use `sql` lexer for `code-block` instead of `java`.
```
./presto/presto-docs/src/main/sphinx/develop/procedures.rst:155: WARNING: Lexing literal_block "call iceberg.system.expire_snapshots('default', 'test_table');\ncall hive.system.invalidate_directory_list_cache();\n......" as "java" resulted in an error at token: "'". Retrying in relaxed mode. [misc.highlighting_failure]
```
2. Code block `http` was used for `shell` commands.
```
./presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:58: WARNING: Lexing literal_block 'curl -X GET "http://localhost:7777/v1/operation/server/clearCache?type=memory"\n\nCleared memory cache' as "http" resulted in an error at token: 'c'. Retrying in relaxed mode. [misc.highlighting_failure]
./presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:66: WARNING: Lexing literal_block 'curl -X GET "http://localhost:7777/v1/operation/server/clearCache?type=ssd"\n\nCleared ssd cache' as "http" resulted in an error at token: 'c'. Retrying in relaxed mode. [misc.highlighting_failure]
./presto/presto-docs/src/main/sphinx/presto_cpp/features.rst:74: WARNING: Lexing literal_block 'curl -X GET "http://localhost:7777/v1/operation/server/writeSsd"\n\nSucceeded write ssd cache' as "http" resulted in an error at token: 'c'. Retrying in relaxed mode. [misc.highlighting_failure]
```
3. Too short underline.
```
./presto/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst:110: WARNING: Title underline too short.

Expression optimizer
----------------- [docutils]
```
4. Title underline for `Materialized Views` sub-section. 
```
./presto/presto-docs/src/main/sphinx/connector/iceberg.rst:2390: CRITICAL: Title level inconsistent:

Stale Data Handling
""""""""""""""""""" [docutils]

```

## Impact
`None`

## Test Plan
Build documentation and check there are no related warning mentioned in the description:
```shell
presto-docs/build
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

