### PR TITLE
fix(native): Avoid implicit conversions from velox::StringView to std::string

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/BinarySortableSerializerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BinarySortableSerializerTest.cpp
@@ -26,12 +26,13 @@
 
 namespace facebook::presto::operators::test {
 namespace {
+
 // return -1 if key1 < key2, 0 if key1 == key2, 1 if key1 > key 2
-int lexicographicalCompare(std::string key1, std::string key2) {
+int lexicographicalCompare(velox::StringView key1, velox::StringView key2) {
   // doing unsinged byte comparison following the Cosco test suite's semantic.
-  const auto begin1 = reinterpret_cast<unsigned char*>(key1.data());
+  const auto begin1 = reinterpret_cast<unsigned const char*>(key1.data());
   const auto end1 = begin1 + key1.size();
-  const auto begin2 = reinterpret_cast<unsigned char*>(key2.data());
+  const auto begin2 = reinterpret_cast<unsigned const char*>(key2.data());
   const auto end2 = begin2 + key2.size();
   bool lessThan = std::lexicographical_compare(begin1, end1, begin2, end2);
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -125,8 +125,8 @@ velox::variant VeloxExprConverter::getConstantValue(
               0));
     case TypeKind::VARBINARY:
       return velox::variant::binary(
-          valueVector->as<velox::SimpleVector<velox::StringView>>()->valueAt(
-              0));
+          std::string(valueVector->as<velox::SimpleVector<velox::StringView>>()
+                          ->valueAt(0)));
     default:
       throw std::invalid_argument(
           fmt::format("Unexpected Block type: {}", typeKind));


### PR DESCRIPTION
Summary:
Removing places that relied on the performance risky behavior we are
removing from Velox soon.

Differential Revision: D90194162


```
== NO RELEASE NOTE ==
```

