### PR TITLE
fix(native): Enable plan consistency check for presto-on-spark velox

### DIFF
--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -344,6 +344,9 @@ proxygen::RequestHandler* TaskResource::createOrUpdateBatchTask(
             pool_);
         auto planFragment = converter.toVeloxQueryPlan(
             prestoPlan, updateRequest.tableWriteInfo, taskId);
+        if (SystemConfig::instance()->planConsistencyCheckEnabled()) {
+          velox::core::PlanConsistencyChecker::check(planFragment.planNode);
+        }
 
         return taskManager_.createOrUpdateBatchTask(
             taskId,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionSystemConfig.java
@@ -77,6 +77,7 @@ public class NativeExecutionSystemConfig
     public static final String REMOTE_FUNCTION_SERVER_SIGNATURE_FILES_DIRECTORY_PATH = "remote-function-server.signature.files.directory.path";
     public static final String REMOTE_FUNCTION_SERVER_SERDE = "remote-function-server.serde";
     public static final String REMOTE_FUNCTION_SERVER_CATALOG_NAME = "remote-function-server.catalog-name";
+    public static final String PLAN_CONSISTENCY_CHECK = "plan-consistency-check-enabled";
 
     private final String remoteFunctionServerSignatureFilesDirectoryPathDefault = "./functions/spark/";
     private final String remoteFunctionServerSerdeDefault = "presto_page";
@@ -119,6 +120,7 @@ public class NativeExecutionSystemConfig
     private final String joinSpillEnabledDefault = "true";
     private final String orderBySpillEnabledDefault = "true";
     private final String maxSpillBytesDefault = String.valueOf(600L << 30);
+    private final String planConsistencyCheckEnabled = "true";
 
     private final Map<String, String> systemConfigs;
     private final Map<String, String> defaultSystemConfigs;
@@ -184,6 +186,7 @@ public class NativeExecutionSystemConfig
                 .put(JOIN_SPILL_ENABLED, joinSpillEnabledDefault)
                 .put(ORDER_BY_SPILL_ENABLED, orderBySpillEnabledDefault)
                 .put(MAX_SPILL_BYTES, maxSpillBytesDefault)
+                .put(PLAN_CONSISTENCY_CHECK, planConsistencyCheckEnabled)
                 .build();
     }
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/property/TestNativeExecutionSystemConfig.java
@@ -79,6 +79,7 @@ public class TestNativeExecutionSystemConfig
                 .put("join-spill-enabled", "true")
                 .put("order-by-spill-enabled", "true")
                 .put("max-spill-bytes", String.valueOf(600L << 30))
+                .put("plan-consistency-check-enabled", "true")
                 .build();
         assertEquals(nativeExecutionSystemConfig.getAllProperties(), expectedConfigs);
 
@@ -122,6 +123,7 @@ public class TestNativeExecutionSystemConfig
                 .put("aggregation-spill-enabled", "false")
                 .put("join-spill-enabled", "false")
                 .put("order-by-spill-enabled", "false")
+                .put("plan-consistency-check-enabled", "false")
                 .put("non-defined-property-key-0", "non-defined-property-value-0")
                 .put("non-defined-property-key-1", "non-defined-property-value-1")
                 .put("non-defined-property-key-2", "non-defined-property-value-2")
@@ -168,6 +170,7 @@ public class TestNativeExecutionSystemConfig
                 .put("aggregation-spill-enabled", "false")
                 .put("join-spill-enabled", "false")
                 .put("order-by-spill-enabled", "false")
+                .put("plan-consistency-check-enabled", "false")
                 .put("non-defined-property-key-0", "non-defined-property-value-0")
                 .put("non-defined-property-key-1", "non-defined-property-value-1")
                 .put("non-defined-property-key-2", "non-defined-property-value-2")


### PR DESCRIPTION
Adding plan-consistency-check in presto-on-spark velox e2e tests

```
== NO RELEASE NOTE ==
```


