### PR TITLE
fix(docs): Khyperloglog uniqueness_distribution default behavior

### DIFF
--- a/presto-docs/src/main/sphinx/functions/khyperloglog.rst
+++ b/presto-docs/src/main/sphinx/functions/khyperloglog.rst
@@ -56,7 +56,7 @@ Functions
 
 .. function:: uniqueness_distribution(khll, histogramSize) ->  map<bigint,double>
 
-    Returns the uniqueness histogram with the given amount of buckets, ``histogramSize``.
+    Returns the uniqueness histogram with the given number of buckets, ``histogramSize``.
     All ``uniqueness`` values greater than ``histogramSize`` are accumulated
     in the last bucket.
 


### PR DESCRIPTION
Summary:
The docs mention that a default value of 256 will be used as the default value for histogramSize if omitted. The KHyperLogLog.java class correctly reflects this behavior. However, in [KHyperLogLogFunctions.java](https://github.com/prestodb/presto/blob/441a3d3e2f382f37a9f082eceb7d68a402af2b49/presto-main-base/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogFunctions.java#L83), in the one parameter version of the function uniqueness_distribution, we see that the size fo the minhash is passed in, so the default value in the class itself would never actually get used.

For instance, a query like
```
WITH test_data AS (
    SELECT
        KHYPERLOGLOG_AGG(join_key, uii) AS khll
    FROM (
        VALUES
            (5, 100),
            (1, 200)
    ) AS t(join_key, uii)
)
SELECT
    UNIQUENESS_DISTRIBUTION(khll) AS dist_map
FROM test_data
```
returns
```
{
  "1": 1,
  "2": 0
}
```
and not
```
{
  "1": 1,
  "2": 0,
  "3": 0,
  "4": 0,
...}
```

Updating the doc to represent the actual behavior.

Alternatively, we can change the function implementation to use the default value.

Differential Revision: D90611985

```
== NO RELEASE NOTE ==
```

