### PR TITLE
test: Add e2e tests for binary functions

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1046,6 +1046,9 @@ public abstract class AbstractTestNativeGeneralQueries
         // crc32.
         assertQuery("SELECT crc32(cast(comment as varbinary)) FROM orders");
 
+        // length.
+        assertQuery("SELECT length(cast(comment as varbinary)) FROM orders ORDER BY orderkey LIMIT 10");
+
         // from_base64, to_base64.
         assertQuery("SELECT from_base64(to_base64(cast(comment as varbinary))) FROM orders");
 
@@ -1091,7 +1094,8 @@ public abstract class AbstractTestNativeGeneralQueries
         // from_hex, to_hex.
         assertQuery("SELECT from_hex(to_hex(cast(comment as varbinary))) FROM orders");
 
-        // hmac_sha1, hmac_sha256, hmac_sha512.
+        // hmac_md5, hmac_sha1, hmac_sha256, hmac_sha512.
+        assertQuery("SELECT hmac_md5(cast(comment as varbinary), cast(clerk as varbinary)) FROM orders ORDER BY orderkey LIMIT 10");
         assertQuery("SELECT hmac_sha1(cast(comment as varbinary), cast(clerk as varbinary)) FROM orders");
         assertQuery("SELECT hmac_sha256(cast(comment as varbinary), cast(clerk as varbinary)) FROM orders");
         assertQuery("SELECT hmac_sha512(cast(comment as varbinary), cast(clerk as varbinary)) FROM orders");
@@ -1110,6 +1114,14 @@ public abstract class AbstractTestNativeGeneralQueries
 
         // xxhash64.
         assertQuery("SELECT xxhash64(cast(comment as varbinary)) FROM orders");
+        assertQuery("SELECT xxhash64(cast(comment as varbinary), orderkey) FROM orders ORDER BY orderkey LIMIT 10");
+
+        // lpad, rpad.
+        assertQuery("SELECT lpad(cast(comment as varbinary), 50, cast('x' as varbinary)) FROM orders ORDER BY orderkey LIMIT 10");
+        assertQuery("SELECT rpad(cast(comment as varbinary), 50, cast('x' as varbinary)) FROM orders ORDER BY orderkey LIMIT 10");
+
+        // murmur3_x64_128.
+        assertQuery("SELECT murmur3_x64_128(cast(comment as varbinary)) FROM orders ORDER BY orderkey LIMIT 10");
 
         // from_base64url, to_base64url
         assertQuery("SELECT from_base64url(to_base64url(cast(comment as varbinary))) FROM orders");


### PR DESCRIPTION
## Description
Add E2E tests for murmur3_x64_128, length(binary), hmac_md5(binary, key), xxhash64(binary, seed), lpad(binary, size, padbinary), rpad(binary, size, padbinary)

## Motivation and Context
Closes https://github.com/prestodb/presto/issues/26938 
## Impact


## Test Plan
Ran e2e tests locally with passing results.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```


