### PR TITLE
feat: Add catchableByTry field to ErrorCode in native protocol

### DIFF
--- a/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift.cpp
+++ b/presto-native-execution/presto_cpp/main/thrift/ProtocolToThrift.cpp
@@ -1074,6 +1074,7 @@ void toThrift(
   toThrift(proto.name, *thrift.name_ref());
   toThrift(proto.type, *thrift.type_ref());
   toThrift(proto.retriable, *thrift.retriable_ref());
+  toThrift(proto.catchableByTry, *thrift.catchableByTry_ref());
 }
 void fromThrift(
     const ErrorCode& thrift,
@@ -1082,6 +1083,7 @@ void fromThrift(
   fromThrift(*thrift.name_ref(), proto.name);
   fromThrift(*thrift.type_ref(), proto.type);
   fromThrift(*thrift.retriable_ref(), proto.retriable);
+  fromThrift(*thrift.catchableByTry_ref(), proto.catchableByTry);
 }
 
 void toThrift(

--- a/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
@@ -375,6 +375,7 @@ struct ErrorCode {
   2: string name;
   3: ErrorType type;
   4: bool retriable;
+  5: bool catchableByTry;
 }
 struct StageExecutionId {
   1: StageId stageId;

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.cpp
@@ -5206,6 +5206,13 @@ void to_json(json& j, const ErrorCode& p) {
   to_json_key(j, "name", p.name, "ErrorCode", "String", "name");
   to_json_key(j, "type", p.type, "ErrorCode", "ErrorType", "type");
   to_json_key(j, "retriable", p.retriable, "ErrorCode", "bool", "retriable");
+  to_json_key(
+      j,
+      "catchableByTry",
+      p.catchableByTry,
+      "ErrorCode",
+      "bool",
+      "catchableByTry");
 }
 
 void from_json(const json& j, ErrorCode& p) {
@@ -5213,6 +5220,13 @@ void from_json(const json& j, ErrorCode& p) {
   from_json_key(j, "name", p.name, "ErrorCode", "String", "name");
   from_json_key(j, "type", p.type, "ErrorCode", "ErrorType", "type");
   from_json_key(j, "retriable", p.retriable, "ErrorCode", "bool", "retriable");
+  from_json_key(
+      j,
+      "catchableByTry",
+      p.catchableByTry,
+      "ErrorCode",
+      "bool",
+      "catchableByTry");
 }
 } // namespace facebook::presto::protocol
 namespace facebook::presto::protocol {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.h
@@ -1271,6 +1271,7 @@ struct ErrorCode {
   String name = {};
   ErrorType type = {};
   bool retriable = {};
+  bool catchableByTry = {};
 };
 void to_json(json& j, const ErrorCode& p);
 void from_json(const json& j, ErrorCode& p);


### PR DESCRIPTION
Add the catchableByTry boolean field to the ErrorCode struct in the native execution layer. This field indicates whether an error can be caught by the TRY() SQL function, enabling extensible error handling without code changes.

Changes:
- Add catchableByTry field to Thrift ErrorCode definition (presto_thrift.thrift)
- Add catchableByTry handling in ProtocolToThrift.cpp (toThrift/fromThrift)
- Regenerate presto_protocol_core.h/cpp with catchableByTry field
- Add unit tests for ErrorCode JSON parsing with catchableByTry

Note: No behavior changes - catchableByTry defaults to false. 

```
== NO RELEASE NOTE ==
```

