### PR TITLE
chore(native): Revert castDateToVarchar parameter and add cast based on storageFormat

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeCteExecution.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeCteExecution.java
@@ -47,7 +47,7 @@ public abstract class AbstractTestNativeCteExecution
         // This call avoids casting date fields to VARCHAR. DWRF requires the conversion, but this test uses PARQUET
         // which doesn't have this restriction. The change is needed because several CTE tests use
         // EXTRACT functions from date columns.
-        NativeQueryRunnerUtils.createAllTables(queryRunner, false);
+        NativeQueryRunnerUtils.createAllTables(queryRunner, "PARQUET");
     }
 
     @Override

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeHiveExternalTableTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeHiveExternalTableTpchQueries.java
@@ -87,8 +87,9 @@ public abstract class AbstractTestNativeHiveExternalTableTpchQueries
      * @param tableName the name of the TPCH table
      * @return a list of Column objects representing the columns of the table
      */
-    private static List<Column> getTpchTableColumns(String tableName, boolean castDateToVarchar)
+    private static List<Column> getTpchTableColumns(String tableName, String storageFormat)
     {
+        boolean castDateToVarchar = storageFormat.equals("DWRF");
         TpchTable<?> table = TpchTable.getTable(tableName);
         ColumnNaming columnNaming = ColumnNaming.SIMPLIFIED;
         ImmutableList.Builder<Column> columns = ImmutableList.builder();
@@ -108,7 +109,7 @@ public abstract class AbstractTestNativeHiveExternalTableTpchQueries
         QueryRunner javaQueryRunner = (QueryRunner) getExpectedQueryRunner();
         createSchemaIfNotExist(javaQueryRunner, TPCH_SCHEMA);
         Session session = Session.builder(super.getSession()).setCatalog(HIVE).setSchema(TPCH_SCHEMA).build();
-        createOrders(session, javaQueryRunner, true);
+        createOrders(session, javaQueryRunner, "DWRF");
         createLineitemStandard(session, javaQueryRunner);
         createNationWithFormat(session, javaQueryRunner, "PARQUET");
         createCustomer(session, javaQueryRunner);
@@ -118,7 +119,7 @@ public abstract class AbstractTestNativeHiveExternalTableTpchQueries
         createSupplier(session, javaQueryRunner);
 
         for (String tableName : TPCH_TABLES) {
-            createExternalTable(javaQueryRunner, TPCH_SCHEMA, tableName, getTpchTableColumns(tableName, true), TPCH_EXTERNAL_SCHEMA);
+            createExternalTable(javaQueryRunner, TPCH_SCHEMA, tableName, getTpchTableColumns(tableName, "DWRF"), TPCH_EXTERNAL_SCHEMA);
         }
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -78,13 +78,13 @@ public class NativeQueryRunnerUtils
      */
     public static void createAllTables(QueryRunner queryRunner)
     {
-        createAllTables(queryRunner, true);
+        createAllTables(queryRunner, "DWRF");
     }
 
-    public static void createAllTables(QueryRunner queryRunner, boolean castDateToVarchar)
+    public static void createAllTables(QueryRunner queryRunner, String storageFormat)
     {
-        createLineitem(queryRunner, castDateToVarchar);
-        createOrders(queryRunner, castDateToVarchar);
+        createLineitem(queryRunner, storageFormat);
+        createOrders(queryRunner, storageFormat);
         createOrdersEx(queryRunner);
         createOrdersHll(queryRunner);
         createNation(queryRunner);
@@ -119,11 +119,12 @@ public class NativeQueryRunnerUtils
 
     public static void createLineitem(QueryRunner queryRunner)
     {
-        createLineitem(queryRunner, true);
+        createLineitem(queryRunner, "DWRF");
     }
 
-    public static void createLineitem(QueryRunner queryRunner, boolean castDateToVarchar)
+    public static void createLineitem(QueryRunner queryRunner, String storageFormat)
     {
+        boolean castDateToVarchar = storageFormat.equals("DWRF");
         queryRunner.execute("DROP TABLE IF EXISTS lineitem");
         String shipDate = castDateToVarchar ? "cast(shipdate as varchar) as shipdate" : "shipdate";
         String commitDate = castDateToVarchar ? "cast(commitdate as varchar) as commitdate" : "commitdate";
@@ -157,16 +158,17 @@ public class NativeQueryRunnerUtils
 
     public static void createOrders(QueryRunner queryRunner)
     {
-        createOrders(queryRunner, true);
+        createOrders(queryRunner, "DWRF");
     }
 
-    public static void createOrders(QueryRunner queryRunner, boolean castDateToVarchar)
+    public static void createOrders(QueryRunner queryRunner, String storageFormat)
     {
-        createOrders(queryRunner.getDefaultSession(), queryRunner, castDateToVarchar);
+        createOrders(queryRunner.getDefaultSession(), queryRunner, storageFormat);
     }
 
-    public static void createOrders(Session session, QueryRunner queryRunner, boolean castDateToVarchar)
+    public static void createOrders(Session session, QueryRunner queryRunner, String storageFormat)
     {
+        boolean castDateToVarchar = storageFormat.equals("DWRF");
         queryRunner.execute(session, "DROP TABLE IF EXISTS orders");
         String orderDate = castDateToVarchar ? "cast(orderdate as varchar) as orderdate" : "orderdate";
         queryRunner.execute(session, "CREATE TABLE orders AS " +

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/NativeTestsUtils.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/NativeTestsUtils.java
@@ -46,12 +46,7 @@ public class NativeTestsUtils
                     .setStorageFormat(storageFormat)
                     .setAddStorageFormatToPath(true)
                     .build();
-            if (storageFormat.equals("DWRF")) {
-                NativeQueryRunnerUtils.createAllTables(javaQueryRunner, true);
-            }
-            else {
-                NativeQueryRunnerUtils.createAllTables(javaQueryRunner, false);
-            }
+            NativeQueryRunnerUtils.createAllTables(javaQueryRunner, storageFormat);
             javaQueryRunner.close();
         }
         catch (Exception e) {


### PR DESCRIPTION
## Description
Reverts parameter `castDateToVarchar` in helper methods used to create Tpch tables for testing. Passes in the `storageFormat` instead, and modifies the `createTable` methods to use the storage format to decide if `Date` columns should be cast to `Varchar`.

## Motivation and Context
Cleanup test utility methods for `presto-native-tests`: https://github.com/prestodb/presto/pull/23671.

## Impact
NA.

## Test Plan
Verified with existing native e2e tests.


```
== NO RELEASE NOTE ==
```

