### PR TITLE
fix(ci): Remove deprecated mac 13 runner from build tests

### DIFF
--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -27,7 +27,7 @@ jobs:
   prestocpp-macos-build-engine:
     strategy:
       matrix:
-        os: [macos-13, macos-15]
+        os: [macos-15]
     runs-on: ${{ matrix.os }}
     needs: changes
     permissions:
@@ -121,13 +121,6 @@ jobs:
           export PATH=$(brew --prefix m4)/bin:$(brew --prefix bison)/bin:${PATH}
           export BOOST_ROOT=${INSTALL_PREFIX}
           cd presto-native-execution
-          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
-            # Velox sets -Wno-sign-compare but it needs to apply to Arrow.
-            # There is also a conflict with Arrow and Velox (Glog) macros which are fixed
-            # in a newer version of Arrow. The issues cannot be easily fixed in Velox so
-            # override the warnings that would throw errors.
-            export CXXFLAGS="-Wno-error=sign-compare -Wno-error=macro-redefined"
-          fi
           cmake -B _build/${BUILD_TYPE} \
             -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 \
             -DENABLE_ALL_WARNINGS=1 \


### PR DESCRIPTION
## Description
The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more details see https://github.com/actions/runner-images/issues/13046

## Motivation and Context

## Impact
CI

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

