### PR TITLE
fix(security): Bump transitive dependency org.apache.logging.log4j:log4j-core to 2.25.3 to fix CVE-2025-68161

### DIFF
--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -20,6 +20,7 @@
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.fastutil.version>8.5.15</dep.fastutil.version>
         <dep.datasketches-memory.version>3.0.2</dep.datasketches-memory.version>
+        <dep.log4j.version>2.25.3</dep.log4j.version>
     </properties>
 
     <dependencyManagement>
@@ -33,6 +34,16 @@
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>4.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${dep.log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${dep.log4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -19,6 +19,7 @@
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.datasketches-java.version>6.1.1</dep.datasketches-java.version>
         <dep.datasketches-memory.version>3.0.2</dep.datasketches-memory.version>
+        <dep.log4j.version>2.25.3</dep.log4j.version>
     </properties>
 
     <dependencyManagement>
@@ -32,6 +33,16 @@
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>4.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${dep.log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${dep.log4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description

org.apache.logging.log4j:log4j-core 2.17.1 is coming into presto image transitively from presto-pinot module
which introduces the following CVE to presto .

https://nvd.nist.gov/vuln/detail/CVE-2025-68161

This PR fixes the issue by adding the vulnerable free version org.apache.logging.log4j:log4j-core 2.25.3 in dependency management.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan

<img width="1655" height="404" alt="image" src="https://github.com/user-attachments/assets/c5ab7d6a-77d3-4ef6-8e5c-9dd446a4a794" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade transitive dependency org.apache.logging.log4j:log4j-core to 2.25.3 to fix `CVE-2025-68161 <https://nvd.nist.gov/vuln/detail/CVE-2025-68161>`_.
```


