### PR TITLE
chore(deps): Bump org.apache.logging.log4j:log4j-core from 2.24.3 to 2.25.3

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -17,7 +17,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.accumulo.version>1.10.1</dep.accumulo.version>
         <dep.curator.version>2.12.0</dep.curator.version>
-        <dep.log4j.version>2.24.3</dep.log4j.version>
+        <dep.log4j.version>2.25.3</dep.log4j.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.log4j.version>2.24.3</dep.log4j.version>
+        <dep.log4j.version>2.25.3</dep.log4j.version>
         <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.elasticsearch.version>7.17.27</dep.elasticsearch.version>
-        <dep.log4j.version>2.24.3</dep.log4j.version>
+        <dep.log4j.version>2.25.3</dep.log4j.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <dep.lucene.version>8.11.3</dep.lucene.version>
     </properties>


### PR DESCRIPTION
## Description
Bump org.apache.logging.log4j:log4j-core from 2.24.3 to 2.25.3

## Motivation and Context
https://github.com/prestodb/presto/pull/26863
https://github.com/prestodb/presto/pull/26839
https://github.com/prestodb/presto/pull/26835

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== RELEASE NOTES ==

Security Changes
* Upgrade org.apache.logging.log4j:log4j-core from from 2.24.3 to 2.25.3 to address `CVE-2025-68161 <https://nvd.nist.gov/vuln/detail/CVE-2025-68161>`_. 
```

