### PR TITLE
test: Add end-to-end tests for numeric_histogram function

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeAggregations.java
@@ -354,6 +354,29 @@ public abstract class AbstractTestNativeAggregations
         assertQuery("SELECT orderkey, multimap_agg(linenumber % 3, discount) FROM lineitem GROUP BY 1");
     }
 
+    @Test
+    public void testNumericHistogram()
+    {
+        assertQuery("SELECT numeric_histogram(2, v) FROM (VALUES (1.0), (2.0), (1000.0)) AS t(v)");
+        assertQuery("SELECT numeric_histogram(2, v) FROM (VALUES (1.0), (2.0), (1000.0), (1001.0)) AS t(v)");
+        assertQuery("SELECT numeric_histogram(5, v) FROM (VALUES (1.0), (2.0), (3.0)) AS t(v)");
+
+        assertQuery("SELECT numeric_histogram(2, v, w) FROM (VALUES (0.0, 1.0), (10.0, 3.0), (10000.0, 1.0)) AS t(v, w)");
+        assertQuery("SELECT numeric_histogram(3, v, w) FROM (VALUES (1.0, 2.0), (2.0, 3.0), (3.0, 1.5)) AS t(v, w)");
+
+        assertQuery("SELECT numeric_histogram(3, v) FROM (VALUES (1.0), (null), (2.0), (null), (1000.0)) AS t(v)");
+        assertQuery("SELECT numeric_histogram(2, v, w) FROM (VALUES (1.0, 1.0), (null, 2.0), (2.0, null), (1000.0, 1.0)) AS t(v, w)");
+        assertQuery("SELECT numeric_histogram(3, v) FROM (VALUES (CAST(null AS DOUBLE)), (null), (null)) AS t(v)");
+
+        // numeric_histogram is approximate; results may differ between Java and C++ on large datasets,
+        // consistent with other approximate aggregates (approx_percentile, approx_distinct, etc.).
+        assertQuerySucceeds("SELECT numeric_histogram(5, quantity) FROM lineitem");
+        assertQuerySucceeds("SELECT numeric_histogram(10, extendedprice, quantity) FROM lineitem");
+
+        assertQuery("SELECT cardinality(numeric_histogram(3, quantity)) <= 3 FROM lineitem", "SELECT true");
+        assertQuery("SELECT reduce(map_values(numeric_histogram(3, v)), 0.0, (s, x) -> s + x, s -> s) FROM (VALUES (1.0), (2.0), (1000.0), (1001.0), (2000.0)) AS t(v)");
+    }
+
     @Test(dataProvider = "exchangeEncodingProvider")
     public void testMarkDistinct(String exchangeEncoding)
     {


### PR DESCRIPTION
## Description
Add E2E tests for numeric_histogram aggregate function

## Motivation and Context
Closes https://github.com/prestodb/presto/issues/26940
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Ran aggregation tests locally and passed. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

