### PR TITLE
feat(connector): Add read-only Opensearch connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,7 @@
         <module>presto-sql-helpers/presto-sql-invoked-functions-plugin</module>
         <module>presto-sql-helpers/presto-native-sql-invoked-functions-plugin</module>
         <module>presto-lance</module>
+        <module>presto-opensearch</module>
     </modules>
 
     <dependencyManagement>
@@ -2080,6 +2081,12 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>4.4.16</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpasyncclient</artifactId>
+                <version>4.1.5</version>
             </dependency>
 
             <dependency>

--- a/presto-docs/src/main/sphinx/connector.rst
+++ b/presto-docs/src/main/sphinx/connector.rst
@@ -33,6 +33,7 @@ from different data sources.
     connector/memory
     connector/mongodb
     connector/mysql
+    connector/opensearch
     connector/oracle
     connector/pinot
     connector/postgresql

--- a/presto-docs/src/main/sphinx/connector/opensearch.rst
+++ b/presto-docs/src/main/sphinx/connector/opensearch.rst
@@ -1,0 +1,352 @@
+====================
+OpenSearch Connector
+====================
+
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 1
+
+Overview
+--------
+
+The OpenSearch Connector allows access to OpenSearch data from Presto.
+This document describes how to setup the OpenSearch Connector to run SQL queries against OpenSearch.
+
+.. note::
+
+    OpenSearch 1.0.0 or later is required.
+
+Configuration
+-------------
+
+To configure the OpenSearch connector, create a catalog properties file
+``etc/catalog/opensearch.properties`` with the following contents,
+replacing the properties as appropriate:
+
+.. code-block:: none
+
+    connector.name=opensearch
+    opensearch.host=localhost
+    opensearch.port=9200
+    opensearch.scheme=https
+    opensearch.auth.username=admin
+    opensearch.auth.password=admin
+
+Configuration Properties
+------------------------
+
+Connection Properties
+^^^^^^^^^^^^^^^^^^^^^
+
+================================================= ==============================================================================
+Property Name                                     Description
+================================================= ==============================================================================
+``opensearch.host``                               Host name of the OpenSearch server.
+``opensearch.port``                               Port of the OpenSearch server. Default is ``9200``.
+``opensearch.scheme``                             Connection scheme (http or https). Default is ``https``.
+``opensearch.max-connections``                    Maximum number of HTTP connections. Default is ``100``.
+``opensearch.connection-timeout``                 Connection timeout in milliseconds. Default is ``10000``.
+``opensearch.socket-timeout``                     Socket timeout in milliseconds. Default is ``60000``.
+================================================= ==============================================================================
+
+Authentication Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+================================================= ==============================================================================
+Property Name                                     Description
+================================================= ==============================================================================
+``opensearch.auth.username``                      Username for basic authentication.
+``opensearch.auth.password``                      Password for basic authentication.
+================================================= ==============================================================================
+
+SSL/TLS Properties
+^^^^^^^^^^^^^^^^^^
+
+========================================================= ============================================================================================
+Property Name                                             Description
+========================================================= ============================================================================================
+``opensearch.ssl.enabled``                                Enable SSL/TLS connections. Default is ``true``.
+``opensearch.ssl.verify-hostname``                        Verify SSL hostname. Default is ``true``.
+``opensearch.ssl.skip-certificate-validation``            Skip SSL certificate validation (including expiration checks).
+                                                          Use only for testing with expired or self-signed certificates.
+                                                          Default is ``false``.
+``opensearch.ssl.truststore.path``                        Path to SSL truststore file (optional when using valid certificates).
+``opensearch.ssl.truststore.password``                    Password for SSL truststore.
+========================================================= ============================================================================================
+
+.. warning::
+
+    The ``opensearch.ssl.skip-certificate-validation`` property should only be used in testing or development
+    environments with expired or self-signed certificates. In production, always use valid certificates and
+    keep this property set to ``false`` (default).
+
+Query Properties
+^^^^^^^^^^^^^^^^
+
+================================================= ==============================================================================
+Property Name                                     Description
+================================================= ==============================================================================
+``opensearch.scroll.size``                        Maximum number of hits per scroll request. Default is ``1000``.
+``opensearch.scroll.timeout``                     Search context timeout for scroll requests. Default is ``5m``.
+``opensearch.max-result-window``                  Maximum result window size. Default is ``10000``.
+================================================= ==============================================================================
+
+Schema Discovery Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+================================================= ==============================================================================
+Property Name                                     Description
+================================================= ==============================================================================
+``opensearch.schema-pattern``                     Pattern for discovering indices. Default is ``*``.
+``opensearch.hide-system-indices``                Hide system indices (starting with ``.``). Default is ``true``.
+``opensearch.hide-document-id-column``            Hide the ``_id`` column from table schema. Default is ``false``.
+================================================= ==============================================================================
+
+Vector Search Properties
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+================================================= ==============================================================================
+Property Name                                     Description
+================================================= ==============================================================================
+``opensearch.vector-search.enabled``              Enable vector search support. Default is ``true``.
+``opensearch.vector-search.default-k``            Default number of nearest neighbors. Default is ``10``.
+``opensearch.vector-search.default-space-type``   Default distance metric (cosine, l2, inner_product). Default is ``cosine``.
+``opensearch.vector-search.default-ef-search``    Default ef_search parameter for HNSW. Default is ``100``.
+================================================= ==============================================================================
+
+Nested Field Properties
+^^^^^^^^^^^^^^^^^^^^^^^
+
+================================================= ==============================================================================
+Property Name                                     Description
+================================================= ==============================================================================
+``opensearch.nested.enabled``                     Enable nested field access with dot notation. Default is ``true``.
+``opensearch.nested.max-depth``                   Maximum depth for nested field discovery. Default is ``5``.
+``opensearch.nested.optimize-queries``            Optimize nested queries by grouping predicates. Default is ``true``.
+``opensearch.nested.discover-dynamic-fields``     Discover dynamic fields not in mapping. Default is ``false``.
+``opensearch.nested.log-missing-fields``          Log warnings for missing nested fields. Default is ``false``.
+================================================= ==============================================================================
+
+Data Types
+----------
+
+The data type mappings are as follows:
+
+============= =============
+OpenSearch    Presto
+============= =============
+``binary``    ``VARBINARY``
+``boolean``   ``BOOLEAN``
+``byte``      ``TINYINT``
+``short``     ``SMALLINT``
+``integer``   ``INTEGER``
+``long``      ``BIGINT``
+``float``     ``REAL``
+``half_float````REAL``
+``double``    ``DOUBLE``
+``scaled_float``  ``DOUBLE``
+``text``      ``VARCHAR``
+``keyword``   ``VARCHAR``
+``ip``        ``VARCHAR``
+``date``      ``DATE``
+``knn_vector````ARRAY(REAL)``
+``nested``    ``VARCHAR``
+``object``    ``VARCHAR``
+============= =============
+
+.. note::
+
+    The ``knn_vector`` type is mapped to ``ARRAY(REAL)`` to support vector similarity search operations.
+    Nested and object types are currently mapped to ``VARCHAR`` containing JSON strings.
+
+Special Columns
+---------------
+
+The following hidden columns are available:
+
+======= =======================================================
+Column  Description
+======= =======================================================
+_id     The OpenSearch document ID
+_score  The document score returned by the OpenSearch query
+_source The source of the original document
+======= =======================================================
+
+Querying OpenSearch
+-------------------
+
+The OpenSearch connector provides a schema for every OpenSearch index. You can see the available schemas by running ``SHOW SCHEMAS``::
+
+    SHOW SCHEMAS FROM opensearch;
+
+If you have an OpenSearch index named ``products``, you can view the table in the ``default`` schema::
+
+    DESCRIBE opensearch.default.products;
+    SHOW COLUMNS FROM opensearch.default.products;
+
+Basic Queries
+^^^^^^^^^^^^^
+
+You can query the ``products`` table::
+
+    SELECT * FROM opensearch.default.products;
+
+    SELECT _id, name, price
+    FROM opensearch.default.products
+    WHERE price > 100
+    ORDER BY price DESC
+    LIMIT 10;
+
+Parallel Query Execution
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector automatically handles multi-shard OpenSearch indices with proper shard routing and parallel execution. The split manager creates one split per shard, allowing Presto workers to read data from multiple shards concurrently.
+
+Each split uses OpenSearch's ``preference`` parameter with ``_shards:N`` syntax to route queries to specific shards, ensuring correct results without data duplication. This enables efficient distributed query execution for large-scale deployments with proper load distribution across shards.
+
+For k-NN vector searches using the table function, a single split is created that queries all shards globally, since k-NN search must aggregate results across the entire index to find the true nearest neighbors.
+
+Nested Field Access
+-------------------
+
+The connector supports querying nested JSON structures using dot notation. Nested fields are automatically discovered from OpenSearch index mappings and exposed as virtual columns.
+
+Example with nested fields::
+
+    SELECT _id, user.name, user.profile.age, metadata.tags
+    FROM opensearch.default.users
+    WHERE user.profile.age > 25;
+
+Configuration for nested fields:
+
+- ``opensearch.nested.enabled`` - Enable nested field access (default: ``true``)
+- ``opensearch.nested.max-depth`` - Maximum nesting depth to discover (default: ``5``)
+- ``opensearch.nested.optimize-queries`` - Group predicates on same parent (default: ``true``)
+
+Vector Search
+-------------
+
+The OpenSearch connector supports vector similarity search using the OpenSearch k-NN plugin. Vector fields with type ``knn_vector`` are automatically discovered and exposed as ``ARRAY(REAL)`` columns.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+Your OpenSearch cluster must have the k-NN plugin installed and indices must be configured with ``knn_vector`` fields.
+
+Querying Vector Fields
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Vector fields can be queried like regular array columns::
+
+    -- View vector field
+    SELECT id, title, embedding
+    FROM opensearch.default.documents
+    LIMIT 10;
+
+    -- Check vector dimension
+    SELECT id, cardinality(embedding) as dimension
+    FROM opensearch.default.documents
+    LIMIT 1;
+
+k-NN Table Function
+^^^^^^^^^^^^^^^^^^^^
+
+The connector provides a table function for executing k-NN vector searches directly in SQL::
+
+    SELECT * FROM TABLE(opensearch.system.knn_search(
+      index_name => 'documents',
+      vector_field => 'embedding',
+      query_vector => ARRAY[0.1, 0.2, 0.3],
+      k => 10
+    ))
+    ORDER BY _score DESC;
+
+Table Function Parameters
+""""""""""""""""""""""""""
+
+=================== ============ ======== ============ =====================================================
+Parameter           Type         Required Default      Description
+=================== ============ ======== ============ =====================================================
+``index_name``      VARCHAR      Yes      -            Name of the OpenSearch index to search
+``vector_field``    VARCHAR      Yes      -            Name of the knn_vector field in the index
+``query_vector``    ARRAY(REAL)  Yes      -            Query vector for similarity search
+``k``               INTEGER      No       10           Number of nearest neighbors to return
+``space_type``      VARCHAR      No       'cosine'     Distance metric: 'cosine', 'l2', or 'inner_product'
+``ef_search``       INTEGER      No       100          HNSW ef_search parameter for accuracy/speed tradeoff
+=================== ============ ======== ============ =====================================================
+
+The table function returns columns from the index plus ``_id`` and ``_score`` columns.
+
+Examples
+""""""""
+
+Basic k-NN search::
+
+    SELECT _id, title, category, _score
+    FROM TABLE(opensearch.system.knn_search(
+      index_name => 'products',
+      vector_field => 'embedding',
+      query_vector => ARRAY[0.1, 0.2, 0.3],
+      k => 5
+    ))
+    ORDER BY _score DESC;
+
+Using custom distance metric::
+
+    SELECT _id, title, _score
+    FROM TABLE(opensearch.system.knn_search(
+      index_name => 'documents',
+      vector_field => 'embedding',
+      query_vector => ARRAY[0.5, 0.5, 0.0],
+      k => 10,
+      space_type => 'l2',
+      ef_search => 200
+    ))
+    ORDER BY _score ASC;
+
+Filtering k-NN results::
+
+    SELECT _id, title, category
+    FROM TABLE(opensearch.system.knn_search(
+      index_name => 'products',
+      vector_field => 'embedding',
+      query_vector => ARRAY[0.2, 0.3, 0.4],
+      k => 50
+    ))
+    WHERE category = 'electronics'
+    ORDER BY _score DESC
+    LIMIT 10;
+
+Joining with other tables::
+
+    SELECT p.product_id, p.name, k._score
+    FROM products p
+    JOIN TABLE(opensearch.system.knn_search(
+      index_name => 'product_vectors',
+      vector_field => 'embedding',
+      query_vector => ARRAY[0.1, 0.2, 0.3],
+      k => 20
+    )) k ON p.product_id = k._id
+    WHERE k._score > 0.8
+    ORDER BY k._score DESC;
+
+The connector creates splits based on OpenSearch shards for parallel execution. For k-NN searches using the table function, a single split queries all shards globally since k-NN search must be executed across the entire index.
+
+Limitations
+-----------
+
+The following SQL statements are not supported:
+
+* ``DELETE``
+* ``INSERT``
+* ``CREATE TABLE``
+* ``DROP TABLE``
+* ``ALTER TABLE``
+
+The connector is read-only and does not support write operations.
+
+Array Types
+^^^^^^^^^^^
+
+OpenSearch does not have a dedicated array type. Fields can contain zero or more values. The connector automatically detects ``knn_vector`` fields and maps them to ``ARRAY(REAL)``. Other array fields are not automatically detected and will be treated as their base type.

--- a/presto-opensearch/pom.xml
+++ b/presto-opensearch/pom.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.298-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-opensearch</artifactId>
+    <description>Presto - OpenSearch Connector</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <opensearch.version>2.11.1</opensearch.version>
+    </properties>
+
+    <dependencies>
+        <!-- OpenSearch Client -->
+        <dependency>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-rest-client</artifactId>
+            <version>${opensearch.version}</version>
+        </dependency>
+
+        <!-- HTTP Client dependencies (required by OpenSearch client) -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+        </dependency>
+
+        <!-- Presto Core -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Configuration & DI -->
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <!-- Utilities -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <groupId>com.facebook.airlift.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testing-docker</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- TPCH for standard test queries -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers for OpenSearch -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+
+

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/KnnSearchTableFunction.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/KnnSearchTableFunction.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.table.AbstractConnectorTableFunction;
+import com.facebook.presto.spi.function.table.Argument;
+import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
+import com.facebook.presto.spi.function.table.Descriptor;
+import com.facebook.presto.spi.function.table.ScalarArgument;
+import com.facebook.presto.spi.function.table.ScalarArgumentSpecification;
+import com.facebook.presto.spi.function.table.TableFunctionAnalysis;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.slice.Slice;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.spi.function.table.GenericTableReturnTypeSpecification.GENERIC_TABLE;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Table function for k-NN vector search using OpenSearch k-NN plugin.
+ *
+ * Usage:
+ * SELECT * FROM TABLE(opensearch.system.knn_search(
+ *   index_name => 'my_index',
+ *   vector_field => 'embedding',
+ *   query_vector => ARRAY[0.1, 0.2, 0.3],
+ *   k => 10,
+ *   space_type => 'cosine',
+ *   ef_search => 100
+ *))
+ */
+public class KnnSearchTableFunction
+        extends AbstractConnectorTableFunction
+{
+    private static final Logger log = Logger.get(KnnSearchTableFunction.class);
+    private static final String SCHEMA_NAME = "system";
+    private static final String FUNCTION_NAME = "knn_search";
+
+    private final OpenSearchClient client;
+    private final OpenSearchConfig config;
+
+    @Inject
+    public KnnSearchTableFunction(OpenSearchClient client, OpenSearchConfig config)
+    {
+        super(
+                SCHEMA_NAME,
+                FUNCTION_NAME,
+                List.of(
+                        ScalarArgumentSpecification.builder()
+                                .name("INDEX_NAME")
+                                .type(VARCHAR)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("VECTOR_FIELD")
+                                .type(VARCHAR)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("QUERY_VECTOR")
+                                .type(new ArrayType(DOUBLE))
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("K")
+                                .type(INTEGER)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("SPACE_TYPE")
+                                .type(VARCHAR)
+                                .defaultValue(null)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name("EF_SEARCH")
+                                .type(INTEGER)
+                                .defaultValue(null)
+                                .build()),
+                GENERIC_TABLE);
+
+        this.client = requireNonNull(client, "client is null");
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    @Override
+    public TableFunctionAnalysis analyze(
+            ConnectorSession session,
+            ConnectorTransactionHandle transaction,
+            Map<String, Argument> arguments)
+    {
+        // Extract arguments
+        String indexName = ((Slice) ((ScalarArgument) arguments.get("INDEX_NAME")).getValue()).toStringUtf8();
+        String vectorField = ((Slice) ((ScalarArgument) arguments.get("VECTOR_FIELD")).getValue()).toStringUtf8();
+        float[] queryVector = extractVectorFromArgument((ScalarArgument) arguments.get("QUERY_VECTOR"));
+
+        int k = arguments.containsKey("K") ?
+                ((Long) ((ScalarArgument) arguments.get("K")).getValue()).intValue() :
+                config.getVectorSearchDefaultK();
+
+        String spaceType = arguments.containsKey("SPACE_TYPE") && ((ScalarArgument) arguments.get("SPACE_TYPE")).getValue() != null ?
+                ((Slice) ((ScalarArgument) arguments.get("SPACE_TYPE")).getValue()).toStringUtf8() :
+                config.getVectorSearchDefaultSpaceType();
+
+        Integer efSearch = arguments.containsKey("EF_SEARCH") && ((ScalarArgument) arguments.get("EF_SEARCH")).getValue() != null ?
+                ((Long) ((ScalarArgument) arguments.get("EF_SEARCH")).getValue()).intValue() :
+                config.getVectorSearchDefaultEfSearch();
+
+        log.debug("k-NN search: index=%s, field=%s, k=%d, space_type=%s",
+                indexName, vectorField, k, spaceType);
+        // Validate k value
+        if (k <= 0) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "k must be positive, got: " + k);
+        }
+
+        // Get index mapping to determine result schema
+        Map<String, Object> indexMapping = client.getIndexMapping(indexName);
+
+        // Validate that the vector field exists and is of type knn_vector
+        validateVectorField(indexMapping, vectorField, queryVector.length);
+
+        List<ColumnHandle> columns = buildColumnsFromMapping(indexMapping);
+
+        // Create descriptor for return type
+        List<Descriptor.Field> fields = new ArrayList<>();
+        fields.add(new Descriptor.Field("_id", Optional.of(VARCHAR)));
+        fields.add(new Descriptor.Field("_score", Optional.of(DOUBLE)));
+
+        // Add fields from index mapping (skip _id and _score as they're already added)
+        for (ColumnHandle columnHandle : columns) {
+            OpenSearchColumnHandle col = (OpenSearchColumnHandle) columnHandle;
+            if (!col.getColumnName().equals("_id") && !col.getColumnName().equals("_score")) {
+                fields.add(new Descriptor.Field(col.getColumnName(), Optional.of(col.getColumnType())));
+            }
+        }
+
+        Descriptor returnedType = new Descriptor(fields);
+
+        // Create handle with search parameters
+        KnnSearchHandle handle = new KnnSearchHandle(
+                indexName, vectorField, queryVector, k, spaceType, efSearch, columns);
+
+        return TableFunctionAnalysis.builder()
+                .returnedType(returnedType)
+                .handle(handle)
+                .build();
+    }
+
+    private float[] extractVectorFromArgument(ScalarArgument argument)
+    {
+        Block block = (Block) argument.getValue();
+        int size = block.getPositionCount();
+
+        float[] vector = new float[size];
+
+        for (int i = 0; i < size; i++) {
+            if (block.isNull(i)) {
+                throw new IllegalArgumentException("Query vector cannot contain null values");
+            }
+            vector[i] = (float) DOUBLE.getDouble(block, i);
+        }
+
+        return vector;
+    }
+
+    private List<ColumnHandle> buildColumnsFromMapping(Map<String, Object> indexMapping)
+    {
+        List<ColumnHandle> columns = new ArrayList<>();
+
+        // Add _id and _score columns (must match descriptor order)
+        columns.add(new OpenSearchColumnHandle("_id", VARCHAR, "keyword"));
+        columns.add(new OpenSearchColumnHandle("_score", DOUBLE, "double"));
+
+        // Add columns from mapping
+        for (Map.Entry<String, Object> entry : indexMapping.entrySet()) {
+            String fieldName = entry.getKey();
+            // Skip knn_vector fields as they can't be retrieved
+            if (entry.getValue() instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> fieldMapping = (Map<String, Object>) entry.getValue();
+                Object typeObj = fieldMapping.get("type");
+                if (typeObj instanceof String) {
+                    String fieldType = (String) typeObj;
+                    if (!"knn_vector".equals(fieldType)) {
+                        columns.add(new OpenSearchColumnHandle(fieldName, VARCHAR, fieldType));
+                    }
+                }
+            }
+        }
+
+        return columns;
+    }
+
+    /**
+     * Validates that the specified field exists in the index mapping and is of type knn_vector.
+     *
+     * @param indexMapping The index mapping
+     * @param vectorField The name of the vector field
+     * @param queryVectorDimension The dimension of the query vector
+     * @throws PrestoException if the field doesn't exist, is not a knn_vector, or has dimension mismatch
+     */
+    private void validateVectorField(Map<String, Object> indexMapping, String vectorField, int queryVectorDimension)
+    {
+        // Check if field exists in mapping
+        if (!indexMapping.containsKey(vectorField)) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    String.format("Vector field '%s' does not exist in index mapping. Available fields: %s",
+                            vectorField, indexMapping.keySet()));
+        }
+
+        Object fieldValue = indexMapping.get(vectorField);
+        if (!(fieldValue instanceof Map)) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    String.format("Vector field '%s' has invalid mapping structure", vectorField));
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> fieldMapping = (Map<String, Object>) fieldValue;
+        Object typeObj = fieldMapping.get("type");
+
+        if (!(typeObj instanceof String)) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    String.format("Vector field '%s' does not have a type specified in mapping", vectorField));
+        }
+
+        String fieldType = (String) typeObj;
+        if (!"knn_vector".equals(fieldType)) {
+            throw new PrestoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    String.format("Field '%s' is not a knn_vector field. Found type: %s. " +
+                            "k-NN search can only be performed on fields of type 'knn_vector'.",
+                            vectorField, fieldType));
+        }
+
+        // Validate vector dimensions if specified in mapping
+        Object dimensionObj = fieldMapping.get("dimension");
+        if (dimensionObj instanceof Number) {
+            int fieldDimension = ((Number) dimensionObj).intValue();
+            if (fieldDimension != queryVectorDimension) {
+                throw new PrestoException(
+                        INVALID_FUNCTION_ARGUMENT,
+                        String.format("Query vector dimension (%d) does not match field '%s' dimension (%d)",
+                                queryVectorDimension, vectorField, fieldDimension));
+            }
+        }
+
+        log.debug("Validated vector field '%s': type=knn_vector, dimension=%s",
+                vectorField, dimensionObj != null ? dimensionObj : "unspecified");
+    }
+
+    /**
+     * Handle for k-NN search table function.
+     */
+    public static class KnnSearchHandle
+            implements ConnectorTableFunctionHandle
+    {
+        private final String indexName;
+        private final String vectorField;
+        private final float[] queryVector;
+        private final int k;
+        private final String spaceType;
+        private final Integer efSearch;
+        private final List<ColumnHandle> columns;
+
+        @JsonCreator
+        public KnnSearchHandle(
+                @JsonProperty("indexName") String indexName,
+                @JsonProperty("vectorField") String vectorField,
+                @JsonProperty("queryVector") float[] queryVector,
+                @JsonProperty("k") int k,
+                @JsonProperty("spaceType") String spaceType,
+                @JsonProperty("efSearch") Integer efSearch,
+                @JsonProperty("columns") List<ColumnHandle> columns)
+        {
+            this.indexName = requireNonNull(indexName, "indexName is null");
+            this.vectorField = requireNonNull(vectorField, "vectorField is null");
+            this.queryVector = requireNonNull(queryVector, "queryVector is null");
+            this.k = k;
+            this.spaceType = requireNonNull(spaceType, "spaceType is null");
+            this.efSearch = efSearch;
+            this.columns = requireNonNull(columns, "columns is null");
+        }
+
+        @JsonProperty
+        public String getIndexName()
+        {
+            return indexName;
+        }
+
+        @JsonProperty
+        public String getVectorField()
+        {
+            return vectorField;
+        }
+
+        @JsonProperty
+        public float[] getQueryVector()
+        {
+            return queryVector;
+        }
+
+        @JsonProperty
+        public int getK()
+        {
+            return k;
+        }
+
+        @JsonProperty
+        public String getSpaceType()
+        {
+            return spaceType;
+        }
+
+        @JsonProperty
+        public Integer getEfSearch()
+        {
+            return efSearch;
+        }
+
+        @JsonProperty
+        public List<ColumnHandle> getColumns()
+        {
+            return columns;
+        }
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/NestedFieldInfo.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/NestedFieldInfo.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.type.Type;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Information about a nested field discovered in OpenSearch mapping.
+ * Represents metadata for fields that may be nested within object structures.
+ *
+ * Example:
+ * For a field "token_usage.total_tokens":
+ * - fieldPath: "token_usage.total_tokens"
+ * - parentPath: "token_usage"
+ * - fieldName: "total_tokens"
+ * - fieldPathList: ["token_usage", "total_tokens"]
+ */
+public class NestedFieldInfo
+{
+    private final String fieldPath;           // Full path: "token_usage.total_tokens"
+    private final String parentPath;          // Parent path: "token_usage" (empty for top-level)
+    private final String fieldName;           // Field name: "total_tokens"
+    private final Type prestoType;            // Presto type: BIGINT or ROW type for objects
+    private final String openSearchType;      // OpenSearch type: "long"
+    private final int nestingLevel;           // Nesting depth: 0 for top-level, 1+ for nested
+    private final boolean isLeafField;        // true if primitive type, false if object/nested
+    private final List<String> fieldPathList; // Path as list: ["token_usage", "total_tokens"]
+
+    public NestedFieldInfo(
+            String fieldPath,
+            String parentPath,
+            String fieldName,
+            Type prestoType,
+            String openSearchType,
+            int nestingLevel,
+            boolean isLeafField,
+            List<String> fieldPathList)
+    {
+        this.fieldPath = requireNonNull(fieldPath, "fieldPath is null");
+        this.parentPath = parentPath != null ? parentPath : "";
+        this.fieldName = requireNonNull(fieldName, "fieldName is null");
+        this.prestoType = requireNonNull(prestoType, "prestoType is null");
+        this.openSearchType = requireNonNull(openSearchType, "openSearchType is null");
+        this.nestingLevel = nestingLevel;
+        this.isLeafField = isLeafField;
+        this.fieldPathList = fieldPathList != null ?
+            Collections.unmodifiableList(fieldPathList) :
+            Collections.emptyList();
+    }
+
+    public String getFieldPath()
+    {
+        return fieldPath;
+    }
+
+    public String getParentPath()
+    {
+        return parentPath;
+    }
+
+    public String getFieldName()
+    {
+        return fieldName;
+    }
+
+    public Type getPrestoType()
+    {
+        return prestoType;
+    }
+
+    public String getOpenSearchType()
+    {
+        return openSearchType;
+    }
+
+    public int getNestingLevel()
+    {
+        return nestingLevel;
+    }
+
+    public boolean isLeafField()
+    {
+        return isLeafField;
+    }
+
+    public List<String> getFieldPathList()
+    {
+        return fieldPathList;
+    }
+
+    /**
+     * Returns true if this field is nested (has more than one path segment)
+     * A field is considered nested if its path contains dots, indicating
+     * it's a child of a parent object (e.g., token_usage.total_tokens)
+     */
+    public boolean isNestedField()
+    {
+        return fieldPathList != null && fieldPathList.size() > 1;
+    }
+
+    /**
+     * Returns the JSON path for this field (e.g., "$.token_usage.total_tokens")
+     */
+    public String getJsonPath()
+    {
+        return "$." + fieldPath;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        NestedFieldInfo that = (NestedFieldInfo) obj;
+        return Objects.equals(fieldPath, that.fieldPath) &&
+                Objects.equals(prestoType, that.prestoType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(fieldPath, prestoType);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "NestedFieldInfo{" +
+                "fieldPath='" + fieldPath + '\'' +
+                ", parentPath='" + parentPath + '\'' +
+                ", prestoType=" + prestoType +
+                ", openSearchType='" + openSearchType + '\'' +
+                ", nestingLevel=" + nestingLevel +
+                ", isLeafField=" + isLeafField +
+                '}';
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/NestedFieldMapper.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/NestedFieldMapper.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.plugin.opensearch.types.TypeMapper;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+/**
+ * Discovers and maps nested fields from OpenSearch index mappings.
+ * Recursively traverses object and nested types to create virtual columns
+ * that can be queried using dot notation (e.g., token_usage.total_tokens).
+ *
+ * Example mapping:
+ * {
+ *   "token_usage": {
+ *     "type": "object",
+ *     "properties": {
+ *       "total_tokens": {"type": "long"},
+ *       "input_tokens": {"type": "long"},
+ *       "output_tokens": {"type": "long"}
+ *     }
+ *   }
+ * }
+ *
+ * Produces fields:
+ * - token_usage.total_tokens (BIGINT)
+ * - token_usage.input_tokens (BIGINT)
+ * - token_usage.output_tokens (BIGINT)
+ */
+public class NestedFieldMapper
+{
+    private static final Logger log = Logger.get(NestedFieldMapper.class);
+
+    private final int maxDepth;
+
+    @Inject
+    public NestedFieldMapper(OpenSearchConfig config)
+    {
+        this.maxDepth = config.getNestedMaxDepth();
+    }
+
+    // Constructor for testing
+    public NestedFieldMapper(int maxDepth)
+    {
+        this.maxDepth = maxDepth;
+    }
+
+    /**
+     * Discovers all nested fields in the mapping.
+     *
+     * @param mapping The OpenSearch index mapping (properties section)
+     * @return Map of field path to NestedFieldInfo
+     */
+    public Map<String, NestedFieldInfo> discoverNestedFields(Map<String, Object> mapping)
+    {
+        Map<String, NestedFieldInfo> result = new LinkedHashMap<>();
+        discoverFieldsRecursive(mapping, "", new ArrayList<>(), 0, result);
+        log.debug("Discovered %d nested fields", result.size());
+        return result;
+    }
+
+    /**
+     * Recursively discovers fields in the mapping.
+     *
+     * @param properties Current level properties
+     * @param currentPath Current field path (e.g., "token_usage")
+     * @param pathList Current path as list (e.g., ["token_usage"])
+     * @param depth Current nesting depth
+     * @param result Accumulator for discovered fields
+     */
+    private void discoverFieldsRecursive(
+            Map<String, Object> properties,
+            String currentPath,
+            List<String> pathList,
+            int depth,
+            Map<String, NestedFieldInfo> result)
+    {
+        // Check depth limit to prevent infinite recursion
+        if (depth > maxDepth) {
+            log.warn("Maximum nesting depth (%d) exceeded at path: %s", maxDepth, currentPath);
+            return;
+        }
+
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            String fieldName = entry.getKey();
+
+            // Skip if not a map (invalid structure)
+            if (!(entry.getValue() instanceof Map)) {
+                log.debug("Skipping non-map field: %s", fieldName);
+                continue;
+            }
+
+            Map<String, Object> fieldProps = (Map<String, Object>) entry.getValue();
+            String fieldType = (String) fieldProps.getOrDefault("type", "object");
+
+            // Build field path
+            String fieldPath = currentPath.isEmpty()
+                    ? fieldName
+                    : currentPath + "." + fieldName;
+
+            List<String> newPathList = new ArrayList<>(pathList);
+            newPathList.add(fieldName);
+
+            // Determine if this is a leaf field (primitive type)
+            boolean isLeaf = !fieldType.equals("object") && !fieldType.equals("nested");
+
+            Type prestoType;
+            if (isLeaf) {
+                // Leaf field - use TypeMapper to get Presto type
+                prestoType = TypeMapper.toPrestoType(fieldType, fieldProps, fieldName);
+
+                // Add leaf field - these are queryable columns
+                NestedFieldInfo fieldInfo = new NestedFieldInfo(
+                        fieldPath,
+                        currentPath,
+                        fieldName,
+                        prestoType,
+                        fieldType,
+                        depth,
+                        true,
+                        newPathList);
+                result.put(fieldPath, fieldInfo);
+                log.debug("Discovered leaf field: %s (type: %s, depth: %d)",
+                         fieldPath, fieldType, depth);
+            }
+            else {
+                // Parent field (object/nested type) - build proper ROW type for SQL dereference support
+                if (fieldProps.containsKey("properties")) {
+                    Map<String, Object> nestedProps = (Map<String, Object>) fieldProps.get("properties");
+
+                    // Build ROW type for the nested object to enable SQL dereference (e.g., details.address)
+                    Optional<RowType> rowType = buildRowType(nestedProps);
+                    if (rowType.isPresent()) {
+                        prestoType = rowType.get();
+
+                        NestedFieldInfo fieldInfo = new NestedFieldInfo(
+                                fieldPath,
+                                currentPath,
+                                fieldName,
+                                prestoType,
+                                fieldType,
+                                depth,
+                                false,
+                                newPathList);
+                        result.put(fieldPath, fieldInfo);
+                        log.debug("Discovered parent field as ROW: %s (type: %s, depth: %d)",
+                                 fieldPath, fieldType, depth);
+                    }
+                    else {
+                        // If ROW type building failed, fall back to VARCHAR
+                        prestoType = VARCHAR;
+
+                        NestedFieldInfo fieldInfo = new NestedFieldInfo(
+                                fieldPath,
+                                currentPath,
+                                fieldName,
+                                prestoType,
+                                fieldType,
+                                depth,
+                                false,
+                                newPathList);
+                        result.put(fieldPath, fieldInfo);
+                        log.debug("Discovered parent field as VARCHAR (ROW build failed): %s (type: %s, depth: %d)",
+                                 fieldPath, fieldType, depth);
+                    }
+
+                    // Recurse into nested properties to discover leaf fields
+                    // Leaf fields will be added with their full paths
+                    discoverFieldsRecursive(
+                            nestedProps,
+                            fieldPath,
+                            newPathList,
+                            depth + 1,
+                            result);
+                }
+                else {
+                    // Object with no properties - expose as VARCHAR
+                    log.debug("Object field %s has no properties, exposing as VARCHAR", fieldPath);
+                    prestoType = VARCHAR;
+
+                    NestedFieldInfo fieldInfo = new NestedFieldInfo(
+                            fieldPath,
+                            currentPath,
+                            fieldName,
+                            prestoType,
+                            fieldType,
+                            depth,
+                            false,
+                            newPathList);
+                    result.put(fieldPath, fieldInfo);
+                    log.debug("Discovered parent field without properties as VARCHAR: %s (type: %s, depth: %d)",
+                             fieldPath, fieldType, depth);
+                }
+            }
+        }
+    }
+
+    /**
+     * Filters discovered fields to only include leaf fields (queryable columns).
+     * Parent object fields are excluded as they cannot be directly queried.
+     *
+     * @param allFields All discovered fields
+     * @return Map containing only leaf fields
+     */
+    public Map<String, NestedFieldInfo> getLeafFieldsOnly(
+            Map<String, NestedFieldInfo> allFields)
+    {
+        Map<String, NestedFieldInfo> leafFields = new HashMap<>();
+        for (Map.Entry<String, NestedFieldInfo> entry : allFields.entrySet()) {
+            if (entry.getValue().isLeafField()) {
+                leafFields.put(entry.getKey(), entry.getValue());
+            }
+        }
+        log.debug("Filtered to %d leaf fields from %d total fields",
+                 leafFields.size(), allFields.size());
+        return leafFields;
+    }
+
+    /**
+     * Gets the maximum nesting depth configured for this mapper.
+     */
+    public int getMaxDepth()
+    {
+        return maxDepth;
+    }
+
+    /**
+     * Builds a ROW type for a nested object field based on its properties.
+     * This allows nested objects to be accessed using SQL dereference syntax.
+     *
+     * @param properties The properties map from the OpenSearch mapping
+     * @return A RowType representing the nested structure, or empty if no valid properties
+     */
+    public Optional<RowType> buildRowType(Map<String, Object> properties)
+    {
+        if (properties == null || properties.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<RowType.Field> fields = new ArrayList<>();
+
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            String fieldName = entry.getKey();
+
+            if (!(entry.getValue() instanceof Map)) {
+                continue;
+            }
+
+            Map<String, Object> fieldProps = (Map<String, Object>) entry.getValue();
+            String fieldType = (String) fieldProps.getOrDefault("type", "object");
+
+            Type prestoType;
+            if (fieldType.equals("object") || fieldType.equals("nested")) {
+                // Recursively build ROW type for nested objects
+                if (fieldProps.containsKey("properties")) {
+                    Map<String, Object> nestedProps = (Map<String, Object>) fieldProps.get("properties");
+                    Optional<RowType> nestedRowType = buildRowType(nestedProps);
+                    if (nestedRowType.isPresent()) {
+                        prestoType = nestedRowType.get();
+                    }
+                    else {
+                        // If no valid nested properties, skip this field
+                        continue;
+                    }
+                }
+                else {
+                    // Object with no properties - skip
+                    continue;
+                }
+            }
+            else {
+                // Leaf field - use TypeMapper to get Presto type
+                prestoType = TypeMapper.toPrestoType(fieldType, fieldProps, fieldName);
+            }
+
+            fields.add(RowType.field(fieldName, prestoType));
+        }
+
+        if (fields.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(RowType.from(fields));
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/NestedValueExtractor.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/NestedValueExtractor.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+/**
+ * Extracts nested field values from OpenSearch documents.
+ * Handles navigation through nested object structures and type conversion.
+ *
+ * Example:
+ * Document: {"token_usage": {"total_tokens": 90616}}
+ * Path: ["token_usage", "total_tokens"]
+ * Result: 90616 (as Long)
+ *
+ * Null Handling:
+ * - Returns null if any part of the path doesn't exist
+ * - Returns null if the value is explicitly null
+ * - Returns null if type conversion fails
+ */
+public class NestedValueExtractor
+{
+    private static final Logger log = Logger.get(NestedValueExtractor.class);
+    private static final ObjectMapper OBJECT_MAPPER = new JsonObjectMapperProvider().get();
+
+    /**
+     * Extracts a nested field value from a document.
+     *
+     * @param document The OpenSearch document
+     * @param fieldPath The path to the field (e.g., ["token_usage", "total_tokens"])
+     * @param targetType The expected Presto type
+     * @return The extracted value, or null if not found or conversion fails
+     */
+    public Object extractNestedValue(
+            Map<String, Object> document,
+            List<String> fieldPath,
+            Type targetType)
+    {
+        if (fieldPath == null || fieldPath.isEmpty()) {
+            return null;
+        }
+
+        if (document == null) {
+            return null;
+        }
+
+        Object current = document;
+
+        // Navigate through the path
+        for (int i = 0; i < fieldPath.size(); i++) {
+            String pathSegment = fieldPath.get(i);
+
+            if (current == null) {
+                // Parent is null, cannot navigate further
+                return null;
+            }
+
+            if (current instanceof Map) {
+                Map<String, Object> map = (Map<String, Object>) current;
+                if (!map.containsKey(pathSegment)) {
+                    // Field doesn't exist in this document
+                    return null;
+                }
+                current = map.get(pathSegment);
+            }
+            else {
+                // Path doesn't exist (parent is not an object)
+                return null;
+            }
+        }
+
+        // current is now the field value (or null)
+        return convertToPrestoType(current, targetType);
+    }
+
+    /**
+     * Converts an OpenSearch value to the appropriate Presto type.
+     * Returns null if conversion fails.
+     *
+     * @param value The value to convert
+     * @param targetType The target Presto type
+     * @return The converted value, or null if conversion fails
+     */
+    private Object convertToPrestoType(Object value, Type targetType)
+    {
+        if (value == null) {
+            return null;
+        }
+
+        try {
+            if (targetType.equals(BIGINT)) {
+                if (value instanceof Number) {
+                    return ((Number) value).longValue();
+                }
+                return Long.parseLong(value.toString());
+            }
+            else if (targetType.equals(INTEGER)) {
+                if (value instanceof Number) {
+                    return ((Number) value).intValue();
+                }
+                return Integer.parseInt(value.toString());
+            }
+            else if (targetType.equals(SMALLINT)) {
+                if (value instanceof Number) {
+                    return ((Number) value).shortValue();
+                }
+                return Short.parseShort(value.toString());
+            }
+            else if (targetType.equals(TINYINT)) {
+                if (value instanceof Number) {
+                    return ((Number) value).byteValue();
+                }
+                return Byte.parseByte(value.toString());
+            }
+            else if (targetType.equals(DOUBLE)) {
+                if (value instanceof Number) {
+                    return ((Number) value).doubleValue();
+                }
+                return Double.parseDouble(value.toString());
+            }
+            else if (targetType.equals(REAL)) {
+                if (value instanceof Number) {
+                    return ((Number) value).floatValue();
+                }
+                return Float.parseFloat(value.toString());
+            }
+            else if (targetType.equals(BOOLEAN)) {
+                if (value instanceof Boolean) {
+                    return value;
+                }
+                return Boolean.parseBoolean(value.toString());
+            }
+            else if (targetType.equals(TIMESTAMP)) {
+                // Handle timestamp conversion
+                if (value instanceof Number) {
+                    return ((Number) value).longValue();
+                }
+                return value.toString();
+            }
+            else if (targetType.equals(VARBINARY)) {
+                // Handle binary data
+                if (value instanceof byte[]) {
+                    return value;
+                }
+                return value.toString().getBytes();
+            }
+            else if (targetType instanceof ArrayType) {
+                // Handle array types - return the value as-is if it's already a List or array
+                // The OpenSearchPageSource will handle the conversion to Presto blocks
+                if (value instanceof List) {
+                    return value;
+                }
+                else if (value instanceof Object[]) {
+                    // Convert Object[] to List for consistent handling
+                    Object[] array = (Object[]) value;
+                    List<Object> list = new ArrayList<>(array.length);
+                    for (Object element : array) {
+                        list.add(element);
+                    }
+                    return list;
+                }
+                else {
+                    // Single value - wrap in a list
+                    List<Object> list = new ArrayList<>(1);
+                    list.add(value);
+                    return list;
+                }
+            }
+            else if (targetType.equals(VARCHAR)) {
+                // For VARCHAR, if the value is a complex object (Map or List), convert to JSON
+                if (value instanceof Map || value instanceof List) {
+                    try {
+                        return OBJECT_MAPPER.writeValueAsString(value);
+                    }
+                    catch (Exception e) {
+                        log.warn(e, "Failed to convert object to JSON, using toString()");
+                        return value.toString();
+                    }
+                }
+                return value.toString();
+            }
+
+            // Default: return as string
+            log.debug("Unknown type conversion for %s, returning as string", targetType);
+            return value.toString();
+        }
+        catch (Exception e) {
+            // If conversion fails, return null and log warning
+            log.warn(e, "Type conversion failed for value '%s' to type %s", value, targetType);
+            return null;
+        }
+    }
+
+    /**
+     * Extracts a flat (non-nested) field value from a document.
+     * This is a convenience method for extracting top-level fields.
+     *
+     * @param document The OpenSearch document
+     * @param fieldName The field name
+     * @param targetType The expected Presto type
+     * @return The extracted value, or null if not found
+     */
+    public Object extractFlatValue(
+            Map<String, Object> document,
+            String fieldName,
+            Type targetType)
+    {
+        if (document == null || fieldName == null) {
+            return null;
+        }
+
+        Object value = document.get(fieldName);
+        return convertToPrestoType(value, targetType);
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchClient.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchClient.java
@@ -1,0 +1,804 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.PrestoException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import jakarta.inject.Inject;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+
+import javax.net.ssl.SSLContext;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Client for communicating with OpenSearch cluster.
+ * Uses OpenSearch REST API for all operations.
+ */
+public class OpenSearchClient
+{
+    private static final Logger log = Logger.get(OpenSearchClient.class);
+    private static final ObjectMapper OBJECT_MAPPER = new JsonObjectMapperProvider().get()
+            .configure(DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY, false);
+    private static final String METADATA_INDEX = ".presto_metadata";
+
+    private final OpenSearchConfig config;
+    private final RestClient restClient;
+
+    @Inject
+    public OpenSearchClient(OpenSearchConfig config)
+    {
+        this.config = requireNonNull(config, "config is null");
+        this.restClient = createRestClient();
+        log.info("OpenSearch client initialized for %s:%d", config.getHost(), config.getPort());
+    }
+
+    private RestClient createRestClient()
+    {
+        HttpHost host = new HttpHost(
+                config.getHost(),
+                config.getPort(),
+                config.isSslEnabled() ? "https" : "http");
+
+        RestClientBuilder builder = RestClient.builder(host)
+                .setRequestConfigCallback(requestConfigBuilder ->
+                        requestConfigBuilder
+                                .setConnectTimeout(config.getConnectTimeout())
+                                .setSocketTimeout(config.getSocketTimeout()));
+
+        // Configure SSL and authentication
+        builder.setHttpClientConfigCallback(httpClientBuilder -> {
+            // Add authentication if configured
+            if (config.getUsername() != null && config.getPassword() != null) {
+                CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                credentialsProvider.setCredentials(
+                        AuthScope.ANY,
+                        new UsernamePasswordCredentials(config.getUsername(), config.getPassword()));
+                httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+            }
+
+            // Configure SSL certificate validation
+            if (config.isSslEnabled() && config.isSslSkipCertificateValidation()) {
+                try {
+                    SSLContext sslContext = SSLContextBuilder.create()
+                            .loadTrustMaterial(new TrustAllStrategy())
+                            .build();
+                    httpClientBuilder.setSSLContext(sslContext);
+                    httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+                    log.warn("SSL certificate validation is disabled. This should only be used for testing with expired certificates.");
+                }
+                catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+                    throw new RuntimeException("Failed to configure SSL context", e);
+                }
+            }
+
+            return httpClientBuilder;
+        });
+
+        return builder.build();
+    }
+
+    public List<String> listIndices()
+    {
+        try {
+            Request request = new Request("GET", "/_cat/indices?format=json&h=index");
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                ImmutableList.Builder<String> indices = ImmutableList.builder();
+
+                if (root.isArray()) {
+                    for (JsonNode node : root) {
+                        String indexName = node.get("index").asText();
+                        // Filter out system indices (starting with .)
+                        if (!indexName.startsWith(".")) {
+                            indices.add(indexName);
+                        }
+                    }
+                }
+
+                List<String> result = indices.build();
+                log.debug("Found %d indices", result.size());
+                return result;
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to list OpenSearch indices", e);
+        }
+    }
+
+    public Map<String, Object> getIndexMapping(String indexName)
+    {
+        try {
+            Request request = new Request("GET", "/" + indexName + "/_mapping");
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                JsonNode indexNode = root.get(indexName);
+
+                if (indexNode == null) {
+                    return Collections.emptyMap();
+                }
+
+                JsonNode mappingsNode = indexNode.get("mappings");
+                if (mappingsNode == null) {
+                    return Collections.emptyMap();
+                }
+
+                JsonNode propertiesNode = mappingsNode.get("properties");
+                if (propertiesNode == null) {
+                    return Collections.emptyMap();
+                }
+
+                // Use LinkedHashMap to preserve field order from OpenSearch
+                Map<String, Object> properties = new LinkedHashMap<>();
+                Iterator<Map.Entry<String, JsonNode>> fields = propertiesNode.fields();
+                while (fields.hasNext()) {
+                    Map.Entry<String, JsonNode> field = fields.next();
+                    // Convert to LinkedHashMap to preserve nested field order
+                    properties.put(field.getKey(), OBJECT_MAPPER.convertValue(field.getValue(), LinkedHashMap.class));
+                }
+
+                log.debug("Retrieved mapping for index %s with %d fields", indexName, properties.size());
+                return properties;
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to get OpenSearch index mapping", e);
+        }
+    }
+
+    public List<Map<String, Object>> executeQuery(String indexName, String query, List<String> fields, int from, int size)
+    {
+        return executeQuery(indexName, query, fields, from, size, null);
+    }
+
+    public List<Map<String, Object>> executeQuery(String indexName, String query, List<String> fields, int from, int size, Integer shardId)
+    {
+        try {
+            // Build search request
+            Map<String, Object> searchRequest = new HashMap<>();
+            searchRequest.put("from", from);
+            searchRequest.put("size", size);
+
+            // Add query
+            Map<String, Object> queryMap = OBJECT_MAPPER.readValue(query, Map.class);
+            searchRequest.put("query", queryMap);
+
+            // Add source filtering if fields specified
+            if (fields != null && !fields.isEmpty()) {
+                searchRequest.put("_source", fields);
+            }
+
+            String requestBody = OBJECT_MAPPER.writeValueAsString(searchRequest);
+
+            Request request = new Request("POST", "/" + indexName + "/_search");
+            request.setJsonEntity(requestBody);
+
+            // Add preference parameter to route to specific shard if provided
+            if (shardId != null) {
+                request.addParameter("preference", "_shards:" + shardId);
+            }
+
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                JsonNode hitsNode = root.get("hits").get("hits");
+
+                List<Map<String, Object>> results = new ArrayList<>();
+                if (hitsNode.isArray()) {
+                    for (JsonNode hit : hitsNode) {
+                        Map<String, Object> document = new HashMap<>();
+
+                        // Add _id
+                        document.put("_id", hit.get("_id").asText());
+
+                        // Add _source fields
+                        JsonNode sourceNode = hit.get("_source");
+                        if (sourceNode != null) {
+                            Map<String, Object> source = OBJECT_MAPPER.convertValue(sourceNode, Map.class);
+                            document.putAll(source);
+                        }
+
+                        results.add(document);
+                    }
+                }
+
+                log.debug("Query returned %d documents from index %s", results.size(), indexName);
+                return results;
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to execute OpenSearch query", e);
+        }
+    }
+
+    /**
+     * Execute a k-NN vector search query.
+     *
+     * @param indexName The index to search
+     * @param vectorField The vector field name
+     * @param queryVector The query vector
+     * @param k Number of nearest neighbors
+     * @return List of matching documents with scores
+     */
+    public List<Map<String, Object>> executeVectorSearch(String indexName, String vectorField, float[] queryVector, int k)
+    {
+        return executeVectorSearch(indexName, vectorField, queryVector, k, null, null, null);
+    }
+
+    /**
+     * Execute a k-NN vector search query with advanced options.
+     *
+     * @param indexName The index to search
+     * @param vectorField The vector field name
+     * @param queryVector The query vector
+     * @param k Number of nearest neighbors
+     * @param spaceType Distance metric (cosine, l2, inner_product)
+     * @param efSearch HNSW ef_search parameter for search quality/speed tradeoff
+     * @param filterQuery Optional filter query to apply (JSON string)
+     * @return List of matching documents with scores
+     */
+    public List<Map<String, Object>> executeVectorSearch(
+            String indexName,
+            String vectorField,
+            float[] queryVector,
+            int k,
+            String spaceType,
+            Integer efSearch,
+            String filterQuery)
+    {
+        try {
+            // Build k-NN search request for OpenSearch 2.x k-NN plugin
+            // For HNSW indices, use script_score query approach with doc values
+            Map<String, Object> searchRequest = new HashMap<>();
+            searchRequest.put("size", k);
+
+            // Build script score query for k-NN
+            Map<String, Object> scriptParams = new HashMap<>();
+            scriptParams.put("field", vectorField);
+            scriptParams.put("query_value", queryVector);
+
+            // Determine space type for script
+            // Use doc[field] syntax to access k-NN vector fields
+            String scriptSpaceType = spaceType != null ? spaceType : "cosinesimil";
+            String scriptSource;
+            if ("cosine".equals(scriptSpaceType) || "cosinesimil".equals(scriptSpaceType)) {
+                scriptSource = "1.0 + cosineSimilarity(params.query_value, doc[params.field])";
+            }
+            else if ("l2".equals(scriptSpaceType)) {
+                scriptSource = "1.0 / (1.0 + l2norm(params.query_value, doc[params.field]))";
+            }
+            else if ("inner_product".equals(scriptSpaceType) || "innerproduct".equals(scriptSpaceType)) {
+                scriptSource = "dotProduct(params.query_value, doc[params.field]) + 1.0";
+            }
+            else {
+                scriptSource = "1.0 + cosineSimilarity(params.query_value, doc[params.field])";
+            }
+
+            Map<String, Object> script = new HashMap<>();
+            script.put("source", scriptSource);
+            script.put("params", scriptParams);
+
+            Map<String, Object> scriptScore = new HashMap<>();
+            scriptScore.put("query", Collections.singletonMap("match_all", Collections.emptyMap()));
+            scriptScore.put("script", script);
+
+            Map<String, Object> query = new HashMap<>();
+            query.put("script_score", scriptScore);
+
+            searchRequest.put("query", query);
+
+            String requestBody = OBJECT_MAPPER.writeValueAsString(searchRequest);
+            log.debug("Executing k-NN search on index %s: %s", indexName, requestBody);
+
+            // Use regular _search endpoint for OpenSearch 2.x
+            Request request = new Request("POST", "/" + indexName + "/_search");
+            request.setJsonEntity(requestBody);
+
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                JsonNode hitsNode = root.get("hits").get("hits");
+
+                List<Map<String, Object>> results = new ArrayList<>();
+                if (hitsNode.isArray()) {
+                    for (JsonNode hit : hitsNode) {
+                        Map<String, Object> document = new HashMap<>();
+
+                        // Add _id and _score
+                        document.put("_id", hit.get("_id").asText());
+                        document.put("_score", hit.get("_score").asDouble());
+
+                        // Add _source fields
+                        JsonNode sourceNode = hit.get("_source");
+                        if (sourceNode != null) {
+                            Map<String, Object> source = OBJECT_MAPPER.convertValue(sourceNode, Map.class);
+                            document.putAll(source);
+                        }
+
+                        results.add(document);
+                    }
+                }
+
+                log.debug("Vector search returned %d documents from index %s", results.size(), indexName);
+                return results;
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to execute OpenSearch vector search", e);
+        }
+    }
+
+    /**
+     * Execute a raw k-NN query (provided as JSON string).
+     * Useful for custom queries built by VectorSearchHandler.
+     *
+     * @param indexName The index to search
+     * @param knnQueryJson The complete k-NN query as JSON
+     * @param size Maximum number of results to return
+     * @return List of matching documents with scores
+     */
+    public List<Map<String, Object>> executeKnnQuery(String indexName, String knnQueryJson, int size)
+    {
+        try {
+            // Parse the k-NN query
+            @SuppressWarnings("unchecked")
+            Map<String, Object> queryMap = OBJECT_MAPPER.readValue(knnQueryJson, Map.class);
+
+            // Build search request
+            Map<String, Object> searchRequest = new HashMap<>();
+            searchRequest.put("size", size);
+            searchRequest.put("query", queryMap);
+
+            String requestBody = OBJECT_MAPPER.writeValueAsString(searchRequest);
+            log.debug("Executing k-NN query on index %s: %s", indexName, requestBody);
+
+            Request request = new Request("POST", "/" + indexName + "/_search");
+            request.setJsonEntity(requestBody);
+
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                JsonNode hitsNode = root.get("hits").get("hits");
+
+                List<Map<String, Object>> results = new ArrayList<>();
+                if (hitsNode.isArray()) {
+                    for (JsonNode hit : hitsNode) {
+                        Map<String, Object> document = new HashMap<>();
+
+                        // Add _id and _score
+                        document.put("_id", hit.get("_id").asText());
+                        document.put("_score", hit.get("_score").asDouble());
+
+                        // Add _source fields
+                        JsonNode sourceNode = hit.get("_source");
+                        if (sourceNode != null) {
+                            Map<String, Object> source = OBJECT_MAPPER.convertValue(sourceNode, Map.class);
+                            document.putAll(source);
+                        }
+
+                        results.add(document);
+                    }
+                }
+
+                log.debug("k-NN query returned %d documents from index %s", results.size(), indexName);
+                return results;
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to execute OpenSearch k-NN query", e);
+        }
+    }
+
+    /**
+     * Initiates a scroll context for paginating through large result sets.
+     *
+     * @param indexName The index to search
+     * @param query The query JSON string
+     * @param fields Fields to include in results
+     * @param size Batch size per scroll
+     * @param scrollTimeout Scroll context timeout (e.g., "5m")
+     * @param shardId Optional shard ID for routing
+     * @return ScrollResult containing documents and scroll ID
+     */
+    public ScrollResult initiateScroll(
+            String indexName,
+            String query,
+            List<String> fields,
+            int size,
+            String scrollTimeout,
+            Integer shardId)
+    {
+        try {
+            // Build search request
+            Map<String, Object> searchRequest = new HashMap<>();
+            searchRequest.put("size", size);
+
+            // Add query
+            Map<String, Object> queryMap = OBJECT_MAPPER.readValue(query, Map.class);
+            searchRequest.put("query", queryMap);
+
+            // Add source filtering if fields specified
+            if (fields != null && !fields.isEmpty()) {
+                searchRequest.put("_source", fields);
+            }
+
+            String requestBody = OBJECT_MAPPER.writeValueAsString(searchRequest);
+
+            Request request = new Request("POST", "/" + indexName + "/_search");
+            request.addParameter("scroll", scrollTimeout);
+            request.setJsonEntity(requestBody);
+
+            // Add preference parameter to route to specific shard if provided
+            if (shardId != null) {
+                request.addParameter("preference", "_shards:" + shardId);
+            }
+
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                String scrollId = root.get("_scroll_id").asText();
+                JsonNode hitsNode = root.get("hits").get("hits");
+
+                List<Map<String, Object>> results = new ArrayList<>();
+                if (hitsNode.isArray()) {
+                    for (JsonNode hit : hitsNode) {
+                        Map<String, Object> document = new HashMap<>();
+
+                        // Add _id
+                        document.put("_id", hit.get("_id").asText());
+
+                        // Add _source fields
+                        JsonNode sourceNode = hit.get("_source");
+                        if (sourceNode != null) {
+                            Map<String, Object> source = OBJECT_MAPPER.convertValue(sourceNode, Map.class);
+                            document.putAll(source);
+                        }
+
+                        results.add(document);
+                    }
+                }
+
+                log.debug("Initiated scroll for index %s: scroll_id=%s, documents=%d",
+                        indexName, scrollId, results.size());
+                return new ScrollResult(scrollId, results);
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to initiate scroll", e);
+        }
+    }
+
+    /**
+     * Continues scrolling through results using a scroll ID.
+     *
+     * @param scrollId The scroll ID from previous scroll request
+     * @param scrollTimeout Scroll context timeout (e.g., "5m")
+     * @return ScrollResult containing documents and updated scroll ID
+     */
+    public ScrollResult continueScroll(String scrollId, String scrollTimeout)
+    {
+        try {
+            Map<String, Object> scrollRequest = new HashMap<>();
+            scrollRequest.put("scroll", scrollTimeout);
+            scrollRequest.put("scroll_id", scrollId);
+
+            String requestBody = OBJECT_MAPPER.writeValueAsString(scrollRequest);
+
+            Request request = new Request("POST", "/_search/scroll");
+            request.setJsonEntity(requestBody);
+
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                String newScrollId = root.get("_scroll_id").asText();
+                JsonNode hitsNode = root.get("hits").get("hits");
+
+                List<Map<String, Object>> results = new ArrayList<>();
+                if (hitsNode.isArray()) {
+                    for (JsonNode hit : hitsNode) {
+                        Map<String, Object> document = new HashMap<>();
+
+                        // Add _id
+                        document.put("_id", hit.get("_id").asText());
+
+                        // Add _source fields
+                        JsonNode sourceNode = hit.get("_source");
+                        if (sourceNode != null) {
+                            Map<String, Object> source = OBJECT_MAPPER.convertValue(sourceNode, Map.class);
+                            document.putAll(source);
+                        }
+
+                        results.add(document);
+                    }
+                }
+
+                log.debug("Continued scroll: scroll_id=%s, documents=%d", newScrollId, results.size());
+                return new ScrollResult(newScrollId, results);
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to continue scroll", e);
+        }
+    }
+
+    /**
+     * Clears a scroll context to free resources.
+     *
+     * @param scrollId The scroll ID to clear
+     */
+    public void clearScroll(String scrollId)
+    {
+        try {
+            Map<String, Object> clearRequest = new HashMap<>();
+            clearRequest.put("scroll_id", scrollId);
+
+            String requestBody = OBJECT_MAPPER.writeValueAsString(clearRequest);
+
+            Request request = new Request("DELETE", "/_search/scroll");
+            request.setJsonEntity(requestBody);
+
+            restClient.performRequest(request);
+            log.debug("Cleared scroll: scroll_id=%s", scrollId);
+        }
+        catch (IOException e) {
+            log.warn(e, "Failed to clear scroll: scroll_id=%s", scrollId);
+            // Non-fatal - scroll will expire automatically
+        }
+    }
+
+    public List<ShardInfo> getShardInfo(String indexName)
+    {
+        try {
+            Request request = new Request("GET", "/_cat/shards/" + indexName + "?format=json&h=shard,node");
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                ImmutableList.Builder<ShardInfo> shards = ImmutableList.builder();
+
+                if (root.isArray()) {
+                    for (JsonNode node : root) {
+                        int shardId = node.get("shard").asInt();
+                        String nodeAddress = node.get("node").asText();
+                        shards.add(new ShardInfo(shardId, nodeAddress));
+                    }
+                }
+
+                List<ShardInfo> result = shards.build();
+                log.debug("Found %d shards for index %s", result.size(), indexName);
+                return result.isEmpty() ?
+                        ImmutableList.of(new ShardInfo(0, config.getHost() + ":" + config.getPort())) :
+                        result;
+            }
+        }
+        catch (IOException e) {
+            log.warn(e, "Failed to get shard info for index %s, using default", indexName);
+            // Return default single shard on error
+            return ImmutableList.of(new ShardInfo(0, config.getHost() + ":" + config.getPort()));
+        }
+    }
+
+    /**
+     * Result from a scroll operation containing documents and scroll ID.
+     */
+    public static class ScrollResult
+    {
+        private final String scrollId;
+        private final List<Map<String, Object>> documents;
+
+        public ScrollResult(String scrollId, List<Map<String, Object>> documents)
+        {
+            this.scrollId = scrollId;
+            this.documents = documents;
+        }
+
+        public String getScrollId()
+        {
+            return scrollId;
+        }
+
+        public List<Map<String, Object>> getDocuments()
+        {
+            return documents;
+        }
+    }
+
+    /**
+     * Store column order and type metadata for an index to preserve field order and types.
+     * OpenSearch returns fields alphabetically and loses VARCHAR length info, so we store the original order and types.
+     */
+    public void storeColumnOrderMetadata(String indexName, List<String> columnNames, List<String> columnTypes)
+    {
+        try {
+            // Create metadata index if it doesn't exist
+            try {
+                Request checkIndex = new Request("HEAD", "/" + METADATA_INDEX);
+                restClient.performRequest(checkIndex);
+            }
+            catch (IOException e) {
+                // Index doesn't exist, create it
+                Request createIndex = new Request("PUT", "/" + METADATA_INDEX);
+                createIndex.setJsonEntity("{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0}}");
+                restClient.performRequest(createIndex);
+                log.info("Created metadata index: %s", METADATA_INDEX);
+            }
+
+            // Store column order and types as a document
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put("index_name", indexName);
+            metadata.put("column_order", columnNames);
+            if (columnTypes != null) {
+                metadata.put("column_types", columnTypes);
+            }
+            metadata.put("timestamp", System.currentTimeMillis());
+
+            String metadataJson = OBJECT_MAPPER.writeValueAsString(metadata);
+            Request indexRequest = new Request("PUT", "/" + METADATA_INDEX + "/_doc/" + indexName);
+            indexRequest.setJsonEntity(metadataJson);
+            restClient.performRequest(indexRequest);
+
+            log.debug("Stored column metadata for index %s: %d columns", indexName, columnNames.size());
+        }
+        catch (IOException e) {
+            log.warn(e, "Failed to store column metadata for index %s", indexName);
+            // Non-fatal - we can fall back to alphabetical order
+        }
+    }
+
+    /**
+     * Store column order metadata for an index (backward compatibility).
+     */
+    public void storeColumnOrderMetadata(String indexName, List<String> columnNames)
+    {
+        storeColumnOrderMetadata(indexName, columnNames, null);
+    }
+
+    /**
+     * Retrieve stored column order for an index.
+     * Returns empty list if metadata doesn't exist.
+     */
+    public List<String> getColumnOrderMetadata(String indexName)
+    {
+        Map<String, List<String>> metadata = getColumnMetadata(indexName);
+        return metadata.getOrDefault("column_order", Collections.emptyList());
+    }
+
+    /**
+     * Retrieve stored column metadata (order and types) for an index.
+     * Returns map with "column_order" and "column_types" keys.
+     */
+    public Map<String, List<String>> getColumnMetadata(String indexName)
+    {
+        try {
+            Request request = new Request("GET", "/" + METADATA_INDEX + "/_doc/" + indexName);
+            Response response = restClient.performRequest(request);
+
+            try (InputStream content = response.getEntity().getContent()) {
+                JsonNode root = OBJECT_MAPPER.readTree(content);
+                JsonNode source = root.get("_source");
+                if (source != null) {
+                    Map<String, List<String>> result = new HashMap<>();
+
+                    // Get column order
+                    if (source.has("column_order")) {
+                        JsonNode columnOrderNode = source.get("column_order");
+                        List<String> columnOrder = new ArrayList<>();
+                        if (columnOrderNode.isArray()) {
+                            for (JsonNode node : columnOrderNode) {
+                                columnOrder.add(node.asText());
+                            }
+                        }
+                        result.put("column_order", columnOrder);
+                    }
+
+                    // Get column types
+                    if (source.has("column_types")) {
+                        JsonNode columnTypesNode = source.get("column_types");
+                        List<String> columnTypes = new ArrayList<>();
+                        if (columnTypesNode.isArray()) {
+                            for (JsonNode node : columnTypesNode) {
+                                columnTypes.add(node.asText());
+                            }
+                        }
+                        result.put("column_types", columnTypes);
+                    }
+
+                    log.debug("Retrieved column metadata for index %s", indexName);
+                    return result;
+                }
+            }
+        }
+        catch (IOException e) {
+            log.debug("No column metadata found for index %s", indexName);
+        }
+        return Collections.emptyMap();
+    }
+
+    public void close()
+    {
+        try {
+            if (restClient != null) {
+                restClient.close();
+                log.info("OpenSearch client closed");
+            }
+        }
+        catch (IOException e) {
+            log.error(e, "Error closing OpenSearch client");
+        }
+    }
+
+    /**
+     * Information about an OpenSearch shard.
+     */
+    public static class ShardInfo
+    {
+        private final int shardId;
+        private final String nodeAddress;
+
+        public ShardInfo(int shardId, String nodeAddress)
+        {
+            this.shardId = shardId;
+            this.nodeAddress = nodeAddress;
+        }
+
+        public int getShardId()
+        {
+            return shardId;
+        }
+
+        public String getNodeAddress()
+        {
+            return nodeAddress;
+        }
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchColumnHandle.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchColumnHandle.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Column handle for OpenSearch connector.
+ * Represents a field in an OpenSearch index, including support for nested fields.
+ *
+ * For nested fields (e.g., token_usage.total_tokens):
+ * - columnName: "token_usage.total_tokens"
+ * - parentFieldPath: "token_usage"
+ * - fieldPathList: ["token_usage", "total_tokens"]
+ * - isNestedField: true
+ */
+public class OpenSearchColumnHandle
+        implements ColumnHandle
+{
+    private final String columnName;
+    private final Type columnType;
+    private final String openSearchType;
+    private final boolean isVector;
+    private final int vectorDimension;
+
+    // Nested field support
+    private final boolean isNestedField;
+    private final String parentFieldPath;
+    private final List<String> fieldPathList;
+    private final String jsonPath;
+
+    @JsonCreator
+    public OpenSearchColumnHandle(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("columnType") Type columnType,
+            @JsonProperty("openSearchType") String openSearchType,
+            @JsonProperty("isVector") boolean isVector,
+            @JsonProperty("vectorDimension") int vectorDimension,
+            @JsonProperty("isNestedField") boolean isNestedField,
+            @JsonProperty("parentFieldPath") String parentFieldPath,
+            @JsonProperty("fieldPathList") List<String> fieldPathList,
+            @JsonProperty("jsonPath") String jsonPath)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.columnType = requireNonNull(columnType, "columnType is null");
+        this.openSearchType = requireNonNull(openSearchType, "openSearchType is null");
+        this.isVector = isVector;
+        this.vectorDimension = vectorDimension;
+        this.isNestedField = isNestedField;
+        this.parentFieldPath = parentFieldPath;
+        this.fieldPathList = fieldPathList != null ?
+                Collections.unmodifiableList(fieldPathList) :
+                Collections.emptyList();
+        this.jsonPath = jsonPath;
+    }
+
+    // Constructor for backward compatibility (non-nested fields)
+    public OpenSearchColumnHandle(
+            String columnName,
+            Type columnType,
+            String openSearchType,
+            boolean isVector,
+            int vectorDimension)
+    {
+        this(columnName, columnType, openSearchType, isVector, vectorDimension,
+                false, null, null, null);
+    }
+
+    // Convenience constructor for simple fields
+    public OpenSearchColumnHandle(String columnName, Type columnType, String openSearchType)
+    {
+        this(columnName, columnType, openSearchType, false, 0, false, null, null, null);
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public Type getColumnType()
+    {
+        return columnType;
+    }
+
+    @JsonProperty
+    public String getOpenSearchType()
+    {
+        return openSearchType;
+    }
+
+    @JsonProperty
+    public boolean isVector()
+    {
+        return isVector;
+    }
+
+    @JsonProperty
+    public int getVectorDimension()
+    {
+        return vectorDimension;
+    }
+
+    @JsonProperty
+    public boolean isNestedField()
+    {
+        // Compute from fieldPathList instead of using stored field
+        // This ensures correctness even after JSON deserialization
+        return fieldPathList != null && fieldPathList.size() > 1;
+    }
+
+    @JsonProperty
+    public String getParentFieldPath()
+    {
+        return parentFieldPath;
+    }
+
+    @JsonProperty
+    public List<String> getFieldPathList()
+    {
+        return fieldPathList;
+    }
+
+    @JsonProperty
+    public String getJsonPath()
+    {
+        return jsonPath;
+    }
+
+    public ColumnMetadata toColumnMetadata()
+    {
+        return ColumnMetadata.builder()
+                .setName(columnName)
+                .setType(columnType)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        OpenSearchColumnHandle other = (OpenSearchColumnHandle) obj;
+        return Objects.equals(columnName, other.columnName) &&
+                Objects.equals(columnType, other.columnType) &&
+                Objects.equals(openSearchType, other.openSearchType) &&
+                isVector == other.isVector &&
+                vectorDimension == other.vectorDimension &&
+                isNestedField == other.isNestedField &&
+                Objects.equals(parentFieldPath, other.parentFieldPath) &&
+                Objects.equals(fieldPathList, other.fieldPathList);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(columnName, columnType, openSearchType, isVector, vectorDimension,
+                isNestedField, parentFieldPath, fieldPathList);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(columnName).append(":").append(columnType)
+          .append(" (").append(openSearchType);
+
+        if (isVector) {
+            sb.append(", vector[").append(vectorDimension).append("]");
+        }
+
+        if (isNestedField) {
+            sb.append(", nested, parent=").append(parentFieldPath);
+        }
+
+        sb.append(")");
+        return sb.toString();
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchConfig.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchConfig.java
@@ -1,0 +1,436 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
+
+/**
+ * Configuration for OpenSearch connector.
+ * Provides connection, authentication, query settings, and nested field support.
+ */
+public class OpenSearchConfig
+{
+    private String host = "localhost";
+    private int port = 9200;
+    private String scheme = "https";
+    private String username;
+    private String password;
+    private boolean sslEnabled = true;
+    private boolean sslVerifyHostname = true;
+    private boolean sslSkipCertificateValidation;
+    private String sslTruststorePath;
+    private String sslTruststorePassword;
+    private boolean vectorSearchEnabled = true;
+    private int vectorSearchDefaultK = 10;
+    private String vectorSearchDefaultSpaceType = "cosine";
+    private int vectorSearchDefaultEfSearch = 100;
+    private int scrollSize = 1000;
+    private String scrollTimeout = "5m";
+    private int maxConnections = 100;
+    private int connectionTimeout = 10000;
+    private int socketTimeout = 60000;
+    private String schemaPattern = "*";
+    private boolean hideSystemIndices = true;
+    private int maxResultWindow = 10000;
+
+    // Nested field configuration
+    private boolean nestedFieldAccessEnabled = true;
+    private int nestedMaxDepth = 5;
+    private boolean nestedOptimizeQueries = true;
+    private boolean nestedDiscoverDynamicFields;
+    private boolean nestedLogMissingFields;
+
+    // Column visibility configuration
+    private boolean hideDocumentIdColumn;
+
+    public String getHost()
+    {
+        return host;
+    }
+
+    @Config("opensearch.host")
+    @ConfigDescription("OpenSearch host")
+    public OpenSearchConfig setHost(String host)
+    {
+        this.host = host;
+        return this;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    @Config("opensearch.port")
+    @ConfigDescription("OpenSearch port")
+    public OpenSearchConfig setPort(int port)
+    {
+        this.port = port;
+        return this;
+    }
+
+    public String getScheme()
+    {
+        return scheme;
+    }
+
+    @Config("opensearch.scheme")
+    @ConfigDescription("Connection scheme (http or https)")
+    public OpenSearchConfig setScheme(String scheme)
+    {
+        this.scheme = scheme;
+        return this;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    @Config("opensearch.auth.username")
+    @ConfigDescription("Authentication username")
+    public OpenSearchConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("opensearch.auth.password")
+    @ConfigDescription("Authentication password")
+    @ConfigSecuritySensitive
+    public OpenSearchConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+
+    public boolean isSslEnabled()
+    {
+        return sslEnabled;
+    }
+
+    @Config("opensearch.ssl.enabled")
+    @ConfigDescription("Enable SSL/TLS")
+    public OpenSearchConfig setSslEnabled(boolean sslEnabled)
+    {
+        this.sslEnabled = sslEnabled;
+        return this;
+    }
+
+    public boolean isSslVerifyHostname()
+    {
+        return sslVerifyHostname;
+    }
+
+    @Config("opensearch.ssl.verify-hostname")
+    @ConfigDescription("Verify SSL hostname")
+    public OpenSearchConfig setSslVerifyHostname(boolean sslVerifyHostname)
+    {
+        this.sslVerifyHostname = sslVerifyHostname;
+        return this;
+    }
+
+    public String getSslTruststorePath()
+    {
+        return sslTruststorePath;
+    }
+
+    @Config("opensearch.ssl.truststore.path")
+    @ConfigDescription("Path to SSL truststore")
+    public OpenSearchConfig setSslTruststorePath(String sslTruststorePath)
+    {
+        this.sslTruststorePath = sslTruststorePath;
+        return this;
+    }
+
+    public String getSslTruststorePassword()
+    {
+        return sslTruststorePassword;
+    }
+
+    @Config("opensearch.ssl.truststore.password")
+    @ConfigDescription("SSL truststore password")
+    @ConfigSecuritySensitive
+    public OpenSearchConfig setSslTruststorePassword(String sslTruststorePassword)
+    {
+        this.sslTruststorePassword = sslTruststorePassword;
+        return this;
+    }
+
+    public boolean isSslSkipCertificateValidation()
+    {
+        return sslSkipCertificateValidation;
+    }
+
+    @Config("opensearch.ssl.skip-certificate-validation")
+    @ConfigDescription("Skip SSL certificate validation (including expiration checks). Use only for testing with expired certificates.")
+    public OpenSearchConfig setSslSkipCertificateValidation(boolean sslSkipCertificateValidation)
+    {
+        this.sslSkipCertificateValidation = sslSkipCertificateValidation;
+        return this;
+    }
+
+    public boolean isVectorSearchEnabled()
+    {
+        return vectorSearchEnabled;
+    }
+
+    @Config("opensearch.vector-search.enabled")
+    @ConfigDescription("Enable vector search support")
+    public OpenSearchConfig setVectorSearchEnabled(boolean vectorSearchEnabled)
+    {
+        this.vectorSearchEnabled = vectorSearchEnabled;
+        return this;
+    }
+
+    public int getVectorSearchDefaultK()
+    {
+        return vectorSearchDefaultK;
+    }
+
+    @Config("opensearch.vector-search.default-k")
+    @ConfigDescription("Default k for vector search")
+    public OpenSearchConfig setVectorSearchDefaultK(int vectorSearchDefaultK)
+    {
+        this.vectorSearchDefaultK = vectorSearchDefaultK;
+        return this;
+    }
+
+    public String getVectorSearchDefaultSpaceType()
+    {
+        return vectorSearchDefaultSpaceType;
+    }
+
+    @Config("opensearch.vector-search.default-space-type")
+    @ConfigDescription("Default distance metric for vector search (cosine, l2, inner_product)")
+    public OpenSearchConfig setVectorSearchDefaultSpaceType(String vectorSearchDefaultSpaceType)
+    {
+        this.vectorSearchDefaultSpaceType = vectorSearchDefaultSpaceType;
+        return this;
+    }
+
+    public int getVectorSearchDefaultEfSearch()
+    {
+        return vectorSearchDefaultEfSearch;
+    }
+
+    @Config("opensearch.vector-search.default-ef-search")
+    @ConfigDescription("Default ef_search parameter for HNSW algorithm (higher = better accuracy, slower)")
+    public OpenSearchConfig setVectorSearchDefaultEfSearch(int vectorSearchDefaultEfSearch)
+    {
+        this.vectorSearchDefaultEfSearch = vectorSearchDefaultEfSearch;
+        return this;
+    }
+
+    public int getScrollSize()
+    {
+        return scrollSize;
+    }
+
+    @Config("opensearch.scroll.size")
+    @ConfigDescription("Scroll batch size")
+    public OpenSearchConfig setScrollSize(int scrollSize)
+    {
+        this.scrollSize = scrollSize;
+        return this;
+    }
+
+    public String getScrollTimeout()
+    {
+        return scrollTimeout;
+    }
+
+    @Config("opensearch.scroll.timeout")
+    @ConfigDescription("Scroll timeout")
+    public OpenSearchConfig setScrollTimeout(String scrollTimeout)
+    {
+        this.scrollTimeout = scrollTimeout;
+        return this;
+    }
+
+    public int getMaxConnections()
+    {
+        return maxConnections;
+    }
+
+    @Config("opensearch.max-connections")
+    @ConfigDescription("Maximum number of connections")
+    public OpenSearchConfig setMaxConnections(int maxConnections)
+    {
+        this.maxConnections = maxConnections;
+        return this;
+    }
+
+    public int getConnectionTimeout()
+    {
+        return connectionTimeout;
+    }
+
+    @Config("opensearch.connection-timeout")
+    @ConfigDescription("Connection timeout in milliseconds")
+    public OpenSearchConfig setConnectionTimeout(int connectionTimeout)
+    {
+        this.connectionTimeout = connectionTimeout;
+        return this;
+    }
+
+    public int getConnectTimeout()
+    {
+        return connectionTimeout;
+    }
+
+    public int getSocketTimeout()
+    {
+        return socketTimeout;
+    }
+
+    @Config("opensearch.socket-timeout")
+    @ConfigDescription("Socket timeout in milliseconds")
+    public OpenSearchConfig setSocketTimeout(int socketTimeout)
+    {
+        this.socketTimeout = socketTimeout;
+        return this;
+    }
+
+    public int getMaxRetryTimeout()
+    {
+        return socketTimeout * 3;
+    }
+
+    public String getSchemaPattern()
+    {
+        return schemaPattern;
+    }
+
+    @Config("opensearch.schema-pattern")
+    @ConfigDescription("Index pattern for schema discovery")
+    public OpenSearchConfig setSchemaPattern(String schemaPattern)
+    {
+        this.schemaPattern = schemaPattern;
+        return this;
+    }
+
+    public boolean isHideSystemIndices()
+    {
+        return hideSystemIndices;
+    }
+
+    @Config("opensearch.hide-system-indices")
+    @ConfigDescription("Hide system indices from schema")
+    public OpenSearchConfig setHideSystemIndices(boolean hideSystemIndices)
+    {
+        this.hideSystemIndices = hideSystemIndices;
+        return this;
+    }
+
+    public int getMaxResultWindow()
+    {
+        return maxResultWindow;
+    }
+
+    @Config("opensearch.max-result-window")
+    @ConfigDescription("Maximum result window size")
+    public OpenSearchConfig setMaxResultWindow(int maxResultWindow)
+    {
+        this.maxResultWindow = maxResultWindow;
+        return this;
+    }
+
+    // Nested field configuration getters and setters
+
+    public boolean isNestedFieldAccessEnabled()
+    {
+        return nestedFieldAccessEnabled;
+    }
+
+    @Config("opensearch.nested.enabled")
+    @ConfigDescription("Enable nested field access with dot notation (default: true)")
+    public OpenSearchConfig setNestedFieldAccessEnabled(boolean nestedFieldAccessEnabled)
+    {
+        this.nestedFieldAccessEnabled = nestedFieldAccessEnabled;
+        return this;
+    }
+
+    public int getNestedMaxDepth()
+    {
+        return nestedMaxDepth;
+    }
+
+    @Config("opensearch.nested.max-depth")
+    @ConfigDescription("Maximum depth for nested field discovery (default: 5)")
+    public OpenSearchConfig setNestedMaxDepth(int nestedMaxDepth)
+    {
+        this.nestedMaxDepth = nestedMaxDepth;
+        return this;
+    }
+
+    public boolean isNestedOptimizeQueries()
+    {
+        return nestedOptimizeQueries;
+    }
+
+    @Config("opensearch.nested.optimize-queries")
+    @ConfigDescription("Optimize nested queries by grouping predicates (default: true)")
+    public OpenSearchConfig setNestedOptimizeQueries(boolean nestedOptimizeQueries)
+    {
+        this.nestedOptimizeQueries = nestedOptimizeQueries;
+        return this;
+    }
+
+    public boolean isNestedDiscoverDynamicFields()
+    {
+        return nestedDiscoverDynamicFields;
+    }
+
+    @Config("opensearch.nested.discover-dynamic-fields")
+    @ConfigDescription("Discover dynamic fields not in mapping (default: false, for safety)")
+    public OpenSearchConfig setNestedDiscoverDynamicFields(boolean nestedDiscoverDynamicFields)
+    {
+        this.nestedDiscoverDynamicFields = nestedDiscoverDynamicFields;
+        return this;
+    }
+
+    public boolean isNestedLogMissingFields()
+    {
+        return nestedLogMissingFields;
+    }
+
+    @Config("opensearch.nested.log-missing-fields")
+    @ConfigDescription("Log warnings when nested fields are missing in documents (default: false)")
+    public OpenSearchConfig setNestedLogMissingFields(boolean nestedLogMissingFields)
+    {
+        this.nestedLogMissingFields = nestedLogMissingFields;
+        return this;
+    }
+
+    public boolean isHideDocumentIdColumn()
+    {
+        return hideDocumentIdColumn;
+    }
+
+    @Config("opensearch.hide-document-id-column")
+    @ConfigDescription("Hide the _id column from table schema (default: false)")
+    public OpenSearchConfig setHideDocumentIdColumn(boolean hideDocumentIdColumn)
+    {
+        this.hideDocumentIdColumn = hideDocumentIdColumn;
+        return this;
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchConnector.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchConnector.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.table.ConnectorTableFunction;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+import com.google.common.collect.ImmutableSet;
+import jakarta.inject.Inject;
+
+import java.util.Set;
+
+import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
+import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Main connector implementation for OpenSearch.
+ * Provides metadata, split manager, page source provider, and table functions.
+ */
+public class OpenSearchConnector
+        implements Connector
+{
+    private final OpenSearchMetadata metadata;
+    private final OpenSearchSplitManager splitManager;
+    private final OpenSearchPageSourceProvider pageSourceProvider;
+    private final Set<ConnectorTableFunction> tableFunctions;
+
+    @Inject
+    public OpenSearchConnector(
+            OpenSearchMetadata metadata,
+            OpenSearchSplitManager splitManager,
+            OpenSearchPageSourceProvider pageSourceProvider,
+            Set<ConnectorTableFunction> tableFunctions)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.tableFunctions = ImmutableSet.copyOf(requireNonNull(tableFunctions, "tableFunctions is null"));
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+    {
+        checkConnectorSupports(READ_COMMITTED, isolationLevel);
+        return new OpenSearchTransactionHandle();
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorPageSourceProvider getPageSourceProvider()
+    {
+        return pageSourceProvider;
+    }
+
+    @Override
+    public Set<ConnectorTableFunction> getTableFunctions()
+    {
+        return tableFunctions;
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchConnectorFactory.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchConnectorFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Factory for creating OpenSearch connector instances.
+ */
+public class OpenSearchConnectorFactory
+        implements ConnectorFactory
+{
+    @Override
+    public String getName()
+    {
+        return "opensearch";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new OpenSearchHandleResolver();
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(config, "config is null");
+        requireNonNull(context, "context is null");
+
+        Bootstrap app = new Bootstrap(
+                new JsonModule(),
+                new OpenSearchModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(OpenSearchConnector.class);
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchHandleResolver.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchHandleResolver.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+/**
+ * Handle resolver for OpenSearch connector.
+ * Resolves connector-specific handles for serialization/deserialization.
+ */
+public class OpenSearchHandleResolver
+        implements ConnectorHandleResolver
+{
+    @Override
+    public Class<? extends ConnectorTableHandle> getTableHandleClass()
+    {
+        return OpenSearchTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ColumnHandle> getColumnHandleClass()
+    {
+        return OpenSearchColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass()
+    {
+        return OpenSearchSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableLayoutHandle> getTableLayoutHandleClass()
+    {
+        return OpenSearchTableLayoutHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
+    {
+        return OpenSearchTransactionHandle.class;
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchMetadata.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchMetadata.java
@@ -1,0 +1,573 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.plugin.opensearch.types.TypeMapper;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.TableFunctionApplicationResult;
+import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Metadata provider for OpenSearch connector.
+ * Handles schema/table/column discovery and metadata operations.
+ * Supports nested field discovery when enabled in configuration.
+ */
+public class OpenSearchMetadata
+        implements ConnectorMetadata
+{
+    private static final Logger log = Logger.get(OpenSearchMetadata.class);
+    private static final String DEFAULT_SCHEMA = "default";
+
+    private final OpenSearchClient client;
+    private final OpenSearchConfig config;
+    private final NestedFieldMapper nestedFieldMapper;
+
+    @Inject
+    public OpenSearchMetadata(
+            OpenSearchClient client,
+            OpenSearchConfig config,
+            NestedFieldMapper nestedFieldMapper)
+    {
+        this.client = requireNonNull(client, "client is null");
+        this.config = requireNonNull(config, "config is null");
+        this.nestedFieldMapper = requireNonNull(nestedFieldMapper, "nestedFieldMapper is null");
+    }
+
+    @Override
+    public Optional<TableFunctionApplicationResult<ConnectorTableHandle>> applyTableFunction(
+            ConnectorSession session,
+            ConnectorTableFunctionHandle handle)
+    {
+        if (handle instanceof KnnSearchTableFunction.KnnSearchHandle) {
+            KnnSearchTableFunction.KnnSearchHandle knnHandle = (KnnSearchTableFunction.KnnSearchHandle) handle;
+
+            // Create a table handle for the k-NN search with search parameters
+            OpenSearchTableHandle tableHandle = new OpenSearchTableHandle(
+                    DEFAULT_SCHEMA,
+                    knnHandle.getIndexName(),
+                    knnHandle.getIndexName(),
+                    knnHandle.getVectorField(),
+                    knnHandle.getQueryVector(),
+                    knnHandle.getK(),
+                    knnHandle.getSpaceType(),
+                    knnHandle.getEfSearch());
+
+            // Return the table handle with columns from the k-NN search
+            return Optional.of(new TableFunctionApplicationResult<>(
+                    tableHandle,
+                    new ArrayList<>(knnHandle.getColumns())));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        // For OpenSearch, we use a single schema "default"
+        return ImmutableList.of(DEFAULT_SCHEMA);
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    {
+        if (!DEFAULT_SCHEMA.equals(tableName.getSchemaName())) {
+            return null;
+        }
+
+        // Verify the index exists
+        List<String> indices = client.listIndices();
+        if (!indices.contains(tableName.getTableName())) {
+            return null;
+        }
+
+        // Table name corresponds to index name
+        return new OpenSearchTableHandle(
+                tableName.getSchemaName(),
+                tableName.getTableName(),
+                tableName.getTableName());
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        OpenSearchTableHandle tableHandle = (OpenSearchTableHandle) table;
+
+        // For k-NN searches, build column metadata from index mapping
+        if (tableHandle.isKnnSearch()) {
+            Map<String, ColumnHandle> columnHandles = getColumnHandles(session, tableHandle);
+            List<ColumnMetadata> columns = new ArrayList<>();
+            for (Map.Entry<String, ColumnHandle> entry : columnHandles.entrySet()) {
+                OpenSearchColumnHandle columnHandle = (OpenSearchColumnHandle) entry.getValue();
+                columns.add(ColumnMetadata.builder()
+                        .setName(columnHandle.getColumnName())
+                        .setType(columnHandle.getColumnType())
+                        .build());
+            }
+            return new ConnectorTableMetadata(tableHandle.toSchemaTableName(), columns);
+        }
+
+        List<ColumnMetadata> columns = getColumnsFromMapping(tableHandle.getIndexName());
+        return new ConnectorTableMetadata(tableHandle.toSchemaTableName(), columns);
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        if (schemaName.isPresent() && !DEFAULT_SCHEMA.equals(schemaName.get())) {
+            return ImmutableList.of();
+        }
+
+        List<String> indices = client.listIndices();
+        ImmutableList.Builder<SchemaTableName> tables = ImmutableList.builder();
+
+        for (String index : indices) {
+            tables.add(new SchemaTableName(DEFAULT_SCHEMA, index));
+        }
+
+        List<SchemaTableName> result = tables.build();
+        log.debug("Listed %d tables", result.size());
+        return result;
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        OpenSearchTableHandle table = (OpenSearchTableHandle) tableHandle;
+        Map<String, Object> mapping = client.getIndexMapping(table.getIndexName());
+
+        // For k-NN searches, build columns from index mapping (including _id and _score)
+        if (table.isKnnSearch()) {
+            Map<String, ColumnHandle> columns = new LinkedHashMap<>();
+            columns.put("_id", new OpenSearchColumnHandle("_id", VARCHAR, "keyword"));
+            columns.put("_score", new OpenSearchColumnHandle("_score", DOUBLE, "double"));
+
+            // Add other fields from mapping (skip knn_vector fields)
+            for (Map.Entry<String, Object> entry : mapping.entrySet()) {
+                String fieldName = entry.getKey();
+                if (entry.getValue() instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> fieldMapping = (Map<String, Object>) entry.getValue();
+                    Object typeObj = fieldMapping.get("type");
+                    if (typeObj instanceof String) {
+                        String fieldType = (String) typeObj;
+                        if (!"knn_vector".equals(fieldType)) {
+                            columns.put(fieldName, new OpenSearchColumnHandle(fieldName, VARCHAR, fieldType));
+                        }
+                    }
+                }
+            }
+            return columns;
+        }
+
+        // Use LinkedHashMap to preserve insertion order, then sort by column name
+        Map<String, ColumnHandle> columns = new LinkedHashMap<>();
+
+        // Add _id column unless configured to hide it
+        if (!config.isHideDocumentIdColumn()) {
+            columns.put("_id", new OpenSearchColumnHandle("_id", VARCHAR, "keyword"));
+        }
+
+        // Check if nested field access is enabled
+        if (config.isNestedFieldAccessEnabled()) {
+            // Use NestedFieldMapper to discover all fields including nested ones
+            Map<String, NestedFieldInfo> allFields = nestedFieldMapper.discoverNestedFields(mapping);
+
+            // Add ALL fields as columns (both parent objects and leaf fields)
+            // Parent objects will be exposed as ROW types for dereference support
+            // Leaf fields will be exposed with their proper types
+            for (Map.Entry<String, NestedFieldInfo> entry : allFields.entrySet()) {
+                NestedFieldInfo fieldInfo = entry.getValue();
+
+                // Use the Presto type from NestedFieldInfo
+                // For parent objects, this will be a ROW type
+                // For leaf fields, this will be the primitive type
+                Type columnType = fieldInfo.getPrestoType();
+
+                // Check if it's a vector field
+                boolean isVector = "knn_vector".equals(fieldInfo.getOpenSearchType());
+                int vectorDimension = 0;
+                if (isVector) {
+                    // Vector dimension would be in the original mapping
+                    Map<String, Object> fieldProps = getFieldProperties(mapping, fieldInfo.getFieldPathList());
+                    if (fieldProps != null && fieldProps.containsKey("dimension")) {
+                        vectorDimension = ((Number) fieldProps.get("dimension")).intValue();
+                    }
+                }
+
+                columns.put(fieldInfo.getFieldPath(), new OpenSearchColumnHandle(
+                        fieldInfo.getFieldPath(),
+                        columnType,
+                        fieldInfo.getOpenSearchType(),
+                        isVector,
+                        vectorDimension,
+                        fieldInfo.isNestedField(),
+                        fieldInfo.getParentPath(),
+                        fieldInfo.getFieldPathList(),
+                        fieldInfo.getJsonPath()));
+            }
+        }
+        else {
+            // Original flat field logic (backward compatibility)
+            for (Map.Entry<String, Object> entry : mapping.entrySet()) {
+                String fieldName = entry.getKey();
+                Map<String, Object> fieldProperties = (Map<String, Object>) entry.getValue();
+
+                String fieldType = (String) fieldProperties.getOrDefault("type", "text");
+                Type prestoType = TypeMapper.toPrestoType(fieldType, fieldProperties, fieldName);
+
+                // Check if it's a vector field
+                boolean isVector = "knn_vector".equals(fieldType);
+                int vectorDimension = 0;
+                if (isVector && fieldProperties.containsKey("dimension")) {
+                    vectorDimension = ((Number) fieldProperties.get("dimension")).intValue();
+                }
+
+                columns.put(fieldName, new OpenSearchColumnHandle(
+                        fieldName,
+                        prestoType,
+                        fieldType,
+                        isVector,
+                        vectorDimension));
+            }
+        }
+
+        log.debug("Retrieved %d columns for table %s", columns.size(), table.getTableName());
+        return columns;
+    }
+
+    /**
+     * Helper method to get field properties from mapping using a field path.
+     * Used to retrieve additional properties like vector dimension for nested fields.
+     */
+    private Map<String, Object> getFieldProperties(Map<String, Object> mapping, List<String> fieldPath)
+    {
+        if (fieldPath == null || fieldPath.isEmpty()) {
+            return null;
+        }
+
+        Map<String, Object> current = mapping;
+
+        for (int i = 0; i < fieldPath.size(); i++) {
+            String pathSegment = fieldPath.get(i);
+
+            if (!current.containsKey(pathSegment)) {
+                return null;
+            }
+
+            Object value = current.get(pathSegment);
+            if (!(value instanceof Map)) {
+                return null;
+            }
+
+            Map<String, Object> fieldMap = (Map<String, Object>) value;
+
+            // If this is the last segment, return the field properties
+            if (i == fieldPath.size() - 1) {
+                return fieldMap;
+            }
+
+            // Otherwise, navigate to the nested properties
+            if (fieldMap.containsKey("properties")) {
+                current = (Map<String, Object>) fieldMap.get("properties");
+            }
+            else {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        OpenSearchColumnHandle column = (OpenSearchColumnHandle) columnHandle;
+        return column.toColumnMetadata();
+    }
+
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        String schemaName = prefix.getSchemaName();
+        if (schemaName != null && !DEFAULT_SCHEMA.equals(schemaName)) {
+            return ImmutableMap.of();
+        }
+
+        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
+
+        List<SchemaTableName> tables;
+        String tableName = prefix.getTableName();
+        if (tableName != null) {
+            // Specific table requested
+            tables = ImmutableList.of(new SchemaTableName(DEFAULT_SCHEMA, tableName));
+        }
+        else {
+            // All tables
+            tables = listTables(session, Optional.of(DEFAULT_SCHEMA));
+        }
+
+        for (SchemaTableName table : tables) {
+            try {
+                List<ColumnMetadata> tableColumns = getColumnsFromMapping(table.getTableName());
+                columns.put(table, tableColumns);
+            }
+            catch (Exception e) {
+                log.warn(e, "Failed to get columns for table: %s", table);
+            }
+        }
+
+        return columns.build();
+    }
+
+    @Override
+    public List<ConnectorTableLayoutResult> getTableLayouts(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            Constraint<ColumnHandle> constraint,
+            Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        OpenSearchTableHandle tableHandle = (OpenSearchTableHandle) table;
+        ConnectorTableLayout layout = new ConnectorTableLayout(
+                new OpenSearchTableLayoutHandle(tableHandle),
+                Optional.empty(),
+                constraint.getSummary(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of());
+
+        return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+    }
+
+    @Override
+    public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+    {
+        OpenSearchTableLayoutHandle layoutHandle = (OpenSearchTableLayoutHandle) handle;
+        return new ConnectorTableLayout(
+                layoutHandle,
+                Optional.empty(),
+                TupleDomain.all(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of());
+    }
+
+    private List<ColumnMetadata> getColumnsFromMapping(String indexName)
+    {
+        Map<String, Object> mapping = client.getIndexMapping(indexName);
+        List<ColumnMetadata> columns = new ArrayList<>();
+
+        // Add _id column first unless configured to hide it
+        if (!config.isHideDocumentIdColumn()) {
+            columns.add(ColumnMetadata.builder()
+                    .setName("_id")
+                    .setType(VARCHAR)
+                    .setComment("")
+                    .build());
+        }
+
+        // Try to get stored column metadata (order and types)
+        // OpenSearch returns fields alphabetically and loses VARCHAR length info
+        Map<String, List<String>> storedMetadata = client.getColumnMetadata(indexName);
+        List<String> columnOrder = storedMetadata.getOrDefault("column_order", new ArrayList<>());
+        List<String> columnTypes = storedMetadata.getOrDefault("column_types", new ArrayList<>());
+
+        // Build a map of column name to Presto type from stored metadata
+        Map<String, Type> storedTypes = new HashMap<>();
+        if (!columnOrder.isEmpty() && columnOrder.size() == columnTypes.size()) {
+            for (int i = 0; i < columnOrder.size(); i++) {
+                Type type = parsePrestoType(columnTypes.get(i));
+                if (type != null) {
+                    storedTypes.put(columnOrder.get(i), type);
+                }
+            }
+        }
+
+        // Check if nested field access is enabled
+        if (config.isNestedFieldAccessEnabled()) {
+            // Use NestedFieldMapper to discover all fields including nested ones
+            Map<String, NestedFieldInfo> allFields = nestedFieldMapper.discoverNestedFields(mapping);
+
+            // If we have stored column order, use it; otherwise use discovery order
+            if (!columnOrder.isEmpty()) {
+                // Add columns in the stored order
+                for (String columnName : columnOrder) {
+                    NestedFieldInfo fieldInfo = allFields.get(columnName);
+                    if (fieldInfo != null) {
+                        // Use stored type if available, otherwise infer
+                        Type columnType;
+                        if (storedTypes.containsKey(columnName)) {
+                            columnType = storedTypes.get(columnName);
+                        }
+                        else {
+                            columnType = fieldInfo.isLeafField() ? fieldInfo.getPrestoType() : VARCHAR;
+                        }
+                        columns.add(ColumnMetadata.builder()
+                                .setName(fieldInfo.getFieldPath())
+                                .setType(columnType)
+                                .setComment("")
+                                .build());
+                    }
+                }
+            }
+            else {
+                // Fall back to discovery order
+                for (Map.Entry<String, NestedFieldInfo> entry : allFields.entrySet()) {
+                    NestedFieldInfo fieldInfo = entry.getValue();
+                    // Use the Presto type from NestedFieldInfo (ROW for objects, primitive for leaves)
+                    Type columnType = fieldInfo.getPrestoType();
+                    columns.add(ColumnMetadata.builder()
+                            .setName(fieldInfo.getFieldPath())
+                            .setType(columnType)
+                            .setComment("")
+                            .build());
+                }
+            }
+        }
+        else {
+            // Original flat field logic (backward compatibility)
+            if (!columnOrder.isEmpty()) {
+                // Add columns in the stored order
+                for (String columnName : columnOrder) {
+                    Map<String, Object> fieldProperties = (Map<String, Object>) mapping.get(columnName);
+                    if (fieldProperties != null) {
+                        // Use stored type if available, otherwise infer from OpenSearch type
+                        Type prestoType;
+                        if (storedTypes.containsKey(columnName)) {
+                            prestoType = storedTypes.get(columnName);
+                        }
+                        else {
+                            String fieldType = (String) fieldProperties.getOrDefault("type", "text");
+                            prestoType = TypeMapper.toPrestoType(fieldType, fieldProperties, columnName);
+                        }
+                        columns.add(ColumnMetadata.builder()
+                                .setName(columnName)
+                                .setType(prestoType)
+                                .setComment("")
+                                .build());
+                    }
+                }
+            }
+            else {
+                // Fall back to mapping order (alphabetical from OpenSearch)
+                for (Map.Entry<String, Object> entry : mapping.entrySet()) {
+                    String fieldName = entry.getKey();
+                    Map<String, Object> fieldProperties = (Map<String, Object>) entry.getValue();
+                    String fieldType = (String) fieldProperties.getOrDefault("type", "text");
+                    Type prestoType = TypeMapper.toPrestoType(fieldType, fieldProperties, fieldName);
+                    columns.add(ColumnMetadata.builder()
+                            .setName(fieldName)
+                            .setType(prestoType)
+                            .setComment("")
+                            .build());
+                }
+            }
+        }
+
+        log.debug("Retrieved %d columns from mapping for index %s", columns.size(), indexName);
+        return columns;
+    }
+
+    /**
+     * Parse a Presto type string (e.g., "varchar(25)", "bigint") into a Type object.
+     */
+    private Type parsePrestoType(String typeString)
+    {
+        if (typeString == null || typeString.isEmpty()) {
+            return null;
+        }
+
+        // Handle parameterized types like varchar(25)
+        if (typeString.startsWith("varchar(") && typeString.endsWith(")")) {
+            try {
+                String lengthStr = typeString.substring(8, typeString.length() - 1);
+                int length = Integer.parseInt(lengthStr);
+                return createVarcharType(length);
+            }
+            catch (NumberFormatException e) {
+                log.warn("Failed to parse varchar length from: %s", typeString);
+                return VARCHAR;
+            }
+        }
+
+        // Handle simple types
+        switch (typeString.toLowerCase(java.util.Locale.ENGLISH)) {
+            case "varchar":
+                return VARCHAR;
+            case "bigint":
+                return BIGINT;
+            case "integer":
+                return INTEGER;
+            case "smallint":
+                return SMALLINT;
+            case "tinyint":
+                return TINYINT;
+            case "double":
+                return DOUBLE;
+            case "real":
+                return REAL;
+            case "boolean":
+                return BOOLEAN;
+            case "date":
+                return DATE;
+            case "timestamp":
+                return TIMESTAMP;
+            case "varbinary":
+                return VARBINARY;
+            default:
+                log.warn("Unknown type string: %s, defaulting to VARCHAR", typeString);
+                return VARCHAR;
+        }
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchModule.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchModule.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.function.table.ConnectorTableFunction;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
+/**
+ * Guice module for OpenSearch connector dependency injection.
+ */
+public class OpenSearchModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(OpenSearchConnector.class).in(Scopes.SINGLETON);
+        binder.bind(OpenSearchMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(OpenSearchSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(OpenSearchPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(OpenSearchClient.class).in(Scopes.SINGLETON);
+        binder.bind(OpenSearchHandleResolver.class).in(Scopes.SINGLETON);
+        binder.bind(NestedValueExtractor.class).in(Scopes.SINGLETON);
+        binder.bind(NestedFieldMapper.class).in(Scopes.SINGLETON);
+        binder.bind(QueryBuilder.class).in(Scopes.SINGLETON);
+        binder.bind(VectorSearchHandler.class).in(Scopes.SINGLETON);
+
+        // Register table functions using Multibinder
+        newSetBinder(binder, ConnectorTableFunction.class)
+                .addBinding()
+                .to(KnnSearchTableFunction.class)
+                .in(Scopes.SINGLETON);
+
+        configBinder(binder).bindConfig(OpenSearchConfig.class);
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchPageSource.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchPageSource.java
@@ -1,0 +1,532 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.PrestoException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.slice.Slices;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Page source for OpenSearch connector.
+ * Fetches data from OpenSearch and converts to Presto pages.
+ * Uses OpenSearch Scroll API for efficient pagination of large result sets.
+ * Supports nested field extraction using NestedValueExtractor.
+ */
+public class OpenSearchPageSource
+        implements ConnectorPageSource
+{
+    private static final Logger log = Logger.get(OpenSearchPageSource.class);
+    private static final ObjectMapper OBJECT_MAPPER = new JsonObjectMapperProvider().get();
+
+    private final OpenSearchClient client;
+    private final OpenSearchSplit split;
+    private final List<OpenSearchColumnHandle> columns;
+    private final QueryBuilder queryBuilder;
+    private final NestedValueExtractor nestedExtractor;
+    private final OpenSearchConfig config;
+
+    private boolean finished;
+    private long completedBytes;
+    private long completedPositions;
+    private String scrollId;
+    private boolean useScroll;
+
+    public OpenSearchPageSource(
+            OpenSearchClient client,
+            OpenSearchSplit split,
+            List<OpenSearchColumnHandle> columns,
+            NestedValueExtractor nestedExtractor,
+            QueryBuilder queryBuilder,
+            OpenSearchConfig config)
+    {
+        this.client = requireNonNull(client, "client is null");
+        this.split = requireNonNull(split, "split is null");
+        this.columns = requireNonNull(columns, "columns is null");
+        this.nestedExtractor = requireNonNull(nestedExtractor, "nestedExtractor is null");
+        this.queryBuilder = requireNonNull(queryBuilder, "queryBuilder is null");
+        this.config = requireNonNull(config, "config is null");
+        this.finished = false;
+        this.completedBytes = 0;
+        this.completedPositions = 0;
+        this.scrollId = null;
+        this.useScroll = true; // Enable scroll by default for better performance
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return completedBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        if (finished) {
+            return null;
+        }
+
+        try {
+            List<Map<String, Object>> documents;
+
+            // Check if this is a k-NN search
+            if (split.isKnnSearch()) {
+                // For k-NN searches, we execute once and return all results
+                if (scrollId != null) {
+                    finished = true;
+                    return null;
+                }
+
+                // Execute k-NN search
+                documents = client.executeVectorSearch(
+                        split.getIndexName(),
+                        split.getVectorField().get(),
+                        split.getQueryVector().get(),
+                        split.getK().get().intValue(),
+                        split.getSpaceType().orElse(null),
+                        split.getEfSearch().isPresent() ? split.getEfSearch().get().intValue() : null,
+                        null); // No filter for now
+
+                log.debug("k-NN search returned %d documents from index %s",
+                        documents.size(), split.getIndexName());
+                scrollId = "knn_complete"; // Mark as complete
+            }
+            else if (useScroll) {
+                // Use Scroll API for efficient pagination
+                if (scrollId == null) {
+                    // First request - initiate scroll
+                    String query = queryBuilder.buildQuery(split.getTupleDomain());
+                    List<String> fieldNames = getFieldNames();
+
+                    OpenSearchClient.ScrollResult result = client.initiateScroll(
+                            split.getIndexName(),
+                            query,
+                            fieldNames,
+                            config.getScrollSize(),
+                            config.getScrollTimeout(),
+                            split.getShardId());
+
+                    scrollId = result.getScrollId();
+                    documents = result.getDocuments();
+
+                    log.debug("Initiated scroll for index %s: scroll_id=%s, documents=%d",
+                            split.getIndexName(), scrollId, documents.size());
+                }
+                else {
+                    // Continue scrolling
+                    OpenSearchClient.ScrollResult result = client.continueScroll(
+                            scrollId,
+                            config.getScrollTimeout());
+
+                    scrollId = result.getScrollId();
+                    documents = result.getDocuments();
+
+                    log.debug("Continued scroll: documents=%d", documents.size());
+                }
+            }
+            else {
+                // Fallback to offset-based pagination (for compatibility)
+                String query = queryBuilder.buildQuery(split.getTupleDomain());
+                List<String> fieldNames = getFieldNames();
+
+                documents = client.executeQuery(
+                        split.getIndexName(),
+                        query,
+                        fieldNames,
+                        (int) completedPositions,
+                        config.getScrollSize(),
+                        split.getShardId());
+
+                log.debug("Fetched %d documents from index %s (offset: %d)",
+                        documents.size(), split.getIndexName(), completedPositions);
+            }
+
+            if (documents.isEmpty()) {
+                finished = true;
+                return null;
+            }
+
+            // Build page from documents
+            Page page = buildPage(documents);
+
+            // Update state
+            completedPositions += documents.size();
+            completedBytes += estimatePageSize(page);
+
+            // Check if we're done
+            if (split.isKnnSearch() || documents.size() < config.getScrollSize()) {
+                finished = true;
+            }
+
+            return page;
+        }
+        catch (Exception e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to fetch data from OpenSearch", e);
+        }
+    }
+
+    private List<String> getFieldNames()
+    {
+        // Get field names for source filtering
+        // For nested fields, we need to request only the top-level parent objects,
+        // not the dot-notation paths, because OpenSearch's _source filter doesn't
+        // work correctly when you mix parent and child paths
+        List<String> fieldNames = new ArrayList<>();
+        Set<String> topLevelFields = new HashSet<>();
+
+        for (OpenSearchColumnHandle column : columns) {
+            if (!"_id".equals(column.getColumnName())) {
+                String fieldName = column.getColumnName();
+
+                // Extract top-level field name (before first dot)
+                String topLevelField;
+                int dotIndex = fieldName.indexOf('.');
+                if (dotIndex > 0) {
+                    topLevelField = fieldName.substring(0, dotIndex);
+                }
+                else {
+                    topLevelField = fieldName;
+                }
+
+                // Only add top-level field once
+                if (topLevelFields.add(topLevelField)) {
+                    fieldNames.add(topLevelField);
+                }
+            }
+        }
+
+        return fieldNames;
+    }
+
+    private Page buildPage(List<Map<String, Object>> documents)
+    {
+        int positionCount = documents.size();
+        Block[] blocks = new Block[columns.size()];
+
+        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+            OpenSearchColumnHandle column = columns.get(columnIndex);
+            Type type = column.getColumnType();
+            BlockBuilder builder = type.createBlockBuilder(null, positionCount);
+
+            for (Map<String, Object> document : documents) {
+                Object value;
+
+                // Check if this is a nested field
+                if (column.isNestedField()) {
+                    // Extract nested field value using NestedValueExtractor
+                    value = nestedExtractor.extractNestedValue(
+                            document,
+                            column.getFieldPathList(),
+                            type);
+                }
+                else {
+                    // Extract flat field value (existing logic)
+                    value = document.get(column.getColumnName());
+
+                    // For ROW types, keep the Map as-is (will be handled by writeValue)
+                    // For VARCHAR with Map/List, convert to JSON string for backward compatibility
+                    if (value != null && type.equals(VARCHAR) && (value instanceof Map || value instanceof List)) {
+                        try {
+                            value = OBJECT_MAPPER.writeValueAsString(value);
+                        }
+                        catch (Exception e) {
+                            log.warn(e, "Failed to convert object to JSON for column %s, using toString()",
+                                    column.getColumnName());
+                            value = value.toString();
+                        }
+                    }
+                    // For ROW types with Map values, keep as-is (handled in writeValue)
+                }
+
+                writeValue(builder, type, value);
+            }
+
+            blocks[columnIndex] = builder.build();
+        }
+
+        return new Page(positionCount, blocks);
+    }
+
+    private void writeValue(BlockBuilder builder, Type type, Object value)
+    {
+        if (value == null) {
+            builder.appendNull();
+            return;
+        }
+
+        try {
+            if (type.equals(VARCHAR)) {
+                type.writeSlice(builder, Slices.utf8Slice(value.toString()));
+            }
+            else if (type.equals(BIGINT)) {
+                type.writeLong(builder, ((Number) value).longValue());
+            }
+            else if (type.equals(INTEGER)) {
+                type.writeLong(builder, ((Number) value).intValue());
+            }
+            else if (type.equals(SMALLINT)) {
+                type.writeLong(builder, ((Number) value).shortValue());
+            }
+            else if (type.equals(TINYINT)) {
+                type.writeLong(builder, ((Number) value).byteValue());
+            }
+            else if (type.equals(DOUBLE)) {
+                type.writeDouble(builder, ((Number) value).doubleValue());
+            }
+            else if (type.equals(REAL)) {
+                type.writeLong(builder, Float.floatToIntBits(((Number) value).floatValue()));
+            }
+            else if (type.equals(BOOLEAN)) {
+                type.writeBoolean(builder, (Boolean) value);
+            }
+            else if (type.equals(DATE)) {
+                // Parse date - OpenSearch can return either:
+                // 1. Milliseconds since epoch (as Number)
+                // 2. ISO 8601 formatted date string (e.g., "1996-01-02")
+                long days;
+                if (value instanceof Number) {
+                    // Convert milliseconds to days since epoch
+                    days = ((Number) value).longValue() / (24 * 60 * 60 * 1000);
+                }
+                else if (value instanceof String) {
+                    try {
+                        // Parse ISO 8601 date string (yyyy-MM-dd)
+                        String dateStr = (String) value;
+                        // Handle date strings that may have time component
+                        if (dateStr.contains("T")) {
+                            dateStr = dateStr.substring(0, dateStr.indexOf('T'));
+                        }
+                        Instant instant = Instant.parse(dateStr + "T00:00:00Z");
+                        // Convert to days since epoch
+                        days = instant.toEpochMilli() / (24 * 60 * 60 * 1000);
+                    }
+                    catch (DateTimeParseException e) {
+                        log.warn("Failed to parse date string: %s, setting to null", value);
+                        builder.appendNull();
+                        return;
+                    }
+                }
+                else {
+                    log.warn("Unexpected date type: %s for value: %s, setting to null",
+                            value.getClass().getName(), value);
+                    builder.appendNull();
+                    return;
+                }
+                type.writeLong(builder, days);
+            }
+            else if (type.equals(TIMESTAMP)) {
+                // Parse timestamp - OpenSearch can return either:
+                // 1. Milliseconds since epoch (as Number)
+                // 2. ISO 8601 formatted string (e.g., "2025-12-05T10:55:49.526757")
+                long timestamp;
+                if (value instanceof Number) {
+                    timestamp = ((Number) value).longValue();
+                }
+                else if (value instanceof String) {
+                    try {
+                        // Parse ISO 8601 timestamp string
+                        String timestampStr = (String) value;
+
+                        // Handle timestamps with microsecond precision by padding to nanoseconds
+                        // OpenSearch may return timestamps like "2025-12-04T12:37:32.007263"
+                        // which have 6 decimal places (microseconds) instead of 9 (nanoseconds)
+                        if (timestampStr.contains(".")) {
+                            int dotIndex = timestampStr.indexOf('.');
+                            int endIndex = timestampStr.length();
+                            // Find where the fractional seconds end (before 'Z' or '+' or '-')
+                            for (int i = dotIndex + 1; i < timestampStr.length(); i++) {
+                                char c = timestampStr.charAt(i);
+                                if (c == 'Z' || c == '+' || c == '-') {
+                                    endIndex = i;
+                                    break;
+                                }
+                            }
+
+                            String fractionalPart = timestampStr.substring(dotIndex + 1, endIndex);
+                            String suffix = endIndex < timestampStr.length() ? timestampStr.substring(endIndex) : "Z";
+
+                            // Pad or truncate to 9 digits (nanoseconds)
+                            if (fractionalPart.length() < 9) {
+                                fractionalPart = String.format("%-9s", fractionalPart).replace(' ', '0');
+                            }
+                            else if (fractionalPart.length() > 9) {
+                                fractionalPart = fractionalPart.substring(0, 9);
+                            }
+
+                            timestampStr = timestampStr.substring(0, dotIndex + 1) + fractionalPart + suffix;
+                        }
+                        else if (!timestampStr.endsWith("Z")) {
+                            // Add 'Z' if no timezone specified
+                            timestampStr += "Z";
+                        }
+
+                        Instant instant = Instant.parse(timestampStr);
+                        // Convert to milliseconds since epoch
+                        timestamp = instant.toEpochMilli();
+                    }
+                    catch (DateTimeParseException e) {
+                        log.warn("Failed to parse timestamp string: %s, setting to null", value);
+                        builder.appendNull();
+                        return;
+                    }
+                }
+                else {
+                    log.warn("Unexpected timestamp type: %s for value: %s, setting to null",
+                            value.getClass().getName(), value);
+                    builder.appendNull();
+                    return;
+                }
+                type.writeLong(builder, timestamp);
+            }
+            else if (type instanceof RowType) {
+                // Handle ROW types (nested objects)
+                RowType rowType = (RowType) type;
+                List<RowType.Field> fields = rowType.getFields();
+
+                if (value instanceof Map) {
+                    Map<String, Object> map = (Map<String, Object>) value;
+                    BlockBuilder rowBlockBuilder = builder.beginBlockEntry();
+
+                    for (int i = 0; i < fields.size(); i++) {
+                        RowType.Field field = fields.get(i);
+                        String fieldName = field.getName().orElse("field" + i);
+                        Type fieldType = field.getType();
+                        Object fieldValue = map.get(fieldName);
+
+                        writeValue(rowBlockBuilder, fieldType, fieldValue);
+                    }
+
+                    builder.closeEntry();
+                }
+                else {
+                    builder.appendNull();
+                }
+            }
+            else if (type instanceof ArrayType) {
+                // Handle arrays (including vectors)
+                ArrayType arrayType = (ArrayType) type;
+                Type elementType = arrayType.getElementType();
+
+                if (value instanceof List) {
+                    List<?> list = (List<?>) value;
+                    BlockBuilder arrayBuilder = builder.beginBlockEntry();
+
+                    for (Object element : list) {
+                        writeValue(arrayBuilder, elementType, element);
+                    }
+
+                    builder.closeEntry();
+                }
+                else if (value instanceof Object[]) {
+                    // Handle Object arrays (Jackson sometimes returns Object[] instead of List)
+                    Object[] array = (Object[]) value;
+                    BlockBuilder arrayBuilder = builder.beginBlockEntry();
+
+                    for (Object element : array) {
+                        writeValue(arrayBuilder, elementType, element);
+                    }
+
+                    builder.closeEntry();
+                }
+                else {
+                    builder.appendNull();
+                }
+            }
+            else {
+                // Default: convert to string
+                type.writeSlice(builder, Slices.utf8Slice(value.toString()));
+            }
+        }
+        catch (Exception e) {
+            log.warn(e, "Failed to write value of type %s: %s", type, value);
+            builder.appendNull();
+        }
+    }
+
+    private long estimatePageSize(Page page)
+    {
+        return page.getSizeInBytes();
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return completedPositions;
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        // Clear scroll context if active
+        if (scrollId != null && !scrollId.equals("knn_complete")) {
+            try {
+                client.clearScroll(scrollId);
+                log.debug("Cleared scroll context: %s", scrollId);
+            }
+            catch (Exception e) {
+                log.warn(e, "Failed to clear scroll context: %s", scrollId);
+            }
+        }
+        finished = true;
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchPageSourceProvider.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchPageSourceProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import jakarta.inject.Inject;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Page source provider for OpenSearch connector.
+ * Creates page sources for reading data from OpenSearch.
+ */
+public class OpenSearchPageSourceProvider
+        implements ConnectorPageSourceProvider
+{
+    private final OpenSearchClient client;
+    private final NestedValueExtractor nestedValueExtractor;
+    private final QueryBuilder queryBuilder;
+    private final OpenSearchConfig config;
+
+    @Inject
+    public OpenSearchPageSourceProvider(
+            OpenSearchClient client,
+            NestedValueExtractor nestedValueExtractor,
+            QueryBuilder queryBuilder,
+            OpenSearchConfig config)
+    {
+        this.client = requireNonNull(client, "client is null");
+        this.nestedValueExtractor = requireNonNull(nestedValueExtractor, "nestedValueExtractor is null");
+        this.queryBuilder = requireNonNull(queryBuilder, "queryBuilder is null");
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableLayoutHandle layout,
+            List<ColumnHandle> columns,
+            SplitContext splitContext,
+            RuntimeStats runtimeStats)
+    {
+        requireNonNull(split, "split is null");
+        requireNonNull(layout, "layout is null");
+
+        OpenSearchSplit openSearchSplit = (OpenSearchSplit) split;
+
+        List<OpenSearchColumnHandle> openSearchColumns = columns.stream()
+                .map(OpenSearchColumnHandle.class::cast)
+                .collect(toList());
+
+        return new OpenSearchPageSource(client, openSearchSplit, openSearchColumns, nestedValueExtractor, queryBuilder, config);
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchPlugin.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchPlugin.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * OpenSearch connector plugin for Presto.
+ * Provides connectivity to OpenSearch clusters and supports:
+ * - Standard SQL queries on OpenSearch indices
+ * - Vector similarity search via k-NN plugin with table functions
+ * - Full-text search capabilities
+ * - Nested field access with dot notation
+ *
+ * Table Functions:
+ * - knn_search: Execute k-NN vector similarity search using OpenSearch k-NN plugin
+ */
+public class OpenSearchPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new OpenSearchConnectorFactory());
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchSplit.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchSplit.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Split for OpenSearch connector.
+ * Represents a shard or partition of an OpenSearch index.
+ * Can optionally represent a k-NN vector search query.
+ */
+public class OpenSearchSplit
+        implements ConnectorSplit
+{
+    private final String indexName;
+    private final int shardId;
+    private final List<HostAddress> addresses;
+    private final TupleDomain<ColumnHandle> tupleDomain;
+    private final Optional<String> vectorField;
+    private final Optional<float[]> queryVector;
+    private final Optional<Integer> k;
+    private final Optional<String> spaceType;
+    private final Optional<Integer> efSearch;
+
+    @JsonCreator
+    public OpenSearchSplit(
+            @JsonProperty("indexName") String indexName,
+            @JsonProperty("shardId") int shardId,
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> tupleDomain,
+            @JsonProperty("vectorField") Optional<String> vectorField,
+            @JsonProperty("queryVector") Optional<float[]> queryVector,
+            @JsonProperty("k") Optional<Integer> k,
+            @JsonProperty("spaceType") Optional<String> spaceType,
+            @JsonProperty("efSearch") Optional<Integer> efSearch)
+    {
+        this.indexName = requireNonNull(indexName, "indexName is null");
+        this.shardId = shardId;
+        this.addresses = requireNonNull(addresses, "addresses is null");
+        this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
+        this.vectorField = requireNonNull(vectorField, "vectorField is null");
+        this.queryVector = requireNonNull(queryVector, "queryVector is null");
+        this.k = requireNonNull(k, "k is null");
+        this.spaceType = requireNonNull(spaceType, "spaceType is null");
+        this.efSearch = requireNonNull(efSearch, "efSearch is null");
+    }
+
+    public OpenSearchSplit(String indexName, int shardId, List<HostAddress> addresses)
+    {
+        this(indexName, shardId, addresses, TupleDomain.all(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    // Constructor for k-NN searches
+    public OpenSearchSplit(
+            String indexName,
+            int shardId,
+            List<HostAddress> addresses,
+            String vectorField,
+            float[] queryVector,
+            int k,
+            String spaceType,
+            Integer efSearch)
+    {
+        this(indexName, shardId, addresses, TupleDomain.all(), Optional.of(vectorField),
+                Optional.of(queryVector), Optional.of(k), Optional.of(spaceType), Optional.ofNullable(efSearch));
+    }
+
+    @JsonProperty
+    public String getIndexName()
+    {
+        return indexName;
+    }
+
+    @JsonProperty
+    public int getShardId()
+    {
+        return shardId;
+    }
+
+    @JsonProperty
+    public List<HostAddress> getAddresses()
+    {
+        return addresses;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getTupleDomain()
+    {
+        return tupleDomain;
+    }
+
+    @JsonProperty
+    public Optional<String> getVectorField()
+    {
+        return vectorField;
+    }
+
+    @JsonProperty
+    public Optional<float[]> getQueryVector()
+    {
+        return queryVector;
+    }
+
+    @JsonProperty
+    public Optional<Integer> getK()
+    {
+        return k;
+    }
+
+    @JsonProperty
+    public Optional<String> getSpaceType()
+    {
+        return spaceType;
+    }
+
+    @JsonProperty
+    public Optional<Integer> getEfSearch()
+    {
+        return efSearch;
+    }
+
+    public boolean isKnnSearch()
+    {
+        return vectorField.isPresent();
+    }
+
+    @Override
+    public NodeSelectionStrategy getNodeSelectionStrategy()
+    {
+        return NO_PREFERENCE;
+    }
+
+    @Override
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
+    {
+        return addresses;
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        OpenSearchSplit other = (OpenSearchSplit) obj;
+        return Objects.equals(indexName, other.indexName) &&
+                shardId == other.shardId &&
+                Objects.equals(addresses, other.addresses) &&
+                Objects.equals(tupleDomain, other.tupleDomain) &&
+                Objects.equals(vectorField, other.vectorField) &&
+                Objects.deepEquals(queryVector.orElse(null), other.queryVector.orElse(null)) &&
+                Objects.equals(k, other.k) &&
+                Objects.equals(spaceType, other.spaceType) &&
+                Objects.equals(efSearch, other.efSearch);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(indexName, shardId, addresses, tupleDomain, vectorField,
+                Objects.hashCode(queryVector.orElse(null)), k, spaceType, efSearch);
+    }
+
+    @Override
+    public String toString()
+    {
+        return indexName + "[" + shardId + "] @ " +
+                addresses.stream()
+                        .map(HostAddress::toString)
+                        .collect(toImmutableList());
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchSplitManager.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchSplitManager.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.FixedSplitSource;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.common.collect.ImmutableList;
+import jakarta.inject.Inject;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Split manager for OpenSearch connector.
+ * Creates splits based on OpenSearch shards for parallel execution.
+ */
+public class OpenSearchSplitManager
+        implements ConnectorSplitManager
+{
+    private final OpenSearchClient client;
+
+    @Inject
+    public OpenSearchSplitManager(OpenSearchClient client)
+    {
+        this.client = requireNonNull(client, "client is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
+    {
+        OpenSearchTableLayoutHandle layoutHandle = (OpenSearchTableLayoutHandle) layout;
+        OpenSearchTableHandle table = layoutHandle.getTable();
+
+        ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
+
+        // For k-NN searches, create a single split that queries all shards
+        // k-NN search must be executed globally, not per shard
+        if (table.isKnnSearch()) {
+            // Get shard information to determine node address
+            List<OpenSearchClient.ShardInfo> shards = client.getShardInfo(table.getIndexName());
+
+            // Use the first shard's node address (k-NN search will query all shards)
+            List<HostAddress> addresses = shards.isEmpty()
+                    ? ImmutableList.of()
+                    : ImmutableList.of(HostAddress.fromString(shards.get(0).getNodeAddress()));
+
+            OpenSearchSplit split = new OpenSearchSplit(
+                    table.getIndexName(),
+                    0, // Use shard 0 as placeholder since we query all shards
+                    addresses,
+                    table.getVectorField().get(),
+                    table.getQueryVector().get(),
+                    table.getK().get(),
+                    table.getSpaceType().get(),
+                    table.getEfSearch().orElse(null));
+
+            splits.add(split);
+        }
+        else {
+            // For regular queries, get shard information from OpenSearch
+            List<OpenSearchClient.ShardInfo> shards = client.getShardInfo(table.getIndexName());
+
+            // Create one split per shard for parallel execution
+            for (OpenSearchClient.ShardInfo shard : shards) {
+                List<HostAddress> addresses = ImmutableList.of(
+                        HostAddress.fromString(shard.getNodeAddress()));
+
+                OpenSearchSplit split = new OpenSearchSplit(
+                        table.getIndexName(),
+                        shard.getShardId(),
+                        addresses);
+
+                splits.add(split);
+            }
+        }
+
+        return new FixedSplitSource(splits.build());
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchTableHandle.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchTableHandle.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Table handle for OpenSearch connector.
+ * Represents an OpenSearch index as a Presto table.
+ * Can optionally represent a k-NN vector search query.
+ */
+public class OpenSearchTableHandle
+        implements ConnectorTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+    private final String indexName;
+    private final Optional<String> vectorField;
+    private final Optional<float[]> queryVector;
+    private final Optional<Integer> k;
+    private final Optional<String> spaceType;
+    private final Optional<Integer> efSearch;
+
+    @JsonCreator
+    public OpenSearchTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("indexName") String indexName,
+            @JsonProperty("vectorField") Optional<String> vectorField,
+            @JsonProperty("queryVector") Optional<float[]> queryVector,
+            @JsonProperty("k") Optional<Integer> k,
+            @JsonProperty("spaceType") Optional<String> spaceType,
+            @JsonProperty("efSearch") Optional<Integer> efSearch)
+    {
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.indexName = requireNonNull(indexName, "indexName is null");
+        this.vectorField = requireNonNull(vectorField, "vectorField is null");
+        this.queryVector = requireNonNull(queryVector, "queryVector is null");
+        this.k = requireNonNull(k, "k is null");
+        this.spaceType = requireNonNull(spaceType, "spaceType is null");
+        this.efSearch = requireNonNull(efSearch, "efSearch is null");
+    }
+
+    // Constructor for regular table scans (backward compatibility)
+    public OpenSearchTableHandle(String schemaName, String tableName, String indexName)
+    {
+        this(schemaName, tableName, indexName, Optional.empty(), Optional.empty(),
+                Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    // Constructor for k-NN searches
+    public OpenSearchTableHandle(
+            String schemaName,
+            String tableName,
+            String indexName,
+            String vectorField,
+            float[] queryVector,
+            int k,
+            String spaceType,
+            Integer efSearch)
+    {
+        this(schemaName, tableName, indexName, Optional.of(vectorField), Optional.of(queryVector),
+                Optional.of(k), Optional.of(spaceType), Optional.ofNullable(efSearch));
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty
+    public String getIndexName()
+    {
+        return indexName;
+    }
+
+    @JsonProperty
+    public Optional<String> getVectorField()
+    {
+        return vectorField;
+    }
+
+    @JsonProperty
+    public Optional<float[]> getQueryVector()
+    {
+        return queryVector;
+    }
+
+    @JsonProperty
+    public Optional<Integer> getK()
+    {
+        return k;
+    }
+
+    @JsonProperty
+    public Optional<String> getSpaceType()
+    {
+        return spaceType;
+    }
+
+    @JsonProperty
+    public Optional<Integer> getEfSearch()
+    {
+        return efSearch;
+    }
+
+    public boolean isKnnSearch()
+    {
+        return vectorField.isPresent();
+    }
+
+    public SchemaTableName toSchemaTableName()
+    {
+        return new SchemaTableName(schemaName, tableName);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        OpenSearchTableHandle other = (OpenSearchTableHandle) obj;
+        return Objects.equals(schemaName, other.schemaName) &&
+                Objects.equals(tableName, other.tableName) &&
+                Objects.equals(indexName, other.indexName) &&
+                Objects.equals(vectorField, other.vectorField) &&
+                Objects.deepEquals(queryVector.orElse(null), other.queryVector.orElse(null)) &&
+                Objects.equals(k, other.k) &&
+                Objects.equals(spaceType, other.spaceType) &&
+                Objects.equals(efSearch, other.efSearch);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(schemaName, tableName, indexName, vectorField,
+                           Objects.hashCode(queryVector.orElse(null)), k, spaceType, efSearch);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (isKnnSearch()) {
+            return schemaName + "." + tableName + " (" + indexName + ") [k-NN search]";
+        }
+        return schemaName + "." + tableName + " (" + indexName + ")";
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchTableLayoutHandle.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchTableLayoutHandle.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Table layout handle for OpenSearch connector.
+ * Represents the layout of an OpenSearch index for query planning.
+ */
+public class OpenSearchTableLayoutHandle
+        implements ConnectorTableLayoutHandle
+{
+    private final OpenSearchTableHandle table;
+
+    @JsonCreator
+    public OpenSearchTableLayoutHandle(@JsonProperty("table") OpenSearchTableHandle table)
+    {
+        this.table = requireNonNull(table, "table is null");
+    }
+
+    @JsonProperty
+    public OpenSearchTableHandle getTable()
+    {
+        return table;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        OpenSearchTableLayoutHandle other = (OpenSearchTableLayoutHandle) obj;
+        return Objects.equals(table, other.table);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table);
+    }
+
+    @Override
+    public String toString()
+    {
+        return table.toString();
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchTransactionHandle.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/OpenSearchTransactionHandle.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Transaction handle for OpenSearch connector.
+ * OpenSearch doesn't support transactions, so this is a simple identifier.
+ */
+public class OpenSearchTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    private final UUID uuid;
+
+    public OpenSearchTransactionHandle()
+    {
+        this(UUID.randomUUID());
+    }
+
+    @JsonCreator
+    public OpenSearchTransactionHandle(@JsonProperty("uuid") UUID uuid)
+    {
+        this.uuid = requireNonNull(uuid, "uuid is null");
+    }
+
+    @JsonProperty
+    public UUID getUuid()
+    {
+        return uuid;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        OpenSearchTransactionHandle other = (OpenSearchTransactionHandle) obj;
+        return Objects.equals(uuid, other.uuid);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(uuid);
+    }
+
+    @Override
+    public String toString()
+    {
+        return uuid.toString();
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/QueryBuilder.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/QueryBuilder.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds OpenSearch queries from Presto predicates.
+ * Translates SQL WHERE clauses to OpenSearch Query DSL.
+ * Supports nested field queries with automatic optimization.
+ */
+public class QueryBuilder
+{
+    private static final Logger log = Logger.get(QueryBuilder.class);
+
+    private final boolean optimizeNestedQueries;
+
+    public QueryBuilder()
+    {
+        this(true);
+    }
+
+    public QueryBuilder(boolean optimizeNestedQueries)
+    {
+        this.optimizeNestedQueries = optimizeNestedQueries;
+    }
+
+    public String buildQuery(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        if (tupleDomain.isAll()) {
+            return "{\"match_all\":{}}";
+        }
+
+        if (tupleDomain.isNone()) {
+            return "{\"match_none\":{}}";
+        }
+
+        Map<ColumnHandle, Domain> domains = tupleDomain.getDomains().get();
+        if (domains.isEmpty()) {
+            return "{\"match_all\":{}}";
+        }
+
+        List<String> conditions = new ArrayList<>();
+
+        // Group nested field predicates by parent path for optimization
+        if (optimizeNestedQueries) {
+            Map<String, List<NestedPredicate>> nestedPredicates = groupNestedPredicates(domains);
+
+            // Build optimized nested queries
+            for (Map.Entry<String, List<NestedPredicate>> entry : nestedPredicates.entrySet()) {
+                String parentPath = entry.getKey();
+                List<NestedPredicate> predicates = entry.getValue();
+
+                if (predicates.size() == 1) {
+                    // Single predicate - use simple nested query
+                    conditions.add(predicates.get(0).query);
+                }
+                else {
+                    // Multiple predicates on same parent - group them
+                    conditions.add(buildGroupedNestedQuery(parentPath, predicates));
+                }
+            }
+
+            // Add flat field conditions
+            for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+                OpenSearchColumnHandle column = (OpenSearchColumnHandle) entry.getKey();
+                if (!column.isNestedField()) {
+                    String condition = buildCondition(column, entry.getValue());
+                    if (condition != null) {
+                        conditions.add(condition);
+                    }
+                }
+            }
+        }
+        else {
+            // No optimization - build conditions individually
+            for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+                OpenSearchColumnHandle column = (OpenSearchColumnHandle) entry.getKey();
+                Domain domain = entry.getValue();
+
+                String condition = buildCondition(column, domain);
+                if (condition != null) {
+                    conditions.add(condition);
+                }
+            }
+        }
+
+        if (conditions.isEmpty()) {
+            return "{\"match_all\":{}}";
+        }
+
+        if (conditions.size() == 1) {
+            return conditions.get(0);
+        }
+
+        // Multiple conditions - use bool query with must
+        StringBuilder query = new StringBuilder();
+        query.append("{\"bool\":{\"must\":[");
+        query.append(String.join(",", conditions));
+        query.append("]}}");
+
+        return query.toString();
+    }
+
+    private String buildCondition(OpenSearchColumnHandle column, Domain domain)
+    {
+        if (domain.isNullAllowed()) {
+            // Handle NULL values
+            return null; // Skip for now
+        }
+
+        // Check if this is a nested field
+        if (column.isNestedField()) {
+            return buildNestedCondition(column, domain);
+        }
+
+        // Flat field logic
+        if (domain.isSingleValue()) {
+            Object value = domain.getSingleValue();
+            return buildTermQuery(column.getColumnName(), value);
+        }
+
+        List<Range> ranges = ImmutableList.copyOf(domain.getValues().getRanges().getOrderedRanges());
+        if (ranges.size() == 1) {
+            Range range = ranges.get(0);
+            return buildRangeQuery(column.getColumnName(), range);
+        }
+
+        // Multiple ranges - use bool should
+        List<String> rangeQueries = new ArrayList<>();
+        for (Range range : ranges) {
+            String rangeQuery = buildRangeQuery(column.getColumnName(), range);
+            if (rangeQuery != null) {
+                rangeQueries.add(rangeQuery);
+            }
+        }
+
+        if (rangeQueries.isEmpty()) {
+            return null;
+        }
+
+        if (rangeQueries.size() == 1) {
+            return rangeQueries.get(0);
+        }
+
+        return "{\"bool\":{\"should\":[" + String.join(",", rangeQueries) + "]}}";
+    }
+
+    /**
+     * Builds an OpenSearch nested query for a nested field predicate.
+     *
+     * Example:
+     * SQL: WHERE token_usage.total_tokens > 50000
+     *
+     * OpenSearch DSL:
+     * {
+     *   "nested": {
+     *     "path": "token_usage",
+     *     "query": {
+     *       "range": {
+     *         "token_usage.total_tokens": {"gt": 50000}
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    private String buildNestedCondition(OpenSearchColumnHandle column, Domain domain)
+    {
+        String parentPath = column.getParentFieldPath();
+        String fullFieldPath = column.getColumnName();
+
+        // Build inner query
+        String innerQuery;
+        if (domain.isSingleValue()) {
+            Object value = domain.getSingleValue();
+            innerQuery = buildTermQuery(fullFieldPath, value);
+        }
+        else {
+            List<Range> ranges = ImmutableList.copyOf(domain.getValues().getRanges().getOrderedRanges());
+            if (ranges.size() == 1) {
+                innerQuery = buildRangeQuery(fullFieldPath, ranges.get(0));
+            }
+            else {
+                // Multiple ranges
+                List<String> rangeQueries = new ArrayList<>();
+                for (Range range : ranges) {
+                    String rangeQuery = buildRangeQuery(fullFieldPath, range);
+                    if (rangeQuery != null) {
+                        rangeQueries.add(rangeQuery);
+                    }
+                }
+                innerQuery = "{\"bool\":{\"should\":[" + String.join(",", rangeQueries) + "]}}";
+            }
+        }
+
+        // Wrap in nested query
+        String nestedQuery = String.format(
+                "{\"nested\":{\"path\":\"%s\",\"query\":%s}}",
+                parentPath,
+                innerQuery);
+
+        log.debug("Built nested query for field %s: %s", fullFieldPath, nestedQuery);
+        return nestedQuery;
+    }
+
+    /**
+     * Groups nested field predicates by parent path for optimization.
+     * This allows multiple predicates on the same nested object to be combined.
+     */
+    private Map<String, List<NestedPredicate>> groupNestedPredicates(
+            Map<ColumnHandle, Domain> domains)
+    {
+        Map<String, List<NestedPredicate>> grouped = new HashMap<>();
+
+        for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+            OpenSearchColumnHandle column = (OpenSearchColumnHandle) entry.getKey();
+            if (column.isNestedField()) {
+                String parentPath = column.getParentFieldPath();
+                String innerQuery = buildInnerQuery(column, entry.getValue());
+
+                if (innerQuery != null) {
+                    grouped.computeIfAbsent(parentPath, k -> new ArrayList<>())
+                            .add(new NestedPredicate(
+                                    buildNestedCondition(column, entry.getValue()),
+                                    innerQuery));
+                }
+            }
+        }
+
+        return grouped;
+    }
+
+    /**
+     * Builds the inner query for a nested field (without the nested wrapper).
+     */
+    private String buildInnerQuery(OpenSearchColumnHandle column, Domain domain)
+    {
+        String fullFieldPath = column.getColumnName();
+
+        if (domain.isSingleValue()) {
+            return buildTermQuery(fullFieldPath, domain.getSingleValue());
+        }
+
+        List<Range> ranges = ImmutableList.copyOf(domain.getValues().getRanges().getOrderedRanges());
+        if (ranges.size() == 1) {
+            return buildRangeQuery(fullFieldPath, ranges.get(0));
+        }
+
+        // Multiple ranges
+        List<String> rangeQueries = new ArrayList<>();
+        for (Range range : ranges) {
+            String rangeQuery = buildRangeQuery(fullFieldPath, range);
+            if (rangeQuery != null) {
+                rangeQueries.add(rangeQuery);
+            }
+        }
+
+        if (rangeQueries.isEmpty()) {
+            return null;
+        }
+
+        return "{\"bool\":{\"should\":[" + String.join(",", rangeQueries) + "]}}";
+    }
+
+    /**
+     * Builds an optimized nested query that groups multiple predicates on the same parent.
+     *
+     * Example:
+     * SQL: WHERE token_usage.total_tokens > 50000 AND token_usage.output_tokens < 2000
+     *
+     * OpenSearch DSL:
+     * {
+     *   "nested": {
+     *     "path": "token_usage",
+     *     "query": {
+     *       "bool": {
+     *         "must": [
+     *           {"range": {"token_usage.total_tokens": {"gt": 50000}}},
+     *           {"range": {"token_usage.output_tokens": {"lt": 2000}}}
+     *         ]
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    private String buildGroupedNestedQuery(String parentPath, List<NestedPredicate> predicates)
+    {
+        List<String> innerQueries = new ArrayList<>();
+        for (NestedPredicate predicate : predicates) {
+            innerQueries.add(predicate.innerQuery);
+        }
+
+        String combinedInnerQuery = "{\"bool\":{\"must\":[" +
+                                   String.join(",", innerQueries) + "]}}";
+
+        String groupedQuery = String.format(
+                "{\"nested\":{\"path\":\"%s\",\"query\":%s}}",
+                parentPath,
+                combinedInnerQuery);
+
+        log.debug("Built grouped nested query for path %s with %d predicates",
+                 parentPath, predicates.size());
+        return groupedQuery;
+    }
+
+    /**
+     * Helper class to store nested predicate information.
+     */
+    private static class NestedPredicate
+    {
+        final String query;       // Full nested query
+        final String innerQuery;  // Inner query without nested wrapper
+
+        NestedPredicate(String query, String innerQuery)
+        {
+            this.query = query;
+            this.innerQuery = innerQuery;
+        }
+    }
+
+    private String buildTermQuery(String field, Object value)
+    {
+        String valueStr = formatValue(value);
+        return "{\"term\":{\"" + field + "\":" + valueStr + "}}";
+    }
+
+    private String buildRangeQuery(String field, Range range)
+    {
+        StringBuilder query = new StringBuilder();
+        query.append("{\"range\":{\"").append(field).append("\":{");
+
+        List<String> conditions = new ArrayList<>();
+
+        if (!range.isLowUnbounded()) {
+            String operator = range.isLowInclusive() ? "gte" : "gt";
+            conditions.add("\"" + operator + "\":" + formatValue(range.getLowBoundedValue()));
+        }
+
+        if (!range.isHighUnbounded()) {
+            String operator = range.isHighInclusive() ? "lte" : "lt";
+            conditions.add("\"" + operator + "\":" + formatValue(range.getHighBoundedValue()));
+        }
+
+        if (conditions.isEmpty()) {
+            return null;
+        }
+
+        query.append(String.join(",", conditions));
+        query.append("}}}");
+
+        return query.toString();
+    }
+
+    private String formatValue(Object value)
+    {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof String) {
+            return "\"" + escapeJson((String) value) + "\"";
+        }
+        if (value instanceof Number || value instanceof Boolean) {
+            return value.toString();
+        }
+        return "\"" + value.toString() + "\"";
+    }
+
+    private String escapeJson(String value)
+    {
+        return value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/VectorSearchHandler.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/VectorSearchHandler.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.PrestoException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Handles vector search operations for OpenSearch k-NN plugin.
+ * Translates vector search requests into OpenSearch k-NN query DSL.
+ *
+ * Supports:
+ * - Basic k-NN search with configurable distance metrics
+ * - Hybrid search combining vector similarity with filters
+ * - Efficient search with ef_search parameter
+ * - Multiple distance metrics: cosine, euclidean (l2), dot_product (inner_product)
+ */
+public class VectorSearchHandler
+{
+    private static final Logger log = Logger.get(VectorSearchHandler.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final OpenSearchConfig config;
+
+    @Inject
+    public VectorSearchHandler(OpenSearchConfig config)
+    {
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    /**
+     * Builds a k-NN vector search query using OpenSearch k-NN plugin.
+     *
+     * @param vectorField The name of the vector field
+     * @param queryVector The query vector as float array
+     * @param k The number of nearest neighbors to return
+     * @return JSON string representing the k-NN query
+     */
+    public String buildKnnQuery(String vectorField, float[] queryVector, int k)
+    {
+        return buildKnnQuery(vectorField, queryVector, k, "cosine", null);
+    }
+
+    /**
+     * Builds a k-NN vector search query with specified distance metric.
+     *
+     * @param vectorField The name of the vector field
+     * @param queryVector The query vector as float array
+     * @param k The number of nearest neighbors to return
+     * @param spaceType Distance metric: "cosine", "l2" (euclidean), "inner_product" (dot product)
+     * @param efSearch Efficiency parameter for HNSW algorithm (null for default)
+     * @return JSON string representing the k-NN query
+     */
+    public String buildKnnQuery(
+            String vectorField,
+            float[] queryVector,
+            int k,
+            String spaceType,
+            Integer efSearch)
+    {
+        requireNonNull(vectorField, "vectorField is null");
+        requireNonNull(queryVector, "queryVector is null");
+        requireNonNull(spaceType, "spaceType is null");
+
+        validateVectorSearchEnabled();
+        validateK(k);
+        validateQueryVector(queryVector);
+        validateSpaceType(spaceType);
+
+        try {
+            Map<String, Object> knnQuery = new HashMap<>();
+            Map<String, Object> fieldQuery = new HashMap<>();
+
+            fieldQuery.put("vector", queryVector);
+            fieldQuery.put("k", k);
+
+            // Add ef_search if specified (for HNSW algorithm tuning)
+            if (efSearch != null && efSearch > 0) {
+                fieldQuery.put("ef_search", efSearch);
+            }
+
+            knnQuery.put(vectorField, fieldQuery);
+
+            Map<String, Object> query = new HashMap<>();
+            query.put("knn", knnQuery);
+
+            String queryJson = OBJECT_MAPPER.writeValueAsString(query);
+            log.debug("Built k-NN query for field %s with k=%d, space_type=%s: %s",
+                    vectorField, k, spaceType, queryJson);
+
+            return queryJson;
+        }
+        catch (JsonProcessingException e) {
+            throw new PrestoException(NOT_SUPPORTED, "Failed to build k-NN query", e);
+        }
+    }
+
+    /**
+     * Builds a hybrid search query combining k-NN vector search with filters.
+     * Uses the efficient_filter approach for better performance.
+     *
+     * @param vectorField The name of the vector field
+     * @param queryVector The query vector as float array
+     * @param k The number of nearest neighbors to return
+     * @param filterQuery JSON string representing the filter query
+     * @return JSON string representing the hybrid search query
+     */
+    public String buildHybridSearchQuery(
+            String vectorField,
+            float[] queryVector,
+            int k,
+            String filterQuery)
+    {
+        return buildHybridSearchQuery(vectorField, queryVector, k, filterQuery, "cosine", null);
+    }
+
+    /**
+     * Builds a hybrid search query with specified distance metric.
+     *
+     * @param vectorField The name of the vector field
+     * @param queryVector The query vector as float array
+     * @param k The number of nearest neighbors to return
+     * @param filterQuery JSON string representing the filter query
+     * @param spaceType Distance metric
+     * @param efSearch Efficiency parameter for HNSW algorithm
+     * @return JSON string representing the hybrid search query
+     */
+    public String buildHybridSearchQuery(
+            String vectorField,
+            float[] queryVector,
+            int k,
+            String filterQuery,
+            String spaceType,
+            Integer efSearch)
+    {
+        requireNonNull(vectorField, "vectorField is null");
+        requireNonNull(queryVector, "queryVector is null");
+        requireNonNull(filterQuery, "filterQuery is null");
+        requireNonNull(spaceType, "spaceType is null");
+
+        validateVectorSearchEnabled();
+        validateK(k);
+        validateQueryVector(queryVector);
+        validateSpaceType(spaceType);
+
+        try {
+            // Parse the filter query
+            @SuppressWarnings("unchecked")
+            Map<String, Object> filter = OBJECT_MAPPER.readValue(filterQuery, Map.class);
+
+            // Build k-NN query with filter
+            Map<String, Object> knnQuery = new HashMap<>();
+            Map<String, Object> fieldQuery = new HashMap<>();
+
+            fieldQuery.put("vector", queryVector);
+            fieldQuery.put("k", k);
+            fieldQuery.put("filter", filter);
+
+            if (efSearch != null && efSearch > 0) {
+                fieldQuery.put("ef_search", efSearch);
+            }
+
+            knnQuery.put(vectorField, fieldQuery);
+
+            Map<String, Object> query = new HashMap<>();
+            query.put("knn", knnQuery);
+
+            String queryJson = OBJECT_MAPPER.writeValueAsString(query);
+            log.debug("Built hybrid k-NN query for field %s with k=%d, space_type=%s, filter: %s",
+                    vectorField, k, spaceType, filterQuery);
+
+            return queryJson;
+        }
+        catch (JsonProcessingException e) {
+            throw new PrestoException(NOT_SUPPORTED, "Failed to build hybrid k-NN query", e);
+        }
+    }
+
+    /**
+     * Builds a script score query for vector similarity.
+     * Useful when you need more control over scoring or when k-NN is not available.
+     *
+     * @param vectorField The name of the vector field
+     * @param queryVector The query vector as float array
+     * @param spaceType Distance metric
+     * @return JSON string representing the script score query
+     */
+    public String buildScriptScoreQuery(
+            String vectorField,
+            float[] queryVector,
+            String spaceType)
+    {
+        requireNonNull(vectorField, "vectorField is null");
+        requireNonNull(queryVector, "queryVector is null");
+        requireNonNull(spaceType, "spaceType is null");
+
+        validateVectorSearchEnabled();
+        validateQueryVector(queryVector);
+        validateSpaceType(spaceType);
+
+        try {
+            // Map space type to script function
+            String scriptFunction = getScriptFunction(spaceType);
+
+            Map<String, Object> scriptParams = new HashMap<>();
+            scriptParams.put("field", vectorField);
+            scriptParams.put("query_value", queryVector);
+
+            Map<String, Object> script = new HashMap<>();
+            script.put("source", scriptFunction);
+            script.put("params", scriptParams);
+
+            Map<String, Object> scriptScore = new HashMap<>();
+            scriptScore.put("query", Map.of("match_all", Map.of()));
+            scriptScore.put("script", script);
+
+            Map<String, Object> query = new HashMap<>();
+            query.put("script_score", scriptScore);
+
+            String queryJson = OBJECT_MAPPER.writeValueAsString(query);
+            log.debug("Built script score query for field %s with space_type=%s",
+                    vectorField, spaceType);
+
+            return queryJson;
+        }
+        catch (JsonProcessingException e) {
+            throw new PrestoException(NOT_SUPPORTED, "Failed to build script score query", e);
+        }
+    }
+
+    private String getScriptFunction(String spaceType)
+    {
+        switch (spaceType.toLowerCase(java.util.Locale.ENGLISH)) {
+            case "cosine":
+            case "cosinesimil":
+                return "cosineSimilarity(params.query_value, params.field) + 1.0";
+            case "l2":
+            case "euclidean":
+                return "1 / (1 + l2norm(params.query_value, params.field))";
+            case "inner_product":
+            case "dot_product":
+                return "dotProduct(params.query_value, params.field) + 1.0";
+            default:
+                throw new PrestoException(NOT_SUPPORTED,
+                        "Unsupported space type for script score: " + spaceType);
+        }
+    }
+
+    private void validateVectorSearchEnabled()
+    {
+        if (!config.isVectorSearchEnabled()) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "Vector search is not enabled. Set opensearch.vector-search.enabled=true");
+        }
+    }
+
+    private void validateK(int k)
+    {
+        if (k <= 0) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "k must be positive, got: " + k);
+        }
+    }
+
+    private void validateQueryVector(float[] queryVector)
+    {
+        if (queryVector.length == 0) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "Query vector cannot be empty");
+        }
+    }
+
+    private void validateSpaceType(String spaceType)
+    {
+        String normalized = spaceType.toLowerCase(java.util.Locale.ENGLISH);
+        if (!normalized.equals("cosine") &&
+                !normalized.equals("cosinesimil") &&
+                !normalized.equals("l2") &&
+                !normalized.equals("euclidean") &&
+                !normalized.equals("inner_product") &&
+                !normalized.equals("dot_product")) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "Unsupported space type: " + spaceType +
+                    ". Supported types: cosine, l2, inner_product");
+        }
+    }
+
+    /**
+     * Calculates cosine similarity between two vectors.
+     *
+     * @param vector1 First vector
+     * @param vector2 Second vector
+     * @return Cosine similarity score between -1 and 1
+     */
+    public static double cosineSimilarity(float[] vector1, float[] vector2)
+    {
+        requireNonNull(vector1, "vector1 is null");
+        requireNonNull(vector2, "vector2 is null");
+
+        if (vector1.length != vector2.length) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    String.format("Vector dimensions must match: %d vs %d",
+                            vector1.length, vector2.length));
+        }
+
+        if (vector1.length == 0) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "Vectors cannot be empty");
+        }
+
+        double dotProduct = 0.0;
+        double norm1 = 0.0;
+        double norm2 = 0.0;
+
+        for (int i = 0; i < vector1.length; i++) {
+            dotProduct += vector1[i] * vector2[i];
+            norm1 += vector1[i] * vector1[i];
+            norm2 += vector2[i] * vector2[i];
+        }
+
+        if (norm1 == 0.0 || norm2 == 0.0) {
+            return 0.0;
+        }
+
+        return dotProduct / (Math.sqrt(norm1) * Math.sqrt(norm2));
+    }
+
+    /**
+     * Calculates Euclidean distance between two vectors.
+     *
+     * @param vector1 First vector
+     * @param vector2 Second vector
+     * @return Euclidean distance
+     */
+    public static double euclideanDistance(float[] vector1, float[] vector2)
+    {
+        requireNonNull(vector1, "vector1 is null");
+        requireNonNull(vector2, "vector2 is null");
+
+        if (vector1.length != vector2.length) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    String.format("Vector dimensions must match: %d vs %d",
+                            vector1.length, vector2.length));
+        }
+
+        if (vector1.length == 0) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "Vectors cannot be empty");
+        }
+
+        double sum = 0.0;
+        for (int i = 0; i < vector1.length; i++) {
+            double diff = vector1[i] - vector2[i];
+            sum += diff * diff;
+        }
+
+        return Math.sqrt(sum);
+    }
+
+    /**
+     * Calculates dot product between two vectors.
+     *
+     * @param vector1 First vector
+     * @param vector2 Second vector
+     * @return Dot product
+     */
+    public static double dotProduct(float[] vector1, float[] vector2)
+    {
+        requireNonNull(vector1, "vector1 is null");
+        requireNonNull(vector2, "vector2 is null");
+
+        if (vector1.length != vector2.length) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    String.format("Vector dimensions must match: %d vs %d",
+                            vector1.length, vector2.length));
+        }
+
+        if (vector1.length == 0) {
+            throw new PrestoException(
+                    NOT_SUPPORTED,
+                    "Vectors cannot be empty");
+        }
+
+        double result = 0.0;
+        for (int i = 0; i < vector1.length; i++) {
+            result += vector1[i] * vector2[i];
+        }
+
+        return result;
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/package-info.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OpenSearch connector for Presto.
+ * <p>
+ * This connector enables Presto to query OpenSearch indices using SQL.
+ * It supports:
+ * <ul>
+ *   <li>Full SQL query capabilities (SELECT, WHERE, projections,
+ *   aggregations)</li>
+ *   <li>Predicate pushdown for efficient filtering at the
+ *   source</li>
+ *   <li>Comprehensive type system including arrays, maps, and nested
+ *   structures</li>
+ *   <li>Vector search support for k-NN queries</li>
+ *   <li>Distributed execution with shard-aware splitting</li>
+ *   <li>Scroll API for efficient pagination of large result sets</li>
+ * </ul>
+ */
+package com.facebook.presto.plugin.opensearch;

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/types/TypeMapper.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/types/TypeMapper.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch.types;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+/**
+ * Maps OpenSearch field types to Presto types.
+ * Provides robust error handling for unknown or malformed type names.
+ */
+public final class TypeMapper
+{
+    private static final Logger log = Logger.get(TypeMapper.class);
+
+    private TypeMapper() {}
+
+    public static Type toPrestoType(String openSearchType, Map<String, Object> properties, String fieldName)
+    {
+        // Validate input - protect against null or malformed type strings
+        if (openSearchType == null || openSearchType.trim().isEmpty()) {
+            log.warn("Null or empty OpenSearch type for field '%s', defaulting to VARCHAR", fieldName);
+            return VARCHAR;
+        }
+
+        // Sanitize type string - remove any field name prefix if present
+        String sanitizedType = sanitizeTypeString(openSearchType, fieldName);
+
+        // Check if this is an embedding/vector field that should be treated as an array
+        if (fieldName != null && (fieldName.equals("embedding") || fieldName.contains("vector") || fieldName.contains("embedding"))) {
+            if ("float".equalsIgnoreCase(sanitizedType) || "half_float".equalsIgnoreCase(sanitizedType)) {
+                return new ArrayType(REAL);
+            }
+        }
+        return toPrestoType(sanitizedType, properties);
+    }
+
+    public static Type toPrestoType(String openSearchType, Map<String, Object> properties)
+    {
+        // Validate input
+        if (openSearchType == null || openSearchType.trim().isEmpty()) {
+            log.warn("Null or empty OpenSearch type, defaulting to VARCHAR");
+            return VARCHAR;
+        }
+
+        // Sanitize and normalize the type string
+        String sanitizedType = sanitizeTypeString(openSearchType, null);
+
+        switch (sanitizedType.toLowerCase(Locale.ENGLISH)) {
+            case "text":
+            case "keyword":
+            case "ip":
+            case "varchar":
+                return VARCHAR;
+
+            case "long":
+            case "bigint":
+                return BIGINT;
+
+            case "integer":
+                return INTEGER;
+
+            case "short":
+            case "smallint":
+                return SMALLINT;
+
+            case "byte":
+            case "tinyint":
+                return TINYINT;
+
+            case "double":
+            case "scaled_float":
+                return DOUBLE;
+
+            case "float":
+            case "half_float":
+            case "real":
+                // Check if this is actually an array field (OpenSearch doesn't have explicit array types)
+                // If the field name suggests it's an embedding/vector, treat it as an array
+                // This is a heuristic for dynamically mapped array fields
+                return REAL;
+
+            case "boolean":
+                return BOOLEAN;
+
+            case "date":
+                // OpenSearch date type - always map to Presto DATE
+                // OpenSearchPageSource will handle the conversion from whatever format OpenSearch returns
+                return DATE;
+
+            case "binary":
+            case "varbinary":
+                return VARBINARY;
+
+            case "knn_vector":
+                // Vector fields are represented as ARRAY(REAL)
+                return new ArrayType(REAL);
+
+            case "nested":
+            case "object":
+                // For now, treat nested/object as VARCHAR (JSON string)
+                // TODO: Implement proper ROW type mapping
+                return VARCHAR;
+
+            default:
+                // Unknown types default to VARCHAR with warning
+                log.warn("Unknown OpenSearch type '%s', defaulting to VARCHAR. " +
+                        "This may indicate a custom type, plugin-provided type, or malformed type string. " +
+                        "Consider adding explicit mapping if this type is commonly used.", sanitizedType);
+                return VARCHAR;
+        }
+    }
+
+    public static Type toPrestoType(String openSearchType)
+    {
+        return toPrestoType(openSearchType, Map.of());
+    }
+
+    /**
+     * Sanitizes a type string to extract just the type name, removing any field name prefix.
+     * Handles cases where type strings may be malformed like "field_name type_name".
+     *
+     * @param typeString The type string to sanitize
+     * @param fieldName The field name (optional, used for better error messages)
+     * @return Sanitized type string containing only the type name
+     */
+    private static String sanitizeTypeString(String typeString, String fieldName)
+    {
+        if (typeString == null) {
+            return "";
+        }
+
+        String trimmed = typeString.trim();
+
+        // Check if the type string contains spaces (potential malformed string like "field_name bigint")
+        if (trimmed.contains(" ")) {
+            String[] parts = trimmed.split("\\s+");
+
+            // Try to find a known type in the parts
+            // Check last part first (most common case: "field_name type")
+            if (parts.length >= 2) {
+                String lastPart = parts[parts.length - 1].toLowerCase(Locale.ENGLISH);
+                if (isKnownType(lastPart)) {
+                    log.warn("Type string '%s' for field '%s' appears malformed (contains field name). " +
+                            "Extracted type '%s'. This may indicate a serialization issue.",
+                            typeString, fieldName, lastPart);
+                    return lastPart;
+                }
+            }
+
+            // Check first part (case: "type field_name")
+            String firstPart = parts[0].toLowerCase(Locale.ENGLISH);
+            if (isKnownType(firstPart)) {
+                log.warn("Type string '%s' for field '%s' appears malformed (contains field name). " +
+                        "Extracted type '%s'. This may indicate a serialization issue.",
+                        typeString, fieldName, firstPart);
+                return firstPart;
+            }
+
+            // If we can't determine the correct part, log warning and use first part
+            log.warn("Type string '%s' for field '%s' contains spaces and cannot be parsed reliably. " +
+                    "Using first token '%s'. This may cause type mapping issues.",
+                    typeString, fieldName, parts[0]);
+            return parts[0];
+        }
+
+        return trimmed;
+    }
+
+    /**
+     * Checks if a type string is a known OpenSearch/Presto type.
+     *
+     * @param type The type string to check
+     * @return true if the type is known, false otherwise
+     */
+    private static boolean isKnownType(String type)
+    {
+        switch (type.toLowerCase(Locale.ENGLISH)) {
+            case "text":
+            case "keyword":
+            case "ip":
+            case "long":
+            case "integer":
+            case "short":
+            case "byte":
+            case "double":
+            case "scaled_float":
+            case "float":
+            case "half_float":
+            case "boolean":
+            case "date":
+            case "binary":
+            case "knn_vector":
+            case "nested":
+            case "object":
+            case "bigint":
+            case "varchar":
+            case "real":
+            case "smallint":
+            case "tinyint":
+            case "varbinary":
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/types/package-info.java
+++ b/presto-opensearch/src/main/java/com/facebook/presto/plugin/opensearch/types/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Type mapping utilities for OpenSearch connector.
+ * <p>
+ * This package contains classes for mapping between OpenSearch field types
+ * and Presto types, including support for:
+ * <ul>
+ *   <li>Primitive types (text, keyword, numeric types, boolean, date)</li>
+ *   <li>Complex types (nested, object)</li>
+ *   <li>Array types</li>
+ *   <li>Vector types (knn_vector for similarity search)</li>
+ * </ul>
+ */
+package com.facebook.presto.plugin.opensearch.types;

--- a/presto-opensearch/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
+++ b/presto-opensearch/src/main/resources/META-INF/services/com.facebook.presto.spi.Plugin
@@ -1,0 +1,1 @@
+com.facebook.presto.plugin.opensearch.OpenSearchPlugin

--- a/presto-opensearch/src/main/resources/opensearch.properties.example
+++ b/presto-opensearch/src/main/resources/opensearch.properties.example
@@ -1,0 +1,79 @@
+# OpenSearch Connector Configuration Example
+# Copy this file to etc/catalog/opensearch.properties and customize
+
+# Connector name (required)
+connector.name=opensearch
+
+# Connection Settings
+opensearch.host=localhost
+opensearch.port=9200
+opensearch.scheme=https
+
+# Authentication (Basic Auth)
+opensearch.auth.username=admin
+opensearch.auth.password=admin
+
+# SSL/TLS Configuration
+opensearch.ssl.enabled=true
+opensearch.ssl.verify-hostname=true
+
+# Skip SSL certificate validation (for expired/self-signed certificates)
+# WARNING: Only use for testing/development. Set to false in production.
+# Default: false
+opensearch.ssl.skip-certificate-validation=false
+
+# Optional: Use custom truststore for valid certificates
+# opensearch.ssl.truststore.path=/path/to/truststore.jks
+# opensearch.ssl.truststore.password=changeit
+
+# Query Settings
+opensearch.scroll.size=1000
+opensearch.scroll.timeout=5m
+opensearch.max-connections=100
+opensearch.connection-timeout=10000
+opensearch.socket-timeout=60000
+
+# Schema Discovery
+opensearch.schema-pattern=*
+opensearch.hide-system-indices=true
+opensearch.max-result-window=10000
+
+# Vector Search (k-NN Plugin)
+# Enable vector search support using OpenSearch k-NN plugin
+opensearch.vector-search.enabled=true
+
+# Default number of nearest neighbors to return
+opensearch.vector-search.default-k=10
+
+# Default distance metric: cosine, l2 (euclidean), or inner_product (dot product)
+opensearch.vector-search.default-space-type=cosine
+
+# Default ef_search parameter for HNSW algorithm (higher = better accuracy, slower)
+# Typical range: 50-500, default: 100
+opensearch.vector-search.default-ef-search=100
+
+# Nested Field Access (NEW)
+# Enable querying nested JSON fields with dot notation (e.g., token_usage.total_tokens)
+opensearch.nested.enabled=true
+
+# Maximum depth for nested field discovery (default: 5)
+# Prevents infinite recursion and performance issues
+opensearch.nested.max-depth=5
+
+# Optimize nested queries by grouping predicates on the same parent (default: true)
+# Example: WHERE token_usage.total_tokens > 50000 AND token_usage.output_tokens < 2000
+# Will be combined into a single nested query for better performance
+opensearch.nested.optimize-queries=true
+
+# Discover dynamic fields not in mapping (default: false)
+# Set to true for exploratory analysis, false for production (safer)
+opensearch.nested.discover-dynamic-fields=false
+
+# Log warnings when nested fields are missing in documents (default: false)
+# Useful for debugging but can be noisy in production
+
+# Column Visibility
+# Hide the _id column from table schema (default: false)
+# Set to true if you don't need to query the document ID column
+opensearch.hide-document-id-column=false
+opensearch.nested.log-missing-fields=false

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/OpenSearchQueryRunner.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/OpenSearchQueryRunner.java
@@ -1,0 +1,407 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.log.Logging;
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
+import org.apache.http.HttpHost;
+import org.opensearch.client.Request;
+import org.opensearch.client.RestClient;
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+/**
+ * Query runner for OpenSearch connector tests.
+ * Sets up a DistributedQueryRunner with OpenSearch catalog configured.
+ */
+public final class OpenSearchQueryRunner
+{
+    private static final Logger log = Logger.get(OpenSearchQueryRunner.class);
+    private static final String OPENSEARCH_CATALOG = "opensearch";
+    private static final String OPENSEARCH_SCHEMA = "default";
+
+    private OpenSearchQueryRunner()
+    {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Create a DistributedQueryRunner with OpenSearch connector.
+     *
+     * @param opensearchContainer The OpenSearch testcontainer instance
+     * @param tables TPCH tables to load into OpenSearch
+     * @return Configured DistributedQueryRunner
+     * @throws Exception if setup fails
+     */
+    public static DistributedQueryRunner createQueryRunner(
+            GenericContainer<?> opensearchContainer,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createQueryRunner(opensearchContainer, tables, ImmutableMap.of(), ImmutableMap.of());
+    }
+
+    /**
+     * Create a DistributedQueryRunner with OpenSearch connector and custom properties.
+     *
+     * @param opensearchContainer The OpenSearch testcontainer instance
+     * @param tables TPCH tables to load into OpenSearch
+     * @param extraProperties Extra properties for the query runner
+     * @param coordinatorProperties Coordinator-specific properties
+     * @return Configured DistributedQueryRunner
+     * @throws Exception if setup fails
+     */
+    public static DistributedQueryRunner createQueryRunner(
+            GenericContainer<?> opensearchContainer,
+            Iterable<TpchTable<?>> tables,
+            Map<String, String> extraProperties,
+            Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        // Use OpenSearch catalog as default for inherited AbstractTestQueries tests
+        Session session = testSessionBuilder()
+                .setCatalog(OPENSEARCH_CATALOG)
+                .setSchema(OPENSEARCH_SCHEMA)
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setExtraProperties(extraProperties)
+                .setCoordinatorProperties(coordinatorProperties)
+                .build();
+
+        try {
+            // Install TPCH plugin first (needed for copying data)
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
+
+            log.info("TPCH catalog created successfully");
+
+            // Install OpenSearch plugin
+            queryRunner.installPlugin(new OpenSearchPlugin());
+
+            // Get OpenSearch connection details from container
+            String host = opensearchContainer.getHost();
+            Integer port = opensearchContainer.getMappedPort(9200);
+            String opensearchUrl = String.format("http://%s:%d", host, port);
+
+            log.info("Connecting to OpenSearch at: %s", opensearchUrl);
+
+            // Create main catalog with _id hidden for TPCH compatibility (inherited AbstractTestQueries tests)
+            Map<String, String> catalogProperties = ImmutableMap.<String, String>builder()
+                    .put("opensearch.host", host)
+                    .put("opensearch.port", String.valueOf(port))
+                    .put("opensearch.scheme", "http")
+                    .put("opensearch.ssl.enabled", "false")
+                    .put("opensearch.scroll.size", "1000")
+                    .put("opensearch.scroll.timeout", "5m")
+                    .put("opensearch.socket-timeout", "60000")
+                    .put("opensearch.connection-timeout", "10000")
+                    // Enable nested field support
+                    .put("opensearch.nested.enabled", "true")
+                    .put("opensearch.nested.max-depth", "5")
+                    // Hide _id column for TPCH compatibility
+                    .put("opensearch.hide-document-id-column", "true")
+                    .build();
+
+            queryRunner.createCatalog(OPENSEARCH_CATALOG, "opensearch", catalogProperties);
+
+            log.info("OpenSearch catalog created successfully");
+
+            // Create second catalog with _id visible for OpenSearch-specific tests
+            Map<String, String> catalogWithIdProperties = ImmutableMap.<String, String>builder()
+                    .put("opensearch.host", host)
+                    .put("opensearch.port", String.valueOf(port))
+                    .put("opensearch.scheme", "http")
+                    .put("opensearch.ssl.enabled", "false")
+                    .put("opensearch.scroll.size", "1000")
+                    .put("opensearch.scroll.timeout", "5m")
+                    .put("opensearch.socket-timeout", "60000")
+                    .put("opensearch.connection-timeout", "10000")
+                    // Enable nested field support
+                    .put("opensearch.nested.enabled", "true")
+                    .put("opensearch.nested.max-depth", "5")
+                    // Show _id column for OpenSearch-specific tests
+                    .put("opensearch.hide-document-id-column", "false")
+                    .build();
+
+            queryRunner.createCatalog("opensearch_with_id", "opensearch", catalogWithIdProperties);
+
+            log.info("OpenSearch catalog with _id created successfully");
+
+            // Load TPCH data into OpenSearch via REST API
+            log.info("Loading TPCH tables into OpenSearch...");
+            loadTpchDataIntoOpenSearch(queryRunner, opensearchContainer, tables);
+            log.info("TPCH tables loaded successfully");
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw new RuntimeException("Failed to create OpenSearchQueryRunner", e);
+        }
+    }
+
+    /**
+     * Load TPCH data into OpenSearch indices by querying TPCH catalog and indexing via REST API.
+     * Uses proper type mapping to ensure DATE fields are stored correctly.
+     */
+    private static void loadTpchDataIntoOpenSearch(
+            DistributedQueryRunner queryRunner,
+            GenericContainer<?> opensearchContainer,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        String host = opensearchContainer.getHost();
+        Integer port = opensearchContainer.getMappedPort(9200);
+
+        try (RestClient restClient = RestClient.builder(new HttpHost(host, port, "http")).build()) {
+            for (TpchTable<?> table : tables) {
+                String tableName = table.getTableName();
+                log.info("Loading TPCH table: %s", tableName);
+
+                // Query TPCH data
+                Session tpchSession = testSessionBuilder()
+                        .setCatalog("tpch")
+                        .setSchema(TINY_SCHEMA_NAME)
+                        .build();
+
+                // Get column metadata from TPCH
+                String describeQuery = "SELECT column_name, data_type FROM information_schema.columns " +
+                        "WHERE table_schema = '" + TINY_SCHEMA_NAME + "' AND table_name = '" + tableName + "' " +
+                        "ORDER BY ordinal_position";
+                MaterializedResult describeResult = queryRunner.execute(tpchSession, describeQuery);
+
+                List<String> columnNames = new ArrayList<>();
+                List<String> columnTypes = new ArrayList<>();
+                for (MaterializedRow row : describeResult.getMaterializedRows()) {
+                    columnNames.add((String) row.getField(0));
+                    columnTypes.add((String) row.getField(1));
+                }
+
+                // Create index with explicit mapping based on TPCH schema
+                String indexName = tableName.toLowerCase(Locale.ENGLISH);
+
+                // Delete index if it exists
+                try {
+                    Request deleteIndex = new Request("DELETE", "/" + indexName);
+                    restClient.performRequest(deleteIndex);
+                    log.info("Deleted existing index %s", indexName);
+                }
+                catch (Exception e) {
+                    log.debug("Index %s doesn't exist, will create new one", indexName);
+                }
+
+                // Build OpenSearch mapping with multiple shards for testing distributed queries
+                StringBuilder mapping = new StringBuilder();
+                mapping.append("{\"settings\":{\"number_of_shards\":5,\"number_of_replicas\":0,\"index.max_result_window\":100000},");
+                mapping.append("\"mappings\":{\"properties\":{");
+
+                for (int i = 0; i < columnNames.size(); i++) {
+                    if (i > 0) {
+                        mapping.append(",");
+                    }
+                    String columnName = columnNames.get(i);
+                    String prestoType = columnTypes.get(i);
+
+                    mapping.append("\"").append(columnName).append("\":{");
+
+                    // Map Presto types to OpenSearch types
+                    if (prestoType.equals("bigint")) {
+                        mapping.append("\"type\":\"long\"");
+                    }
+                    else if (prestoType.equals("integer")) {
+                        mapping.append("\"type\":\"integer\"");
+                    }
+                    else if (prestoType.equals("double")) {
+                        mapping.append("\"type\":\"double\"");
+                    }
+                    else if (prestoType.equals("real")) {
+                        mapping.append("\"type\":\"float\"");
+                    }
+                    else if (prestoType.equals("date")) {
+                        // Map date type to OpenSearch date with epoch_millis format
+                        mapping.append("\"type\":\"date\",\"format\":\"epoch_millis\"");
+                    }
+                    else if (prestoType.equals("timestamp")) {
+                        mapping.append("\"type\":\"date\",\"format\":\"epoch_millis\"");
+                    }
+                    else if (prestoType.startsWith("varchar") || prestoType.startsWith("char")) {
+                        mapping.append("\"type\":\"keyword\"");
+                    }
+                    else {
+                        mapping.append("\"type\":\"keyword\"");
+                    }
+
+                    mapping.append("}");
+                }
+
+                mapping.append("}}}");
+
+                // Create index
+                Request createIndex = new Request("PUT", "/" + indexName);
+                createIndex.setJsonEntity(mapping.toString());
+                restClient.performRequest(createIndex);
+                log.info("Created index %s with explicit mapping", indexName);
+
+                // Store column order and type metadata to preserve field order and VARCHAR lengths
+                // OpenSearch returns fields alphabetically and loses VARCHAR length info
+                OpenSearchConfig clientConfig = new OpenSearchConfig()
+                        .setHost(opensearchContainer.getHost())
+                        .setPort(opensearchContainer.getMappedPort(9200))
+                        .setScheme("http")
+                        .setSslEnabled(false);
+                OpenSearchClient openSearchClient = new OpenSearchClient(clientConfig);
+                openSearchClient.storeColumnOrderMetadata(indexName, columnNames, columnTypes);
+                openSearchClient.close();
+
+                // Get data with types
+                MaterializedResult result = queryRunner.execute(tpchSession, "SELECT * FROM " + tableName);
+                List<Type> types = result.getTypes();
+
+                // Bulk index documents
+                StringBuilder bulkRequest = new StringBuilder();
+                int docCount = 0;
+                for (MaterializedRow row : result.getMaterializedRows()) {
+                    // Index action
+                    bulkRequest.append(String.format("{\"index\":{\"_index\":\"%s\"}}\n", indexName));
+
+                    // Document
+                    bulkRequest.append("{");
+                    for (int i = 0; i < columnNames.size(); i++) {
+                        if (i > 0) {
+                            bulkRequest.append(",");
+                        }
+                        String columnName = columnNames.get(i);
+                        Object value = row.getField(i);
+                        Type type = types.get(i);
+
+                        bulkRequest.append("\"").append(columnName).append("\":");
+                        if (value == null) {
+                            bulkRequest.append("null");
+                        }
+                        else if (type.equals(DATE)) {
+                            // DATE type: value can be LocalDate or days since epoch
+                            long millis;
+                            if (value instanceof java.time.LocalDate) {
+                                java.time.LocalDate localDate = (java.time.LocalDate) value;
+                                millis = localDate.toEpochDay() * 24 * 60 * 60 * 1000;
+                            }
+                            else {
+                                // Days since epoch
+                                long days = ((Number) value).longValue();
+                                millis = days * 24 * 60 * 60 * 1000;
+                            }
+                            bulkRequest.append(millis);
+                        }
+                        else if (type.equals(TIMESTAMP)) {
+                            // TIMESTAMP type: value is milliseconds since epoch or Instant
+                            long millis;
+                            if (value instanceof java.time.Instant) {
+                                millis = ((java.time.Instant) value).toEpochMilli();
+                            }
+                            else {
+                                millis = ((Number) value).longValue();
+                            }
+                            bulkRequest.append(millis);
+                        }
+                        else if (value instanceof String) {
+                            bulkRequest.append("\"").append(value.toString().replace("\"", "\\\"")).append("\"");
+                        }
+                        else if (value instanceof Number || value instanceof Boolean) {
+                            bulkRequest.append(value);
+                        }
+                        else {
+                            bulkRequest.append("\"").append(value.toString().replace("\"", "\\\"")).append("\"");
+                        }
+                    }
+                    bulkRequest.append("}\n");
+                    docCount++;
+
+                    // Send bulk request every 1000 documents
+                    if (docCount % 1000 == 0) {
+                        Request bulkReq = new Request("POST", "/_bulk");
+                        bulkReq.setJsonEntity(bulkRequest.toString());
+                        bulkReq.addParameter("refresh", "true");
+                        restClient.performRequest(bulkReq);
+                        bulkRequest = new StringBuilder();
+                    }
+                }
+
+                // Send remaining documents
+                if (bulkRequest.length() > 0) {
+                    Request bulkReq = new Request("POST", "/_bulk");
+                    bulkReq.setJsonEntity(bulkRequest.toString());
+                    bulkReq.addParameter("refresh", "true");
+                    restClient.performRequest(bulkReq);
+                }
+
+                log.info("Loaded %d documents into %s", docCount, indexName);
+            }
+        }
+    }
+
+    /**
+     * Main method for manual testing.
+     * Starts an OpenSearch container and query runner for interactive testing.
+     */
+    public static void main(String[] args)
+            throws Exception
+    {
+        Logging.initialize();
+
+        // Start OpenSearch container
+        GenericContainer<?> opensearch = new GenericContainer<>(
+                org.testcontainers.utility.DockerImageName.parse("opensearchproject/opensearch:2.11.1"))
+                .withExposedPorts(9200, 9600)
+                .withEnv("discovery.type", "single-node")
+                .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+                .withEnv("DISABLE_SECURITY_PLUGIN", "true");
+
+        opensearch.start();
+
+        log.info("OpenSearch container started at: http://%s:%d",
+                opensearch.getHost(),
+                opensearch.getMappedPort(9200));
+
+        // Create query runner with all TPCH tables
+        DistributedQueryRunner queryRunner = createQueryRunner(
+                opensearch,
+                TpchTable.getTables(),
+                ImmutableMap.of("http-server.http.port", "8080"),
+                ImmutableMap.of());
+
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+
+        // Keep running until interrupted
+        Thread.currentThread().join();
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestNestedFieldInfo.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestNestedFieldInfo.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.VarcharType;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for NestedFieldInfo class.
+ */
+public class TestNestedFieldInfo
+{
+    @Test
+    public void testBasicConstruction()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "token_usage.total_tokens",
+                "token_usage",
+                "total_tokens",
+                BigintType.BIGINT,
+                "long",
+                2,
+                true,
+                Arrays.asList("token_usage", "total_tokens"));
+
+        assertEquals(info.getFieldPath(), "token_usage.total_tokens");
+        assertEquals(info.getParentPath(), "token_usage");
+        assertEquals(info.getFieldName(), "total_tokens");
+        assertEquals(info.getPrestoType(), BigintType.BIGINT);
+        assertEquals(info.getOpenSearchType(), "long");
+        assertEquals(info.getNestingLevel(), 2);
+        assertTrue(info.isLeafField());
+        assertEquals(info.getFieldPathList(), Arrays.asList("token_usage", "total_tokens"));
+    }
+
+    @Test
+    public void testRootLevelField()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "id",
+                "",
+                "id",
+                VarcharType.VARCHAR,
+                "keyword",
+                0,
+                true,
+                Collections.singletonList("id"));
+
+        assertEquals(info.getFieldPath(), "id");
+        assertEquals(info.getParentPath(), "");
+        assertEquals(info.getFieldName(), "id");
+        assertEquals(info.getNestingLevel(), 0);
+        assertFalse(info.isNestedField());
+    }
+
+    @Test
+    public void testIsNestedField()
+    {
+        NestedFieldInfo nested = new NestedFieldInfo(
+                "user.name",
+                "user",
+                "name",
+                VarcharType.VARCHAR,
+                "text",
+                1,
+                true,
+                Arrays.asList("user", "name"));
+
+        assertTrue(nested.isNestedField());
+
+        NestedFieldInfo root = new NestedFieldInfo(
+                "name",
+                "",
+                "name",
+                VarcharType.VARCHAR,
+                "text",
+                0,
+                true,
+                Collections.singletonList("name"));
+
+        assertFalse(root.isNestedField());
+    }
+
+    @Test
+    public void testJsonPath()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "token_usage.total_tokens",
+                "token_usage",
+                "total_tokens",
+                BigintType.BIGINT,
+                "long",
+                2,
+                true,
+                Arrays.asList("token_usage", "total_tokens"));
+
+        assertEquals(info.getJsonPath(), "$.token_usage.total_tokens");
+    }
+
+    @Test
+    public void testDeeplyNestedField()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "a.b.c.d.e",
+                "a.b.c.d",
+                "e",
+                VarcharType.VARCHAR,
+                "text",
+                5,
+                true,
+                Arrays.asList("a", "b", "c", "d", "e"));
+
+        assertEquals(info.getNestingLevel(), 5);
+        assertTrue(info.isNestedField());
+        assertEquals(info.getFieldPathList().size(), 5);
+    }
+
+    @Test
+    public void testNonLeafField()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "user",
+                "",
+                "user",
+                VarcharType.VARCHAR,
+                "object",
+                1,
+                false,
+                Collections.singletonList("user"));
+
+        assertFalse(info.isLeafField());
+    }
+
+    @Test
+    public void testEquality()
+    {
+        NestedFieldInfo info1 = new NestedFieldInfo(
+                "token_usage.total_tokens",
+                "token_usage",
+                "total_tokens",
+                BigintType.BIGINT,
+                "long",
+                2,
+                true,
+                Arrays.asList("token_usage", "total_tokens"));
+
+        NestedFieldInfo info2 = new NestedFieldInfo(
+                "token_usage.total_tokens",
+                "token_usage",
+                "total_tokens",
+                BigintType.BIGINT,
+                "long",
+                2,
+                true,
+                Arrays.asList("token_usage", "total_tokens"));
+
+        assertEquals(info1, info2);
+        assertEquals(info1.hashCode(), info2.hashCode());
+    }
+
+    @Test
+    public void testInequality()
+    {
+        NestedFieldInfo info1 = new NestedFieldInfo(
+                "token_usage.total_tokens",
+                "token_usage",
+                "total_tokens",
+                BigintType.BIGINT,
+                "long",
+                2,
+                true,
+                Arrays.asList("token_usage", "total_tokens"));
+
+        NestedFieldInfo info2 = new NestedFieldInfo(
+                "token_usage.prompt_tokens",
+                "token_usage",
+                "prompt_tokens",
+                BigintType.BIGINT,
+                "long",
+                2,
+                true,
+                Arrays.asList("token_usage", "prompt_tokens"));
+
+        assertNotEquals(info1, info2);
+    }
+
+    @Test
+    public void testDifferentTypes()
+    {
+        NestedFieldInfo bigintField = new NestedFieldInfo(
+                "count",
+                "",
+                "count",
+                BigintType.BIGINT,
+                "long",
+                0,
+                true,
+                Collections.singletonList("count"));
+
+        NestedFieldInfo doubleField = new NestedFieldInfo(
+                "price",
+                "",
+                "price",
+                DoubleType.DOUBLE,
+                "double",
+                0,
+                true,
+                Collections.singletonList("price"));
+
+        NestedFieldInfo boolField = new NestedFieldInfo(
+                "active",
+                "",
+                "active",
+                BooleanType.BOOLEAN,
+                "boolean",
+                0,
+                true,
+                Collections.singletonList("active"));
+
+        assertEquals(bigintField.getPrestoType(), BigintType.BIGINT);
+        assertEquals(doubleField.getPrestoType(), DoubleType.DOUBLE);
+        assertEquals(boolField.getPrestoType(), BooleanType.BOOLEAN);
+    }
+
+    @Test
+    public void testToString()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "token_usage.total_tokens",
+                "token_usage",
+                "total_tokens",
+                BigintType.BIGINT,
+                "long",
+                2,
+                true,
+                Arrays.asList("token_usage", "total_tokens"));
+
+        String str = info.toString();
+        assertTrue(str.contains("token_usage.total_tokens"));
+        assertTrue(str.contains("bigint"));
+        assertTrue(str.contains("long"));
+    }
+
+    @Test
+    public void testNullParentPath()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "field",
+                null,
+                "field",
+                VarcharType.VARCHAR,
+                "text",
+                0,
+                true,
+                Collections.singletonList("field"));
+
+        assertEquals(info.getParentPath(), "");
+    }
+
+    @Test
+    public void testEmptyFieldPathList()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "field",
+                "",
+                "field",
+                VarcharType.VARCHAR,
+                "text",
+                0,
+                true,
+                null);
+
+        assertEquals(info.getFieldPathList(), Collections.emptyList());
+    }
+
+    @Test
+    public void testFieldPathListImmutable()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "a.b",
+                "a",
+                "b",
+                VarcharType.VARCHAR,
+                "text",
+                1,
+                true,
+                Arrays.asList("a", "b"));
+
+        // Verify the list is unmodifiable
+        try {
+            info.getFieldPathList().add("c");
+            throw new AssertionError("Expected UnsupportedOperationException");
+        }
+        catch (UnsupportedOperationException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testMaxNestingDepth()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "a.b.c.d.e.f",
+                "a.b.c.d.e",
+                "f",
+                VarcharType.VARCHAR,
+                "text",
+                6,
+                true,
+                Arrays.asList("a", "b", "c", "d", "e", "f"));
+
+        assertEquals(info.getNestingLevel(), 6);
+        assertTrue(info.isNestedField());
+    }
+
+    @Test
+    public void testFieldNameExtraction()
+    {
+        NestedFieldInfo info = new NestedFieldInfo(
+                "user.profile.email",
+                "user.profile",
+                "email",
+                VarcharType.VARCHAR,
+                "keyword",
+                2,
+                true,
+                Arrays.asList("user", "profile", "email"));
+
+        assertEquals(info.getFieldName(), "email");
+        assertEquals(info.getParentPath(), "user.profile");
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestNestedFieldIntegration.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestNestedFieldIntegration.java
@@ -1,0 +1,439 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.VarcharType;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Integration tests for nested field functionality.
+ * Tests the complete flow from mapping discovery to value extraction.
+ */
+@Test(singleThreaded = true)
+public class TestNestedFieldIntegration
+{
+    private NestedFieldMapper mapper;
+    private NestedValueExtractor extractor;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        mapper = new NestedFieldMapper(5);
+        extractor = new NestedValueExtractor();
+    }
+
+    @Test
+    public void testCompleteTokenUsageFlow()
+    {
+        // Step 1: Define mapping
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("type", "object");
+
+        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> totalTokens = new HashMap<>();
+        totalTokens.put("type", "long");
+        properties.put("total_tokens", totalTokens);
+
+        Map<String, Object> promptTokens = new HashMap<>();
+        promptTokens.put("type", "long");
+        properties.put("prompt_tokens", promptTokens);
+
+        tokenUsage.put("properties", properties);
+        mapping.put("token_usage", tokenUsage);
+
+        // Step 2: Discover fields
+        Map<String, NestedFieldInfo> fields = mapper.discoverNestedFields(mapping);
+
+        assertTrue(fields.containsKey("token_usage.total_tokens"));
+        assertTrue(fields.containsKey("token_usage.prompt_tokens"));
+
+        NestedFieldInfo totalTokensInfo = fields.get("token_usage.total_tokens");
+        assertNotNull(totalTokensInfo);
+        assertEquals(totalTokensInfo.getFieldPath(), "token_usage.total_tokens");
+        assertEquals(totalTokensInfo.getPrestoType(), BigintType.BIGINT);
+
+        // Step 3: Create document
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> tokenUsageData = new HashMap<>();
+        tokenUsageData.put("total_tokens", 90616L);
+        tokenUsageData.put("prompt_tokens", 45308L);
+        document.put("token_usage", tokenUsageData);
+
+        // Step 4: Extract values
+        Object totalValue = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "total_tokens"),
+                BigintType.BIGINT);
+
+        Object promptValue = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "prompt_tokens"),
+                BigintType.BIGINT);
+
+        assertEquals(totalValue, 90616L);
+        assertEquals(promptValue, 45308L);
+    }
+
+    @Test
+    public void testMultipleNestedObjects()
+    {
+        // Mapping with multiple nested objects
+        Map<String, Object> mapping = new HashMap<>();
+
+        // User object
+        Map<String, Object> user = new HashMap<>();
+        user.put("type", "object");
+        Map<String, Object> userProps = new HashMap<>();
+        Map<String, Object> userName = new HashMap<>();
+        userName.put("type", "text");
+        userProps.put("name", userName);
+        user.put("properties", userProps);
+        mapping.put("user", user);
+
+        // Metadata object
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("type", "object");
+        Map<String, Object> metaProps = new HashMap<>();
+        Map<String, Object> metaId = new HashMap<>();
+        metaId.put("type", "keyword");
+        metaProps.put("id", metaId);
+        metadata.put("properties", metaProps);
+        mapping.put("metadata", metadata);
+
+        // Discover fields
+        Map<String, NestedFieldInfo> fields = mapper.discoverNestedFields(mapping);
+
+        assertTrue(fields.containsKey("user.name"));
+        assertTrue(fields.containsKey("metadata.id"));
+
+        // Create document
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> userData = new HashMap<>();
+        userData.put("name", "John Doe");
+        document.put("user", userData);
+
+        Map<String, Object> metadataData = new HashMap<>();
+        metadataData.put("id", "doc123");
+        document.put("metadata", metadataData);
+
+        // Extract values
+        Object userNameValue = extractor.extractNestedValue(
+                document,
+                Arrays.asList("user", "name"),
+                VarcharType.VARCHAR);
+
+        Object metaIdValue = extractor.extractNestedValue(
+                document,
+                Arrays.asList("metadata", "id"),
+                VarcharType.VARCHAR);
+
+        assertEquals(userNameValue, "John Doe");
+        assertEquals(metaIdValue, "doc123");
+    }
+
+    @Test
+    public void testDeeplyNestedStructure()
+    {
+        // Create a.b.c.d mapping
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> a = new HashMap<>();
+        a.put("type", "object");
+        Map<String, Object> aProps = new HashMap<>();
+
+        Map<String, Object> b = new HashMap<>();
+        b.put("type", "object");
+        Map<String, Object> bProps = new HashMap<>();
+
+        Map<String, Object> c = new HashMap<>();
+        c.put("type", "object");
+        Map<String, Object> cProps = new HashMap<>();
+
+        Map<String, Object> d = new HashMap<>();
+        d.put("type", "long");
+
+        cProps.put("d", d);
+        c.put("properties", cProps);
+        bProps.put("c", c);
+        b.put("properties", bProps);
+        aProps.put("b", b);
+        a.put("properties", aProps);
+        mapping.put("a", a);
+
+        // Discover
+        Map<String, NestedFieldInfo> fields = mapper.discoverNestedFields(mapping);
+        assertTrue(fields.containsKey("a.b.c.d"));
+
+        // Create document
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> aData = new HashMap<>();
+        Map<String, Object> bData = new HashMap<>();
+        Map<String, Object> cData = new HashMap<>();
+        cData.put("d", 42L);
+        bData.put("c", cData);
+        aData.put("b", bData);
+        document.put("a", aData);
+
+        // Extract
+        Object value = extractor.extractNestedValue(
+                document,
+                Arrays.asList("a", "b", "c", "d"),
+                BigintType.BIGINT);
+
+        assertEquals(value, 42L);
+    }
+
+    @Test
+    public void testMissingFieldHandling()
+    {
+        // Mapping
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> user = new HashMap<>();
+        user.put("type", "object");
+        Map<String, Object> userProps = new HashMap<>();
+        Map<String, Object> name = new HashMap<>();
+        name.put("type", "text");
+        userProps.put("name", name);
+        user.put("properties", userProps);
+        mapping.put("user", user);
+
+        // Discover
+        Map<String, NestedFieldInfo> fields = mapper.discoverNestedFields(mapping);
+        assertTrue(fields.containsKey("user.name"));
+
+        // Document without the nested field
+        Map<String, Object> document = new HashMap<>();
+        document.put("other_field", "value");
+
+        // Extract - should return null
+        Object value = extractor.extractNestedValue(
+                document,
+                Arrays.asList("user", "name"),
+                VarcharType.VARCHAR);
+
+        assertNull(value);
+    }
+
+    @Test
+    public void testMissingParentHandling()
+    {
+        // Mapping
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> user = new HashMap<>();
+        user.put("type", "object");
+        Map<String, Object> userProps = new HashMap<>();
+        Map<String, Object> name = new HashMap<>();
+        name.put("type", "text");
+        userProps.put("name", name);
+        user.put("properties", userProps);
+        mapping.put("user", user);
+
+        // Discover
+        Map<String, NestedFieldInfo> fields = mapper.discoverNestedFields(mapping);
+        assertTrue(fields.containsKey("user.name"));
+
+        // Document with user but missing name
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> userData = new HashMap<>();
+        userData.put("email", "john@example.com");
+        document.put("user", userData);
+
+        // Extract - should return null
+        Object value = extractor.extractNestedValue(
+                document,
+                Arrays.asList("user", "name"),
+                VarcharType.VARCHAR);
+
+        assertNull(value);
+    }
+
+    @Test
+    public void testRealWorldAnalyticsDocument()
+    {
+        // Complex analytics mapping
+        Map<String, Object> mapping = new HashMap<>();
+
+        // Metadata
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("type", "object");
+        Map<String, Object> metaProps = new HashMap<>();
+        Map<String, Object> id = new HashMap<>();
+        id.put("type", "keyword");
+        metaProps.put("id", id);
+        Map<String, Object> timestamp = new HashMap<>();
+        timestamp.put("type", "date");
+        metaProps.put("timestamp", timestamp);
+        metadata.put("properties", metaProps);
+        mapping.put("metadata", metadata);
+
+        // Token usage
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("type", "object");
+        Map<String, Object> tokenProps = new HashMap<>();
+        Map<String, Object> total = new HashMap<>();
+        total.put("type", "long");
+        tokenProps.put("total_tokens", total);
+        tokenUsage.put("properties", tokenProps);
+        mapping.put("token_usage", tokenUsage);
+
+        // Model info
+        Map<String, Object> model = new HashMap<>();
+        model.put("type", "object");
+        Map<String, Object> modelProps = new HashMap<>();
+        Map<String, Object> modelName = new HashMap<>();
+        modelName.put("type", "keyword");
+        modelProps.put("name", modelName);
+        model.put("properties", modelProps);
+        mapping.put("model", model);
+
+        // Discover all fields
+        Map<String, NestedFieldInfo> fields = mapper.discoverNestedFields(mapping);
+
+        assertTrue(fields.containsKey("metadata.id"));
+        assertTrue(fields.containsKey("token_usage.total_tokens"));
+        assertTrue(fields.containsKey("model.name"));
+
+        // Create document
+        Map<String, Object> document = new HashMap<>();
+
+        Map<String, Object> metaData = new HashMap<>();
+        metaData.put("id", "doc123");
+        metaData.put("timestamp", "2024-01-01T00:00:00Z");
+        document.put("metadata", metaData);
+
+        Map<String, Object> tokenData = new HashMap<>();
+        tokenData.put("total_tokens", 90616L);
+        document.put("token_usage", tokenData);
+
+        Map<String, Object> modelData = new HashMap<>();
+        modelData.put("name", "gpt-4");
+        document.put("model", modelData);
+
+        // Extract all values
+        Object metaId = extractor.extractNestedValue(
+                document,
+                Arrays.asList("metadata", "id"),
+                VarcharType.VARCHAR);
+
+        Object tokens = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "total_tokens"),
+                BigintType.BIGINT);
+
+        Object modelNameValue = extractor.extractNestedValue(
+                document,
+                Arrays.asList("model", "name"),
+                VarcharType.VARCHAR);
+
+        assertEquals(metaId, "doc123");
+        assertEquals(tokens, 90616L);
+        assertEquals(modelNameValue, "gpt-4");
+    }
+
+    @Test
+    public void testFieldInfoMetadata()
+    {
+        // Mapping
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> user = new HashMap<>();
+        user.put("type", "object");
+        Map<String, Object> userProps = new HashMap<>();
+        Map<String, Object> age = new HashMap<>();
+        age.put("type", "integer");
+        userProps.put("age", age);
+        user.put("properties", userProps);
+        mapping.put("user", user);
+
+        // Discover
+        Map<String, NestedFieldInfo> fields = mapper.discoverNestedFields(mapping);
+
+        NestedFieldInfo ageInfo = fields.get("user.age");
+        assertNotNull(ageInfo);
+
+        // Verify metadata
+        assertEquals(ageInfo.getFieldPath(), "user.age");
+        assertEquals(ageInfo.getParentPath(), "user");
+        assertEquals(ageInfo.getFieldName(), "age");
+        assertEquals(ageInfo.getNestingLevel(), 1);
+        assertTrue(ageInfo.isNestedField());
+        assertTrue(ageInfo.isLeafField());
+        assertEquals(ageInfo.getFieldPathList(), Arrays.asList("user", "age"));
+        assertEquals(ageInfo.getJsonPath(), "$.user.age");
+    }
+
+    @Test
+    public void testLeafFieldFiltering()
+    {
+        // Mapping with parent and leaf fields
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> user = new HashMap<>();
+        user.put("type", "object");
+        Map<String, Object> userProps = new HashMap<>();
+        Map<String, Object> name = new HashMap<>();
+        name.put("type", "text");
+        userProps.put("name", name);
+        user.put("properties", userProps);
+        mapping.put("user", user);
+
+        // Discover all fields
+        Map<String, NestedFieldInfo> allFields = mapper.discoverNestedFields(mapping);
+        assertEquals(allFields.size(), 2); // user + user.name
+
+        // Get only leaf fields
+        Map<String, NestedFieldInfo> leafFields = mapper.getLeafFieldsOnly(allFields);
+        assertEquals(leafFields.size(), 1); // only user.name
+        assertTrue(leafFields.containsKey("user.name"));
+    }
+
+    @Test
+    public void testEmptyDocumentHandling()
+    {
+        // Mapping
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> user = new HashMap<>();
+        user.put("type", "object");
+        Map<String, Object> userProps = new HashMap<>();
+        Map<String, Object> name = new HashMap<>();
+        name.put("type", "text");
+        userProps.put("name", name);
+        user.put("properties", userProps);
+        mapping.put("user", user);
+
+        // Discover
+        Map<String, NestedFieldInfo> fields = mapper.discoverNestedFields(mapping);
+        assertTrue(fields.containsKey("user.name"));
+
+        // Empty document
+        Map<String, Object> document = new HashMap<>();
+
+        // Extract - should return null
+        Object value = extractor.extractNestedValue(
+                document,
+                Arrays.asList("user", "name"),
+                VarcharType.VARCHAR);
+
+        assertNull(value);
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestNestedFieldMapper.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestNestedFieldMapper.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for NestedFieldMapper class.
+ */
+@Test(singleThreaded = true)
+public class TestNestedFieldMapper
+{
+    private NestedFieldMapper mapper;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        mapper = new NestedFieldMapper(5);
+    }
+
+    @Test
+    public void testSimpleNestedObject()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("type", "object");
+
+        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> totalTokens = new HashMap<>();
+        totalTokens.put("type", "long");
+        properties.put("total_tokens", totalTokens);
+
+        tokenUsage.put("properties", properties);
+        mapping.put("token_usage", tokenUsage);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertEquals(result.size(), 2); // parent + leaf
+        assertTrue(result.containsKey("token_usage"));
+        assertTrue(result.containsKey("token_usage.total_tokens"));
+        assertTrue(result.get("token_usage.total_tokens").isLeafField());
+    }
+
+    @Test
+    public void testMultipleNestedFields()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("type", "object");
+
+        Map<String, Object> properties = new HashMap<>();
+
+        Map<String, Object> totalTokens = new HashMap<>();
+        totalTokens.put("type", "long");
+        properties.put("total_tokens", totalTokens);
+
+        Map<String, Object> promptTokens = new HashMap<>();
+        promptTokens.put("type", "long");
+        properties.put("prompt_tokens", promptTokens);
+
+        Map<String, Object> completionTokens = new HashMap<>();
+        completionTokens.put("type", "long");
+        properties.put("completion_tokens", completionTokens);
+
+        tokenUsage.put("properties", properties);
+        mapping.put("token_usage", tokenUsage);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertEquals(result.size(), 4); // 1 parent + 3 leaves
+        assertTrue(result.containsKey("token_usage.total_tokens"));
+        assertTrue(result.containsKey("token_usage.prompt_tokens"));
+        assertTrue(result.containsKey("token_usage.completion_tokens"));
+    }
+
+    @Test
+    public void testDeeplyNestedStructure()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+
+        // Create a.b.c.d structure
+        Map<String, Object> a = new HashMap<>();
+        a.put("type", "object");
+        Map<String, Object> aProps = new HashMap<>();
+
+        Map<String, Object> b = new HashMap<>();
+        b.put("type", "object");
+        Map<String, Object> bProps = new HashMap<>();
+
+        Map<String, Object> c = new HashMap<>();
+        c.put("type", "object");
+        Map<String, Object> cProps = new HashMap<>();
+
+        Map<String, Object> d = new HashMap<>();
+        d.put("type", "long");
+
+        cProps.put("d", d);
+        c.put("properties", cProps);
+        bProps.put("c", c);
+        b.put("properties", bProps);
+        aProps.put("b", b);
+        a.put("properties", aProps);
+        mapping.put("a", a);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertTrue(result.containsKey("a.b.c.d"));
+        NestedFieldInfo leafField = result.get("a.b.c.d");
+        assertEquals(leafField.getNestingLevel(), 3);
+        assertTrue(leafField.isLeafField());
+    }
+
+    @Test
+    public void testMaxDepthLimit()
+    {
+        NestedFieldMapper limitedMapper = new NestedFieldMapper(2);
+
+        Map<String, Object> mapping = new HashMap<>();
+
+        // Create a.b.c.d structure (depth 3)
+        Map<String, Object> a = new HashMap<>();
+        a.put("type", "object");
+        Map<String, Object> aProps = new HashMap<>();
+
+        Map<String, Object> b = new HashMap<>();
+        b.put("type", "object");
+        Map<String, Object> bProps = new HashMap<>();
+
+        Map<String, Object> c = new HashMap<>();
+        c.put("type", "object");
+        Map<String, Object> cProps = new HashMap<>();
+
+        Map<String, Object> d = new HashMap<>();
+        d.put("type", "long");
+
+        cProps.put("d", d);
+        c.put("properties", cProps);
+        bProps.put("c", c);
+        b.put("properties", bProps);
+        aProps.put("b", b);
+        a.put("properties", aProps);
+        mapping.put("a", a);
+
+        Map<String, NestedFieldInfo> result = limitedMapper.discoverNestedFields(mapping);
+
+        // Should stop at depth 2, so a.b.c.d should not be discovered
+        assertFalse(result.containsKey("a.b.c.d"));
+        assertTrue(result.containsKey("a.b"));
+    }
+
+    @Test
+    public void testMixedNestedAndRegularFields()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+
+        // Regular field
+        Map<String, Object> id = new HashMap<>();
+        id.put("type", "keyword");
+        mapping.put("id", id);
+
+        // Nested object
+        Map<String, Object> user = new HashMap<>();
+        user.put("type", "object");
+        Map<String, Object> userProps = new HashMap<>();
+        Map<String, Object> name = new HashMap<>();
+        name.put("type", "text");
+        userProps.put("name", name);
+        user.put("properties", userProps);
+        mapping.put("user", user);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertTrue(result.containsKey("id"));
+        assertTrue(result.containsKey("user"));
+        assertTrue(result.containsKey("user.name"));
+        assertEquals(result.get("id").getNestingLevel(), 0);
+        assertEquals(result.get("user.name").getNestingLevel(), 1);
+    }
+
+    @Test
+    public void testVariousDataTypes()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+
+        Map<String, Object> longField = new HashMap<>();
+        longField.put("type", "long");
+        mapping.put("count", longField);
+
+        Map<String, Object> doubleField = new HashMap<>();
+        doubleField.put("type", "double");
+        mapping.put("price", doubleField);
+
+        Map<String, Object> boolField = new HashMap<>();
+        boolField.put("type", "boolean");
+        mapping.put("active", boolField);
+
+        Map<String, Object> textField = new HashMap<>();
+        textField.put("type", "text");
+        mapping.put("description", textField);
+
+        Map<String, Object> keywordField = new HashMap<>();
+        keywordField.put("type", "keyword");
+        mapping.put("id", keywordField);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertEquals(result.size(), 5);
+        assertTrue(result.containsKey("count"));
+        assertTrue(result.containsKey("price"));
+        assertTrue(result.containsKey("active"));
+        assertTrue(result.containsKey("description"));
+        assertTrue(result.containsKey("id"));
+    }
+
+    @Test
+    public void testEmptyMapping()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertEquals(result.size(), 0);
+    }
+
+    @Test
+    public void testObjectWithoutProperties()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> emptyObject = new HashMap<>();
+        emptyObject.put("type", "object");
+        // No properties defined
+        mapping.put("empty_obj", emptyObject);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        // Should still create entry for the parent object
+        assertTrue(result.containsKey("empty_obj"));
+        assertFalse(result.get("empty_obj").isLeafField());
+    }
+
+    @Test
+    public void testNestedArrayOfObjects()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> items = new HashMap<>();
+        items.put("type", "nested");
+
+        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> name = new HashMap<>();
+        name.put("type", "text");
+        properties.put("name", name);
+
+        Map<String, Object> quantity = new HashMap<>();
+        quantity.put("type", "integer");
+        properties.put("quantity", quantity);
+
+        items.put("properties", properties);
+        mapping.put("items", items);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertTrue(result.containsKey("items"));
+        assertTrue(result.containsKey("items.name"));
+        assertTrue(result.containsKey("items.quantity"));
+        assertFalse(result.get("items").isLeafField());
+        assertTrue(result.get("items.name").isLeafField());
+    }
+
+    @Test
+    public void testComplexRealWorldStructure()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+
+        // Metadata object
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("type", "object");
+        Map<String, Object> metaProps = new HashMap<>();
+
+        Map<String, Object> id = new HashMap<>();
+        id.put("type", "keyword");
+        metaProps.put("id", id);
+
+        Map<String, Object> timestamp = new HashMap<>();
+        timestamp.put("type", "date");
+        metaProps.put("timestamp", timestamp);
+
+        metadata.put("properties", metaProps);
+        mapping.put("metadata", metadata);
+
+        // Token usage object
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("type", "object");
+        Map<String, Object> tokenProps = new HashMap<>();
+
+        Map<String, Object> total = new HashMap<>();
+        total.put("type", "long");
+        tokenProps.put("total_tokens", total);
+
+        tokenUsage.put("properties", tokenProps);
+        mapping.put("token_usage", tokenUsage);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertTrue(result.containsKey("metadata.id"));
+        assertTrue(result.containsKey("metadata.timestamp"));
+        assertTrue(result.containsKey("token_usage.total_tokens"));
+    }
+
+    @Test
+    public void testGetLeafFieldsOnly()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> user = new HashMap<>();
+        user.put("type", "object");
+
+        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> name = new HashMap<>();
+        name.put("type", "text");
+        properties.put("name", name);
+
+        user.put("properties", properties);
+        mapping.put("user", user);
+
+        Map<String, NestedFieldInfo> allFields = mapper.discoverNestedFields(mapping);
+        Map<String, NestedFieldInfo> leafFields = mapper.getLeafFieldsOnly(allFields);
+
+        // Should only contain user.name, not user
+        assertEquals(leafFields.size(), 1);
+        assertTrue(leafFields.containsKey("user.name"));
+        assertFalse(leafFields.containsKey("user"));
+    }
+
+    @Test
+    public void testGetMaxDepth()
+    {
+        NestedFieldMapper mapper1 = new NestedFieldMapper(5);
+        assertEquals(mapper1.getMaxDepth(), 5);
+
+        NestedFieldMapper mapper2 = new NestedFieldMapper(10);
+        assertEquals(mapper2.getMaxDepth(), 10);
+    }
+
+    @Test
+    public void testFieldPathConstruction()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> a = new HashMap<>();
+        a.put("type", "object");
+        Map<String, Object> aProps = new HashMap<>();
+
+        Map<String, Object> b = new HashMap<>();
+        b.put("type", "object");
+        Map<String, Object> bProps = new HashMap<>();
+
+        Map<String, Object> c = new HashMap<>();
+        c.put("type", "text");
+
+        bProps.put("c", c);
+        b.put("properties", bProps);
+        aProps.put("b", b);
+        a.put("properties", aProps);
+        mapping.put("a", a);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        NestedFieldInfo field = result.get("a.b.c");
+        assertNotNull(field);
+        assertEquals(field.getFieldPath(), "a.b.c");
+        assertEquals(field.getParentPath(), "a.b");
+        assertEquals(field.getFieldName(), "c");
+    }
+
+    @Test
+    public void testNestingLevelCalculation()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+
+        // Root level
+        Map<String, Object> root = new HashMap<>();
+        root.put("type", "text");
+        mapping.put("root", root);
+
+        // Level 1
+        Map<String, Object> level1 = new HashMap<>();
+        level1.put("type", "object");
+        Map<String, Object> l1Props = new HashMap<>();
+        Map<String, Object> field1 = new HashMap<>();
+        field1.put("type", "text");
+        l1Props.put("field", field1);
+        level1.put("properties", l1Props);
+        mapping.put("level1", level1);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertEquals(result.get("root").getNestingLevel(), 0);
+        assertEquals(result.get("level1").getNestingLevel(), 0);
+        assertEquals(result.get("level1.field").getNestingLevel(), 1);
+    }
+
+    @Test
+    public void testDefaultTypeHandling()
+    {
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> field = new HashMap<>();
+        // No type specified - should default to "object"
+        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> subfield = new HashMap<>();
+        subfield.put("type", "text");
+        properties.put("subfield", subfield);
+        field.put("properties", properties);
+        mapping.put("field", field);
+
+        Map<String, NestedFieldInfo> result = mapper.discoverNestedFields(mapping);
+
+        assertTrue(result.containsKey("field"));
+        assertTrue(result.containsKey("field.subfield"));
+        assertFalse(result.get("field").isLeafField());
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestNestedValueExtractor.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestNestedValueExtractor.java
@@ -1,0 +1,516 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.VarcharType;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Tests for NestedValueExtractor class.
+ */
+@Test(singleThreaded = true)
+public class TestNestedValueExtractor
+{
+    private NestedValueExtractor extractor;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        extractor = new NestedValueExtractor();
+    }
+
+    @Test
+    public void testExtractSimpleNestedLong()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("total_tokens", 90616L);
+        document.put("token_usage", tokenUsage);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "total_tokens"),
+                BigintType.BIGINT);
+
+        assertEquals(result, 90616L);
+    }
+
+    @Test
+    public void testExtractDeeplyNestedValue()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> level1 = new HashMap<>();
+        Map<String, Object> level2 = new HashMap<>();
+        Map<String, Object> level3 = new HashMap<>();
+        level3.put("value", 42L);
+        level2.put("c", level3);
+        level1.put("b", level2);
+        document.put("a", level1);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("a", "b", "c", "value"),
+                BigintType.BIGINT);
+
+        assertEquals(result, 42L);
+    }
+
+    @Test
+    public void testExtractMissingField()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("total_tokens", 90616L);
+        document.put("token_usage", tokenUsage);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "missing_field"),
+                BigintType.BIGINT);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractMissingParent()
+    {
+        Map<String, Object> document = new HashMap<>();
+        document.put("other_field", "value");
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "total_tokens"),
+                BigintType.BIGINT);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractWithNullDocument()
+    {
+        Object result = extractor.extractNestedValue(
+                null,
+                Arrays.asList("token_usage", "total_tokens"),
+                BigintType.BIGINT);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractWithEmptyPath()
+    {
+        Map<String, Object> document = new HashMap<>();
+        document.put("field", "value");
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Collections.emptyList(),
+                VarcharType.VARCHAR);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractWithNullPath()
+    {
+        Map<String, Object> document = new HashMap<>();
+        document.put("field", "value");
+
+        Object result = extractor.extractNestedValue(
+                document,
+                null,
+                VarcharType.VARCHAR);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testTypeConversionIntegerToLong()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("count", 100);  // Integer
+        document.put("data", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("data", "count"),
+                BigintType.BIGINT);
+
+        assertEquals(result, 100L);
+    }
+
+    @Test
+    public void testTypeConversionFloatToDouble()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("price", 19.99f);  // Float
+        document.put("product", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("product", "price"),
+                DoubleType.DOUBLE);
+
+        assertEquals(((Double) result), 19.99, 0.01);
+    }
+
+    @Test
+    public void testExtractBoolean()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("active", true);
+        document.put("status", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("status", "active"),
+                BooleanType.BOOLEAN);
+
+        assertEquals(result, true);
+    }
+
+    @Test
+    public void testExtractString()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("name", "John Doe");
+        document.put("user", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("user", "name"),
+                VarcharType.VARCHAR);
+
+        assertEquals(result, "John Doe");
+    }
+
+    @Test
+    public void testExtractMultipleFieldsFromSameParent()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("total_tokens", 90616L);
+        tokenUsage.put("prompt_tokens", 45308L);
+        tokenUsage.put("completion_tokens", 45308L);
+        document.put("token_usage", tokenUsage);
+
+        Object total = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "total_tokens"),
+                BigintType.BIGINT);
+        Object prompt = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "prompt_tokens"),
+                BigintType.BIGINT);
+        Object completion = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "completion_tokens"),
+                BigintType.BIGINT);
+
+        assertEquals(total, 90616L);
+        assertEquals(prompt, 45308L);
+        assertEquals(completion, 45308L);
+    }
+
+    @Test
+    public void testExtractRootLevelField()
+    {
+        Map<String, Object> document = new HashMap<>();
+        document.put("id", "12345");
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Collections.singletonList("id"),
+                VarcharType.VARCHAR);
+
+        assertEquals(result, "12345");
+    }
+
+    @Test
+    public void testExtractNullValue()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("nullable_field", null);
+        document.put("data", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("data", "nullable_field"),
+                VarcharType.VARCHAR);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testExtractFromComplexDocument()
+    {
+        Map<String, Object> document = new HashMap<>();
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("id", "doc123");
+        metadata.put("timestamp", 1234567890L);
+
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("total_tokens", 90616L);
+        tokenUsage.put("prompt_tokens", 45308L);
+
+        Map<String, Object> model = new HashMap<>();
+        model.put("name", "gpt-4");
+        model.put("version", "0613");
+
+        document.put("metadata", metadata);
+        document.put("token_usage", tokenUsage);
+        document.put("model", model);
+
+        assertEquals(
+                extractor.extractNestedValue(document, Arrays.asList("metadata", "id"), VarcharType.VARCHAR),
+                "doc123");
+        assertEquals(
+                extractor.extractNestedValue(document, Arrays.asList("token_usage", "total_tokens"), BigintType.BIGINT),
+                90616L);
+        assertEquals(
+                extractor.extractNestedValue(document, Arrays.asList("model", "name"), VarcharType.VARCHAR),
+                "gpt-4");
+    }
+
+    @Test
+    public void testExtractFlatValue()
+    {
+        Map<String, Object> document = new HashMap<>();
+        document.put("count", 42L);
+        document.put("name", "test");
+        document.put("active", true);
+
+        assertEquals(extractor.extractFlatValue(document, "count", BigintType.BIGINT), 42L);
+        assertEquals(extractor.extractFlatValue(document, "name", VarcharType.VARCHAR), "test");
+        assertEquals(extractor.extractFlatValue(document, "active", BooleanType.BOOLEAN), true);
+    }
+
+    @Test
+    public void testExtractFlatValueMissing()
+    {
+        Map<String, Object> document = new HashMap<>();
+        document.put("field", "value");
+
+        assertNull(extractor.extractFlatValue(document, "missing", VarcharType.VARCHAR));
+    }
+
+    @Test
+    public void testExtractFlatValueNullDocument()
+    {
+        assertNull(extractor.extractFlatValue(null, "field", VarcharType.VARCHAR));
+    }
+
+    @Test
+    public void testExtractFlatValueNullFieldName()
+    {
+        Map<String, Object> document = new HashMap<>();
+        document.put("field", "value");
+
+        assertNull(extractor.extractFlatValue(document, null, VarcharType.VARCHAR));
+    }
+
+    @Test
+    public void testTypeConversionNumberToString()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("count", 42);
+        document.put("data", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("data", "count"),
+                VarcharType.VARCHAR);
+
+        assertEquals(result, "42");
+    }
+
+    @Test
+    public void testExtractZeroValue()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("count", 0L);
+        document.put("data", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("data", "count"),
+                BigintType.BIGINT);
+
+        assertEquals(result, 0L);
+    }
+
+    @Test
+    public void testExtractNegativeValue()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("balance", -100L);
+        document.put("account", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("account", "balance"),
+                BigintType.BIGINT);
+
+        assertEquals(result, -100L);
+    }
+
+    @Test
+    public void testExtractLargeNumber()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("big_value", Long.MAX_VALUE);
+        document.put("data", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("data", "big_value"),
+                BigintType.BIGINT);
+
+        assertEquals(result, Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testExtractEmptyString()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("text", "");
+        document.put("data", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("data", "text"),
+                VarcharType.VARCHAR);
+
+        assertEquals(result, "");
+    }
+
+    @Test
+    public void testExtractWhitespaceString()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("text", "   ");
+        document.put("data", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("data", "text"),
+                VarcharType.VARCHAR);
+
+        assertEquals(result, "   ");
+    }
+
+    @Test
+    public void testExtractIntegerType()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("count", 100);
+        document.put("data", nested);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("data", "count"),
+                IntegerType.INTEGER);
+
+        assertEquals(result, 100);
+    }
+
+    @Test
+    public void testExtractNestedArrayFieldAsList()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("models_used", Arrays.asList("anthropic/claude-haiku-4-5-20251001"));
+        tokenUsage.put("total_tokens", 336777);
+        document.put("token_usage", tokenUsage);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "models_used"),
+                new ArrayType(VarcharType.VARCHAR));
+
+        assertEquals(result instanceof List, true);
+        List<?> resultList = (List<?>) result;
+        assertEquals(resultList.size(), 1);
+        assertEquals(resultList.get(0), "anthropic/claude-haiku-4-5-20251001");
+    }
+
+    @Test
+    public void testExtractNestedArrayFieldAsObjectArray()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("models_used", new Object[]{"anthropic/claude-haiku-4-5-20251001", "gpt-4"});
+        tokenUsage.put("total_tokens", 336777);
+        document.put("token_usage", tokenUsage);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage", "models_used"),
+                new ArrayType(VarcharType.VARCHAR));
+
+        assertEquals(result.getClass(), java.util.ArrayList.class);
+        java.util.List<?> resultList = (java.util.List<?>) result;
+        assertEquals(resultList.size(), 2);
+        assertEquals(resultList.get(0), "anthropic/claude-haiku-4-5-20251001");
+        assertEquals(resultList.get(1), "gpt-4");
+    }
+
+    @Test
+    public void testExtractNestedComplexObjectAsVarchar()
+    {
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("total_tokens", 336777);
+        tokenUsage.put("models_used", Arrays.asList("model1", "model2"));
+        document.put("token_usage", tokenUsage);
+
+        Object result = extractor.extractNestedValue(
+                document,
+                Arrays.asList("token_usage"),
+                VarcharType.VARCHAR);
+
+        assertEquals(result.getClass(), String.class);
+        String jsonString = (String) result;
+        assertEquals(jsonString.contains("total_tokens"), true);
+        assertEquals(jsonString.contains("models_used"), true);
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchColumnHandleSerialization.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchColumnHandleSerialization.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for OpenSearchColumnHandle to ensure proper handling of complex field names.
+ * This addresses the bug where field names like "cache_creation_input_tokens"
+ * could cause issues during query execution.
+ */
+public class TestOpenSearchColumnHandleSerialization
+{
+    @Test
+    public void testSimpleColumnHandleCreation()
+    {
+        OpenSearchColumnHandle handle = new OpenSearchColumnHandle(
+                "user_id",
+                VARCHAR,
+                "keyword");
+
+        assertEquals(handle.getColumnName(), "user_id");
+        assertEquals(handle.getColumnType(), VARCHAR);
+        assertEquals(handle.getOpenSearchType(), "keyword");
+        assertFalse(handle.isVector());
+        assertFalse(handle.isNestedField());
+    }
+
+    @Test
+    public void testProblematicFieldNamesCreation()
+    {
+        // Test field names that caused the original bug
+        String[] problematicFieldNames = {
+            "cache_creation_input_tokens",
+            "cache_creation_output_tokens",
+            "cache_read_input_tokens",
+            "total_input_tokens",
+            "prompt_tokens_used",
+            "completion_tokens_generated",
+            "model_response_time_ms"
+        };
+
+        for (String fieldName : problematicFieldNames) {
+            OpenSearchColumnHandle handle = new OpenSearchColumnHandle(
+                    fieldName,
+                    BIGINT,
+                    "long");
+
+            assertEquals(handle.getColumnName(), fieldName,
+                    "Field name mismatch for: " + fieldName);
+            assertEquals(handle.getColumnType(), BIGINT,
+                    "Type mismatch for field: " + fieldName);
+            assertEquals(handle.getOpenSearchType(), "long",
+                    "OpenSearch type mismatch for field: " + fieldName);
+        }
+    }
+
+    @Test
+    public void testVectorColumnHandleCreation()
+    {
+        OpenSearchColumnHandle handle = new OpenSearchColumnHandle(
+                "embedding",
+                new ArrayType(REAL),
+                "knn_vector",
+                true,
+                128);
+
+        assertEquals(handle.getColumnName(), "embedding");
+        assertEquals(handle.getColumnType(), new ArrayType(REAL));
+        assertEquals(handle.getOpenSearchType(), "knn_vector");
+        assertTrue(handle.isVector());
+        assertEquals(handle.getVectorDimension(), 128);
+    }
+
+    @Test
+    public void testNestedFieldColumnHandleCreation()
+    {
+        List<String> fieldPath = ImmutableList.of("reliability_scores", "answer_relevance", "score");
+
+        OpenSearchColumnHandle handle = new OpenSearchColumnHandle(
+                "reliability_scores.answer_relevance.score",
+                INTEGER,
+                "integer",
+                false,
+                0,
+                true,
+                "reliability_scores",
+                fieldPath,
+                "reliability_scores");
+
+        assertEquals(handle.getColumnName(), "reliability_scores.answer_relevance.score");
+        assertEquals(handle.getColumnType(), INTEGER);
+        assertTrue(handle.isNestedField());
+        assertEquals(handle.getParentFieldPath(), "reliability_scores");
+        assertEquals(handle.getFieldPathList(), fieldPath);
+    }
+
+    @Test
+    public void testFieldNameWithSpecialCharacters()
+    {
+        // Test field names with special characters
+        String[] specialFieldNames = {
+            "field_with_underscores",
+            "field-with-dashes",
+            "field.with.dots"
+        };
+
+        for (String fieldName : specialFieldNames) {
+            OpenSearchColumnHandle handle = new OpenSearchColumnHandle(
+                    fieldName,
+                    VARCHAR,
+                    "keyword");
+
+            assertEquals(handle.getColumnName(), fieldName);
+            assertEquals(handle.getColumnType(), VARCHAR);
+        }
+    }
+
+    @Test
+    public void testColumnMetadataGeneration()
+    {
+        OpenSearchColumnHandle handle = new OpenSearchColumnHandle(
+                "cache_creation_input_tokens",
+                BIGINT,
+                "long");
+
+        // Verify we can generate column metadata without errors
+        assertEquals(handle.toColumnMetadata().getName(), "cache_creation_input_tokens");
+        assertEquals(handle.toColumnMetadata().getType(), BIGINT);
+    }
+
+    @Test
+    public void testEqualsAndHashCode()
+    {
+        OpenSearchColumnHandle handle1 = new OpenSearchColumnHandle(
+                "cache_creation_input_tokens",
+                BIGINT,
+                "long");
+
+        OpenSearchColumnHandle handle2 = new OpenSearchColumnHandle(
+                "cache_creation_input_tokens",
+                BIGINT,
+                "long");
+
+        assertEquals(handle1, handle2);
+        assertEquals(handle1.hashCode(), handle2.hashCode());
+    }
+
+    @Test
+    public void testToString()
+    {
+        OpenSearchColumnHandle handle = new OpenSearchColumnHandle(
+                "cache_creation_input_tokens",
+                BIGINT,
+                "long");
+
+        String toString = handle.toString();
+        assertTrue(toString.contains("cache_creation_input_tokens"));
+        assertTrue(toString.contains("bigint") || toString.contains("BIGINT"));
+    }
+}
+
+// Made with Bob

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchConfigNestedFields.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchConfigNestedFields.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for OpenSearchConfig nested field configuration properties.
+ */
+public class TestOpenSearchConfigNestedFields
+{
+    @Test
+    public void testDefaultValues()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+
+        assertTrue(config.isNestedFieldAccessEnabled());
+        assertEquals(config.getNestedMaxDepth(), 5);
+        assertTrue(config.isNestedOptimizeQueries());
+        assertFalse(config.isNestedDiscoverDynamicFields());
+        assertFalse(config.isNestedLogMissingFields());
+    }
+
+    @Test
+    public void testEnableNestedFieldAccess()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedFieldAccessEnabled(true);
+
+        assertTrue(config.isNestedFieldAccessEnabled());
+    }
+
+    @Test
+    public void testDisableNestedFieldAccess()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedFieldAccessEnabled(false);
+
+        assertFalse(config.isNestedFieldAccessEnabled());
+    }
+
+    @Test
+    public void testSetMaxDepth()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedMaxDepth(10);
+
+        assertEquals(config.getNestedMaxDepth(), 10);
+    }
+
+    @Test
+    public void testSetMaxDepthMinimum()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedMaxDepth(1);
+
+        assertEquals(config.getNestedMaxDepth(), 1);
+    }
+
+    @Test
+    public void testSetMaxDepthLarge()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedMaxDepth(20);
+
+        assertEquals(config.getNestedMaxDepth(), 20);
+    }
+
+    @Test
+    public void testEnableQueryOptimization()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedOptimizeQueries(true);
+
+        assertTrue(config.isNestedOptimizeQueries());
+    }
+
+    @Test
+    public void testDisableQueryOptimization()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedOptimizeQueries(false);
+
+        assertFalse(config.isNestedOptimizeQueries());
+    }
+
+    @Test
+    public void testEnableDynamicFieldDiscovery()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedDiscoverDynamicFields(true);
+
+        assertTrue(config.isNestedDiscoverDynamicFields());
+    }
+
+    @Test
+    public void testDisableDynamicFieldDiscovery()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedDiscoverDynamicFields(false);
+
+        assertFalse(config.isNestedDiscoverDynamicFields());
+    }
+
+    @Test
+    public void testEnableMissingFieldLogging()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedLogMissingFields(true);
+
+        assertTrue(config.isNestedLogMissingFields());
+    }
+
+    @Test
+    public void testDisableMissingFieldLogging()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedLogMissingFields(false);
+
+        assertFalse(config.isNestedLogMissingFields());
+    }
+
+    @Test
+    public void testProductionConfiguration()
+    {
+        // Production: enabled, moderate depth, optimized, no dynamic discovery, no logging
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedFieldAccessEnabled(true);
+        config.setNestedMaxDepth(5);
+        config.setNestedOptimizeQueries(true);
+        config.setNestedDiscoverDynamicFields(false);
+        config.setNestedLogMissingFields(false);
+
+        assertTrue(config.isNestedFieldAccessEnabled());
+        assertEquals(config.getNestedMaxDepth(), 5);
+        assertTrue(config.isNestedOptimizeQueries());
+        assertFalse(config.isNestedDiscoverDynamicFields());
+        assertFalse(config.isNestedLogMissingFields());
+    }
+
+    @Test
+    public void testDevelopmentConfiguration()
+    {
+        // Development: enabled, higher depth, optimized, dynamic discovery, logging enabled
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedFieldAccessEnabled(true);
+        config.setNestedMaxDepth(10);
+        config.setNestedOptimizeQueries(true);
+        config.setNestedDiscoverDynamicFields(true);
+        config.setNestedLogMissingFields(true);
+
+        assertTrue(config.isNestedFieldAccessEnabled());
+        assertEquals(config.getNestedMaxDepth(), 10);
+        assertTrue(config.isNestedOptimizeQueries());
+        assertTrue(config.isNestedDiscoverDynamicFields());
+        assertTrue(config.isNestedLogMissingFields());
+    }
+
+    @Test
+    public void testPerformanceOptimizedConfiguration()
+    {
+        // Performance: enabled, shallow depth, optimized, no extras
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedFieldAccessEnabled(true);
+        config.setNestedMaxDepth(3);
+        config.setNestedOptimizeQueries(true);
+        config.setNestedDiscoverDynamicFields(false);
+        config.setNestedLogMissingFields(false);
+
+        assertTrue(config.isNestedFieldAccessEnabled());
+        assertEquals(config.getNestedMaxDepth(), 3);
+        assertTrue(config.isNestedOptimizeQueries());
+        assertFalse(config.isNestedDiscoverDynamicFields());
+        assertFalse(config.isNestedLogMissingFields());
+    }
+
+    @Test
+    public void testDebuggingConfiguration()
+    {
+        // Debugging: enabled, deep depth, not optimized, dynamic discovery, logging
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setNestedFieldAccessEnabled(true);
+        config.setNestedMaxDepth(15);
+        config.setNestedOptimizeQueries(false);
+        config.setNestedDiscoverDynamicFields(true);
+        config.setNestedLogMissingFields(true);
+
+        assertTrue(config.isNestedFieldAccessEnabled());
+        assertEquals(config.getNestedMaxDepth(), 15);
+        assertFalse(config.isNestedOptimizeQueries());
+        assertTrue(config.isNestedDiscoverDynamicFields());
+        assertTrue(config.isNestedLogMissingFields());
+    }
+
+    @Test
+    public void testIndependentSettings()
+    {
+        // Verify settings are independent
+        OpenSearchConfig config = new OpenSearchConfig();
+
+        config.setNestedFieldAccessEnabled(false);
+        assertFalse(config.isNestedFieldAccessEnabled());
+        assertTrue(config.isNestedOptimizeQueries()); // Should still be default
+
+        config.setNestedOptimizeQueries(false);
+        assertFalse(config.isNestedOptimizeQueries());
+        assertEquals(config.getNestedMaxDepth(), 5); // Should still be default
+
+        config.setNestedMaxDepth(8);
+        assertEquals(config.getNestedMaxDepth(), 8);
+        assertFalse(config.isNestedDiscoverDynamicFields()); // Should still be default
+    }
+
+    @Test
+    public void testMultipleConfigurationChanges()
+    {
+        OpenSearchConfig config = new OpenSearchConfig();
+
+        // Change multiple times
+        config.setNestedMaxDepth(3);
+        assertEquals(config.getNestedMaxDepth(), 3);
+
+        config.setNestedMaxDepth(7);
+        assertEquals(config.getNestedMaxDepth(), 7);
+
+        config.setNestedMaxDepth(5);
+        assertEquals(config.getNestedMaxDepth(), 5);
+
+        // Toggle boolean settings
+        config.setNestedFieldAccessEnabled(false);
+        assertFalse(config.isNestedFieldAccessEnabled());
+
+        config.setNestedFieldAccessEnabled(true);
+        assertTrue(config.isNestedFieldAccessEnabled());
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchPlugin.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestOpenSearchPlugin
+{
+    @Test
+    public void testCreateConnectorFactory()
+    {
+        OpenSearchPlugin plugin = new OpenSearchPlugin();
+        Iterable<ConnectorFactory> factories = plugin.getConnectorFactories();
+
+        assertNotNull(factories);
+
+        ConnectorFactory factory = factories.iterator().next();
+        assertNotNull(factory);
+        assertEquals(factory.getName(), "opensearch");
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchQueries.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchQueries.java
@@ -1,0 +1,2103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueries;
+import io.airlift.tpch.TpchTable;
+import org.apache.http.HttpHost;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Comprehensive integration tests for OpenSearch connector.
+ * Extends AbstractTestQueries to inherit standard query test suite (500+ tests)
+ * and adds OpenSearch-specific tests including nested field queries.
+ */
+public class TestOpenSearchQueries
+        extends AbstractTestQueries
+{
+    private static final Logger log = Logger.get(TestOpenSearchQueries.class);
+    private static final String OPENSEARCH_IMAGE = "opensearchproject/opensearch:2.11.1";
+    private static volatile boolean indexCreated;
+    private static final Object INDEX_LOCK = new Object();
+
+    private static GenericContainer<?> opensearchContainer;
+    private static RestClient restClient;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        // Start OpenSearch container only once (called by framework before @BeforeClass)
+        if (opensearchContainer == null) {
+            synchronized (INDEX_LOCK) {
+                if (opensearchContainer == null) {
+                    opensearchContainer = new GenericContainer<>(DockerImageName.parse(OPENSEARCH_IMAGE))
+                            .withExposedPorts(9200, 9600)
+                            .withEnv("discovery.type", "single-node")
+                            .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+                            .withEnv("DISABLE_SECURITY_PLUGIN", "true")
+                            .waitingFor(new HttpWaitStrategy()
+                                    .forPort(9200)
+                                    .forStatusCode(200)
+                                    .withStartupTimeout(Duration.ofMinutes(2)));
+
+                    opensearchContainer.start();
+
+                    log.info("OpenSearch container started at: http://%s:%d",
+                            opensearchContainer.getHost(),
+                            opensearchContainer.getMappedPort(9200));
+
+                    // Create REST client for index setup
+                    restClient = RestClient.builder(
+                            new HttpHost(
+                                    opensearchContainer.getHost(),
+                                    opensearchContainer.getMappedPort(9200),
+                                    "http"))
+                            .build();
+
+                    // Create test indices with nested fields
+                    createTestIndices();
+                }
+            }
+        }
+
+        return OpenSearchQueryRunner.createQueryRunner(opensearchContainer, TpchTable.getTables());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        if (restClient != null) {
+            restClient.close();
+        }
+        if (opensearchContainer != null) {
+            opensearchContainer.stop();
+        }
+    }
+
+    /**
+     * Helper method to create a session for OpenSearch-specific queries.
+     * Uses the opensearch_with_id catalog which has _id column visible.
+     */
+    private Session createOpenSearchSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("opensearch_with_id")
+                .setSchema("default")
+                .build();
+    }
+
+    /**
+     * Create test indices with nested field mappings and sample data.
+     */
+    private void createTestIndices()
+            throws IOException
+    {
+        // Only create index once across all test instances (double-check locking)
+        synchronized (INDEX_LOCK) {
+            if (indexCreated) {
+                log.info("Index already created, skipping creation");
+                return;
+            }
+
+            // Delete index if it exists to ensure clean state
+            try {
+                Request deleteRequest = new Request("DELETE", "/analytics_query_index");
+                restClient.performRequest(deleteRequest);
+                log.info("Deleted existing analytics_query_index");
+            }
+            catch (Exception e) {
+                // Index doesn't exist, which is fine
+                log.info("Index analytics_query_index does not exist, creating new");
+            }
+
+            // Create analytics_query_index with nested fields and multiple shards
+            // Include problematic field names that could cause serialization issues
+            String analyticsMapping = "{\n" +
+                    "  \"settings\": {\n" +
+                    "    \"number_of_shards\": 3,\n" +
+                    "    \"number_of_replicas\": 0\n" +
+                    "  },\n" +
+                    "  \"mappings\": {\n" +
+                    "    \"properties\": {\n" +
+                    "      \"user_id\": { \"type\": \"keyword\" },\n" +
+                    "      \"query_text\": { \"type\": \"text\" },\n" +
+                    "      \"cache_creation_input_tokens\": { \"type\": \"long\" },\n" +
+                    "      \"cache_creation_output_tokens\": { \"type\": \"long\" },\n" +
+                    "      \"cache_read_input_tokens\": { \"type\": \"long\" },\n" +
+                    "      \"total_input_tokens\": { \"type\": \"long\" },\n" +
+                    "      \"prompt_tokens_used\": { \"type\": \"long\" },\n" +
+                    "      \"completion_tokens_generated\": { \"type\": \"long\" },\n" +
+                    "      \"model_response_time_ms\": { \"type\": \"long\" },\n" +
+                    "      \"api_call_timestamp\": { \"type\": \"date\" },\n" +
+                    "      \"llm_model_version\": { \"type\": \"keyword\" },\n" +
+                    "      \"token_usage\": {\n" +
+                    "        \"type\": \"object\",\n" +
+                    "        \"properties\": {\n" +
+                    "          \"total_tokens\": { \"type\": \"long\" },\n" +
+                    "          \"prompt_tokens\": { \"type\": \"long\" },\n" +
+                    "          \"completion_tokens\": { \"type\": \"long\" }\n" +
+                    "        }\n" +
+                    "      },\n" +
+                    "      \"reliability_scores\": {\n" +
+                    "        \"type\": \"object\",\n" +
+                    "        \"properties\": {\n" +
+                    "          \"answer_relevance\": {\n" +
+                    "            \"type\": \"object\",\n" +
+                    "            \"properties\": {\n" +
+                    "              \"score\": { \"type\": \"integer\" },\n" +
+                    "              \"confidence\": { \"type\": \"double\" }\n" +
+                    "            }\n" +
+                    "          },\n" +
+                    "          \"faithfulness\": {\n" +
+                    "            \"type\": \"object\",\n" +
+                    "            \"properties\": {\n" +
+                    "              \"score\": { \"type\": \"integer\" }\n" +
+                    "            }\n" +
+                    "          }\n" +
+                    "        }\n" +
+                    "      },\n" +
+                    "      \"metadata\": {\n" +
+                    "        \"type\": \"object\",\n" +
+                    "        \"properties\": {\n" +
+                    "          \"model_name\": { \"type\": \"keyword\" },\n" +
+                    "          \"timestamp\": { \"type\": \"date\" }\n" +
+                    "        }\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}";
+
+            Request createIndexRequest = new Request("PUT", "/analytics_query_index");
+            createIndexRequest.setJsonEntity(analyticsMapping);
+            Response response = restClient.performRequest(createIndexRequest);
+            assertEquals(response.getStatusLine().getStatusCode(), 200);
+
+            log.info("Created analytics_query_index");
+
+            // Insert sample documents
+            insertSampleDocuments();
+
+            // Create k-NN index for vector search tests
+            createKnnIndex();
+
+            // Mark index as created
+            indexCreated = true;
+        }
+    }
+
+    /**
+     * Create k-NN index with vector embeddings for table function tests.
+     */
+    private void createKnnIndex()
+            throws IOException
+    {
+        // Delete index if it exists
+        try {
+            Request deleteRequest = new Request("DELETE", "/knn_docs");
+            restClient.performRequest(deleteRequest);
+            log.info("Deleted existing knn_docs index");
+        }
+        catch (Exception e) {
+            log.info("Index knn_docs does not exist, creating new");
+        }
+
+        // Create knn_docs index with k-NN vector field and multiple shards
+        String knnMapping = "{\n" +
+                "  \"settings\": {\n" +
+                "    \"number_of_shards\": 4,\n" +
+                "    \"number_of_replicas\": 0,\n" +
+                "    \"index.knn\": true\n" +
+                "  },\n" +
+                "  \"mappings\": {\n" +
+                "    \"properties\": {\n" +
+                "      \"doc_id\": { \"type\": \"keyword\" },\n" +
+                "      \"category\": { \"type\": \"keyword\" },\n" +
+                "      \"knn_embedding\": {\n" +
+                "        \"type\": \"knn_vector\",\n" +
+                "        \"dimension\": 3,\n" +
+                "        \"method\": {\n" +
+                "          \"name\": \"hnsw\",\n" +
+                "          \"space_type\": \"cosinesimil\",\n" +
+                "          \"engine\": \"nmslib\",\n" +
+                "          \"parameters\": {\n" +
+                "            \"ef_construction\": 128,\n" +
+                "            \"m\": 24\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        Request createKnnIndexRequest = new Request("PUT", "/knn_docs");
+        createKnnIndexRequest.setJsonEntity(knnMapping);
+        Response knnResponse = restClient.performRequest(createKnnIndexRequest);
+        assertEquals(knnResponse.getStatusLine().getStatusCode(), 200);
+        log.info("Created knn_docs index");
+
+        // Insert sample k-NN documents
+        insertKnnDocuments();
+        // Create vector_docs index for vector function tests
+        createVectorDocsIndex();
+    }
+
+    /**
+     * Insert sample documents with k-NN vector embeddings.
+     */
+    private void insertKnnDocuments()
+            throws IOException
+    {
+        // Document 1: vector [1.0, 0.0, 0.0]
+        String knnDoc1 = "{\n" +
+                "  \"doc_id\": \"vec-1\",\n" +
+                "  \"category\": \"tech\",\n" +
+                "  \"knn_embedding\": [1.0, 0.0, 0.0]\n" +
+                "}";
+        Request indexKnnDoc1 = new Request("PUT", "/knn_docs/_doc/1");
+        indexKnnDoc1.setJsonEntity(knnDoc1);
+        restClient.performRequest(indexKnnDoc1);
+
+        // Document 2: vector [0.9, 0.1, 0.0]
+        String knnDoc2 = "{\n" +
+                "  \"doc_id\": \"vec-2\",\n" +
+                "  \"category\": \"tech\",\n" +
+                "  \"knn_embedding\": [0.9, 0.1, 0.0]\n" +
+                "}";
+        Request indexKnnDoc2 = new Request("PUT", "/knn_docs/_doc/2");
+        indexKnnDoc2.setJsonEntity(knnDoc2);
+        restClient.performRequest(indexKnnDoc2);
+
+        // Document 3: vector [0.8, 0.2, 0.0]
+        String knnDoc3 = "{\n" +
+                "  \"doc_id\": \"vec-3\",\n" +
+                "  \"category\": \"science\",\n" +
+                "  \"knn_embedding\": [0.8, 0.2, 0.0]\n" +
+                "}";
+        Request indexKnnDoc3 = new Request("PUT", "/knn_docs/_doc/3");
+        indexKnnDoc3.setJsonEntity(knnDoc3);
+        restClient.performRequest(indexKnnDoc3);
+
+        // Document 4: vector [0.0, 1.0, 0.0]
+        String knnDoc4 = "{\n" +
+                "  \"doc_id\": \"vec-4\",\n" +
+                "  \"category\": \"science\",\n" +
+                "  \"knn_embedding\": [0.0, 1.0, 0.0]\n" +
+                "}";
+        Request indexKnnDoc4 = new Request("PUT", "/knn_docs/_doc/4");
+        indexKnnDoc4.setJsonEntity(knnDoc4);
+        restClient.performRequest(indexKnnDoc4);
+
+        // Document 5: vector [0.0, 0.0, 1.0]
+        String knnDoc5 = "{\n" +
+                "  \"doc_id\": \"vec-5\",\n" +
+                "  \"category\": \"arts\",\n" +
+                "  \"knn_embedding\": [0.0, 0.0, 1.0]\n" +
+                "}";
+        Request indexKnnDoc5 = new Request("PUT", "/knn_docs/_doc/5");
+        indexKnnDoc5.setJsonEntity(knnDoc5);
+        restClient.performRequest(indexKnnDoc5);
+
+        // Refresh index to make documents searchable
+        Request refreshRequest = new Request("POST", "/knn_docs/_refresh");
+        restClient.performRequest(refreshRequest);
+        log.info("Inserted 5 k-NN documents and refreshed index");
+    }
+    /**
+     * Create vector_docs index with array-type embedding field for vector function tests.
+     */
+    private void createVectorDocsIndex()
+            throws IOException
+    {
+        // Delete index if it exists
+        try {
+            Request deleteRequest = new Request("DELETE", "/vector_docs");
+            restClient.performRequest(deleteRequest);
+            log.info("Deleted existing vector_docs index");
+        }
+        catch (Exception e) {
+            log.info("Index vector_docs does not exist, creating new");
+        }
+
+        // Create vector_docs index with array field for embeddings and multiple shards
+        String vectorDocsMapping = "{\n" +
+                "  \"settings\": {\n" +
+                "    \"number_of_shards\": 3,\n" +
+                "    \"number_of_replicas\": 0\n" +
+                "  },\n" +
+                "  \"mappings\": {\n" +
+                "    \"properties\": {\n" +
+                "      \"doc_id\": { \"type\": \"keyword\" },\n" +
+                "      \"embedding\": { \"type\": \"float\", \"index\": false }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        Request createVectorDocsRequest = new Request("PUT", "/vector_docs");
+        createVectorDocsRequest.setJsonEntity(vectorDocsMapping);
+        Response vectorDocsResponse = restClient.performRequest(createVectorDocsRequest);
+        assertEquals(vectorDocsResponse.getStatusLine().getStatusCode(), 200);
+        log.info("Created vector_docs index");
+
+        // Insert sample documents with array embeddings
+        insertVectorDocuments();
+    }
+
+    /**
+     * Insert sample documents with array-type embeddings for vector function tests.
+     */
+    private void insertVectorDocuments()
+            throws IOException
+    {
+        // Document 1: embedding [1.0, 0.0, 0.0] - unit vector on x-axis
+        String vecDoc1 = "{\n" +
+                "  \"doc_id\": \"vec-1\",\n" +
+                "  \"embedding\": [1.0, 0.0, 0.0]\n" +
+                "}";
+        Request indexVecDoc1 = new Request("PUT", "/vector_docs/_doc/1");
+        indexVecDoc1.setJsonEntity(vecDoc1);
+        restClient.performRequest(indexVecDoc1);
+
+        // Document 2: embedding [0.0, 1.0, 0.0] - unit vector on y-axis
+        String vecDoc2 = "{\n" +
+                "  \"doc_id\": \"vec-2\",\n" +
+                "  \"embedding\": [0.0, 1.0, 0.0]\n" +
+                "}";
+        Request indexVecDoc2 = new Request("PUT", "/vector_docs/_doc/2");
+        indexVecDoc2.setJsonEntity(vecDoc2);
+        restClient.performRequest(indexVecDoc2);
+
+        // Document 3: embedding [3.0, 4.0, 0.0] - 3-4-5 triangle, magnitude 5.0
+        String vecDoc3 = "{\n" +
+                "  \"doc_id\": \"vec-3\",\n" +
+                "  \"embedding\": [3.0, 4.0, 0.0]\n" +
+                "}";
+        Request indexVecDoc3 = new Request("PUT", "/vector_docs/_doc/3");
+        indexVecDoc3.setJsonEntity(vecDoc3);
+        restClient.performRequest(indexVecDoc3);
+
+        // Refresh index to make documents searchable
+        Request refreshRequest = new Request("POST", "/vector_docs/_refresh");
+        restClient.performRequest(refreshRequest);
+        log.info("Inserted 3 vector documents and refreshed index");
+    }
+
+    /**
+     * Insert sample documents with nested field data.
+     */
+    private void insertSampleDocuments()
+            throws IOException
+    {
+        // Document 1 - includes problematic field names
+        String doc1 = "{\n" +
+                "  \"user_id\": \"user1\",\n" +
+                "  \"query_text\": \"What is machine learning?\",\n" +
+                "  \"cache_creation_input_tokens\": 1000,\n" +
+                "  \"cache_creation_output_tokens\": 500,\n" +
+                "  \"cache_read_input_tokens\": 200,\n" +
+                "  \"total_input_tokens\": 1200,\n" +
+                "  \"prompt_tokens_used\": 800,\n" +
+                "  \"completion_tokens_generated\": 400,\n" +
+                "  \"model_response_time_ms\": 1500,\n" +
+                "  \"api_call_timestamp\": \"2024-01-01T00:00:00Z\",\n" +
+                "  \"llm_model_version\": \"gpt-4-0613\",\n" +
+                "  \"token_usage\": {\n" +
+                "    \"total_tokens\": 90616,\n" +
+                "    \"prompt_tokens\": 45308,\n" +
+                "    \"completion_tokens\": 45308\n" +
+                "  },\n" +
+                "  \"reliability_scores\": {\n" +
+                "    \"answer_relevance\": {\n" +
+                "      \"score\": 80,\n" +
+                "      \"confidence\": 0.85\n" +
+                "    },\n" +
+                "    \"faithfulness\": {\n" +
+                "      \"score\": 75\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"metadata\": {\n" +
+                "    \"model_name\": \"gpt-4\",\n" +
+                "    \"timestamp\": \"2024-01-01T00:00:00Z\"\n" +
+                "  }\n" +
+                "}";
+
+        Request indexDoc1 = new Request("PUT", "/analytics_query_index/_doc/test-id-1");
+        indexDoc1.setJsonEntity(doc1);
+        restClient.performRequest(indexDoc1);
+
+        // Document 2
+        String doc2 = "{\n" +
+                "  \"user_id\": \"user2\",\n" +
+                "  \"query_text\": \"Explain neural networks\",\n" +
+                "  \"token_usage\": {\n" +
+                "    \"total_tokens\": 120000,\n" +
+                "    \"prompt_tokens\": 60000,\n" +
+                "    \"completion_tokens\": 60000\n" +
+                "  },\n" +
+                "  \"reliability_scores\": {\n" +
+                "    \"answer_relevance\": {\n" +
+                "      \"score\": 90,\n" +
+                "      \"confidence\": 0.92\n" +
+                "    },\n" +
+                "    \"faithfulness\": {\n" +
+                "      \"score\": 85\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"metadata\": {\n" +
+                "    \"model_name\": \"gpt-4\",\n" +
+                "    \"timestamp\": \"2024-01-02T00:00:00Z\"\n" +
+                "  }\n" +
+                "}";
+
+        Request indexDoc2 = new Request("PUT", "/analytics_query_index/_doc/test-id-2");
+        indexDoc2.setJsonEntity(doc2);
+        restClient.performRequest(indexDoc2);
+
+        // Document 3
+        String doc3 = "{\n" +
+                "  \"user_id\": \"user1\",\n" +
+                "  \"query_text\": \"Deep learning basics\",\n" +
+                "  \"token_usage\": {\n" +
+                "    \"total_tokens\": 45000,\n" +
+                "    \"prompt_tokens\": 22500,\n" +
+                "    \"completion_tokens\": 22500\n" +
+                "  },\n" +
+                "  \"reliability_scores\": {\n" +
+                "    \"answer_relevance\": {\n" +
+                "      \"score\": 70,\n" +
+                "      \"confidence\": 0.78\n" +
+                "    },\n" +
+                "    \"faithfulness\": {\n" +
+                "      \"score\": 65\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"metadata\": {\n" +
+                "    \"model_name\": \"gpt-3.5\",\n" +
+                "    \"timestamp\": \"2024-01-03T00:00:00Z\"\n" +
+                "  }\n" +
+                "}";
+
+        Request indexDoc3 = new Request("PUT", "/analytics_query_index/_doc/test-id-3");
+        indexDoc3.setJsonEntity(doc3);
+        restClient.performRequest(indexDoc3);
+
+        // Refresh index to make documents searchable
+        Request refreshRequest = new Request("POST", "/analytics_query_index/_refresh");
+        restClient.performRequest(refreshRequest);
+
+        log.info("Inserted sample documents into analytics_query_index");
+    }
+
+    // ========== Nested Field Query Tests ==========
+
+    @Test
+    public void testSelectNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT \"token_usage.total_tokens\" FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT CAST(90616 AS BIGINT)");
+    }
+
+    @Test
+    public void testSelectMultipleNestedFields()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT \"token_usage.total_tokens\", \"token_usage.prompt_tokens\" " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT CAST(90616 AS BIGINT), CAST(45308 AS BIGINT)");
+    }
+
+    @Test
+    public void testPredicateOnNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"token_usage.total_tokens\" > 50000 ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testDeeplyNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT \"reliability_scores.answer_relevance.score\" FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT 80");
+    }
+
+    @Test
+    public void testDeeplyNestedFieldWithConfidence()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT \"reliability_scores.answer_relevance.score\", \"reliability_scores.answer_relevance.confidence\" " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-2'",
+                "SELECT 90, 0.92");
+    }
+
+    @Test
+    public void testAggregateOnNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(DISTINCT _id), AVG(\"token_usage.total_tokens\") FROM analytics_query_index",
+                "SELECT CAST(3 AS BIGINT), 85205.33333333333");
+    }
+
+    @Test
+    public void testGroupByNestedField()
+    {
+        // user1 has 2 documents: 90616 + 45000 = 135616
+        // user2 has 1 document: 120000
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT user_id, SUM(\"token_usage.total_tokens\") FROM analytics_query_index GROUP BY user_id ORDER BY user_id",
+                "VALUES ('user1', CAST(135616 AS BIGINT)), ('user2', CAST(120000 AS BIGINT))");
+    }
+
+    @Test
+    public void testOrderByNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id, \"token_usage.total_tokens\" FROM analytics_query_index " +
+                        "ORDER BY \"token_usage.total_tokens\" DESC",
+                "VALUES ('test-id-2', CAST(120000 AS BIGINT)), ('test-id-1', CAST(90616 AS BIGINT)), ('test-id-3', CAST(45000 AS BIGINT))");
+    }
+
+    @Test
+    public void testMultipleNestedFieldsInPredicate()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" > 50000 " +
+                        "AND \"reliability_scores.answer_relevance.score\" > 75 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testNestedFieldWithMetadata()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT \"metadata.model_name\", \"token_usage.total_tokens\" " +
+                        "FROM analytics_query_index " +
+                        "WHERE \"metadata.model_name\" = 'gpt-4' " +
+                        "ORDER BY \"token_usage.total_tokens\"",
+                "VALUES ('gpt-4', CAST(90616 AS BIGINT)), ('gpt-4', CAST(120000 AS BIGINT))");
+    }
+
+    @Test
+    public void testCountWithNestedFieldFilter()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(DISTINCT _id) FROM analytics_query_index WHERE \"token_usage.total_tokens\" > 80000",
+                "SELECT CAST(2 AS BIGINT)");
+    }
+
+    @Test
+    public void testMaxMinOnNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT MAX(\"token_usage.total_tokens\"), MIN(\"token_usage.total_tokens\") FROM analytics_query_index",
+                "SELECT CAST(120000 AS BIGINT), CAST(45000 AS BIGINT)");
+    }
+
+    @Test
+    public void testSumOnNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT SUM(\"token_usage.total_tokens\") FROM analytics_query_index",
+                "SELECT CAST(255616 AS BIGINT)");
+    }
+
+    @Test
+    public void testSumOnMultipleNestedFields()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT SUM(\"token_usage.prompt_tokens\"), SUM(\"token_usage.completion_tokens\") FROM analytics_query_index",
+                "SELECT CAST(127808 AS BIGINT), CAST(127808 AS BIGINT)");
+    }
+
+    @Test
+    public void testAvgOnDeeplyNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT AVG(\"reliability_scores.answer_relevance.score\") FROM analytics_query_index",
+                "SELECT 80.0");
+    }
+
+    @Test
+    public void testCountDistinctOnNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(DISTINCT \"metadata.model_name\") FROM analytics_query_index",
+                "SELECT CAST(2 AS BIGINT)");
+    }
+
+    @Test
+    public void testAggregateWithGroupByOnNestedFields()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT \"metadata.model_name\", " +
+                        "COUNT(DISTINCT _id), " +
+                        "AVG(\"token_usage.total_tokens\"), " +
+                        "MAX(\"reliability_scores.answer_relevance.score\") " +
+                        "FROM analytics_query_index " +
+                        "GROUP BY \"metadata.model_name\" " +
+                        "ORDER BY \"metadata.model_name\"",
+                "VALUES ('gpt-3.5', CAST(1 AS BIGINT), 45000.0, CAST(70 AS BIGINT)), " +
+                        "('gpt-4', CAST(2 AS BIGINT), 105308.0, CAST(90 AS BIGINT))");
+    }
+
+    @Test
+    public void testMultipleAggregatesOnSameNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT " +
+                        "COUNT(DISTINCT _id), " +
+                        "SUM(\"token_usage.total_tokens\"), " +
+                        "AVG(\"token_usage.total_tokens\"), " +
+                        "MAX(\"token_usage.total_tokens\"), " +
+                        "MIN(\"token_usage.total_tokens\") " +
+                        "FROM analytics_query_index",
+                "SELECT CAST(3 AS BIGINT), CAST(255616 AS BIGINT), 85205.33333333333, CAST(120000 AS BIGINT), CAST(45000 AS BIGINT)");
+    }
+
+    @Test
+    public void testAggregateOnNestedFieldWithFilter()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT SUM(\"token_usage.total_tokens\") " +
+                        "FROM analytics_query_index " +
+                        "WHERE \"reliability_scores.answer_relevance.score\" >= 80",
+                "SELECT CAST(210616 AS BIGINT)");
+    }
+
+    // ========== ROW Type Dereference Query Tests ==========
+    // These tests verify that nested objects are properly exposed as ROW types,
+    // enabling SQL dereference syntax (e.g., token_usage.total_tokens without quotes)
+
+    @Test
+    public void testRowTypeDereferenceSimple()
+    {
+        // Test basic ROW type dereference: parent_object.field
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT token_usage.total_tokens FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT CAST(90616 AS BIGINT)");
+    }
+
+    @Test
+    public void testRowTypeDereferenceMultipleFields()
+    {
+        // Test multiple field dereferences from same ROW
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT token_usage.total_tokens, token_usage.prompt_tokens, token_usage.completion_tokens " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT CAST(90616 AS BIGINT), CAST(45308 AS BIGINT), CAST(45308 AS BIGINT)");
+    }
+
+    @Test
+    public void testRowTypeDereferenceDeeplyNested()
+    {
+        // Test deeply nested ROW dereference: parent.child.grandchild
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT reliability_scores.answer_relevance.score FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT 80");
+    }
+
+    @Test
+    public void testRowTypeDereferenceDeeplyNestedMultiple()
+    {
+        // Test multiple deeply nested field dereferences
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT reliability_scores.answer_relevance.score, reliability_scores.answer_relevance.confidence " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-2'",
+                "SELECT 90, 0.92");
+    }
+
+    @Test
+    public void testRowTypeDereferenceInPredicate()
+    {
+        // Test ROW dereference in WHERE clause
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE token_usage.total_tokens > 50000 ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testRowTypeDereferenceInComplexPredicate()
+    {
+        // Test ROW dereference with complex predicate
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE token_usage.total_tokens > 50000 AND reliability_scores.answer_relevance.score >= 80 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testRowTypeDereferenceWithAggregate()
+    {
+        // Test ROW dereference in aggregate functions
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(DISTINCT _id), AVG(token_usage.total_tokens) FROM analytics_query_index",
+                "SELECT CAST(3 AS BIGINT), 85205.33333333333");
+    }
+
+    @Test
+    public void testRowTypeDereferenceInGroupBy()
+    {
+        // Test ROW dereference in GROUP BY
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT user_id, SUM(token_usage.total_tokens) FROM analytics_query_index GROUP BY user_id ORDER BY user_id",
+                "VALUES ('user1', CAST(135616 AS BIGINT)), ('user2', CAST(120000 AS BIGINT))");
+    }
+
+    @Test
+    public void testRowTypeDereferenceInOrderBy()
+    {
+        // Test ROW dereference in ORDER BY
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id, token_usage.total_tokens FROM analytics_query_index " +
+                        "ORDER BY token_usage.total_tokens DESC",
+                "VALUES ('test-id-2', CAST(120000 AS BIGINT)), ('test-id-1', CAST(90616 AS BIGINT)), ('test-id-3', CAST(45000 AS BIGINT))");
+    }
+
+    @Test
+    public void testRowTypeDereferenceMultipleObjects()
+    {
+        // Test dereferencing fields from multiple ROW objects
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT metadata.model_name, token_usage.total_tokens " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "VALUES ('gpt-4', CAST(90616 AS BIGINT))");
+    }
+
+    @Test
+    public void testRowTypeDereferenceWithJoin()
+    {
+        // Test ROW dereference in self-join scenario
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT a._id, a.token_usage.total_tokens " +
+                        "FROM analytics_query_index a " +
+                        "WHERE a.token_usage.total_tokens > 80000 " +
+                        "ORDER BY a._id",
+                "VALUES ('test-id-1', CAST(90616 AS BIGINT)), ('test-id-2', CAST(120000 AS BIGINT))");
+    }
+
+    @Test
+    public void testRowTypeDereferenceParentObject()
+    {
+        // Test selecting the parent ROW object itself (should return as JSON string)
+        MaterializedResult result = computeActual(
+                createOpenSearchSession(),
+                "SELECT DISTINCT token_usage FROM analytics_query_index WHERE _id = 'test-id-1'");
+        assertEquals(result.getRowCount(), 1);
+        // The ROW should be returned as a structured value
+        assertTrue(result.getMaterializedRows().get(0).getField(0).toString().contains("90616"));
+    }
+
+    @Test
+    public void testRowTypeDereferenceNestedParentObject()
+    {
+        // Test selecting a nested parent ROW object
+        MaterializedResult result = computeActual(
+                createOpenSearchSession(),
+                "SELECT DISTINCT reliability_scores.answer_relevance FROM analytics_query_index WHERE _id = 'test-id-1'");
+        assertEquals(result.getRowCount(), 1);
+        // The nested ROW should contain both score and confidence
+        String rowValue = result.getMaterializedRows().get(0).getField(0).toString();
+        assertTrue(rowValue.contains("80"));
+        assertTrue(rowValue.contains("0.85"));
+    }
+
+    @Test
+    public void testRowTypeDereferenceMixedSyntax()
+    {
+        // Test mixing quoted column names with ROW dereference
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT \"metadata.model_name\", token_usage.total_tokens " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "VALUES ('gpt-4', CAST(90616 AS BIGINT))");
+    }
+
+    @Test
+    public void testAggregateOnDeeplyNestedFieldWithGroupBy()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT user_id, " +
+                        "AVG(\"reliability_scores.answer_relevance.score\"), " +
+                        "AVG(\"reliability_scores.answer_relevance.confidence\") " +
+                        "FROM analytics_query_index " +
+                        "GROUP BY user_id " +
+                        "ORDER BY user_id",
+                "VALUES ('user1', 75.0, 0.815), ('user2', 90.0, 0.92)");
+    }
+
+    @Test
+    public void testMaxMinOnDeeplyNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT " +
+                        "MAX(\"reliability_scores.answer_relevance.confidence\"), " +
+                        "MIN(\"reliability_scores.answer_relevance.confidence\") " +
+                        "FROM analytics_query_index",
+                "SELECT 0.92, 0.78");
+    }
+
+    @Test
+    public void testAggregateWithHavingOnNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT user_id, SUM(\"token_usage.total_tokens\") as total " +
+                        "FROM analytics_query_index " +
+                        "GROUP BY user_id " +
+                        "HAVING SUM(\"token_usage.total_tokens\") > 100000 " +
+                        "ORDER BY user_id",
+                "VALUES ('user1', CAST(135616 AS BIGINT)), ('user2', CAST(120000 AS BIGINT))");
+    }
+
+    @Test
+    public void testCountWithNestedFieldGroupBy()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT \"metadata.model_name\", COUNT(DISTINCT _id) " +
+                        "FROM analytics_query_index " +
+                        "GROUP BY \"metadata.model_name\" " +
+                        "ORDER BY \"metadata.model_name\"",
+                "VALUES ('gpt-3.5', CAST(1 AS BIGINT)), ('gpt-4', CAST(2 AS BIGINT))");
+    }
+
+    @Test
+    public void testAggregateOnMultipleDeeplyNestedFields()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT " +
+                        "AVG(\"reliability_scores.answer_relevance.score\"), " +
+                        "AVG(\"reliability_scores.faithfulness.score\") " +
+                        "FROM analytics_query_index",
+                "SELECT 80.0, 75.0");
+    }
+
+    @Test
+    public void testSumWithNestedFieldFilter()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT SUM(\"token_usage.prompt_tokens\") " +
+                        "FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" > 50000",
+                "SELECT CAST(105308 AS BIGINT)");
+    }
+
+    @Test
+    public void testAggregateOnNestedFieldWithComplexFilter()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT " +
+                        "COUNT(DISTINCT _id), " +
+                        "AVG(\"token_usage.total_tokens\") " +
+                        "FROM analytics_query_index " +
+                        "WHERE \"reliability_scores.answer_relevance.score\" > 75 " +
+                        "AND \"metadata.model_name\" = 'gpt-4'",
+                "SELECT CAST(2 AS BIGINT), 105308.0");
+    }
+
+    @Test
+    public void testGroupByMultipleNestedFields()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT " +
+                        "user_id, " +
+                        "\"metadata.model_name\", " +
+                        "COUNT(DISTINCT _id) " +
+                        "FROM analytics_query_index " +
+                        "GROUP BY user_id, \"metadata.model_name\" " +
+                        "ORDER BY user_id, \"metadata.model_name\"",
+                "VALUES ('user1', 'gpt-3.5', CAST(1 AS BIGINT)), " +
+                        "('user1', 'gpt-4', CAST(1 AS BIGINT)), " +
+                        "('user2', 'gpt-4', CAST(1 AS BIGINT))");
+    }
+
+    @Test
+    public void testAggregateWithOrderByOnNestedField()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT user_id, SUM(\"token_usage.total_tokens\") as total " +
+                        "FROM analytics_query_index " +
+                        "GROUP BY user_id " +
+                        "ORDER BY SUM(\"token_usage.total_tokens\") DESC",
+                "VALUES ('user1', CAST(135616 AS BIGINT)), ('user2', CAST(120000 AS BIGINT))");
+    }
+
+    @Test
+    public void testMinMaxOnMultipleNestedFields()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT " +
+                        "MAX(\"token_usage.prompt_tokens\"), " +
+                        "MIN(\"token_usage.prompt_tokens\"), " +
+                        "MAX(\"token_usage.completion_tokens\"), " +
+                        "MIN(\"token_usage.completion_tokens\") " +
+                        "FROM analytics_query_index",
+                "SELECT CAST(60000 AS BIGINT), CAST(22500 AS BIGINT), CAST(60000 AS BIGINT), CAST(22500 AS BIGINT)");
+    }
+
+    // ========== Vector Search Function Tests Using Array Column from OpenSearch Index ==========
+
+    @Test
+    public void testVectorMagnitudeFromArrayColumn()
+    {
+        // Test magnitude calculation: sqrt(dot_product(v, v))
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id, sqrt(dot_product(embedding, embedding)) as magnitude " +
+                        "FROM vector_docs WHERE doc_id = 'vec-3'",
+                "VALUES ('vec-3', 5.0)");
+    }
+
+    @Test
+    public void testVectorCosineSimilarityFromArrayColumn()
+    {
+        // Test cosine similarity with embedding array column
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id, " +
+                        "cosine_similarity(embedding, ARRAY[1.0, 0.0, 0.0]) as similarity " +
+                        "FROM vector_docs " +
+                        "ORDER BY similarity DESC",
+                "VALUES ('vec-1', 1.0), ('vec-3', 0.6), ('vec-2', 0.0)");
+    }
+
+    @Test
+    public void testVectorEuclideanDistanceFromArrayColumn()
+    {
+        // Test Euclidean distance: sqrt(l2_squared(v1, v2))
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id, " +
+                        "sqrt(l2_squared(CAST(ARRAY[0.0, 0.0, 0.0] AS array(real)), embedding)) as distance " +
+                        "FROM vector_docs WHERE doc_id = 'vec-3'",
+                "VALUES ('vec-3', 5.0)");
+    }
+
+    @Test
+    public void testVectorDotProductFromArrayColumn()
+    {
+        // Test dot product with embedding array column
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id, " +
+                        "dot_product(embedding, ARRAY[1.0, 1.0, 0.0]) as score " +
+                        "FROM vector_docs " +
+                        "ORDER BY score DESC",
+                "VALUES ('vec-3', 7.0), ('vec-1', 1.0), ('vec-2', 1.0)");
+    }
+
+    @Test
+    public void testVectorSearchWithArrayColumnFilter()
+    {
+        // Filter documents using vector magnitude
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id FROM vector_docs " +
+                        "WHERE sqrt(dot_product(embedding, embedding)) > 1.5 " +
+                        "ORDER BY doc_id",
+                "VALUES ('vec-3')");
+    }
+
+    // ========== k-NN Table Function Tests ==========
+    // Tests for k-NN vector search using SQL table functions
+
+    /**
+     * Test basic k-NN search using table function.
+     */
+    @Test
+    public void testKnnTableFunctionBasicSearch()
+    {
+        // Query for top 3 nearest neighbors to [1.0, 0.0, 0.0]
+        // Expected: vec-1 (exact match), vec-2 (close), vec-3 (further)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT _id, doc_id, category " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "  k => 3" +
+                        ")) " +
+                        "ORDER BY _score DESC",
+                "VALUES ('1', 'vec-1', 'tech'), " +
+                        "('2', 'vec-2', 'tech'), " +
+                        "('3', 'vec-3', 'science')");
+    }
+
+    /**
+     * Test k-NN search with custom k value.
+     */
+    @Test
+    public void testKnnTableFunctionWithCustomK()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(*) " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[0.7, 0.7, 0.0], " +
+                        "  k => 2" +
+                        "))",
+                "SELECT CAST(2 AS BIGINT)");
+    }
+
+    /**
+     * Test k-NN search with space_type parameter.
+     */
+    @Test
+    public void testKnnTableFunctionWithSpaceType()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT _id, category " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "  k => 5, " +
+                        "  space_type => 'cosine'" +
+                        ")) " +
+                        "ORDER BY _score DESC " +
+                        "LIMIT 3",
+                "VALUES ('1', 'tech'), ('2', 'tech'), ('3', 'science')");
+    }
+
+    /**
+     * Test k-NN search with ef_search parameter for accuracy tuning.
+     */
+    @Test
+    public void testKnnTableFunctionWithEfSearch()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(*) " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[0.5, 0.5, 0.0], " +
+                        "  k => 3, " +
+                        "  ef_search => 200" +
+                        "))",
+                "SELECT CAST(3 AS BIGINT)");
+    }
+
+    /**
+     * Test k-NN search with filtering on results.
+     */
+    @Test
+    public void testKnnTableFunctionWithFilter()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT _id, category " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "  k => 10" +
+                        ")) " +
+                        "WHERE category = 'tech' " +
+                        "ORDER BY _score DESC",
+                "VALUES ('1', 'tech'), ('2', 'tech')");
+    }
+
+    /**
+     * Test k-NN search with aggregation.
+     */
+    @Test
+    public void testKnnTableFunctionWithAggregation()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT category, COUNT(*) " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "  k => 10" +
+                        ")) " +
+                        "GROUP BY category " +
+                        "ORDER BY COUNT(*) DESC",
+                "VALUES ('tech', CAST(2 AS BIGINT)), ('science', CAST(2 AS BIGINT)), ('arts', CAST(1 AS BIGINT))");
+    }
+
+    /**
+     * Test k-NN search with JOIN.
+     */
+    @Test
+    public void testKnnTableFunctionWithJoin()
+    {
+        // Test JOIN with k-NN results - no matching rows since doc_id values don't match user_id values
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(*) " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "  k => 5" +
+                        ")) k " +
+                        "JOIN analytics_query_index a ON k.doc_id = a.user_id",
+                "SELECT CAST(0 AS BIGINT)");
+    }
+
+    /**
+     * Test k-NN search with UNION.
+     */
+    @Test
+    public void testKnnTableFunctionWithUnion()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT 'query1' as source, _id " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "  k => 2" +
+                        ")) " +
+                        "UNION ALL " +
+                        "SELECT 'query2' as source, _id " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[0.0, 1.0, 0.0], " +
+                        "  k => 2" +
+                        ")) " +
+                        "ORDER BY _id",
+                "VALUES ('query1', '1'), ('query1', '2'), ('query2', '3'), ('query2', '4')");
+    }
+
+    /**
+     * Test k-NN search with subquery.
+     */
+    @Test
+    public void testKnnTableFunctionWithSubquery()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT category, num_results " +
+                        "FROM (" +
+                        "  SELECT category, COUNT(*) as num_results " +
+                        "  FROM TABLE(opensearch.system.knn_search(" +
+                        "    index_name => 'knn_docs', " +
+                        "    vector_field => 'knn_embedding', " +
+                        "    query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "    k => 10" +
+                        "  )) " +
+                        "  GROUP BY category" +
+                        ") " +
+                        "WHERE num_results > 1 " +
+                        "ORDER BY category",
+                "VALUES ('science', CAST(2 AS BIGINT)), ('tech', CAST(2 AS BIGINT))");
+    }
+
+    /**
+     * Test k-NN search with LIMIT and OFFSET.
+     */
+    @Test
+    public void testKnnTableFunctionWithLimitOffset()
+    {
+        // Test LIMIT on k-NN results
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT _id " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "  k => 5" +
+                        ")) " +
+                        "ORDER BY _id " +
+                        "LIMIT 3",
+                "VALUES ('1'), ('2'), ('3')");
+    }
+    /**
+     * Test k-NN search with array containing scientific notation.
+     * When array contains scientific notation (e.g., 9.158867E-4), Presto parses it as DOUBLE.
+     * This test verifies that ARRAY(DOUBLE) is accepted by the knn_search function.
+     */
+    @Test
+    public void testKnnTableFunctionWithScientificNotation()
+    {
+        // Query with scientific notation - this gets parsed as array(double)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT knn._id, knn._score " +
+                        "FROM TABLE(opensearch.system.knn_search(" +
+                        "index_name => 'knn_docs', " +
+                        "vector_field => 'knn_embedding', " +
+                        "query_vector => ARRAY[0.0053062416, 9.158867E-4, -0.032646563], " +
+                        "k => 5, " +
+                        "space_type => 'cosine')) AS knn " +
+                        "ORDER BY knn._score DESC LIMIT 3",
+                "VALUES ('2', 1.1624452), ('3', 1.1622945), ('1', 1.1603692)");
+    }
+
+    // ========== k-NN Table Function Negative Tests ==========
+    // Tests for error handling and validation
+
+    /**
+     * Test k-NN search with non-existent vector field.
+     */
+    @Test
+    public void testKnnTableFunctionWithNonExistentField()
+    {
+        assertQueryFails(
+                createOpenSearchSession(),
+                "SELECT * FROM TABLE(opensearch.system.knn_search(" +
+                       "  index_name => 'knn_docs', " +
+                       "  vector_field => 'nonexistent_field', " +
+                       "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                       "  k => 10" +
+                       "))",
+                ".*Vector field 'nonexistent_field' does not exist in index mapping.*");
+    }
+
+    /**
+     * Test k-NN search with non-vector field (text field).
+     */
+    @Test
+    public void testKnnTableFunctionWithNonVectorField()
+    {
+        assertQueryFails(
+                createOpenSearchSession(),
+                "SELECT * FROM TABLE(opensearch.system.knn_search(" +
+                       "  index_name => 'knn_docs', " +
+                       "  vector_field => 'category', " +  // category is a keyword field, not knn_vector
+                       "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                       "  k => 10" +
+                       "))",
+                ".*Field 'category' is not a knn_vector field.*");
+    }
+
+    /**
+     * Test k-NN search with wrong vector dimensions.
+     */
+    @Test
+    public void testKnnTableFunctionWithWrongDimensions()
+    {
+        // knn_embedding has 3 dimensions, but we provide 5
+        assertQueryFails(
+                createOpenSearchSession(),
+                "SELECT * FROM TABLE(opensearch.system.knn_search(" +
+                       "  index_name => 'knn_docs', " +
+                       "  vector_field => 'knn_embedding', " +
+                       "  query_vector => ARRAY[1.0, 0.0, 0.0, 0.0, 0.0], " +  // 5 dimensions instead of 3
+                       "  k => 10" +
+                       "))",
+                ".*Query vector dimension \\(5\\) does not match field 'knn_embedding' dimension \\(3\\).*");
+    }
+
+    /**
+     * Test k-NN search on regular index without knn_vector fields.
+     */
+    @Test
+    public void testKnnTableFunctionOnNonKnnIndex()
+    {
+        // analytics_query_index has no knn_vector fields
+        assertQueryFails(
+                createOpenSearchSession(),
+                "SELECT * FROM TABLE(opensearch.system.knn_search(" +
+                       "  index_name => 'analytics_query_index', " +
+                       "  vector_field => 'user_id', " +
+                       "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                       "  k => 10" +
+                       "))",
+                ".*Field 'user_id' is not a knn_vector field.*");
+    }
+
+    /**
+     * Test k-NN search with empty query vector.
+     */
+    @Test
+    public void testKnnTableFunctionWithEmptyVector()
+    {
+        assertQueryFails(
+                createOpenSearchSession(),
+                "SELECT * FROM TABLE(opensearch.system.knn_search(" +
+                       "  index_name => 'knn_docs', " +
+                       "  vector_field => 'knn_embedding', " +
+                       "  query_vector => ARRAY[], " +  // Empty array
+                       "  k => 10" +
+                       "))",
+                ".*Query vector dimension \\(0\\) does not match field 'knn_embedding' dimension \\(3\\).*");
+    }
+
+    /**
+     * Test k-NN search with invalid k value (0).
+     */
+    @Test
+    public void testKnnTableFunctionWithZeroK()
+    {
+        // This should be caught by VectorSearchHandler validation
+        assertQueryFails(
+                createOpenSearchSession(),
+                "SELECT * FROM TABLE(opensearch.system.knn_search(" +
+                       "  index_name => 'knn_docs', " +
+                       "  vector_field => 'knn_embedding', " +
+                       "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                       "  k => 0" +
+                       "))",
+                ".*k must be positive.*");
+    }
+
+    /**
+     * Test k-NN search with negative k value.
+     */
+    @Test
+    public void testKnnTableFunctionWithNegativeK()
+    {
+        assertQueryFails(
+                createOpenSearchSession(),
+                "SELECT * FROM TABLE(opensearch.system.knn_search(" +
+                        "  index_name => 'knn_docs', " +
+                        "  vector_field => 'knn_embedding', " +
+                        "  query_vector => ARRAY[1.0, 0.0, 0.0], " +
+                        "  k => -5" +
+                        "))",
+                ".*k must be positive.*");
+    }
+
+    // ========== Multi-Shard Integration Tests ==========
+
+    /**
+     * Test that verifies data is distributed across multiple shards.
+     */
+    @Test
+    public void testMultiShardDataDistribution()
+            throws IOException
+    {
+        // Verify TPCH tables are using multiple shards
+        Request statsRequest = new Request("GET", "/nation/_stats/docs");
+        Response response = restClient.performRequest(statsRequest);
+        assertEquals(response.getStatusLine().getStatusCode(), 200);
+        log.info("Verified multi-shard setup for nation table");
+    }
+
+    /**
+     * Test aggregations work correctly across multiple shards.
+     */
+    @Test
+    public void testAggregationsAcrossMultipleShards()
+    {
+        Session session = createOpenSearchSession();
+        assertQuery(session, "SELECT COUNT(*) FROM nation");
+        assertQuery(session, "SELECT regionkey, COUNT(*) FROM nation GROUP BY regionkey");
+    }
+
+    /**
+     * Test ORDER BY works correctly across multiple shards.
+     */
+    @Test
+    public void testOrderByAcrossMultipleShards()
+    {
+        Session session = createOpenSearchSession();
+        assertQuery(session, "SELECT nationkey, name FROM nation ORDER BY nationkey LIMIT 5");
+    }
+
+    /**
+     * Test JOIN operations work correctly with multi-shard indices.
+     */
+    @Test
+    public void testJoinAcrossMultipleShards()
+    {
+        Session session = createOpenSearchSession();
+        // Test JOIN between two multi-sharded tables
+        MaterializedResult result = computeActual(session,
+                "SELECT n.name, r.name " +
+                "FROM nation n JOIN region r ON n.regionkey = r.regionkey " +
+                "LIMIT 10");
+        assertEquals(result.getRowCount(), 10);
+        // Verify we got valid data from both tables
+        assertTrue(result.getMaterializedRows().stream()
+                .allMatch(row -> row.getField(0) != null && row.getField(1) != null));
+    }
+
+    /**
+     * Test nested field queries work correctly across multiple shards.
+     */
+    @Test
+    public void testNestedFieldsAcrossMultipleShards()
+    {
+        Session session = createOpenSearchSession();
+        // Test nested field access across shards
+        MaterializedResult result = computeActual(session,
+                "SELECT user_id, \"token_usage.total_tokens\" " +
+                "FROM analytics_query_index " +
+                "WHERE \"token_usage.total_tokens\" > 0");
+        // Verify we got at least some data with nested fields
+        assertTrue(result.getRowCount() > 0, "Expected at least one row with token_usage.total_tokens > 0");
+        // Verify nested field values are retrieved correctly
+        assertTrue(result.getMaterializedRows().stream()
+                .allMatch(row -> row.getField(1) != null && ((Long) row.getField(1)) > 0));
+    }
+
+    /**
+     * Test vector search functions work correctly across multiple shards.
+     */
+    @Test
+    public void testVectorSearchAcrossMultipleShards()
+    {
+        Session session = createOpenSearchSession();
+        // Test vector data retrieval across shards
+        MaterializedResult result = computeActual(session,
+                "SELECT doc_id, embedding " +
+                "FROM vector_docs " +
+                "LIMIT 5");
+        // Verify we got vector data from the multi-shard index
+        assertTrue(result.getRowCount() > 0, "Expected at least one row from vector_docs");
+        assertTrue(result.getRowCount() <= 5, "Expected at most 5 rows");
+        // Verify we got vector data (embedding is an array)
+        assertTrue(result.getMaterializedRows().stream()
+                .allMatch(row -> row.getField(0) != null && row.getField(1) != null));
+    }
+
+    /**
+     * Test k-NN table function works correctly with multi-shard index.
+     */
+    @Test
+    public void testKnnSearchAcrossMultipleShards()
+    {
+        Session session = createOpenSearchSession();
+        MaterializedResult result = computeActual(session,
+                "SELECT doc_id, category, _score " +
+                "FROM TABLE(opensearch.system.knn_search(" +
+                "  index_name => 'knn_docs', " +
+                "  vector_field => 'knn_embedding', " +
+                "  query_vector => ARRAY[1.0, 0.5, 0.3], " +
+                "  k => 3" +
+                "))");
+        assertTrue(result.getRowCount() > 0 && result.getRowCount() <= 3);
+    }
+
+    /**
+     * Test DISTINCT works correctly across multiple shards.
+     */
+    @Test
+    public void testDistinctAcrossMultipleShards()
+    {
+        Session session = createOpenSearchSession();
+        assertQuery(session, "SELECT DISTINCT regionkey FROM nation");
+    }
+
+    /**
+     * Test LIMIT and OFFSET work correctly across multiple shards.
+     */
+    @Test
+    public void testLimitOffsetAcrossMultipleShards()
+    {
+        Session session = createOpenSearchSession();
+        MaterializedResult result = computeActual(session,
+                "SELECT nationkey FROM nation ORDER BY nationkey LIMIT 5");
+        assertEquals(result.getRowCount(), 5);
+    }
+
+    // ========== QueryBuilder Method Coverage Tests ==========
+    // These tests ensure all QueryBuilder methods are exercised through integration tests
+
+    // Tests for buildCondition() with flat fields
+    @Test
+    public void testFlatFieldEquality()
+    {
+        // Tests buildCondition() -> buildTermQuery() for keyword field
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE user_id = 'user1' ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-3')");
+    }
+
+    @Test
+    public void testFlatFieldStringEquality()
+    {
+        // Tests buildCondition() -> buildTermQuery() for string values with special characters
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"metadata.model_name\" = 'gpt-4' ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testFlatFieldRangeGreaterThan()
+    {
+        // Tests buildCondition() -> buildRangeQuery() with gt operator
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id FROM knn_docs WHERE doc_id > 'vec-2' ORDER BY doc_id",
+                "VALUES ('vec-3'), ('vec-4'), ('vec-5')");
+    }
+
+    @Test
+    public void testFlatFieldRangeLessThan()
+    {
+        // Tests buildCondition() -> buildRangeQuery() with lt operator
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id FROM knn_docs WHERE doc_id < 'vec-3' ORDER BY doc_id",
+                "VALUES ('vec-1'), ('vec-2')");
+    }
+
+    @Test
+    public void testFlatFieldRangeGreaterThanOrEqual()
+    {
+        // Tests buildCondition() -> buildRangeQuery() with gte operator
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id FROM knn_docs WHERE doc_id >= 'vec-3' ORDER BY doc_id",
+                "VALUES ('vec-3'), ('vec-4'), ('vec-5')");
+    }
+
+    @Test
+    public void testFlatFieldRangeLessThanOrEqual()
+    {
+        // Tests buildCondition() -> buildRangeQuery() with lte operator
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id FROM knn_docs WHERE doc_id <= 'vec-2' ORDER BY doc_id",
+                "VALUES ('vec-1'), ('vec-2')");
+    }
+
+    @Test
+    public void testFlatFieldBetween()
+    {
+        // Tests buildCondition() -> buildRangeQuery() with both bounds (gte and lte)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"token_usage.total_tokens\" BETWEEN 50000 AND 100000",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testFlatFieldMultipleRanges()
+    {
+        // Tests buildCondition() with multiple ranges (bool should query)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"token_usage.total_tokens\" IN (45000, 90616, 120000) ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2'), ('test-id-3')");
+    }
+
+    @Test
+    public void testMultipleFlatFieldConditions()
+    {
+        // Tests buildQuery() with multiple flat field conditions (bool must query)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE user_id = 'user1' AND \"metadata.model_name\" = 'gpt-4'",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testNestedFieldSingleValue()
+    {
+        // Tests buildNestedCondition() with single value (term query)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"reliability_scores.answer_relevance.score\" = 90",
+                "VALUES ('test-id-2')");
+    }
+
+    @Test
+    public void testNestedFieldRangeQuery()
+    {
+        // Tests buildNestedCondition() with range query
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"token_usage.prompt_tokens\" >= 45000 ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testNestedFieldMultipleRanges()
+    {
+        // Tests buildNestedCondition() with multiple ranges (bool should inside nested)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"reliability_scores.faithfulness.score\" IN (65, 75, 85) ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2'), ('test-id-3')");
+    }
+
+    @Test
+    public void testGroupedNestedQuerySameParent()
+    {
+        // Tests groupNestedPredicates() and buildGroupedNestedQuery()
+        // Multiple predicates on same parent path should be grouped
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" > 50000 " +
+                        "AND \"token_usage.prompt_tokens\" > 30000 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testGroupedNestedQueryDifferentLevels()
+    {
+        // Tests groupNestedPredicates() with deeply nested fields on same parent
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"reliability_scores.answer_relevance.score\" > 75 " +
+                        "AND \"reliability_scores.answer_relevance.confidence\" > 0.8 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testMixedFlatAndNestedConditions()
+    {
+        // Tests buildQuery() with both flat and nested field conditions
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE user_id = 'user1' " +
+                        "AND \"token_usage.total_tokens\" > 50000",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testComplexQueryAllMethods()
+    {
+        // Comprehensive test covering multiple QueryBuilder methods:
+        // - buildQuery() with multiple conditions
+        // - buildCondition() for flat fields
+        // - buildNestedCondition() for nested fields
+        // - groupNestedPredicates() for optimization
+        // - buildGroupedNestedQuery() for same parent predicates
+        // - buildTermQuery() for equality
+        // - buildRangeQuery() for comparisons
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE user_id = 'user1' " +
+                        "AND \"metadata.model_name\" = 'gpt-4' " +
+                        "AND \"token_usage.total_tokens\" > 80000 " +
+                        "AND \"token_usage.prompt_tokens\" > 40000 " +
+                        "AND \"reliability_scores.answer_relevance.score\" >= 80",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testNestedFieldWithDifferentParents()
+    {
+        // Tests that predicates on different parent paths are not grouped
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" > 50000 " +
+                        "AND \"reliability_scores.faithfulness.score\" > 70 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testBuildInnerQueryWithSingleValue()
+    {
+        // Tests buildInnerQuery() with single value (used in grouping)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" = 90616 " +
+                        "AND \"token_usage.prompt_tokens\" = 45308",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testBuildInnerQueryWithRange()
+    {
+        // Tests buildInnerQuery() with range (used in grouping)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" BETWEEN 80000 AND 100000 " +
+                        "AND \"token_usage.completion_tokens\" > 40000",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testFormatValueWithNumbers()
+    {
+        // Tests formatValue() with numeric values
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"reliability_scores.answer_relevance.score\" = 80",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testFormatValueWithDoubles()
+    {
+        // Tests formatValue() with double values
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE \"reliability_scores.answer_relevance.confidence\" > 0.9",
+                "VALUES ('test-id-2')");
+    }
+
+    @Test
+    public void testRangeQueryBothBoundsInclusive()
+    {
+        // Tests buildRangeQuery() with both bounds inclusive (gte and lte)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" >= 45000 AND \"token_usage.total_tokens\" <= 90616 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-3')");
+    }
+
+    @Test
+    public void testRangeQueryBothBoundsExclusive()
+    {
+        // Tests buildRangeQuery() with both bounds exclusive (gt and lt)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" > 45000 AND \"token_usage.total_tokens\" < 120000 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testRangeQueryMixedBounds()
+    {
+        // Tests buildRangeQuery() with mixed bounds (gt and lte)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE \"token_usage.total_tokens\" > 45000 AND \"token_usage.total_tokens\" <= 90616",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testEmptyResultSet()
+    {
+        // Tests buildQuery() with conditions that match no documents
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index WHERE user_id = 'nonexistent'",
+                "SELECT 'dummy' WHERE false");
+    }
+
+    @Test
+    public void testMatchAllQuery()
+    {
+        // Tests buildQuery() with no predicates (should generate match_all)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(DISTINCT _id) FROM analytics_query_index",
+                "SELECT CAST(3 AS BIGINT)");
+    }
+
+    @Test
+    public void testCategoryFieldEquality()
+    {
+        // Tests buildCondition() with keyword field on knn_docs
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id FROM knn_docs WHERE category = 'tech' ORDER BY doc_id",
+                "VALUES ('vec-1'), ('vec-2')");
+    }
+
+    @Test
+    public void testMultipleCategoriesWithOr()
+    {
+        // Tests buildCondition() with multiple values (IN clause)
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT doc_id FROM knn_docs WHERE category IN ('tech', 'science') ORDER BY doc_id",
+                "VALUES ('vec-1'), ('vec-2'), ('vec-3'), ('vec-4')");
+    }
+
+    // Tests for ROW type dereference syntax (unquoted identifiers)
+    @Test
+    public void testDereferenceNestedFieldUnquoted()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT token_usage.total_tokens FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT CAST(90616 AS BIGINT)");
+    }
+
+    @Test
+    public void testDeferenceDeeplyNestedFieldUnquoted()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT reliability_scores.answer_relevance.score FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT 80");
+    }
+
+    @Test
+    public void testDereferenceMultipleFieldsUnquoted()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT token_usage.total_tokens, token_usage.prompt_tokens " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT CAST(90616 AS BIGINT), CAST(45308 AS BIGINT)");
+    }
+
+    @Test
+    public void testDereferenceInAggregateUnquoted()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT COUNT(*), SUM(reliability_scores.answer_relevance.score), AVG(reliability_scores.answer_relevance.score) " +
+                        "FROM analytics_query_index",
+                "SELECT CAST(3 AS BIGINT), CAST(240 AS BIGINT), 80.0");
+    }
+
+    @Test
+    public void testDereferenceInWhereClauseUnquoted()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE token_usage.total_tokens > 50000 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1'), ('test-id-2')");
+    }
+
+    @Test
+    public void testDereferenceInOrderByUnquoted()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id, token_usage.total_tokens FROM analytics_query_index " +
+                        "ORDER BY token_usage.total_tokens DESC",
+                "VALUES ('test-id-2', CAST(120000 AS BIGINT)), ('test-id-1', CAST(90616 AS BIGINT)), ('test-id-3', CAST(45000 AS BIGINT))");
+    }
+
+    @Test
+    public void testDereferenceInGroupByUnquoted()
+    {
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT user_id, SUM(token_usage.total_tokens) FROM analytics_query_index GROUP BY user_id ORDER BY user_id",
+                "VALUES ('user1', CAST(135616 AS BIGINT)), ('user2', CAST(120000 AS BIGINT))");
+    }
+
+    @Test
+    public void testMixedQuotedAndUnquotedDereference()
+    {
+        // Test that both quoted and unquoted syntax work together
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT token_usage.total_tokens, \"token_usage.prompt_tokens\" " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT CAST(90616 AS BIGINT), CAST(45308 AS BIGINT)");
+    }
+    // ========== Complex Field Name Tests ==========
+
+    /**
+     * Test SELECT * with problematic field names that could cause serialization issues.
+     * This test specifically addresses the bug where field names like "cache_creation_input_tokens"
+     * could cause type parsing errors during distributed query execution.
+     */
+    @Test
+    public void testSelectStarWithProblematicFieldNames()
+    {
+        // This should work without errors despite complex field names
+        MaterializedResult result = computeActual(
+                createOpenSearchSession(),
+                "SELECT * FROM analytics_query_index WHERE _id = 'test-id-1'");
+
+        // Verify we got results - this is the key test, ensuring SELECT * works
+        assertTrue(result.getRowCount() > 0, "Should return at least one row");
+
+        // Verify we got multiple columns (including the problematic field names)
+        assertTrue(result.getTypes().size() > 10, "Should have multiple columns including problematic fields");
+    }
+
+    @Test
+    public void testSelectProblematicFieldsExplicitly()
+    {
+        // Test selecting problematic fields explicitly
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT cache_creation_input_tokens, cache_creation_output_tokens, total_input_tokens " +
+                        "FROM analytics_query_index WHERE _id = 'test-id-1'",
+                "SELECT CAST(1000 AS BIGINT), CAST(500 AS BIGINT), CAST(1200 AS BIGINT)");
+    }
+
+    @Test
+    public void testAggregateOnProblematicFields()
+    {
+        // Test aggregations on fields with complex names
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT SUM(cache_creation_input_tokens), AVG(prompt_tokens_used), MAX(model_response_time_ms) " +
+                        "FROM analytics_query_index",
+                "SELECT CAST(1000 AS BIGINT), 800.0, CAST(1500 AS BIGINT)");
+    }
+
+    @Test
+    public void testPredicateOnProblematicFields()
+    {
+        // Test WHERE clause with problematic field names
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id FROM analytics_query_index " +
+                        "WHERE cache_creation_input_tokens > 500 " +
+                        "ORDER BY _id",
+                "VALUES ('test-id-1')");
+    }
+
+    @Test
+    public void testGroupByProblematicFields()
+    {
+        // Test GROUP BY with problematic field names
+        // Note: Only doc1 has llm_model_version, doc2 and doc3 don't have this field
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT llm_model_version, COUNT(*) FROM analytics_query_index " +
+                        "GROUP BY llm_model_version " +
+                        "ORDER BY llm_model_version",
+                "VALUES (CAST(NULL AS VARCHAR), CAST(2 AS BIGINT)), ('gpt-4-0613', CAST(1 AS BIGINT))");
+    }
+
+    @Test
+    public void testOrderByProblematicFields()
+    {
+        // Test ORDER BY with problematic field names
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT DISTINCT _id, model_response_time_ms FROM analytics_query_index " +
+                        "WHERE model_response_time_ms IS NOT NULL " +
+                        "ORDER BY model_response_time_ms DESC",
+                "VALUES ('test-id-1', CAST(1500 AS BIGINT))");
+    }
+
+    @Test
+    public void testJoinWithProblematicFields()
+    {
+        // Test JOIN involving tables with problematic field names
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT a._id, a.cache_creation_input_tokens " +
+                        "FROM analytics_query_index a " +
+                        "WHERE a.cache_creation_input_tokens > 0 " +
+                        "ORDER BY a._id",
+                "VALUES ('test-id-1', CAST(1000 AS BIGINT))");
+    }
+
+    @Test
+    public void testComplexQueryWithProblematicFields()
+    {
+        // Test complex query combining multiple operations on problematic fields
+        assertQuery(
+                createOpenSearchSession(),
+                "SELECT " +
+                        "  llm_model_version, " +
+                        "  COUNT(*) as query_count, " +
+                        "  SUM(cache_creation_input_tokens) as total_cache_input, " +
+                        "  AVG(prompt_tokens_used) as avg_prompt_tokens, " +
+                        "  MAX(model_response_time_ms) as max_response_time " +
+                        "FROM analytics_query_index " +
+                        "WHERE cache_creation_input_tokens > 0 " +
+                        "GROUP BY llm_model_version " +
+                        "ORDER BY llm_model_version",
+                "VALUES ('gpt-4-0613', CAST(1 AS BIGINT), CAST(1000 AS BIGINT), 800.0, CAST(1500 AS BIGINT))");
+    }
+
+    @Test
+    public void testAllProblematicFieldsAccessible()
+    {
+        // Verify all problematic fields can be accessed without errors
+        String[] problematicFields = {
+            "cache_creation_input_tokens",
+            "cache_creation_output_tokens",
+            "cache_read_input_tokens",
+            "total_input_tokens",
+            "prompt_tokens_used",
+            "completion_tokens_generated",
+            "model_response_time_ms",
+            "llm_model_version"
+        };
+
+        for (String field : problematicFields) {
+            MaterializedResult result = computeActual(
+                    createOpenSearchSession(),
+                    String.format("SELECT %s FROM analytics_query_index WHERE _id = 'test-id-1'", field));
+
+            assertTrue(result.getRowCount() > 0,
+                    "Should be able to query field: " + field);
+        }
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchSSLConnection.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestOpenSearchSSLConnection.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import org.apache.http.HttpHost;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestClient;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.net.ssl.SSLContext;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+/**
+ * Integration tests for SSL configuration in OpenSearch connector.
+ * Tests connection to actual OpenSearch instances with and without SSL.
+ */
+public class TestOpenSearchSSLConnection
+{
+    private static final Logger log = Logger.get(TestOpenSearchSSLConnection.class);
+    private static final String OPENSEARCH_IMAGE = "opensearchproject/opensearch:2.11.1";
+
+    private static GenericContainer<?> opensearchContainerWithSSL;
+    private static GenericContainer<?> opensearchContainerWithoutSSL;
+    private static RestClient restClientSSL;
+    private static RestClient restClientNoSSL;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        // Start OpenSearch container WITH SSL (uses self-signed certificate)
+        opensearchContainerWithSSL = new GenericContainer<>(DockerImageName.parse(OPENSEARCH_IMAGE))
+                .withExposedPorts(9200, 9600)
+                .withEnv("discovery.type", "single-node")
+                .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+                // Enable security plugin with self-signed certificate
+                .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "false")
+                .waitingFor(Wait.forLogMessage(".*Node started.*", 1)
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+
+        opensearchContainerWithSSL.start();
+
+        log.info("OpenSearch container with SSL started at: https://%s:%d",
+                opensearchContainerWithSSL.getHost(),
+                opensearchContainerWithSSL.getMappedPort(9200));
+
+        // Create REST client for SSL container (with certificate validation disabled for testing)
+        SSLContext sslContext = SSLContextBuilder.create()
+                .loadTrustMaterial(new TrustAllStrategy())
+                .build();
+
+        restClientSSL = RestClient.builder(
+                        new HttpHost(
+                                opensearchContainerWithSSL.getHost(),
+                                opensearchContainerWithSSL.getMappedPort(9200),
+                                "https"))
+                .setHttpClientConfigCallback((HttpAsyncClientBuilder httpClientBuilder) ->
+                        httpClientBuilder
+                                .setSSLContext(sslContext)
+                                .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE))
+                .build();
+
+        // Start OpenSearch container WITHOUT SSL for comparison
+        opensearchContainerWithoutSSL = new GenericContainer<>(DockerImageName.parse(OPENSEARCH_IMAGE))
+                .withExposedPorts(9200, 9600)
+                .withEnv("discovery.type", "single-node")
+                .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+                .withEnv("DISABLE_SECURITY_PLUGIN", "true")
+                .waitingFor(Wait.forLogMessage(".*Node started.*", 1)
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+
+        opensearchContainerWithoutSSL.start();
+
+        log.info("OpenSearch container without SSL started at: http://%s:%d",
+                opensearchContainerWithoutSSL.getHost(),
+                opensearchContainerWithoutSSL.getMappedPort(9200));
+
+        restClientNoSSL = RestClient.builder(
+                        new HttpHost(
+                                opensearchContainerWithoutSSL.getHost(),
+                                opensearchContainerWithoutSSL.getMappedPort(9200),
+                                "http"))
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        if (restClientSSL != null) {
+            restClientSSL.close();
+        }
+        if (restClientNoSSL != null) {
+            restClientNoSSL.close();
+        }
+        if (opensearchContainerWithSSL != null) {
+            opensearchContainerWithSSL.stop();
+        }
+        if (opensearchContainerWithoutSSL != null) {
+            opensearchContainerWithoutSSL.stop();
+        }
+    }
+
+    @Test
+    public void testConnectionToOpenSearchWithoutSSL()
+            throws IOException
+    {
+        // Configure client to connect to non-SSL container
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setHost(opensearchContainerWithoutSSL.getHost());
+        config.setPort(opensearchContainerWithoutSSL.getMappedPort(9200));
+        config.setSslEnabled(false);
+
+        // Create client and test connection
+        OpenSearchClient client = new OpenSearchClient(config);
+        List<String> indices = client.listIndices();
+
+        assertNotNull(indices, "Should be able to list indices");
+        log.info("Successfully connected to OpenSearch without SSL. Found %d indices", indices.size());
+    }
+
+    @Test
+    public void testConnectionToSSLOpenSearchWithoutSkipValidation()
+    {
+        // Configure client to connect to SSL container WITHOUT skip validation
+        // This should FAIL because the certificate is self-signed
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setHost(opensearchContainerWithSSL.getHost());
+        config.setPort(opensearchContainerWithSSL.getMappedPort(9200));
+        config.setSslEnabled(true);
+        config.setSslSkipCertificateValidation(false);
+        config.setUsername("admin");
+        config.setPassword("admin");
+
+        try {
+            OpenSearchClient client = new OpenSearchClient(config);
+            client.listIndices();
+            fail("Should have failed with certificate validation error");
+        }
+        catch (Exception e) {
+            // Expected - certificate validation should fail
+            log.info("Expected failure with certificate validation: %s", e.getMessage());
+            // The error message might be wrapped, so we just verify an exception was thrown
+            assertNotNull(e, "Should have thrown an exception for invalid certificate");
+        }
+    }
+
+    @Test
+    public void testConnectionToSSLOpenSearchWithSkipValidation()
+            throws IOException
+    {
+        // Configure client to connect to SSL container WITH skip validation
+        // This should SUCCEED even with self-signed certificate
+        OpenSearchConfig config = new OpenSearchConfig();
+        config.setHost(opensearchContainerWithSSL.getHost());
+        config.setPort(opensearchContainerWithSSL.getMappedPort(9200));
+        config.setSslEnabled(true);
+        config.setSslSkipCertificateValidation(true);
+        config.setUsername("admin");
+        config.setPassword("admin");
+
+        // Create client and test connection - should work with skip validation
+        OpenSearchClient client = new OpenSearchClient(config);
+        List<String> indices = client.listIndices();
+
+        assertNotNull(indices, "Should be able to list indices with skip validation enabled");
+        log.info("Successfully connected to SSL OpenSearch with skip certificate validation. Found %d indices", indices.size());
+    }
+
+    @Test
+    public void testClusterHealthCheckSSL()
+            throws IOException
+    {
+        // Verify SSL OpenSearch cluster is healthy
+        Request request = new Request("GET", "/_cluster/health");
+        request.setOptions(request.getOptions().toBuilder()
+                .addHeader("Authorization", "Basic YWRtaW46YWRtaW4="));  // admin:admin
+        Response response = restClientSSL.performRequest(request);
+
+        assertEquals(response.getStatusLine().getStatusCode(), 200, "SSL cluster health check should succeed");
+        log.info("OpenSearch SSL cluster is healthy");
+    }
+
+    @Test
+    public void testClusterHealthCheckNoSSL()
+            throws IOException
+    {
+        // Verify non-SSL OpenSearch cluster is healthy
+        Request request = new Request("GET", "/_cluster/health");
+        Response response = restClientNoSSL.performRequest(request);
+
+        assertEquals(response.getStatusLine().getStatusCode(), 200, "Non-SSL cluster health check should succeed");
+        log.info("OpenSearch non-SSL cluster is healthy");
+    }
+}
+
+// Made with Bob

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestParentObjectColumns.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestParentObjectColumns.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ColumnHandle;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for parent object column support.
+ * Verifies that both parent objects (as JSON strings) and leaf fields
+ * are properly exposed and can be queried.
+ */
+public class TestParentObjectColumns
+{
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Test that NestedFieldMapper discovers both parent and leaf fields
+     */
+    @Test
+    public void testNestedFieldDiscovery()
+    {
+        // Create a mapping with nested structure like token_usage
+        Map<String, Object> mapping = new HashMap<>();
+
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("type", "object");
+
+        Map<String, Object> properties = new HashMap<>();
+
+        Map<String, Object> totalTokens = new HashMap<>();
+        totalTokens.put("type", "long");
+        properties.put("total_tokens", totalTokens);
+
+        Map<String, Object> inputTokens = new HashMap<>();
+        inputTokens.put("type", "long");
+        properties.put("input_tokens", inputTokens);
+
+        Map<String, Object> outputTokens = new HashMap<>();
+        outputTokens.put("type", "long");
+        properties.put("output_tokens", outputTokens);
+
+        tokenUsage.put("properties", properties);
+        mapping.put("token_usage", tokenUsage);
+
+        // Discover fields
+        NestedFieldMapper mapper = new NestedFieldMapper(5);
+        Map<String, NestedFieldInfo> allFields = mapper.discoverNestedFields(mapping);
+
+        // Verify all fields are discovered (parent + 3 leaf fields)
+        assertEquals(allFields.size(), 4, "Should discover 4 fields total");
+
+        // Verify parent field
+        assertTrue(allFields.containsKey("token_usage"), "Should have parent field");
+        NestedFieldInfo parentField = allFields.get("token_usage");
+        assertFalse(parentField.isLeafField(), "Parent should not be a leaf field");
+        assertEquals(parentField.getOpenSearchType(), "object");
+        assertEquals(parentField.getNestingLevel(), 0, "Parent should be at depth 0");
+
+        // Verify leaf fields
+        assertTrue(allFields.containsKey("token_usage.total_tokens"));
+        NestedFieldInfo totalField = allFields.get("token_usage.total_tokens");
+        assertTrue(totalField.isLeafField(), "Should be a leaf field");
+        assertTrue(totalField.isNestedField(), "Should be marked as nested (depth > 0)");
+        assertEquals(totalField.getPrestoType(), BIGINT);
+        assertEquals(totalField.getOpenSearchType(), "long");
+        assertEquals(totalField.getNestingLevel(), 1, "Leaf should be at depth 1");
+        assertEquals(totalField.getParentPath(), "token_usage");
+
+        assertTrue(allFields.containsKey("token_usage.input_tokens"));
+        assertTrue(allFields.containsKey("token_usage.output_tokens"));
+    }
+
+    /**
+     * Test that OpenSearchMetadata exposes both parent and leaf columns
+     */
+    @Test
+    public void testColumnExposure()
+    {
+        // Create mapping
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("type", "object");
+
+        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> totalTokens = new HashMap<>();
+        totalTokens.put("type", "long");
+        properties.put("total_tokens", totalTokens);
+
+        tokenUsage.put("properties", properties);
+        mapping.put("token_usage", tokenUsage);
+
+        // Discover fields
+        NestedFieldMapper mapper = new NestedFieldMapper(5);
+        Map<String, NestedFieldInfo> allFields = mapper.discoverNestedFields(mapping);
+
+        // Verify parent field type
+        NestedFieldInfo parentField = allFields.get("token_usage");
+        assertNotNull(parentField);
+
+        // Parent objects should be exposed as VARCHAR (for JSON strings)
+        // This is determined in OpenSearchMetadata
+        Type parentColumnType = parentField.isLeafField() ? parentField.getPrestoType() : VARCHAR;
+        assertEquals(parentColumnType, VARCHAR, "Parent object should be VARCHAR");
+
+        // Verify leaf field type
+        NestedFieldInfo leafField = allFields.get("token_usage.total_tokens");
+        assertNotNull(leafField);
+        Type leafColumnType = leafField.isLeafField() ? leafField.getPrestoType() : VARCHAR;
+        assertEquals(leafColumnType, BIGINT, "Leaf field should keep its type");
+    }
+
+    /**
+     * Test that NestedValueExtractor correctly extracts nested values
+     */
+    @Test
+    public void testNestedValueExtraction()
+    {
+        // Create a document with nested structure
+        Map<String, Object> document = new HashMap<>();
+
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("total_tokens", 90616L);
+        tokenUsage.put("input_tokens", 89091L);
+        tokenUsage.put("output_tokens", 1525L);
+
+        document.put("token_usage", tokenUsage);
+        document.put("_id", "test-id-123");
+
+        // Create extractor
+        NestedValueExtractor extractor = new NestedValueExtractor();
+
+        // Test extracting nested field
+        List<String> fieldPath = new ArrayList<>();
+        fieldPath.add("token_usage");
+        fieldPath.add("total_tokens");
+
+        Object value = extractor.extractNestedValue(document, fieldPath, BIGINT);
+        assertNotNull(value, "Should extract value");
+        assertEquals(value, 90616L, "Should extract correct value");
+
+        // Test extracting another nested field
+        fieldPath = new ArrayList<>();
+        fieldPath.add("token_usage");
+        fieldPath.add("input_tokens");
+
+        value = extractor.extractNestedValue(document, fieldPath, BIGINT);
+        assertEquals(value, 89091L);
+    }
+
+    /**
+     * Test that parent objects are converted to JSON strings
+     */
+    @Test
+    public void testParentObjectJsonConversion() throws Exception
+    {
+        // Create a document with nested structure
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("total_tokens", 90616);
+        tokenUsage.put("input_tokens", 89091);
+        tokenUsage.put("output_tokens", 1525);
+
+        // Convert to JSON string (simulating what OpenSearchPageSource does)
+        String jsonString = objectMapper.writeValueAsString(tokenUsage);
+
+        // Verify JSON is valid and contains expected data
+        assertNotNull(jsonString);
+        assertTrue(jsonString.contains("total_tokens"));
+        assertTrue(jsonString.contains("90616"));
+        assertTrue(jsonString.contains("input_tokens"));
+        assertTrue(jsonString.contains("89091"));
+        assertTrue(jsonString.contains("output_tokens"));
+        assertTrue(jsonString.contains("1525"));
+
+        // Verify we can parse it back
+        Map<String, Object> parsed = objectMapper.readValue(jsonString, Map.class);
+        assertEquals(parsed.get("total_tokens"), 90616);
+    }
+
+    /**
+     * Test column handle creation for both parent and leaf fields
+     */
+    @Test
+    public void testColumnHandleCreation()
+    {
+        // Create parent column handle (object type, exposed as VARCHAR)
+        List<String> parentPath = new ArrayList<>();
+        parentPath.add("token_usage");
+
+        OpenSearchColumnHandle parentColumn = new OpenSearchColumnHandle(
+                "token_usage",
+                VARCHAR,  // Parent objects are VARCHAR
+                "object",
+                false,
+                0,
+                false,  // Parent itself is not nested (depth 0)
+                "",
+                parentPath,
+                "$.token_usage");
+
+        assertEquals(parentColumn.getColumnName(), "token_usage");
+        assertEquals(parentColumn.getColumnType(), VARCHAR);
+        assertFalse(parentColumn.isNestedField());
+
+        // Create leaf column handle (nested field)
+        List<String> leafPath = new ArrayList<>();
+        leafPath.add("token_usage");
+        leafPath.add("total_tokens");
+
+        OpenSearchColumnHandle leafColumn = new OpenSearchColumnHandle(
+                "token_usage.total_tokens",
+                BIGINT,
+                "long",
+                false,
+                0,
+                true,  // Leaf field is nested (depth > 0)
+                "token_usage",
+                leafPath,
+                "$.token_usage.total_tokens");
+
+        assertEquals(leafColumn.getColumnName(), "token_usage.total_tokens");
+        assertEquals(leafColumn.getColumnType(), BIGINT);
+        assertTrue(leafColumn.isNestedField());
+        assertEquals(leafColumn.getParentFieldPath(), "token_usage");
+        assertEquals(leafColumn.getFieldPathList().size(), 2);
+    }
+
+    /**
+     * Integration test: Full workflow from mapping to column metadata
+     */
+    @Test
+    public void testFullWorkflow()
+    {
+        // 1. Create mapping
+        Map<String, Object> mapping = new HashMap<>();
+        Map<String, Object> tokenUsage = new HashMap<>();
+        tokenUsage.put("type", "object");
+
+        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> totalTokens = new HashMap<>();
+        totalTokens.put("type", "long");
+        properties.put("total_tokens", totalTokens);
+
+        tokenUsage.put("properties", properties);
+        mapping.put("token_usage", tokenUsage);
+
+        // 2. Discover fields
+        NestedFieldMapper mapper = new NestedFieldMapper(5);
+        Map<String, NestedFieldInfo> allFields = mapper.discoverNestedFields(mapping);
+
+        // 3. Create column handles (simulating OpenSearchMetadata logic)
+        Map<String, ColumnHandle> columns = new HashMap<>();
+
+        for (Map.Entry<String, NestedFieldInfo> entry : allFields.entrySet()) {
+            NestedFieldInfo fieldInfo = entry.getValue();
+
+            // Determine column type (parent = VARCHAR, leaf = actual type)
+            Type columnType = fieldInfo.isLeafField() ?
+                    fieldInfo.getPrestoType() : VARCHAR;
+
+            OpenSearchColumnHandle column = new OpenSearchColumnHandle(
+                    fieldInfo.getFieldPath(),
+                    columnType,
+                    fieldInfo.getOpenSearchType(),
+                    false,
+                    0,
+                    fieldInfo.isNestedField(),
+                    fieldInfo.getParentPath(),
+                    fieldInfo.getFieldPathList(),
+                    fieldInfo.getJsonPath());
+
+            columns.put(fieldInfo.getFieldPath(), column);
+        }
+
+        // 4. Verify columns
+        assertEquals(columns.size(), 2, "Should have 2 columns");
+
+        // Verify parent column
+        assertTrue(columns.containsKey("token_usage"));
+        OpenSearchColumnHandle parentCol = (OpenSearchColumnHandle) columns.get("token_usage");
+        assertEquals(parentCol.getColumnType(), VARCHAR);
+
+        // Verify leaf column
+        assertTrue(columns.containsKey("token_usage.total_tokens"));
+        OpenSearchColumnHandle leafCol = (OpenSearchColumnHandle) columns.get("token_usage.total_tokens");
+        assertEquals(leafCol.getColumnType(), BIGINT);
+        assertTrue(leafCol.isNestedField());
+
+        // 5. Test data extraction
+        Map<String, Object> document = new HashMap<>();
+        Map<String, Object> tokenUsageData = new HashMap<>();
+        tokenUsageData.put("total_tokens", 90616L);
+        document.put("token_usage", tokenUsageData);
+
+        // Extract parent (as JSON)
+        Object parentValue = document.get("token_usage");
+        assertTrue(parentValue instanceof Map);
+
+        // Extract leaf (using NestedValueExtractor)
+        NestedValueExtractor extractor = new NestedValueExtractor();
+        Object leafValue = extractor.extractNestedValue(
+                document,
+                leafCol.getFieldPathList(),
+                BIGINT);
+        assertEquals(leafValue, 90616L);
+    }
+}

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestScrollPagination.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestScrollPagination.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.http.HttpHost;
+import org.opensearch.client.Request;
+import org.opensearch.client.RestClient;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests OpenSearch Scroll API pagination with large result sets.
+ * Verifies that queries returning more than scroll.size (default 1000) rows
+ * correctly use scroll continuation to fetch all results.
+ */
+public class TestScrollPagination
+{
+    private static final Logger log = Logger.get(TestScrollPagination.class);
+    private static final String OPENSEARCH_IMAGE = "opensearchproject/opensearch:2.11.1";
+    private static final int SCROLL_SIZE = 100; // Small scroll size to force multiple iterations
+    private static final int TOTAL_DOCS = 2500; // More than 2x scroll size
+
+    private GenericContainer<?> opensearchContainer;
+    private RestClient restClient;
+    private QueryRunner queryRunner;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        // Start OpenSearch container
+        opensearchContainer = new GenericContainer<>(DockerImageName.parse(OPENSEARCH_IMAGE))
+                .withExposedPorts(9200, 9600)
+                .withEnv("discovery.type", "single-node")
+                .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m")
+                .withEnv("DISABLE_SECURITY_PLUGIN", "true")
+                .waitingFor(new HttpWaitStrategy()
+                        .forPort(9200)
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(2)));
+
+        opensearchContainer.start();
+
+        log.info("OpenSearch container started at: http://%s:%d",
+                opensearchContainer.getHost(),
+                opensearchContainer.getMappedPort(9200));
+
+        // Create REST client
+        restClient = RestClient.builder(
+                new HttpHost(
+                        opensearchContainer.getHost(),
+                        opensearchContainer.getMappedPort(9200),
+                        "http"))
+                .build();
+
+        // Create test index with many documents
+        createLargeTestIndex();
+
+        // Create query runner - we'll manually configure scroll size via catalog properties
+        queryRunner = OpenSearchQueryRunner.createQueryRunner(
+                opensearchContainer,
+                ImmutableList.of()); // No TPCH tables needed
+
+        // Create catalog with custom scroll size
+        String host = opensearchContainer.getHost();
+        Integer port = opensearchContainer.getMappedPort(9200);
+
+        // Plugin is already installed by OpenSearchQueryRunner, just create the catalog
+        queryRunner.createCatalog("opensearch_scroll", "opensearch",
+                ImmutableMap.<String, String>builder()
+                        .put("opensearch.host", host)
+                        .put("opensearch.port", String.valueOf(port))
+                        .put("opensearch.scheme", "http")
+                        .put("opensearch.ssl.enabled", "false")
+                        .put("opensearch.scroll.size", String.valueOf(SCROLL_SIZE))
+                        .put("opensearch.scroll.timeout", "1m")
+                        .build());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+        }
+        if (restClient != null) {
+            restClient.close();
+        }
+        if (opensearchContainer != null) {
+            opensearchContainer.stop();
+        }
+    }
+
+    private void createLargeTestIndex()
+            throws Exception
+    {
+        String indexName = "scroll_test";
+
+        // Create index
+        Request createIndex = new Request("PUT", "/" + indexName);
+        createIndex.setJsonEntity(
+                "{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0}," +
+                "\"mappings\":{\"properties\":{" +
+                "\"id\":{\"type\":\"long\"}," +
+                "\"value\":{\"type\":\"keyword\"}," +
+                "\"score\":{\"type\":\"double\"}" +
+                "}}}");
+        restClient.performRequest(createIndex);
+
+        log.info("Created index: %s", indexName);
+
+        // Bulk insert documents
+        StringBuilder bulkRequest = new StringBuilder();
+        for (int i = 1; i <= TOTAL_DOCS; i++) {
+            bulkRequest.append("{\"index\":{\"_index\":\"").append(indexName).append("\"}}\n");
+            bulkRequest.append("{\"id\":").append(i)
+                    .append(",\"value\":\"doc_").append(i)
+                    .append("\",\"score\":").append(i * 1.5).append("}\n");
+        }
+
+        Request bulk = new Request("POST", "/_bulk");
+        bulk.addParameter("refresh", "true");
+        bulk.setJsonEntity(bulkRequest.toString());
+        restClient.performRequest(bulk);
+
+        log.info("Inserted %d documents into index: %s", TOTAL_DOCS, indexName);
+    }
+
+    @Test
+    public void testScrollPaginationFetchesAllRows()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("opensearch_scroll")
+                .setSchema("default")
+                .build();
+
+        // Query all documents - should trigger multiple scroll iterations
+        String query = "SELECT COUNT(*) FROM scroll_test";
+        MaterializedResult result = queryRunner.execute(session, query);
+
+        long count = (Long) result.getOnlyValue();
+        assertEquals(count, TOTAL_DOCS, "Should fetch all documents using scroll pagination");
+
+        log.info("Successfully fetched all %d documents using scroll (scroll_size=%d, iterations=%d)",
+                TOTAL_DOCS, SCROLL_SIZE, (TOTAL_DOCS + SCROLL_SIZE - 1) / SCROLL_SIZE);
+    }
+
+    @Test
+    public void testScrollPaginationWithFilter()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("opensearch_scroll")
+                .setSchema("default")
+                .build();
+
+        // Query with filter - should still use scroll
+        String query = "SELECT COUNT(*) FROM scroll_test WHERE id > 500";
+        MaterializedResult result = queryRunner.execute(session, query);
+
+        long count = (Long) result.getOnlyValue();
+        assertEquals(count, TOTAL_DOCS - 500, "Should fetch filtered documents using scroll");
+
+        log.info("Successfully fetched %d filtered documents using scroll", count);
+    }
+
+    @Test
+    public void testScrollPaginationWithProjection()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("opensearch_scroll")
+                .setSchema("default")
+                .build();
+
+        // Query specific columns - should use scroll with source filtering
+        String query = "SELECT id, value FROM scroll_test ORDER BY id LIMIT " + TOTAL_DOCS;
+        MaterializedResult result = queryRunner.execute(session, query);
+
+        assertEquals(result.getRowCount(), TOTAL_DOCS, "Should fetch all rows with projection");
+
+        // Verify first and last rows
+        assertEquals(result.getMaterializedRows().get(0).getField(0), 1L);
+        assertEquals(result.getMaterializedRows().get(TOTAL_DOCS - 1).getField(0), (long) TOTAL_DOCS);
+
+        log.info("Successfully fetched %d rows with projection using scroll", TOTAL_DOCS);
+    }
+
+    @Test
+    public void testScrollPaginationWithAggregation()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("opensearch_scroll")
+                .setSchema("default")
+                .build();
+
+        // Aggregation over large dataset
+        String query = "SELECT AVG(score) FROM scroll_test";
+        MaterializedResult result = queryRunner.execute(session, query);
+
+        double avgScore = (Double) result.getOnlyValue();
+        double expectedAvg = ((1 + TOTAL_DOCS) / 2.0) * 1.5; // Average of 1.5, 3.0, 4.5, ...
+
+        assertTrue(Math.abs(avgScore - expectedAvg) < 0.01,
+                String.format("Average should be close to %.2f, got %.2f", expectedAvg, avgScore));
+
+        log.info("Successfully computed aggregation over %d documents using scroll", TOTAL_DOCS);
+    }
+
+    @Test
+    public void testMultipleQueriesReuseScrollContext()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("opensearch_scroll")
+                .setSchema("default")
+                .build();
+
+        // Execute multiple queries to verify scroll contexts are properly managed
+        for (int i = 0; i < 3; i++) {
+            String query = "SELECT COUNT(*) FROM scroll_test WHERE id > " + (i * 500);
+            MaterializedResult result = queryRunner.execute(session, query);
+            long count = (Long) result.getOnlyValue();
+            assertTrue(count > 0, "Query " + i + " should return results");
+        }
+
+        log.info("Successfully executed multiple queries with independent scroll contexts");
+    }
+}
+
+// Made with Bob

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestTypeMapper.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestTypeMapper.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.plugin.opensearch.types.TypeMapper;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for TypeMapper to ensure robust handling of various type strings,
+ * including malformed and edge cases.
+ */
+public class TestTypeMapper
+{
+    @Test
+    public void testStandardOpenSearchTypes()
+    {
+        // Text types
+        assertEquals(TypeMapper.toPrestoType("text"), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("keyword"), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("ip"), VARCHAR);
+
+        // Numeric types
+        assertEquals(TypeMapper.toPrestoType("long"), BIGINT);
+        assertEquals(TypeMapper.toPrestoType("integer"), INTEGER);
+        assertEquals(TypeMapper.toPrestoType("short"), SMALLINT);
+        assertEquals(TypeMapper.toPrestoType("byte"), TINYINT);
+        assertEquals(TypeMapper.toPrestoType("double"), DOUBLE);
+        assertEquals(TypeMapper.toPrestoType("scaled_float"), DOUBLE);
+        assertEquals(TypeMapper.toPrestoType("float"), REAL);
+        assertEquals(TypeMapper.toPrestoType("half_float"), REAL);
+
+        // Other types
+        assertEquals(TypeMapper.toPrestoType("boolean"), BOOLEAN);
+        assertEquals(TypeMapper.toPrestoType("date"), DATE);
+        assertEquals(TypeMapper.toPrestoType("binary"), VARBINARY);
+        assertEquals(TypeMapper.toPrestoType("nested"), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("object"), VARCHAR);
+    }
+
+    @Test
+    public void testVectorTypes()
+    {
+        // knn_vector should map to ARRAY(REAL)
+        Type knnVectorType = TypeMapper.toPrestoType("knn_vector");
+        assertTrue(knnVectorType instanceof ArrayType);
+        assertEquals(((ArrayType) knnVectorType).getElementType(), REAL);
+
+        // Vector field names with float type should map to ARRAY(REAL)
+        Type embeddingType = TypeMapper.toPrestoType("float", Map.of(), "embedding");
+        assertTrue(embeddingType instanceof ArrayType);
+        assertEquals(((ArrayType) embeddingType).getElementType(), REAL);
+
+        Type vectorFieldType = TypeMapper.toPrestoType("float", Map.of(), "knn_vector_field");
+        assertTrue(vectorFieldType instanceof ArrayType);
+        assertEquals(((ArrayType) vectorFieldType).getElementType(), REAL);
+    }
+
+    @Test
+    public void testCaseInsensitivity()
+    {
+        assertEquals(TypeMapper.toPrestoType("TEXT"), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("Text"), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("BIGINT"), BIGINT); // Now accepts Presto type names for malformed string handling
+        assertEquals(TypeMapper.toPrestoType("LONG"), BIGINT);
+        assertEquals(TypeMapper.toPrestoType("Long"), BIGINT);
+    }
+
+    @Test
+    public void testUnknownTypes()
+    {
+        // Unknown types should default to VARCHAR
+        assertEquals(TypeMapper.toPrestoType("unknown_type"), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("custom_plugin_type"), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("geo_point"), VARCHAR);
+    }
+
+    @Test
+    public void testMalformedTypeStrings()
+    {
+        // Test the specific case from the bug: "cache_creation_input_tokens bigint"
+        // Now we accept Presto type names (like "bigint") to handle malformed serialization strings
+        // The sanitizer extracts "bigint" from the second position and maps it correctly to BIGINT
+        assertEquals(TypeMapper.toPrestoType("cache_creation_input_tokens bigint"), BIGINT);
+
+        // Test with known OpenSearch type in second position - should extract and use it
+        assertEquals(TypeMapper.toPrestoType("field_name long"), BIGINT);
+        assertEquals(TypeMapper.toPrestoType("some_field integer"), INTEGER);
+        assertEquals(TypeMapper.toPrestoType("my_field text"), VARCHAR);
+
+        // Test with multiple spaces
+        assertEquals(TypeMapper.toPrestoType("field   name   long"), BIGINT);
+
+        // Test with known type in first position (should use first token)
+        assertEquals(TypeMapper.toPrestoType("long field_name"), BIGINT);
+    }
+
+    @Test
+    public void testComplexFieldNames()
+    {
+        // Field names that might be confused with types
+        assertEquals(TypeMapper.toPrestoType("long", Map.of(), "cache_creation_input_tokens"), BIGINT);
+        assertEquals(TypeMapper.toPrestoType("integer", Map.of(), "bigint_value"), INTEGER);
+        assertEquals(TypeMapper.toPrestoType("text", Map.of(), "array_of_strings"), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("keyword", Map.of(), "varchar_field"), VARCHAR);
+
+        // Underscore-heavy field names
+        assertEquals(TypeMapper.toPrestoType("long", Map.of(), "user_session_cache_tokens"), BIGINT);
+        assertEquals(TypeMapper.toPrestoType("text", Map.of(), "llm_response_text_content"), VARCHAR);
+    }
+
+    @Test
+    public void testNullAndEmptyTypes()
+    {
+        // Null type should default to VARCHAR
+        assertEquals(TypeMapper.toPrestoType(null), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType(null, Map.of()), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType(null, Map.of(), "field_name"), VARCHAR);
+
+        // Empty type should default to VARCHAR
+        assertEquals(TypeMapper.toPrestoType(""), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("   "), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("", Map.of(), "field_name"), VARCHAR);
+    }
+
+    @Test
+    public void testWhitespaceHandling()
+    {
+        // Leading/trailing whitespace should be trimmed
+        assertEquals(TypeMapper.toPrestoType("  long  "), BIGINT);
+        assertEquals(TypeMapper.toPrestoType("\tinteger\t"), INTEGER);
+        assertEquals(TypeMapper.toPrestoType("\ntext\n"), VARCHAR);
+
+        // Whitespace with field name
+        assertEquals(TypeMapper.toPrestoType("  field_name   long  "), BIGINT);
+    }
+
+    @Test
+    public void testRealWorldProblematicFieldNames()
+    {
+        // Real-world field names from LLM/analytics systems that might cause issues
+        String[] problematicFieldNames = {
+            "cache_creation_input_tokens",
+            "cache_creation_output_tokens",
+            "total_input_tokens",
+            "prompt_tokens_used",
+            "completion_tokens_generated",
+            "embedding_vector_dimension",
+            "model_response_time_ms",
+            "api_call_timestamp",
+            "user_query_text",
+            "llm_model_version"
+        };
+
+        // All should work correctly with their respective types
+        for (String fieldName : problematicFieldNames) {
+            assertEquals(TypeMapper.toPrestoType("long", Map.of(), fieldName), BIGINT);
+            assertEquals(TypeMapper.toPrestoType("text", Map.of(), fieldName), VARCHAR);
+            assertEquals(TypeMapper.toPrestoType("keyword", Map.of(), fieldName), VARCHAR);
+        }
+    }
+
+    @Test
+    public void testTypeStringWithSpecialCharacters()
+    {
+        // Type strings with special characters should be handled gracefully
+        assertEquals(TypeMapper.toPrestoType("long-type"), VARCHAR); // Unknown type
+        assertEquals(TypeMapper.toPrestoType("type.long"), VARCHAR); // Unknown type
+        assertEquals(TypeMapper.toPrestoType("long_type"), VARCHAR); // Unknown type
+    }
+
+    @Test
+    public void testPropertiesParameter()
+    {
+        // Test that properties parameter doesn't affect basic type mapping
+        Map<String, Object> properties = Map.of(
+                "index", "true",
+                "store", "true");
+
+        assertEquals(TypeMapper.toPrestoType("long", properties), BIGINT);
+        assertEquals(TypeMapper.toPrestoType("text", properties), VARCHAR);
+        assertEquals(TypeMapper.toPrestoType("boolean", properties), BOOLEAN);
+    }
+}
+
+// Made with Bob

--- a/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestVectorSearchHandler.java
+++ b/presto-opensearch/src/test/java/com/facebook/presto/plugin/opensearch/TestVectorSearchHandler.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.opensearch;
+
+import com.facebook.presto.spi.PrestoException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for VectorSearchHandler k-NN query building functionality.
+ */
+@Test(singleThreaded = true)
+public class TestVectorSearchHandler
+{
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private VectorSearchHandler handler;
+    private OpenSearchConfig config;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        config = new OpenSearchConfig();
+        config.setVectorSearchEnabled(true);
+        config.setVectorSearchDefaultK(10);
+        config.setVectorSearchDefaultSpaceType("cosine");
+        config.setVectorSearchDefaultEfSearch(100);
+        handler = new VectorSearchHandler(config);
+    }
+
+    @Test
+    public void testBuildBasicKnnQuery()
+            throws Exception
+    {
+        float[] queryVector = {0.1f, 0.2f, 0.3f, 0.4f};
+        String query = handler.buildKnnQuery("embedding", queryVector, 10);
+
+        assertNotNull(query);
+        JsonNode root = OBJECT_MAPPER.readTree(query);
+
+        assertTrue(root.has("knn"));
+        JsonNode knn = root.get("knn");
+        assertTrue(knn.has("embedding"));
+
+        JsonNode embeddingQuery = knn.get("embedding");
+        assertTrue(embeddingQuery.has("vector"));
+        assertTrue(embeddingQuery.has("k"));
+        assertEquals(embeddingQuery.get("k").asInt(), 10);
+
+        JsonNode vector = embeddingQuery.get("vector");
+        assertEquals(vector.size(), 4);
+        assertEquals(vector.get(0).asDouble(), 0.1, 0.001);
+    }
+
+    @Test
+    public void testBuildKnnQueryWithEfSearch()
+            throws Exception
+    {
+        float[] queryVector = {0.1f, 0.2f, 0.3f};
+        String query = handler.buildKnnQuery("embedding", queryVector, 20, "cosine", 200);
+
+        JsonNode root = OBJECT_MAPPER.readTree(query);
+        JsonNode embeddingQuery = root.get("knn").get("embedding");
+
+        assertTrue(embeddingQuery.has("ef_search"));
+        assertEquals(embeddingQuery.get("ef_search").asInt(), 200);
+        assertEquals(embeddingQuery.get("k").asInt(), 20);
+    }
+
+    @Test
+    public void testBuildKnnQueryWithDifferentSpaceTypes()
+            throws Exception
+    {
+        float[] queryVector = {0.1f, 0.2f};
+
+        // Test cosine
+        String cosineQuery = handler.buildKnnQuery("embedding", queryVector, 10, "cosine", null);
+        assertNotNull(cosineQuery);
+
+        // Test l2
+        String l2Query = handler.buildKnnQuery("embedding", queryVector, 10, "l2", null);
+        assertNotNull(l2Query);
+
+        // Test inner_product
+        String ipQuery = handler.buildKnnQuery("embedding", queryVector, 10, "inner_product", null);
+        assertNotNull(ipQuery);
+    }
+
+    @Test
+    public void testBuildHybridSearchQuery()
+            throws Exception
+    {
+        float[] queryVector = {0.1f, 0.2f, 0.3f};
+        String filterQuery = "{\"term\":{\"category\":\"electronics\"}}";
+
+        String query = handler.buildHybridSearchQuery("embedding", queryVector, 10, filterQuery);
+
+        JsonNode root = OBJECT_MAPPER.readTree(query);
+        JsonNode embeddingQuery = root.get("knn").get("embedding");
+
+        assertTrue(embeddingQuery.has("filter"));
+        JsonNode filter = embeddingQuery.get("filter");
+        assertTrue(filter.has("term"));
+    }
+
+    @Test
+    public void testBuildHybridSearchQueryWithEfSearch()
+            throws Exception
+    {
+        float[] queryVector = {0.1f, 0.2f};
+        String filterQuery = "{\"range\":{\"price\":{\"gte\":100,\"lte\":500}}}";
+
+        String query = handler.buildHybridSearchQuery(
+                "embedding", queryVector, 15, filterQuery, "l2", 150);
+
+        JsonNode root = OBJECT_MAPPER.readTree(query);
+        JsonNode embeddingQuery = root.get("knn").get("embedding");
+
+        assertTrue(embeddingQuery.has("filter"));
+        assertTrue(embeddingQuery.has("ef_search"));
+        assertEquals(embeddingQuery.get("ef_search").asInt(), 150);
+        assertEquals(embeddingQuery.get("k").asInt(), 15);
+    }
+
+    @Test
+    public void testBuildScriptScoreQuery()
+            throws Exception
+    {
+        float[] queryVector = {0.1f, 0.2f, 0.3f};
+
+        String query = handler.buildScriptScoreQuery("embedding", queryVector, "cosine");
+
+        JsonNode root = OBJECT_MAPPER.readTree(query);
+        assertTrue(root.has("script_score"));
+
+        JsonNode scriptScore = root.get("script_score");
+        assertTrue(scriptScore.has("query"));
+        assertTrue(scriptScore.has("script"));
+
+        JsonNode script = scriptScore.get("script");
+        assertTrue(script.has("source"));
+        assertTrue(script.has("params"));
+
+        JsonNode params = script.get("params");
+        assertEquals(params.get("field").asText(), "embedding");
+        assertTrue(params.has("query_value"));
+    }
+
+    @Test
+    public void testScriptScoreQueryDifferentMetrics()
+            throws Exception
+    {
+        float[] queryVector = {0.1f, 0.2f};
+
+        // Test cosine
+        String cosineQuery = handler.buildScriptScoreQuery("embedding", queryVector, "cosine");
+        assertTrue(cosineQuery.contains("cosineSimilarity"));
+
+        // Test l2
+        String l2Query = handler.buildScriptScoreQuery("embedding", queryVector, "l2");
+        assertTrue(l2Query.contains("l2norm"));
+
+        // Test inner_product
+        String ipQuery = handler.buildScriptScoreQuery("embedding", queryVector, "inner_product");
+        assertTrue(ipQuery.contains("dotProduct"));
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testVectorSearchDisabled()
+    {
+        config.setVectorSearchEnabled(false);
+        VectorSearchHandler disabledHandler = new VectorSearchHandler(config);
+
+        float[] queryVector = {0.1f, 0.2f};
+        disabledHandler.buildKnnQuery("embedding", queryVector, 10);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testInvalidK()
+    {
+        float[] queryVector = {0.1f, 0.2f};
+        handler.buildKnnQuery("embedding", queryVector, 0);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testNegativeK()
+    {
+        float[] queryVector = {0.1f, 0.2f};
+        handler.buildKnnQuery("embedding", queryVector, -5);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testEmptyQueryVector()
+    {
+        float[] queryVector = {};
+        handler.buildKnnQuery("embedding", queryVector, 10);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testInvalidSpaceType()
+    {
+        float[] queryVector = {0.1f, 0.2f};
+        handler.buildKnnQuery("embedding", queryVector, 10, "invalid_metric", null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullVectorField()
+    {
+        float[] queryVector = {0.1f, 0.2f};
+        handler.buildKnnQuery(null, queryVector, 10);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testNullQueryVector()
+    {
+        handler.buildKnnQuery("embedding", null, 10);
+    }
+
+    @Test
+    public void testCosineSimilarityCalculation()
+    {
+        float[] vector1 = {1.0f, 0.0f, 0.0f};
+        float[] vector2 = {1.0f, 0.0f, 0.0f};
+
+        double similarity = VectorSearchHandler.cosineSimilarity(vector1, vector2);
+        assertEquals(similarity, 1.0, 0.001);
+    }
+
+    @Test
+    public void testCosineSimilarityOrthogonal()
+    {
+        float[] vector1 = {1.0f, 0.0f};
+        float[] vector2 = {0.0f, 1.0f};
+
+        double similarity = VectorSearchHandler.cosineSimilarity(vector1, vector2);
+        assertEquals(similarity, 0.0, 0.001);
+    }
+
+    @Test
+    public void testEuclideanDistance()
+    {
+        float[] vector1 = {0.0f, 0.0f};
+        float[] vector2 = {3.0f, 4.0f};
+
+        double distance = VectorSearchHandler.euclideanDistance(vector1, vector2);
+        assertEquals(distance, 5.0, 0.001);
+    }
+
+    @Test
+    public void testDotProduct()
+    {
+        float[] vector1 = {1.0f, 2.0f, 3.0f};
+        float[] vector2 = {4.0f, 5.0f, 6.0f};
+
+        double dotProduct = VectorSearchHandler.dotProduct(vector1, vector2);
+        assertEquals(dotProduct, 32.0, 0.001); // 1*4 + 2*5 + 3*6 = 32
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testCosineSimilarityDimensionMismatch()
+    {
+        float[] vector1 = {1.0f, 2.0f};
+        float[] vector2 = {1.0f, 2.0f, 3.0f};
+
+        VectorSearchHandler.cosineSimilarity(vector1, vector2);
+    }
+
+    @Test(expectedExceptions = PrestoException.class)
+    public void testEuclideanDistanceDimensionMismatch()
+    {
+        float[] vector1 = {1.0f, 2.0f};
+        float[] vector2 = {1.0f};
+
+        VectorSearchHandler.euclideanDistance(vector1, vector2);
+    }
+
+    @Test
+    public void testCosineSimilarityZeroVector()
+    {
+        float[] vector1 = {0.0f, 0.0f};
+        float[] vector2 = {1.0f, 1.0f};
+
+        double similarity = VectorSearchHandler.cosineSimilarity(vector1, vector2);
+        assertEquals(similarity, 0.0, 0.001);
+    }
+
+    @Test
+    public void testLargeVectorDimensions()
+            throws Exception
+    {
+        // Test with 768-dimensional vector (common for embeddings)
+        float[] queryVector = new float[768];
+        for (int i = 0; i < 768; i++) {
+            queryVector[i] = (float) Math.random();
+        }
+
+        String query = handler.buildKnnQuery("embedding", queryVector, 10);
+
+        JsonNode root = OBJECT_MAPPER.readTree(query);
+        JsonNode vector = root.get("knn").get("embedding").get("vector");
+        assertEquals(vector.size(), 768);
+    }
+
+    @Test
+    public void testMultipleSpaceTypeAliases()
+            throws Exception
+    {
+        float[] queryVector = {0.1f, 0.2f};
+
+        // Test that both "cosine" and "cosinesimil" work
+        String query1 = handler.buildKnnQuery("embedding", queryVector, 10, "cosine", null);
+        String query2 = handler.buildKnnQuery("embedding", queryVector, 10, "cosinesimil", null);
+        assertNotNull(query1);
+        assertNotNull(query2);
+
+        // Test that both "l2" and "euclidean" work
+        String query3 = handler.buildKnnQuery("embedding", queryVector, 10, "l2", null);
+        String query4 = handler.buildKnnQuery("embedding", queryVector, 10, "euclidean", null);
+        assertNotNull(query3);
+        assertNotNull(query4);
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
This PR adds a new read only connector for [Opensearch](https://opensearch.org/)

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
We had a need to run federated queries that also retrieved values from indices in Opensearch instances. This OpenSearch connector enables Presto to query OpenSearch indices using SQL syntax with support for vector similarity search via k-NN plugin and nested field access using dot notation. 

#### Basic OpenSearch Index Querying

Query OpenSearch indices using standard SQL syntax:
```sql
SELECT _id, title, category, price
FROM opensearch.default.products
WHERE category = 'electronics' AND price > 100
ORDER BY price DESC
LIMIT 10;
```

#### Vector Search Table Function

Execute k-NN vector similarity searches directly in SQL using the table function syntax:
```sql
SELECT * FROM TABLE(opensearch.system.knn_search(
  index_name => 'documents',
  vector_field => 'embedding',
  query_vector => ARRAY[0.1, 0.2, 0.3],
  k => 10
)) ORDER BY _score DESC;
```

#### Nested Field Access with Dot Notation

Query nested JSON structures using dot notation without complex parsing:
```sql
SELECT id, user.name, user.profile.age, metadata.tags
FROM opensearch.default.users
WHERE user.profile.age > 25;
```

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
The unit tests include test classes extending AbstractTestQueries. So the full set of regression tests intended for connectors are run against this connector as well. Additional tests are included for the vector functions and individual classes.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Added new read only Opensearch connector.

```



