### PR TITLE
feat(optimizer): Add ValuesJoinOptimizer for joins with small VALUES nodes

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -731,19 +731,17 @@ concurrency.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.local-exchange-parent-preference-strategy\`\``.
 
-``join_prefilter_build_side_with_complex_probe_side``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``optimize_values_join``
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
-* **Default value:** ``false``
+* **Default value:** ``true``
 
-Extends the ``join_prefilter_build_side`` optimization to clone more complex probe-side
-patterns (``UNION ALL``, cross join, ``UNNEST``, aggregation) when building the prefilter,
-and to push the prefilter ``SemiJoin`` below right-side aggregations so the build side is
-filtered before grouping. Only takes effect when ``join_prefilter_build_side`` is also
-enabled. Disabled by default because cloning additional probe-side work adds planning
-and runtime overhead, which only pays off when the build side is large enough to dominate
-the join cost.
+When enabled, optimizes joins where one side is a small ``VALUES`` clause (table literal) by
+converting the join into a map lookup. Instead of performing a hash join, the optimizer builds
+an in-memory map from the ``VALUES`` rows and rewrites the join as a projection that looks up
+each probe-side key in the map. This eliminates the join operator entirely and can significantly
+reduce CPU and memory usage for joins against small inline value sets.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.join-prefilter-build-side-with-complex-probe-side\`\``.
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -391,6 +391,7 @@ public final class SystemSessionProperties
     public static final String RPC_FUNCTION_PARALLELISM = "rpc_function_parallelism";
     public static final String OPTIMIZE_TOP_N_USING_ROW_ID = "optimize_top_n_using_row_id";
     public static final String OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS = "optimize_top_n_using_row_id_min_column_savings";
+    public static final String OPTIMIZE_VALUES_JOIN = "optimize_values_join";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -2259,6 +2260,10 @@ public final class SystemSessionProperties
                         false,
                         value -> validateIntegerValue(value, RPC_FUNCTION_PARALLELISM, 0, false),
                         object -> object),
+                booleanProperty(OPTIMIZE_VALUES_JOIN,
+                        "Enable optimizing joins when one side is a table literal - VALUES",
+                        true,
+                        false),
                 new PropertyMetadata<>(
                         QUERY_CLIENT_TIMEOUT,
                         "Configures how long the query runs without contact from the client application, such as the CLI, before it's abandoned",
@@ -3844,6 +3849,11 @@ public final class SystemSessionProperties
     public static boolean isPushSubfieldsForCardinalityEnabled(Session session)
     {
         return session.getSystemProperty(PUSHDOWN_SUBFIELDS_FOR_CARDINALITY, Boolean.class);
+    }
+
+    public static boolean isOptimizeValuesJoin(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZE_VALUES_JOIN, Boolean.class);
     }
 
     public static boolean isUtilizeUniquePropertyInQueryPlanningEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -221,6 +221,7 @@ import com.facebook.presto.sql.planner.optimizations.SortedExchangeRule;
 import com.facebook.presto.sql.planner.optimizations.StatsRecordingPlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.TransformQuantifiedComparisonApplyToLateralJoin;
 import com.facebook.presto.sql.planner.optimizations.UnaliasSymbolReferences;
+import com.facebook.presto.sql.planner.optimizations.ValuesJoinOptimizer;
 import com.facebook.presto.sql.planner.optimizations.WindowFilterPushDown;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.google.common.collect.ImmutableList;
@@ -389,6 +390,8 @@ public class PlanOptimizers
                 new PruneTableFunctionProcessorColumns(),
                 new PruneTableFunctionProcessorSourceColumns(),
                 new PruneTableScanColumns());
+
+        builder.add(new ValuesJoinOptimizer(metadata));
 
         builder.add(new LogicalCteOptimizer(metadata));
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ValuesJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ValuesJoinOptimizer.java
@@ -1,0 +1,617 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.SystemSessionProperties.isOptimizeValuesJoin;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.spi.plan.JoinType.LEFT;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IF;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.ROW_CONSTRUCTOR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.callOperator;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static com.facebook.presto.sql.relational.Expressions.constantNull;
+import static com.facebook.presto.sql.relational.Expressions.specialForm;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/*
+ * Optimizes joins with small-sized VALUES nodes for INNER and LEFT OUTER joins
+ * (when only equi-conditions are present, no additional filters).
+ *
+ * For single row VALUES:
+ *   INNER JOIN:
+ *     - Inlines constants and filters rows where join condition matches
+ *   LEFT JOIN:
+ *     - Inlines constants for matching rows, NULLs for non-matching rows
+ *     - Uses IF(condition, value, NULL) for each column
+ *
+ * For multiple row VALUES (without duplicate join keys):
+ *   - Builds a MAP from join key -> ROW(all columns)
+ *   - INNER JOIN: Filters with contains_key, then extracts via element_at
+ *   - LEFT JOIN: Extracts via element_at (returns NULL for non-matching keys)
+ *
+ * Note: If the VALUES node contains duplicate join keys, the optimization is skipped
+ * and the plan is returned unchanged to ensure correctness.
+ */
+public class ValuesJoinOptimizer
+        implements PlanOptimizer
+{
+    private static final int MAX_VALUES_ROW_COUNT = 1000;
+
+    private final Metadata metadata;
+
+    public ValuesJoinOptimizer(Metadata metadata)
+    {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public PlanOptimizerResult optimize(PlanNode plan, Session session, TypeProvider types, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        requireNonNull(plan, "plan is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(variableAllocator, "variableAllocator is null");
+        requireNonNull(idAllocator, "idAllocator is null");
+        requireNonNull(warningCollector, "warningCollector is null");
+        if (isOptimizeValuesJoin(session)) {
+            Rewriter rewriter = new Rewriter(session, metadata, idAllocator, variableAllocator, metadata.getFunctionAndTypeManager());
+            PlanNode rewritten = SimplePlanRewriter.rewriteWith(rewriter, plan, null);
+            return PlanOptimizerResult.optimizerResult(rewritten, rewriter.isPlanChanged());
+        }
+
+        return PlanOptimizerResult.optimizerResult(plan, false);
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final Session session;
+        private final Metadata metadata;
+        private final PlanNodeIdAllocator idAllocator;
+        private final VariableAllocator variableAllocator;
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private boolean planChanged;
+
+        private Rewriter(Session session, Metadata metadata, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.variableAllocator = requireNonNull(variableAllocator, "variableAllocator is null");
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+        }
+
+        @Override
+        public PlanNode visitJoin(JoinNode node, RewriteContext<Void> context)
+        {
+            PlanNode left = node.getLeft();
+            PlanNode right = node.getRight();
+
+            PlanNode rewrittenLeft = rewriteWith(this, left);
+            PlanNode rewrittenRight = rewriteWith(this, right);
+
+            // Only optimize if right side is a simple ValuesNode (no projection/filter on top)
+            if ((node.getType() == INNER || (node.getType() == LEFT && !node.getFilter().isPresent())) &&
+                    rewrittenRight instanceof ValuesNode &&
+                    !node.getCriteria().isEmpty()) {
+                ValuesNode valuesNode = (ValuesNode) rewrittenRight;
+
+                // Check if ValuesNode is within size limit
+                if (valuesNode.getRows().size() > MAX_VALUES_ROW_COUNT) {
+                    if (rewrittenLeft != node.getLeft() || rewrittenRight != node.getRight()) {
+                        planChanged = true;
+                        return replaceChildren(node, ImmutableList.of(rewrittenLeft, rewrittenRight));
+                    }
+                    return node;
+                }
+
+                PlanNode newProjection;
+
+                if (valuesNode.getRows().size() == 1) {
+                    // Single row: inline the constants with proper join semantics
+                    newProjection = buildSingleRowJoin(node, rewrittenLeft, valuesNode);
+                    if (newProjection == null) {
+                        // Optimization not possible, return with children replaced if needed
+                        if (rewrittenLeft != node.getLeft() || rewrittenRight != node.getRight()) {
+                            planChanged = true;
+                            return replaceChildren(node, ImmutableList.of(rewrittenLeft, rewrittenRight));
+                        }
+                        return node;
+                    }
+                }
+                else {
+                    // Skip optimization if there are duplicate keys
+                    if (hasDuplicateKeys(valuesNode, node.getCriteria())) {
+                        if (rewrittenLeft != node.getLeft() || rewrittenRight != node.getRight()) {
+                            planChanged = true;
+                            return replaceChildren(node, ImmutableList.of(rewrittenLeft, rewrittenRight));
+                        }
+                        return node;
+                    }
+
+                    // Multiple rows: create a map for efficient lookup
+                    newProjection = buildMapBasedJoin(node, rewrittenLeft, valuesNode);
+                    if (newProjection == null) {
+                        // Optimization not possible, return with children replaced if needed
+                        if (rewrittenLeft != node.getLeft() || rewrittenRight != node.getRight()) {
+                            planChanged = true;
+                            return replaceChildren(node, ImmutableList.of(rewrittenLeft, rewrittenRight));
+                        }
+                        return node;
+                    }
+                }
+
+                planChanged = true;
+                return newProjection;
+            }
+
+            if (rewrittenLeft != node.getLeft() || rewrittenRight != node.getRight()) {
+                planChanged = true;
+                return replaceChildren(node, ImmutableList.of(rewrittenLeft, rewrittenRight));
+            }
+
+            return node;
+        }
+
+        private PlanNode buildSingleRowJoin(JoinNode node, PlanNode leftSide, ValuesNode valuesNode)
+        {
+            List<RowExpression> singleRow = valuesNode.getRows().get(0);
+            List<VariableReferenceExpression> valuesOutputVariables = valuesNode.getOutputVariables();
+
+            // Build index mapping from variable name to its position in ValuesNode
+            Map<String, Integer> nameToIndex = new java.util.HashMap<>();
+            for (int i = 0; i < valuesOutputVariables.size(); i++) {
+                nameToIndex.put(valuesOutputVariables.get(i).getName(), i);
+            }
+
+            // Get the constant value for a given variable name
+            java.util.function.Function<String, RowExpression> getConstant = name -> {
+                Integer index = nameToIndex.get(name);
+                return index != null ? singleRow.get(index) : null;
+            };
+
+            if (node.getType() == INNER) {
+                // INNER JOIN: filter on join condition using left side variables and constant values
+                // We compare left variable = constant (not left variable = right variable)
+                RowExpression filter = null;
+                for (EquiJoinClause clause : node.getCriteria()) {
+                    RowExpression rightConstant = getConstant.apply(clause.getRight().getName());
+                    if (rightConstant == null) {
+                        // Couldn't find constant, skip optimization
+                        return null;
+                    }
+                    RowExpression equality = callOperator(
+                            functionAndTypeManager.getFunctionAndTypeResolver(),
+                            OperatorType.EQUAL,
+                            BOOLEAN,
+                            clause.getLeft(),
+                            rightConstant);
+                    if (filter == null) {
+                        filter = equality;
+                    }
+                    else {
+                        filter = specialForm(AND, BOOLEAN, filter, equality);
+                    }
+                }
+
+                // First filter based on join condition, then project the VALUES columns
+                PlanNode filterNode = new FilterNode(
+                        leftSide.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        leftSide,
+                        filter);
+
+                // Now add the VALUES columns as constant projections using NEW variables
+                // (not the ValuesNode's output variables, to avoid identity issues)
+                ImmutableList.Builder<VariableReferenceExpression> newVariables = ImmutableList.builder();
+                for (VariableReferenceExpression var : valuesOutputVariables) {
+                    newVariables.add(variableAllocator.newVariable(var.getName(), var.getType()));
+                }
+
+                return addProjections(
+                        filterNode,
+                        idAllocator,
+                        variableAllocator,
+                        singleRow,
+                        newVariables.build());
+            }
+            else {
+                // LEFT JOIN: use IF(condition, value, NULL) for each column
+                // Build join condition using left variables and constants
+                RowExpression joinCondition = null;
+                for (EquiJoinClause clause : node.getCriteria()) {
+                    RowExpression rightConstant = getConstant.apply(clause.getRight().getName());
+                    if (rightConstant == null) {
+                        // Couldn't find constant, skip optimization
+                        return null;
+                    }
+                    RowExpression equality = callOperator(
+                            functionAndTypeManager.getFunctionAndTypeResolver(),
+                            OperatorType.EQUAL,
+                            BOOLEAN,
+                            clause.getLeft(),
+                            rightConstant);
+                    if (joinCondition == null) {
+                        joinCondition = equality;
+                    }
+                    else {
+                        joinCondition = specialForm(AND, BOOLEAN, joinCondition, equality);
+                    }
+                }
+
+                // Build conditional assignments: IF(condition, constant, NULL)
+                List<RowExpression> conditionalValues = new java.util.ArrayList<>();
+                for (int i = 0; i < valuesOutputVariables.size(); i++) {
+                    RowExpression value = singleRow.get(i);
+                    conditionalValues.add(specialForm(IF, value.getType(), joinCondition, value, constantNull(value.getType())));
+                }
+
+                // Use NEW variables (not the ValuesNode's output variables)
+                ImmutableList.Builder<VariableReferenceExpression> newVariables = ImmutableList.builder();
+                for (VariableReferenceExpression var : valuesOutputVariables) {
+                    newVariables.add(variableAllocator.newVariable(var.getName(), var.getType()));
+                }
+
+                return addProjections(
+                        leftSide,
+                        idAllocator,
+                        variableAllocator,
+                        conditionalValues,
+                        newVariables.build());
+            }
+        }
+
+        private RowExpression buildEquiJoinFilterWithConstants(
+                List<EquiJoinClause> criteria,
+                List<VariableReferenceExpression> rightVariables,
+                List<RowExpression> rightValues)
+        {
+            RowExpression filter = null;
+            for (EquiJoinClause clause : criteria) {
+                // Find the index of the right variable by name
+                int rightIndex = -1;
+                String targetName = clause.getRight().getName();
+                for (int i = 0; i < rightVariables.size(); i++) {
+                    if (rightVariables.get(i).getName().equals(targetName)) {
+                        rightIndex = i;
+                        break;
+                    }
+                }
+
+                // Use the constant value if found, otherwise use the original variable
+                RowExpression rightExpr = (rightIndex >= 0) ? rightValues.get(rightIndex) : clause.getRight();
+
+                RowExpression equality = callOperator(
+                        functionAndTypeManager.getFunctionAndTypeResolver(),
+                        OperatorType.EQUAL,
+                        BOOLEAN,
+                        clause.getLeft(),
+                        rightExpr);
+                if (filter == null) {
+                    filter = equality;
+                }
+                else {
+                    filter = specialForm(AND, BOOLEAN, filter, equality);
+                }
+            }
+            return filter;
+        }
+
+        private PlanNode buildMapBasedJoin(JoinNode node, PlanNode leftSide, ValuesNode valuesNode)
+        {
+            FunctionResolution functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+
+            List<VariableReferenceExpression> outputVariables = valuesNode.getOutputVariables();
+            List<EquiJoinClause> criteria = node.getCriteria();
+
+            // Find key column indices for all join criteria
+            List<Integer> keyColumnIndices = criteria.stream()
+                    .map(clause -> findVariableIndex(outputVariables, clause.getRight()))
+                    .collect(Collectors.toList());
+
+            // Validate all indices were found
+            if (keyColumnIndices.stream().anyMatch(idx -> idx < 0)) {
+                return null; // Skip optimization if we can't find all key columns
+            }
+
+            // Build key type - use ROW for multiple keys, simple type for single key
+            Type keyType;
+            if (criteria.size() == 1) {
+                keyType = outputVariables.get(keyColumnIndices.get(0)).getType();
+            }
+            else {
+                List<RowType.Field> keyFields = criteria.stream()
+                        .map(clause -> RowType.field(clause.getRight().getName(), clause.getRight().getType()))
+                        .collect(toImmutableList());
+                keyType = RowType.from(keyFields);
+            }
+
+            // Build the value RowType (all columns from ValuesNode)
+            List<RowType.Field> valueFields = outputVariables.stream()
+                    .map(var -> RowType.field(var.getName(), var.getType()))
+                    .collect(toImmutableList());
+            RowType valueRowType = RowType.from(valueFields);
+
+            // Build keys and values lists, filtering out rows with any NULL key
+            ImmutableList.Builder<RowExpression> keys = ImmutableList.builder();
+            ImmutableList.Builder<RowExpression> values = ImmutableList.builder();
+
+            for (List<RowExpression> row : valuesNode.getRows()) {
+                // Check if any key column is NULL
+                boolean hasNullKey = keyColumnIndices.stream()
+                        .map(row::get)
+                        .anyMatch(this::isNullConstant);
+
+                // Skip rows with NULL keys - they can never match in a join
+                if (hasNullKey) {
+                    continue;
+                }
+
+                // Build the key expression
+                RowExpression key;
+                if (criteria.size() == 1) {
+                    key = row.get(keyColumnIndices.get(0));
+                }
+                else {
+                    // Build composite key as ROW
+                    List<RowExpression> keyValues = keyColumnIndices.stream()
+                            .map(row::get)
+                            .collect(toImmutableList());
+                    key = specialForm(ROW_CONSTRUCTOR, keyType, keyValues);
+                }
+
+                // Value: entire row as ROW
+                RowExpression rowValue = specialForm(ROW_CONSTRUCTOR, valueRowType, row);
+
+                keys.add(key);
+                values.add(rowValue);
+            }
+
+            // Build key and value arrays
+            List<RowExpression> keysList = keys.build();
+            List<RowExpression> valuesList = values.build();
+
+            // If all rows had NULL keys, the map is empty
+            // For INNER JOIN: no matches possible, return empty result via false filter
+            // For LEFT JOIN: all rows get NULLs, just project NULLs
+            if (keysList.isEmpty()) {
+                if (node.getType() == INNER) {
+                    // Filter that's always false - no rows will match
+                    RowExpression falseFilter = constant(false, BOOLEAN);
+                    PlanNode filterNode = new FilterNode(
+                            leftSide.getSourceLocation(),
+                            idAllocator.getNextId(),
+                            leftSide,
+                            falseFilter);
+
+                    // Still need to project NULL values for the VALUES columns
+                    ImmutableList.Builder<RowExpression> nullValues = ImmutableList.builder();
+                    for (VariableReferenceExpression var : outputVariables) {
+                        nullValues.add(constantNull(var.getType()));
+                    }
+
+                    return addProjections(
+                            filterNode,
+                            idAllocator,
+                            variableAllocator,
+                            nullValues.build(),
+                            outputVariables);
+                }
+                else {
+                    // LEFT JOIN: all left rows get NULLs for VALUES columns
+                    ImmutableList.Builder<RowExpression> nullValues = ImmutableList.builder();
+                    for (VariableReferenceExpression var : outputVariables) {
+                        nullValues.add(constantNull(var.getType()));
+                    }
+
+                    return addProjections(
+                            leftSide,
+                            idAllocator,
+                            variableAllocator,
+                            nullValues.build(),
+                            outputVariables);
+                }
+            }
+
+            RowExpression keyArray = call(
+                    "ARRAY",
+                    functionResolution.arrayConstructor(keysList.stream().map(RowExpression::getType).collect(toImmutableList())),
+                    new ArrayType(keyType),
+                    keysList);
+
+            RowExpression valueArray = call(
+                    "ARRAY",
+                    functionResolution.arrayConstructor(valuesList.stream().map(RowExpression::getType).collect(toImmutableList())),
+                    new ArrayType(valueRowType),
+                    valuesList);
+
+            // Build the map using MAP(keys, values) function
+            MethodHandle keyEquals = functionAndTypeManager.getJavaScalarFunctionImplementation(
+                    functionAndTypeManager.resolveOperator(OperatorType.EQUAL, fromTypes(keyType, keyType))).getMethodHandle();
+            MethodHandle keyHashcode = functionAndTypeManager.getJavaScalarFunctionImplementation(
+                    functionAndTypeManager.resolveOperator(OperatorType.HASH_CODE, fromTypes(keyType))).getMethodHandle();
+
+            MapType mapType = new MapType(keyType, valueRowType, keyEquals, keyHashcode);
+            RowExpression mapConstructor = call(functionAndTypeManager, "MAP", mapType, keyArray, valueArray);
+
+            // Create a variable for the map and project it onto the left side
+            VariableReferenceExpression mapVariable = variableAllocator.newVariable("valuesMap", mapType);
+            PlanNode result = addProjections(
+                    leftSide,
+                    idAllocator,
+                    variableAllocator,
+                    ImmutableList.of(mapConstructor),
+                    ImmutableList.of(mapVariable));
+
+            // Build the lookup key from left side of join criteria
+            RowExpression lookupKey;
+            if (criteria.size() == 1) {
+                lookupKey = criteria.get(0).getLeft();
+            }
+            else {
+                // Build composite lookup key as ROW
+                List<RowExpression> leftKeyExprs = criteria.stream()
+                        .map(EquiJoinClause::getLeft)
+                        .collect(toImmutableList());
+                lookupKey = specialForm(ROW_CONSTRUCTOR, keyType, leftKeyExprs);
+            }
+
+            // For INNER JOIN: filter out rows where key doesn't exist in map
+            if (node.getType() == INNER) {
+                RowExpression containsKeyFilter = call(
+                        functionAndTypeManager,
+                        "contains_key",
+                        BOOLEAN,
+                        mapVariable,
+                        lookupKey);
+
+                result = new FilterNode(
+                        result.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        result,
+                        containsKeyFilter);
+            }
+
+            // element_at(mapVariable, lookupKey) returns the matching row (or NULL for LEFT JOIN)
+            RowExpression elementAt = call(
+                    functionAndTypeManager,
+                    "element_at",
+                    valueRowType,
+                    mapVariable,
+                    lookupKey);
+
+            // Extract each field from the row and assign to output variables
+            ImmutableList.Builder<RowExpression> fieldExtractions = ImmutableList.builder();
+            for (int i = 0; i < outputVariables.size(); i++) {
+                RowExpression fieldAccess = specialForm(
+                        DEREFERENCE,
+                        outputVariables.get(i).getType(),
+                        elementAt,
+                        new ConstantExpression((long) i, INTEGER));
+                fieldExtractions.add(fieldAccess);
+            }
+
+            return addProjections(
+                    result,
+                    idAllocator,
+                    variableAllocator,
+                    fieldExtractions.build(),
+                    outputVariables);
+        }
+
+        private boolean isNullConstant(RowExpression expression)
+        {
+            return expression instanceof ConstantExpression && ((ConstantExpression) expression).isNull();
+        }
+
+        private RowExpression buildEquiJoinFilter(List<EquiJoinClause> criteria, Map<String, VariableReferenceExpression> nameToRightVar)
+        {
+            RowExpression filter = null;
+            for (EquiJoinClause clause : criteria) {
+                // Find the matching variable by name
+                VariableReferenceExpression rightVar = nameToRightVar.getOrDefault(
+                        clause.getRight().getName(),
+                        clause.getRight());
+
+                RowExpression equality = callOperator(
+                        functionAndTypeManager.getFunctionAndTypeResolver(),
+                        OperatorType.EQUAL,
+                        BOOLEAN,
+                        clause.getLeft(),
+                        rightVar);
+                if (filter == null) {
+                    filter = equality;
+                }
+                else {
+                    filter = specialForm(AND, BOOLEAN, filter, equality);
+                }
+            }
+            return filter;
+        }
+
+        private int findVariableIndex(List<VariableReferenceExpression> variables, VariableReferenceExpression target)
+        {
+            for (int i = 0; i < variables.size(); i++) {
+                if (variables.get(i).getName().equals(target.getName())) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private boolean hasDuplicateKeys(ValuesNode valuesNode, List<EquiJoinClause> criteria)
+        {
+            List<VariableReferenceExpression> outputVariables = valuesNode.getOutputVariables();
+            List<Integer> keyColumnIndices = criteria.stream()
+                    .map(clause -> findVariableIndex(outputVariables, clause.getRight()))
+                    .collect(Collectors.toList());
+
+            // If any index is -1, we couldn't find the key column - treat as duplicate to skip optimization
+            if (keyColumnIndices.stream().anyMatch(idx -> idx < 0)) {
+                return true;
+            }
+
+            List<List<Object>> allKeys = valuesNode.getRows().stream()
+                    .map(row -> keyColumnIndices.stream()
+                            .map(row::get)
+                            .map(expr -> expr instanceof ConstantExpression ? ((ConstantExpression) expr).getValue() : expr)
+                            .collect(Collectors.toList()))
+                    .collect(Collectors.toList());
+
+            return allKeys.size() != allKeys.stream().distinct().count();
+        }
+
+        public boolean isPlanChanged()
+        {
+            return planChanged;
+        }
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ValuesJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ValuesJoinOptimizer.java
@@ -249,19 +249,14 @@ public class ValuesJoinOptimizer
                         leftSide,
                         filter);
 
-                // Now add the VALUES columns as constant projections using NEW variables
-                // (not the ValuesNode's output variables, to avoid identity issues)
-                ImmutableList.Builder<VariableReferenceExpression> newVariables = ImmutableList.builder();
-                for (VariableReferenceExpression var : valuesOutputVariables) {
-                    newVariables.add(variableAllocator.newVariable(var.getName(), var.getType()));
-                }
-
+                // Use the original ValuesNode output variables to preserve identities
+                // for downstream consumers
                 return addProjections(
                         filterNode,
                         idAllocator,
                         variableAllocator,
                         singleRow,
-                        newVariables.build());
+                        valuesOutputVariables);
             }
             else {
                 // LEFT JOIN: use IF(condition, value, NULL) for each column
@@ -294,18 +289,14 @@ public class ValuesJoinOptimizer
                     conditionalValues.add(specialForm(IF, value.getType(), joinCondition, value, constantNull(value.getType())));
                 }
 
-                // Use NEW variables (not the ValuesNode's output variables)
-                ImmutableList.Builder<VariableReferenceExpression> newVariables = ImmutableList.builder();
-                for (VariableReferenceExpression var : valuesOutputVariables) {
-                    newVariables.add(variableAllocator.newVariable(var.getName(), var.getType()));
-                }
-
+                // Use the original ValuesNode output variables to preserve identities
+                // for downstream consumers
                 return addProjections(
                         leftSide,
                         idAllocator,
                         variableAllocator,
                         conditionalValues,
-                        newVariables.build());
+                        valuesOutputVariables);
             }
         }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestValuesJoinOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestValuesJoinOptimizer.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.spi.plan.EquiJoinClause;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.assertions.OptimizerAssert;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_VALUES_JOIN;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.plan.JoinType.INNER;
+import static com.facebook.presto.spi.plan.JoinType.LEFT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+
+public class TestValuesJoinOptimizer
+        extends BaseRuleTest
+{
+    private OptimizerAssert assertOptimizer()
+    {
+        RuleTester tester = tester();
+        return tester.assertThat(new ValuesJoinOptimizer(tester.getMetadata()))
+                .setSystemProperty(OPTIMIZE_VALUES_JOIN, "true");
+    }
+
+    private OptimizerAssert assertOptimizerDisabled()
+    {
+        RuleTester tester = tester();
+        return tester.assertThat(new ValuesJoinOptimizer(tester.getMetadata()))
+                .setSystemProperty(OPTIMIZE_VALUES_JOIN, "false");
+    }
+
+    @Test
+    public void testSingleRowInnerJoinReplacedWithFilterProject()
+    {
+        // Single-row VALUES INNER JOIN should be replaced with Filter + Project (no JoinNode)
+        assertOptimizer()
+                .on(p -> {
+                    VariableReferenceExpression nationkey = p.variable("nationkey", BIGINT);
+                    VariableReferenceExpression name = p.variable("name", VARCHAR);
+                    VariableReferenceExpression regionkey = p.variable("regionkey", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+
+                    PlanNode left = p.values(nationkey, name, regionkey);
+                    ValuesNode right = p.values(
+                            ImmutableList.of(x),
+                            ImmutableList.of(ImmutableList.of(constant(1L, BIGINT))));
+
+                    return p.output(
+                            ImmutableList.of("nationkey", "name", "x"),
+                            ImmutableList.of(nationkey, name, x),
+                            p.join(INNER, left, right, new EquiJoinClause(regionkey, x)));
+                })
+                .matches(
+                        output(
+                                project(
+                                        filter(
+                                                values("nationkey", "name", "regionkey")))));
+    }
+
+    @Test
+    public void testSingleRowLeftJoinReplacedWithIfProjection()
+    {
+        // Single-row VALUES LEFT JOIN should be replaced with IF-based projection
+        assertOptimizer()
+                .on(p -> {
+                    VariableReferenceExpression nationkey = p.variable("nationkey", BIGINT);
+                    VariableReferenceExpression regionkey = p.variable("regionkey", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+
+                    PlanNode left = p.values(nationkey, regionkey);
+                    ValuesNode right = p.values(
+                            ImmutableList.of(x),
+                            ImmutableList.of(ImmutableList.of(constant(1L, BIGINT))));
+
+                    return p.output(
+                            ImmutableList.of("nationkey", "x"),
+                            ImmutableList.of(nationkey, x),
+                            p.join(LEFT, left, right, new EquiJoinClause(regionkey, x)));
+                })
+                .matches(
+                        output(
+                                project(
+                        values("nationkey", "regionkey"))));
+    }
+
+    @Test
+    public void testOptimizationSkippedWhenDisabled()
+    {
+        // When disabled, the JoinNode should remain
+        assertOptimizerDisabled()
+                .on(p -> {
+                    VariableReferenceExpression nationkey = p.variable("nationkey", BIGINT);
+                    VariableReferenceExpression regionkey = p.variable("regionkey", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+
+                    PlanNode left = p.values(nationkey, regionkey);
+                    ValuesNode right = p.values(
+                            ImmutableList.of(x),
+                            ImmutableList.of(ImmutableList.of(constant(1L, BIGINT))));
+
+                    return p.output(
+                            ImmutableList.of("nationkey", "x"),
+                            ImmutableList.of(nationkey, x),
+                            p.join(INNER, left, right, new EquiJoinClause(regionkey, x)));
+                })
+                .matches(
+                        output(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("regionkey", "x")),
+                                        values("nationkey", "regionkey"),
+                                        values("x"))));
+    }
+
+    @Test
+    public void testLargeValuesSkipped()
+    {
+        // Optimization should be skipped for VALUES with > 1000 rows
+        assertOptimizer()
+                .on(p -> {
+                    VariableReferenceExpression key = p.variable("key", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+
+                    PlanNode left = p.values(key);
+
+                    ImmutableList.Builder<List<com.facebook.presto.spi.relation.RowExpression>> rowsBuilder = ImmutableList.builder();
+                    for (int i = 0; i < 1001; i++) {
+                        rowsBuilder.add(ImmutableList.of(constant((long) i, BIGINT)));
+                    }
+
+                    ValuesNode right = p.values(ImmutableList.of(x), rowsBuilder.build());
+
+                    return p.output(
+                            ImmutableList.of("key", "x"),
+                            ImmutableList.of(key, x),
+                            p.join(INNER, left, right, new EquiJoinClause(key, x)));
+                })
+                .matches(
+                        output(
+                                join(INNER,
+                                        ImmutableList.of(equiJoinClause("key", "x")),
+                                        values("key"),
+                                        values("x"))));
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8440,6 +8440,92 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT 'line1\rline2' = U&'line1\\000Dline2'", "SELECT true");
     }
 
+    @Test
+    public void testOptimizeValuesJoin()
+    {
+        // Single row VALUES - INNER JOIN
+        assertQuery("select count(*) from nation join (values (1,'x')) AS T(x, newString) on nationkey=x", "select 1");
+        assertQuery("select count(*) from nation join (values (-1,'x')) AS T(x, newString) on nationkey=x", "select 0");
+        assertQuery("select count(*) from nation join (values (1,'x')) AS T(x, newString) on regionkey=x join region using(regionkey) group by regionkey", "select 5");
+        assertQuery("select n.name, t.newString from nation n join (values (0,'matched')) AS T(x, newString) on n.regionkey=x order by n.name limit 3",
+                "select name, 'matched' from nation where regionkey=0 order by name limit 3");
+
+        // Single row VALUES - LEFT JOIN
+        assertQuery("select count(*) from nation left join (values (1,'x')) AS T(x, newString) on nationkey=x", "select 25");
+        assertQuery("select count(*), count(newString) from nation left join (values (1,'x')) AS T(x, newString) on nationkey=x", "select 25, 1");
+        assertQuery("select n.name, t.newString from nation n left join (values (0,'matched')) AS T(x, newString) on n.regionkey=x order by n.name limit 5",
+                "select name, case when regionkey=0 then 'matched' else null end from nation order by name limit 5");
+
+        // Multiple rows VALUES - INNER JOIN
+        assertQuery("select count(*) from nation join (values (1,'x'), (2, 'a'), (3, 'y')) AS T(x, newString) on regionkey=x", "select count(*) from nation where regionkey in (1,2,3)");
+        assertQuery("select array_join(array_sort(array_agg(y)), ',') from nation join (values (1,'x'), (2, 'a'), (3, 'y'),(4,'y')) AS T(x, y) on regionkey=x", "select 'a,a,a,a,a,x,x,x,x,x,y,y,y,y,y,y,y,y,y,y'");
+        assertQuery("select count(*) from nation join (values (0,'zero'), (1,'one'), (2,'two'), (3,'three'), (4,'four')) AS T(x, label) on regionkey=x", "select 25");
+        assertQuery("select n.name, t.label from nation n join (values (0,'zero'), (1,'one')) AS T(x, label) on n.regionkey=x order by n.name limit 5",
+                "select name, case regionkey when 0 then 'zero' when 1 then 'one' end from nation where regionkey in (0,1) order by name limit 5");
+
+        // Multiple rows VALUES - LEFT JOIN
+        assertQuery("select count(*) from nation left join (values (1,'x'), (2, 'a')) AS T(x, newString) on regionkey=x", "select 25");
+        assertQuery("select count(*), count(newString) from nation left join (values (1,'x'), (2, 'a')) AS T(x, newString) on regionkey=x",
+                "select 25, (select count(*) from nation where regionkey in (1,2))");
+        assertQuery("select n.name, t.label from nation n left join (values (0,'zero'), (1,'one')) AS T(x, label) on n.regionkey=x order by n.name limit 10",
+                "select name, case regionkey when 0 then 'zero' when 1 then 'one' else null end from nation order by name limit 10");
+
+        // Duplicate keys in VALUES - should still return correct results (optimization skipped)
+        assertQuery("select count(*) from nation join (values (1,'x'), (1, 'y')) AS T(x, newString) on regionkey=x",
+                "select count(*) * 2 from nation where regionkey = 1");
+        assertQuery("select count(*) from nation join (values (1,'x'), (1, 'y'), (2, 'z')) AS T(x, newString) on regionkey=x",
+                "select (select count(*) from nation where regionkey = 1) * 2 + (select count(*) from nation where regionkey = 2)");
+        assertQuery("select count(*) from nation left join (values (1,'x'), (1, 'y')) AS T(x, newString) on regionkey=x",
+                "select (select count(*) from nation where regionkey = 1) * 2 + (select count(*) from nation where regionkey != 1)");
+
+        // Many rows VALUES (exceeds small values threshold) - optimization should be skipped
+        assertQuery("select count(*) from nation join (values (0,'a'),(1,'b'),(2,'c'),(3,'d'),(4,'e'),(5,'f'),(6,'g'),(7,'h'),(8,'i'),(9,'j'),(10,'k')) AS T(x, label) on nationkey=x",
+                "select count(*) from nation where nationkey between 0 and 10");
+
+        // Multiple join keys - now optimized with composite ROW key
+        assertQuery("select count(*) from nation join (values (0, 0, 'x')) AS T(rk, nk, label) on regionkey=rk and nationkey=nk", "select 1");
+        // nationkey=0 has regionkey=0 (ALGERIA), nationkey=1 has regionkey=1 (ARGENTINA)
+        assertQuery("select count(*) from nation join (values (0, 0, 'x'), (1, 1, 'y')) AS T(rk, nk, label) on regionkey=rk and nationkey=nk", "select 2");
+        assertQuery("select n.name, t.label from nation n join (values (0, 0, 'x'), (1, 1, 'y')) AS T(rk, nk, label) on regionkey=rk and nationkey=nk order by n.name",
+                "select 'ALGERIA', 'x' union all select 'ARGENTINA', 'y' order by 1");
+
+        // Multiple join keys - LEFT JOIN
+        assertQuery("select count(*), count(label) from nation left join (values (0, 0, 'x'), (1, 1, 'y')) AS T(rk, nk, label) on regionkey=rk and nationkey=nk",
+                "select 25, 2");
+
+        // Verify values are correctly projected
+        assertQuery("select n.nationkey, t.x, t.newString from nation n join (values (1,'hello'), (2,'world')) AS T(x, newString) on n.regionkey=x order by n.nationkey",
+                "select nationkey, regionkey, case regionkey when 1 then 'hello' when 2 then 'world' end from nation where regionkey in (1,2) order by nationkey");
+
+        // NULL keys in VALUES - single row INNER JOIN (should match nothing)
+        assertQuery("select count(*) from nation join (values (null,'x')) AS T(x, newString) on regionkey=x", "select 0");
+        assertQuery("select count(*) from nation join (values (CAST(null AS INTEGER),'x')) AS T(x, newString) on nationkey=x", "select 0");
+
+        // NULL keys in VALUES - single row LEFT JOIN (all rows get NULLs)
+        assertQuery("select count(*), count(newString) from nation left join (values (null,'x')) AS T(x, newString) on regionkey=x", "select 25, 0");
+        assertQuery("select count(*), count(x) from nation left join (values (CAST(null AS INTEGER),'x')) AS T(x, newString) on nationkey=x", "select 25, 0");
+
+        // NULL keys in VALUES - multiple rows INNER JOIN (NULL key rows filtered out)
+        assertQuery("select count(*) from nation join (values (null,'a'), (1,'b'), (2,'c')) AS T(x, newString) on regionkey=x",
+                "select count(*) from nation where regionkey in (1,2)");
+        assertQuery("select count(*) from nation join (values (0,'a'), (null,'b'), (null,'c')) AS T(x, newString) on regionkey=x",
+                "select count(*) from nation where regionkey = 0");
+
+        // NULL keys in VALUES - multiple rows LEFT JOIN (NULL key rows filtered out)
+        assertQuery("select count(*), count(newString) from nation left join (values (null,'a'), (1,'b'), (2,'c')) AS T(x, newString) on regionkey=x",
+                "select 25, (select count(*) from nation where regionkey in (1,2))");
+
+        // All NULL keys in VALUES - INNER JOIN (should match nothing)
+        assertQuery("select count(*) from nation join (values (null,'a'), (null,'b')) AS T(x, newString) on regionkey=x", "select 0");
+
+        // All NULL keys in VALUES - LEFT JOIN (all rows get NULLs)
+        assertQuery("select count(*), count(newString) from nation left join (values (null,'a'), (null,'b')) AS T(x, newString) on regionkey=x", "select 25, 0");
+
+        // NULL keys with multiple join keys (optimization skipped, results still correct)
+        assertQuery("select count(*) from nation join (values (null, 0, 'x'), (0, 0, 'y')) AS T(rk, nk, label) on regionkey=rk and nationkey=nk", "select 1");
+        assertQuery("select count(*) from nation join (values (0, null, 'x'), (0, 0, 'y')) AS T(rk, nk, label) on regionkey=rk and nationkey=nk", "select 1");
+    }
+
     private List<MaterializedRow> getNativeWorkerSessionProperties(List<MaterializedRow> inputRows, String sessionPropertyName)
     {
         return inputRows.stream()


### PR DESCRIPTION
Summary:
Adds a new optimizer that transforms joins with small VALUES nodes into more efficient operations. This optimization is controlled by the session property 'optimize_values_join'.

For single row VALUES:
- INNER JOIN: Inlines constants and filters rows where join condition matches
- LEFT JOIN: Uses IF(condition, value, NULL) for each column

For multiple row VALUES (without duplicate join keys):
- Builds a MAP from join key -> ROW(all columns)
- INNER JOIN: Filters with contains_key, then extracts via element_at
- LEFT JOIN: Extracts via element_at (returns NULL for non-matching keys)

The optimization is skipped when:
- VALUES node has duplicate join keys
- Multiple join keys are used (composite key not yet supported)
- VALUES node exceeds the size limit (254 rows)

Test Plan:
Added comprehensive tests in testOptimizeValuesJoin covering:
- Single row VALUES with INNER and LEFT JOIN
- Multiple row VALUES with INNER and LEFT JOIN
- Duplicate keys (optimization skipped, correct results)
- Multiple join keys (optimization skipped, correct results)
- Many rows VALUES (exceeds threshold)
- Value projection verification

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improve Presto optimizations by adding a new optimizer for inner/left joins where right side is values that a) inlines single row values joins to simply filter and project and b) builds a map for multi-row/multikey join conditions. This is controlled by the session property ```optimize_values_join```


