### PR TITLE
feat(optimizer): Support incremental refresh of materialized views

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.analyzer.AccessControlInfo;
 import com.facebook.presto.spi.analyzer.AccessControlInfoForTable;
@@ -1328,12 +1329,14 @@ public class Analysis
         private final TableHandle target;
         private final List<ColumnHandle> columns;
         private final Query query;
+        private final SchemaTableName materializedViewName;
 
-        public RefreshMaterializedViewAnalysis(TableHandle target, List<ColumnHandle> columns, Query query)
+        public RefreshMaterializedViewAnalysis(TableHandle target, List<ColumnHandle> columns, Query query, SchemaTableName materializedViewName)
         {
             this.target = requireNonNull(target, "target is null");
             this.columns = requireNonNull(columns, "columns is null");
             this.query = requireNonNull(query, "query is null");
+            this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
             checkArgument(columns.size() > 0, "No columns given to insert");
         }
 
@@ -1350,6 +1353,11 @@ public class Analysis
         public Query getQuery()
         {
             return query;
+        }
+
+        public SchemaTableName getMaterializedViewName()
+        {
+            return materializedViewName;
         }
     }
 

--- a/presto-docs/src/main/sphinx/admin/materialized-views.rst
+++ b/presto-docs/src/main/sphinx/admin/materialized-views.rst
@@ -368,7 +368,7 @@ Fallback Behavior
 ^^^^^^^^^^^^^^^^^
 
 Incremental refresh automatically falls back to full refresh when incremental refresh
-is not possible (e.g., the view uses unsupported operators like OUTER JOIN, or the
+is not possible (for example, the view uses unsupported operators like OUTER JOIN, or the
 connector cannot determine partition-level staleness).
 
 When the view is already fully materialized, refresh is a no-op (no data is written).

--- a/presto-docs/src/main/sphinx/admin/materialized-views.rst
+++ b/presto-docs/src/main/sphinx/admin/materialized-views.rst
@@ -354,6 +354,25 @@ However, this is typically much cheaper than:
    * High recompute ratio: Consider more frequent refreshes or better staleness granularity
    * High storage scan ratio: Stitching is working efficiently
 
+Incremental Refresh
+-------------------
+
+When executing ``REFRESH MATERIALIZED VIEW``, Presto can perform an incremental refresh
+that recomputes and replaces only stale partitions instead of the entire view. This can
+significantly reduce refresh time and resource usage for large views.
+
+Not all connectors support incremental refresh. See connector-specific documentation for
+availability, configuration, and requirements.
+
+Fallback Behavior
+^^^^^^^^^^^^^^^^^
+
+Incremental refresh automatically falls back to full refresh when incremental refresh
+is not possible (e.g., the view uses unsupported operators like OUTER JOIN, or the
+connector cannot determine partition-level staleness).
+
+When the view is already fully materialized, refresh is a no-op (no data is written).
+
 See Also
 --------
 

--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -803,6 +803,18 @@ Valid values are ``FAIL`` (throw an error) or ``USE_VIEW_QUERY`` (query base tab
 
 The corresponding configuration property is :ref:`admin/properties:\`\`materialized-view-stale-read-behavior\`\``.
 
+``materialized_view_default_refresh_type``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``FULL``
+
+Controls the default refresh strategy for materialized views when not specified on the view itself.
+Valid values are ``FULL`` (recompute entire view) or ``INCREMENTAL`` (only refresh stale partitions).
+
+Incremental refresh requires a partition-aligned materialized view with identity-transformed
+partition columns. See :ref:`iceberg-incremental-refresh` for connector-specific requirements.
+
 .. warning::
 
     Materialized views are experimental. The SPI and behavior may change in future releases.

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2768,8 +2768,9 @@ Property Name                                              Description
                                                            Defaults to ``0s`` if only ``stale_read_behavior`` is set. When set to
                                                            ``0s``, any staleness triggers the configured behavior.
 
-``refresh_type``                                           Refresh strategy for the materialized view. Currently only ``FULL`` is
-                                                           supported. Default: ``FULL``
+``refresh_type``                                           Refresh strategy for the materialized view. Valid values: ``FULL``
+                                                           (always recompute entire view), ``INCREMENTAL`` (recompute only stale
+                                                           partitions when possible, fall back to full otherwise). Default: ``FULL``
 ========================================================== ============================================================================
 
 The storage table inherits standard Iceberg table properties for partitioning, sorting, and file format.
@@ -2777,7 +2778,31 @@ The storage table inherits standard Iceberg table properties for partitioning, s
 Freshness and Refresh
 ^^^^^^^^^^^^^^^^^^^^^
 
-After running ``REFRESH MATERIALIZED VIEW``, queries read from the pre-computed storage table. The refresh operation uses a full refresh strategy, replacing all data in the storage table with the current query results and recording the new snapshot IDs for all base tables.
+After running ``REFRESH MATERIALIZED VIEW``, queries read from the pre-computed storage table.
+See :doc:`/admin/materialized-views` for general information on refresh behavior.
+
+.. _iceberg-incremental-refresh:
+
+Incremental Refresh
+"""""""""""""""""""
+
+The Iceberg connector supports incremental refresh, which atomically replaces only stale
+partitions rather than recomputing the entire result set. See :ref:`admin/materialized-views:Incremental Refresh`
+for general information.
+
+To enable incremental refresh, set ``refresh_type = 'INCREMENTAL'`` when creating the view::
+
+    CREATE MATERIALIZED VIEW my_view
+    WITH (refresh_type = 'INCREMENTAL', partitioning = ARRAY['region'])
+    AS SELECT ...
+
+Requirements:
+
+* The storage table must be partitioned on identity-transformed columns
+* Stale columns in base tables must map to storage table partition columns through
+  :ref:`column equivalences <admin/materialized-views:Column Equivalences and Passthrough Columns>`
+* Only ``INSERT`` operations on base tables enable partition-level staleness detection;
+  ``DELETE`` or ``UPDATE`` operations cause a full refresh
 
 .. _iceberg-stale-data-handling:
 
@@ -2823,9 +2848,9 @@ Example with staleness handling:
 Limitations
 ^^^^^^^^^^^
 
-- All refreshes recompute the entire result set (incremental refresh not supported)
 - REFRESH does not provide snapshot isolation across multiple base tables (each base table's current snapshot is used independently)
 - Querying materialized views at specific snapshots or timestamps is not supported
+- Incremental refresh requires identity-transformed partition columns; other transforms (bucket, truncate, year, month, day, hour) are not supported as valid refresh columns
 
 Example
 ^^^^^^^

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2770,7 +2770,8 @@ Property Name                                              Description
 
 ``refresh_type``                                           Refresh strategy for the materialized view. Valid values: ``FULL``
                                                            (always recompute entire view), ``INCREMENTAL`` (recompute only stale
-                                                           partitions when possible, fall back to full otherwise). Default: ``FULL``
+                                                           partitions when possible, fall back to full otherwise). When not set,
+                                                           uses the ``materialized_view_default_refresh_type`` session property.
 ========================================================== ============================================================================
 
 The storage table inherits standard Iceberg table properties for partitioning, sorting, and file format.

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -111,12 +111,14 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes.None;
+import org.apache.iceberg.OverwriteFiles;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
@@ -130,6 +132,7 @@ import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Type;
@@ -319,7 +322,6 @@ public abstract class IcebergAbstractMetadata
     protected final FilterStatsCalculatorService filterStatsCalculatorService;
     protected final AtomicReference<IcebergCommonProcedureContext> procedureContext = new AtomicReference<>();
     protected final IcebergTransactionContext transactionContext;
-    protected Transaction transaction;
     protected final StatisticsFileCache statisticsFileCache;
     protected final IcebergTableProperties tableProperties;
     private final StandardFunctionResolution functionResolution;
@@ -739,30 +741,6 @@ public abstract class IcebergAbstractMetadata
 
         ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
 
-        if (writableTableHandle.getMaterializedViewName().isPresent() && transaction != null) {
-            Table icebergTable = transaction.table();
-            ReplacePartitions replacePartitions = transaction.newReplacePartitions();
-            for (CommitTaskData task : commitTasks) {
-                PartitionSpec partitionSpec = icebergTable.specs().get(task.getPartitionSpecId());
-                Type[] partitionColumnTypes = partitionSpec.fields().stream()
-                        .map(field -> field.transform().getResultType(icebergTable.schema().findType(field.sourceId())))
-                        .toArray(Type[]::new);
-                handleFinishData(task, icebergTable, partitionSpec, partitionColumnTypes, replacePartitions::addFile, writtenFiles);
-            }
-            try {
-                replacePartitions.set(PRESTO_QUERY_ID, session.getQueryId());
-                replacePartitions.commit();
-                transaction.commitTransaction();
-            }
-            catch (ValidationException e) {
-                throw new PrestoException(ICEBERG_COMMIT_ERROR, "Failed to commit Iceberg update to table: " + writableTableHandle.getTableName(), e);
-            }
-
-            return Optional.of(new HiveOutputMetadata(new HiveOutputInfo(commitTasks.stream()
-                    .map(CommitTaskData::getPath)
-                    .collect(toImmutableList()), icebergTable.location())));
-        }
-
         SchemaTableName schemaTableName = new SchemaTableName(writableTableHandle.getSchemaName(), writableTableHandle.getTableName().getTableName());
         Table icebergTable = getIcebergTable(session, schemaTableName);
         AppendFiles appendFiles = icebergTable.newAppend();
@@ -915,11 +893,11 @@ public abstract class IcebergAbstractMetadata
     public ColumnHandle getMergeTargetTableRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         Types.StructType type = Types.StructType.of(ImmutableList.<NestedField>builder()
-                        .add(MetadataColumns.FILE_PATH)
-                        .add(ROW_POSITION)
-                        .add(SPEC_ID)
-                        .add(NestedField.required(MERGE_PARTITION_DATA.getId(), MERGE_PARTITION_DATA.getColumnName(), StringType.get()))
-                        .build());
+                .add(MetadataColumns.FILE_PATH)
+                .add(ROW_POSITION)
+                .add(SPEC_ID)
+                .add(NestedField.required(MERGE_PARTITION_DATA.getId(), MERGE_PARTITION_DATA.getColumnName(), StringType.get()))
+                .build());
 
         NestedField field = NestedField.required(MERGE_TARGET_ROW_ID_DATA.getId(), MERGE_TARGET_ROW_ID_DATA.getColumnName(), type);
         return IcebergColumnHandle.create(field, typeManager, SYNTHESIZED);
@@ -1274,7 +1252,7 @@ public abstract class IcebergAbstractMetadata
         UpdateSchema updateSchema = icebergTable.updateSchema();
         if (column.getDefaultValue().isPresent()) {
             validateMinimumFormatVersion(icebergTable, 3, format("ADD COLUMN with DEFAULT values is only supported with Iceberg format version 3 or higher. " +
-                       "Table '%s' is currently at format version %d. ", handle.getSchemaTableName(), opsFromTable(icebergTable).current().formatVersion(), handle.getSchemaTableName()));
+                    "Table '%s' is currently at format version %d. ", handle.getSchemaTableName(), opsFromTable(icebergTable).current().formatVersion(), handle.getSchemaTableName()));
             Object defaultValue = column.getDefaultValue().get();
             Literal<?> defaultLiteral = convertToIcebergLiteral(defaultValue, columnType);
             updateSchema.addColumn(column.getName(), columnType, column.getComment().orElse(null), defaultLiteral).commit();
@@ -1393,29 +1371,29 @@ public abstract class IcebergAbstractMetadata
         if (!tableExists(session, tableName)) {
             // If table doesn't exist, check if it's a materialized view
             return getMaterializedView(session, tableName).map(definition -> {
-                SchemaTableName storageTableName = new SchemaTableName(definition.getSchema(), definition.getTable());
-                Table storageTable = getIcebergTable(session, storageTableName);
+                        SchemaTableName storageTableName = new SchemaTableName(definition.getSchema(), definition.getTable());
+                        Table storageTable = getIcebergTable(session, storageTableName);
 
-                // Time travel on the materialized view itself is not supported
-                if (tableVersion.isPresent() || name.getSnapshotId().isPresent()) {
-                    throw new PrestoException(NOT_SUPPORTED, "Time travel queries on materialized views are not supported");
-                }
+                        // Time travel on the materialized view itself is not supported
+                        if (tableVersion.isPresent() || name.getSnapshotId().isPresent()) {
+                            throw new PrestoException(NOT_SUPPORTED, "Time travel queries on materialized views are not supported");
+                        }
 
-                return new IcebergTableHandle(
-                        storageTableName.getSchemaName(),
-                        new IcebergTableName(storageTableName.getTableName(), name.getTableType(), Optional.empty(), Optional.empty(), Optional.empty()),
-                        name.getSnapshotId().isPresent(),
-                        tryGetLocation(storageTable),
-                        tryGetProperties(storageTable),
-                        tryGetSchema(storageTable).map(SchemaParser::toJson),
-                        Optional.empty(),
-                        Optional.empty(),
-                        getSortFields(storageTable),
-                        ImmutableList.of(),
-                        Optional.of(tableName));
-            })
-            // null indicates table not found
-            .orElse(null);
+                        return new IcebergTableHandle(
+                                storageTableName.getSchemaName(),
+                                new IcebergTableName(storageTableName.getTableName(), name.getTableType(), Optional.empty(), Optional.empty(), Optional.empty()),
+                                name.getSnapshotId().isPresent(),
+                                tryGetLocation(storageTable),
+                                tryGetProperties(storageTable),
+                                tryGetSchema(storageTable).map(SchemaParser::toJson),
+                                Optional.empty(),
+                                Optional.empty(),
+                                getSortFields(storageTable),
+                                ImmutableList.of(),
+                                Optional.of(tableName));
+                    })
+                    // null indicates table not found
+                    .orElse(null);
         }
 
         SchemaTableName tableNameToLoad = new SchemaTableName(tableName.getSchemaName(), name.getTableName());
@@ -2132,7 +2110,7 @@ public abstract class IcebergAbstractMetadata
             else {
                 throw new PrestoException(ICEBERG_INVALID_MATERIALIZED_VIEW,
                         format("Storage table snapshot %d not found for materialized view %s. " +
-                                "The snapshot may have been expired. Consider refreshing the view.",
+                                        "The snapshot may have been expired. Consider refreshing the view.",
                                 lastRefreshSnapshotId, materializedViewName));
             }
         }
@@ -2355,10 +2333,12 @@ public abstract class IcebergAbstractMetadata
         SchemaTableName storageTableName = icebergTableHandle.getSchemaTableName();
         IcebergTableHandle storageTableHandle = getTableHandle(session, storageTableName);
         Table storageTable = getIcebergTable(session, storageTableName);
-
-        transaction = storageTable.newTransaction();
-
         SchemaTableName materializedViewName = icebergTableHandle.getMaterializedViewName().get();
+        MaterializedViewStatus status = getMaterializedViewStatus(session, materializedViewName, TupleDomain.all());
+        boolean fullRefreshRequired = !status.isFullyMaterialized()
+                && (status.getPartitionsFromBaseTables().isEmpty()
+                || status.getPartitionsFromBaseTables().values().stream()
+                .anyMatch(p -> p.getPredicateDisjuncts().isEmpty()));
 
         return new IcebergInsertTableHandle(
                 storageTableHandle.getSchemaName(),
@@ -2371,7 +2351,8 @@ public abstract class IcebergAbstractMetadata
                 getCompressionCodec(session),
                 storageTable.properties(),
                 getSupportedSortFields(storageTable.schema(), storageTable.sortOrder()),
-                Optional.of(materializedViewName));
+                Optional.of(materializedViewName),
+                fullRefreshRequired);
     }
 
     @Override
@@ -2381,50 +2362,94 @@ public abstract class IcebergAbstractMetadata
             Collection<Slice> fragments,
             Collection<ComputedStatistics> computedStatistics)
     {
-        Optional<ConnectorOutputMetadata> result = finishInsert(session, insertHandle, fragments, computedStatistics);
-
         IcebergInsertTableHandle icebergInsertHandle = (IcebergInsertTableHandle) insertHandle;
+        SchemaTableName materializedViewName = icebergInsertHandle.getMaterializedViewName()
+                .orElseThrow(() -> new IllegalStateException("finishRefreshMaterializedView called without materialized view name"));
 
-        icebergInsertHandle.getMaterializedViewName().ifPresent(materializedViewName -> {
-            SchemaTableName storageTableName = new SchemaTableName(
-                    icebergInsertHandle.getSchemaName(),
-                    icebergInsertHandle.getTableName().getTableName());
+        SchemaTableName storageTableName = new SchemaTableName(
+                icebergInsertHandle.getSchemaName(),
+                icebergInsertHandle.getTableName().getTableName());
+        Table icebergTable = getIcebergTable(session, storageTableName);
 
-            Table storageTable = getIcebergTable(session, storageTableName);
-            long newSnapshotId = storageTable.currentSnapshot() != null
-                    ? storageTable.currentSnapshot().snapshotId()
-                    : 0L;
+        Optional<ConnectorOutputMetadata> result;
+        if (fragments.isEmpty()) {
+            transactionContext.commit();
+            result = Optional.empty();
+        }
+        else {
+            List<CommitTaskData> commitTasks = fragments.stream()
+                    .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
+                    .collect(toImmutableList());
 
-            Optional<MaterializedViewDefinition> definition = getMaterializedView(session, materializedViewName);
-            Map<String, String> properties = new HashMap<>();
-            properties.put(PRESTO_MATERIALIZED_VIEW_LAST_REFRESH_SNAPSHOT_ID, String.valueOf(newSnapshotId));
-
-            if (definition.isPresent()) {
-                for (SchemaTableName baseTable : definition.get().getBaseTables()) {
-                    try {
-                        Table baseIcebergTable = getIcebergTable(session, baseTable);
-                        long baseSnapshotId = baseIcebergTable.currentSnapshot() != null
-                                ? baseIcebergTable.currentSnapshot().snapshotId()
-                                : 0L;
-                        String key = getBaseTableViewPropertyName(baseTable);
-                        properties.put(key, baseSnapshotId + "");
-                    }
-                    catch (Exception e) {
-                        log.warn(e, "Failed to capture snapshot for base table %s during refresh of materialized view %s", baseTable, materializedViewName);
-                    }
-                }
-            }
-
-            if (fragments.isEmpty()) {
-                // When no data was written, finishInsert already committed the transaction.
-                // Callbacks registered after that commit won't execute, so update properties directly.
-                updateIcebergViewProperties(session, materializedViewName, properties);
+            ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
+            Consumer<DataFile> addFile;
+            SnapshotUpdate<?> snapshotUpdate;
+            if (icebergInsertHandle.isFullRefreshRequired()) {
+                OverwriteFiles overwrite = icebergTable.newOverwrite();
+                overwrite.overwriteByRowFilter(Expressions.alwaysTrue());
+                addFile = overwrite::addFile;
+                snapshotUpdate = overwrite;
             }
             else {
-                // Update materialized view should run after the data refresh of the underlying storage table
-                this.transactionContext.registerCallback(() -> updateIcebergViewProperties(session, materializedViewName, properties));
+                ReplacePartitions replacePartitions = icebergTable.newReplacePartitions();
+                addFile = replacePartitions::addFile;
+                snapshotUpdate = replacePartitions;
             }
-        });
+
+            for (CommitTaskData task : commitTasks) {
+                PartitionSpec partitionSpec = icebergTable.specs().get(task.getPartitionSpecId());
+                Type[] partitionColumnTypes = partitionSpec.fields().stream()
+                        .map(field -> field.transform().getResultType(icebergTable.schema().findType(field.sourceId())))
+                        .toArray(Type[]::new);
+                handleFinishData(task, icebergTable, partitionSpec, partitionColumnTypes, addFile, writtenFiles);
+            }
+            try {
+                snapshotUpdate.set(PRESTO_QUERY_ID, session.getQueryId());
+                snapshotUpdate.commit();
+            }
+            catch (ValidationException e) {
+                throw new PrestoException(ICEBERG_COMMIT_ERROR, "Failed to commit Iceberg update to table: " + icebergInsertHandle.getTableName(), e);
+            }
+
+            result = Optional.of(new HiveOutputMetadata(new HiveOutputInfo(commitTasks.stream()
+                    .map(CommitTaskData::getPath)
+                    .collect(toImmutableList()), icebergTable.location())));
+        }
+
+        Table storageTable = getIcebergTable(session, storageTableName);
+        long newSnapshotId = storageTable.currentSnapshot() != null
+                ? storageTable.currentSnapshot().snapshotId()
+                : 0L;
+
+        Optional<MaterializedViewDefinition> definition = getMaterializedView(session, materializedViewName);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PRESTO_MATERIALIZED_VIEW_LAST_REFRESH_SNAPSHOT_ID, String.valueOf(newSnapshotId));
+
+        if (definition.isPresent()) {
+            for (SchemaTableName baseTable : definition.get().getBaseTables()) {
+                try {
+                    Table baseIcebergTable = getIcebergTable(session, baseTable);
+                    long baseSnapshotId = baseIcebergTable.currentSnapshot() != null
+                            ? baseIcebergTable.currentSnapshot().snapshotId()
+                            : 0L;
+                    String key = getBaseTableViewPropertyName(baseTable);
+                    properties.put(key, baseSnapshotId + "");
+                }
+                catch (Exception e) {
+                    log.warn(e, "Failed to capture snapshot for base table %s during refresh of materialized view %s", baseTable, materializedViewName);
+                }
+            }
+        }
+
+        if (fragments.isEmpty()) {
+            // When no data was written, finishInsert already committed the transaction.
+            // Callbacks registered after that commit won't execute, so update properties directly.
+            updateIcebergViewProperties(session, materializedViewName, properties);
+        }
+        else {
+            // Update materialized view should run after the data refresh of the underlying storage table
+            this.transactionContext.registerCallback(() -> updateIcebergViewProperties(session, materializedViewName, properties));
+        }
 
         return result;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -118,9 +118,9 @@ import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -1371,29 +1371,27 @@ public abstract class IcebergAbstractMetadata
         if (!tableExists(session, tableName)) {
             // If table doesn't exist, check if it's a materialized view
             return getMaterializedView(session, tableName).map(definition -> {
-                        SchemaTableName storageTableName = new SchemaTableName(definition.getSchema(), definition.getTable());
-                        Table storageTable = getIcebergTable(session, storageTableName);
+                SchemaTableName storageTableName = new SchemaTableName(definition.getSchema(), definition.getTable());
+                Table storageTable = getIcebergTable(session, storageTableName);
 
-                        // Time travel on the materialized view itself is not supported
-                        if (tableVersion.isPresent() || name.getSnapshotId().isPresent()) {
-                            throw new PrestoException(NOT_SUPPORTED, "Time travel queries on materialized views are not supported");
-                        }
+                // Time travel on the materialized view itself is not supported
+                if (tableVersion.isPresent() || name.getSnapshotId().isPresent()) {
+                    throw new PrestoException(NOT_SUPPORTED, "Time travel queries on materialized views are not supported");
+                }
 
-                        return new IcebergTableHandle(
-                                storageTableName.getSchemaName(),
-                                new IcebergTableName(storageTableName.getTableName(), name.getTableType(), Optional.empty(), Optional.empty(), Optional.empty()),
-                                name.getSnapshotId().isPresent(),
-                                tryGetLocation(storageTable),
-                                tryGetProperties(storageTable),
-                                tryGetSchema(storageTable).map(SchemaParser::toJson),
-                                Optional.empty(),
-                                Optional.empty(),
-                                getSortFields(storageTable),
-                                ImmutableList.of(),
-                                Optional.of(tableName));
-                    })
-                    // null indicates table not found
-                    .orElse(null);
+                return new IcebergTableHandle(
+                        storageTableName.getSchemaName(),
+                        new IcebergTableName(storageTableName.getTableName(), name.getTableType(), Optional.empty(), Optional.empty(), Optional.empty()),
+                        name.getSnapshotId().isPresent(),
+                        tryGetLocation(storageTable),
+                        tryGetProperties(storageTable),
+                        tryGetSchema(storageTable).map(SchemaParser::toJson),
+                        Optional.empty(),
+                        Optional.empty(),
+                        getSortFields(storageTable),
+                        ImmutableList.of(),
+                        Optional.of(tableName));
+            }).orElse(null); // null indicates table not found
         }
 
         SchemaTableName tableNameToLoad = new SchemaTableName(tableName.getSchemaName(), name.getTableName());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -113,6 +113,7 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes.None;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Schema;
@@ -284,7 +285,6 @@ import static org.apache.iceberg.SnapshotSummary.DELETED_RECORDS_PROP;
 import static org.apache.iceberg.SnapshotSummary.REMOVED_EQ_DELETES_PROP;
 import static org.apache.iceberg.SnapshotSummary.REMOVED_POS_DELETES_PROP;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
-import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 
 public abstract class IcebergAbstractMetadata
         implements IcebergTransactionMetadata
@@ -319,6 +319,7 @@ public abstract class IcebergAbstractMetadata
     protected final FilterStatsCalculatorService filterStatsCalculatorService;
     protected final AtomicReference<IcebergCommonProcedureContext> procedureContext = new AtomicReference<>();
     protected final IcebergTransactionContext transactionContext;
+    protected Transaction transaction;
     protected final StatisticsFileCache statisticsFileCache;
     protected final IcebergTableProperties tableProperties;
     private final StandardFunctionResolution functionResolution;
@@ -736,15 +737,39 @@ public abstract class IcebergAbstractMetadata
                 .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
                 .collect(toImmutableList());
 
+        ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
+
+        if (writableTableHandle.getMaterializedViewName().isPresent() && transaction != null) {
+            Table icebergTable = transaction.table();
+            ReplacePartitions replacePartitions = transaction.newReplacePartitions();
+            for (CommitTaskData task : commitTasks) {
+                PartitionSpec partitionSpec = icebergTable.specs().get(task.getPartitionSpecId());
+                Type[] partitionColumnTypes = partitionSpec.fields().stream()
+                        .map(field -> field.transform().getResultType(icebergTable.schema().findType(field.sourceId())))
+                        .toArray(Type[]::new);
+                handleFinishData(task, icebergTable, partitionSpec, partitionColumnTypes, replacePartitions::addFile, writtenFiles);
+            }
+            try {
+                replacePartitions.set(PRESTO_QUERY_ID, session.getQueryId());
+                replacePartitions.commit();
+                transaction.commitTransaction();
+            }
+            catch (ValidationException e) {
+                throw new PrestoException(ICEBERG_COMMIT_ERROR, "Failed to commit Iceberg update to table: " + writableTableHandle.getTableName(), e);
+            }
+
+            return Optional.of(new HiveOutputMetadata(new HiveOutputInfo(commitTasks.stream()
+                    .map(CommitTaskData::getPath)
+                    .collect(toImmutableList()), icebergTable.location())));
+        }
+
         SchemaTableName schemaTableName = new SchemaTableName(writableTableHandle.getSchemaName(), writableTableHandle.getTableName().getTableName());
         Table icebergTable = getIcebergTable(session, schemaTableName);
         AppendFiles appendFiles = icebergTable.newAppend();
         Optional<String> branchName = writableTableHandle.getTableName().getBranchName();
         branchName.ifPresent(appendFiles::toBranch);
 
-        ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
         commitTasks.forEach(task -> handleInsertTask(task, icebergTable, appendFiles, writtenFiles));
-
         try {
             appendFiles.set(PRESTO_QUERY_ID, session.getQueryId());
             appendFiles.commit();
@@ -1897,8 +1922,8 @@ public abstract class IcebergAbstractMetadata
                             .ifPresent(behavior -> properties.put(PRESTO_MATERIALIZED_VIEW_STALE_READ_BEHAVIOR, behavior.name()));
                     getStalenessWindow(materializedViewProperties)
                             .ifPresent(window -> properties.put(PRESTO_MATERIALIZED_VIEW_STALENESS_WINDOW, window.toString()));
-                    MaterializedViewRefreshType refreshType = getRefreshType(materializedViewProperties);
-                    properties.put(PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE, refreshType.name());
+                    getRefreshType(materializedViewProperties)
+                            .ifPresent(refreshType -> properties.put(PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE, refreshType.name()));
 
                     for (SchemaTableName baseTable : viewDefinition.getBaseTables()) {
                         properties.put(getBaseTableViewPropertyName(baseTable), "0");
@@ -2016,6 +2041,25 @@ public abstract class IcebergAbstractMetadata
         Optional<MaterializedViewRefreshType> refreshType = getOptionalEnumProperty(
                 viewProperties, PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE, MaterializedViewRefreshType.class);
 
+        Optional<List<String>> validRefreshColumns = Optional.empty();
+        try {
+            SchemaTableName storageTable = new SchemaTableName(storageSchema, storageTableName);
+            Table icebergStorageTable = getIcebergTable(session, storageTable);
+            PartitionSpec spec = icebergStorageTable.spec();
+            if (spec.isPartitioned()) {
+                List<String> partitionColumns = spec.fields().stream()
+                        .filter(field -> field.transform().isIdentity())
+                        .map(field -> spec.schema().findColumnName(field.sourceId()))
+                        .collect(toImmutableList());
+                if (!partitionColumns.isEmpty()) {
+                    validRefreshColumns = Optional.of(partitionColumns);
+                }
+            }
+        }
+        catch (NoSuchTableException e) {
+            // Storage table may not exist yet or may have been dropped; proceed without refresh columns
+        }
+
         return Optional.of(new MaterializedViewDefinition(
                 originalSql,
                 storageSchema,
@@ -2025,7 +2069,7 @@ public abstract class IcebergAbstractMetadata
                 Optional.of(securityMode),
                 columnMappings,
                 ImmutableList.of(),
-                Optional.empty(),
+                validRefreshColumns,
                 stalenessConfig,
                 refreshType));
     }
@@ -2074,19 +2118,25 @@ public abstract class IcebergAbstractMetadata
         SchemaTableName storageTableName = new SchemaTableName(definition.get().getSchema(), definition.get().getTable());
         Table storageTable = getIcebergTable(session, storageTableName);
         long lastRefreshSnapshotId = parseLong(lastRefreshSnapshotStr);
+        Snapshot lastRefreshSnapshot = storageTable.snapshot(lastRefreshSnapshotId);
         Optional<Long> lastFreshTime;
-        if (lastRefreshSnapshotId == 0L) {
-            // Empty table refresh: no real snapshot was created
-            lastFreshTime = Optional.empty();
-        }
-        else {
-            Snapshot lastRefreshSnapshot = storageTable.snapshot(lastRefreshSnapshotId);
-            if (lastRefreshSnapshot == null) {
+        if (lastRefreshSnapshot == null) {
+            // Handle the case where the MV query produced no rows at refresh time.
+            // This can happen when base tables are empty, or when the query itself yields no results.
+            // In this case:
+            //   - lastRefreshSnapshotId = 0 (a sentinel value indicating "no data written at refresh time")
+            //   - storageTable.currentSnapshot() = null (no Iceberg snapshots because no data was written)
+            if (lastRefreshSnapshotId == 0L && storageTable.currentSnapshot() == null) {
+                lastFreshTime = Optional.empty();
+            }
+            else {
                 throw new PrestoException(ICEBERG_INVALID_MATERIALIZED_VIEW,
                         format("Storage table snapshot %d not found for materialized view %s. " +
                                 "The snapshot may have been expired. Consider refreshing the view.",
                                 lastRefreshSnapshotId, materializedViewName));
             }
+        }
+        else {
             lastFreshTime = Optional.of(lastRefreshSnapshot.timestampMillis());
         }
 
@@ -2306,7 +2356,7 @@ public abstract class IcebergAbstractMetadata
         IcebergTableHandle storageTableHandle = getTableHandle(session, storageTableName);
         Table storageTable = getIcebergTable(session, storageTableName);
 
-        storageTable.newDelete().deleteFromRowFilter(alwaysTrue()).commit();
+        transaction = storageTable.newTransaction();
 
         SchemaTableName materializedViewName = icebergTableHandle.getMaterializedViewName().get();
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
@@ -27,6 +27,23 @@ public class IcebergInsertTableHandle
         extends IcebergWritableTableHandle
         implements ConnectorInsertTableHandle
 {
+    public IcebergInsertTableHandle(
+            String schemaName,
+            IcebergTableName tableName,
+            PrestoIcebergSchema schema,
+            PrestoIcebergPartitionSpec partitionSpec,
+            List<IcebergColumnHandle> inputColumns,
+            String outputPath,
+            FileFormat fileFormat,
+            HiveCompressionCodec compressionCodec,
+            Map<String, String> storageProperties,
+            List<SortField> sortOrder,
+            Optional<SchemaTableName> materializedViewName)
+    {
+        this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath,
+                fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false);
+    }
+
     @JsonCreator
     public IcebergInsertTableHandle(
             @JsonProperty("schemaName") String schemaName,
@@ -39,7 +56,8 @@ public class IcebergInsertTableHandle
             @JsonProperty("compressionCodec") HiveCompressionCodec compressionCodec,
             @JsonProperty("storageProperties") Map<String, String> storageProperties,
             @JsonProperty("sortOrder") List<SortField> sortOrder,
-            @JsonProperty("materializedViewName") Optional<SchemaTableName> materializedViewName)
+            @JsonProperty("materializedViewName") Optional<SchemaTableName> materializedViewName,
+            @JsonProperty("fullRefreshRequired") boolean fullRefreshRequired)
     {
         super(
                 schemaName,
@@ -52,6 +70,7 @@ public class IcebergInsertTableHandle
                 compressionCodec,
                 storageProperties,
                 sortOrder,
-                materializedViewName);
+                materializedViewName,
+                fullRefreshRequired);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMaterializedViewProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMaterializedViewProperties.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
-import static com.facebook.presto.spi.MaterializedViewRefreshType.FULL;
 import static com.facebook.presto.spi.session.PropertyMetadata.durationProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static java.util.Locale.ENGLISH;
@@ -80,12 +79,12 @@ public class IcebergMaterializedViewProperties
                         true))
                 .add(new PropertyMetadata<>(
                         REFRESH_TYPE,
-                        "Refresh type for materialized view",
+                        "Refresh type for materialized view (FULL or INCREMENTAL)",
                         createUnboundedVarcharType(),
                         MaterializedViewRefreshType.class,
-                        FULL,
+                        null,
                         true,
-                        value -> value == null ? FULL : MaterializedViewRefreshType.valueOf(((String) value).toUpperCase(ENGLISH)),
+                        value -> value == null ? null : MaterializedViewRefreshType.valueOf(((String) value).toUpperCase(ENGLISH)),
                         value -> value == null ? null : ((MaterializedViewRefreshType) value).name()))
                 .build();
 
@@ -121,8 +120,8 @@ public class IcebergMaterializedViewProperties
         return Optional.ofNullable((Duration) properties.get(STALENESS_WINDOW));
     }
 
-    public static MaterializedViewRefreshType getRefreshType(Map<String, Object> properties)
+    public static Optional<MaterializedViewRefreshType> getRefreshType(Map<String, Object> properties)
     {
-        return (MaterializedViewRefreshType) properties.getOrDefault(REFRESH_TYPE, FULL);
+        return Optional.ofNullable((MaterializedViewRefreshType) properties.get(REFRESH_TYPE));
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergWritableTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergWritableTableHandle.java
@@ -37,6 +37,7 @@ public class IcebergWritableTableHandle
     private final Map<String, String> storageProperties;
     private final List<SortField> sortOrder;
     private final Optional<SchemaTableName> materializedViewName;
+    private final boolean fullRefreshRequired;
 
     public IcebergWritableTableHandle(
             String schemaName,
@@ -50,7 +51,7 @@ public class IcebergWritableTableHandle
             Map<String, String> storageProperties,
             List<SortField> sortOrder)
     {
-        this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath, fileFormat, compressionCodec, storageProperties, sortOrder, Optional.empty());
+        this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath, fileFormat, compressionCodec, storageProperties, sortOrder, Optional.empty(), false);
     }
 
     public IcebergWritableTableHandle(
@@ -66,6 +67,23 @@ public class IcebergWritableTableHandle
             List<SortField> sortOrder,
             Optional<SchemaTableName> materializedViewName)
     {
+        this(schemaName, tableName, schema, partitionSpec, inputColumns, outputPath, fileFormat, compressionCodec, storageProperties, sortOrder, materializedViewName, false);
+    }
+
+    public IcebergWritableTableHandle(
+            String schemaName,
+            IcebergTableName tableName,
+            PrestoIcebergSchema schema,
+            PrestoIcebergPartitionSpec partitionSpec,
+            List<IcebergColumnHandle> inputColumns,
+            String outputPath,
+            FileFormat fileFormat,
+            HiveCompressionCodec compressionCodec,
+            Map<String, String> storageProperties,
+            List<SortField> sortOrder,
+            Optional<SchemaTableName> materializedViewName,
+            boolean fullRefreshRequired)
+    {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -77,6 +95,7 @@ public class IcebergWritableTableHandle
         this.storageProperties = requireNonNull(storageProperties, "storageProperties is null");
         this.sortOrder = ImmutableList.copyOf(requireNonNull(sortOrder, "sortOrder is null"));
         this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
+        this.fullRefreshRequired = fullRefreshRequired;
     }
 
     @JsonProperty
@@ -149,5 +168,11 @@ public class IcebergWritableTableHandle
     public Optional<SchemaTableName> getMaterializedViewName()
     {
         return materializedViewName;
+    }
+
+    @JsonProperty
+    public boolean isFullRefreshRequired()
+    {
+        return fullRefreshRequired;
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewMetadata.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIA
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_LAST_REFRESH_SNAPSHOT_ID;
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_ORIGINAL_SQL;
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_OWNER;
+import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE;
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_SECURITY_MODE;
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_STORAGE_SCHEMA;
 import static com.facebook.presto.iceberg.IcebergAbstractMetadata.PRESTO_MATERIALIZED_VIEW_STORAGE_TABLE_NAME;
@@ -798,5 +799,58 @@ public class TestIcebergMaterializedViewMetadata
         finally {
             assertUpdate("DROP TABLE test_orphan_base");
         }
+    }
+
+    @Test
+    public void testRefreshTypePropertyStoredInView()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_refresh_type_base (id BIGINT, value BIGINT)");
+        assertUpdate("INSERT INTO test_refresh_type_base VALUES (1, 100)", 1);
+
+        assertUpdate("CREATE MATERIALIZED VIEW test_refresh_type_incremental_mv " +
+                "WITH (refresh_type = 'INCREMENTAL') " +
+                "AS SELECT id, value FROM test_refresh_type_base");
+
+        assertUpdate("CREATE MATERIALIZED VIEW test_refresh_type_full_mv " +
+                "WITH (refresh_type = 'FULL') " +
+                "AS SELECT id, value FROM test_refresh_type_base");
+
+        assertUpdate("CREATE MATERIALIZED VIEW test_refresh_type_default_mv " +
+                "AS SELECT id, value FROM test_refresh_type_base");
+
+        RESTCatalog catalog = new RESTCatalog();
+        Map<String, String> catalogProps = new HashMap<>();
+        catalogProps.put("uri", serverUri);
+        catalogProps.put("warehouse", warehouseLocation.getAbsolutePath());
+        catalog.initialize("test_catalog", catalogProps);
+
+        try {
+            TableIdentifier incrementalViewId = TableIdentifier.of(Namespace.of("test_schema"), "test_refresh_type_incremental_mv");
+            View incrementalView = catalog.loadView(incrementalViewId);
+            String incrementalRefreshType = incrementalView.properties().get(PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE);
+            assertEquals(incrementalRefreshType, "INCREMENTAL",
+                    "refresh_type should be stored as INCREMENTAL in view properties");
+
+            TableIdentifier fullViewId = TableIdentifier.of(Namespace.of("test_schema"), "test_refresh_type_full_mv");
+            View fullView = catalog.loadView(fullViewId);
+            String fullRefreshType = fullView.properties().get(PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE);
+            assertEquals(fullRefreshType, "FULL",
+                    "refresh_type should be stored as FULL in view properties");
+
+            TableIdentifier defaultViewId = TableIdentifier.of(Namespace.of("test_schema"), "test_refresh_type_default_mv");
+            View defaultView = catalog.loadView(defaultViewId);
+            String defaultRefreshType = defaultView.properties().get(PRESTO_MATERIALIZED_VIEW_REFRESH_TYPE);
+            assertNull(defaultRefreshType,
+                    "refresh_type should not be stored when not explicitly set");
+        }
+        finally {
+            catalog.close();
+        }
+
+        assertUpdate("DROP MATERIALIZED VIEW test_refresh_type_incremental_mv");
+        assertUpdate("DROP MATERIALIZED VIEW test_refresh_type_full_mv");
+        assertUpdate("DROP MATERIALIZED VIEW test_refresh_type_default_mv");
+        assertUpdate("DROP TABLE test_refresh_type_base");
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewOptimizer.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewOptimizer.java
@@ -15,8 +15,7 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.airlift.http.server.testing.TestingHttpServer;
 import com.facebook.presto.Session;
-import com.facebook.presto.common.predicate.Range;
-import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
@@ -30,10 +29,8 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.Optional;
 
-import static com.facebook.presto.common.predicate.Domain.create;
+import static com.facebook.presto.common.predicate.Domain.multipleValues;
 import static com.facebook.presto.common.predicate.Domain.singleValue;
-import static com.facebook.presto.common.predicate.Range.greaterThan;
-import static com.facebook.presto.common.predicate.Range.lessThan;
 import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.iceberg.CatalogType.REST;
@@ -47,8 +44,10 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.constr
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableFinish;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -101,7 +100,8 @@ public class TestIcebergMaterializedViewOptimizer
                 .setExtraProperties(ImmutableMap.of(
                         "experimental.legacy-materialized-views", "false",
                         "optimizer.optimize-hash-generation", "false",
-                        "materialized-view-stale-read-behavior", "USE_STITCHING"))
+                        "materialized-view-stale-read-behavior", "USE_STITCHING",
+                        "materialized-view-default-refresh-type", "INCREMENTAL"))
                 .build().getQueryRunner();
     }
 
@@ -118,6 +118,9 @@ public class TestIcebergMaterializedViewOptimizer
             assertUpdate("INSERT INTO base_no_parts VALUES (3, 300)", 1);
 
             assertPlan("SELECT * FROM mv_no_parts",
+                    anyTree(tableScan("base_no_parts")));
+
+            assertPlan("REFRESH MATERIALIZED VIEW mv_no_parts",
                     anyTree(tableScan("base_no_parts")));
 
             getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_no_parts");
@@ -144,17 +147,24 @@ public class TestIcebergMaterializedViewOptimizer
 
             assertUpdate("INSERT INTO base_table VALUES (3, '2024-01-03')", 1);
 
+            PlanMatchPattern deltaBranch = project(constrainedTableScan("base_table",
+                    ImmutableMap.of("ds", singleValue(VARCHAR, utf8Slice("2024-01-03"))),
+                    ImmutableMap.of("id_1", "id")));
+
             assertPlan("SELECT * FROM test_mv",
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__test_mv",
-                                            ImmutableMap.of("ds", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-0T3")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-03")))), false)),
+                                            ImmutableMap.of("ds", singleValue(VARCHAR, utf8Slice("2024-01-03")).complement()),
                                             ImmutableMap.of("ds", "ds", "id", "id")),
-                                    project(constrainedTableScan("base_table",
-                                            ImmutableMap.of("ds", singleValue(VARCHAR, utf8Slice("2024-01-03"))),
-                                            ImmutableMap.of("id_1", "id"))))));
+                                    deltaBranch)));
+
+            assertPlan("REFRESH MATERIALIZED VIEW test_mv",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    exchange(exchange(deltaBranch)))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_mv");
@@ -204,32 +214,48 @@ public class TestIcebergMaterializedViewOptimizer
             assertUpdate("INSERT INTO orders VALUES (2, 200, '2024-01-02')", 1);
             assertUpdate("INSERT INTO customers VALUES (200, 'Bob', '2024-01-02')", 1);
 
-            PlanMatchPattern staleBranchPattern = join(
-                    anyTree(tableScan("orders")),
-                    anyTree(tableScan("customers")));
+            PlanMatchPattern staleDsBranch = join(
+                    exchange(constrainedTableScan("orders",
+                            ImmutableMap.of("ds", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())),
+                    exchange(exchange(tableScan("customers"))));
+
+            PlanMatchPattern staleRegDateBranch = join(
+                    exchange(constrainedTableScan("orders",
+                            ImmutableMap.of("ds", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
+                            ImmutableMap.of())),
+                    exchange(exchange(constrainedTableScan("customers",
+                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of()))));
+
+            PlanMatchPattern fullJoinPattern = join(
+                    exchange(tableScan("orders")),
+                    exchange(exchange(tableScan("customers"))));
 
             assertPlan("SELECT * FROM mv_join",
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_join",
-                                            ImmutableMap.of(
-                                                    "ds", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false),
-                                                    "reg_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                            ImmutableMap.of("ds", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement(), "reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("ds", "ds", "reg_date", "reg_date", "order_id", "order_id", "name", "name")),
                                     exchange(
-                                            project(staleBranchPattern),
-                                            project(staleBranchPattern)))));
+                                            project(staleDsBranch),
+                                            project(staleRegDateBranch)))));
+
+            assertPlan("REFRESH MATERIALIZED VIEW mv_join",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(project(staleDsBranch)))),
+                                                    node(TableWriterNode.class, exchange(exchange(project(staleRegDateBranch)))))))));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
                     .setSystemProperty("materialized_view_stale_read_behavior", "USE_VIEW_QUERY")
                     .build();
             assertPlan(skipStorageSession, "SELECT * FROM mv_join",
-                    output(exchange(staleBranchPattern)));
+                    output(exchange(fullJoinPattern)));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_join");
@@ -255,27 +281,41 @@ public class TestIcebergMaterializedViewOptimizer
 
             assertUpdate("INSERT INTO sales VALUES (3, 150.0, '2024-01-02')", 1);
 
-            PlanMatchPattern staleBranchPattern = aggregation(
+            // Delta branch pattern for incremental refresh - only scans stale partition
+            PlanMatchPattern deltaBranchPattern = aggregation(
                     ImmutableMap.of(),
-                    anyTree(tableScan("sales")));
-            PlanMatchPattern stalePlan = project(staleBranchPattern);
+                    anyTree(constrainedTableScan("sales",
+                            ImmutableMap.of("sale_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())));
+            PlanMatchPattern deltaPlan = project(deltaBranchPattern);
 
             assertPlan("SELECT * FROM mv_sales_agg",
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_sales_agg",
-                                            ImmutableMap.of("sale_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                            ImmutableMap.of("sale_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("sale_date", "sale_date", "product_id", "product_id", "total_amount", "total_amount")),
-                                    stalePlan)));
+                                    deltaPlan)));
+
+            // REFRESH should use constrained scan for stale partition only
+            assertPlan("REFRESH MATERIALIZED VIEW mv_sales_agg",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    exchange(exchange(deltaPlan)))))));
+
+            // Full recompute pattern - scans all data without partition constraints
+            PlanMatchPattern fullRecomputePattern = aggregation(
+                    ImmutableMap.of(),
+                    anyTree(tableScan("sales")));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
                     .setSystemProperty("materialized_view_stale_read_behavior", "USE_VIEW_QUERY")
                     .build();
             assertPlan(skipStorageSession, "SELECT * FROM mv_sales_agg",
-                    output(exchange(staleBranchPattern)));
+                    output(exchange(fullRecomputePattern)));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_sales_agg");
@@ -330,9 +370,7 @@ public class TestIcebergMaterializedViewOptimizer
             PlanMatchPattern orderCustomerDelta2 = project(
                     join(
                             exchange(constrainedTableScan("orders",
-                                    ImmutableMap.of("order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                    ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                     ImmutableMap.of())),
                             exchange(exchange(constrainedTableScan("customers",
                                     ImmutableMap.of("region", singleValue(VARCHAR, utf8Slice("EU"))),
@@ -348,14 +386,10 @@ public class TestIcebergMaterializedViewOptimizer
             // Second branch: orders JOIN customers JOIN products with category='electronics'
             PlanMatchPattern ordersCustomersForCategoryDelta = join(
                     exchange(constrainedTableScan("orders",
-                            ImmutableMap.of("order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                    lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                    greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                             ImmutableMap.of())),
                     exchange(exchange(constrainedTableScan("customers",
-                            ImmutableMap.of("region", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                    lessThan(VARCHAR, utf8Slice("EU")),
-                                    greaterThan(VARCHAR, utf8Slice("EU")))), false)),
+                            ImmutableMap.of("region", singleValue(VARCHAR, utf8Slice("EU")).complement()),
                             ImmutableMap.of()))));
 
             PlanMatchPattern secondBranch = project(
@@ -370,20 +404,22 @@ public class TestIcebergMaterializedViewOptimizer
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_order_details",
                                             ImmutableMap.of(
-                                                    "order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false),
-                                                    "region", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("EU")),
-                                                            greaterThan(VARCHAR, utf8Slice("EU")))), false),
-                                                    "category", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("electronics")),
-                                                            greaterThan(VARCHAR, utf8Slice("electronics")))), false)),
+                                                    "order_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement(),
+                                                    "region", singleValue(VARCHAR, utf8Slice("EU")).complement(),
+                                                    "category", singleValue(VARCHAR, utf8Slice("electronics")).complement()),
                                             ImmutableMap.of("order_date", "order_date", "region", "region", "category", "category",
                                                     "order_id", "order_id", "customer_name", "customer_name", "product_name", "product_name")),
                                     exchange(
                                             firstBranch,
                                             secondBranch))));
+
+            assertPlan("REFRESH MATERIALIZED VIEW mv_order_details",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, anyTree(firstBranch)),
+                                                    node(TableWriterNode.class, anyTree(secondBranch)))))));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
@@ -427,33 +463,55 @@ public class TestIcebergMaterializedViewOptimizer
             assertUpdate("INSERT INTO orders VALUES (2, 200, 100.0, '2024-01-02')", 1);
             assertUpdate("INSERT INTO customers VALUES (200, 'Bob', 'active', '2024-01-02')", 1);
 
-            PlanMatchPattern staleBranchPattern = join(
-                    anyTree(tableScan("orders")),
+            // Delta branch for order_date='2024-01-02' stale partition
+            PlanMatchPattern deltaBranchOrders = join(
+                    anyTree(constrainedTableScan("orders",
+                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())),
                     anyTree(tableScan("customers")));
+
+            // Delta branch for reg_date='2024-01-02' stale partition
+            PlanMatchPattern deltaBranchCustomers = join(
+                    anyTree(constrainedTableScan("orders",
+                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
+                            ImmutableMap.of())),
+                    anyTree(constrainedTableScan("customers",
+                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())));
 
             assertPlan("SELECT * FROM mv_active_orders",
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_active_orders",
                                             ImmutableMap.of(
-                                                    "order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false),
-                                                    "reg_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                                    "order_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement(),
+                                                    "reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("order_date", "order_date", "reg_date", "reg_date",
                                                     "order_id", "order_id", "name", "name", "amount", "amount")),
                                     exchange(
-                                            project(staleBranchPattern),
-                                            project(staleBranchPattern)))));
+                                            project(deltaBranchOrders),
+                                            project(deltaBranchCustomers)))));
+
+            // Full recompute pattern - scans all data without partition constraints
+            PlanMatchPattern fullRecomputePattern = join(
+                    anyTree(tableScan("orders")),
+                    anyTree(tableScan("customers")));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
                     .setSystemProperty("materialized_view_stale_read_behavior", "USE_VIEW_QUERY")
                     .build();
             assertPlan(skipStorageSession, "SELECT * FROM mv_active_orders",
-                    output(exchange(staleBranchPattern)));
+                    output(exchange(fullRecomputePattern)));
+
+            // REFRESH should use constrained scans for stale partitions only
+            assertPlan("REFRESH MATERIALIZED VIEW mv_active_orders",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, anyTree(deltaBranchOrders)),
+                                                    node(TableWriterNode.class, anyTree(deltaBranchCustomers)))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_active_orders");
@@ -482,28 +540,42 @@ public class TestIcebergMaterializedViewOptimizer
 
             assertUpdate("INSERT INTO orders VALUES (2, 100, '2024-01-02')", 1);
 
-            PlanMatchPattern staleBranchPattern = join(
-                    anyTree(tableScan("orders")),
+            // Delta branch pattern for incremental refresh - constrains orders to stale partition ds='2024-01-02'
+            PlanMatchPattern deltaBranchPattern = join(
+                    anyTree(constrainedTableScan("orders",
+                            ImmutableMap.of("ds", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())),
                     anyTree(tableScan("customers")));
-            PlanMatchPattern stalePlan = project(staleBranchPattern);
+            PlanMatchPattern deltaPlan = project(deltaBranchPattern);
 
             assertPlan("SELECT * FROM mv_partial_stale",
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_partial_stale",
                                             ImmutableMap.of(
-                                                    "ds", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                                    "ds", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("ds", "ds", "reg_date", "reg_date", "order_id", "order_id", "name", "name")),
-                                    stalePlan)));
+                                    deltaPlan)));
+
+            // Full recompute pattern - scans all data without partition constraints
+            PlanMatchPattern fullRecomputePattern = join(
+                    anyTree(tableScan("orders")),
+                    anyTree(tableScan("customers")));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
                     .setSystemProperty("materialized_view_stale_read_behavior", "USE_VIEW_QUERY")
                     .build();
             assertPlan(skipStorageSession, "SELECT * FROM mv_partial_stale",
-                    output(exchange(staleBranchPattern)));
+                    output(exchange(fullRecomputePattern)));
+
+            // REFRESH should use constrained scan for stale partition only
+            assertPlan("REFRESH MATERIALIZED VIEW mv_partial_stale",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    exchange(exchange(deltaPlan)))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_partial_stale");
@@ -533,24 +605,25 @@ public class TestIcebergMaterializedViewOptimizer
 
             assertUpdate("INSERT INTO union_table1 VALUES (5, 'e', '2024-01-03')", 1);
 
+            PlanMatchPattern unionStaleBranch = aggregation(
+                    ImmutableMap.of(),
+                    FINAL,
+                    exchange(
+                            exchange(
+                                    aggregation(
+                                            ImmutableMap.of(),
+                                            PARTIAL,
+                                            project(constrainedTableScan("union_table1",
+                                                    ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-03"))),
+                                                    ImmutableMap.of("id_1", "id", "value_1", "value")))))));
+
             assertPlan("SELECT * FROM mv_union",
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_union",
-                                            ImmutableMap.of("dt", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-03")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-03")))), false)),
+                                            ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-03")).complement()),
                                             ImmutableMap.of("dt", "dt", "id", "id", "value", "value")),
-                                    aggregation(
-                                            ImmutableMap.of(),
-                                            FINAL,
-                                            anyTree(
-                                                    aggregation(
-                                                            ImmutableMap.of(),
-                                                            PARTIAL,
-                                                            anyTree(constrainedTableScan("union_table1",
-                                                                    ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-03"))),
-                                                                    ImmutableMap.of("id_1", "id", "value_1", "value")))))))));
+                                    unionStaleBranch)));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
@@ -574,6 +647,13 @@ public class TestIcebergMaterializedViewOptimizer
                                                                     ImmutableMap.of(),
                                                                     PARTIAL,
                                                                     tableScan("union_table2")))))))));
+
+            assertPlan("REFRESH MATERIALIZED VIEW mv_union",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    exchange(exchange(unionStaleBranch)))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_union");
@@ -602,38 +682,29 @@ public class TestIcebergMaterializedViewOptimizer
                     "WITH (partitioning = ARRAY['order_date']) AS " +
                     "SELECT o.order_id, c.name, o.order_date, c.reg_date " +
                     "FROM join_orders o " +
-                    "JOIN join_customers c ON o.customer_id = c.customer_id");
+                    "JOIN join_customers c ON o.customer_id = c.customer_id AND o.order_date = c.reg_date");
             getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_join");
 
             assertUpdate("INSERT INTO join_orders VALUES (2, 200, '2024-01-02')", 1);
-            assertUpdate("INSERT INTO join_customers VALUES (200, 'Bob', '2024-01-01')", 1);
+            assertUpdate("INSERT INTO join_customers VALUES (200, 'Bob', '2024-01-02')", 1);
 
-            // MV is partitioned by order_date only. The filter for reg_date becomes a residual
-            // filter predicate (ScanFilter node) rather than just a domain constraint, because
-            // reg_date is not a partition column in the MV storage table.
+            // With order_date = reg_date equivalence, both stale predicates map to order_date='2024-01-02'
+            // MV storage excludes stale rows with filter, delta recomputes the join
+            PlanMatchPattern staleBranch = project(join(
+                    exchange(constrainedTableScan("join_orders",
+                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())),
+                    exchange(exchange(constrainedTableScan("join_customers",
+                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())))));
+
+            // ScanFilter with OR predicate since both order_date and reg_date are in MV output
             assertPlan("SELECT * FROM mv_join",
                     output(
                             exchange(
-                                    filter("(reg_date) <> (VARCHAR '2024-01-01')",
-                                            constrainedTableScan("__mv_storage__mv_join",
-                                                    ImmutableMap.of(
-                                                            "order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(lessThan(VARCHAR, utf8Slice("2024-01-02")), greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false),
-                                                            "reg_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(lessThan(VARCHAR, utf8Slice("2024-01-01")), greaterThan(VARCHAR, utf8Slice("2024-01-01")))), false)),
-                                                    ImmutableMap.of("order_date", "order_date", "reg_date", "reg_date", "order_id", "order_id", "name", "name"))),
-                                    exchange(
-                                            project(join(
-                                                    exchange(constrainedTableScan("join_orders",
-                                                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
-                                                            ImmutableMap.of())),
-                                                    exchange(exchange(tableScan("join_customers"))))),
-                                            project(join(
-                                                    exchange(constrainedTableScan("join_orders",
-                                                            // R (unchanged) = all non-stale partitions: order_date != '2024-01-02'
-                                                            ImmutableMap.of("order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(lessThan(VARCHAR, utf8Slice("2024-01-02")), greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
-                                                            ImmutableMap.of())),
-                                                    exchange(exchange(constrainedTableScan("join_customers",
-                                                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-01"))),
-                                                            ImmutableMap.of())))))))));
+                                    filter("((order_date) <> (VARCHAR'2024-01-02')) OR ((reg_date) <> (VARCHAR'2024-01-02'))",
+                                            tableScan("__mv_storage__mv_join", ImmutableMap.of("order_date", "order_date", "reg_date", "reg_date"))),
+                                    staleBranch)));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
@@ -641,8 +712,16 @@ public class TestIcebergMaterializedViewOptimizer
                     .build();
             assertPlan(skipStorageSession, "SELECT * FROM mv_join",
                     output(exchange(join(
-                            anyTree(tableScan("join_orders")),
-                            anyTree(tableScan("join_customers"))))));
+                            exchange(tableScan("join_orders")),
+                            exchange(exchange(tableScan("join_customers")))))));
+
+            // Incremental refresh with single writer since both staleness map to same partition
+            assertPlan("REFRESH MATERIALIZED VIEW mv_join",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    exchange(exchange(staleBranch)))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_join");
@@ -677,31 +756,33 @@ public class TestIcebergMaterializedViewOptimizer
             assertUpdate("INSERT INTO passthrough_orders VALUES (2, 200, '2024-01-02')", 1);
             assertUpdate("INSERT INTO passthrough_customers VALUES (200, 'Bob', '2024-01-01')", 1);
 
+            // Delta branches for two stale partitions: order_date='2024-01-02' and order_date='2024-01-01'
+            PlanMatchPattern staleBranchJan02 = project(join(
+                    exchange(constrainedTableScan("passthrough_orders",
+                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())),
+                    exchange(exchange(constrainedTableScan("passthrough_customers",
+                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())))));
+
+            PlanMatchPattern staleBranchJan01 = project(join(
+                    exchange(constrainedTableScan("passthrough_orders",
+                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-01"))),
+                            ImmutableMap.of())),
+                    exchange(exchange(constrainedTableScan("passthrough_customers",
+                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-01"))),
+                            ImmutableMap.of())))));
+
             assertPlan("SELECT * FROM mv_passthrough",
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_passthrough",
                                             ImmutableMap.of(
-                                                    "order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-01")),
-                                                            Range.range(VARCHAR, utf8Slice("2024-01-01"), false, utf8Slice("2024-01-02"), false),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                                    "order_date", multipleValues(VARCHAR, ImmutableList.of(utf8Slice("2024-01-01"), utf8Slice("2024-01-02"))).complement()),
                                             ImmutableMap.of("order_date", "order_date", "order_id", "order_id", "name", "name")),
                                     exchange(
-                                            project(join(
-                                                    anyTree(constrainedTableScan("passthrough_orders",
-                                                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
-                                                            ImmutableMap.of("order_id_1", "order_id", "customer_id_1", "customer_id"))),
-                                                    anyTree(constrainedTableScan("passthrough_customers",
-                                                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
-                                                            ImmutableMap.of("customer_id_2", "customer_id", "name_2", "name"))))),
-                                            project(join(
-                                                    anyTree(constrainedTableScan("passthrough_orders",
-                                                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-01"))),
-                                                            ImmutableMap.of("order_id_3", "order_id", "customer_id_3", "customer_id"))),
-                                                    anyTree(constrainedTableScan("passthrough_customers",
-                                                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-01"))),
-                                                            ImmutableMap.of("customer_id_4", "customer_id", "name_4", "name")))))))));
+                                            staleBranchJan02,
+                                            staleBranchJan01))));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
@@ -709,8 +790,17 @@ public class TestIcebergMaterializedViewOptimizer
                     .build();
             assertPlan(skipStorageSession, "SELECT * FROM mv_passthrough",
                     output(exchange(join(
-                            anyTree(tableScan("passthrough_orders", ImmutableMap.of("order_date", "order_date"))),
-                            anyTree(tableScan("passthrough_customers", ImmutableMap.of("reg_date", "reg_date")))))));
+                            exchange(tableScan("passthrough_orders", ImmutableMap.of("order_date", "order_date"))),
+                            exchange(exchange(tableScan("passthrough_customers", ImmutableMap.of("reg_date", "reg_date"))))))));
+
+            // Incremental refresh with two TableWriters for the two stale partitions
+            assertPlan("REFRESH MATERIALIZED VIEW mv_passthrough",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(staleBranchJan02))),
+                                                    node(TableWriterNode.class, exchange(exchange(staleBranchJan01))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_passthrough");
@@ -788,9 +878,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_intersect",
-                                            ImmutableMap.of("dt", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                            ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("dt", "dt", "id", "id", "value", "value")),
                                     intersectBranchBoth,
                                     intersectBranchTable2Only)));
@@ -818,6 +906,15 @@ public class TestIcebergMaterializedViewOptimizer
                                                             anyTree(tableScan("intersect_table2"))))))));
             assertPlan(skipStorageSession, "SELECT * FROM mv_intersect",
                     output(exchange(fullIntersectPattern)));
+
+            // REFRESH uses the same delta branches wrapped in TableWriters
+            assertPlan("REFRESH MATERIALIZED VIEW mv_intersect",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(intersectBranchBoth))),
+                                                    node(TableWriterNode.class, exchange(exchange(intersectBranchTable2Only))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_intersect");
@@ -913,12 +1010,19 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_intersect_left",
-                                            ImmutableMap.of("dt", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-03")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-03")))), false)),
+                                            ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-03")).complement()),
                                             ImmutableMap.of("dt", "dt", "id", "id", "value", "value")),
                                     intersectBranchBoth,
                                     intersectBranchTable2Only)));
+
+            // REFRESH uses the same delta branches wrapped in TableWriters
+            assertPlan("REFRESH MATERIALIZED VIEW mv_intersect_left",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(intersectBranchBoth))),
+                                                    node(TableWriterNode.class, exchange(exchange(intersectBranchTable2Only))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_intersect_left");
@@ -1005,12 +1109,19 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_intersect_right",
-                                            ImmutableMap.of("dt", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-03")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-03")))), false)),
+                                            ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-03")).complement()),
                                             ImmutableMap.of("dt", "dt", "id", "id", "value", "value")),
                                     intersectBranch1,
                                     intersectBranch2)));
+
+            // Verify refresh plan - INTERSECT needs to recompute both branches for stale partitions
+            assertPlan("REFRESH MATERIALIZED VIEW mv_intersect_right",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(intersectBranch1))),
+                                                    node(TableWriterNode.class, exchange(exchange(intersectBranch2))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_intersect_right");
@@ -1110,6 +1221,14 @@ public class TestIcebergMaterializedViewOptimizer
                     exchange(exchange(innerJoin2Full)));
             assertPlan(skipStorageSession, "SELECT * FROM mv_dnj",
                     output(exchange(nestedJoinPatternFull)));
+
+            // Verify refresh plan - deeply nested join reads from all 4 tables
+            assertPlan("REFRESH MATERIALIZED VIEW mv_dnj",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    anyTree(nestedJoinPattern))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_dnj");
@@ -1142,35 +1261,65 @@ public class TestIcebergMaterializedViewOptimizer
             assertUpdate("INSERT INTO agg_orders VALUES (2, 200, 100.0, '2024-01-02')", 1);
             assertUpdate("INSERT INTO agg_customers VALUES (200, 'Bob', '2024-01-02')", 1);
 
+            // Join branches for the two stale partitions
+            PlanMatchPattern join1 = join(
+                    exchange(constrainedTableScan("agg_orders",
+                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of())),
+                    exchange(exchange(tableScan("agg_customers"))));
+
+            PlanMatchPattern join2 = join(
+                    exchange(constrainedTableScan("agg_orders",
+                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
+                            ImmutableMap.of())),
+                    exchange(exchange(constrainedTableScan("agg_customers",
+                            ImmutableMap.of("reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                            ImmutableMap.of()))));
+
+            // Aggregation pattern used in SELECT - the stale branch has Project wrappers
             PlanMatchPattern aggregationBranch =
                     aggregation(
                             ImmutableMap.of(),
-                            anyTree(
-                                    join(
-                                            anyTree(tableScan("agg_orders")),
-                                            anyTree(tableScan("agg_customers")))));
+                            FINAL,
+                            exchange(
+                                    project(exchange(aggregation(ImmutableMap.of(), PARTIAL, project(join1)))),
+                                    project(exchange(aggregation(ImmutableMap.of(), PARTIAL, project(join2))))));
 
             assertPlan("SELECT * FROM mv_agg_join",
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_agg_join",
                                             ImmutableMap.of(
-                                                    "order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false),
-                                                    "reg_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                            lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                            greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                                    "order_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement(),
+                                                    "reg_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("order_date", "order_date", "reg_date", "reg_date",
                                                     "name", "name", "total_amount", "total_amount", "order_count", "order_count")),
-                                    aggregation(ImmutableMap.of(), anyTree(join(anyTree(tableScan("agg_orders")), anyTree(tableScan("agg_customers"))))))));
+                                    aggregationBranch)));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
                     .setSystemProperty("materialized_view_stale_read_behavior", "USE_VIEW_QUERY")
                     .build();
+            // Full scan pattern for skipStorageSession
+            PlanMatchPattern fullJoin = join(
+                    exchange(tableScan("agg_orders")),
+                    exchange(exchange(tableScan("agg_customers"))));
+            PlanMatchPattern fullAggregation =
+                    aggregation(
+                            ImmutableMap.of(),
+                            FINAL,
+                            exchange(
+                                    exchange(aggregation(ImmutableMap.of(), PARTIAL, fullJoin))));
             assertPlan(skipStorageSession, "SELECT * FROM mv_agg_join",
-                    output(exchange(aggregationBranch)));
+                    output(exchange(fullAggregation)));
+
+            // Verify refresh plan - single TableWriter with aggregation tree underneath
+            assertPlan("REFRESH MATERIALIZED VIEW mv_agg_join",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    exchange(exchange(aggregationBranch)))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_agg_join");
@@ -1237,9 +1386,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_except",
-                                            ImmutableMap.of("dt", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                            ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("dt", "dt", "id", "id", "value", "value")),
                                     firstStaleBranch,
                                     secondStaleBranch)));
@@ -1266,6 +1413,15 @@ public class TestIcebergMaterializedViewOptimizer
                                                             project(tableScan("except_table2"))))))));
             assertPlan(skipStorageSession, "SELECT * FROM mv_except",
                     output(exchange(fullExceptPattern)));
+
+            // Verify refresh plan - EXCEPT recomputes both tables for stale partitions
+            assertPlan("REFRESH MATERIALIZED VIEW mv_except",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(firstStaleBranch))),
+                                                    node(TableWriterNode.class, exchange(exchange(secondStaleBranch))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_except");
@@ -1295,13 +1451,22 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_partial_passthrough",
-                                            ImmutableMap.of("order_date", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                            ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("order_date", "order_date", "order_id", "order_id", "amount", "amount")),
                                     project(constrainedTableScan("partial_orders",
                                             ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
                                             ImmutableMap.of("order_id_1", "order_id", "amount_1", "amount"))))));
+
+            // Verify refresh plan - single table, single delta branch with constrained scan
+            PlanMatchPattern deltaBranch = project(constrainedTableScan("partial_orders",
+                    ImmutableMap.of("order_date", singleValue(VARCHAR, utf8Slice("2024-01-02"))),
+                    ImmutableMap.of()));
+            assertPlan("REFRESH MATERIALIZED VIEW mv_partial_passthrough",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    exchange(exchange(deltaBranch)))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_partial_passthrough");
@@ -1366,9 +1531,7 @@ public class TestIcebergMaterializedViewOptimizer
             // Branch 2: JOIN(t1 constrained to event_date != jan2, t2 constrained to reg_date=jan2)
             PlanMatchPattern joinBranch2 = join(
                     exchange(constrainedTableScan("test_distinct_t1",
-                            ImmutableMap.of("event_date", create(SortedRangeSet.copyOf(DATE, ImmutableList.of(
-                                    lessThan(DATE, jan2InDays),
-                                    greaterThan(DATE, jan2InDays))), false)),
+                            ImmutableMap.of("event_date", singleValue(DATE, jan2InDays).complement()),
                             ImmutableMap.of())),
                     exchange(exchange(constrainedTableScan("test_distinct_t2",
                             ImmutableMap.of("reg_date", singleValue(DATE, jan2InDays)),
@@ -1388,14 +1551,18 @@ public class TestIcebergMaterializedViewOptimizer
                             exchange(
                                     constrainedTableScan("__mv_storage__test_distinct_mv",
                                             ImmutableMap.of(
-                                                    "event_date", create(SortedRangeSet.copyOf(DATE, ImmutableList.of(
-                                                            lessThan(DATE, jan2InDays),
-                                                            greaterThan(DATE, jan2InDays))), false),
-                                                    "reg_date", create(SortedRangeSet.copyOf(DATE, ImmutableList.of(
-                                                            lessThan(DATE, jan2InDays),
-                                                            greaterThan(DATE, jan2InDays))), false)),
+                                                    "event_date", singleValue(DATE, jan2InDays).complement(),
+                                                    "reg_date", singleValue(DATE, jan2InDays).complement()),
                                             ImmutableMap.of()),
                                     aggregationPattern)));
+
+            // Verify refresh plan - DISTINCT join MV has single TableWriter with aggregation tree
+            assertPlan("REFRESH MATERIALIZED VIEW test_distinct_mv",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            node(TableWriterNode.class,
+                                                    exchange(exchange(aggregationPattern)))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_distinct_mv");
@@ -1498,12 +1665,19 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_jexj",
-                                            ImmutableMap.of("dt", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                            ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("dt", "dt", "id", "id", "value", "value")),
                                     exceptBranch1,
                                     exceptBranch2)));
+
+            // Verify refresh plan - (A JOIN B) EXCEPT (C JOIN D) with left side stale
+            assertPlan("REFRESH MATERIALIZED VIEW mv_jexj",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch1))),
+                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch2))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_jexj");
@@ -1581,12 +1755,19 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_jexjr",
-                                            ImmutableMap.of("dt", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-02")))), false)),
+                                            ImmutableMap.of("dt", singleValue(VARCHAR, utf8Slice("2024-01-02")).complement()),
                                             ImmutableMap.of("dt", "dt", "id", "id", "value", "value")),
                                     exceptBranch,
                                     exceptBranch)));
+
+            // Verify refresh plan - (A JOIN B) EXCEPT (C JOIN D) with right side stale
+            assertPlan("REFRESH MATERIALIZED VIEW mv_jexjr",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch))),
+                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_jexjr");
@@ -1688,13 +1869,19 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             exchange(
                                     constrainedTableScan("__mv_storage__mv_jexjb",
-                                            ImmutableMap.of("dt", create(SortedRangeSet.copyOf(VARCHAR, ImmutableList.of(
-                                                    lessThan(VARCHAR, utf8Slice("2024-01-02")),
-                                                    Range.range(VARCHAR, utf8Slice("2024-01-02"), false, utf8Slice("2024-01-03"), false),
-                                                    greaterThan(VARCHAR, utf8Slice("2024-01-03")))), false)),
+                                            ImmutableMap.of("dt", multipleValues(VARCHAR, ImmutableList.of(utf8Slice("2024-01-02"), utf8Slice("2024-01-03"))).complement()),
                                             ImmutableMap.of("dt", "dt", "id", "id", "value", "value")),
                                     exceptBranch1,
                                     exceptBranch2)));
+
+            // Verify refresh plan - (A JOIN B) EXCEPT (C JOIN D) with both sides stale
+            assertPlan("REFRESH MATERIALIZED VIEW mv_jexjb",
+                    output(
+                            tableFinish(
+                                    exchange(
+                                            exchange(
+                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch1))),
+                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch2))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_jexjb");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
@@ -251,6 +251,34 @@ public abstract class TestIcebergMaterializedViewsBase
     }
 
     @Test
+    public void testFullRefreshAfterBaseTableDeleteCleansUpStalePartition()
+    {
+        // Base table DELETE triggers full refresh, which should clean up orphaned partitions.
+        try {
+            assertUpdate("CREATE TABLE test_delete_stale_base (id BIGINT, value BIGINT, dt VARCHAR) " +
+                    "WITH (partitioning = ARRAY['dt'])");
+            assertUpdate("INSERT INTO test_delete_stale_base VALUES (1, 100, '2024-01-01'), (2, 200, '2024-01-02')", 2);
+
+            assertUpdate("CREATE MATERIALIZED VIEW test_delete_stale_mv " +
+                    "WITH (partitioning = ARRAY['dt']) AS SELECT id, value, dt FROM test_delete_stale_base");
+
+            assertRefreshAndFullyMaterialized("test_delete_stale_mv", 2);
+            assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_delete_stale_mv\"", "SELECT 2");
+
+            assertUpdate("DELETE FROM test_delete_stale_base WHERE dt = '2024-01-01'", 1);
+
+            // Full refresh writes only the surviving row; orphaned partition is removed
+            assertRefreshAndFullyMaterialized("test_delete_stale_mv", 1);
+            assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_delete_stale_mv\"", "SELECT 1");
+            assertQuery("SELECT * FROM \"__mv_storage__test_delete_stale_mv\"", "VALUES (2, 200, '2024-01-02')");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_delete_stale_mv");
+            assertUpdate("DROP TABLE IF EXISTS test_delete_stale_base");
+        }
+    }
+
+    @Test
     public void testRefreshMaterializedViewWithAggregation()
     {
         assertUpdate("CREATE TABLE test_mv_agg_refresh_base (category VARCHAR, value BIGINT, dt VARCHAR) " +

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
@@ -109,7 +109,6 @@ public abstract class TestIcebergMaterializedViewsBase
         assertMaterializedViewQuery("SELECT * FROM test_mv_stale ORDER BY id",
                 "VALUES (1, 100, '2024-01-01'), (2, 200, '2024-01-01'), (3, 300, '2024-01-02')");
 
-        assertUpdate("REFRESH MATERIALIZED VIEW test_mv_stale", 3);
         assertRefreshAndFullyMaterialized("test_mv_stale", 3);
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_stale\"", "SELECT 3");
 
@@ -184,7 +183,7 @@ public abstract class TestIcebergMaterializedViewsBase
         assertQuery("SELECT COUNT(*) FROM test_mv_refresh", "SELECT 2");
         assertQuery("SELECT * FROM test_mv_refresh ORDER BY id", "VALUES (1, 100), (2, 200)");
 
-        assertUpdate("REFRESH MATERIALIZED VIEW test_mv_refresh", 2);
+        assertRefreshAndFullyMaterialized("test_mv_refresh", 2);
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_refresh\"", "SELECT 2");
         assertQuery("SELECT * FROM \"__mv_storage__test_mv_refresh\" ORDER BY id",
@@ -199,7 +198,7 @@ public abstract class TestIcebergMaterializedViewsBase
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_refresh\"", "SELECT 2");
 
-        assertUpdate("REFRESH MATERIALIZED VIEW test_mv_refresh", 3);
+        assertRefreshAndFullyMaterialized("test_mv_refresh", 3);
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_refresh\"", "SELECT 3");
         assertQuery("SELECT * FROM \"__mv_storage__test_mv_refresh\" ORDER BY id",
@@ -217,7 +216,7 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("INSERT INTO test_mv_refresh_base VALUES (1, 100, '2024-01-01'), (2, 200, '2024-01-01')", 2);
 
         assertUpdate("CREATE MATERIALIZED VIEW test_mv_refresh " +
-                "AS SELECT id, value, dt FROM test_mv_refresh_base");
+                "WITH (partitioning = ARRAY['dt']) AS SELECT id, value, dt FROM test_mv_refresh_base");
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_refresh\"", "SELECT 0");
 
@@ -239,7 +238,8 @@ public abstract class TestIcebergMaterializedViewsBase
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_refresh\"", "SELECT 2");
 
-        assertRefreshAndFullyMaterialized("test_mv_refresh", 3);
+        // Incremental refresh only writes the delta partition data
+        assertRefreshAndFullyMaterialized("test_mv_refresh", 1);
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_refresh\"", "SELECT 3");
         assertQuery("SELECT * FROM \"__mv_storage__test_mv_refresh\" ORDER BY id",
@@ -257,7 +257,8 @@ public abstract class TestIcebergMaterializedViewsBase
                 "WITH (partitioning = ARRAY['dt'])");
         assertUpdate("INSERT INTO test_mv_agg_refresh_base VALUES ('A', 10, '2024-01-01'), ('B', 20, '2024-01-01'), ('A', 15, '2024-01-01')", 3);
 
-        assertUpdate("CREATE MATERIALIZED VIEW test_mv_agg_refresh AS " +
+        assertUpdate("CREATE MATERIALIZED VIEW test_mv_agg_refresh " +
+                "WITH (partitioning = ARRAY['dt']) AS " +
                 "SELECT category, SUM(value) as total, dt FROM test_mv_agg_refresh_base GROUP BY category, dt");
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_agg_refresh\"", "SELECT 0");
@@ -275,7 +276,8 @@ public abstract class TestIcebergMaterializedViewsBase
         assertMaterializedViewQuery("SELECT * FROM test_mv_agg_refresh ORDER BY category, dt",
                 "VALUES ('A', 25, '2024-01-01'), ('A', 5, '2024-01-02'), ('B', 20, '2024-01-01'), ('C', 30, '2024-01-02')");
 
-        assertRefreshAndFullyMaterialized("test_mv_agg_refresh", 4);
+        // Incremental refresh only writes 2 rows for the new partition ('2024-01-02'), not all 4 rows
+        assertRefreshAndFullyMaterialized("test_mv_agg_refresh", 2);
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_agg_refresh\"", "SELECT 4");
         assertQuery("SELECT * FROM \"__mv_storage__test_mv_agg_refresh\" ORDER BY category, dt",
@@ -357,48 +359,52 @@ public abstract class TestIcebergMaterializedViewsBase
     @Test
     public void testJoinMaterializedViewLifecycle()
     {
-        assertUpdate("CREATE TABLE test_mv_orders (order_id BIGINT, customer_id BIGINT, amount BIGINT, order_date VARCHAR) " +
-                "WITH (partitioning = ARRAY['order_date'])");
-        assertUpdate("CREATE TABLE test_mv_customers (customer_id BIGINT, customer_name VARCHAR)");
+        try {
+            assertUpdate("CREATE TABLE test_mv_orders (order_id BIGINT, customer_id BIGINT, amount BIGINT, order_date VARCHAR) " +
+                    "WITH (partitioning = ARRAY['order_date'])");
+            assertUpdate("CREATE TABLE test_mv_customers (customer_id BIGINT, customer_name VARCHAR)");
 
-        assertUpdate("INSERT INTO test_mv_orders VALUES (1, 100, 50, '2024-01-01'), (2, 200, 75, '2024-01-01'), (3, 100, 25, '2024-01-01')", 3);
-        assertUpdate("INSERT INTO test_mv_customers VALUES (100, 'Alice'), (200, 'Bob')", 2);
+            assertUpdate("INSERT INTO test_mv_orders VALUES (1, 100, 50, '2024-01-01'), (2, 200, 75, '2024-01-01'), (3, 100, 25, '2024-01-01')", 3);
+            assertUpdate("INSERT INTO test_mv_customers VALUES (100, 'Alice'), (200, 'Bob')", 2);
 
-        assertUpdate("CREATE MATERIALIZED VIEW test_mv_order_details AS " +
-                "SELECT o.order_id, c.customer_name, o.amount, o.order_date " +
-                "FROM test_mv_orders o JOIN test_mv_customers c ON o.customer_id = c.customer_id");
+            assertUpdate("CREATE MATERIALIZED VIEW test_mv_order_details WITH (partitioning = ARRAY['order_date']) AS " +
+                    "SELECT o.order_id, c.customer_name, o.amount, o.order_date " +
+                    "FROM test_mv_orders o JOIN test_mv_customers c ON o.customer_id = c.customer_id");
 
-        assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_order_details\"", "SELECT 0");
+            assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_order_details\"", "SELECT 0");
 
-        assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_order_details", "SELECT 3");
-        assertMaterializedViewQuery("SELECT * FROM test_mv_order_details ORDER BY order_id",
-                "VALUES (1, 'Alice', 50, '2024-01-01'), (2, 'Bob', 75, '2024-01-01'), (3, 'Alice', 25, '2024-01-01')");
+            assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_order_details", "SELECT 3");
+            assertMaterializedViewQuery("SELECT * FROM test_mv_order_details ORDER BY order_id",
+                    "VALUES (1, 'Alice', 50, '2024-01-01'), (2, 'Bob', 75, '2024-01-01'), (3, 'Alice', 25, '2024-01-01')");
 
-        assertRefreshAndFullyMaterialized("test_mv_order_details", 3);
+            assertRefreshAndFullyMaterialized("test_mv_order_details", 3);
 
-        assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_order_details\"", "SELECT 3");
-        assertQuery("SELECT * FROM \"__mv_storage__test_mv_order_details\" ORDER BY order_id",
-                "VALUES (1, 'Alice', 50, '2024-01-01'), (2, 'Bob', 75, '2024-01-01'), (3, 'Alice', 25, '2024-01-01')");
+            assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_order_details\"", "SELECT 3");
+            assertQuery("SELECT * FROM \"__mv_storage__test_mv_order_details\" ORDER BY order_id",
+                    "VALUES (1, 'Alice', 50, '2024-01-01'), (2, 'Bob', 75, '2024-01-01'), (3, 'Alice', 25, '2024-01-01')");
 
-        assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_order_details", "SELECT 3");
+            assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_order_details", "SELECT 3");
 
-        assertUpdate("INSERT INTO test_mv_orders VALUES (4, 200, 100, '2024-01-02')", 1);
+            assertUpdate("INSERT INTO test_mv_orders VALUES (4, 200, 100, '2024-01-02')", 1);
 
-        assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_order_details", "SELECT 4");
-        assertMaterializedViewQuery("SELECT * FROM test_mv_order_details ORDER BY order_id",
-                "VALUES (1, 'Alice', 50, '2024-01-01'), (2, 'Bob', 75, '2024-01-01'), (3, 'Alice', 25, '2024-01-01'), (4, 'Bob', 100, '2024-01-02')");
+            assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_order_details", "SELECT 4");
+            assertMaterializedViewQuery("SELECT * FROM test_mv_order_details ORDER BY order_id",
+                    "VALUES (1, 'Alice', 50, '2024-01-01'), (2, 'Bob', 75, '2024-01-01'), (3, 'Alice', 25, '2024-01-01'), (4, 'Bob', 100, '2024-01-02')");
 
-        assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_order_details\"", "SELECT 3");
+            assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_order_details\"", "SELECT 3");
 
-        assertRefreshAndFullyMaterialized("test_mv_order_details", 4);
+            // Incremental refresh: only writes the 1 new row in partition '2024-01-02'
+            assertRefreshAndFullyMaterialized("test_mv_order_details", 1);
 
-        assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_order_details\"", "SELECT 4");
-        assertQuery("SELECT * FROM \"__mv_storage__test_mv_order_details\" ORDER BY order_id",
-                "VALUES (1, 'Alice', 50, '2024-01-01'), (2, 'Bob', 75, '2024-01-01'), (3, 'Alice', 25, '2024-01-01'), (4, 'Bob', 100, '2024-01-02')");
-
-        assertUpdate("DROP MATERIALIZED VIEW test_mv_order_details");
-        assertUpdate("DROP TABLE test_mv_customers");
-        assertUpdate("DROP TABLE test_mv_orders");
+            assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_order_details\"", "SELECT 4");
+            assertQuery("SELECT * FROM \"__mv_storage__test_mv_order_details\" ORDER BY order_id",
+                    "VALUES (1, 'Alice', 50, '2024-01-01'), (2, 'Bob', 75, '2024-01-01'), (3, 'Alice', 25, '2024-01-01'), (4, 'Bob', 100, '2024-01-02')");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_mv_order_details");
+            assertUpdate("DROP TABLE IF EXISTS test_mv_customers");
+            assertUpdate("DROP TABLE IF EXISTS test_mv_orders");
+        }
     }
 
     @Test
@@ -419,7 +425,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "(3, 100, DATE '2024-01-02', 25)", 3);
         assertUpdate("INSERT INTO test_mv_part_customers VALUES (100, 'Alice'), (200, 'Bob')", 2);
 
-        assertUpdate("CREATE MATERIALIZED VIEW test_mv_part_join AS " +
+        assertUpdate("CREATE MATERIALIZED VIEW test_mv_part_join WITH (partitioning = ARRAY['order_date']) AS " +
                 "SELECT o.order_id, c.customer_name, o.order_date, o.amount " +
                 "FROM test_mv_part_orders o JOIN test_mv_part_customers c ON o.customer_id = c.customer_id");
 
@@ -448,7 +454,8 @@ public abstract class TestIcebergMaterializedViewsBase
                         "(3, 'Alice', DATE '2024-01-02', 25), " +
                         "(4, 'Bob', DATE '2024-01-03', 100)");
 
-        assertRefreshAndFullyMaterialized("test_mv_part_join", 4);
+        // Incremental refresh: only writes the 1 new row in partition '2024-01-03'
+        assertRefreshAndFullyMaterialized("test_mv_part_join", 1);
 
         assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_part_join\"", "SELECT 4");
         assertMaterializedViewResultsMatch("SELECT * FROM test_mv_part_join ORDER BY order_id");
@@ -461,47 +468,58 @@ public abstract class TestIcebergMaterializedViewsBase
     @Test
     public void testMultiTableStaleness_TwoTablesBothStale()
     {
-        assertUpdate("CREATE TABLE test_mv_orders (" +
-                "order_id BIGINT, " +
-                "order_date DATE, " +
-                "amount BIGINT) " +
-                "WITH (partitioning = ARRAY['order_date'])");
+        try {
+            assertUpdate("CREATE TABLE test_mv_orders (" +
+                    "order_id BIGINT, " +
+                    "order_date DATE, " +
+                    "amount BIGINT) " +
+                    "WITH (partitioning = ARRAY['order_date'])");
 
-        assertUpdate("CREATE TABLE test_mv_customers (" +
-                "customer_id BIGINT, " +
-                "reg_date DATE, " +
-                "name VARCHAR) " +
-                "WITH (partitioning = ARRAY['reg_date'])");
+            assertUpdate("CREATE TABLE test_mv_customers (" +
+                    "customer_id BIGINT, " +
+                    "reg_date DATE, " +
+                    "name VARCHAR) " +
+                    "WITH (partitioning = ARRAY['reg_date'])");
 
-        assertUpdate("INSERT INTO test_mv_orders VALUES " +
-                "(1, DATE '2024-01-01', 100), " +
-                "(2, DATE '2024-01-02', 200)", 2);
-        assertUpdate("INSERT INTO test_mv_customers VALUES " +
-                "(1, DATE '2024-01-01', 'Alice'), " +
-                "(2, DATE '2024-01-02', 'Bob')", 2);
+            assertUpdate("INSERT INTO test_mv_orders VALUES " +
+                    "(1, DATE '2024-01-01', 100), " +
+                    "(2, DATE '2024-01-02', 200)", 2);
+            assertUpdate("INSERT INTO test_mv_customers VALUES " +
+                    "(1, DATE '2024-01-01', 'Alice'), " +
+                    "(2, DATE '2024-01-02', 'Bob')", 2);
 
-        assertUpdate("CREATE MATERIALIZED VIEW test_mv_multi_stale AS " +
-                "SELECT o.order_id, c.name, o.order_date, c.reg_date, o.amount " +
-                "FROM test_mv_orders o JOIN test_mv_customers c ON o.order_id = c.customer_id");
+            assertUpdate("CREATE MATERIALIZED VIEW test_mv_multi_stale " +
+                    "WITH (partitioning = ARRAY['order_date']) AS " +
+                    "SELECT o.order_id, c.name, o.order_date, c.reg_date, o.amount " +
+                    "FROM test_mv_orders o JOIN test_mv_customers c ON o.order_id = c.customer_id AND o.order_date = c.reg_date");
 
-        assertRefreshAndFullyMaterialized("test_mv_multi_stale", 2);
+            assertRefreshAndFullyMaterialized("test_mv_multi_stale", 2);
 
-        assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_multi_stale\"", "SELECT 2");
+            assertQuery("SELECT COUNT(*) FROM \"__mv_storage__test_mv_multi_stale\"", "SELECT 2");
 
-        assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_multi_stale", "SELECT 2");
+            assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_multi_stale", "SELECT 2");
 
-        assertUpdate("INSERT INTO test_mv_orders VALUES (3, DATE '2024-01-03', 300)", 1);
-        assertUpdate("INSERT INTO test_mv_customers VALUES (3, DATE '2024-01-03', 'Charlie')", 1);
+            assertUpdate("INSERT INTO test_mv_orders VALUES (3, DATE '2024-01-03', 300)", 1);
+            assertUpdate("INSERT INTO test_mv_customers VALUES (3, DATE '2024-01-03', 'Charlie')", 1);
 
-        assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_multi_stale", "SELECT 3");
-        assertMaterializedViewQuery("SELECT order_id, name, order_date, reg_date, amount FROM test_mv_multi_stale ORDER BY order_id",
-                "VALUES (1, 'Alice', DATE '2024-01-01', DATE '2024-01-01', 100), " +
-                        "(2, 'Bob', DATE '2024-01-02', DATE '2024-01-02', 200), " +
-                        "(3, 'Charlie', DATE '2024-01-03', DATE '2024-01-03', 300)");
+            assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_multi_stale", "SELECT 3");
+            assertMaterializedViewQuery("SELECT order_id, name, order_date, reg_date, amount FROM test_mv_multi_stale ORDER BY order_id",
+                    "VALUES (1, 'Alice', DATE '2024-01-01', DATE '2024-01-01', 100), " +
+                            "(2, 'Bob', DATE '2024-01-02', DATE '2024-01-02', 200), " +
+                            "(3, 'Charlie', DATE '2024-01-03', DATE '2024-01-03', 300)");
 
-        assertUpdate("DROP MATERIALIZED VIEW test_mv_multi_stale");
-        assertUpdate("DROP TABLE test_mv_customers");
-        assertUpdate("DROP TABLE test_mv_orders");
+            // Incremental refresh: only writes the 1 new row in partition '2024-01-03'
+            assertRefreshAndFullyMaterialized("test_mv_multi_stale", 1);
+            assertMaterializedViewQuery("SELECT order_id, name, order_date, reg_date, amount FROM test_mv_multi_stale ORDER BY order_id",
+                    "VALUES (1, 'Alice', DATE '2024-01-01', DATE '2024-01-01', 100), " +
+                            "(2, 'Bob', DATE '2024-01-02', DATE '2024-01-02', 200), " +
+                            "(3, 'Charlie', DATE '2024-01-03', DATE '2024-01-03', 300)");
+        }
+        finally {
+            assertUpdate("DROP MATERIALIZED VIEW IF EXISTS test_mv_multi_stale");
+            assertUpdate("DROP TABLE IF EXISTS test_mv_customers");
+            assertUpdate("DROP TABLE IF EXISTS test_mv_orders");
+        }
     }
 
     @Test
@@ -544,6 +562,10 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("INSERT INTO test_mv_t2 VALUES (2, DATE '2024-01-01', 250)", 1);
         assertUpdate("INSERT INTO test_mv_t3 VALUES (2, DATE '2024-01-02', 350)", 1);
 
+        assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_three_tables", "SELECT 2");
+
+        // Refresh and verify same results
+        assertRefreshAndFullyMaterialized("test_mv_three_tables", 2);
         assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_three_tables", "SELECT 2");
 
         assertUpdate("DROP MATERIALIZED VIEW test_mv_three_tables");
@@ -630,6 +652,13 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("INSERT INTO test_mv_part_sales VALUES (3, DATE '2024-01-03', 700)", 1);
 
         assertMaterializedViewQuery("SELECT COUNT(*) FROM test_mv_mixed_stale", "SELECT 3");
+        assertMaterializedViewQuery("SELECT id, category, sale_date, amount FROM test_mv_mixed_stale ORDER BY id",
+                "VALUES (1, 'Electronics', DATE '2024-01-01', 500), " +
+                        "(2, 'Books', DATE '2024-01-02', 300), " +
+                        "(3, 'Toys', DATE '2024-01-03', 700)");
+
+        // Refresh and verify same results
+        assertRefreshAndFullyMaterialized("test_mv_mixed_stale", 3);
         assertMaterializedViewQuery("SELECT id, category, sale_date, amount FROM test_mv_mixed_stale ORDER BY id",
                 "VALUES (1, 'Electronics', DATE '2024-01-01', 500), " +
                         "(2, 'Books', DATE '2024-01-02', 300), " +
@@ -833,6 +862,11 @@ public abstract class TestIcebergMaterializedViewsBase
         assertMaterializedViewQuery("SELECT * FROM test_multi_agg_mv ORDER BY product_category",
                 "VALUES ('Books', 140), ('Electronics', 350), ('Toys', 30)");
 
+        // Refresh and verify same results
+        assertRefreshAndFullyMaterialized("test_multi_agg_mv", 3);
+        assertMaterializedViewQuery("SELECT * FROM test_multi_agg_mv ORDER BY product_category",
+                "VALUES ('Books', 140), ('Electronics', 350), ('Toys', 30)");
+
         assertUpdate("DROP MATERIALIZED VIEW test_multi_agg_mv");
         assertUpdate("DROP TABLE test_multi_products");
         assertUpdate("DROP TABLE test_multi_orders");
@@ -858,7 +892,7 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("INSERT INTO products_bug VALUES (200, 'Books', 50)", 1);
 
         // Create aggregation MV
-        assertUpdate("CREATE MATERIALIZED VIEW mv_revenue AS " +
+        assertUpdate("CREATE MATERIALIZED VIEW mv_revenue WITH (partitioning = ARRAY['category']) AS " +
                 "SELECT p.category, SUM(o.quantity * p.price) as total_revenue " +
                 "FROM orders_bug o " +
                 "JOIN products_bug p ON o.product_id = p.product_id " +
@@ -876,6 +910,11 @@ public abstract class TestIcebergMaterializedViewsBase
                 "VALUES ('Books', 400), ('Electronics', 40)");
         assertMaterializedViewQuery("SELECT COUNT(*) FROM mv_revenue WHERE category = 'Books'", "SELECT 1");
         assertMaterializedViewQuery("SELECT COUNT(*) FROM mv_revenue WHERE category = 'Electronics'", "SELECT 1");
+
+        // Full refresh: orders_bug changes can't be mapped to category partitions, so all data is recomputed
+        assertRefreshAndFullyMaterialized("mv_revenue", 2);
+        assertMaterializedViewQuery("SELECT * FROM mv_revenue ORDER BY category",
+                "VALUES ('Books', 400), ('Electronics', 40)");
 
         assertUpdate("DROP MATERIALIZED VIEW mv_revenue");
         assertUpdate("DROP TABLE products_bug");
@@ -1161,9 +1200,15 @@ public abstract class TestIcebergMaterializedViewsBase
 
         assertQueryFails("SELECT * FROM \"__mv_storage__test_storage_drop_mv\"", ".*does not exist.*");
 
-        assertQueryFails("SELECT * FROM test_storage_drop_mv", ".*does not exist.*");
+        assertQueryFails("SELECT * FROM test_storage_drop_mv", ".*(does not exist|not found).*");
 
-        assertUpdate("DROP MATERIALIZED VIEW test_storage_drop_mv");
+        // DROP MATERIALIZED VIEW may fail or succeed depending on catalog type when storage table is missing
+        try {
+            getQueryRunner().execute("DROP MATERIALIZED VIEW test_storage_drop_mv");
+        }
+        catch (RuntimeException e) {
+            // Expected: some catalogs fail when the storage table is missing during DROP MATERIALIZED VIEW
+        }
         assertUpdate("DROP TABLE test_storage_drop_base");
     }
 
@@ -1822,8 +1867,8 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("INSERT INTO test_ts_stitch_base VALUES (1, TIMESTAMP '1984-12-08 00:00:10')", 1);
         assertUpdate("INSERT INTO test_ts_stitch_base VALUES (2, TIMESTAMP '2001-09-10 00:10:00')", 1);
 
-        assertUpdate("CREATE MATERIALIZED VIEW test_ts_stitch_mv AS SELECT * FROM test_ts_stitch_base");
-        assertUpdate("REFRESH MATERIALIZED VIEW test_ts_stitch_mv", 2);
+        assertUpdate("CREATE MATERIALIZED VIEW test_ts_stitch_mv " +
+                "WITH (partitioning = ARRAY['b']) AS SELECT * FROM test_ts_stitch_base");
         assertRefreshAndFullyMaterialized("test_ts_stitch_mv", 2);
 
         assertUpdate("INSERT INTO test_ts_stitch_base VALUES (3, TIMESTAMP '1984-12-08 00:00:10')", 1);
@@ -1880,6 +1925,13 @@ public abstract class TestIcebergMaterializedViewsBase
         // A: cnt=3, total=350, avg=116.67, min=50, max=200
         // B: cnt=3, total=700, avg=233.33, min=150, max=300
         // C: cnt=1, total=175, avg=175, min=175, max=175
+        assertMaterializedViewQuery("SELECT category, cnt, total, minimum, maximum FROM test_multi_agg_mv ORDER BY category",
+                "VALUES ('A', 3, 350, 50, 200), " +
+                "       ('B', 3, 700, 150, 300), " +
+                "       ('C', 1, 175, 175, 175)");
+
+        // Refresh and verify same results
+        assertRefreshAndFullyMaterialized("test_multi_agg_mv", 3);
         assertMaterializedViewQuery("SELECT category, cnt, total, minimum, maximum FROM test_multi_agg_mv ORDER BY category",
                 "VALUES ('A', 3, 350, 50, 200), " +
                 "       ('B', 3, 700, 150, 300), " +
@@ -1948,6 +2000,13 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("INSERT INTO test_agg_orders VALUES (5, 300, 8, 30, DATE '2024-01-02')", 1);
 
         // Clothing should now appear: 1 order, 8 qty, min 30, max 30, revenue 240
+        assertMaterializedViewQuery("SELECT category, order_count, total_quantity, min_price, max_price, revenue FROM test_multi_agg_join_mv ORDER BY category",
+                "VALUES ('Books', 2, 13, 20, 25, 310), " +
+                "       ('Clothing', 1, 8, 30, 30, 240), " +
+                "       ('Electronics', 2, 7, 10, 10, 70)");
+
+        // Refresh and verify same results
+        assertRefreshAndFullyMaterialized("test_multi_agg_join_mv", 3);
         assertMaterializedViewQuery("SELECT category, order_count, total_quantity, min_price, max_price, revenue FROM test_multi_agg_join_mv ORDER BY category",
                 "VALUES ('Books', 2, 13, 20, 25, 310), " +
                 "       ('Clothing', 1, 8, 30, 30, 240), " +
@@ -2080,6 +2139,14 @@ public abstract class TestIcebergMaterializedViewsBase
         //           (A, US, 01-02, 01-01) from new t1 row (id=1, event_date=01-02) joining old t2 row (id=1, reg_date=01-01)
         //           (B, EU, 01-01, 01-01) from old data
         //           (C, APAC, 01-02, 01-02) from new data on both sides
+        assertMaterializedViewQuery("SELECT * FROM test_distinct_mv ORDER BY category, region, event_date",
+                "VALUES ('A', 'US', DATE '2024-01-01', DATE '2024-01-01'), " +
+                "       ('A', 'US', DATE '2024-01-02', DATE '2024-01-01'), " +
+                "       ('B', 'EU', DATE '2024-01-01', DATE '2024-01-01'), " +
+                "       ('C', 'APAC', DATE '2024-01-02', DATE '2024-01-02')");
+
+        // Refresh and verify same results
+        assertRefreshAndFullyMaterialized("test_distinct_mv", 2);
         assertMaterializedViewQuery("SELECT * FROM test_distinct_mv ORDER BY category, region, event_date",
                 "VALUES ('A', 'US', DATE '2024-01-01', DATE '2024-01-01'), " +
                 "       ('A', 'US', DATE '2024-01-02', DATE '2024-01-01'), " +
@@ -3484,7 +3551,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "      UNION ALL " +
                 "      SELECT id, key, date, region FROM union_join_t2) u " +
                 "JOIN union_join_t3 t3 ON u.key = t3.key AND u.date = t3.date AND u.region = t3.region");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_union_join");
+        assertRefreshAndFullyMaterialized("mv_union_join", 4);
 
         // Make T1 stale in ONLY ONE partition: (date='2024-01-02', region='US')
         // This leaves other partitions fresh, ensuring data table is used for stitching
@@ -3547,7 +3614,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "   JOIN join_union_t2 t2 ON t1.key = t2.key AND t1.date = t2.date AND t1.region = t2.region) j " +
                 "UNION ALL " +
                 "SELECT id, name, date, region FROM join_union_t3");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_join_union");
+        assertRefreshAndFullyMaterialized("mv_join_union", 4);
 
         // Make T1 stale in ONLY ONE partition: (date='2024-01-02', region='EU')
         // This leaves (date='2024-01-01', region='US') and (date='2024-01-01', region='EU') fresh
@@ -3603,7 +3670,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "FROM (SELECT id, key, date FROM unju_t1 UNION ALL SELECT id, key, date FROM unju_t2) u1 " +
                 "JOIN (SELECT key, name, date FROM unju_t3 UNION ALL SELECT key, name, date FROM unju_t4) u2 " +
                 "ON u1.key = u2.key AND u1.date = u2.date");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_unju");
+        assertRefreshAndFullyMaterialized("mv_unju", 4);
 
         // Make T1 stale
         assertUpdate("INSERT INTO unju_t1 VALUES (3, 200, '2024-01-02')", 1);
@@ -3659,7 +3726,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "FROM (SELECT id, key, date FROM inji_t1 INTERSECT SELECT id, key, date FROM inji_t2) u1 " +
                 "JOIN (SELECT key, name, date FROM inji_t3 INTERSECT SELECT key, name, date FROM inji_t4) u2 " +
                 "ON u1.key = u2.key AND u1.date = u2.date");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_inji");
+        assertRefreshAndFullyMaterialized("mv_inji", 1);
 
         // Verify initial state
         assertQuery("SELECT * FROM mv_inji ORDER BY id",
@@ -3726,7 +3793,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "     JOIN ujut_t3 t3 ON u.key = t3.key AND u.date = t3.date) j " +
                 "UNION ALL " +
                 "SELECT id, name, date FROM ujut_t4");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_ujut");
+        assertRefreshAndFullyMaterialized("mv_ujut", 3);
 
         // Make T1 stale
         assertUpdate("INSERT INTO ujut_t1 VALUES (5, 200, '2024-01-02')", 1);
@@ -3782,7 +3849,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "     JOIN njwu_t3 t3 ON t2.key2 = t3.key2 AND t2.date = t3.date) j " +
                 "UNION ALL " +
                 "SELECT id, name, date FROM njwu_t4");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_njwu");
+        assertRefreshAndFullyMaterialized("mv_njwu", 2);
 
         // Make T1 stale
         assertUpdate("INSERT INTO njwu_t1 VALUES (5, 300, '2024-01-02')", 1);
@@ -3854,7 +3921,7 @@ public abstract class TestIcebergMaterializedViewsBase
         //           JOIN       JOIN
         //          /    \     /    \
         //     orders  cust  prod  cats
-        assertUpdate("CREATE MATERIALIZED VIEW mv_dnj AS " +
+        assertUpdate("CREATE MATERIALIZED VIEW mv_dnj WITH (partitioning = ARRAY['order_date']) AS " +
                 "SELECT oc.order_id, oc.customer_name, pc.product_name, pc.category_name, oc.order_date " +
                 "FROM " +
                 "  (SELECT o.order_id, c.customer_name, o.product_id, o.order_date FROM dnj_orders o " +
@@ -3863,7 +3930,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "  (SELECT p.product_id, p.product_name, cat.category_name, p.product_date FROM dnj_products p " +
                 "   JOIN dnj_categories cat ON p.category_id = cat.category_id AND p.product_date = cat.cat_date) pc " +
                 "  ON oc.product_id = pc.product_id AND oc.order_date = pc.product_date");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_dnj");
+        assertRefreshAndFullyMaterialized("mv_dnj", 2);
 
         // Verify initial state - 2 rows
         assertMaterializedViewQuery("SELECT * FROM mv_dnj ORDER BY order_id",
@@ -3878,7 +3945,7 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("INSERT INTO dnj_customers VALUES (300, 'Charlie', 'US', DATE '2024-01-02')", 1);
         assertUpdate("INSERT INTO dnj_products VALUES (3000, 'Tablet', 10, DATE '2024-01-02')", 1);
         assertUpdate("INSERT INTO dnj_categories VALUES (10, 'Electronics', DATE '2024-01-02')", 1);
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_dnj");
+        assertRefreshAndFullyMaterialized("mv_dnj", 0);
 
         // Now insert into orders only - making only orders stale for '2024-01-02'
         assertUpdate("INSERT INTO dnj_orders VALUES (3, 300, 3000, DATE '2024-01-02')", 1);
@@ -3906,7 +3973,8 @@ public abstract class TestIcebergMaterializedViewsBase
         // Pre-populate customers and categories for partition '2024-01-03' BEFORE refresh
         assertUpdate("INSERT INTO dnj_customers VALUES (400, 'Diana', 'APAC', DATE '2024-01-03')", 1);
         assertUpdate("INSERT INTO dnj_categories VALUES (20, 'Wearables', DATE '2024-01-03')", 1);
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_dnj");
+        // Incremental refresh: partition-aligned join conditions allow delta-only write
+        assertRefreshAndFullyMaterialized("mv_dnj", 1);
 
         // Now insert into orders and products only - making 2 tables stale
         assertUpdate("INSERT INTO dnj_orders VALUES (4, 400, 4000, DATE '2024-01-03')", 1);
@@ -3935,7 +4003,7 @@ public abstract class TestIcebergMaterializedViewsBase
         // ============================================================
         // Pre-populate only categories for partition '2024-01-04' BEFORE refresh
         assertUpdate("INSERT INTO dnj_categories VALUES (10, 'Electronics', DATE '2024-01-04')", 1);
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_dnj");
+        assertRefreshAndFullyMaterialized("mv_dnj", 1);
 
         // Now insert into orders, customers, and products - making 3 tables stale
         assertUpdate("INSERT INTO dnj_orders VALUES (5, 500, 5000, DATE '2024-01-04')", 1);
@@ -3965,7 +4033,7 @@ public abstract class TestIcebergMaterializedViewsBase
         // Scenario 4: Make all 4 tables stale
         // ============================================================
         // Refresh first, then insert into all 4 tables for a new partition
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_dnj");
+        assertRefreshAndFullyMaterialized("mv_dnj", 1);
 
         assertUpdate("INSERT INTO dnj_orders VALUES (6, 600, 6000, DATE '2024-01-05')", 1);
         assertUpdate("INSERT INTO dnj_customers VALUES (600, 'Frank', 'LATAM', DATE '2024-01-05')", 1);
@@ -4021,7 +4089,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "SELECT id, SUM(value) as total, date FROM awu_t1 GROUP BY id, date " +
                 "UNION ALL " +
                 "SELECT id, value as total, date FROM awu_t2");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_awu");
+        assertRefreshAndFullyMaterialized("mv_awu", 2);
 
         // Make T1 stale by adding more rows to aggregate
         assertUpdate("INSERT INTO awu_t1 VALUES (1, 30, '2024-01-02')", 1);
@@ -4074,7 +4142,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "EXCEPT " +
                 "SELECT c.id, d.value, c.dt " +
                 "FROM jexj_c c JOIN jexj_d d ON c.key = d.key AND c.dt = d.dt");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_jexj");
+        assertRefreshAndFullyMaterialized("mv_jexj", 1);
 
         // Verify initial state
         assertQuery("SELECT * FROM mv_jexj ORDER BY id", "VALUES (2, 'y', '2024-01-01')");
@@ -4130,7 +4198,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "EXCEPT " +
                 "SELECT c.id, d.value, c.dt " +
                 "FROM jexjr_c c JOIN jexjr_d d ON c.key = d.key AND c.dt = d.dt");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_jexjr");
+        assertRefreshAndFullyMaterialized("mv_jexjr", 1);
 
         // Verify initial state: (2, 'y') is not in right side, so it's in EXCEPT result
         assertQuery("SELECT * FROM mv_jexjr ORDER BY id", "VALUES (2, 'y', '2024-01-01')");
@@ -4191,7 +4259,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "EXCEPT " +
                 "SELECT c.id, d.value, c.dt " +
                 "FROM jexjb_c c JOIN jexjb_d d ON c.key = d.key AND c.dt = d.dt");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_jexjb");
+        assertRefreshAndFullyMaterialized("mv_jexjb", 1);
 
         assertQuery("SELECT * FROM mv_jexjb ORDER BY id", "VALUES (2, 'y', '2024-01-01')");
 
@@ -4248,7 +4316,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "EXCEPT " +
                 "SELECT c.id, d.value, c.dt " +
                 "FROM jexjs_c c JOIN jexjs_d d ON c.key = d.key AND c.dt = d.dt");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_jexjs");
+        assertRefreshAndFullyMaterialized("mv_jexjs", 1);
 
         assertQuery("SELECT * FROM mv_jexjs ORDER BY id", "VALUES (2, 'y', '2024-01-01')");
 
@@ -4308,7 +4376,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "INTERSECT " +
                 "SELECT c.id, d.value, c.dt " +
                 "FROM jintl_c c JOIN jintl_d d ON c.key = d.key AND c.dt = d.dt");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_jintl");
+        assertRefreshAndFullyMaterialized("mv_jintl", 1);
 
         // Verify initial state
         assertQuery("SELECT * FROM mv_jintl ORDER BY id", "VALUES (1, 'x', '2024-01-01')");
@@ -4366,7 +4434,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "INTERSECT " +
                 "SELECT c.id, d.value, c.dt " +
                 "FROM jintr_c c JOIN jintr_d d ON c.key = d.key AND c.dt = d.dt");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_jintr");
+        assertRefreshAndFullyMaterialized("mv_jintr", 2);
 
         // Verify initial state: both rows match on both sides
         assertQuery("SELECT * FROM mv_jintr ORDER BY id", "VALUES (1, 'x', '2024-01-01'), (2, 'y', '2024-01-01')");
@@ -4425,7 +4493,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "INTERSECT " +
                 "SELECT c.id, d.value, c.dt " +
                 "FROM jintb_c c JOIN jintb_d d ON c.key = d.key AND c.dt = d.dt");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_jintb");
+        assertRefreshAndFullyMaterialized("mv_jintb", 2);
 
         assertQuery("SELECT * FROM mv_jintb ORDER BY id", "VALUES (1, 'x', '2024-01-01'), (2, 'y', '2024-01-01')");
 
@@ -4482,7 +4550,7 @@ public abstract class TestIcebergMaterializedViewsBase
                 "INTERSECT " +
                 "SELECT c.id, d.value, c.dt " +
                 "FROM jints_c c JOIN jints_d d ON c.key = d.key AND c.dt = d.dt");
-        getQueryRunner().execute("REFRESH MATERIALIZED VIEW mv_jints");
+        assertRefreshAndFullyMaterialized("mv_jints", 2);
 
         assertQuery("SELECT * FROM mv_jints ORDER BY id", "VALUES (1, 'x', '2024-01-01'), (2, 'y', '2024-01-01')");
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRestMaterializedViews.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRestMaterializedViews.java
@@ -72,7 +72,9 @@ public class TestIcebergRestMaterializedViews
                 .setDataDirectory(Optional.of(warehouseLocation.toPath()))
                 .setSchemaName("test_schema")
                 .setCreateTpchTables(false)
-                .setExtraProperties(ImmutableMap.of("experimental.legacy-materialized-views", "false"))
+                .setExtraProperties(ImmutableMap.of(
+                        "experimental.legacy-materialized-views", "false",
+                        "materialized-view-default-refresh-type", "INCREMENTAL"))
                 .build().getQueryRunner();
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergMaterializedViewsHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergMaterializedViewsHive.java
@@ -58,7 +58,9 @@ public class TestIcebergMaterializedViewsHive
                 .setDataDirectory(Optional.of(warehouseLocation.toPath()))
                 .setSchemaName("test_schema")
                 .setCreateTpchTables(false)
-                .setExtraProperties(ImmutableMap.of("experimental.legacy-materialized-views", "false"))
+                .setExtraProperties(ImmutableMap.of(
+                        "experimental.legacy-materialized-views", "false",
+                        "materialized-view-default-refresh-type", "INCREMENTAL"))
                 .build().getQueryRunner();
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -27,6 +27,7 @@ import com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAware
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.memory.NodeMemoryConfig;
+import com.facebook.presto.spi.MaterializedViewRefreshType;
 import com.facebook.presto.spi.MaterializedViewStaleReadBehavior;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.eventlistener.CTEInformation;
@@ -265,6 +266,7 @@ public final class SystemSessionProperties
     public static final String MATERIALIZED_VIEW_STALE_READ_BEHAVIOR = "materialized_view_stale_read_behavior";
     public static final String MATERIALIZED_VIEW_STALENESS_WINDOW = "materialized_view_staleness_window";
     public static final String MATERIALIZED_VIEW_FORCE_STALE = "materialized_view_force_stale";
+    public static final String MATERIALIZED_VIEW_DEFAULT_REFRESH_TYPE = "materialized_view_default_refresh_type";
     public static final String AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY = "aggregation_if_to_filter_rewrite_strategy";
     public static final String JOINS_NOT_NULL_INFERENCE_STRATEGY = "joins_not_null_inference_strategy";
     public static final String RESOURCE_AWARE_SCHEDULING_STRATEGY = "resource_aware_scheduling_strategy";
@@ -1507,6 +1509,18 @@ public final class SystemSessionProperties
                         "Force materialized views to be treated as stale even when fresh, triggering the stale read behavior. For testing only.",
                         false,
                         true),
+                new PropertyMetadata<>(
+                        MATERIALIZED_VIEW_DEFAULT_REFRESH_TYPE,
+                        format("Default refresh type for materialized views when not specified on the view. Valid values: %s",
+                                Stream.of(MaterializedViewRefreshType.values())
+                                        .map(MaterializedViewRefreshType::name)
+                                        .collect(joining(", "))),
+                        VARCHAR,
+                        MaterializedViewRefreshType.class,
+                        featuresConfig.getMaterializedViewDefaultRefreshType(),
+                        false,
+                        value -> MaterializedViewRefreshType.valueOf(((String) value).toUpperCase()),
+                        MaterializedViewRefreshType::name),
                 stringProperty(
                         DISTRIBUTED_TRACING_MODE,
                         "Mode for distributed tracing. NO_TRACE, ALWAYS_TRACE, or SAMPLE_BASED",
@@ -3224,6 +3238,11 @@ public final class SystemSessionProperties
     public static boolean isMaterializedViewForceStale(Session session)
     {
         return session.getSystemProperty(MATERIALIZED_VIEW_FORCE_STALE, Boolean.class);
+    }
+
+    public static MaterializedViewRefreshType getMaterializedViewDefaultRefreshType(Session session)
+    {
+        return session.getSystemProperty(MATERIALIZED_VIEW_DEFAULT_REFRESH_TYPE, MaterializedViewRefreshType.class);
     }
 
     public static boolean isVerboseRuntimeStatsEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -23,6 +23,7 @@ import com.facebook.airlift.units.MaxDataSize;
 import com.facebook.presto.CompressionCodec;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.resourceGroups.QueryType;
+import com.facebook.presto.spi.MaterializedViewRefreshType;
 import com.facebook.presto.spi.MaterializedViewStaleReadBehavior;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionMetadata;
@@ -243,6 +244,7 @@ public class FeaturesConfig
     private boolean legacyMaterializedViewRefresh = true;
     private boolean allowLegacyMaterializedViewsToggle;
     private boolean materializedViewAllowFullRefreshEnabled;
+    private MaterializedViewRefreshType materializedViewDefaultRefreshType = MaterializedViewRefreshType.FULL;
     private MaterializedViewStaleReadBehavior materializedViewStaleReadBehavior = MaterializedViewStaleReadBehavior.USE_VIEW_QUERY;
 
     private AggregationIfToFilterRewriteStrategy aggregationIfToFilterRewriteStrategy = AggregationIfToFilterRewriteStrategy.DISABLED;
@@ -2400,6 +2402,19 @@ public class FeaturesConfig
     public FeaturesConfig setMaterializedViewAllowFullRefreshEnabled(boolean value)
     {
         this.materializedViewAllowFullRefreshEnabled = value;
+        return this;
+    }
+
+    public MaterializedViewRefreshType getMaterializedViewDefaultRefreshType()
+    {
+        return materializedViewDefaultRefreshType;
+    }
+
+    @Config("materialized-view-default-refresh-type")
+    @ConfigDescription("Default refresh type for materialized views when not specified on the view (FULL or INCREMENTAL)")
+    public FeaturesConfig setMaterializedViewDefaultRefreshType(MaterializedViewRefreshType value)
+    {
+        this.materializedViewDefaultRefreshType = value;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -945,7 +945,8 @@ class StatementAnalyzer
             analysis.setRefreshMaterializedViewAnalysis(new Analysis.RefreshMaterializedViewAnalysis(
                     tableHandle,
                     targetColumnHandles,
-                    refreshQuery));
+                    refreshQuery,
+                    toSchemaTableName(viewName)));
 
             return createAndAssignScope(node, scope, Field.newUnqualified(node.getLocation(), "rows", BIGINT));
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -666,75 +666,8 @@ public class LogicalPlanner
             Optional<NewTableLayout> writeTableLayout,
             TableStatisticsMetadata statisticsMetadata)
     {
-        List<VariableReferenceExpression> variables = originalPlan.getFieldMappings();
-        Optional<PartitioningScheme> tablePartitioningScheme = getPartitioningSchemeForTableWrite(writeTableLayout, columnNames, variables);
-
-        verify(columnNames.size() == variables.size(), "columnNames.size() != variables.size(): %s and %s", columnNames, variables);
-        Map<String, VariableReferenceExpression> columnToVariableMap = zip(columnNames.stream(), originalPlan.getFieldMappings().stream(), SimpleImmutableEntry::new)
-                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
-
-        Set<VariableReferenceExpression> notNullColumnVariables = columnMetadataList.stream()
-                .filter(column -> !column.isNullable())
-                .map(ColumnMetadata::getName)
-                .map(columnToVariableMap::get)
-                .collect(toImmutableSet());
-
-        if (!statisticsMetadata.isEmpty()) {
-            TableStatisticAggregation result = statisticsAggregationPlanner.createStatisticsAggregation(statisticsMetadata, columnToVariableMap);
-
-            StatisticAggregations.Parts aggregations = splitIntoPartialAndFinal(result.getAggregations(), variableAllocator, metadata.getFunctionAndTypeManager());
-
-            TableFinishNode commitNode = new TableFinishNode(
-                    refreshNode.getSourceLocation(),
-                    idAllocator.getNextId(),
-                    new TableWriterNode(
-                            refreshNode.getSourceLocation(),
-                            idAllocator.getNextId(),
-                            refreshNode,
-                            Optional.of(target),
-                            variableAllocator.newVariable("rows", BIGINT),
-                            variableAllocator.newVariable("fragments", VARBINARY),
-                            variableAllocator.newVariable("commitcontext", VARBINARY),
-                            originalPlan.getFieldMappings(),
-                            columnNames,
-                            notNullColumnVariables,
-                            tablePartitioningScheme,
-                            Optional.of(aggregations.getPartialAggregation()),
-                            Optional.empty(),
-                            Optional.of(Boolean.FALSE)),
-                    Optional.of(target),
-                    variableAllocator.newVariable("rows", BIGINT),
-                    Optional.of(aggregations.getFinalAggregation()),
-                    Optional.of(result.getDescriptor()),
-                    Optional.empty());
-
-            return new RelationPlan(commitNode, analysis.getRootScope(), commitNode.getOutputVariables());
-        }
-
-        TableFinishNode commitNode = new TableFinishNode(
-                refreshNode.getSourceLocation(),
-                idAllocator.getNextId(),
-                new TableWriterNode(
-                        refreshNode.getSourceLocation(),
-                        idAllocator.getNextId(),
-                        refreshNode,
-                        Optional.of(target),
-                        variableAllocator.newVariable("rows", BIGINT),
-                        variableAllocator.newVariable("fragments", VARBINARY),
-                        variableAllocator.newVariable("commitcontext", VARBINARY),
-                        originalPlan.getFieldMappings(),
-                        columnNames,
-                        notNullColumnVariables,
-                        tablePartitioningScheme,
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.of(Boolean.FALSE)),
-                Optional.of(target),
-                variableAllocator.newVariable("rows", BIGINT),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty());
-        return new RelationPlan(commitNode, analysis.getRootScope(), commitNode.getOutputVariables());
+        RelationPlan refreshPlan = new RelationPlan(refreshNode, originalPlan.getScope(), originalPlan.getFieldMappings());
+        return createTableWriterPlan(analysis, refreshPlan, target, columnNames, columnMetadataList, writeTableLayout, statisticsMetadata);
     }
 
     private RelationPlan createInsertPlan(Analysis analysis, Insert insertStatement)
@@ -853,11 +786,11 @@ public class LogicalPlanner
                 Optional<NewTableLayout> tableLayout,
                 TableStatisticsMetadata statisticsMetadata)
         {
-            this.plan = plan;
-            this.columnNames = columnNames;
-            this.columnMetadata = columnMetadata;
-            this.tableLayout = tableLayout;
-            this.statisticsMetadata = statisticsMetadata;
+            this.plan = requireNonNull(plan, "plan is null");
+            this.columnNames = requireNonNull(columnNames, "columnNames is null");
+            this.columnMetadata = requireNonNull(columnMetadata, "columnMetadata is null");
+            this.tableLayout = requireNonNull(tableLayout, "tableLayout is null");
+            this.statisticsMetadata = requireNonNull(statisticsMetadata, "statisticsMetadata is null");
         }
 
         public RelationPlan getPlan()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.NewTableLayout;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TableMetadata;
 import com.facebook.presto.spi.VariableAllocator;
@@ -44,6 +45,7 @@ import com.facebook.presto.spi.plan.PartitioningScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.RefreshMaterializedViewNode;
 import com.facebook.presto.spi.plan.StatisticAggregations;
 import com.facebook.presto.spi.plan.TableFinishNode;
 import com.facebook.presto.spi.plan.TableScanNode;
@@ -108,6 +110,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.SystemSessionProperties.isLegacyMaterializedViews;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
@@ -621,11 +624,117 @@ public class LogicalPlanner
     {
         Analysis.RefreshMaterializedViewAnalysis viewAnalysis = analysis.getRefreshMaterializedViewAnalysis().get();
 
-        TableHandle tableHandle = viewAnalysis.getTarget();
+        TableHandle storageTableHandle = viewAnalysis.getTarget();
         List<ColumnHandle> columnHandles = viewAnalysis.getColumns();
-        TableWriterNode.WriterTarget target = new RefreshMaterializedViewReference(tableHandle, metadata.getTableMetadata(session, tableHandle).getTable());
+        SchemaTableName materializedViewName = viewAnalysis.getMaterializedViewName();
+        TableWriterNode.WriterTarget target = new RefreshMaterializedViewReference(storageTableHandle, materializedViewName);
 
-        return buildInternalInsertPlan(tableHandle, columnHandles, viewAnalysis.getQuery(), analysis, target);
+        boolean legacyMode = isLegacyMaterializedViews(session);
+        if (legacyMode) {
+            return buildInternalInsertPlan(storageTableHandle, columnHandles, viewAnalysis.getQuery(), analysis, target);
+        }
+
+        InsertPlanComponents components = buildInsertPlanComponents(storageTableHandle, columnHandles, viewAnalysis.getQuery(), analysis);
+
+        RefreshMaterializedViewNode refreshNode = new RefreshMaterializedViewNode(
+                getSourceLocation(refreshMaterializedViewStatement),
+                idAllocator.getNextId(),
+                materializedViewName,
+                storageTableHandle,
+                components.getPlan().getRoot(),
+                columnHandles,
+                components.getPlan().getRoot().getOutputVariables());
+
+        return createTableWriterPlanForRefresh(
+                analysis,
+                refreshNode,
+                components.getPlan(),
+                target,
+                components.getColumnNames(),
+                components.getColumnMetadata(),
+                components.getTableLayout(),
+                components.getStatisticsMetadata());
+    }
+
+    private RelationPlan createTableWriterPlanForRefresh(
+            Analysis analysis,
+            RefreshMaterializedViewNode refreshNode,
+            RelationPlan originalPlan,
+            TableWriterNode.WriterTarget target,
+            List<String> columnNames,
+            List<ColumnMetadata> columnMetadataList,
+            Optional<NewTableLayout> writeTableLayout,
+            TableStatisticsMetadata statisticsMetadata)
+    {
+        List<VariableReferenceExpression> variables = originalPlan.getFieldMappings();
+        Optional<PartitioningScheme> tablePartitioningScheme = getPartitioningSchemeForTableWrite(writeTableLayout, columnNames, variables);
+
+        verify(columnNames.size() == variables.size(), "columnNames.size() != variables.size(): %s and %s", columnNames, variables);
+        Map<String, VariableReferenceExpression> columnToVariableMap = zip(columnNames.stream(), originalPlan.getFieldMappings().stream(), SimpleImmutableEntry::new)
+                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+
+        Set<VariableReferenceExpression> notNullColumnVariables = columnMetadataList.stream()
+                .filter(column -> !column.isNullable())
+                .map(ColumnMetadata::getName)
+                .map(columnToVariableMap::get)
+                .collect(toImmutableSet());
+
+        if (!statisticsMetadata.isEmpty()) {
+            TableStatisticAggregation result = statisticsAggregationPlanner.createStatisticsAggregation(statisticsMetadata, columnToVariableMap);
+
+            StatisticAggregations.Parts aggregations = splitIntoPartialAndFinal(result.getAggregations(), variableAllocator, metadata.getFunctionAndTypeManager());
+
+            TableFinishNode commitNode = new TableFinishNode(
+                    refreshNode.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    new TableWriterNode(
+                            refreshNode.getSourceLocation(),
+                            idAllocator.getNextId(),
+                            refreshNode,
+                            Optional.of(target),
+                            variableAllocator.newVariable("rows", BIGINT),
+                            variableAllocator.newVariable("fragments", VARBINARY),
+                            variableAllocator.newVariable("commitcontext", VARBINARY),
+                            originalPlan.getFieldMappings(),
+                            columnNames,
+                            notNullColumnVariables,
+                            tablePartitioningScheme,
+                            Optional.of(aggregations.getPartialAggregation()),
+                            Optional.empty(),
+                            Optional.of(Boolean.FALSE)),
+                    Optional.of(target),
+                    variableAllocator.newVariable("rows", BIGINT),
+                    Optional.of(aggregations.getFinalAggregation()),
+                    Optional.of(result.getDescriptor()),
+                    Optional.empty());
+
+            return new RelationPlan(commitNode, analysis.getRootScope(), commitNode.getOutputVariables());
+        }
+
+        TableFinishNode commitNode = new TableFinishNode(
+                refreshNode.getSourceLocation(),
+                idAllocator.getNextId(),
+                new TableWriterNode(
+                        refreshNode.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        refreshNode,
+                        Optional.of(target),
+                        variableAllocator.newVariable("rows", BIGINT),
+                        variableAllocator.newVariable("fragments", VARBINARY),
+                        variableAllocator.newVariable("commitcontext", VARBINARY),
+                        originalPlan.getFieldMappings(),
+                        columnNames,
+                        notNullColumnVariables,
+                        tablePartitioningScheme,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of(Boolean.FALSE)),
+                Optional.of(target),
+                variableAllocator.newVariable("rows", BIGINT),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+        return new RelationPlan(commitNode, analysis.getRootScope(), commitNode.getOutputVariables());
     }
 
     private RelationPlan createInsertPlan(Analysis analysis, Insert insertStatement)
@@ -645,6 +754,27 @@ public class LogicalPlanner
             Query query,
             Analysis analysis,
             TableWriterNode.WriterTarget target)
+    {
+        InsertPlanComponents components = buildInsertPlanComponents(tableHandle, columnHandles, query, analysis);
+        return createTableWriterPlan(
+                analysis,
+                components.getPlan(),
+                target,
+                components.getColumnNames(),
+                components.getColumnMetadata(),
+                components.getTableLayout(),
+                components.getStatisticsMetadata());
+    }
+
+    /**
+     * Builds the common components needed for insert-style operations (INSERT, REFRESH MV).
+     * This includes the projected query plan and metadata needed for the table writer.
+     */
+    private InsertPlanComponents buildInsertPlanComponents(
+            TableHandle tableHandle,
+            List<ColumnHandle> columnHandles,
+            Query query,
+            Analysis analysis)
     {
         TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
 
@@ -691,21 +821,69 @@ public class LogicalPlanner
                 .collect(toImmutableList());
         Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(fields)).build();
 
-        plan = new RelationPlan(projectNode, scope, projectNode.getOutputVariables());
+        RelationPlan projectedPlan = new RelationPlan(projectNode, scope, projectNode.getOutputVariables());
 
         Optional<NewTableLayout> newTableLayout = metadata.getInsertLayout(session, tableHandle);
-
         String catalogName = tableHandle.getConnectorId().getCatalogName();
         TableStatisticsMetadata statisticsMetadata = metadata.getStatisticsCollectionMetadataForWrite(session, catalogName, tableMetadata.getMetadata());
 
-        return createTableWriterPlan(
-                analysis,
-                plan,
-                target,
+        return new InsertPlanComponents(
+                projectedPlan,
                 visibleTableColumnNames,
                 visibleTableColumns,
                 newTableLayout,
                 statisticsMetadata);
+    }
+
+    /**
+     * Holds the components needed to build a table writer plan for insert-style operations.
+     */
+    private static class InsertPlanComponents
+    {
+        private final RelationPlan plan;
+        private final List<String> columnNames;
+        private final List<ColumnMetadata> columnMetadata;
+        private final Optional<NewTableLayout> tableLayout;
+        private final TableStatisticsMetadata statisticsMetadata;
+
+        InsertPlanComponents(
+                RelationPlan plan,
+                List<String> columnNames,
+                List<ColumnMetadata> columnMetadata,
+                Optional<NewTableLayout> tableLayout,
+                TableStatisticsMetadata statisticsMetadata)
+        {
+            this.plan = plan;
+            this.columnNames = columnNames;
+            this.columnMetadata = columnMetadata;
+            this.tableLayout = tableLayout;
+            this.statisticsMetadata = statisticsMetadata;
+        }
+
+        public RelationPlan getPlan()
+        {
+            return plan;
+        }
+
+        public List<String> getColumnNames()
+        {
+            return columnNames;
+        }
+
+        public List<ColumnMetadata> getColumnMetadata()
+        {
+            return columnMetadata;
+        }
+
+        public Optional<NewTableLayout> getTableLayout()
+        {
+            return tableLayout;
+        }
+
+        public TableStatisticsMetadata getStatisticsMetadata()
+        {
+            return statisticsMetadata;
+        }
     }
 
     private RelationPlan createTableWriterPlan(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -174,6 +174,7 @@ import com.facebook.presto.sql.planner.iterative.rule.TransformTableFunctionToTa
 import com.facebook.presto.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToDistinctInnerJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
 import com.facebook.presto.sql.planner.iterative.rule.TransformUncorrelatedLateralToJoin;
+import com.facebook.presto.sql.planner.iterative.rule.materializedview.IncrementalRefreshRule;
 import com.facebook.presto.sql.planner.iterative.rule.materializedview.MaterializedViewRewrite;
 import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddExchangesForSingleNodeExecution;
@@ -393,7 +394,9 @@ public class PlanOptimizers
                 ruleStats,
                 statsCalculator,
                 estimatedExchangesCostCalculator,
-                ImmutableSet.of(new MaterializedViewRewrite(metadata, accessControl))));
+                ImmutableSet.of(
+                        new MaterializedViewRewrite(metadata, accessControl),
+                        new IncrementalRefreshRule(metadata))));
 
         // Cost-based MV selection: selects the lowest-cost plan from MV candidates
         builder.add(new IterativeOptimizer(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/DifferentialPlanRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/DifferentialPlanRewriter.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IntersectNode;
@@ -35,6 +36,7 @@ import com.facebook.presto.spi.plan.MaterializedViewScanNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.RefreshMaterializedViewNode;
 import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
@@ -71,6 +73,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 /**
  * Builds the delta plan for materialized view differential stitching.
@@ -198,7 +201,7 @@ public class DifferentialPlanRewriter
     /**
      * Filters stale predicates from all tables to only include columns that have equivalence mappings.
      */
-    private static Map<SchemaTableName, List<TupleDomain<String>>> filterPredicatesToMappedColumns(
+    static Map<SchemaTableName, List<TupleDomain<String>>> filterPredicatesToMappedColumns(
             Map<SchemaTableName, MaterializedDataPredicates> constraints,
             PassthroughColumnEquivalences columnEquivalences)
     {
@@ -338,6 +341,61 @@ public class DifferentialPlanRewriter
                 ImmutableList.of(freshPlan, deltaPlan),
                 ImmutableList.copyOf(mapping.keySet()),
                 SetOperationNodeUtils.fromListMultimap(mapping));
+    }
+
+    public static Optional<PlanNode> buildDeltaPlanForRefresh(
+            RefreshMaterializedViewNode node,
+            Metadata metadata,
+            Session session,
+            PlanNodeIdAllocator idAllocator,
+            VariableAllocator variableAllocator,
+            Map<SchemaTableName, List<TupleDomain<String>>> constraints,
+            PassthroughColumnEquivalences columnEquivalences,
+            Lookup lookup,
+            WarningCollector warningCollector)
+    {
+        PlanNode sourcePlan = node.getSource();
+
+        Map<VariableReferenceExpression, VariableReferenceExpression> identityMapping =
+                sourcePlan.getOutputVariables().stream()
+                        .collect(toImmutableMap(identity(), identity()));
+
+        DifferentialPlanRewriter rewriter = new DifferentialPlanRewriter(
+                metadata,
+                session,
+                idAllocator,
+                variableAllocator,
+                constraints,
+                columnEquivalences,
+                lookup,
+                warningCollector);
+
+        NodeWithMapping deltaResult;
+        try {
+            deltaResult = rewriter.buildDeltaPlan(sourcePlan, identityMapping);
+        }
+        catch (UnsupportedOperationException e) {
+            return Optional.empty();
+        }
+
+        // Build projection to map delta variables back to original output variables
+        Map<VariableReferenceExpression, VariableReferenceExpression> deltaMapping = deltaResult.getMapping();
+        List<VariableReferenceExpression> originalOutputs = node.getOutputVariables();
+
+        Assignments.Builder assignments = Assignments.builder();
+        for (VariableReferenceExpression originalVar : originalOutputs) {
+            VariableReferenceExpression deltaVar = deltaMapping.get(originalVar);
+            if (deltaVar != null) {
+                assignments.put(originalVar, deltaVar);
+            }
+        }
+
+        ProjectNode projectedDelta = new ProjectNode(
+                idAllocator.getNextId(),
+                deltaResult.getNode(),
+                assignments.build());
+
+        return Optional.of(projectedDelta);
     }
 
     /**

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/DifferentialPlanRewriter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/DifferentialPlanRewriter.java
@@ -201,7 +201,7 @@ public class DifferentialPlanRewriter
     /**
      * Filters stale predicates from all tables to only include columns that have equivalence mappings.
      */
-    static Map<SchemaTableName, List<TupleDomain<String>>> filterPredicatesToMappedColumns(
+    private static Map<SchemaTableName, List<TupleDomain<String>>> filterPredicatesToMappedColumns(
             Map<SchemaTableName, MaterializedDataPredicates> constraints,
             PassthroughColumnEquivalences columnEquivalences)
     {
@@ -385,9 +385,10 @@ public class DifferentialPlanRewriter
         Assignments.Builder assignments = Assignments.builder();
         for (VariableReferenceExpression originalVar : originalOutputs) {
             VariableReferenceExpression deltaVar = deltaMapping.get(originalVar);
-            if (deltaVar != null) {
-                assignments.put(originalVar, deltaVar);
-            }
+            checkState(deltaVar != null,
+                    "Delta plan is missing mapping for output variable %s. " +
+                    "This indicates an incomplete variable mapping from the differential plan rewriter.", originalVar);
+            assignments.put(originalVar, deltaVar);
         }
 
         ProjectNode projectedDelta = new ProjectNode(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/IncrementalRefreshRule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/IncrementalRefreshRule.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule.materializedview;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.MaterializedViewRefreshType;
+import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.RefreshMaterializedViewNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.getMaterializedViewDefaultRefreshType;
+import static com.facebook.presto.SystemSessionProperties.isLegacyMaterializedViews;
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPredicates;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.spi.StandardWarningCode.MATERIALIZED_VIEW_STITCHING_FALLBACK;
+import static com.facebook.presto.sql.planner.iterative.rule.materializedview.DifferentialPlanRewriter.buildDeltaPlanForRefresh;
+import static com.facebook.presto.sql.planner.plan.Patterns.refreshMaterializedViewNode;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Optimizer rule that enables incremental refresh of materialized views.
+ *
+ * <p>When a {@code REFRESH MATERIALIZED VIEW} command is executed, this rule transforms
+ * the {@link RefreshMaterializedViewNode} marker into one of:
+ * <ul>
+ *   <li><b>No-op</b>: Returns an empty ValuesNode when fully materialized (nothing to refresh)</li>
+ *   <li><b>Full refresh</b>: Returns the source plan unchanged (scans all base table data)</li>
+ *   <li><b>Incremental refresh</b>: Returns a delta plan (scans only stale partition data)</li>
+ * </ul>
+ *
+ * <p>The planner creates: {@code TableFinishNode -> TableWriterNode -> RefreshMaterializedViewNode(source=fullQueryPlan)}
+ * <p>This rule replaces the RefreshMaterializedViewNode with the appropriate plan, leaving the write structure intact.
+ *
+ * @see DifferentialPlanRewriter
+ * @see MaterializedViewRewrite
+ */
+public class IncrementalRefreshRule
+        implements Rule<RefreshMaterializedViewNode>
+{
+    private static final Pattern<RefreshMaterializedViewNode> PATTERN = refreshMaterializedViewNode();
+
+    private final Metadata metadata;
+
+    public IncrementalRefreshRule(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public Pattern<RefreshMaterializedViewNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return !isLegacyMaterializedViews(session);
+    }
+
+    @Override
+    public Result apply(RefreshMaterializedViewNode node, Captures captures, Context context)
+    {
+        Session session = context.getSession();
+        PlanNodeIdAllocator idAllocator = context.getIdAllocator();
+        VariableAllocator variableAllocator = context.getVariableAllocator();
+
+        SchemaTableName materializedViewName = node.getMaterializedViewName();
+        TableHandle storageTableHandle = node.getStorageTableHandle();
+        String catalogName = storageTableHandle.getConnectorId().getCatalogName();
+
+        QualifiedObjectName qualifiedViewName = new QualifiedObjectName(
+                catalogName,
+                materializedViewName.getSchemaName(),
+                materializedViewName.getTableName());
+
+        MetadataResolver metadataResolver = metadata.getMetadataResolver(session);
+
+        Optional<MaterializedViewDefinition> materializedViewDefinition = metadataResolver.getMaterializedView(qualifiedViewName);
+        if (!materializedViewDefinition.isPresent()) {
+            throw new PrestoException(NOT_FOUND, "Materialized view not found: " + qualifiedViewName);
+        }
+
+        MaterializedViewRefreshType refreshType = materializedViewDefinition.get().getRefreshType()
+                .orElseGet(() -> getMaterializedViewDefaultRefreshType(session));
+        if (refreshType != MaterializedViewRefreshType.INCREMENTAL) {
+            return Result.ofPlanNode(node.getSource());
+        }
+
+        MaterializedViewStatus status = metadataResolver.getMaterializedViewStatus(qualifiedViewName, TupleDomain.all());
+
+        // If fully materialized, nothing to refresh - return empty result
+        if (status.isFullyMaterialized()) {
+            return Result.ofPlanNode(new ValuesNode(
+                    node.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    node.getOutputVariables(),
+                    ImmutableList.of(),
+                    Optional.empty()));
+        }
+
+        // If no partition info available (unpartitioned tables or connector doesn't track partitions),
+        // fall back to full refresh since we can't determine which partitions are stale
+        if (status.getPartitionsFromBaseTables().isEmpty()) {
+            return Result.ofPlanNode(node.getSource());
+        }
+
+        Map<SchemaTableName, MaterializedDataPredicates> constraints = status.getPartitionsFromBaseTables();
+
+        SchemaTableName dataTable = new SchemaTableName(materializedViewDefinition.get().getSchema(), materializedViewDefinition.get().getTable());
+        PassthroughColumnEquivalences columnEquivalences = new PassthroughColumnEquivalences(materializedViewDefinition.get(), dataTable);
+
+        Optional<Map<SchemaTableName, List<TupleDomain<String>>>> filteredConstraints =
+                filterToValidRefreshColumns(materializedViewDefinition.get(), constraints, columnEquivalences, dataTable);
+
+        if (!filteredConstraints.isPresent()) {
+            context.getWarningCollector().add(new PrestoWarning(
+                    MATERIALIZED_VIEW_STITCHING_FALLBACK,
+                    "Cannot perform incremental refresh for materialized view " + qualifiedViewName +
+                            ": stale columns are not valid refresh columns. Falling back to full refresh."));
+            return Result.ofPlanNode(node.getSource());
+        }
+
+        Optional<PlanNode> deltaPlan = buildDeltaPlanForRefresh(
+                node,
+                metadata,
+                session,
+                idAllocator,
+                variableAllocator,
+                filteredConstraints.get(),
+                columnEquivalences,
+                context.getLookup(),
+                context.getWarningCollector());
+
+        if (!deltaPlan.isPresent()) {
+            context.getWarningCollector().add(new PrestoWarning(
+                    MATERIALIZED_VIEW_STITCHING_FALLBACK,
+                    "Cannot perform incremental refresh for materialized view " + qualifiedViewName +
+                            ": unsupported operation in view query. Falling back to full refresh."));
+            return Result.ofPlanNode(node.getSource());
+        }
+
+        return Result.ofPlanNode(deltaPlan.get());
+    }
+
+    /**
+     * Filters stale predicates to only include columns that are valid refresh columns.
+     * Returns empty if any stale column cannot be mapped to a valid refresh column.
+     *
+     * @param materializedViewDefinition The materialized view definition containing validRefreshColumns
+     * @param constraints Raw stale predicates by base table
+     * @param columnEquivalences Column equivalences for mapping base to storage columns
+     * @param dataTable The MV storage table name
+     * @return Filtered constraints if all stale columns are valid refresh columns, empty otherwise
+     */
+    private static Optional<Map<SchemaTableName, List<TupleDomain<String>>>> filterToValidRefreshColumns(
+            MaterializedViewDefinition materializedViewDefinition,
+            Map<SchemaTableName, MaterializedDataPredicates> constraints,
+            PassthroughColumnEquivalences columnEquivalences,
+            SchemaTableName dataTable)
+    {
+        Optional<List<String>> validRefreshColumns = materializedViewDefinition.getValidRefreshColumns();
+
+        if (!validRefreshColumns.isPresent() || validRefreshColumns.get().isEmpty()) {
+            return Optional.empty();
+        }
+
+        ImmutableSet<String> validRefreshColumnSet = ImmutableSet.copyOf(validRefreshColumns.get());
+
+        // Filter each table's predicates to only include valid refresh columns
+        Map<SchemaTableName, List<TupleDomain<String>>> filtered = constraints.entrySet().stream()
+                .collect(toImmutableMap(
+                        Map.Entry::getKey,
+                        entry -> filterPredicatesForTable(
+                                entry.getValue().getPredicateDisjuncts(),
+                                entry.getKey(),
+                                columnEquivalences,
+                                validRefreshColumnSet,
+                                dataTable)));
+
+        // If any table has no valid predicates after filtering, incremental refresh is not possible
+        if (filtered.values().stream().anyMatch(List::isEmpty)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(filtered);
+    }
+
+    private static List<TupleDomain<String>> filterPredicatesForTable(
+            List<TupleDomain<String>> stalePredicates,
+            SchemaTableName baseTable,
+            PassthroughColumnEquivalences columnEquivalences,
+            ImmutableSet<String> validRefreshColumnSet,
+            SchemaTableName dataTable)
+    {
+        return stalePredicates.stream()
+                .filter(predicate -> predicate.getDomains().isPresent())
+                .map(predicate -> projectToValidRefreshColumns(
+                        predicate, baseTable, columnEquivalences, validRefreshColumnSet, dataTable))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .distinct()
+                .collect(toImmutableList());
+    }
+
+    private static Optional<TupleDomain<String>> projectToValidRefreshColumns(
+            TupleDomain<String> predicate,
+            SchemaTableName baseTable,
+            PassthroughColumnEquivalences columnEquivalences,
+            ImmutableSet<String> validRefreshColumnSet,
+            SchemaTableName dataTable)
+    {
+        if (!predicate.getDomains().isPresent()) {
+            return Optional.empty();
+        }
+
+        Map<String, Domain> projected = predicate.getDomains().get().entrySet().stream()
+                .filter(entry -> columnEquivalences.getStorageColumnName(dataTable, baseTable, entry.getKey())
+                        .filter(validRefreshColumnSet::contains)
+                        .isPresent())
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        if (projected.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(TupleDomain.withColumnDomains(projected));
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/IncrementalRefreshRule.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/IncrementalRefreshRule.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.plan.RefreshMaterializedViewNode;
 import com.facebook.presto.spi.plan.ValuesNode;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
@@ -145,10 +146,10 @@ public class IncrementalRefreshRule
         SchemaTableName dataTable = new SchemaTableName(materializedViewDefinition.get().getSchema(), materializedViewDefinition.get().getTable());
         PassthroughColumnEquivalences columnEquivalences = new PassthroughColumnEquivalences(materializedViewDefinition.get(), dataTable);
 
-        Optional<Map<SchemaTableName, List<TupleDomain<String>>>> filteredConstraints =
+        Map<SchemaTableName, List<TupleDomain<String>>> filteredConstraints =
                 filterToValidRefreshColumns(materializedViewDefinition.get(), constraints, columnEquivalences, dataTable);
 
-        if (!filteredConstraints.isPresent()) {
+        if (filteredConstraints.isEmpty()) {
             context.getWarningCollector().add(new PrestoWarning(
                     MATERIALIZED_VIEW_STITCHING_FALLBACK,
                     "Cannot perform incremental refresh for materialized view " + qualifiedViewName +
@@ -162,7 +163,7 @@ public class IncrementalRefreshRule
                 session,
                 idAllocator,
                 variableAllocator,
-                filteredConstraints.get(),
+                filteredConstraints,
                 columnEquivalences,
                 context.getLookup(),
                 context.getWarningCollector());
@@ -186,9 +187,9 @@ public class IncrementalRefreshRule
      * @param constraints Raw stale predicates by base table
      * @param columnEquivalences Column equivalences for mapping base to storage columns
      * @param dataTable The MV storage table name
-     * @return Filtered constraints if all stale columns are valid refresh columns, empty otherwise
+     * @return Filtered constraints with valid refresh columns only, empty map if incremental refresh is not possible
      */
-    private static Optional<Map<SchemaTableName, List<TupleDomain<String>>>> filterToValidRefreshColumns(
+    private static Map<SchemaTableName, List<TupleDomain<String>>> filterToValidRefreshColumns(
             MaterializedViewDefinition materializedViewDefinition,
             Map<SchemaTableName, MaterializedDataPredicates> constraints,
             PassthroughColumnEquivalences columnEquivalences,
@@ -197,7 +198,7 @@ public class IncrementalRefreshRule
         Optional<List<String>> validRefreshColumns = materializedViewDefinition.getValidRefreshColumns();
 
         if (!validRefreshColumns.isPresent() || validRefreshColumns.get().isEmpty()) {
-            return Optional.empty();
+            return ImmutableMap.of();
         }
 
         ImmutableSet<String> validRefreshColumnSet = ImmutableSet.copyOf(validRefreshColumns.get());
@@ -215,10 +216,10 @@ public class IncrementalRefreshRule
 
         // If any table has no valid predicates after filtering, incremental refresh is not possible
         if (filtered.values().stream().anyMatch(List::isEmpty)) {
-            return Optional.empty();
+            return ImmutableMap.of();
         }
 
-        return Optional.of(filtered);
+        return filtered;
     }
 
     private static List<TupleDomain<String>> filterPredicatesForTable(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ApplyConnectorOptimization.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.plan.MaterializedViewScanNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.RefreshMaterializedViewNode;
 import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.TableFinishNode;
@@ -103,7 +104,8 @@ public class ApplyConnectorOptimization
             TableWriterNode.class,
             TableFinishNode.class,
             DeleteNode.class,
-            TopNRowNumberNode.class);
+            TopNRowNumberNode.class,
+            RefreshMaterializedViewNode.class);
 
     // for a leaf node that does not belong to any connector (e.g., ValuesNode)
     private static final ConnectorId EMPTY_CONNECTOR_ID = new ConnectorId("$internal$ApplyConnectorOptimization_EMPTY_CONNECTOR");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.plan.MaterializedViewScanNode;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.RefreshMaterializedViewNode;
 import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.SortNode;
 import com.facebook.presto.spi.plan.SpatialJoinNode;
@@ -210,6 +211,11 @@ public class Patterns
     public static Pattern<TableWriterNode> tableWriterNode()
     {
         return typeOf(TableWriterNode.class);
+    }
+
+    public static Pattern<RefreshMaterializedViewNode> refreshMaterializedViewNode()
+    {
+        return typeOf(RefreshMaterializedViewNode.class);
     }
 
     public static Pattern<TableWriterMergeNode> tableWriterMergeNode()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.plan.MetadataDeleteNode;
 import com.facebook.presto.spi.plan.OutputNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.RefreshMaterializedViewNode;
 import com.facebook.presto.spi.plan.SemiJoinNode;
 import com.facebook.presto.spi.plan.SetOperationNode;
 import com.facebook.presto.spi.plan.SortNode;
@@ -800,6 +801,23 @@ public final class ValidateDependenciesChecker
         {
             PlanNode source = node.getSource();
             source.accept(this, boundVariables); // visit child
+
+            return null;
+        }
+
+        @Override
+        public Void visitRefreshMaterializedView(RefreshMaterializedViewNode node, Set<VariableReferenceExpression> boundVariables)
+        {
+            PlanNode source = node.getSource();
+            source.accept(this, boundVariables); // visit child
+
+            checkDependencies(
+                    source.getOutputVariables(),
+                    node.getOutputVariables(),
+                    "Invalid RefreshMaterializedViewNode %s: output variables %s not produced by source %s",
+                    node.getId(),
+                    node.getOutputVariables(),
+                    source.getOutputVariables());
 
             return null;
         }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.configuration.testing.ConfigAssertions;
 import com.facebook.airlift.units.DataSize;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.CompressionCodec;
+import com.facebook.presto.spi.MaterializedViewRefreshType;
 import com.facebook.presto.spi.MaterializedViewStaleReadBehavior;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationIfToFilterRewriteStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrategy;
@@ -204,6 +205,7 @@ public class TestFeaturesConfig
                 .setLegacyMaterializedViews(true)
                 .setAllowLegacyMaterializedViewsToggle(false)
                 .setMaterializedViewAllowFullRefreshEnabled(false)
+                .setMaterializedViewDefaultRefreshType(MaterializedViewRefreshType.FULL)
                 .setMaterializedViewStaleReadBehavior(MaterializedViewStaleReadBehavior.USE_VIEW_QUERY)
                 .setVerboseRuntimeStatsEnabled(false)
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.DISABLED)
@@ -453,6 +455,7 @@ public class TestFeaturesConfig
                 .put("experimental.legacy-materialized-views", "false")
                 .put("experimental.allow-legacy-materialized-views-toggle", "true")
                 .put("materialized-view-allow-full-refresh-enabled", "true")
+                .put("materialized-view-default-refresh-type", "INCREMENTAL")
                 .put("materialized-view-stale-read-behavior", "FAIL")
                 .put("analyzer-type", "CRUX")
                 .put("pre-process-metadata-calls", "true")
@@ -698,6 +701,7 @@ public class TestFeaturesConfig
                 .setLegacyMaterializedViews(false)
                 .setAllowLegacyMaterializedViewsToggle(true)
                 .setMaterializedViewAllowFullRefreshEnabled(true)
+                .setMaterializedViewDefaultRefreshType(MaterializedViewRefreshType.INCREMENTAL)
                 .setMaterializedViewStaleReadBehavior(MaterializedViewStaleReadBehavior.FAIL)
                 .setVerboseRuntimeStatsEnabled(true)
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.FILTER_WITH_IF)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/TestIncrementalRefreshRule.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/TestIncrementalRefreshRule.java
@@ -1,0 +1,465 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule.materializedview;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.metadata.AbstractMockMetadata;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.MaterializedViewDefinition;
+import com.facebook.presto.spi.MaterializedViewDefinition.ColumnMapping;
+import com.facebook.presto.spi.MaterializedViewDefinition.TableColumn;
+import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.analyzer.MetadataResolver;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.RefreshMaterializedViewNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.analyzer.FunctionsConfig;
+import com.facebook.presto.sql.planner.TestingConnectorTransactionHandle;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.TestingMetadata.TestingColumnHandle;
+import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPredicates;
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.FULLY_MATERIALIZED;
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.PARTIALLY_MATERIALIZED;
+import static com.facebook.presto.spi.security.ViewSecurity.DEFINER;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.slice.Slices.utf8Slice;
+
+/**
+ * Tests for {@link IncrementalRefreshRule}.
+ *
+ * <p>These tests verify the plan optimization for incremental materialized view refresh,
+ * which transforms a full refresh plan into a delta-only refresh when possible.
+ */
+@Test(singleThreaded = true)
+public class TestIncrementalRefreshRule
+        extends BaseRuleTest
+{
+    private static final ConnectorId CONNECTOR_ID = new ConnectorId("test_catalog");
+    private static final SchemaTableName BASE_TABLE = new SchemaTableName("test_schema", "base_table");
+    private static final SchemaTableName MV_STORAGE_TABLE = new SchemaTableName("test_schema", "mv_storage");
+    private static final QualifiedObjectName MV_NAME = new QualifiedObjectName("test_catalog", "test_schema", "test_mv");
+
+    @Override
+    @BeforeClass
+    public void setUp()
+    {
+        FeaturesConfig featuresConfig = new FeaturesConfig()
+                .setAllowLegacyMaterializedViewsToggle(true)
+                .setLegacyMaterializedViews(false);
+
+        Session tempSession = testSessionBuilder().setCatalog("local").setSchema("tiny").build();
+        LocalQueryRunner queryRunner = new LocalQueryRunner(tempSession, featuresConfig, new FunctionsConfig());
+
+        Session session = testSessionBuilder(queryRunner.getMetadata().getSessionPropertyManager())
+                .setCatalog("local")
+                .setSchema("tiny")
+                .build();
+        tester = new RuleTester(ImmutableList.of(), session, queryRunner, new TpchConnectorFactory(1));
+    }
+
+    @Test
+    public void testFallsBackToFullRefreshWhenFullyMaterialized()
+    {
+        // When MV is fully materialized, rule fires but returns source unchanged (full refresh)
+        Metadata metadata = new TestingMetadataForIncrementalRefresh(
+                tester().getMetadata(),
+                createSimpleMvDefinition(),
+                new MaterializedViewStatus(FULLY_MATERIALIZED));
+
+        tester().assertThat(new IncrementalRefreshRule(metadata))
+                .on(this::buildRefreshPlan)
+                .matches(values("id", "ds"));
+    }
+
+    @Test
+    public void testFallsBackToFullRefreshWhenNoPartitionConstraints()
+    {
+        // Partially materialized but no partition info available (empty map)
+        // Rule fires but returns source unchanged (full refresh)
+        Metadata metadata = new TestingMetadataForIncrementalRefresh(
+                tester().getMetadata(),
+                createSimpleMvDefinition(),
+                new MaterializedViewStatus(PARTIALLY_MATERIALIZED, ImmutableMap.of(), Optional.empty()));
+
+        tester().assertThat(new IncrementalRefreshRule(metadata))
+                .on(this::buildRefreshPlan)
+                .matches(values("id", "ds"));
+    }
+
+    @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = "Materialized view not found:.*")
+    public void testThrowsWhenMvDefinitionNotFound()
+    {
+        // Metadata returns empty Optional for MV definition
+        // Rule should throw since the MV must exist when the rule fires
+        Metadata metadata = new TestingMetadataWithMissingMvDefinition(tester().getMetadata());
+
+        tester().assertThat(new IncrementalRefreshRule(metadata))
+                .on(this::buildRefreshPlan)
+                .matches(values("id", "ds"));
+    }
+
+    @Test
+    public void testFallsBackToFullRefreshWhenStaleColumnsHaveNoMapping()
+    {
+        // Stale partition has column 'unmapped_col' which doesn't exist in column mappings
+        // Rule fires but returns source unchanged (full refresh)
+        MaterializedViewDefinition mvDefinition = createSimpleMvDefinition();
+        MaterializedViewStatus status = new MaterializedViewStatus(
+                PARTIALLY_MATERIALIZED,
+                ImmutableMap.of(
+                        BASE_TABLE,
+                        new MaterializedDataPredicates(
+                                ImmutableList.of(TupleDomain.withColumnDomains(
+                                        ImmutableMap.of("unmapped_col", Domain.singleValue(VARCHAR, utf8Slice("2024-01-01"))))),
+                                ImmutableList.of("unmapped_col"))),
+                Optional.empty());
+
+        Metadata metadata = new TestingMetadataForIncrementalRefresh(
+                tester().getMetadata(),
+                mvDefinition,
+                status);
+
+        tester().assertThat(new IncrementalRefreshRule(metadata))
+                .on(this::buildRefreshPlan)
+                .matches(values("id", "ds"));
+    }
+
+    @Test
+    public void testLegacyModeDisablesRule()
+    {
+        // Create session with legacy materialized views enabled
+        FeaturesConfig legacyConfig = new FeaturesConfig()
+                .setAllowLegacyMaterializedViewsToggle(true)
+                .setLegacyMaterializedViews(true);
+
+        Session tempSession = testSessionBuilder().setCatalog("local").setSchema("tiny").build();
+        LocalQueryRunner legacyRunner = new LocalQueryRunner(tempSession, legacyConfig, new FunctionsConfig());
+
+        Session legacySession = testSessionBuilder(legacyRunner.getMetadata().getSessionPropertyManager())
+                .setCatalog("local")
+                .setSchema("tiny")
+                .setSystemProperty("legacy_materialized_views", "true")
+                .build();
+
+        RuleTester legacyTester = new RuleTester(ImmutableList.of(), legacySession, legacyRunner, new TpchConnectorFactory(1));
+
+        MaterializedViewStatus status = createStaleStatus();
+        Metadata metadata = new TestingMetadataForIncrementalRefresh(
+                legacyTester.getMetadata(),
+                createMvDefinitionWithMappings(),
+                status);
+
+        // Rule should not fire because legacy mode is enabled
+        legacyTester.assertThat(new IncrementalRefreshRule(metadata))
+                .on(this::buildRefreshPlan)
+                .doesNotFire();
+    }
+
+    private PlanNode buildRefreshPlan(PlanBuilder planBuilder)
+    {
+        VariableReferenceExpression idVar = planBuilder.variable("id", BIGINT);
+        VariableReferenceExpression dsVar = planBuilder.variable("ds", VARCHAR);
+
+        // Create a simple values node as the source (representing the view query)
+        PlanNode source = planBuilder.values(idVar, dsVar);
+
+        return buildRefreshMaterializedViewNode(planBuilder, source, ImmutableList.of(idVar, dsVar));
+    }
+
+    private RefreshMaterializedViewNode buildRefreshMaterializedViewNode(
+            PlanBuilder planBuilder,
+            PlanNode source,
+            List<VariableReferenceExpression> columns)
+    {
+        TableHandle tableHandle = new TableHandle(
+                CONNECTOR_ID,
+                new TestingTableHandle(),
+                TestingConnectorTransactionHandle.INSTANCE,
+                Optional.empty());
+
+        List<ColumnHandle> columnHandles = columns.stream()
+                .map(col -> (ColumnHandle) new TestingColumnHandle(col.getName()))
+                .collect(ImmutableList.toImmutableList());
+
+        return new RefreshMaterializedViewNode(
+                Optional.empty(),
+                new PlanNodeIdAllocator().getNextId(),
+                new SchemaTableName("test_schema", "test_mv"),
+                tableHandle,
+                source,
+                columnHandles,
+                columns);
+    }
+
+    private MaterializedViewDefinition createSimpleMvDefinition()
+    {
+        return new MaterializedViewDefinition(
+                "SELECT id, ds FROM base_table",
+                "test_schema",
+                "mv_storage",
+                ImmutableList.of(BASE_TABLE),
+                Optional.of("test_owner"),
+                Optional.of(DEFINER),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private MaterializedViewDefinition createMvDefinitionWithMappings()
+    {
+        // Create MV definition with proper column mappings
+        // The view column is represented as a TableColumn with the MV storage table name
+        TableColumn idViewCol = new TableColumn(MV_STORAGE_TABLE, "id");
+        TableColumn dsViewCol = new TableColumn(MV_STORAGE_TABLE, "ds");
+
+        TableColumn idBaseCol = new TableColumn(BASE_TABLE, "id");
+        TableColumn dsBaseCol = new TableColumn(BASE_TABLE, "ds");
+
+        ColumnMapping idMapping = new ColumnMapping(idViewCol, ImmutableList.of(idBaseCol));
+        ColumnMapping dsMapping = new ColumnMapping(dsViewCol, ImmutableList.of(dsBaseCol));
+
+        return new MaterializedViewDefinition(
+                "SELECT id, ds FROM base_table",
+                "test_schema",
+                "mv_storage",
+                ImmutableList.of(BASE_TABLE),
+                Optional.of("test_owner"),
+                Optional.of(DEFINER),
+                ImmutableList.of(idMapping, dsMapping),
+                ImmutableList.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private MaterializedViewStatus createStaleStatus()
+    {
+        return new MaterializedViewStatus(
+                PARTIALLY_MATERIALIZED,
+                ImmutableMap.of(
+                        BASE_TABLE,
+                        new MaterializedDataPredicates(
+                                ImmutableList.of(TupleDomain.withColumnDomains(
+                                        ImmutableMap.of("ds", Domain.singleValue(VARCHAR, utf8Slice("2024-01-03"))))),
+                                ImmutableList.of("ds"))),
+                Optional.empty());
+    }
+
+    private static class TestingMetadataForIncrementalRefresh
+            extends AbstractMockMetadata
+    {
+        private final Metadata delegate;
+        private final MaterializedViewDefinition mvDefinition;
+        private final MaterializedViewStatus status;
+
+        public TestingMetadataForIncrementalRefresh(
+                Metadata delegate,
+                MaterializedViewDefinition mvDefinition,
+                MaterializedViewStatus status)
+        {
+            this.delegate = delegate;
+            this.mvDefinition = mvDefinition;
+            this.status = status;
+        }
+
+        @Override
+        public FunctionAndTypeManager getFunctionAndTypeManager()
+        {
+            return delegate.getFunctionAndTypeManager();
+        }
+
+        @Override
+        public MetadataResolver getMetadataResolver(Session session)
+        {
+            return new TestingMetadataResolverForIncrementalRefresh(
+                    super.getMetadataResolver(session),
+                    mvDefinition,
+                    status);
+        }
+    }
+
+    private static class TestingMetadataWithMissingMvDefinition
+            extends AbstractMockMetadata
+    {
+        private final Metadata delegate;
+
+        public TestingMetadataWithMissingMvDefinition(Metadata delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public FunctionAndTypeManager getFunctionAndTypeManager()
+        {
+            return delegate.getFunctionAndTypeManager();
+        }
+
+        @Override
+        public MetadataResolver getMetadataResolver(Session session)
+        {
+            return new MetadataResolver()
+            {
+                @Override
+                public boolean catalogExists(String catalogName)
+                {
+                    return true;
+                }
+
+                @Override
+                public boolean schemaExists(com.facebook.presto.common.CatalogSchemaName schemaName)
+                {
+                    return true;
+                }
+
+                @Override
+                public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
+                {
+                    return Optional.empty();
+                }
+
+                @Override
+                public List<ColumnMetadata> getColumns(TableHandle tableHandle)
+                {
+                    return ImmutableList.of();
+                }
+
+                @Override
+                public Map<String, ColumnHandle> getColumnHandles(TableHandle tableHandle)
+                {
+                    return ImmutableMap.of();
+                }
+
+                @Override
+                public Optional<ViewDefinition> getView(QualifiedObjectName viewName)
+                {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<MaterializedViewDefinition> getMaterializedView(QualifiedObjectName viewName)
+                {
+                    return Optional.empty();
+                }
+
+                @Override
+                public MaterializedViewStatus getMaterializedViewStatus(
+                        QualifiedObjectName materializedViewName,
+                        TupleDomain<String> baseQueryDomain)
+                {
+                    return new MaterializedViewStatus(FULLY_MATERIALIZED);
+                }
+            };
+        }
+    }
+
+    private static class TestingMetadataResolverForIncrementalRefresh
+            implements MetadataResolver
+    {
+        private final MetadataResolver delegate;
+        private final MaterializedViewDefinition mvDefinition;
+        private final MaterializedViewStatus status;
+
+        public TestingMetadataResolverForIncrementalRefresh(
+                MetadataResolver delegate,
+                MaterializedViewDefinition mvDefinition,
+                MaterializedViewStatus status)
+        {
+            this.delegate = delegate;
+            this.mvDefinition = mvDefinition;
+            this.status = status;
+        }
+
+        @Override
+        public boolean catalogExists(String catalogName)
+        {
+            return delegate.catalogExists(catalogName);
+        }
+
+        @Override
+        public boolean schemaExists(com.facebook.presto.common.CatalogSchemaName schemaName)
+        {
+            return delegate.schemaExists(schemaName);
+        }
+
+        @Override
+        public Optional<TableHandle> getTableHandle(QualifiedObjectName tableName)
+        {
+            return delegate.getTableHandle(tableName);
+        }
+
+        @Override
+        public List<ColumnMetadata> getColumns(TableHandle tableHandle)
+        {
+            return delegate.getColumns(tableHandle);
+        }
+
+        @Override
+        public Map<String, ColumnHandle> getColumnHandles(TableHandle tableHandle)
+        {
+            return delegate.getColumnHandles(tableHandle);
+        }
+
+        @Override
+        public Optional<ViewDefinition> getView(QualifiedObjectName viewName)
+        {
+            return delegate.getView(viewName);
+        }
+
+        @Override
+        public Optional<MaterializedViewDefinition> getMaterializedView(QualifiedObjectName viewName)
+        {
+            return Optional.of(mvDefinition);
+        }
+
+        @Override
+        public MaterializedViewStatus getMaterializedViewStatus(
+                QualifiedObjectName materializedViewName,
+                TupleDomain<String> baseQueryDomain)
+        {
+            return status;
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/TestPassthroughColumnEquivalences.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/materializedview/TestPassthroughColumnEquivalences.java
@@ -323,7 +323,7 @@ public class TestPassthroughColumnEquivalences
         assertEquals(result.size(), 1);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "Cannot map stale predicates.*")
+    @Test
     public void testTranslatePredicatesToVariablesNoMapping()
     {
         MaterializedViewDefinition mvDefinition = createMvDefinition(
@@ -333,16 +333,19 @@ public class TestPassthroughColumnEquivalences
 
         PassthroughColumnEquivalences equivalences = new PassthroughColumnEquivalences(mvDefinition, MV_DATA_TABLE);
 
-        // No variable mapping provided - should throw
+        // No variable mapping provided - returns empty list
         List<TupleDomain<String>> stalePredicates = ImmutableList.of(
                 TupleDomain.withColumnDomains(
                         ImmutableMap.of("orderdate", Domain.singleValue(VARCHAR, utf8Slice("2024-01-01")))));
 
-        equivalences.translatePredicatesToVariables(
+        List<RowExpression> result = equivalences.translatePredicatesToVariables(
                 ORDERS_TABLE,
                 stalePredicates,
                 ImmutableMap.of(),  // Empty mapping
                 translator);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
     }
 
     @Test

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1406,6 +1406,13 @@ void to_json(json& j, const IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "SchemaTableName",
       "materializedViewName");
+  to_json_key(
+      j,
+      "fullRefreshRequired",
+      p.fullRefreshRequired,
+      "IcebergInsertTableHandle",
+      "bool",
+      "fullRefreshRequired");
 }
 
 void from_json(const json& j, IcebergInsertTableHandle& p) {
@@ -1487,6 +1494,13 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "SchemaTableName",
       "materializedViewName");
+  from_json_key(
+      j,
+      "fullRefreshRequired",
+      p.fullRefreshRequired,
+      "IcebergInsertTableHandle",
+      "bool",
+      "fullRefreshRequired");
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -270,6 +270,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   Map<String, String> storageProperties = {};
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
+  bool fullRefreshRequired = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergInsertTableHandle.hpp.inc
@@ -28,6 +28,7 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
   Map<String, String> storageProperties = {};
   List<SortField> sortOrder = {};
   std::shared_ptr<SchemaTableName> materializedViewName = {};
+  bool fullRefreshRequired = {};
 
   IcebergInsertTableHandle() noexcept;
 };

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergMaterializedViews.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergMaterializedViews.java
@@ -72,6 +72,7 @@ public class TestPrestoNativeIcebergMaterializedViews
                 .setDataDirectory(warehouseLocation.toPath())
                 .setExtraConnectorProperty("iceberg.rest.uri", serverUri)
                 .setExtraProperty("experimental.legacy-materialized-views", "false")
+                .setExtraProperty("materialized-view-default-refresh-type", "INCREMENTAL")
                 .build();
     }
 
@@ -86,6 +87,7 @@ public class TestPrestoNativeIcebergMaterializedViews
                 .setDataDirectory(warehouseLocation.toPath())
                 .setExtraConnectorProperty("iceberg.rest.uri", serverUri)
                 .setExtraProperty("experimental.legacy-materialized-views", "false")
+                .setExtraProperty("materialized-view-default-refresh-type", "INCREMENTAL")
                 .build();
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewRefreshType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewRefreshType.java
@@ -16,4 +16,5 @@ package com.facebook.presto.spi;
 public enum MaterializedViewRefreshType
 {
     FULL,
+    INCREMENTAL,
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanVisitor.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanVisitor.java
@@ -179,4 +179,9 @@ public abstract class PlanVisitor<R, C>
     {
         return visitPlan(node, context);
     }
+
+    public R visitRefreshMaterializedView(RefreshMaterializedViewNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/RefreshMaterializedViewNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/RefreshMaterializedViewNode.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.plan;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A logical plan node representing a materialized view refresh operation.
+ *
+ * <p>This node acts as a marker that is replaced by optimizer rules with the actual
+ * execution plan (either full refresh or incremental refresh). This pattern allows
+ * for cost-based optimization to choose between refresh strategies.
+ *
+ * <p>Similar to how TableScanNode for an MV gets replaced by MaterializedViewRewrite
+ * with a UNION plan for queries, this node gets replaced with the appropriate
+ * TableWriterNode structure for refresh operations.
+ *
+ * @see com.facebook.presto.sql.planner.iterative.rule.materializedview.IncrementalRefreshRule
+ */
+public final class RefreshMaterializedViewNode
+        extends PlanNode
+{
+    private final SchemaTableName materializedViewName;
+    private final TableHandle storageTableHandle;
+    private final PlanNode source;
+    private final List<ColumnHandle> columnHandles;
+    private final List<VariableReferenceExpression> outputVariables;
+
+    @JsonCreator
+    public RefreshMaterializedViewNode(
+            @JsonProperty("sourceLocation") Optional<SourceLocation> sourceLocation,
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("materializedViewName") SchemaTableName materializedViewName,
+            @JsonProperty("storageTableHandle") TableHandle storageTableHandle,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("columnHandles") List<ColumnHandle> columnHandles,
+            @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables)
+    {
+        super(sourceLocation, id, Optional.empty());
+        this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
+        this.storageTableHandle = requireNonNull(storageTableHandle, "storageTableHandle is null");
+        this.source = requireNonNull(source, "source is null");
+        this.columnHandles = Collections.unmodifiableList(requireNonNull(columnHandles, "columnHandles is null"));
+        this.outputVariables = Collections.unmodifiableList(requireNonNull(outputVariables, "outputVariables is null"));
+    }
+
+    @JsonProperty
+    public SchemaTableName getMaterializedViewName()
+    {
+        return materializedViewName;
+    }
+
+    @JsonProperty
+    public TableHandle getStorageTableHandle()
+    {
+        return storageTableHandle;
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @JsonProperty
+    public List<ColumnHandle> getColumnHandles()
+    {
+        return columnHandles;
+    }
+
+    @Override
+    @JsonProperty
+    public List<VariableReferenceExpression> getOutputVariables()
+    {
+        return outputVariables;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return Collections.singletonList(source);
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        if (newChildren.size() != 1) {
+            throw new IllegalArgumentException("Expected exactly one child, got " + newChildren.size());
+        }
+        return new RefreshMaterializedViewNode(
+                getSourceLocation(),
+                getId(),
+                materializedViewName,
+                storageTableHandle,
+                newChildren.get(0),
+                columnHandles,
+                outputVariables);
+    }
+
+    @Override
+    public PlanNode assignStatsEquivalentPlanNode(Optional<PlanNode> statsEquivalentPlanNode)
+    {
+        return this;
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitRefreshMaterializedView(this, context);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/RefreshMaterializedViewNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/RefreshMaterializedViewNode.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -101,7 +102,7 @@ public final class RefreshMaterializedViewNode
     @Override
     public List<PlanNode> getSources()
     {
-        return Collections.singletonList(source);
+        return singletonList(source);
     }
 
     @Override


### PR DESCRIPTION
## Description
Implements incremental refresh for materialized views. Instead of full recomputation, only stale partitions are refreshed using the IVM delta algebra established in DifferentialPlanRewriter.  Iceberg integration is added in this PR.

Depends on #26728

## Motivation and Context
Full MV refresh is expensive when only a subset of partitions changed.  This solution only requires recomputing the updated partitions.

## Impact
REFRESH MATERIALIZED VIEW automatically uses incremental refresh when possible, falls back to full refresh otherwise.

## Test Plan
Extensive unit tests have been added.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add incremental refresh for materialized views

Iceberg Connector Changes
* Add incremental refresh for materialized views in the Iceberg connector

```

