### PR TITLE
misc(native): Remove native-execution-enabled from e2e test worker config

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java
@@ -628,7 +628,6 @@ public class PrestoNativeQueryRunnerUtils
                         // Write config file - use an ephemeral port for the worker.
                         String configProperties = format("discovery.uri=%s%n" +
                                 "presto.version=testversion%n" +
-                                "native-execution-enabled=true%n" +
                                 "plan-consistency-check-enabled=true%n" +
                                 "system-memory-gb=4%n" +
                                 "http-server.http.port=0%n", discoveryUri);


### PR DESCRIPTION
`native-execution-enabled`  is a coordinator config, no need to pass it to worker config properties. Its passed to coordinator here https://github.com/prestodb/presto/blob/7e44169de44c9eb0b4509bd5b9c4b160830aa665/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/PrestoNativeQueryRunnerUtils.java#L155

```
== NO RELEASE NOTE ==
```

