### PR TITLE
feat(build): Support local maven configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,11 @@ benchmark_outputs
 *.class
 .checkstyle
 .mvn/timing.properties
+.mvn/maven.config
 .editorconfig
 node_modules
 presto-docs-venv/
+.m2/
 
 #==============================================================================#
 # presto-native-execution

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Presto is a standard Maven project. Simply run the following command from the pr
 
 On the first build, Maven will download all the dependencies from the internet and cache them in the local repository (`~/.m2/repository`), which can take a considerable amount of time. Subsequent builds will be faster.
 
+When building multiple Presto projects locally, each project may write updates to the user's global M2 cache, which could cause build issues. You can configure your local `.mvn/maven.config` to support a local cache specific to that project via `-Dmaven.repo.local=./.m2/repository`.
+
 Presto has a comprehensive set of unit tests that can take several minutes to run. You can disable the tests when building:
 
     ./mvnw clean install -DskipTests


### PR DESCRIPTION
## Description
When building multiple Presto projects locally, each project may write updates to the user's global M2 cache, causing build issues.  To solve this, you can configure your local `.mvn/maven.config` to support a local cache via `-Dmaven.repo.local=./.m2/repository`.  If one chooses to do this, you need to add these files to `.gitignore`, which is what this PR does.

## Motivation and Context
I want to build multiple changesets concurrently without leaking changes from one into another local Presto build.

## Impact
No impact, it's opt in.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

