### PR TITLE
feat(native): Add hook in presto native worker to override default configs

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -91,6 +91,19 @@ bool ConfigBase::registerProperty(
   return true;
 }
 
+bool ConfigBase::updatePropertyDefault(
+    const std::string& propertyName,
+    const folly::Optional<std::string>& newDefaultValue) {
+  auto it = registeredProps_.find(propertyName);
+  if (it == registeredProps_.end()) {
+    PRESTO_STARTUP_LOG(WARNING)
+        << "Property '" << propertyName << "' is not registered.";
+    return false;
+  }
+  it->second = newDefaultValue;
+  return true;
+}
+
 folly::Optional<std::string> ConfigBase::setValue(
     const std::string& propertyName,
     const std::string& value) {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -50,6 +50,16 @@ class ConfigBase {
       const std::string& propertyName,
       const folly::Optional<std::string>& defaultValue = {});
 
+  /// Updates the default value of an already-registered property.
+  /// Returns true if the property was found and updated, false otherwise.
+  /// This is useful for presto-on-spark to specify specific overrides in code
+  /// which might be different from regular presto deployment.
+  /// Pass folly::none to clear the default (making the property have no
+  /// default).
+  bool updatePropertyDefault(
+      const std::string& propertyName,
+      const folly::Optional<std::string>& newDefaultValue);
+
   /// Adds or replaces value at the given key. Can be used by debugging or
   /// testing code.
   /// Returns previous value if there was any.

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -357,6 +357,51 @@ TEST_F(ConfigTest, readConfigEnvVarTest) {
   unsetenv(kEmptyEnvVarName.c_str());
 }
 
+TEST_F(ConfigTest, updatePropertyDefault) {
+  SystemConfig config;
+  init(config, {});
+
+  // Test updating an existing registered property's default value.
+  // kMaxDriversPerTask has a default of hardware_concurrency, so we update it.
+  ASSERT_TRUE(config.updatePropertyDefault(
+      std::string(SystemConfig::kMaxDriversPerTask), std::string("42")));
+  ASSERT_EQ(config.maxDriversPerTask(), 42);
+
+  // Test updating to a different value.
+  ASSERT_TRUE(config.updatePropertyDefault(
+      std::string(SystemConfig::kMaxDriversPerTask), std::string("100")));
+  ASSERT_EQ(config.maxDriversPerTask(), 100);
+
+  // Test that updating an unregistered property returns false.
+  ASSERT_FALSE(config.updatePropertyDefault(
+      "unregistered.property", std::string("value")));
+
+  // Test clearing a default by passing folly::none.
+  // kDiscoveryUri has no default, so we first set one, then clear it.
+  ASSERT_TRUE(config.updatePropertyDefault(
+      std::string(SystemConfig::kDiscoveryUri), std::string("http://test")));
+  ASSERT_EQ(config.discoveryUri(), "http://test");
+  ASSERT_TRUE(config.updatePropertyDefault(
+      std::string(SystemConfig::kDiscoveryUri), folly::none));
+  ASSERT_EQ(config.discoveryUri(), folly::none);
+}
+
+TEST_F(ConfigTest, updatePropertyDefaultDoesNotOverrideExplicitValue) {
+  SystemConfig config;
+  // Initialize with an explicit value for kMaxDriversPerTask.
+  init(config, {{std::string(SystemConfig::kMaxDriversPerTask), "200"}});
+
+  // The explicit value should be used.
+  ASSERT_EQ(config.maxDriversPerTask(), 200);
+
+  // Update the default value.
+  ASSERT_TRUE(config.updatePropertyDefault(
+      std::string(SystemConfig::kMaxDriversPerTask), std::string("42")));
+
+  // The explicit value should still be used, not the updated default.
+  ASSERT_EQ(config.maxDriversPerTask(), 200);
+}
+
 TEST_F(ConfigTest, prestoDefaultNamespacePrefix) {
   SystemConfig config;
   init(


### PR DESCRIPTION
Summary:
Currently presto native and presto-spark native worker share same codebase for Config setup.
This results in presto-on-spark default values that are different from presto default have to managed
externally in config files.
This is
Not ideal as
- Code default are more maintainable
- Also, when a new feature is rolled out, in config default we would have to setup version based specification so that only code which has the new feature will be supplied the new config and then come back and clean up to move to unversioned default. All of this is messy and unecessary if we can just setup code defaults for presto-on-spark

This diff adds a hook to setup code defaults for presto native worker configs

Differential Revision: D90138416


