### PR TITLE
fix: Fix flaky test caused by duplicate table names

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestMetadata.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestMetadata.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder;
+import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
 
 public class TestMetadata
         extends AbstractTestQueryFramework
@@ -108,7 +109,7 @@ public class TestMetadata
     @Test
     public void testTableWithComplexTypesMetadata()
     {
-        String tableName = "complex_metadata";
+        String tableName = "complex_metadata_" + randomTableSuffix();
 
         try {
             assertUpdate(String.format("CREATE TABLE %s (" +
@@ -529,7 +530,7 @@ public class TestMetadata
     @Test
     public void testWithComplexQueries()
     {
-        String tableName = "complex_metadata";
+        String tableName = "complex_metadata_" + randomTableSuffix();
 
         try {
             assertUpdate(String.format("CREATE TABLE %s (id INTEGER, category VARCHAR, amount DOUBLE) WITH (format = 'PARQUET')", tableName));


### PR DESCRIPTION
## Description

This PR ensures concurrently executed tests use different table names in `TestMetadata`.

## Motivation and Context

Fix flaky test: #26881 

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

