### PR TITLE
docs: Refactor the page explaining how to deploy Presto with Docker

### DIFF
--- a/presto-docs/requirements.txt
+++ b/presto-docs/requirements.txt
@@ -1,3 +1,2 @@
 sphinx==8.2.1
 sphinx-immaterial==0.13.0
-sphinx-copybutton==0.5.2

--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -64,7 +64,7 @@ def get_version():
 needs_sphinx = '8.2.1'
 
 extensions = [
-    'sphinx_immaterial', 'sphinx_copybutton', 'download', 'issue', 'pr', 'sphinx.ext.autosectionlabel'
+    'sphinx_immaterial', 'download', 'issue', 'pr', 'sphinx.ext.autosectionlabel'
 ]
 
 copyright = 'The Presto Foundation. All rights reserved. Presto is a registered trademark of LF Projects, LLC'
@@ -106,12 +106,7 @@ html_title = '%s %s Documentation' % (project, release)
 html_logo = 'images/logo.png'
 html_favicon = 'images/favicon.ico'
 
-# doesn't seem to do anything
-# html_baseurl = 'overview.html'
-
 html_static_path = ['.']
-
-templates_path = ['_templates']
 
 # Set the primary domain to js because if left as the default python
 # the theme errors when functions aren't available in a python module

--- a/presto-docs/src/main/sphinx/installation.rst
+++ b/presto-docs/src/main/sphinx/installation.rst
@@ -6,6 +6,6 @@ Installation
     :maxdepth: 1
 
     installation/deployment
-    installation/deploy-docker
     installation/deploy-brew
+    installation/deploy-docker
     installation/deploy-helm

--- a/presto-docs/src/main/sphinx/installation/deploy-brew.rst
+++ b/presto-docs/src/main/sphinx/installation/deploy-brew.rst
@@ -1,6 +1,6 @@
-============================
-Deploy Presto using Homebrew
-============================
+===========================
+Deploy Presto with Homebrew
+===========================
 
 This guide explains how to install and get started with Presto on macOS, Linux or WSL2 using the Homebrew package manager.
 

--- a/presto-docs/src/main/sphinx/installation/deploy-docker.rst
+++ b/presto-docs/src/main/sphinx/installation/deploy-docker.rst
@@ -1,60 +1,66 @@
+=========================
+Deploy Presto with Docker
+=========================
+
+This guide explains how to install and get started with Presto using Docker.
+
+.. note::
+
+   These steps were developed and tested on Mac OS X, on both Intel and Apple Silicon chips.
+
+Prepare the container environment
 =================================
-Deploy Presto From a Docker Image
-=================================
 
-These steps were developed and tested on Mac OS X, on both Intel and Apple Silicon chips. 
+If Docker is already installed, skip to step 4 to verify the setup.
+Otherwise, follow the instructions below to install Docker and Colima using Homebrew or choose an alternative method.
 
-Follow these steps to:
+1. Install `Homebrew <https://brew.sh/>`_ if it is not already present on the system.
 
-- install the command line tools for brew, docker, and `Colima <https://github.com/abiosoft/colima>`_
-- verify your Docker setup
-- pull the Docker image of the Presto server
-- start your local Presto server
+2. Install the Docker command line and `Colima <https://github.com/abiosoft/colima>`_ tools via the following command:
 
-Installing brew, Docker, and Colima
-===================================
+   .. code-block:: shell
 
-This task shows how to install brew, then to use brew to install Docker and Colima. 
+      brew install docker colima
 
-Note: If you have Docker installed you can skip steps 1-3, but you should 
-verify your Docker setup by running the command in step 4.
+3. Run the following command to start Colima with defaults:
 
-1. If you do not have brew installed, run the following command:
+   .. code-block:: shell
 
-   ``/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"``
+      colima start
 
-2. To install the Docker command line and `Colima <https://github.com/abiosoft/colima>`_ tools, run the following command:
+   .. note::
 
-   ``brew install docker colima``
+      The default VM created by Colima uses 2 CPUs, 2GiB memory and 100GiB storage. To customize the VM resources,
+      see the Colima README for `Customizing the VM <https://github.com/abiosoft/colima#customizing-the-vm>`_.
 
-3. Run the following command: 
+4. Verify the local setup by running the following command:
 
-   ``colima start``
+   .. code-block:: shell
 
-   *Note*: The default VM created by Colima uses 2 CPUs, 2GB memory and 60GB storage. To customize the VM resources, 
-   see the Colima README for `Customizing the VM <https://github.com/abiosoft/colima#customizing-the-vm>`_.
+      docker run hello-world
 
-4. To verify your local setup, run the following command:
+   The following output confirms a successful installation.
 
-   ``docker run hello-world``
+   .. code-block:: shell
+      :class: no-copy
 
-   If you see a response similar to the following, you are ready.
-
-   ``Hello from Docker!`` 
-   ``This message shows that your installation appears to be working correctly.``
+      Hello from Docker!
+      This message shows that your installation appears to be working correctly.
 
 Installing and Running the Presto Docker container
 ==================================================
 
-1. Download the latest non-edge Presto container from `Presto on DockerHub <https://hub.docker.com/r/prestodb/presto/tags>`_. Run the following command: 
+1. Download the latest non-edge Presto container from `Presto on DockerHub <https://hub.docker.com/r/prestodb/presto/tags>`_:
 
-   ``docker pull prestodb/presto:latest``
+   .. code-block:: shell
+
+      docker pull prestodb/presto:latest
 
    Downloading the container may take a few minutes. When the download completes, go on to the next step.
 
-2. On your local system, create a file named ``config.properties`` containing the following text: 
+2. On the local system, create a file named ``config.properties`` containing the following text:
 
-   .. code-block:: none
+   .. code-block:: properties
 
     coordinator=true
     node-scheduler.include-coordinator=true
@@ -62,7 +68,7 @@ Installing and Running the Presto Docker container
     discovery-server.enabled=true
     discovery.uri=http://localhost:8080
 
-3. On your local system, create a file named ``jvm.config`` containing the following text: 
+3. On the local system, create a file named ``jvm.config`` containing the following text:
 
    .. code-block:: none
 
@@ -78,20 +84,26 @@ Installing and Running the Presto Docker container
      
 4. To start the Presto server in the Docker container, run the command:
 
-   ``docker run -p 8080:8080 -it -v ./config.properties:/opt/presto-server/etc/config.properties -v ./jvm.config:/opt/presto-server/etc/jvm.config --name presto prestodb/presto:latest``
+   .. code-block:: shell
+
+      docker run -p 8080:8080 -it -v ./config.properties:/opt/presto-server/etc/config.properties -v ./jvm.config:/opt/presto-server/etc/jvm.config --name presto prestodb/presto:latest
 
    This command assigns the name ``presto`` for the newly-created container that uses the downloaded image ``prestodb/presto:latest``.
 
-   The Presto server logs startup information in the terminal window. Once you see a response similar to the following, the Presto server is running in the Docker container.
+   The Presto server logs startup information in the terminal window. The following output confirms the Presto server is running in the Docker container.
 
-   ``======== SERVER STARTED ========``
+   .. code-block:: shell
+      :class: no-copy
+
+      ======== SERVER STARTED ========
 
 Removing the Presto Docker container
 ====================================
-To remove the Presto Docker container, run the following two commands: 
+To stop and remove the Presto Docker container, run the following commands:
 
-``docker stop presto``
+.. code-block:: shell
 
-``docker rm presto``
+   docker stop presto
+   docker rm presto
 
 These commands return the name of the container ``presto`` when they succeed. 

--- a/presto-docs/src/main/sphinx/installation/deploy-helm.rst
+++ b/presto-docs/src/main/sphinx/installation/deploy-helm.rst
@@ -1,5 +1,5 @@
-===============================
-Deploy Presto Using Helm Charts
-===============================
+=======================
+Deploy Presto with Helm
+=======================
 
-To deploy Presto using Helm charts, see the `Presto Helm Charts README <https://github.com/prestodb/presto-helm-charts/>`_. 
+To deploy Presto using Helm, see the `Presto Helm Charts README <https://github.com/prestodb/presto-helm-charts/>`_.


### PR DESCRIPTION
## Description
 - Refactor the documentation page that explains how to deploy Presto with Docker.
 - Make minor adjustments to the `Installation` menu and related documentation page names. 
 - Remove `sphinx-copybutton` dependency.
 - Remove duplicated configuration property `templates_path = ['_templates']`.

## Motivation and Context
Documentation configs:
 - The `sphinx-copybutton` dependency is redundant and does not function correctly because copy buttons for code block are already provided globally by the `content.code.copy` feature of the `sphinx-immaterial` theme.

Refining documentation and visual styling:
 - Reordered `Installation` menu from local to containerized options.
 - Changed documentation page names for common pattern `Deploy Presto with *****`.
 - Specified/refined code block lexers and used `note` directives.

<img width="488" height="899" alt="image" src="https://github.com/user-attachments/assets/80160fac-863e-4ab4-8534-4049924eb44a" />


## Impact
_None_

## Test Plan
Build the documentation and check that the page is correct:
```shell
presto-docs/build
open presto-docs/target/html/installation/deploy-docker.html
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

