### PR TITLE
chore(native): Cleanup expression optimizer API

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -231,7 +231,7 @@ json::array_t getOptimizedExpressions(
     expressions.push_back(j);
   }
   const auto optimizedList = expression::optimizeExpressions(
-      expressions, timezone, optimizerLevel, queryCtx.get(), pool);
+      expressions, optimizerLevel, queryCtx.get(), pool);
 
   json::array_t result;
   for (const auto& optimized : optimizedList) {

--- a/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.cpp
+++ b/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.cpp
@@ -99,7 +99,6 @@ protocol::RowExpressionOptimizationResult optimizeExpression(
 
 std::vector<protocol::RowExpressionOptimizationResult> optimizeExpressions(
     const std::vector<RowExpressionPtr>& input,
-    const std::string& timezone,
     OptimizerLevel& optimizerLevel,
     velox::core::QueryCtx* queryCtx,
     velox::memory::MemoryPool* pool) {

--- a/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.h
+++ b/presto-native-execution/presto_cpp/main/types/ExpressionOptimizer.h
@@ -38,17 +38,15 @@ enum class OptimizerLevel {
 /// Optimizes the input list of RowExpressions. For each input RowExpression,
 /// the result is an optimized expression on success or failure info.
 /// @param input List of RowExpressions to be optimized.
-/// @param timezone Session timezone, received from Presto coordinator.
 /// @param optimizerLevel Optimizer level, received from Presto coordinator.
 /// The optimizerLevel can either be OPTIMIZED or EVALUATED. OPTIMIZED removes
-/// all redundancy in a RowExpression by leveraging the ExpressionOptimizer in
-/// Velox, and EVALUATED attempts to evaluate the RowExpression into a constant
-/// even when the expression is non-deterministic.
+/// all redundancy in a RowExpression by leveraging the Velox ExprOptimizer.
+/// EVALUATED attempts to evaluate the RowExpression into a constant, even when
+/// the expression is non-deterministic.
 /// @param queryCtx Query context to be used during optimization.
 /// @param pool Memory pool, required for expression evaluation.
 std::vector<protocol::RowExpressionOptimizationResult> optimizeExpressions(
     const std::vector<RowExpressionPtr>& input,
-    const std::string& timezone,
     OptimizerLevel& optimizerLevel,
     velox::core::QueryCtx* queryCtx,
     velox::memory::MemoryPool* pool);


### PR DESCRIPTION
## Description
Removes unused parameter `timezone` from `ExprOptimizer::optimizeExpressions()` API.

## Motivation and Context
This parameter was used in the initial implementation, and is no longer required since the `queryCtx` contains this info.

## Impact
NA

## Test Plan
Verified with e2e tests.


```
== NO RELEASE NOTE ==
```

