### PR TITLE
feat(optimizer): Add option to not push down remote project below exchange

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -360,6 +360,7 @@ public final class SystemSessionProperties
     public static final String EXPRESSION_OPTIMIZER_IN_ROW_EXPRESSION_REWRITE = "expression_optimizer_in_row_expression_rewrite";
     public static final String TABLE_SCAN_SHUFFLE_PARALLELISM_THRESHOLD = "table_scan_shuffle_parallelism_threshold";
     public static final String TABLE_SCAN_SHUFFLE_STRATEGY = "table_scan_shuffle_strategy";
+    public static final String SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION = "skip_pushdown_through_exchange_for_remote_projection";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -1390,7 +1391,7 @@ public final class SystemSessionProperties
                             if (!featuresConfig.isAllowLegacyMaterializedViewsToggle()) {
                                 throw new PrestoException(INVALID_SESSION_PROPERTY,
                                         "Cannot toggle legacy_materialized_views session property. " +
-                                        "Set experimental.allow-legacy-materialized-views-toggle=true in config to allow changing this setting.");
+                                                "Set experimental.allow-legacy-materialized-views-toggle=true in config to allow changing this setting.");
                             }
                             return (Boolean) value;
                         },
@@ -1993,9 +1994,9 @@ public final class SystemSessionProperties
                         featuresConfig.isIncludeValuesNodeInConnectorOptimizer(),
                         false),
                 booleanProperty(ENABLE_EMPTY_CONNECTOR_OPTIMIZER,
-                    "Run optimizers which optimize queries with values node",
-                    false,
-                    false),
+                        "Run optimizers which optimize queries with values node",
+                        false,
+                        false),
                 booleanProperty(
                         INNER_JOIN_PUSHDOWN_ENABLED,
                         "Enable Join Predicate Pushdown",
@@ -2073,6 +2074,11 @@ public final class SystemSessionProperties
                         false,
                         value -> ShuffleForTableScanStrategy.valueOf(((String) value).toUpperCase()),
                         ShuffleForTableScanStrategy::name),
+                booleanProperty(
+                        SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION,
+                        "Skip pushing down remote projection through exchange",
+                        featuresConfig.isSkipPushdownThroughExchangeForRemoteProjection(),
+                        false),
                 new PropertyMetadata<>(
                         QUERY_CLIENT_TIMEOUT,
                         "Configures how long the query runs without contact from the client application, such as the CLI, before it's abandoned",
@@ -3552,5 +3558,10 @@ public final class SystemSessionProperties
     public static ShuffleForTableScanStrategy getTableScanShuffleStrategy(Session session)
     {
         return session.getSystemProperty(TABLE_SCAN_SHUFFLE_STRATEGY, ShuffleForTableScanStrategy.class);
+    }
+
+    public static boolean isSkipPushdownThroughExchangeForRemoteProjection(Session session)
+    {
+        return session.getSystemProperty(SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION, Boolean.class);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -329,6 +329,7 @@ public class FeaturesConfig
     private String expressionOptimizerUsedInRowExpressionRewrite = "";
     private double tableScanShuffleParallelismThreshold = 0.1;
     private ShuffleForTableScanStrategy tableScanShuffleStrategy = ShuffleForTableScanStrategy.DISABLED;
+    private boolean skipPushdownThroughExchangeForRemoteProjection;
 
     private boolean builtInSidecarFunctionsEnabled;
 
@@ -3330,6 +3331,19 @@ public class FeaturesConfig
     public FeaturesConfig setTableScanShuffleStrategy(ShuffleForTableScanStrategy tableScanShuffleStrategy)
     {
         this.tableScanShuffleStrategy = tableScanShuffleStrategy;
+        return this;
+    }
+
+    public boolean isSkipPushdownThroughExchangeForRemoteProjection()
+    {
+        return skipPushdownThroughExchangeForRemoteProjection;
+    }
+
+    @Config("optimizer.skip-pushdown-through-exchange-for-remote-projection")
+    @ConfigDescription("Skip pushing down remote projection through exchange")
+    public FeaturesConfig setSkipPushdownThroughExchangeForRemoteProjection(boolean skipPushdownThroughExchangeForRemoteProjection)
+    {
+        this.skipPushdownThroughExchangeForRemoteProjection = skipPushdownThroughExchangeForRemoteProjection;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughExchange.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughExchange.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isSkipPushdownThroughExchangeForRemoteProjection;
 import static com.facebook.presto.matching.Capture.newCapture;
 import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
 import static com.facebook.presto.sql.planner.plan.Patterns.exchange;
@@ -80,6 +81,10 @@ public class PushProjectionThroughExchange
     public Result apply(ProjectNode project, Captures captures, Context context)
     {
         ExchangeNode exchange = captures.get(CHILD);
+        if (isSkipPushdownThroughExchangeForRemoteProjection(context.getSession()) && project.getLocality().equals(ProjectNode.Locality.REMOTE)) {
+            return Result.empty();
+        }
+
         Set<VariableReferenceExpression> partitioningColumns = exchange.getPartitioningScheme().getPartitioning().getVariableReferences();
 
         ImmutableList.Builder<PlanNode> newSourceBuilder = ImmutableList.builder();

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -282,6 +282,7 @@ public class TestFeaturesConfig
                 .setMaxSerializableObjectSize(1000)
                 .setTableScanShuffleParallelismThreshold(0.1)
                 .setTableScanShuffleStrategy(FeaturesConfig.ShuffleForTableScanStrategy.DISABLED)
+                .setSkipPushdownThroughExchangeForRemoteProjection(false)
                 .setUseConnectorProvidedSerializationCodecs(false));
     }
 
@@ -510,6 +511,7 @@ public class TestFeaturesConfig
                 .put("max_serializable_object_size", "50")
                 .put("optimizer.table-scan-shuffle-parallelism-threshold", "0.3")
                 .put("optimizer.table-scan-shuffle-strategy", "ALWAYS_ENABLED")
+                .put("optimizer.skip-pushdown-through-exchange-for-remote-projection", "true")
                 .put("use-connector-provided-serialization-codecs", "true")
                 .build();
 
@@ -737,6 +739,7 @@ public class TestFeaturesConfig
                 .setMaxSerializableObjectSize(50)
                 .setTableScanShuffleParallelismThreshold(0.3)
                 .setTableScanShuffleStrategy(FeaturesConfig.ShuffleForTableScanStrategy.ALWAYS_ENABLED)
+                .setSkipPushdownThroughExchangeForRemoteProjection(true)
                 .setUseConnectorProvidedSerializationCodecs(true);
         assertFullMapping(properties, expected);
     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -310,6 +310,11 @@ public class PlanBuilder
         return new ProjectNode(idAllocator.getNextId(), source, assignments);
     }
 
+    public ProjectNode project(PlanNode source, Assignments assignments, ProjectNode.Locality locality)
+    {
+        return new ProjectNode(Optional.empty(), idAllocator.getNextId(), source, assignments, locality);
+    }
+
     public ProjectNode project(Assignments assignments, PlanNode source)
     {
         return new ProjectNode(idAllocator.getNextId(), source, assignments);


### PR DESCRIPTION
## Description
This is targeting queries like the following:

Scan -> Remote Project -> exchange -> ... -> output

So a problem we see is that, when the number of files is small for the scan, the number of tasks for the leaf fragment is small (even after tuning the split size, I still see this problem). What we observe is that, remote project which calls remote service is affected more by the few tasks problem. We have observed queries whose latency decrease from 2 minutes to 12 seconds after we manually add shuffle above the table scan.

In order to solve the problem, I first added https://github.com/prestodb/presto/pull/26941 which adds a shuffle above the table scan. However this is not enough, as the remote project will still be pushed below the exchange node by the `PushProjectionThroughExchange` rule. So to resolve this problem, I added options to not pushdown projections below exchange in certain cases.

There are four options:
* ALWAYS_PUSHDOWN: current behavior
* SKIP_IF_TABLESCAN: if the plan fragment below the exchange is a simple scan fragment, i.e. only have project and filter in addition to the scan node, we may not see much benefit in projection pushdown, hence skip.
* SKIP_IF_REMOTE_PROJECTION: do not pushdown remote project
* SKIP_IF_REMOTE_PROJECTION_ON_TABLESCAN: do not pushdown only when the above two conditions both satisfied

We may only need `SKIP_IF_REMOTE_PROJECTION_ON_TABLESCAN` for the https://github.com/prestodb/presto/pull/26941, but I want to get more flexibility here hence added the other two options too.

## Motivation and Context
As in description

## Impact
We have observed queries whose latency decrease from 2 minutes to 12 seconds after we manually add shuffle above the table scan.

## Test Plan
Unit tests. Also have local end to end test with production queries.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add options to skip projection pushdown through exchange rule
```


