### PR TITLE
chore: Bump datasketches-memory version to 3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
         <dep.jts.version>1.20.0</dep.jts.version>
 
         <dep.fastutil.version>8.5.2</dep.fastutil.version>
-        <dep.datasketches-memory.version>2.2.0</dep.datasketches-memory.version>
-        <dep.datasketches-java.version>5.0.1</dep.datasketches-java.version>
+        <dep.datasketches-memory.version>3.0.2</dep.datasketches-memory.version>
+        <dep.datasketches-java.version>6.2.0</dep.datasketches-java.version>
         <dep.io.opentelemetry.version>1.62.0</dep.io.opentelemetry.version>
 
         <release.autoPublish>true</release.autoPublish>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -274,7 +274,6 @@
         <dependency>
             <groupId>org.apache.datasketches</groupId>
             <artifactId>datasketches-java</artifactId>
-            <version>6.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -19,7 +19,6 @@
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.fastutil.version>8.5.15</dep.fastutil.version>
-        <dep.datasketches-memory.version>3.0.2</dep.datasketches-memory.version>
         <dep.log4j.version>2.25.4</dep.log4j.version>
     </properties>
 

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -17,8 +17,6 @@
         <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <dep.jts.version>1.20.0</dep.jts.version>
-        <dep.datasketches-java.version>6.1.1</dep.datasketches-java.version>
-        <dep.datasketches-memory.version>3.0.2</dep.datasketches-memory.version>
         <dep.log4j.version>2.25.4</dep.log4j.version>
     </properties>
 


### PR DESCRIPTION
## Description
 Bump datasketches-memory version to 3.0.2


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

