### PR TITLE
perf(optimizer): Make cost-based strategy of using parent preference in AddLocalExchanges

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -533,6 +533,22 @@ This property is only effective when ``remote_function_names_for_fixed_paralleli
 
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.remote-function-fixed-parallelism-task-count\`\``.
 
+``local_exchange_parent_preference_strategy``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Allowed values:** ``ALWAYS``, ``NEVER``, ``AUTOMATIC``
+* **Default value:** ``ALWAYS``
+
+Strategy to consider parent preferences when adding local exchange partitioning for aggregations.
+When set to ``ALWAYS``, the optimizer always uses parent preferences for local exchange partitioning.
+When set to ``NEVER``, it never uses parent preferences and instead uses the aggregation's own
+grouping keys. When set to ``AUTOMATIC``, the optimizer makes a cost-based decision, using parent
+preferences only when the estimated partition cardinality is greater than or equal to the task
+concurrency.
+
+The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.local-exchange-parent-preference-strategy\`\``.
+
 
 JDBC Properties
 ---------------

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1136,6 +1136,22 @@ This property is only effective when ``optimizer.remote-function-names-for-fixed
 
 The corresponding session property is :ref:`admin/properties-session:\`\`remote_function_fixed_parallelism_task_count\`\``.
 
+``optimizer.local-exchange-parent-preference-strategy``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Allowed values:** ``ALWAYS``, ``NEVER``, ``AUTOMATIC``
+* **Default value:** ``ALWAYS``
+
+Strategy to consider parent preferences when adding local exchange partitioning for aggregations.
+When set to ``ALWAYS``, the optimizer always uses parent preferences for local exchange partitioning.
+When set to ``NEVER``, it never uses parent preferences and instead uses the aggregation's own
+grouping keys. When set to ``AUTOMATIC``, the optimizer makes a cost-based decision, using parent
+preferences only when the estimated partition cardinality is greater than or equal to the task
+concurrency.
+
+The corresponding session property is :ref:`admin/properties-session:\`\`local_exchange_parent_preference_strategy\`\``.
+
 Planner Properties
 ------------------
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -41,6 +41,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinNotNullInferenceStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.LeftJoinArrayContainsToInnerJoinStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.LocalExchangeParentPreferenceStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartitioningPrecisionStrategy;
@@ -209,6 +210,7 @@ public final class SystemSessionProperties
     public static final String INDEX_LOADER_TIMEOUT = "index_loader_timeout";
     public static final String OPTIMIZED_REPARTITIONING_ENABLED = "optimized_repartitioning";
     public static final String AGGREGATION_PARTITIONING_MERGING_STRATEGY = "aggregation_partitioning_merging_strategy";
+    public static final String LOCAL_EXCHANGE_PARENT_PREFERENCE_STRATEGY = "local_exchange_parent_preference_strategy";
     public static final String LIST_BUILT_IN_FUNCTIONS_ONLY = "list_built_in_functions_only";
     public static final String NON_BUILT_IN_FUNCTION_NAMESPACES_TO_LIST_FUNCTIONS = "non_built_in_function_namespaces_to_list_functions";
     public static final String PARTITIONING_PRECISION_STRATEGY = "partitioning_precision_strategy";
@@ -1152,6 +1154,18 @@ public final class SystemSessionProperties
                         false,
                         value -> AggregationPartitioningMergingStrategy.valueOf(((String) value).toUpperCase()),
                         AggregationPartitioningMergingStrategy::name),
+                new PropertyMetadata<>(
+                        LOCAL_EXCHANGE_PARENT_PREFERENCE_STRATEGY,
+                        format("Strategy to use parent preferences in local exchange partitioning for aggregations. Options are %s",
+                                Stream.of(LocalExchangeParentPreferenceStrategy.values())
+                                        .map(LocalExchangeParentPreferenceStrategy::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        LocalExchangeParentPreferenceStrategy.class,
+                        featuresConfig.getLocalExchangeParentPreferenceStrategy(),
+                        false,
+                        value -> LocalExchangeParentPreferenceStrategy.valueOf(((String) value).toUpperCase()),
+                        LocalExchangeParentPreferenceStrategy::name),
                 booleanProperty(
                         LIST_BUILT_IN_FUNCTIONS_ONLY,
                         "Only List built-in functions in SHOW FUNCTIONS",
@@ -2838,6 +2852,11 @@ public final class SystemSessionProperties
     public static AggregationPartitioningMergingStrategy getAggregationPartitioningMergingStrategy(Session session)
     {
         return session.getSystemProperty(AGGREGATION_PARTITIONING_MERGING_STRATEGY, AggregationPartitioningMergingStrategy.class);
+    }
+
+    public static LocalExchangeParentPreferenceStrategy getLocalExchangeParentPreferenceStrategy(Session session)
+    {
+        return session.getSystemProperty(LOCAL_EXCHANGE_PARENT_PREFERENCE_STRATEGY, LocalExchangeParentPreferenceStrategy.class);
     }
 
     public static boolean isListBuiltInFunctionsOnly(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -161,6 +161,7 @@ public class FeaturesConfig
     private boolean exploitConstraints = true;
     private boolean preferPartialAggregation = true;
     private PartialAggregationStrategy partialAggregationStrategy = PartialAggregationStrategy.ALWAYS;
+    private LocalExchangeParentPreferenceStrategy localExchangeParentPreferenceStrategy = LocalExchangeParentPreferenceStrategy.ALWAYS;
     private double partialAggregationByteReductionThreshold = 0.5;
     private boolean adaptivePartialAggregationEnabled;
     private double adaptivePartialAggregationRowsReductionRatioThreshold = 0.8;
@@ -419,6 +420,13 @@ public class FeaturesConfig
         ALWAYS, // Always do partial aggregation
         NEVER, // Never do partial aggregation
         AUTOMATIC // Let the optimizer decide for each aggregation
+    }
+
+    public enum LocalExchangeParentPreferenceStrategy
+    {
+        ALWAYS, // Always use parent preferences for local exchange partitioning
+        NEVER, // Never use parent preferences, use aggregation's own grouping keys
+        AUTOMATIC // Cost-based: use parent preferences only if cardinality >= taskConcurrency
     }
 
     public enum AggregationIfToFilterRewriteStrategy
@@ -1130,6 +1138,18 @@ public class FeaturesConfig
     public FeaturesConfig setPartialAggregationStrategy(PartialAggregationStrategy partialAggregationStrategy)
     {
         this.partialAggregationStrategy = partialAggregationStrategy;
+        return this;
+    }
+
+    public LocalExchangeParentPreferenceStrategy getLocalExchangeParentPreferenceStrategy()
+    {
+        return localExchangeParentPreferenceStrategy;
+    }
+
+    @Config("optimizer.local-exchange-parent-preference-strategy")
+    public FeaturesConfig setLocalExchangeParentPreferenceStrategy(LocalExchangeParentPreferenceStrategy localExchangeParentPreferenceStrategy)
+    {
+        this.localExchangeParentPreferenceStrategy = localExchangeParentPreferenceStrategy;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -1001,7 +1001,7 @@ public class PlanOptimizers
                 featuresConfig.isNativeExecutionEnabled() && featuresConfig.isPrestoSparkExecutionEnvironment()));
 
         // Optimizers above this don't understand local exchanges, so be careful moving this.
-        builder.add(new AddLocalExchanges(metadata, featuresConfig.isNativeExecutionEnabled()));
+        builder.add(new AddLocalExchanges(metadata, statsCalculator, featuresConfig.isNativeExecutionEnabled()));
 
         // Optimizers above this do not need to care about aggregations with the type other than SINGLE
         // This optimizer must be run after all exchange-related optimizers

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -24,6 +24,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.CteMaterializationStrateg
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.LeftJoinArrayContainsToInnerJoinStrategy;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.LocalExchangeParentPreferenceStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartitioningPrecisionStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PushDownFilterThroughCrossJoinStrategy;
@@ -146,6 +147,7 @@ public class TestFeaturesConfig
                 .setPartialAggregationByteReductionThreshold(0.5)
                 .setAdaptivePartialAggregationEnabled(false)
                 .setAdaptivePartialAggregationRowsReductionRatioThreshold(0.8)
+                .setLocalExchangeParentPreferenceStrategy(LocalExchangeParentPreferenceStrategy.ALWAYS)
                 .setOptimizeTopNRowNumber(true)
                 .setOptimizeCaseExpressionPredicate(false)
                 .setDistributedSortEnabled(true)
@@ -353,6 +355,7 @@ public class TestFeaturesConfig
                 .put("optimizer.treat-low-confidence-zero-estimation-as-unknown", "true")
                 .put("optimizer.push-aggregation-through-join", "false")
                 .put("optimizer.aggregation-partition-merging", "top_down")
+                .put("optimizer.local-exchange-parent-preference-strategy", "automatic")
                 .put("experimental.spill-enabled", "true")
                 .put("experimental.join-spill-enabled", "false")
                 .put("experimental.spiller-spill-path", "/tmp/custom/spill/path1,/tmp/custom/spill/path2")
@@ -607,6 +610,7 @@ public class TestFeaturesConfig
                 .setPartialAggregationByteReductionThreshold(0.8)
                 .setAdaptivePartialAggregationEnabled(true)
                 .setAdaptivePartialAggregationRowsReductionRatioThreshold(0.9)
+                .setLocalExchangeParentPreferenceStrategy(LocalExchangeParentPreferenceStrategy.AUTOMATIC)
                 .setOptimizeTopNRowNumber(false)
                 .setOptimizeCaseExpressionPredicate(true)
                 .setDistributedSortEnabled(false)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -70,6 +70,7 @@ import com.facebook.presto.tests.QueryTemplate;
 import com.facebook.presto.util.MorePredicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -90,6 +91,7 @@ import static com.facebook.presto.SystemSessionProperties.FORCE_SINGLE_NODE_OUTP
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.LEAF_NODE_LIMIT_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.LOCAL_EXCHANGE_PARENT_PREFERENCE_STRATEGY;
 import static com.facebook.presto.SystemSessionProperties.MAX_LEAF_NODES_IN_PLAN;
 import static com.facebook.presto.SystemSessionProperties.NATIVE_EXECUTION_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.OFFSET_CLAUSE_ENABLED;
@@ -98,6 +100,7 @@ import static com.facebook.presto.SystemSessionProperties.PREFER_SORT_MERGE_JOIN
 import static com.facebook.presto.SystemSessionProperties.PUSH_REMOTE_EXCHANGE_THROUGH_GROUP_ID;
 import static com.facebook.presto.SystemSessionProperties.REMOVE_CROSS_JOIN_WITH_CONSTANT_SINGLE_ROW_INPUT;
 import static com.facebook.presto.SystemSessionProperties.SIMPLIFY_PLAN_WITH_EMPTY_INPUT;
+import static com.facebook.presto.SystemSessionProperties.SINGLE_NODE_EXECUTION_ENABLED;
 import static com.facebook.presto.SystemSessionProperties.TASK_CONCURRENCY;
 import static com.facebook.presto.SystemSessionProperties.getMaxLeafNodesInPlan;
 import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_LAST;
@@ -2136,5 +2139,87 @@ public class TestLogicalPlanner
     {
         String query = "SELECT min((SELECT totalprice FROM orders WHERE orderstatus = \"Outer.Table\".\"orderstatus\")) as min FROM orders AS \"Outer.Table\"";
         assertPlanSucceeded(query, this.getQueryRunner().getDefaultSession());
+    }
+
+    @Test
+    public void testLocalExchangeWithParentPreference()
+    {
+        // Query with two nested aggregations on the orders table:
+        // First aggregation: GROUP BY orderstatus, orderpriority (cardinality = 3 * 5 = 15)
+        // Second aggregation: GROUP BY orderstatus (cardinality = 3)
+        String query = "SELECT sum(cnt) FROM (SELECT orderstatus, orderpriority, count(*) cnt FROM orders GROUP BY orderstatus, orderpriority) GROUP BY orderstatus";
+
+        // Test ALWAYS strategy: always use parent preferences regardless of concurrency.
+        // First aggregation partitions by orderstatus (parent preference), second aggregation becomes SINGLE.
+        assertLocalExchangeWithParentPreference(query, "ALWAYS", "4", true);
+        assertLocalExchangeWithParentPreference(query, "ALWAYS", "2", true);
+
+        // Test NEVER strategy: never use parent preferences regardless of concurrency.
+        // Both aggregations partition by their own grouping keys.
+        assertLocalExchangeWithParentPreference(query, "NEVER", "4", false);
+        assertLocalExchangeWithParentPreference(query, "NEVER", "2", false);
+
+        // Test AUTOMATIC strategy: cost-based decision.
+        // When task concurrency (4) > parent cardinality (3), don't use parent preferences.
+        assertLocalExchangeWithParentPreference(query, "AUTOMATIC", "4", false);
+        // When task concurrency (2) <= parent cardinality (3), use parent preferences.
+        assertLocalExchangeWithParentPreference(query, "AUTOMATIC", "2", true);
+    }
+
+    private void assertLocalExchangeWithParentPreference(String query, String strategy, String taskConcurrency, boolean expectParentPreference)
+    {
+        Session session = Session.builder(this.getQueryRunner().getDefaultSession())
+                .setSystemProperty(SINGLE_NODE_EXECUTION_ENABLED, "true")
+                .setSystemProperty(TASK_CONCURRENCY, taskConcurrency)
+                .setSystemProperty(LOCAL_EXCHANGE_PARENT_PREFERENCE_STRATEGY, strategy)
+                .build();
+
+        if (expectParentPreference) {
+            // When using parent preferences, first aggregation partitions by orderstatus (parent preference),
+            // and there is no local exchange at the second aggregation which becomes a SINGLE aggregation
+            assertDistributedPlan(
+                    query,
+                    session,
+                    anyTree(
+                            project(
+                                    aggregation(
+                                            ImmutableMap.of("outer_sum", functionCall("sum", ImmutableList.of("final_count"))),
+                                            SINGLE,
+                                            project(
+                                                    aggregation(
+                                                            ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count"))),
+                                                            FINAL,
+                                                            exchange(LOCAL, REPARTITION, ImmutableList.of(), ImmutableSet.of("orderstatus"),
+                                                                    project(
+                                                                            aggregation(
+                                                                                    ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of())),
+                                                                                    PARTIAL,
+                                                                                    anyTree(
+                                                                                            tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus", "orderpriority", "orderpriority"))))))))))));
+        }
+        else {
+            // When not using parent preferences, local exchanges partition by each aggregation's own grouping keys
+            assertDistributedPlan(
+                    query,
+                    session,
+                    anyTree(
+                            aggregation(
+                                    ImmutableMap.of("final_sum", functionCall("sum", ImmutableList.of("partial_sum"))),
+                                    FINAL,
+                                    exchange(LOCAL, REPARTITION, ImmutableList.of(), ImmutableSet.of("orderstatus"),
+                                            aggregation(
+                                                    ImmutableMap.of("partial_sum", functionCall("sum", ImmutableList.of("final_count"))),
+                                                    PARTIAL,
+                                                    project(
+                                                            aggregation(
+                                                                    ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count"))),
+                                                                    FINAL,
+                                                                    exchange(LOCAL, REPARTITION, ImmutableList.of(), ImmutableSet.of("orderstatus", "orderpriority"),
+                                                                            aggregation(
+                                                                                    ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of())),
+                                                                                    PARTIAL,
+                                                                                    anyTree(
+                                                                                            tableScan("orders", ImmutableMap.of("orderstatus", "orderstatus", "orderpriority", "orderpriority"))))))))))));
+        }
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -141,7 +141,7 @@ public class TestEliminateSorts
                         getQueryRunner().getCostCalculator(),
                         ImmutableSet.of(new RemoveRedundantIdentityProjections())),
                 new AddExchanges(getQueryRunner().getMetadata(), new PartitioningProviderManager(), false),
-                new AddLocalExchanges(getMetadata(), false),
+                new AddLocalExchanges(getMetadata(), getQueryRunner().getStatsCalculator(), false),
                 new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(


### PR DESCRIPTION
We observed that the use of parent preference in AddLocalExchanges can limit parallelism when the cardinality of the partition column of parent preference is low. In a setup where a query is allowed to use many cores, limiting the parallelism significantly affect the query latency. More details can be found in https://github.com/prestodb/presto/issues/26961.

This PR makes three changes:
* This PR introduces a new feature config `localExchangeParentPreferenceStrategy` that has three values: ALWAYS, NEVER, and AUTOMATIC. The default value is ALWAYS (i.e., current behavior).
* This PR makes AddLocalExchanges to use parent preference according to the localExchangeParentPreferenceStrategy. When localExchangeParentPreferenceStrategy is ALWAYS, it always uses parent preference. When localExchangeParentPreferenceStrategy is NEVER, it always not uses parent preference. When localExchangeParentPreferenceStrategy is AUTOMATIC, it uses parent preference only when the estimated cardinality is larger than the task concurrency. (If estimated stats is not available, parent preference is not used.)
  - Notice that the estimated stats is only calculated when localExchangeParentPreferenceStrategy is AUTOMATIC.
* This PR adds unit tests of the new config and the change to local-exchange. 


## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Introduce a configurable strategy for using parent preferences in AddLocalExchanges and make local exchange partitioning for aggregations cost-aware based on estimated cardinality and task concurrency.

New Features:
- Add a local_exchange_parent_preference_strategy session/feature config to control how local exchanges use parent partitioning preferences with options ALWAYS, NEVER, and AUTOMATIC.

Enhancements:
- Update AddLocalExchanges to optionally use stats-based decisions when applying parent partitioning preferences for aggregation local exchanges, leveraging the existing stats calculator.
- Wire the stats calculator into AddLocalExchanges through PlanOptimizers to enable precomputation of plan statistics when the AUTOMATIC strategy is selected.

Tests:
- Add planner tests validating local exchange behavior under ALWAYS, NEVER, and AUTOMATIC parent preference strategies and different task concurrency settings.
- Extend FeaturesConfig tests to cover default and explicit mappings for the new local_exchange_parent_preference_strategy config.