### PR TITLE
fix(native): Enable Velox to Presto lambda expression conversion

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.cpp
+++ b/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.cpp
@@ -91,7 +91,7 @@ protocol::RowExpressionOptimizationResult optimizeExpression(
   }
 
   result.optimizedExpression =
-      veloxToPrestoConverter.getRowExpression(optimized, input);
+      veloxToPrestoConverter.getRowExpression(optimized);
   return result;
 }
 

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
@@ -24,6 +24,8 @@ using ConstantExpressionPtr =
     std::shared_ptr<facebook::presto::protocol::ConstantExpression>;
 using CallExpressionPtr =
     std::shared_ptr<facebook::presto::protocol::CallExpression>;
+using LambdaDefinitionExpressionPtr =
+    std::shared_ptr<facebook::presto::protocol::LambdaDefinitionExpression>;
 using SpecialFormExpressionPtr =
     std::shared_ptr<facebook::presto::protocol::SpecialFormExpression>;
 
@@ -59,11 +61,9 @@ class VeloxToPrestoExprConverter {
       : pool_(pool) {}
 
   /// Converts a Velox expression `expr` to a Presto protocol RowExpression.
-  /// The input Presto RowExpression is returned as the `defaultResult` in case
-  /// the Velox to Presto expression conversion fails.
+  /// Throws an exception if the expression conversion fails.
   RowExpressionPtr getRowExpression(
-      const velox::core::TypedExprPtr& expr,
-      const RowExpressionPtr& defaultResult = nullptr) const;
+      const velox::core::TypedExprPtr& expr) const;
 
  private:
   /// This function is used to serialize a constant velox vector to
@@ -98,6 +98,11 @@ class VeloxToPrestoExprConverter {
   /// type `DEREFERENCE` from a Velox dereference expression.
   SpecialFormExpressionPtr getDereferenceExpression(
       const velox::core::DereferenceTypedExpr* dereferenceExpr) const;
+
+  /// Helper function to construct a Presto
+  /// `protocol::LambdaDefinitionExpression` from a Velox lambda expression.
+  LambdaDefinitionExpressionPtr getLambdaExpression(
+      const velox::core::LambdaTypedExpr* lambdaExpr) const;
 
   /// Helper function to construct a Presto `protocol::CallExpression` from a
   /// Velox call expression.

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/expressions/TestNativeExpressionInterpreter.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/expressions/TestNativeExpressionInterpreter.java
@@ -98,6 +98,13 @@ public class TestNativeExpressionInterpreter
         closeAllRuntimeException(queryRunner);
     }
 
+    @Test
+    public void testLambda()
+    {
+        optimize("array_sort(ARRAY['apple', 'banana', 'pear'], x -> IF(x = 'banana', NULL, length(x)))");
+        optimize("array_sort(ARRAY[ROW('a', 3), ROW('b', 1), ROW('c', 2)], x -> x[2])");
+    }
+
     ///  Velox permits Bigint to Varchar cast but Presto does not.
     @Override
     @Test


### PR DESCRIPTION
## Description
Enables Velox to Presto expression conversion for lambda expressions.

## Motivation and Context
Velox to Presto expression conversion currently returns the input `RowExpression` for Velox expressions of types `kConcat`, `kInput`, and `kLambda`. This is incorrect for Lambda expressions because Velox `ExprOptimizer` optimizes the body of `core::LambdaTypedExpr` and the result isn't translated back to Presto.  This PR adds the missing wiring for Velox to Presto lambda expression conversion required to complete the constant folding.

`getRowExpression` API in `VeloxToPrestoExprConverter` takes an optional `RowExpression` for the default result as and argument. This was being returned for lambda, concat and input Velox expressions. With this change lambda expressions are converted and the Velox ExprOptimizer never returns concat or input expressions. So the default result parameter is unused and can be removed. 

## Impact
Fixes errors uncovered by `array_sort` in https://github.com/prestodb/presto/pull/26903.

## Test Plan
Added e2e tests.


```
== NO RELEASE NOTE ==
```

