### PR TITLE
test: Add end to end tests for string functions

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1038,6 +1038,28 @@ public abstract class AbstractTestNativeGeneralQueries
         finally {
             dropTableIfExists(tmpTableName);
         }
+
+        // bit_length
+        assertQuery("SELECT bit_length(comment) FROM orders");
+        assertQuery("SELECT bit_length(name) FROM nation");
+        assertQuery("SELECT bit_length(shipmode) FROM lineitem");
+        assertQuery("SELECT bit_length(c0) FROM (VALUES ('abc'), (CAST(NULL AS VARCHAR)), ('')) as t (c0)");
+        assertQuery("SELECT bit_length(IF(nationkey % 2 = 0, name, NULL)) FROM nation");
+
+        // longest_common_prefix
+        assertQuery("SELECT longest_common_prefix(name, 'UNITED') FROM nation WHERE name LIKE 'UNITED%' ORDER BY name");
+        assertQuery("SELECT longest_common_prefix(comment, comment) FROM orders ORDER BY orderkey LIMIT 10");
+        assertQuery("SELECT longest_common_prefix('', ''), longest_common_prefix('hello', 'hello world') FROM (VALUES 1)", "SELECT '', 'hello'");
+        assertQuery("SELECT longest_common_prefix(IF(nationkey % 2 = 0, name, NULL), 'UNITED') FROM nation");
+        assertQuery("SELECT longest_common_prefix(c0, c1) FROM (VALUES ('hello', 'help'), (CAST(NULL AS VARCHAR), 'x'), ('x', CAST(NULL AS VARCHAR))) as t (c0, c1)");
+
+        // replace_first
+        assertQuery("SELECT replace_first(comment, 'the', 'THE') FROM orders ORDER BY orderkey LIMIT 10");
+        assertQuery("SELECT replace_first(name, 'A', 'X') FROM nation ORDER BY nationkey LIMIT 10");
+        assertQuery("SELECT replace_first('aaa', 'a', 'b') FROM (VALUES 1)", "SELECT 'baa'");
+        assertQuery("SELECT replace_first(comment, ' ', '') FROM orders ORDER BY orderkey LIMIT 10");
+        assertQuery("SELECT replace_first(c0, c1, c2) FROM (VALUES ('aaa', 'a', 'b'), (CAST(NULL AS VARCHAR), 'a', 'b'), ('aaa', CAST(NULL AS VARCHAR), 'b'), ('aaa', 'a', CAST(NULL AS VARCHAR))) as t (c0, c1, c2)");
+        assertQuery("SELECT replace_first(IF(nationkey % 2 = 0, name, NULL), 'A', 'X') FROM nation");
     }
 
     @Test


### PR DESCRIPTION
## Description
Add E2E tests for bit_length, longest_common_prefix, replace_first


## Motivation and Context
Closes https://github.com/prestodb/presto/issues/26936 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```


