### PR TITLE
feat(connector): Add comprehensive JMX metrics for metadata operations

### DIFF
--- a/presto-docs/src/main/sphinx/admin.rst
+++ b/presto-docs/src/main/sphinx/admin.rst
@@ -22,3 +22,4 @@ Administration
     admin/verifier
     admin/grafana-cloud
     admin/version-support
+    admin/jmx-metrics

--- a/presto-docs/src/main/sphinx/admin/jmx-metrics.rst
+++ b/presto-docs/src/main/sphinx/admin/jmx-metrics.rst
@@ -1,0 +1,208 @@
+=====================
+JMX Metrics Reference
+=====================
+
+Presto exposes comprehensive metrics via Java Management Extensions (JMX) for monitoring
+cluster health, query performance, and system behavior. This page documents some
+important JMX metrics available for production monitoring.
+
+Overview
+--------
+
+JMX metrics can be accessed through:
+
+* **JMX clients**: JConsole, VisualVM, or jmxterm
+* **SQL queries**: Using the :doc:`/connector/jmx` connector
+* **Monitoring systems**: Prometheus, Grafana, or other JMX exporters
+
+Querying Metrics via SQL
+-------------------------
+
+Once configured, you can query metrics using SQL:
+
+.. code-block:: sql
+
+    -- List all available metrics
+    SHOW TABLES FROM jmx.current;
+
+    -- Query specific metrics
+    SELECT * FROM jmx.current."com.facebook.presto.metadata:name=metadatamanagerstats";
+
+Metadata Operation Metrics
+---------------------------
+
+**JMX Table Name:** ``com.facebook.presto.metadata:name=metadatamanagerstats``
+
+Tracks performance and usage of all metadata operations including schema discovery,
+table lookups, and column information retrieval.
+
+Key Metrics
+^^^^^^^^^^^
+
+For each metadata operation such as ``listSchemaNames``, ``listTables``, or ``getTableHandle``:
+
+**Call Counters**
+
+* ``<operation>Calls``: Total number of times the operation was called
+* Example: ``listSchemaNamesCalls``, ``listTablesCalls``
+
+**Timing Statistics**
+
+All timing values are in nanoseconds:
+
+* ``<operation>time.alltime.avg``: Average execution time across all calls
+* ``<operation>time.alltime.min``: Fastest execution time
+* ``<operation>time.alltime.max``: Slowest execution time
+* ``<operation>time.alltime.count``: Number of samples collected
+* ``<operation>time.alltime.p50``: Median (50th percentile)
+* ``<operation>time.alltime.p75``: 75th percentile
+* ``<operation>time.alltime.p90``: 90th percentile
+* ``<operation>time.alltime.p95``: 95th percentile
+* ``<operation>time.alltime.p99``: 99th percentile
+
+**Time Windows**
+
+Statistics are also available for recent time windows:
+
+* ``<operation>time.oneminute.*``: Last 1 minute
+* ``<operation>time.fiveminutes.*``: Last 5 minutes
+* ``<operation>time.fifteenminutes.*``: Last 15 minutes
+
+Common Operations
+^^^^^^^^^^^^^^^^^
+
+**Schema Operations**
+
+* ``listSchemaNames``: List all schemas in a catalog
+* ``getSchemaProperties``: Get schema-level properties
+
+**Table Operations**
+
+* ``listTables``: List tables in a schema
+* ``getTableHandle``: Get table metadata handle
+* ``getTableMetadata``: Get detailed table information
+* ``getTableStatistics``: Get table statistics
+
+**Column Operations**
+
+* ``getColumnHandles``: Get column information
+* ``getColumnMetadata``: Get detailed column metadata
+
+**View Operations**
+
+* ``listViews``: List views in a schema
+* ``getView``: Get view definition
+
+Example Queries
+^^^^^^^^^^^^^^^
+
+**Query Lifecycle Metrics**
+
+Track query begin and completion times:
+
+.. code-block:: sql
+
+    -- Query begin operation metrics
+    SELECT
+        "beginquerytime.alltime.count" as total_queries,
+        "beginquerytime.alltime.avg" / 1000.0 as avg_microseconds,
+        "beginquerytime.alltime.min" / 1000.0 as min_microseconds,
+        "beginquerytime.alltime.max" / 1000.0 as max_microseconds
+    FROM jmx.current."com.facebook.presto.metadata:name=metadatamanagerstats";
+
+    -- Example output:
+    -- total_queries | avg_microseconds | min_microseconds | max_microseconds
+    -- 3.0           | 49.42            | 28.63            | 75.38
+
+**Insert Operation Metrics**
+
+Track data insertion performance:
+
+.. code-block:: sql
+
+    -- Begin insert operation metrics
+    SELECT
+        "begininserttime.alltime.count" as insert_operations,
+        "begininserttime.alltime.avg" / 1000000000.0 as avg_seconds,
+        "begininserttime.alltime.min" / 1000000000.0 as min_seconds,
+        "begininserttime.alltime.max" / 1000000000.0 as max_seconds
+    FROM jmx.current."com.facebook.presto.metadata:name=metadatamanagerstats";
+
+    -- Example output:
+    -- insert_operations | avg_seconds | min_seconds | max_seconds
+    -- 1.0               | 0.82        | 0.82        | 0.82
+
+    -- Finish insert operation metrics
+    SELECT
+        "finishinserttime.alltime.count" as completed_inserts,
+        "finishinserttime.alltime.avg" / 1000000000.0 as avg_seconds,
+        "finishinserttime.alltime.min" / 1000000000.0 as min_seconds,
+        "finishinserttime.alltime.max" / 1000000000.0 as max_seconds
+    FROM jmx.current."com.facebook.presto.metadata:name=metadatamanagerstats";
+
+    -- Example output:
+    -- completed_inserts | avg_seconds | min_seconds | max_seconds
+    -- 1.0               | 11.47       | 11.47       | 11.47
+
+System Access Control Metrics
+------------------------------
+
+**JMX Table Name:** ``com.facebook.presto.security:name=accesscontrolmanager``
+
+Tracks performance of access control checks.
+
+Key Metrics
+^^^^^^^^^^^
+
+Similar structure to metadata metrics, tracking operations like:
+
+* ``checkCanSetUser``: User impersonation checks
+* ``checkCanAccessCatalog``: Catalog access checks
+* ``checkCanSelectFromColumns``: Column-level access checks
+* ``checkCanCreateTable``: Table creation permission checks
+
+Query Execution Metrics
+-----------------------
+
+**Task Metrics**
+
+* ``com.facebook.presto.execution:name=taskmanager``: Task execution statistics
+* ``com.facebook.presto.execution.executor:name=taskexecutor``: Task executor pool metrics
+
+**Memory Metrics**
+
+* ``com.facebook.presto.memory:name=general,type=memorypool``: General memory pool usage
+* ``com.facebook.presto.memory:name=reserved,type=memorypool``: Reserved memory pool usage
+
+**Query Manager Metrics**
+
+* ``com.facebook.presto.dispatcher:name=dispatchmanager``: Query dispatch statistics
+* ``com.facebook.presto.execution:name=querymanager``: Query execution statistics
+
+Connector-Specific Metrics
+---------------------------
+
+Hive Connector
+^^^^^^^^^^^^^^
+
+* ``com.facebook.presto.hive:name=*``: Hive metastore and file system metrics
+Example -
+* com.facebook.presto.hive:name=hive,type=cachingdirectorylister
+
+Iceberg Connector
+^^^^^^^^^^^^^^^^^
+
+* ``com.facebook.presto.iceberg:name=*``: Iceberg-specific caching and I/O metrics
+
+Examples:
+
+* com.facebook.presto.iceberg:name=iceberg,type=icebergsplitmanager
+* com.facebook.presto.iceberg:name=iceberg,type=manifestfilecache
+* com.facebook.presto.iceberg:name=icebergfilewriterfactory
+
+See Also
+--------
+
+* :doc:`/connector/jmx` - JMX Connector documentation
+* :doc:`web-interface` - Web UI monitoring
+* :doc:`tuning` - Performance tuning guide

--- a/presto-docs/src/main/sphinx/presto-cpp.rst
+++ b/presto-docs/src/main/sphinx/presto-cpp.rst
@@ -92,3 +92,20 @@ TPC-DS Connector
 * TPC-DS connector, with ``tpcds.use-varchar-type=true`` in the coordinator's TPCDS catalog file.
 
 For more information see :doc:`/connector/tpcds` documentation.
+
+JMX Connector
+^^^^^^^^^^^^^
+
+* JMX connector is supported for monitoring and observability in Presto C++ clusters.
+
+* In Presto C++ clusters, JMX metrics are only available from the **Java coordinator**, not from C++ workers. This is because C++ workers
+  do not run a JVM and therefore do not have JMX MBeans. Only coordinator-specific metrics are accessible.
+
+* Configuration: The JMX catalog only needs to be configured on the **coordinator**. The C++ workers do not need JMX catalog configuration
+  because they cannot expose JMX metrics.
+
+* Example query to access coordinator metadata metrics::
+
+    SELECT * FROM jmx.current."com.facebook.presto.metadata:name=MetadataManagerStats"
+
+For more information see :doc:`/admin/jmx-metrics`.

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManagerStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManagerStats.java
@@ -1,0 +1,1831 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.stats.TimeStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MetadataManagerStats
+{
+    private final AtomicLong applyTableFunctionCalls = new AtomicLong();
+    private final AtomicLong verifyComparableOrderableContractCalls = new AtomicLong();
+    private final AtomicLong getTypeCalls = new AtomicLong();
+    private final AtomicLong registerBuiltInFunctionsCalls = new AtomicLong();
+    private final AtomicLong registerConnectorFunctionsCalls = new AtomicLong();
+    private final AtomicLong listSchemaNamesCalls = new AtomicLong();
+    private final AtomicLong getSchemaPropertiesCalls = new AtomicLong();
+    private final AtomicLong getSystemTableCalls = new AtomicLong();
+    private final AtomicLong getHandleVersionCalls = new AtomicLong();
+    private final AtomicLong getTableHandleForStatisticsCollectionCalls = new AtomicLong();
+    private final AtomicLong getLayoutCalls = new AtomicLong();
+    private final AtomicLong getAlternativeTableHandleCalls = new AtomicLong();
+    private final AtomicLong isLegacyGetLayoutSupportedCalls = new AtomicLong();
+    private final AtomicLong getCommonPartitioningCalls = new AtomicLong();
+    private final AtomicLong isRefinedPartitioningOverCalls = new AtomicLong();
+    private final AtomicLong getPartitioningHandleForExchangeCalls = new AtomicLong();
+    private final AtomicLong getInfoCalls = new AtomicLong();
+    private final AtomicLong getTableMetadataCalls = new AtomicLong();
+    private final AtomicLong listTablesCalls = new AtomicLong();
+    private final AtomicLong getColumnHandlesCalls = new AtomicLong();
+    private final AtomicLong getColumnMetadataCalls = new AtomicLong();
+    private final AtomicLong toExplainIOConstraintsCalls = new AtomicLong();
+    private final AtomicLong listTableColumnsCalls = new AtomicLong();
+    private final AtomicLong createSchemaCalls = new AtomicLong();
+    private final AtomicLong dropSchemaCalls = new AtomicLong();
+    private final AtomicLong renameSchemaCalls = new AtomicLong();
+    private final AtomicLong createTableCalls = new AtomicLong();
+    private final AtomicLong createTemporaryTableCalls = new AtomicLong();
+    private final AtomicLong dropTableCalls = new AtomicLong();
+    private final AtomicLong truncateTableCalls = new AtomicLong();
+    private final AtomicLong getNewTableLayoutCalls = new AtomicLong();
+    private final AtomicLong beginCreateTableCalls = new AtomicLong();
+    private final AtomicLong finishCreateTableCalls = new AtomicLong();
+    private final AtomicLong getInsertLayoutCalls = new AtomicLong();
+    private final AtomicLong getStatisticsCollectionMetadataForWriteCalls = new AtomicLong();
+    private final AtomicLong getStatisticsCollectionMetadataCalls = new AtomicLong();
+    private final AtomicLong beginStatisticsCollectionCalls = new AtomicLong();
+    private final AtomicLong finishStatisticsCollectionCalls = new AtomicLong();
+    private final AtomicLong beginQueryCalls = new AtomicLong();
+    private final AtomicLong cleanupQueryCalls = new AtomicLong();
+    private final AtomicLong beginInsertCalls = new AtomicLong();
+    private final AtomicLong finishInsertCalls = new AtomicLong();
+    private final AtomicLong getDeleteRowIdColumnCalls = new AtomicLong();
+    private final AtomicLong getUpdateRowIdColumnCalls = new AtomicLong();
+    private final AtomicLong supportsMetadataDeleteCalls = new AtomicLong();
+    private final AtomicLong metadataDeleteCalls = new AtomicLong();
+    private final AtomicLong beginDeleteCalls = new AtomicLong();
+    private final AtomicLong finishDeleteWithOutputCalls = new AtomicLong();
+    private final AtomicLong beginCallDistributedProcedureCalls = new AtomicLong();
+    private final AtomicLong finishCallDistributedProcedureCalls = new AtomicLong();
+    private final AtomicLong beginUpdateCalls = new AtomicLong();
+    private final AtomicLong finishUpdateCalls = new AtomicLong();
+    private final AtomicLong getRowChangeParadigmCalls = new AtomicLong();
+    private final AtomicLong getMergeTargetTableRowIdColumnHandleCalls = new AtomicLong();
+    private final AtomicLong beginMergeCalls = new AtomicLong();
+    private final AtomicLong finishMergeCalls = new AtomicLong();
+    private final AtomicLong getCatalogHandleCalls = new AtomicLong();
+    private final AtomicLong getCatalogNamesCalls = new AtomicLong();
+    private final AtomicLong listViewsCalls = new AtomicLong();
+    private final AtomicLong getViewsCalls = new AtomicLong();
+    private final AtomicLong createViewCalls = new AtomicLong();
+    private final AtomicLong renameViewCalls = new AtomicLong();
+    private final AtomicLong dropViewCalls = new AtomicLong();
+    private final AtomicLong createMaterializedViewCalls = new AtomicLong();
+    private final AtomicLong dropMaterializedViewCalls = new AtomicLong();
+    private final AtomicLong listMaterializedViewsCalls = new AtomicLong();
+    private final AtomicLong getMaterializedViewsCalls = new AtomicLong();
+    private final AtomicLong beginRefreshMaterializedViewCalls = new AtomicLong();
+    private final AtomicLong finishRefreshMaterializedViewCalls = new AtomicLong();
+    private final AtomicLong getReferencedMaterializedViewsCalls = new AtomicLong();
+    private final AtomicLong getMaterializedViewStatusCalls = new AtomicLong();
+    private final AtomicLong resolveIndexCalls = new AtomicLong();
+    private final AtomicLong createRoleCalls = new AtomicLong();
+    private final AtomicLong dropRoleCalls = new AtomicLong();
+    private final AtomicLong listRolesCalls = new AtomicLong();
+    private final AtomicLong listRoleGrantsCalls = new AtomicLong();
+    private final AtomicLong grantRolesCalls = new AtomicLong();
+    private final AtomicLong revokeRolesCalls = new AtomicLong();
+    private final AtomicLong listApplicableRolesCalls = new AtomicLong();
+    private final AtomicLong listEnabledRolesCalls = new AtomicLong();
+    private final AtomicLong grantTablePrivilegesCalls = new AtomicLong();
+    private final AtomicLong revokeTablePrivilegesCalls = new AtomicLong();
+    private final AtomicLong listTablePrivilegesCalls = new AtomicLong();
+    private final AtomicLong commitPageSinkAsyncCalls = new AtomicLong();
+    private final AtomicLong getFunctionAndTypeManagerCalls = new AtomicLong();
+    private final AtomicLong getProcedureRegistryCalls = new AtomicLong();
+    private final AtomicLong getBlockEncodingSerdeCalls = new AtomicLong();
+    private final AtomicLong getSessionPropertyManagerCalls = new AtomicLong();
+    private final AtomicLong getSchemaPropertyManagerCalls = new AtomicLong();
+    private final AtomicLong getTablePropertyManagerCalls = new AtomicLong();
+    private final AtomicLong getColumnPropertyManagerCalls = new AtomicLong();
+    private final AtomicLong getAnalyzePropertyManagerCalls = new AtomicLong();
+    private final AtomicLong getMetadataResolverCalls = new AtomicLong();
+    private final AtomicLong getConnectorCapabilitiesCalls = new AtomicLong();
+    private final AtomicLong dropBranchCalls = new AtomicLong();
+    private final AtomicLong dropTagCalls = new AtomicLong();
+    private final AtomicLong dropConstraintCalls = new AtomicLong();
+    private final AtomicLong addConstraintCalls = new AtomicLong();
+    private final AtomicLong renameTableCalls = new AtomicLong();
+    private final AtomicLong setTablePropertiesCalls = new AtomicLong();
+    private final AtomicLong addColumnCalls = new AtomicLong();
+    private final AtomicLong dropColumnCalls = new AtomicLong();
+    private final AtomicLong renameColumnCalls = new AtomicLong();
+    private final AtomicLong normalizeIdentifierCalls = new AtomicLong();
+    private final AtomicLong getTableLayoutFilterCoverageCalls = new AtomicLong();
+    private final AtomicLong getTableStatisticsCalls = new AtomicLong();
+    private final AtomicLong getCatalogNamesWithConnectorContextCalls = new AtomicLong();
+    private final AtomicLong isPushdownSupportedForFilterCalls = new AtomicLong();
+    private final TimeStat applyTableFunctionTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat verifyComparableOrderableContractTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getTypeTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat registerBuiltInFunctionsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat registerConnectorFunctionsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listSchemaNamesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getSchemaPropertiesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getSystemTableTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getHandleVersionTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getTableHandleForStatisticsCollectionTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getLayoutTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getAlternativeTableHandleTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat isLegacyGetLayoutSupportedTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getCommonPartitioningTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat isRefinedPartitioningOverTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getPartitioningHandleForExchangeTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getInfoTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getTableMetadataTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listTablesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getColumnHandlesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getColumnMetadataTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat toExplainIOConstraintsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listTableColumnsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat createSchemaTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropSchemaTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat renameSchemaTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat createTableTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat createTemporaryTableTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropTableTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat truncateTableTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getNewTableLayoutTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginCreateTableTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat finishCreateTableTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getInsertLayoutTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getStatisticsCollectionMetadataForWriteTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getStatisticsCollectionMetadataTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginStatisticsCollectionTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat finishStatisticsCollectionTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginQueryTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat cleanupQueryTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginInsertTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat finishInsertTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getDeleteRowIdColumnTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getUpdateRowIdColumnTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat supportsMetadataDeleteTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat metadataDeleteTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginDeleteTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat finishDeleteWithOutputTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginCallDistributedProcedureTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat finishCallDistributedProcedureTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginUpdateTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat finishUpdateTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getRowChangeParadigmTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getMergeTargetTableRowIdColumnHandleTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginMergeTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat finishMergeTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getCatalogHandleTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getCatalogNamesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listViewsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getViewsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat createViewTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat renameViewTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropViewTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat createMaterializedViewTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropMaterializedViewTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listMaterializedViewsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getMaterializedViewsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat beginRefreshMaterializedViewTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat finishRefreshMaterializedViewTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getReferencedMaterializedViewsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getMaterializedViewStatusTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat resolveIndexTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat createRoleTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropRoleTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listRolesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listRoleGrantsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat grantRolesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat revokeRolesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listApplicableRolesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listEnabledRolesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat grantTablePrivilegesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat revokeTablePrivilegesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat listTablePrivilegesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat commitPageSinkAsyncTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getFunctionAndTypeManagerTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getProcedureRegistryTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getBlockEncodingSerdeTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getSessionPropertyManagerTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getSchemaPropertyManagerTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getTablePropertyManagerTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getColumnPropertyManagerTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getAnalyzePropertyManagerTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getMetadataResolverTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getConnectorCapabilitiesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropBranchTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropTagTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropConstraintTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat addConstraintTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat renameTableTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat setTablePropertiesTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat addColumnTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat dropColumnTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat renameColumnTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat normalizeIdentifierTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getTableLayoutFilterCoverageTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getTableStatisticsTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat getCatalogNamesWithConnectorContextTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat isPushdownSupportedForFilterTime = new TimeStat(TimeUnit.NANOSECONDS);
+
+    @Managed
+    public long getApplyTableFunctionCalls()
+    {
+        return applyTableFunctionCalls.get();
+    }
+
+    @Managed
+    public long getVerifyComparableOrderableContractCalls()
+    {
+        return verifyComparableOrderableContractCalls.get();
+    }
+
+    @Managed
+    public long getGetTypeCalls()
+    {
+        return getTypeCalls.get();
+    }
+
+    @Managed
+    public long getRegisterBuiltInFunctionsCalls()
+    {
+        return registerBuiltInFunctionsCalls.get();
+    }
+
+    @Managed
+    public long getRegisterConnectorFunctionsCalls()
+    {
+        return registerConnectorFunctionsCalls.get();
+    }
+
+    @Managed
+    public long getListSchemaNamesCalls()
+    {
+        return listSchemaNamesCalls.get();
+    }
+
+    @Managed
+    public long getGetSchemaPropertiesCalls()
+    {
+        return getSchemaPropertiesCalls.get();
+    }
+
+    @Managed
+    public long getGetSystemTableCalls()
+    {
+        return getSystemTableCalls.get();
+    }
+
+    @Managed
+    public long getGetHandleVersionCalls()
+    {
+        return getHandleVersionCalls.get();
+    }
+
+    @Managed
+    public long getGetTableHandleForStatisticsCollectionCalls()
+    {
+        return getTableHandleForStatisticsCollectionCalls.get();
+    }
+
+    @Managed
+    public long getGetLayoutCalls()
+    {
+        return getLayoutCalls.get();
+    }
+
+    @Managed
+    public long getGetAlternativeTableHandleCalls()
+    {
+        return getAlternativeTableHandleCalls.get();
+    }
+
+    @Managed
+    public long getIsLegacyGetLayoutSupportedCalls()
+    {
+        return isLegacyGetLayoutSupportedCalls.get();
+    }
+
+    @Managed
+    public long getGetCommonPartitioningCalls()
+    {
+        return getCommonPartitioningCalls.get();
+    }
+
+    @Managed
+    public long getIsRefinedPartitioningOverCalls()
+    {
+        return isRefinedPartitioningOverCalls.get();
+    }
+
+    @Managed
+    public long getGetPartitioningHandleForExchangeCalls()
+    {
+        return getPartitioningHandleForExchangeCalls.get();
+    }
+
+    @Managed
+    public long getGetInfoCalls()
+    {
+        return getInfoCalls.get();
+    }
+
+    @Managed
+    public long getGetTableMetadataCalls()
+    {
+        return getTableMetadataCalls.get();
+    }
+
+    @Managed
+    public long getListTablesCalls()
+    {
+        return listTablesCalls.get();
+    }
+
+    @Managed
+    public long getGetColumnHandlesCalls()
+    {
+        return getColumnHandlesCalls.get();
+    }
+
+    @Managed
+    public long getGetColumnMetadataCalls()
+    {
+        return getColumnMetadataCalls.get();
+    }
+
+    @Managed
+    public long getToExplainIOConstraintsCalls()
+    {
+        return toExplainIOConstraintsCalls.get();
+    }
+
+    @Managed
+    public long getListTableColumnsCalls()
+    {
+        return listTableColumnsCalls.get();
+    }
+
+    @Managed
+    public long getCreateSchemaCalls()
+    {
+        return createSchemaCalls.get();
+    }
+
+    @Managed
+    public long getDropSchemaCalls()
+    {
+        return dropSchemaCalls.get();
+    }
+
+    @Managed
+    public long getRenameSchemaCalls()
+    {
+        return renameSchemaCalls.get();
+    }
+
+    @Managed
+    public long getNormalizeIdentifierCalls()
+    {
+        return normalizeIdentifierCalls.get();
+    }
+
+    @Managed
+    public long getGetTableLayoutFilterCoverageCalls()
+    {
+        return getTableLayoutFilterCoverageCalls.get();
+    }
+
+    @Managed
+    public long getGetTableStatisticsCalls()
+    {
+        return getTableStatisticsCalls.get();
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getApplyTableFunctionTime()
+    {
+        return applyTableFunctionTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getVerifyComparableOrderableContractTime()
+    {
+        return verifyComparableOrderableContractTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetTypeTime()
+    {
+        return getTypeTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getRegisterBuiltInFunctionsTime()
+    {
+        return registerBuiltInFunctionsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getRegisterConnectorFunctionsTime()
+    {
+        return registerConnectorFunctionsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListSchemaNamesTime()
+    {
+        return listSchemaNamesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetSchemaPropertiesTime()
+    {
+        return getSchemaPropertiesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetSystemTableTime()
+    {
+        return getSystemTableTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetHandleVersionTime()
+    {
+        return getHandleVersionTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetTableHandleForStatisticsCollectionTime()
+    {
+        return getTableHandleForStatisticsCollectionTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetLayoutTime()
+    {
+        return getLayoutTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetAlternativeTableHandleTime()
+    {
+        return getAlternativeTableHandleTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getIsLegacyGetLayoutSupportedTime()
+    {
+        return isLegacyGetLayoutSupportedTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetCommonPartitioningTime()
+    {
+        return getCommonPartitioningTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getIsRefinedPartitioningOverTime()
+    {
+        return isRefinedPartitioningOverTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetPartitioningHandleForExchangeTime()
+    {
+        return getPartitioningHandleForExchangeTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetInfoTime()
+    {
+        return getInfoTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetTableMetadataTime()
+    {
+        return getTableMetadataTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListTablesTime()
+    {
+        return listTablesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetColumnHandlesTime()
+    {
+        return getColumnHandlesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetColumnMetadataTime()
+    {
+        return getColumnMetadataTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getToExplainIOConstraintsTime()
+    {
+        return toExplainIOConstraintsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListTableColumnsTime()
+    {
+        return listTableColumnsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCreateSchemaTime()
+    {
+        return createSchemaTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropSchemaTime()
+    {
+        return dropSchemaTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getRenameSchemaTime()
+    {
+        return renameSchemaTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCreateTableTime()
+    {
+        return createTableTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCreateTemporaryTableTime()
+    {
+        return createTemporaryTableTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropTableTime()
+    {
+        return dropTableTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getTruncateTableTime()
+    {
+        return truncateTableTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetNewTableLayoutTime()
+    {
+        return getNewTableLayoutTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginCreateTableTime()
+    {
+        return beginCreateTableTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFinishCreateTableTime()
+    {
+        return finishCreateTableTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetInsertLayoutTime()
+    {
+        return getInsertLayoutTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetStatisticsCollectionMetadataForWriteTime()
+    {
+        return getStatisticsCollectionMetadataForWriteTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetStatisticsCollectionMetadataTime()
+    {
+        return getStatisticsCollectionMetadataTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginStatisticsCollectionTime()
+    {
+        return beginStatisticsCollectionTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFinishStatisticsCollectionTime()
+    {
+        return finishStatisticsCollectionTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginQueryTime()
+    {
+        return beginQueryTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCleanupQueryTime()
+    {
+        return cleanupQueryTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginInsertTime()
+    {
+        return beginInsertTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFinishInsertTime()
+    {
+        return finishInsertTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetDeleteRowIdColumnTime()
+    {
+        return getDeleteRowIdColumnTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetUpdateRowIdColumnTime()
+    {
+        return getUpdateRowIdColumnTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getSupportsMetadataDeleteTime()
+    {
+        return supportsMetadataDeleteTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getMetadataDeleteTime()
+    {
+        return metadataDeleteTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginDeleteTime()
+    {
+        return beginDeleteTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFinishDeleteWithOutputTime()
+    {
+        return finishDeleteWithOutputTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginCallDistributedProcedureTime()
+    {
+        return beginCallDistributedProcedureTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFinishCallDistributedProcedureTime()
+    {
+        return finishCallDistributedProcedureTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginUpdateTime()
+    {
+        return beginUpdateTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFinishUpdateTime()
+    {
+        return finishUpdateTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetRowChangeParadigmTime()
+    {
+        return getRowChangeParadigmTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetMergeTargetTableRowIdColumnHandleTime()
+    {
+        return getMergeTargetTableRowIdColumnHandleTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginMergeTime()
+    {
+        return beginMergeTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFinishMergeTime()
+    {
+        return finishMergeTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetCatalogHandleTime()
+    {
+        return getCatalogHandleTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetCatalogNamesTime()
+    {
+        return getCatalogNamesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListViewsTime()
+    {
+        return listViewsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetViewsTime()
+    {
+        return getViewsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCreateViewTime()
+    {
+        return createViewTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getRenameViewTime()
+    {
+        return renameViewTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropViewTime()
+    {
+        return dropViewTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCreateMaterializedViewTime()
+    {
+        return createMaterializedViewTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropMaterializedViewTime()
+    {
+        return dropMaterializedViewTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListMaterializedViewsTime()
+    {
+        return listMaterializedViewsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetMaterializedViewsTime()
+    {
+        return getMaterializedViewsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getBeginRefreshMaterializedViewTime()
+    {
+        return beginRefreshMaterializedViewTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getFinishRefreshMaterializedViewTime()
+    {
+        return finishRefreshMaterializedViewTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetReferencedMaterializedViewsTime()
+    {
+        return getReferencedMaterializedViewsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetMaterializedViewStatusTime()
+    {
+        return getMaterializedViewStatusTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getResolveIndexTime()
+    {
+        return resolveIndexTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCreateRoleTime()
+    {
+        return createRoleTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropRoleTime()
+    {
+        return dropRoleTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListRolesTime()
+    {
+        return listRolesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListRoleGrantsTime()
+    {
+        return listRoleGrantsTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGrantRolesTime()
+    {
+        return grantRolesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getRevokeRolesTime()
+    {
+        return revokeRolesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListApplicableRolesTime()
+    {
+        return listApplicableRolesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListEnabledRolesTime()
+    {
+        return listEnabledRolesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGrantTablePrivilegesTime()
+    {
+        return grantTablePrivilegesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getRevokeTablePrivilegesTime()
+    {
+        return revokeTablePrivilegesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getListTablePrivilegesTime()
+    {
+        return listTablePrivilegesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getCommitPageSinkAsyncTime()
+    {
+        return commitPageSinkAsyncTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetFunctionAndTypeManagerTime()
+    {
+        return getFunctionAndTypeManagerTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetProcedureRegistryTime()
+    {
+        return getProcedureRegistryTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetBlockEncodingSerdeTime()
+    {
+        return getBlockEncodingSerdeTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetSessionPropertyManagerTime()
+    {
+        return getSessionPropertyManagerTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetSchemaPropertyManagerTime()
+    {
+        return getSchemaPropertyManagerTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetTablePropertyManagerTime()
+    {
+        return getTablePropertyManagerTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetColumnPropertyManagerTime()
+    {
+        return getColumnPropertyManagerTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetAnalyzePropertyManagerTime()
+    {
+        return getAnalyzePropertyManagerTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetMetadataResolverTime()
+    {
+        return getMetadataResolverTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetConnectorCapabilitiesTime()
+    {
+        return getConnectorCapabilitiesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropBranchTime()
+    {
+        return dropBranchTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropTagTime()
+    {
+        return dropTagTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropConstraintTime()
+    {
+        return dropConstraintTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getAddConstraintTime()
+    {
+        return addConstraintTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getRenameTableTime()
+    {
+        return renameTableTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getSetTablePropertiesTime()
+    {
+        return setTablePropertiesTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getAddColumnTime()
+    {
+        return addColumnTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getDropColumnTime()
+    {
+        return dropColumnTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getRenameColumnTime()
+    {
+        return renameColumnTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getNormalizeIdentifierTime()
+    {
+        return normalizeIdentifierTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetTableLayoutFilterCoverageTime()
+    {
+        return getTableLayoutFilterCoverageTime;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetTableStatisticsTime()
+    {
+        return getTableStatisticsTime;
+    }
+
+    public void recordApplyTableFunctionCall(long duration)
+    {
+        applyTableFunctionCalls.incrementAndGet();
+        applyTableFunctionTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordVerifyComparableOrderableContractCall(long duration)
+    {
+        verifyComparableOrderableContractCalls.incrementAndGet();
+        verifyComparableOrderableContractTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetTypeCall(long duration)
+    {
+        getTypeCalls.incrementAndGet();
+        getTypeTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordRegisterBuiltInFunctionsCall(long duration)
+    {
+        registerBuiltInFunctionsCalls.incrementAndGet();
+        registerBuiltInFunctionsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordRegisterConnectorFunctionsCall(long duration)
+    {
+        registerConnectorFunctionsCalls.incrementAndGet();
+        registerConnectorFunctionsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListSchemaNamesCall(long duration)
+    {
+        listSchemaNamesCalls.incrementAndGet();
+        listSchemaNamesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetSchemaPropertiesCall(long duration)
+    {
+        getSchemaPropertiesCalls.incrementAndGet();
+        getSchemaPropertiesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetSystemTableCall(long duration)
+    {
+        getSystemTableCalls.incrementAndGet();
+        getSystemTableTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetHandleVersionCall(long duration)
+    {
+        getHandleVersionCalls.incrementAndGet();
+        getHandleVersionTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetTableHandleForStatisticsCollectionCall(long duration)
+    {
+        getTableHandleForStatisticsCollectionCalls.incrementAndGet();
+        getTableHandleForStatisticsCollectionTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetLayoutCall(long duration)
+    {
+        getLayoutCalls.incrementAndGet();
+        getLayoutTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetAlternativeTableHandleCall(long duration)
+    {
+        getAlternativeTableHandleCalls.incrementAndGet();
+        getAlternativeTableHandleTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordIsLegacyGetLayoutSupportedCall(long duration)
+    {
+        isLegacyGetLayoutSupportedCalls.incrementAndGet();
+        isLegacyGetLayoutSupportedTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetCommonPartitioningCall(long duration)
+    {
+        getCommonPartitioningCalls.incrementAndGet();
+        getCommonPartitioningTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordIsRefinedPartitioningOverCall(long duration)
+    {
+        isRefinedPartitioningOverCalls.incrementAndGet();
+        isRefinedPartitioningOverTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetPartitioningHandleForExchangeCall(long duration)
+    {
+        getPartitioningHandleForExchangeCalls.incrementAndGet();
+        getPartitioningHandleForExchangeTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetInfoCall(long duration)
+    {
+        getInfoCalls.incrementAndGet();
+        getInfoTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetTableMetadataCall(long duration)
+    {
+        getTableMetadataCalls.incrementAndGet();
+        getTableMetadataTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListTablesCall(long duration)
+    {
+        listTablesCalls.incrementAndGet();
+        listTablesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetColumnHandlesCall(long duration)
+    {
+        getColumnHandlesCalls.incrementAndGet();
+        getColumnHandlesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetColumnMetadataCall(long duration)
+    {
+        getColumnMetadataCalls.incrementAndGet();
+        getColumnMetadataTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordToExplainIOConstraintsCall(long duration)
+    {
+        toExplainIOConstraintsCalls.incrementAndGet();
+        toExplainIOConstraintsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListTableColumnsCall(long duration)
+    {
+        listTableColumnsCalls.incrementAndGet();
+        listTableColumnsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCreateSchemaCall(long duration)
+    {
+        createSchemaCalls.incrementAndGet();
+        createSchemaTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropSchemaCall(long duration)
+    {
+        dropSchemaCalls.incrementAndGet();
+        dropSchemaTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordRenameSchemaCall(long duration)
+    {
+        renameSchemaCalls.incrementAndGet();
+        renameSchemaTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCreateTableCall(long duration)
+    {
+        createTableCalls.incrementAndGet();
+        createTableTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCreateTemporaryTableCall(long duration)
+    {
+        createTemporaryTableCalls.incrementAndGet();
+        createTemporaryTableTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropTableCall(long duration)
+    {
+        dropTableCalls.incrementAndGet();
+        dropTableTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordTruncateTableCall(long duration)
+    {
+        truncateTableCalls.incrementAndGet();
+        truncateTableTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetNewTableLayoutCall(long duration)
+    {
+        getNewTableLayoutCalls.incrementAndGet();
+        getNewTableLayoutTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginCreateTableCall(long duration)
+    {
+        beginCreateTableCalls.incrementAndGet();
+        beginCreateTableTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordFinishCreateTableCall(long duration)
+    {
+        finishCreateTableCalls.incrementAndGet();
+        finishCreateTableTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetInsertLayoutCall(long duration)
+    {
+        getInsertLayoutCalls.incrementAndGet();
+        getInsertLayoutTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetStatisticsCollectionMetadataForWriteCall(long duration)
+    {
+        getStatisticsCollectionMetadataForWriteCalls.incrementAndGet();
+        getStatisticsCollectionMetadataForWriteTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetStatisticsCollectionMetadataCall(long duration)
+    {
+        getStatisticsCollectionMetadataCalls.incrementAndGet();
+        getStatisticsCollectionMetadataTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginStatisticsCollectionCall(long duration)
+    {
+        beginStatisticsCollectionCalls.incrementAndGet();
+        beginStatisticsCollectionTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordFinishStatisticsCollectionCall(long duration)
+    {
+        finishStatisticsCollectionCalls.incrementAndGet();
+        finishStatisticsCollectionTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginQueryCall(long duration)
+    {
+        beginQueryCalls.incrementAndGet();
+        beginQueryTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCleanupQueryCall(long duration)
+    {
+        cleanupQueryCalls.incrementAndGet();
+        cleanupQueryTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginInsertCall(long duration)
+    {
+        beginInsertCalls.incrementAndGet();
+        beginInsertTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordFinishInsertCall(long duration)
+    {
+        finishInsertCalls.incrementAndGet();
+        finishInsertTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetDeleteRowIdColumnCall(long duration)
+    {
+        getDeleteRowIdColumnCalls.incrementAndGet();
+        getDeleteRowIdColumnTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetUpdateRowIdColumnCall(long duration)
+    {
+        getUpdateRowIdColumnCalls.incrementAndGet();
+        getUpdateRowIdColumnTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordSupportsMetadataDeleteCall(long duration)
+    {
+        supportsMetadataDeleteCalls.incrementAndGet();
+        supportsMetadataDeleteTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordMetadataDeleteCall(long duration)
+    {
+        metadataDeleteCalls.incrementAndGet();
+        metadataDeleteTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginDeleteCall(long duration)
+    {
+        beginDeleteCalls.incrementAndGet();
+        beginDeleteTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordFinishDeleteWithOutputCall(long duration)
+    {
+        finishDeleteWithOutputCalls.incrementAndGet();
+        finishDeleteWithOutputTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginCallDistributedProcedureCall(long duration)
+    {
+        beginCallDistributedProcedureCalls.incrementAndGet();
+        beginCallDistributedProcedureTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordFinishCallDistributedProcedureCall(long duration)
+    {
+        finishCallDistributedProcedureCalls.incrementAndGet();
+        finishCallDistributedProcedureTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginUpdateCall(long duration)
+    {
+        beginUpdateCalls.incrementAndGet();
+        beginUpdateTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordFinishUpdateCall(long duration)
+    {
+        finishUpdateCalls.incrementAndGet();
+        finishUpdateTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetRowChangeParadigmCall(long duration)
+    {
+        getRowChangeParadigmCalls.incrementAndGet();
+        getRowChangeParadigmTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetMergeTargetTableRowIdColumnHandleCall(long duration)
+    {
+        getMergeTargetTableRowIdColumnHandleCalls.incrementAndGet();
+        getMergeTargetTableRowIdColumnHandleTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginMergeCall(long duration)
+    {
+        beginMergeCalls.incrementAndGet();
+        beginMergeTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordFinishMergeCall(long duration)
+    {
+        finishMergeCalls.incrementAndGet();
+        finishMergeTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetCatalogHandleCall(long duration)
+    {
+        getCatalogHandleCalls.incrementAndGet();
+        getCatalogHandleTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetCatalogNamesCall(long duration)
+    {
+        getCatalogNamesCalls.incrementAndGet();
+        getCatalogNamesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListViewsCall(long duration)
+    {
+        listViewsCalls.incrementAndGet();
+        listViewsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetViewsCall(long duration)
+    {
+        getViewsCalls.incrementAndGet();
+        getViewsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCreateViewCall(long duration)
+    {
+        createViewCalls.incrementAndGet();
+        createViewTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordRenameViewCall(long duration)
+    {
+        renameViewCalls.incrementAndGet();
+        renameViewTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropViewCall(long duration)
+    {
+        dropViewCalls.incrementAndGet();
+        dropViewTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCreateMaterializedViewCall(long duration)
+    {
+        createMaterializedViewCalls.incrementAndGet();
+        createMaterializedViewTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropMaterializedViewCall(long duration)
+    {
+        dropMaterializedViewCalls.incrementAndGet();
+        dropMaterializedViewTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListMaterializedViewsCall(long duration)
+    {
+        listMaterializedViewsCalls.incrementAndGet();
+        listMaterializedViewsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetMaterializedViewsCall(long duration)
+    {
+        getMaterializedViewsCalls.incrementAndGet();
+        getMaterializedViewsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordBeginRefreshMaterializedViewCall(long duration)
+    {
+        beginRefreshMaterializedViewCalls.incrementAndGet();
+        beginRefreshMaterializedViewTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordFinishRefreshMaterializedViewCall(long duration)
+    {
+        finishRefreshMaterializedViewCalls.incrementAndGet();
+        finishRefreshMaterializedViewTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetReferencedMaterializedViewsCall(long duration)
+    {
+        getReferencedMaterializedViewsCalls.incrementAndGet();
+        getReferencedMaterializedViewsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetMaterializedViewStatusCall(long duration)
+    {
+        getMaterializedViewStatusCalls.incrementAndGet();
+        getMaterializedViewStatusTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordResolveIndexCall(long duration)
+    {
+        resolveIndexCalls.incrementAndGet();
+        resolveIndexTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCreateRoleCall(long duration)
+    {
+        createRoleCalls.incrementAndGet();
+        createRoleTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropRoleCall(long duration)
+    {
+        dropRoleCalls.incrementAndGet();
+        dropRoleTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListRolesCall(long duration)
+    {
+        listRolesCalls.incrementAndGet();
+        listRolesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListRoleGrantsCall(long duration)
+    {
+        listRoleGrantsCalls.incrementAndGet();
+        listRoleGrantsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGrantRolesCall(long duration)
+    {
+        grantRolesCalls.incrementAndGet();
+        grantRolesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordRevokeRolesCall(long duration)
+    {
+        revokeRolesCalls.incrementAndGet();
+        revokeRolesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListApplicableRolesCall(long duration)
+    {
+        listApplicableRolesCalls.incrementAndGet();
+        listApplicableRolesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListEnabledRolesCall(long duration)
+    {
+        listEnabledRolesCalls.incrementAndGet();
+        listEnabledRolesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGrantTablePrivilegesCall(long duration)
+    {
+        grantTablePrivilegesCalls.incrementAndGet();
+        grantTablePrivilegesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordRevokeTablePrivilegesCall(long duration)
+    {
+        revokeTablePrivilegesCalls.incrementAndGet();
+        revokeTablePrivilegesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordListTablePrivilegesCall(long duration)
+    {
+        listTablePrivilegesCalls.incrementAndGet();
+        listTablePrivilegesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCommitPageSinkAsyncCall(long duration)
+    {
+        commitPageSinkAsyncCalls.incrementAndGet();
+        commitPageSinkAsyncTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetFunctionAndTypeManagerCall(long duration)
+    {
+        getFunctionAndTypeManagerCalls.incrementAndGet();
+        getFunctionAndTypeManagerTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetProcedureRegistryCall(long duration)
+    {
+        getProcedureRegistryCalls.incrementAndGet();
+        getProcedureRegistryTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetBlockEncodingSerdeCall(long duration)
+    {
+        getBlockEncodingSerdeCalls.incrementAndGet();
+        getBlockEncodingSerdeTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetSessionPropertyManagerCall(long duration)
+    {
+        getSessionPropertyManagerCalls.incrementAndGet();
+        getSessionPropertyManagerTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetSchemaPropertyManagerCall(long duration)
+    {
+        getSchemaPropertyManagerCalls.incrementAndGet();
+        getSchemaPropertyManagerTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetTablePropertyManagerCall(long duration)
+    {
+        getTablePropertyManagerCalls.incrementAndGet();
+        getTablePropertyManagerTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetColumnPropertyManagerCall(long duration)
+    {
+        getColumnPropertyManagerCalls.incrementAndGet();
+        getColumnPropertyManagerTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetAnalyzePropertyManagerCall(long duration)
+    {
+        getAnalyzePropertyManagerCalls.incrementAndGet();
+        getAnalyzePropertyManagerTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetMetadataResolverCall(long duration)
+    {
+        getMetadataResolverCalls.incrementAndGet();
+        getMetadataResolverTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetConnectorCapabilitiesCall(long duration)
+    {
+        getConnectorCapabilitiesCalls.incrementAndGet();
+        getConnectorCapabilitiesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropBranchCall(long duration)
+    {
+        dropBranchCalls.incrementAndGet();
+        dropBranchTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropTagCall(long duration)
+    {
+        dropTagCalls.incrementAndGet();
+        dropTagTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropConstraintCall(long duration)
+    {
+        dropConstraintCalls.incrementAndGet();
+        dropConstraintTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordAddConstraintCall(long duration)
+    {
+        addConstraintCalls.incrementAndGet();
+        addConstraintTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordRenameTableCall(long duration)
+    {
+        renameTableCalls.incrementAndGet();
+        renameTableTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordSetTablePropertiesCall(long duration)
+    {
+        setTablePropertiesCalls.incrementAndGet();
+        setTablePropertiesTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordAddColumnCall(long duration)
+    {
+        addColumnCalls.incrementAndGet();
+        addColumnTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordDropColumnCall(long duration)
+    {
+        dropColumnCalls.incrementAndGet();
+        dropColumnTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordRenameColumnCall(long duration)
+    {
+        renameColumnCalls.incrementAndGet();
+        renameColumnTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordNormalizeIdentifierCall(long duration)
+    {
+        normalizeIdentifierCalls.incrementAndGet();
+        normalizeIdentifierTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetTableLayoutFilterCoverageCall(long duration)
+    {
+        getTableLayoutFilterCoverageCalls.incrementAndGet();
+        getTableLayoutFilterCoverageTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGetTableStatisticsCall(long duration)
+    {
+        getTableStatisticsCalls.incrementAndGet();
+        getTableStatisticsTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    @Managed
+    public long getGetCatalogNamesWithConnectorContextCalls()
+    {
+        return getCatalogNamesWithConnectorContextCalls.get();
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getGetCatalogNamesWithConnectorContextTime()
+    {
+        return getCatalogNamesWithConnectorContextTime;
+    }
+
+    public void recordGetCatalogNamesWithConnectorContextCall(long duration)
+    {
+        getCatalogNamesWithConnectorContextCalls.incrementAndGet();
+        getCatalogNamesWithConnectorContextTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    @Managed
+    public long getIsPushdownSupportedForFilterCalls()
+    {
+        return isPushdownSupportedForFilterCalls.get();
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getIsPushdownSupportedForFilterTime()
+    {
+        return isPushdownSupportedForFilterTime;
+    }
+
+    public void recordIsPushdownSupportedForFilterCall(long duration)
+    {
+        isPushdownSupportedForFilterCalls.incrementAndGet();
+        isPushdownSupportedForFilterTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -1,0 +1,1421 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.MergeHandle;
+import com.facebook.presto.spi.NewTableLayout;
+import com.facebook.presto.spi.SystemTable;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.TableLayoutFilterCoverage;
+import com.facebook.presto.spi.TableMetadata;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.connector.ConnectorTableVersion;
+import com.facebook.presto.spi.connector.RowChangeParadigm;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
+import com.facebook.presto.spi.constraints.TableConstraint;
+import com.facebook.presto.spi.function.SqlFunction;
+import com.facebook.presto.spi.plan.PartitioningHandle;
+import com.facebook.presto.spi.procedure.ProcedureRegistry;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.security.GrantInfo;
+import com.facebook.presto.spi.security.PrestoPrincipal;
+import com.facebook.presto.spi.security.Privilege;
+import com.facebook.presto.spi.security.RoleGrant;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
+import com.facebook.presto.spi.statistics.TableStatistics;
+import com.facebook.presto.spi.statistics.TableStatisticsMetadata;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.Slice;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+
+public class StatsRecordingMetadataManager
+        implements Metadata
+{
+    private final Metadata delegate;
+    private final MetadataManagerStats stats;
+
+    public StatsRecordingMetadataManager(Metadata delegate, MetadataManagerStats stats)
+    {
+        this.delegate = delegate;
+        this.stats = stats;
+    }
+
+    @Override
+    public void createSchema(Session session, CatalogSchemaName schema, Map<String, Object> properties)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.createSchema(session, schema, properties);
+        }
+        finally {
+            stats.recordCreateSchemaCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropSchema(Session session, CatalogSchemaName schema)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropSchema(session, schema);
+        }
+        finally {
+            stats.recordDropSchemaCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void renameSchema(Session session, CatalogSchemaName source, String target)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.renameSchema(session, source, target);
+        }
+        finally {
+            stats.recordRenameSchemaCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.createTable(session, catalogName, tableMetadata, ignoreExisting);
+        }
+        finally {
+            stats.recordCreateTableCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableHandle createTemporaryTable(Session session, String catalogName, List<ColumnMetadata> columns, Optional<PartitioningMetadata> partitioningMetadata)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.createTemporaryTable(session, catalogName, columns, partitioningMetadata);
+        }
+        finally {
+            stats.recordCreateTemporaryTableCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropTable(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropTable(session, tableHandle);
+        }
+        finally {
+            stats.recordDropTableCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void truncateTable(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.truncateTable(session, tableHandle);
+        }
+        finally {
+            stats.recordTruncateTableCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<NewTableLayout> getNewTableLayout(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getNewTableLayout(session, catalogName, tableMetadata);
+        }
+        finally {
+            stats.recordGetNewTableLayoutCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public OutputTableHandle beginCreateTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, Optional<NewTableLayout> layout)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginCreateTable(session, catalogName, tableMetadata, layout);
+        }
+        finally {
+            stats.recordBeginCreateTableCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.finishCreateTable(session, tableHandle, fragments, computedStatistics);
+        }
+        finally {
+            stats.recordFinishCreateTableCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<NewTableLayout> getInsertLayout(Session session, TableHandle target)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getInsertLayout(session, target);
+        }
+        finally {
+            stats.recordGetInsertLayoutCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadataForWrite(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getStatisticsCollectionMetadataForWrite(session, catalogName, tableMetadata);
+        }
+        finally {
+            stats.recordGetStatisticsCollectionMetadataForWriteCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableStatisticsMetadata getStatisticsCollectionMetadata(Session session, String catalogName, ConnectorTableMetadata tableMetadata)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getStatisticsCollectionMetadata(session, catalogName, tableMetadata);
+        }
+        finally {
+            stats.recordGetStatisticsCollectionMetadataCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public AnalyzeTableHandle beginStatisticsCollection(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginStatisticsCollection(session, tableHandle);
+        }
+        finally {
+            stats.recordBeginStatisticsCollectionCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void finishStatisticsCollection(Session session, AnalyzeTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.finishStatisticsCollection(session, tableHandle, computedStatistics);
+        }
+        finally {
+            stats.recordFinishStatisticsCollectionCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void beginQuery(Session session, Set<ConnectorId> connectors)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.beginQuery(session, connectors);
+        }
+        finally {
+            stats.recordBeginQueryCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void cleanupQuery(Session session)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.cleanupQuery(session);
+        }
+        finally {
+            stats.recordCleanupQueryCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public InsertTableHandle beginInsert(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginInsert(session, tableHandle);
+        }
+        finally {
+            stats.recordBeginInsertCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.finishInsert(session, tableHandle, fragments, computedStatistics);
+        }
+        finally {
+            stats.recordFinishInsertCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<ColumnHandle> getDeleteRowIdColumn(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getDeleteRowIdColumn(session, tableHandle);
+        }
+        finally {
+            stats.recordGetDeleteRowIdColumnCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<ColumnHandle> getUpdateRowIdColumn(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getUpdateRowIdColumn(session, tableHandle, updatedColumns);
+        }
+        finally {
+            stats.recordGetUpdateRowIdColumnCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public boolean supportsMetadataDelete(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.supportsMetadataDelete(session, tableHandle);
+        }
+        finally {
+            stats.recordSupportsMetadataDeleteCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public OptionalLong metadataDelete(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.metadataDelete(session, tableHandle);
+        }
+        finally {
+            stats.recordMetadataDeleteCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public DeleteTableHandle beginDelete(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginDelete(session, tableHandle);
+        }
+        finally {
+            stats.recordBeginDeleteCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishDeleteWithOutput(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.finishDeleteWithOutput(session, tableHandle, fragments);
+        }
+        finally {
+            stats.recordFinishDeleteWithOutputCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public DistributedProcedureHandle beginCallDistributedProcedure(Session session, QualifiedObjectName procedureName, TableHandle tableHandle, Object[] arguments, boolean sourceTableEliminated)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginCallDistributedProcedure(session, procedureName, tableHandle, arguments, sourceTableEliminated);
+        }
+        finally {
+            stats.recordBeginCallDistributedProcedureCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void finishCallDistributedProcedure(Session session, DistributedProcedureHandle procedureHandle, QualifiedObjectName procedureName, Collection<Slice> fragments)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.finishCallDistributedProcedure(session, procedureHandle, procedureName, fragments);
+        }
+        finally {
+            stats.recordFinishCallDistributedProcedureCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginUpdate(session, tableHandle, updatedColumns);
+        }
+        finally {
+            stats.recordBeginUpdateCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void finishUpdate(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.finishUpdate(session, tableHandle, fragments);
+        }
+        finally {
+            stats.recordFinishUpdateCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public RowChangeParadigm getRowChangeParadigm(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getRowChangeParadigm(session, tableHandle);
+        }
+        finally {
+            stats.recordGetRowChangeParadigmCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public ColumnHandle getMergeTargetTableRowIdColumnHandle(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getMergeTargetTableRowIdColumnHandle(session, tableHandle);
+        }
+        finally {
+            stats.recordGetMergeTargetTableRowIdColumnHandleCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public MergeHandle beginMerge(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginMerge(session, tableHandle);
+        }
+        finally {
+            stats.recordBeginMergeCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void finishMerge(Session session, MergeHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.finishMerge(session, tableHandle, fragments, computedStatistics);
+        }
+        finally {
+            stats.recordFinishMergeCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorId> getCatalogHandle(Session session, String catalogName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getCatalogHandle(session, catalogName);
+        }
+        finally {
+            stats.recordGetCatalogHandleCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Map<String, ConnectorId> getCatalogNames(Session session)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getCatalogNames(session);
+        }
+        finally {
+            stats.recordGetCatalogNamesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Map<String, Catalog.CatalogContext> getCatalogNamesWithConnectorContext(Session session)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getCatalogNamesWithConnectorContext(session);
+        }
+        finally {
+            stats.recordGetCatalogNamesWithConnectorContextCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public List<QualifiedObjectName> listViews(Session session, QualifiedTablePrefix prefix)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listViews(session, prefix);
+        }
+        finally {
+            stats.recordListViewsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Map<QualifiedObjectName, ViewDefinition> getViews(Session session, QualifiedTablePrefix prefix)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getViews(session, prefix);
+        }
+        finally {
+            stats.recordGetViewsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void createView(Session session, String catalogName, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.createView(session, catalogName, viewMetadata, viewData, replace);
+        }
+        finally {
+            stats.recordCreateViewCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void renameView(Session session, QualifiedObjectName existingViewName, QualifiedObjectName newViewName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.renameView(session, existingViewName, newViewName);
+        }
+        finally {
+            stats.recordRenameViewCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropView(Session session, QualifiedObjectName viewName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropView(session, viewName);
+        }
+        finally {
+            stats.recordDropViewCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void createMaterializedView(Session session, String catalogName, ConnectorTableMetadata viewMetadata, MaterializedViewDefinition viewDefinition, boolean ignoreExisting)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.createMaterializedView(session, catalogName, viewMetadata, viewDefinition, ignoreExisting);
+        }
+        finally {
+            stats.recordCreateMaterializedViewCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropMaterializedView(session, viewName);
+        }
+        finally {
+            stats.recordDropMaterializedViewCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listMaterializedViews(session, prefix);
+        }
+        finally {
+            stats.recordListMaterializedViewsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Map<QualifiedObjectName, MaterializedViewDefinition> getMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getMaterializedViews(session, prefix);
+        }
+        finally {
+            stats.recordGetMaterializedViewsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public InsertTableHandle beginRefreshMaterializedView(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.beginRefreshMaterializedView(session, tableHandle);
+        }
+        finally {
+            stats.recordBeginRefreshMaterializedViewCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.finishRefreshMaterializedView(session, tableHandle, fragments, computedStatistics);
+        }
+        finally {
+            stats.recordFinishRefreshMaterializedViewCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public List<QualifiedObjectName> getReferencedMaterializedViews(Session session, QualifiedObjectName tableName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getReferencedMaterializedViews(session, tableName);
+        }
+        finally {
+            stats.recordGetReferencedMaterializedViewsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public MaterializedViewStatus getMaterializedViewStatus(Session session, QualifiedObjectName viewName, TupleDomain<String> baseQueryDomain)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getMaterializedViewStatus(session, viewName, baseQueryDomain);
+        }
+        finally {
+            stats.recordGetMaterializedViewStatusCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<ResolvedIndex> resolveIndex(Session session, TableHandle tableHandle, Set<ColumnHandle> indexableColumns, Set<ColumnHandle> outputColumns, TupleDomain<ColumnHandle> tupleDomain)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.resolveIndex(session, tableHandle, indexableColumns, outputColumns, tupleDomain);
+        }
+        finally {
+            stats.recordResolveIndexCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void createRole(Session session, String role, Optional<PrestoPrincipal> grantor, String catalog)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.createRole(session, role, grantor, catalog);
+        }
+        finally {
+            stats.recordCreateRoleCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropRole(Session session, String role, String catalog)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropRole(session, role, catalog);
+        }
+        finally {
+            stats.recordDropRoleCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Set<String> listRoles(Session session, String catalog)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listRoles(session, catalog);
+        }
+        finally {
+            stats.recordListRolesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Set<RoleGrant> listRoleGrants(Session session, String catalog, PrestoPrincipal principal)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listRoleGrants(session, catalog, principal);
+        }
+        finally {
+            stats.recordListRoleGrantsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void grantRoles(Session session, Set<String> roles, Set<PrestoPrincipal> grantees, boolean withAdminOption, Optional<PrestoPrincipal> grantor, String catalog)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.grantRoles(session, roles, grantees, withAdminOption, grantor, catalog);
+        }
+        finally {
+            stats.recordGrantRolesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void revokeRoles(Session session, Set<String> roles, Set<PrestoPrincipal> grantees, boolean adminOptionFor, Optional<PrestoPrincipal> grantor, String catalog)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.revokeRoles(session, roles, grantees, adminOptionFor, grantor, catalog);
+        }
+        finally {
+            stats.recordRevokeRolesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Set<RoleGrant> listApplicableRoles(Session session, PrestoPrincipal principal, String catalog)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listApplicableRoles(session, principal, catalog);
+        }
+        finally {
+            stats.recordListApplicableRolesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Set<String> listEnabledRoles(Session session, String catalog)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listEnabledRoles(session, catalog);
+        }
+        finally {
+            stats.recordListEnabledRolesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void grantTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, PrestoPrincipal grantee, boolean grantOption)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.grantTablePrivileges(session, tableName, privileges, grantee, grantOption);
+        }
+        finally {
+            stats.recordGrantTablePrivilegesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, PrestoPrincipal grantee, boolean grantOption)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption);
+        }
+        finally {
+            stats.recordRevokeTablePrivilegesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listTablePrivileges(session, prefix);
+        }
+        finally {
+            stats.recordListTablePrivilegesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public ListenableFuture<Void> commitPageSinkAsync(Session session, OutputTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+        }
+        finally {
+            stats.recordCommitPageSinkAsyncCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public ListenableFuture<Void> commitPageSinkAsync(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+        }
+        finally {
+            stats.recordCommitPageSinkAsyncCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public ListenableFuture<Void> commitPageSinkAsync(Session session, DeleteTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.commitPageSinkAsync(session, tableHandle, fragments);
+        }
+        finally {
+            stats.recordCommitPageSinkAsyncCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public FunctionAndTypeManager getFunctionAndTypeManager()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getFunctionAndTypeManager();
+        }
+        finally {
+            stats.recordGetFunctionAndTypeManagerCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public ProcedureRegistry getProcedureRegistry()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getProcedureRegistry();
+        }
+        finally {
+            stats.recordGetProcedureRegistryCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public BlockEncodingSerde getBlockEncodingSerde()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getBlockEncodingSerde();
+        }
+        finally {
+            stats.recordGetBlockEncodingSerdeCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public SessionPropertyManager getSessionPropertyManager()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getSessionPropertyManager();
+        }
+        finally {
+            stats.recordGetSessionPropertyManagerCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public SchemaPropertyManager getSchemaPropertyManager()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getSchemaPropertyManager();
+        }
+        finally {
+            stats.recordGetSchemaPropertyManagerCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TablePropertyManager getTablePropertyManager()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getTablePropertyManager();
+        }
+        finally {
+            stats.recordGetTablePropertyManagerCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public MaterializedViewPropertyManager getMaterializedViewPropertyManager()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getMaterializedViewPropertyManager();
+        }
+        finally {
+            stats.recordGetTablePropertyManagerCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public ColumnPropertyManager getColumnPropertyManager()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getColumnPropertyManager();
+        }
+        finally {
+            stats.recordGetColumnPropertyManagerCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public AnalyzePropertyManager getAnalyzePropertyManager()
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getAnalyzePropertyManager();
+        }
+        finally {
+            stats.recordGetAnalyzePropertyManagerCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public MetadataResolver getMetadataResolver(Session session)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getMetadataResolver(session);
+        }
+        finally {
+            stats.recordGetMetadataResolverCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId catalogName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getConnectorCapabilities(session, catalogName);
+        }
+        finally {
+            stats.recordGetConnectorCapabilitiesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableLayoutFilterCoverage getTableLayoutFilterCoverage(Session session, TableHandle tableHandle, Set<String> relevantPartitionColumn)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getTableLayoutFilterCoverage(session, tableHandle, relevantPartitionColumn);
+        }
+        finally {
+            stats.recordGetTableLayoutFilterCoverageCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropBranch(Session session, TableHandle tableHandle, String branchName, boolean branchExists)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropBranch(session, tableHandle, branchName, branchExists);
+        }
+        finally {
+            stats.recordDropBranchCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropTag(Session session, TableHandle tableHandle, String tagName, boolean tagExists)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropTag(session, tableHandle, tagName, tagExists);
+        }
+        finally {
+            stats.recordDropTagCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropConstraint(Session session, TableHandle tableHandle, Optional<String> constraintName, Optional<String> columnName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropConstraint(session, tableHandle, constraintName, columnName);
+        }
+        finally {
+            stats.recordDropConstraintCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void addConstraint(Session session, TableHandle tableHandle, TableConstraint<String> tableConstraint)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.addConstraint(session, tableHandle, tableConstraint);
+        }
+        finally {
+            stats.recordAddConstraintCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public boolean isPushdownSupportedForFilter(Session session, TableHandle tableHandle, RowExpression filter, Map<VariableReferenceExpression, ColumnHandle> symbolToColumnHandleMap)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.isPushdownSupportedForFilter(session, tableHandle, filter, symbolToColumnHandleMap);
+        }
+        finally {
+            stats.recordIsPushdownSupportedForFilterCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void renameTable(Session session, TableHandle tableHandle, QualifiedObjectName newTableName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.renameTable(session, tableHandle, newTableName);
+        }
+        finally {
+            stats.recordRenameTableCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void setTableProperties(Session session, TableHandle tableHandle, Map<String, Object> properties)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.setTableProperties(session, tableHandle, properties);
+        }
+        finally {
+            stats.recordSetTablePropertiesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void addColumn(Session session, TableHandle tableHandle, ColumnMetadata column)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.addColumn(session, tableHandle, column);
+        }
+        finally {
+            stats.recordAddColumnCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void dropColumn(Session session, TableHandle tableHandle, ColumnHandle column)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.dropColumn(session, tableHandle, column);
+        }
+        finally {
+            stats.recordDropColumnCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void renameColumn(Session session, TableHandle tableHandle, ColumnHandle source, String target)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.renameColumn(session, tableHandle, source, target);
+        }
+        finally {
+            stats.recordRenameColumnCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public String normalizeIdentifier(Session session, String catalogName, String identifier)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.normalizeIdentifier(session, catalogName, identifier);
+        }
+        finally {
+            stats.recordNormalizeIdentifierCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<TableHandle>> applyTableFunction(Session session, TableFunctionHandle handle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.applyTableFunction(session, handle);
+        }
+        finally {
+            stats.recordApplyTableFunctionCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void verifyComparableOrderableContract()
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.verifyComparableOrderableContract();
+        }
+        finally {
+            stats.recordVerifyComparableOrderableContractCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Type getType(TypeSignature signature)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getType(signature);
+        }
+        finally {
+            stats.recordGetTypeCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void registerBuiltInFunctions(List<? extends SqlFunction> functions)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.registerBuiltInFunctions(functions);
+        }
+        finally {
+            stats.recordRegisterBuiltInFunctionsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public void registerConnectorFunctions(String catalogName, List<? extends SqlFunction> functionInfos)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.registerConnectorFunctions(catalogName, functionInfos);
+        }
+        finally {
+            stats.recordRegisterConnectorFunctionsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public List<String> listSchemaNames(Session session, String catalogName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listSchemaNames(session, catalogName);
+        }
+        finally {
+            stats.recordListSchemaNamesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(Session session, CatalogSchemaName schemaName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getSchemaProperties(session, schemaName);
+        }
+        finally {
+            stats.recordGetSchemaPropertiesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getSystemTable(session, tableName);
+        }
+        finally {
+            stats.recordGetSystemTableCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<TableHandle> getHandleVersion(Session session, QualifiedObjectName tableName, Optional<ConnectorTableVersion> tableVersion)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getHandleVersion(session, tableName, tableVersion);
+        }
+        finally {
+            stats.recordGetHandleVersionCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandleForStatisticsCollection(Session session, QualifiedObjectName tableName, Map<String, Object> analyzeProperties)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getTableHandleForStatisticsCollection(session, tableName, analyzeProperties);
+        }
+        finally {
+            stats.recordGetTableHandleForStatisticsCollectionCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableLayoutResult getLayout(Session session, TableHandle tableHandle, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getLayout(session, tableHandle, constraint, desiredColumns);
+        }
+        finally {
+            stats.recordGetLayoutCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableLayout getLayout(Session session, TableHandle handle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getLayout(session, handle);
+        }
+        finally {
+            stats.recordGetLayoutCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableHandle getAlternativeTableHandle(Session session, TableHandle tableHandle, PartitioningHandle partitioningHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getAlternativeTableHandle(session, tableHandle, partitioningHandle);
+        }
+        finally {
+            stats.recordGetAlternativeTableHandleCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public boolean isLegacyGetLayoutSupported(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.isLegacyGetLayoutSupported(session, tableHandle);
+        }
+        finally {
+            stats.recordIsLegacyGetLayoutSupportedCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<PartitioningHandle> getCommonPartitioning(Session session, PartitioningHandle left, PartitioningHandle right)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getCommonPartitioning(session, left, right);
+        }
+        finally {
+            stats.recordGetCommonPartitioningCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public boolean isRefinedPartitioningOver(Session session, PartitioningHandle a, PartitioningHandle b)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.isRefinedPartitioningOver(session, a, b);
+        }
+        finally {
+            stats.recordIsRefinedPartitioningOverCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public PartitioningHandle getPartitioningHandleForExchange(Session session, String catalogName, int partitionCount, List<Type> partitionTypes)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getPartitioningHandleForExchange(session, catalogName, partitionCount, partitionTypes);
+        }
+        finally {
+            stats.recordGetPartitioningHandleForExchangeCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Optional<Object> getInfo(Session session, TableHandle handle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getInfo(session, handle);
+        }
+        finally {
+            stats.recordGetInfoCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getTableMetadata(session, tableHandle);
+        }
+        finally {
+            stats.recordGetTableMetadataCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TableStatistics getTableStatistics(Session session, TableHandle tableHandle, List<ColumnHandle> columnHandles, Constraint<ColumnHandle> constraint)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getTableStatistics(session, tableHandle, columnHandles, constraint);
+        }
+        finally {
+            stats.recordGetTableStatisticsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listTables(session, prefix);
+        }
+        finally {
+            stats.recordListTablesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getColumnHandles(session, tableHandle);
+        }
+        finally {
+            stats.recordGetColumnHandlesCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.getColumnMetadata(session, tableHandle, columnHandle);
+        }
+        finally {
+            stats.recordGetColumnMetadataCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public TupleDomain<ColumnHandle> toExplainIOConstraints(Session session, TableHandle tableHandle, TupleDomain<ColumnHandle> constraints)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.toExplainIOConstraints(session, tableHandle, constraints);
+        }
+        finally {
+            stats.recordToExplainIOConstraintsCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
+    public Map<QualifiedObjectName, List<ColumnMetadata>> listTableColumns(Session session, QualifiedTablePrefix prefix)
+    {
+        long startTime = System.nanoTime();
+        try {
+            return delegate.listTableColumns(session, prefix);
+        }
+        finally {
+            stats.recordListTableColumnsCall(System.nanoTime() - startTime);
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestMetadataManagerStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestMetadataManagerStats.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestMetadataManagerStats
+{
+    @Test
+    public void testInitialState()
+    {
+        MetadataManagerStats stats = new MetadataManagerStats();
+
+        // Verify all counters start at 0
+        assertEquals(stats.getListSchemaNamesCalls(), 0);
+        assertEquals(stats.getListTablesCalls(), 0);
+        assertEquals(stats.getGetTableMetadataCalls(), 0);
+        assertEquals(stats.getGetColumnHandlesCalls(), 0);
+
+        // Verify timing stats are initialized
+        assertNotNull(stats.getListSchemaNamesTime());
+        assertNotNull(stats.getListTablesTime());
+        assertEquals(stats.getListSchemaNamesTime().getAllTime().getCount(), 0.0);
+        assertEquals(stats.getListTablesTime().getAllTime().getCount(), 0.0);
+    }
+
+    @Test
+    public void testRecordCalls()
+    {
+        MetadataManagerStats stats = new MetadataManagerStats();
+
+        // Record some calls
+        stats.recordListSchemaNamesCall(1000000); // 1ms in nanoseconds
+        stats.recordListSchemaNamesCall(2000000); // 2ms
+        stats.recordListTablesCall(3000000); // 3ms
+
+        // Verify counters incremented
+        assertEquals(stats.getListSchemaNamesCalls(), 2);
+        assertEquals(stats.getListTablesCalls(), 1);
+
+        // Verify timing recorded
+        assertEquals(stats.getListSchemaNamesTime().getAllTime().getCount(), 2.0);
+        assertEquals(stats.getListTablesTime().getAllTime().getCount(), 1.0);
+    }
+
+    @Test
+    public void testTimingStatistics()
+    {
+        MetadataManagerStats stats = new MetadataManagerStats();
+
+        // Record calls with different durations
+        stats.recordListSchemaNamesCall(1000000); // 1ms
+        stats.recordListSchemaNamesCall(5000000); // 5ms
+        stats.recordListSchemaNamesCall(3000000); // 3ms
+
+        // Verify count
+        assertEquals(stats.getListSchemaNamesTime().getAllTime().getCount(), 3.0);
+
+        // Verify min/max are reasonable
+        assertTrue(stats.getListSchemaNamesTime().getAllTime().getMin() > 0);
+        assertTrue(stats.getListSchemaNamesTime().getAllTime().getMax() > 0);
+        assertTrue(stats.getListSchemaNamesTime().getAllTime().getMax() >= stats.getListSchemaNamesTime().getAllTime().getMin());
+    }
+
+    @Test
+    public void testMultipleOperations()
+    {
+        MetadataManagerStats stats = new MetadataManagerStats();
+
+        // Record various operations
+        stats.recordListSchemaNamesCall(1000000);
+        stats.recordListTablesCall(2000000);
+        stats.recordGetTableMetadataCall(3000000);
+        stats.recordGetColumnHandlesCall(4000000);
+
+        // Verify all were recorded independently
+        assertEquals(stats.getListSchemaNamesCalls(), 1);
+        assertEquals(stats.getListTablesCalls(), 1);
+        assertEquals(stats.getGetTableMetadataCalls(), 1);
+        assertEquals(stats.getGetColumnHandlesCalls(), 1);
+
+        // Verify timing for each
+        assertEquals(stats.getListSchemaNamesTime().getAllTime().getCount(), 1.0);
+        assertEquals(stats.getListTablesTime().getAllTime().getCount(), 1.0);
+        assertEquals(stats.getGetTableMetadataTime().getAllTime().getCount(), 1.0);
+        assertEquals(stats.getGetColumnHandlesTime().getAllTime().getCount(), 1.0);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestStatsRecordingMetadataManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestStatsRecordingMetadataManager.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestStatsRecordingMetadataManager
+{
+    @Test
+    public void testEverythingDelegated()
+    {
+        assertAllMethodsOverridden(Metadata.class, StatsRecordingMetadataManager.class);
+    }
+
+    @Test
+    public void testStatsRecording()
+    {
+        MetadataManagerStats stats = new MetadataManagerStats();
+
+        // Verify initial state - no calls recorded
+        assertEquals(stats.getListSchemaNamesCalls(), 0);
+        assertEquals(stats.getListSchemaNamesTime().getAllTime().getCount(), 0.0);
+
+        // Record a call directly (without session to avoid transaction requirement)
+        stats.recordListSchemaNamesCall(1000000);
+
+        // Verify stats were recorded
+        assertEquals(stats.getListSchemaNamesCalls(), 1);
+        assertEquals(stats.getListSchemaNamesTime().getAllTime().getCount(), 1.0);
+    }
+
+    @Test
+    public void testMultipleCallsRecorded()
+    {
+        MetadataManagerStats stats = new MetadataManagerStats();
+
+        // Verify initial state
+        assertEquals(stats.getListSchemaNamesCalls(), 0);
+        assertEquals(stats.getListTablesCalls(), 0);
+
+        // Record different metadata operations directly
+        stats.recordListSchemaNamesCall(1000000);
+        stats.recordListSchemaNamesCall(2000000);
+        stats.recordListTablesCall(3000000);
+
+        // Verify all calls were recorded
+        assertEquals(stats.getListSchemaNamesCalls(), 2);
+        assertEquals(stats.getListSchemaNamesTime().getAllTime().getCount(), 2.0);
+        assertEquals(stats.getListTablesCalls(), 1);
+        assertEquals(stats.getListTablesTime().getAllTime().getCount(), 1.0);
+    }
+
+    @Test
+    public void testTimingRecorded()
+    {
+        MetadataManagerStats stats = new MetadataManagerStats();
+
+        // Record operation with timing
+        stats.recordListSchemaNamesCall(5000000);
+
+        // Verify timing was recorded - count should be 1
+        assertEquals(stats.getListSchemaNamesTime().getAllTime().getCount(), 1.0);
+        // Verify max and min are greater than 0 (some time was recorded)
+        assertTrue(stats.getListSchemaNamesTime().getAllTime().getMax() > 0, "Max time should be greater than 0");
+        assertTrue(stats.getListSchemaNamesTime().getAllTime().getMin() > 0, "Min time should be greater than 0");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/ForMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/ForMetadata.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER, METHOD })
+public @interface ForMetadata
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataStatsModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataStatsModule.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class MetadataStatsModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(MetadataManagerStats.class).in(SINGLETON);
+        newExporter(binder)
+                .export(MetadataManagerStats.class)
+                .withGeneratedName();
+    }
+
+    @Provides
+    @Singleton
+    public Metadata provideStatsRecordingMetadata(
+            @ForMetadata Metadata delegate,
+            MetadataManagerStats stats)
+    {
+        return new StatsRecordingMetadataManager(delegate, stats);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -103,6 +103,7 @@ import com.facebook.presto.metadata.BuiltInProcedureRegistry;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.ColumnPropertyManager;
 import com.facebook.presto.metadata.DiscoveryNodeManager;
+import com.facebook.presto.metadata.ForMetadata;
 import com.facebook.presto.metadata.ForNodeManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.HandleJsonModule;
@@ -110,6 +111,7 @@ import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.MaterializedViewPropertyManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.MetadataStatsModule;
 import com.facebook.presto.metadata.SchemaPropertyManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.metadata.SessionPropertyProviderConfig;
@@ -673,10 +675,16 @@ public class ServerMainModule
 
         if (serverConfig.isCatalogServerEnabled() && serverConfig.isCoordinator()) {
             binder.bind(RemoteMetadataManager.class).in(Scopes.SINGLETON);
-            binder.bind(Metadata.class).to(RemoteMetadataManager.class).in(Scopes.SINGLETON);
+            binder.bind(Metadata.class)
+                    .annotatedWith(ForMetadata.class)
+                    .to(RemoteMetadataManager.class)
+                    .in(Scopes.SINGLETON);
         }
         else {
-            binder.bind(Metadata.class).to(MetadataManager.class).in(Scopes.SINGLETON);
+            binder.bind(Metadata.class)
+                    .annotatedWith(ForMetadata.class)
+                    .to(MetadataManager.class)
+                    .in(Scopes.SINGLETON);
         }
 
         // row expression utils
@@ -717,6 +725,8 @@ public class ServerMainModule
         // handle resolver
         binder.install(new HandleJsonModule());
         binder.bind(ObjectMapper.class).toProvider(JsonObjectMapperProvider.class);
+
+        binder.install(new MetadataStatsModule());
 
         // connector
         binder.bind(ScalarStatsCalculator.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -830,7 +830,7 @@ public class TestingPrestoServer
         requestBlocker.unblock();
     }
 
-    private static void updateConnectorIdAnnouncement(Announcer announcer, ConnectorId connectorId, InternalNodeManager nodeManager)
+    public static void updateConnectorIdAnnouncement(Announcer announcer, ConnectorId connectorId, InternalNodeManager nodeManager)
     {
         //
         // This code was copied from PrestoServer, and is a hack that should be removed when the connectorId property is removed

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestMetadataStatsModule.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestMetadataStatsModule.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestMetadataStatsModule
+{
+    @Test
+    public void testModuleCreation()
+    {
+        MetadataStatsModule module = new MetadataStatsModule();
+        assertNotNull(module, "Module should be created");
+    }
+
+    @Test
+    public void testModuleBindsMetadata()
+    {
+        MetadataManager testMetadataManager = MetadataManager.createTestMetadataManager();
+        Injector injector = Guice.createInjector(binder -> {
+            binder.bind(Metadata.class).annotatedWith(ForMetadata.class).toInstance(testMetadataManager);
+        }, new MetadataStatsModule());
+
+        MetadataManagerStats stats = injector.getInstance(MetadataManagerStats.class);
+        assertNotNull(stats, "MetadataManagerStats should be bound");
+
+        Metadata metadata = injector.getInstance(Metadata.class);
+        assertNotNull(metadata, "Metadata should be bound");
+
+        assertTrue(metadata instanceof StatsRecordingMetadataManager,
+                "Metadata should be wrapped with StatsRecordingMetadataManager");
+    }
+
+    @Test
+    public void testStatsAreSingleton()
+    {
+        MetadataManager testMetadataManager = MetadataManager.createTestMetadataManager();
+        Injector injector = Guice.createInjector(binder -> {
+            binder.bind(Metadata.class).annotatedWith(ForMetadata.class).toInstance(testMetadataManager);
+        }, new MetadataStatsModule());
+
+        MetadataManagerStats stats1 = injector.getInstance(MetadataManagerStats.class);
+        MetadataManagerStats stats2 = injector.getInstance(MetadataManagerStats.class);
+
+        assertTrue(stats1 == stats2, "MetadataManagerStats should be singleton");
+
+        Metadata metadata1 = injector.getInstance(Metadata.class);
+        Metadata metadata2 = injector.getInstance(Metadata.class);
+
+        assertTrue(metadata1 == metadata2, "Metadata should be singleton");
+    }
+}

--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -158,6 +158,24 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-jmx</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>stats</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>discovery</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJmxMetadataMetrics.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeJmxMetadataMetrics.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker;
+
+import com.facebook.airlift.discovery.client.Announcer;
+import com.facebook.presto.connector.jmx.JmxPlugin;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.metadata.MetadataManagerStats;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.inject.Key;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.weakref.jmx.MBeanExporter;
+
+import javax.management.MBeanServer;
+
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNationWithFormat;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createRegion;
+import static com.facebook.presto.server.testing.TestingPrestoServer.updateConnectorIdAnnouncement;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public abstract class AbstractTestNativeJmxMetadataMetrics
+        extends AbstractTestQueryFramework
+{
+    private final String storageFormat = "PARQUET";
+    protected abstract String getCatalogName();
+    protected abstract String getSchemaName();
+    protected abstract MBeanServer getMBeanServer();
+    protected String getTableName(String table)
+    {
+        return String.format("%s.%s.%s", getCatalogName(), getSchemaName(), table);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createRegion(queryRunner);
+        createNationWithFormat(queryRunner, storageFormat);
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        try {
+            com.facebook.presto.tests.DistributedQueryRunner distributedQueryRunner = (com.facebook.presto.tests.DistributedQueryRunner) getQueryRunner();
+            // Install JMX plugin on coordinator only
+            distributedQueryRunner.getCoordinator().installPlugin(new JmxPlugin());
+            ConnectorId jmxConnectorId = distributedQueryRunner.getCoordinator().createCatalog("jmx", "jmx");
+
+            // Manually update the coordinator's connectorIds announcement
+            // This is needed because createCatalog() skips the announcement update for coordinators
+            // when node-scheduler.include-coordinator is false (see TestingPrestoServer.createCatalog)
+            Announcer announcer = distributedQueryRunner.getCoordinator().getInstance(Key.get(Announcer.class));
+            InternalNodeManager nodeManager = distributedQueryRunner.getCoordinator().getNodeManager();
+            updateConnectorIdAnnouncement(announcer, jmxConnectorId, nodeManager);
+            // Register MetadataManagerStats to the MBeanServer used by JmxPlugin
+            // This is needed because MetadataManagerStats is registered to TestingMBeanServer (via ServerMainModule)
+            // but JmxPlugin queries a different MBeanServer (platform or custom)
+            MetadataManagerStats stats = distributedQueryRunner.getCoordinator().getInstance(Key.get(MetadataManagerStats.class));
+            MBeanExporter exporter = new MBeanExporter(getMBeanServer());
+            exporter.export("com.facebook.presto.metadata:name=MetadataManagerStats", stats);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to set up JMX connector announcement and register MetadataManagerStats MBean", e);
+        }
+    }
+
+    @Test
+    public void testMetadataManagerStatsExist()
+    {
+        String jmxQuery = "SELECT * FROM jmx.current.\"com.facebook.presto.metadata:name=MetadataManagerStats\"";
+        MaterializedResult result = computeActual(jmxQuery);
+        assertTrue(result.getRowCount() > 0);
+    }
+
+    @Test
+    public void testMetadataMetricsAfterQueries()
+    {
+        // Query to get metadata metrics
+        String metricsQuery = "SELECT getTableMetadataCalls, listTablesCalls, getColumnHandlesCalls " +
+                "FROM jmx.current.\"com.facebook.presto.metadata:name=MetadataManagerStats\"";
+
+        MaterializedResult initialResult = computeActual(metricsQuery);
+        assertEquals(initialResult.getRowCount(), 1);
+        long initialTableMetadataCalls = (long) initialResult.getMaterializedRows().get(0).getField(0);
+        long initialColumnHandlesCalls = (long) initialResult.getMaterializedRows().get(0).getField(2);
+
+        assertQuerySucceeds(String.format("SHOW TABLES FROM %s.%s", getCatalogName(), getSchemaName()));
+        assertQuerySucceeds(String.format("SELECT * FROM %s", getTableName("nation")));
+        assertQuerySucceeds(String.format("DESCRIBE %s", getTableName("nation")));
+        assertQuerySucceeds(String.format("SHOW COLUMNS FROM %s", getTableName("region")));
+        assertQuerySucceeds(String.format("SELECT n.name, r.name FROM %s n JOIN %s r ON n.regionkey = r.regionkey", getTableName("nation"), getTableName("region")));
+
+        MaterializedResult updatedResult = computeActual(metricsQuery);
+        assertEquals(updatedResult.getRowCount(), 1);
+        long updatedTableMetadataCalls = (long) updatedResult.getMaterializedRows().get(0).getField(0);
+        long updatedColumnHandlesCalls = (long) updatedResult.getMaterializedRows().get(0).getField(2);
+
+        assertTrue(updatedTableMetadataCalls >= initialTableMetadataCalls);
+        assertTrue(updatedColumnHandlesCalls >= initialColumnHandlesCalls);
+    }
+
+    @Test
+    public void testMetadataTimingMetrics()
+    {
+        assertQuerySucceeds(String.format("SHOW TABLES FROM %s.%s", getCatalogName(), getSchemaName()));
+        assertQuerySucceeds(String.format("DESCRIBE %s", getTableName("nation")));
+        assertQuerySucceeds(String.format("SELECT * FROM %s LIMIT 10", getTableName("nation")));
+        assertQuerySucceeds(String.format("SELECT count(*) FROM %s", getTableName("region")));
+
+        String timingQuery = "SELECT \"gettablemetadatatime.alltime.count\", \"listtablestime.alltime.count\",\"getcolumnhandlestime.alltime.count\" " +
+                "FROM jmx.current.\"com.facebook.presto.metadata:name=MetadataManagerStats\"";
+
+        MaterializedResult result = computeActual(timingQuery);
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getFieldCount(), 3);
+
+        double getTableMetadataCount = (double) result.getMaterializedRows().get(0).getField(0);
+        double listTablesCount = (double) result.getMaterializedRows().get(0).getField(1);
+        double getColumnHandlesCount = (double) result.getMaterializedRows().get(0).getField(2);
+        assertTrue(getTableMetadataCount >= 0);
+        assertTrue(listTablesCount >= 0);
+        assertTrue(getColumnHandlesCount >= 0);
+    }
+
+    @Test
+    public void testMultipleOperationsIncrementMetrics()
+    {
+        String countQuery = "SELECT " +
+                "getTableMetadataCalls + listTablesCalls + getColumnHandlesCalls as total_calls " +
+                "FROM jmx.current.\"com.facebook.presto.metadata:name=MetadataManagerStats\"";
+
+        MaterializedResult initialResult = computeActual(countQuery);
+        long initialTotalCalls = (long) initialResult.getMaterializedRows().get(0).getField(0);
+
+        for (int i = 0; i < 5; i++) {
+            assertQuerySucceeds(String.format("SHOW TABLES FROM %s.%s", getCatalogName(), getSchemaName()));
+            assertQuerySucceeds(String.format("SELECT * FROM %s WHERE nationkey < 10", getTableName("nation")));
+            assertQuerySucceeds(String.format("SELECT count(*) FROM %s", getTableName("region")));
+        }
+
+        MaterializedResult updatedResult = computeActual(countQuery);
+        long updatedTotalCalls = (long) updatedResult.getMaterializedRows().get(0).getField(0);
+
+        assertTrue(updatedTotalCalls > initialTotalCalls);
+    }
+
+    @Test
+    public void testMetadataStatsWithComplexQueries()
+    {
+        String metricsQuery = "SELECT getTableMetadataCalls, getColumnHandlesCalls " +
+                "FROM jmx.current.\"com.facebook.presto.metadata:name=MetadataManagerStats\"";
+
+        MaterializedResult initialResult = computeActual(metricsQuery);
+        long initialTableMetadataCalls = (long) initialResult.getMaterializedRows().get(0).getField(0);
+        long initialColumnHandlesCalls = (long) initialResult.getMaterializedRows().get(0).getField(1);
+
+        assertQuerySucceeds(String.format("SELECT n.name, r.name FROM %s n JOIN %s r ON n.regionkey = r.regionkey WHERE n.nationkey < 10",
+                getTableName("nation"), getTableName("region")));
+        assertQuerySucceeds(String.format("SELECT * FROM %s WHERE nationkey IN (SELECT nationkey FROM %s WHERE regionkey = 1)",
+                getTableName("nation"), getTableName("nation")));
+        assertQuerySucceeds(String.format("WITH nation_counts AS (SELECT regionkey, count(*) as cnt FROM %s GROUP BY regionkey) " +
+                        "SELECT r.name, nc.cnt FROM %s r JOIN nation_counts nc ON r.regionkey = nc.regionkey",
+                getTableName("nation"), getTableName("region")));
+
+        MaterializedResult updatedResult = computeActual(metricsQuery);
+        long updatedTableMetadataCalls = (long) updatedResult.getMaterializedRows().get(0).getField(0);
+        long updatedColumnHandlesCalls = (long) updatedResult.getMaterializedRows().get(0).getField(1);
+
+        assertTrue(updatedTableMetadataCalls >= initialTableMetadataCalls);
+        assertTrue(updatedColumnHandlesCalls >= initialColumnHandlesCalls);
+    }
+
+    @Test
+    public void testMetadataStatsNodeColumn()
+    {
+        String nodeQuery = "SELECT DISTINCT node FROM jmx.current.\"com.facebook.presto.metadata:name=MetadataManagerStats\"";
+        MaterializedResult result = computeActual(nodeQuery);
+
+        assertEquals(result.getRowCount(), 1);
+
+        MaterializedResult coordinatorNodes = computeActual("SELECT node_id FROM system.runtime.nodes WHERE coordinator = true");
+        assertEquals(coordinatorNodes.getRowCount(), 1);
+
+        String metadataStatsNode = (String) result.getMaterializedRows().get(0).getField(0);
+        String coordinatorNode = (String) coordinatorNodes.getMaterializedRows().get(0).getField(0);
+        assertEquals(metadataStatsNode, coordinatorNode);
+    }
+}

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -337,6 +337,7 @@ public class PrestoNativeQueryRunnerUtils
         // whether the query runner returned by builder should use an external worker launcher, it will be true only
         // for the native query runner and should NOT be explicitly configured by users.
         private boolean useExternalWorkerLauncher;
+        private boolean addJmxPlugin;
 
         private IcebergQueryRunnerBuilder(QueryRunnerType queryRunnerType)
         {
@@ -356,6 +357,12 @@ public class PrestoNativeQueryRunnerUtils
                 this.extraConnectorProperties.putAll(ImmutableMap.of("hive.parquet.writer.version", "PARQUET_1_0"));
                 this.useExternalWorkerLauncher = false;
             }
+        }
+
+        public IcebergQueryRunnerBuilder setAddJmxPlugin(boolean addJmxPlugin)
+        {
+            this.addJmxPlugin = addJmxPlugin;
+            return this;
         }
 
         public IcebergQueryRunnerBuilder setStorageFormat(String storageFormat)
@@ -380,6 +387,12 @@ public class PrestoNativeQueryRunnerUtils
         public QueryRunner build()
                 throws Exception
         {
+            return buildIcebergQueryRunner().getQueryRunner();
+        }
+
+        public IcebergQueryRunner buildIcebergQueryRunner()
+                throws Exception
+        {
             Optional<BiFunction<Integer, URI, Process>> externalWorkerLauncher = Optional.empty();
             if (this.useExternalWorkerLauncher) {
                 externalWorkerLauncher = getExternalWorkerLauncher("iceberg", serverBinary, cacheMaxSize, remoteFunctionServerUds,
@@ -390,14 +403,14 @@ public class PrestoNativeQueryRunnerUtils
                     .setExtraConnectorProperties(extraConnectorProperties)
                     .setFormat(FileFormat.valueOf(storageFormat))
                     .setCreateTpchTables(false)
-                    .setAddJmxPlugin(false)
+                    .setAddJmxPlugin(addJmxPlugin)
                     .setNodeCount(OptionalInt.of(workerCount))
                     .setExternalWorkerLauncher(externalWorkerLauncher)
                     .setAddStorageFormatToPath(addStorageFormatToPath)
                     .setDataDirectory(Optional.of(dataDirectory))
                     .setTpcdsProperties(getNativeWorkerTpcdsProperties())
                     .setCatalogType(catalogType)
-                    .build().getQueryRunner();
+                    .build();
         }
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestNativeIcebergJmxMetadataMetrics.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestNativeIcebergJmxMetadataMetrics.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativeworker.iceberg;
+
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.nativeworker.AbstractTestNativeJmxMetadataMetrics;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+
+import javax.management.MBeanServer;
+
+import java.lang.management.ManagementFactory;
+
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder;
+import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder;
+
+/**
+ * Test class to verify JMX metadata metrics work correctly with Presto native (C++) workers using Iceberg connector.
+ */
+public class TestNativeIcebergJmxMetadataMetrics
+        extends AbstractTestNativeJmxMetadataMetrics
+{
+    private IcebergQueryRunner icebergQueryRunner;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        icebergQueryRunner = nativeIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setAddStorageFormatToPath(false)
+                .setAddJmxPlugin(false)
+                .buildIcebergQueryRunner();
+        return icebergQueryRunner.getQueryRunner();
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return javaIcebergQueryRunnerBuilder()
+                .setStorageFormat(ICEBERG_DEFAULT_STORAGE_FORMAT)
+                .setAddStorageFormatToPath(false)
+                .build();
+    }
+
+    @Override
+    protected String getCatalogName()
+    {
+        return "iceberg";
+    }
+
+    @Override
+    protected String getSchemaName()
+    {
+        return "tpch";
+    }
+
+    @Override
+    protected MBeanServer getMBeanServer()
+    {
+        return ManagementFactory.getPlatformMBeanServer();
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestMetadataManager.java
@@ -32,6 +32,7 @@ import com.facebook.presto.transaction.TransactionBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.Key;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -89,7 +90,7 @@ public class TestMetadataManager
             }
         });
         queryRunner.createCatalog("upper_case_schema_catalog", "mock");
-        metadataManager = (MetadataManager) queryRunner.getMetadata();
+        metadataManager = queryRunner.getCoordinator().getInstance(Key.get(MetadataManager.class));
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
Add comprehensive JMX metrics for metadata operations.

## Description
Add comprehensive JMX metrics for all Metadata interface operations to enable production monitoring and performance analysis of metadata-related operations in Presto clusters.

## Motivation and Context
Implement metrics tracking for 100+ metadata operations, providing:

- Call counters for each operation
- Detailed timing statistics (avg, min, max, percentiles)
- Time-windowed metrics (1min, 5min, 15min, all-time)
- JMX exposure for monitoring integration

## Impact
Better monitoring.
New monitoring capabilities via JMX -
`SELECT * FROM jmx.current."com.facebook.presto.metadata:name=metadatamanagerstats";`

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add comprehensive JMX metrics for metadata operations.
```

