### PR TITLE
fix: Enable TestPrestoNativeAsyncDataCacheCleanupAPI

### DIFF
--- a/presto-native-execution/pom.xml
+++ b/presto-native-execution/pom.xml
@@ -510,7 +510,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <excludedGroups combine.self="override">writer,parquet,remote-function,textfile,async_data_cache</excludedGroups>
+                            <excludedGroups combine.self="override">writer,parquet,remote-function,textfile</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeAsyncDataCacheCleanupAPI.java
@@ -67,7 +67,7 @@ public class TestPrestoNativeAsyncDataCacheCleanupAPI
         createCustomer(queryRunner);
     }
 
-    @Test(groups = {"async_data_cache"}, enabled = false)
+    @Test(groups = {"async_data_cache"})
     public void testAsyncDataCacheCleanup() throws Exception
     {
         Session session = Session.builder(super.getSession())
@@ -151,7 +151,7 @@ public class TestPrestoNativeAsyncDataCacheCleanupAPI
         for (InternalNode worker : workerNodes) {
             Map<String, Long> metrics = fetchScalarLongMetrics(worker.getInternalUri().toString(), endpoint, "GET");
             memoryCacheHits += metrics.get("velox_memory_cache_num_hits");
-            memoryCacheEntries += metrics.get("velox_memory_cache_num_entries");
+            memoryCacheEntries += metrics.get("velox_memory_cache_num_tiny_entries") + metrics.get("velox_memory_cache_num_large_entries");
             ssdCacheReadEntries += metrics.get("velox_ssd_cache_read_entries");
             ssdCacheWriteEntries += metrics.get("velox_ssd_cache_written_entries");
             ssdCacheCachedEntries += metrics.get("velox_ssd_cache_cached_entries");
@@ -193,7 +193,7 @@ public class TestPrestoNativeAsyncDataCacheCleanupAPI
                 .collect(Collectors.toSet());
     }
 
-    @Test(groups = {"async_data_cache"}, enabled = false)
+    @Test(groups = {"async_data_cache"})
     public void testAsyncDataCacheCleanupApiFormat()
     {
         QueryRunner queryRunner = getQueryRunner();


### PR DESCRIPTION
## Description
Enable TestPrestoNativeAsyncDataCacheCleanupAPI 
Its running under - https://github.com/prestodb/presto/actions/runs/20914860734/job/60093369386?pr=26923

## Motivation and Context
Enable TestPrestoNativeAsyncDataCacheCleanupAPI
Resolves https://github.com/prestodb/presto/issues/25407

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

