### PR TITLE
chore: Move permissions checks outside of Analyzer

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
@@ -53,6 +53,7 @@ import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MATERIALIZED_VIEW_ALREADY_EXISTS;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Objects.requireNonNull;
@@ -92,7 +93,8 @@ public class CreateMaterializedViewTask
 
         Map<NodeRef<Parameter>, Expression> parameterLookup = parameterExtractor(statement, parameters);
         Analyzer analyzer = new Analyzer(session, metadata, sqlParser, accessControl, Optional.empty(), parameters, parameterLookup, warningCollector, query);
-        Analysis analysis = analyzer.analyze(statement);
+        Analysis analysis = analyzer.analyzeSemantic(statement, false);
+        checkAccessPermissions(analysis.getAccessControlReferences(), query, session.getPreparedStatements());
 
         List<ColumnMetadata> columnMetadata = analysis.getOutputDescriptor(statement.getQuery())
                 .getVisibleFields().stream()

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/DDLDefinitionExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/DDLDefinitionExecution.java
@@ -62,8 +62,7 @@ public class DDLDefinitionExecution<T extends Statement>
     @Override
     protected ListenableFuture<?> executeTask()
     {
-        accessControl.checkQueryIntegrity(stateMachine.getSession().getIdentity(), stateMachine.getSession().getAccessControlContext(), query, stateMachine.getSession().getPreparedStatements(), ImmutableMap.of(), ImmutableMap.of());
-
+        task.queryPermissionCheck(accessControl, stateMachine.getSession().getIdentity(), stateMachine.getSession().getAccessControlContext(), query, stateMachine.getSession().getPreparedStatements(), ImmutableMap.of(), ImmutableMap.of());
         return task.execute(statement, transactionManager, metadata, accessControl, stateMachine.getSession(), parameters, stateMachine.getWarningCollector(), query);
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/DataDefinitionTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/DataDefinitionTask.java
@@ -13,12 +13,19 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.sql.SqlFormatter;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.Statement;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface DataDefinitionTask<T extends Statement>
@@ -32,5 +39,10 @@ public interface DataDefinitionTask<T extends Statement>
         }
 
         return SqlFormatter.formatSql(statement, Optional.of(parameters));
+    }
+
+    default void queryPermissionCheck(AccessControl accessControl, Identity identity, AccessControlContext context, String query, Map<String, String> preparedStatements, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions)
+    {
+        accessControl.checkQueryIntegrity(identity, context, query, preparedStatements, viewDefinitions, materializedViewDefinitions);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SessionDefinitionExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SessionDefinitionExecution.java
@@ -63,8 +63,7 @@ public class SessionDefinitionExecution<T extends Statement>
     @Override
     protected ListenableFuture<?> executeTask()
     {
-        accessControl.checkQueryIntegrity(stateMachine.getSession().getIdentity(), stateMachine.getSession().getAccessControlContext(), query, stateMachine.getSession().getPreparedStatements(), ImmutableMap.of(), ImmutableMap.of());
-
+        task.queryPermissionCheck(accessControl, stateMachine.getSession().getIdentity(), stateMachine.getSession().getAccessControlContext(), query, stateMachine.getSession().getPreparedStatements(), ImmutableMap.of(), ImmutableMap.of());
         return task.execute(statement, transactionManager, metadata, accessControl, stateMachine, parameters, query);
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/security/DenyQueryIntegrityCheckSystemAccessControl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/security/DenyQueryIntegrityCheckSystemAccessControl.java
@@ -95,6 +95,11 @@ public class DenyQueryIntegrityCheckSystemAccessControl
     }
 
     @Override
+    public void checkCanCreateView(Identity identity, AccessControlContext context, CatalogSchemaTableName view)
+    {
+    }
+
+    @Override
     public void checkCanShowCreateTable(Identity identity, AccessControlContext context, CatalogSchemaTableName table)
     {
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/Analyzer.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
-import com.facebook.presto.spi.analyzer.AccessControlReferences;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.parser.SqlParser;
@@ -46,8 +45,6 @@ import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.extractWindow
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.CANNOT_HAVE_AGGREGATIONS_WINDOWS_OR_GROUPING;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.analyzer.UtilizedColumnsAnalyzer.analyzeForUtilizedColumns;
-import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissionsForColumns;
-import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissionsForTable;
 import static java.util.Objects.requireNonNull;
 
 public class Analyzer
@@ -100,21 +97,6 @@ public class Analyzer
         requireNonNull(metadataExtractorExecutor, "metadataExtractorExecutor is null");
         this.metadataExtractor = new MetadataExtractor(session, metadata, metadataExtractorExecutor, sqlParser, warningCollector);
         this.query = requireNonNull(query, "query is null");
-    }
-
-    public Analysis analyze(Statement statement)
-    {
-        return analyze(statement, false);
-    }
-
-    // TODO: Remove this method once all calls are moved to analyzer interface, as this call is overloaded with analyze and columnCheckPermissions
-    public Analysis analyze(Statement statement, boolean isDescribe)
-    {
-        Analysis analysis = analyzeSemantic(statement, isDescribe);
-        AccessControlReferences accessControlReferences = analysis.getAccessControlReferences();
-        checkAccessPermissionsForTable(accessControlReferences);
-        checkAccessPermissionsForColumns(accessControlReferences);
-        return analysis;
     }
 
     public Analysis analyzeSemantic(Statement statement, boolean isDescribe)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/DescribeInputRewrite.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.AccessControlReferences;
 import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
@@ -50,6 +51,7 @@ import static com.facebook.presto.sql.QueryUtil.selectList;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
 import static com.facebook.presto.sql.QueryUtil.values;
 import static com.facebook.presto.sql.analyzer.utils.ParameterExtractor.getParameters;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissionsForTablesAndColumns;
 import static com.facebook.presto.util.AnalyzerUtil.createParsingOptions;
 import static java.util.Objects.requireNonNull;
 
@@ -116,7 +118,9 @@ final class DescribeInputRewrite
 
             // create  analysis for the query we are describing.
             Analyzer analyzer = new Analyzer(session, metadata, parser, accessControl, queryExplainer, parameters, parameterLookup, warningCollector, query);
-            Analysis analysis = analyzer.analyze(statement, true);
+            Analysis analysis = analyzer.analyzeSemantic(statement, true);
+            AccessControlReferences accessControlReferences = analysis.getAccessControlReferences();
+            checkAccessPermissionsForTablesAndColumns(accessControlReferences);
 
             // get all parameters in query
             List<Parameter> parameters = getParameters(statement);

--- a/presto-main-base/src/main/java/com/facebook/presto/util/AnalyzerUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/util/AnalyzerUtil.java
@@ -105,28 +105,18 @@ public class AnalyzerUtil
     {
         // Query check
         checkQueryIntegrity(accessControlReferences, query, preparedStatements);
-        // Table checks
+
+        //Table and column checks
+        checkAccessPermissionsForTablesAndColumns(accessControlReferences);
+    }
+
+    public static void checkAccessPermissionsForTablesAndColumns(AccessControlReferences accessControlReferences)
+    {
         checkAccessPermissionsForTable(accessControlReferences);
-        // Table Column checks
         checkAccessPermissionsForColumns(accessControlReferences);
     }
 
-    public static void checkQueryIntegrity(AccessControlReferences accessControlReferences, String query, Map<String, String> preparedStatements)
-    {
-        AccessControlInfo queryAccessControlInfo = accessControlReferences.getQueryAccessControlInfo();
-        // Only check access if query gets analyzed
-        if (queryAccessControlInfo != null) {
-            AccessControl queryAccessControl = queryAccessControlInfo.getAccessControl();
-            Identity identity = queryAccessControlInfo.getIdentity();
-            AccessControlContext queryAccessControlContext = queryAccessControlInfo.getAccessControlContext();
-            Map<QualifiedObjectName, ViewDefinition> viewDefinitionMap = accessControlReferences.getViewDefinitions();
-            Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitionMap = accessControlReferences.getMaterializedViewDefinitions();
-
-            queryAccessControl.checkQueryIntegrity(identity, queryAccessControlContext, query, preparedStatements, viewDefinitionMap, materializedViewDefinitionMap);
-        }
-    }
-
-    public static void checkAccessPermissionsForColumns(AccessControlReferences accessControlReferences)
+    private static void checkAccessPermissionsForColumns(AccessControlReferences accessControlReferences)
     {
         accessControlReferences.getTableColumnAndSubfieldReferencesForAccessControl()
                 .forEach((accessControlInfo, tableColumnReferences) ->
@@ -142,7 +132,7 @@ public class AnalyzerUtil
                         }));
     }
 
-    public static void checkAccessPermissionsForTable(AccessControlReferences accessControlReferences)
+    private static void checkAccessPermissionsForTable(AccessControlReferences accessControlReferences)
     {
         accessControlReferences.getTableReferences().forEach((accessControlRole, accessControlInfoForTables) -> accessControlInfoForTables.forEach(accessControlInfoForTable -> {
             AccessControlInfo accessControlInfo = accessControlInfoForTable.getAccessControlInfo();
@@ -167,5 +157,20 @@ public class AnalyzerUtil
                     throw new UnsupportedOperationException("Unsupported access control role found: " + accessControlRole);
             }
         }));
+    }
+
+    private static void checkQueryIntegrity(AccessControlReferences accessControlReferences, String query, Map<String, String> preparedStatements)
+    {
+        AccessControlInfo queryAccessControlInfo = accessControlReferences.getQueryAccessControlInfo();
+        // Only check access if query gets analyzed
+        if (queryAccessControlInfo != null) {
+            AccessControl queryAccessControl = queryAccessControlInfo.getAccessControl();
+            Identity identity = queryAccessControlInfo.getIdentity();
+            AccessControlContext queryAccessControlContext = queryAccessControlInfo.getAccessControlContext();
+            Map<QualifiedObjectName, ViewDefinition> viewDefinitionMap = accessControlReferences.getViewDefinitions();
+            Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitionMap = accessControlReferences.getMaterializedViewDefinitions();
+
+            queryAccessControl.checkQueryIntegrity(identity, queryAccessControlContext, query, preparedStatements, viewDefinitionMap, materializedViewDefinitionMap);
+        }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkQueryPlanner.java
@@ -69,6 +69,7 @@ import static com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED_AND_VALIDATE
 import static com.facebook.presto.sql.analyzer.utils.ParameterUtils.parameterExtractor;
 import static com.facebook.presto.sql.analyzer.utils.StatementUtils.getQueryType;
 import static com.facebook.presto.sql.planner.PlanNodeCanonicalInfo.getCanonicalInfo;
+import static com.facebook.presto.util.AnalyzerUtil.checkAccessPermissions;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoSparkQueryPlanner
@@ -119,7 +120,8 @@ public class PrestoSparkQueryPlanner
                 warningCollector,
                 query);
 
-        Analysis analysis = analyzer.analyze(preparedQuery.getStatement());
+        Analysis analysis = analyzer.analyzeSemantic(preparedQuery.getStatement(), false);
+        checkAccessPermissions(analysis.getAccessControlReferences(), query, session.getPreparedStatements());
 
         LogicalPlanner logicalPlanner = new LogicalPlanner(
                 session,

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestCheckAccessPermissionsForQueryTypes.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestCheckAccessPermissionsForQueryTypes.java
@@ -53,5 +53,9 @@ public class TestCheckAccessPermissionsForQueryTypes
         assertAccessDenied("explain (type validate) select * from orders", ".*Query integrity check failed.*");
         assertAccessDenied("CREATE TABLE test_empty (a BIGINT)", ".*Query integrity check failed.*");
         assertAccessDenied("use tpch.tiny", ".*Query integrity check failed.*");
+        assertAccessDenied("create view test_orders_view as select * from orders", ".*Query integrity check failed.*");
+        assertAccessDenied("create function tpch.tiny.square2(x int) returns int return x * x", ".*Query integrity check failed.*");
+        assertAccessDenied("alter function tpch.tiny.tan(double) called on null input", ".*Query integrity check failed.*");
+        assertAccessDenied("drop function tpch.tiny.tan(double)", ".*Query integrity check failed.*");
     }
 }


### PR DESCRIPTION
## Description
Address the TODO comment in Analyzer class to remove the overloaded analyze method and decouple the analyzeSemantic and permissionChecking behaviors.

## Motivation and Context
The overloaded analyze method makes it difficult to ensure that permissions checks are run exactly once for every query type. For example, for nested EXPLAIN statements, the permissions checks being run for each level of nesting because each level of nesting creates a new rewrite and Analysis. By removing these overloaded analyze method calls, it gives flexibility to remove redundant permissions checks.

The new interface method added to `DataDefinitionTask#queryPermissionCheck` is needed because sometimes, a `DataDefinitionTask` implementation (like `CreateViewTask`) will call `analyzeSemantic` followed by `checkAccessPermissions` on the `Analysis` inside of the `execute` method for the task. This ensures that the utilized resources will be permission checked. But some implementations of `DataDefinitionTask` do not ever call `analyzeSemantic` (like `CreateTableTask`), but we still need to be running the query permission check for these query shapes. So for non-Analyze tasks (CreateTable), we can just run the default implementation of query permissions check, and for Analyze tasks (CreateView), we override the default implementation to be NOOP and run the `checkAccessPermissions` after the analyze.

## Impact
- Remove overloaded analyze call in Analyzer
- Add query permission check for DDL executions that call Analyze
- Add query permission check for Presto Spark

## Test Plan
Add unit test cases for checkQueryIntegrity and ensure that each shape runs the check at least once.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```






Differential Revision: D89869624


