### PR TITLE
fix(native): Remove unused exception variable

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -261,7 +261,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                     summarize,
                     startProcessCpuTimeNs,
                     receiveThrift);
-              } catch (const velox::VeloxException& e) {
+              } catch (const velox::VeloxException&) {
                 // Creating an empty task, putting errors inside so that next
                 // status fetch from coordinator will catch the error and well
                 // categorize it.
@@ -271,7 +271,7 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                       std::current_exception(),
                       summarize,
                       startProcessCpuTimeNs);
-                } catch (const velox::VeloxUserError& e) {
+                } catch (const velox::VeloxUserError&) {
                   throw;
                 }
               }

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastExchangeSource.cpp
@@ -123,7 +123,7 @@ BroadcastExchangeSource::createExchangeSource(
   try {
     broadcastFileInfo =
         BroadcastFileInfo::deserialize(broadcastInfoJson.value());
-  } catch (const VeloxException& e) {
+  } catch (const VeloxException&) {
     throw;
   } catch (const std::exception& e) {
     VELOX_USER_FAIL("BroadcastInfo deserialization failed: {}", e.what());

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleExchangeSource.cpp
@@ -23,7 +23,7 @@ namespace facebook::presto::operators {
 #define CALL_SHUFFLE(call, methodName)                                \
   try {                                                               \
     call;                                                             \
-  } catch (const velox::VeloxException& e) {                          \
+  } catch (const velox::VeloxException&) {                            \
     throw;                                                            \
   } catch (const std::exception& e) {                                 \
     VELOX_FAIL("ShuffleReader::{} failed: {}", methodName, e.what()); \

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleWrite.cpp
@@ -26,7 +26,7 @@ velox::core::PlanNodeId deserializePlanNodeId(const folly::dynamic& obj) {
 #define CALL_SHUFFLE(call, methodName)                                \
   try {                                                               \
     call;                                                             \
-  } catch (const VeloxException& e) {                                 \
+  } catch (const VeloxException&) {                                   \
     throw;                                                            \
   } catch (const std::exception& e) {                                 \
     VELOX_FAIL("ShuffleWriter::{} failed: {}", methodName, e.what()); \

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -209,7 +209,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
              try {
                expectedBytes =
                    toCapacity(expectedValue, config::CapacityUnit::BYTE);
-             } catch (const VeloxUserError& e) {
+             } catch (const VeloxUserError&) {
                expectedBytes = std::stoull(expectedValue);
              }
              EXPECT_EQ(expectedBytes, config.maxOutputBufferSize());


### PR DESCRIPTION
Meta internal system does not allow unused variables. A code-mode removed all unsued variables, and now internal repo got out of sync, causing several sync issues. Removing unused variable here to sync first with internal code, and then we can apply /* unusued */ syntax.

```
== NO RELEASE NOTE ==
```