### PR TITLE
misc: Add python language in RoutineCharacteristics

### DIFF
--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/json/JsonFileBasedFunctionNamespaceManager.java
@@ -47,9 +47,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
-import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.CPP;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static java.lang.Long.parseLong;
@@ -138,7 +136,6 @@ public class JsonFileBasedFunctionNamespaceManager
 
     private SqlInvokedFunction createSqlInvokedFunction(String functionName, JsonBasedUdfFunctionMetadata jsonBasedUdfFunctionMetaData)
     {
-        checkState(jsonBasedUdfFunctionMetaData.getRoutineCharacteristics().getLanguage().equals(CPP), "JsonFileBasedFunctionNamespaceManager only supports CPP UDF");
         QualifiedObjectName qualifiedFunctionName = QualifiedObjectName.valueOf(new CatalogSchemaName(getCatalogName(), jsonBasedUdfFunctionMetaData.getSchema()), functionName);
         List<String> parameterNameList = jsonBasedUdfFunctionMetaData.getParamNames();
         List<TypeSignature> parameterTypeList = jsonBasedUdfFunctionMetaData.getParamTypes();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/RoutineCharacteristics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/RoutineCharacteristics.java
@@ -42,6 +42,7 @@ public class RoutineCharacteristics
         public static final Language SQL = new Language("SQL");
         public static final Language JAVA = new Language("Java");
         public static final Language CPP = new Language("CPP");
+        public static final Language PYTHON = new Language("PYTHON");
 
         private final String language;
 


### PR DESCRIPTION
## Description
Language in RoutineCharacteristics represents the language used in the implementation of the functions. Currently it has SQL, JAVA and CPP. I am adding one more option, python, in this PR.

In addition, I also remove the constraint of only support CPP in the `JsonFileBasedFunctionNamespaceManager.java`. This check was added by me and it's because the `JsonFileBasedFunctionNamespaceManager` was intended to be used for registering CPP functions at that time. However, it's only a frontend for function registration, and has nothing to do the implementation of the functions to be registered, we do not need to limit us regarding the usage of it.

## Motivation and Context
As in description.

## Impact
As in description.

## Test Plan
Easy change

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

