### PR TITLE
fix: Union of TVF leaf operators results in multiple split sources

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/FragmentTableScanCounter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/FragmentTableScanCounter.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
+import com.facebook.presto.sql.planner.plan.TableFunctionProcessorNode;
 
 import java.util.Collection;
 
@@ -56,6 +57,18 @@ public final class FragmentTableScanCounter
         public Integer visitTableScan(TableScanNode node, Void context)
         {
             return 1;
+        }
+
+        @Override
+        public Integer visitTableFunctionProcessor(TableFunctionProcessorNode node, Void context)
+        {
+            // Table functions without a source are leaf nodes that generate data,
+            // similar to table scans. They should be counted to ensure proper
+            // fragment separation in UNION ALL scenarios.
+            if (!node.getSource().isPresent()) {
+                return 1;
+            }
+            return visitPlan(node, context);
         }
 
         @Override

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestSequenceFunction.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestSequenceFunction.java
@@ -288,4 +288,132 @@ public class TestSequenceFunction
                         "                    step => %s)) t(x)", start, stop, step),
                 format("SELECT %s, %s", start, Long.MAX_VALUE - 1));
     }
+
+    @Test
+    public void testUnionAllWithMultipleSequences()
+    {
+        // Test UNION ALL with two sequences
+        assertQuery("SELECT 'Even Numbers' AS sequence_type, num AS value " +
+                        "FROM TABLE(sequence(0, 100, 2)) AS t(num) " +
+                        "UNION ALL " +
+                        "SELECT 'Multiples of 5' AS sequence_type, num AS value " +
+                        "FROM TABLE(sequence(0, 100, 5)) AS t(num) " +
+                        "ORDER BY sequence_type, value",
+                "SELECT * FROM (VALUES " +
+                        "('Even Numbers', BIGINT '0'), ('Even Numbers', 2), ('Even Numbers', 4), ('Even Numbers', 6), ('Even Numbers', 8), ('Even Numbers', 10), " +
+                        "('Even Numbers', 12), ('Even Numbers', 14), ('Even Numbers', 16), ('Even Numbers', 18), ('Even Numbers', 20), " +
+                        "('Even Numbers', 22), ('Even Numbers', 24), ('Even Numbers', 26), ('Even Numbers', 28), ('Even Numbers', 30), " +
+                        "('Even Numbers', 32), ('Even Numbers', 34), ('Even Numbers', 36), ('Even Numbers', 38), ('Even Numbers', 40), " +
+                        "('Even Numbers', 42), ('Even Numbers', 44), ('Even Numbers', 46), ('Even Numbers', 48), ('Even Numbers', 50), " +
+                        "('Even Numbers', 52), ('Even Numbers', 54), ('Even Numbers', 56), ('Even Numbers', 58), ('Even Numbers', 60), " +
+                        "('Even Numbers', 62), ('Even Numbers', 64), ('Even Numbers', 66), ('Even Numbers', 68), ('Even Numbers', 70), " +
+                        "('Even Numbers', 72), ('Even Numbers', 74), ('Even Numbers', 76), ('Even Numbers', 78), ('Even Numbers', 80), " +
+                        "('Even Numbers', 82), ('Even Numbers', 84), ('Even Numbers', 86), ('Even Numbers', 88), ('Even Numbers', 90), " +
+                        "('Even Numbers', 92), ('Even Numbers', 94), ('Even Numbers', 96), ('Even Numbers', 98), ('Even Numbers', 100), " +
+                        "('Multiples of 5', BIGINT '0'), ('Multiples of 5', 5), ('Multiples of 5', 10), ('Multiples of 5', 15), ('Multiples of 5', 20), " +
+                        "('Multiples of 5', 25), ('Multiples of 5', 30), ('Multiples of 5', 35), ('Multiples of 5', 40), ('Multiples of 5', 45), " +
+                        "('Multiples of 5', 50), ('Multiples of 5', 55), ('Multiples of 5', 60), ('Multiples of 5', 65), ('Multiples of 5', 70), " +
+                        "('Multiples of 5', 75), ('Multiples of 5', 80), ('Multiples of 5', 85), ('Multiples of 5', 90), ('Multiples of 5', 95), " +
+                        "('Multiples of 5', 100)) AS t(sequence_type, value) " +
+                        "ORDER BY sequence_type, value");
+
+        // Test UNION ALL with three sequences (original failing query)
+        assertQuery("SELECT 'Even Numbers' AS sequence_type, num AS value " +
+                        "FROM TABLE(sequence(0, 100, 2)) AS t(num) " +
+                        "UNION ALL " +
+                        "SELECT 'Multiples of 5' AS sequence_type, num AS value " +
+                        "FROM TABLE(sequence(0, 100, 5)) AS t(num) " +
+                        "UNION ALL " +
+                        "SELECT 'Multiples of 10' AS sequence_type, num AS value " +
+                        "FROM TABLE(sequence(0, 100, 10)) AS t(num) " +
+                        "ORDER BY sequence_type, value",
+                "SELECT sequence_type, value FROM (" +
+                        "SELECT 'Even Numbers' AS sequence_type, x AS value FROM UNNEST(sequence(0, 100, 2)) AS t(x) " +
+                        "UNION ALL " +
+                        "SELECT 'Multiples of 5', x FROM UNNEST(sequence(0, 100, 5)) AS t(x) " +
+                        "UNION ALL " +
+                        "SELECT 'Multiples of 10', x FROM UNNEST(sequence(0, 100, 10)) AS t(x)) " +
+                        "ORDER BY sequence_type, value");
+    }
+
+    @Test
+    public void testUnionAllWithAggregation()
+    {
+        // Test UNION ALL with aggregation to verify correct result counts
+        assertQuery("SELECT sequence_type, COUNT(*) AS cnt, MIN(value) AS min_val, MAX(value) AS max_val " +
+                        "FROM (" +
+                        "  SELECT 'Even Numbers' AS sequence_type, num AS value " +
+                        "  FROM TABLE(sequence(0, 100, 2)) AS t(num) " +
+                        "  UNION ALL " +
+                        "  SELECT 'Odd Numbers' AS sequence_type, num AS value " +
+                        "  FROM TABLE(sequence(1, 99, 2)) AS t(num)" +
+                        ") " +
+                        "GROUP BY sequence_type " +
+                        "ORDER BY sequence_type",
+                "VALUES ('Even Numbers', BIGINT '51', BIGINT '0', BIGINT '100'), " +
+                        "('Odd Numbers', BIGINT '50', BIGINT '1', BIGINT '99')");
+    }
+
+    @Test
+    public void testUnionAllWithLargeSequences()
+    {
+        // Test UNION ALL with sequences that generate multiple splits
+        long sequenceLength = DEFAULT_SPLIT_SIZE * 2;
+        long start1 = 0;
+        long step1 = 1;
+        long stop1 = start1 + (sequenceLength - 1) * step1;
+
+        long start2 = 1000000;
+        long step2 = 1;
+        long stop2 = start2 + (sequenceLength - 1) * step2;
+
+        assertQuery(format("SELECT sequence_type, COUNT(*) AS cnt, MIN(value) AS min_val, MAX(value) AS max_val " +
+                                "FROM (" +
+                                "  SELECT 'First' AS sequence_type, num AS value " +
+                                "  FROM TABLE(sequence(%s, %s, %s)) AS t(num) " +
+                                "  UNION ALL " +
+                                "  SELECT 'Second' AS sequence_type, num AS value " +
+                                "  FROM TABLE(sequence(%s, %s, %s)) AS t(num)" +
+                                ") " +
+                                "GROUP BY sequence_type " +
+                                "ORDER BY sequence_type",
+                        start1, stop1, step1, start2, stop2, step2),
+                format("VALUES ('First', BIGINT '%s', BIGINT '%s', BIGINT '%s'), " +
+                                "('Second', BIGINT '%s', BIGINT '%s', BIGINT '%s')",
+                        sequenceLength, start1, stop1, sequenceLength, start2, stop2));
+    }
+
+    @Test
+    public void testUnionAllWithJoin()
+    {
+        // Test UNION ALL sequences joined with a table
+        assertQuery("SELECT t.name, s.value " +
+                        "FROM tpch.tiny.nation t " +
+                        "JOIN (" +
+                        "  SELECT num AS value FROM TABLE(sequence(0, 10, 1)) AS t(num) " +
+                        "  UNION ALL " +
+                        "  SELECT num AS value FROM TABLE(sequence(15, 25, 1)) AS t(num)" +
+                        ") s ON t.nationkey = s.value " +
+                        "ORDER BY t.name",
+                "SELECT name, nationkey FROM tpch.tiny.nation WHERE nationkey <= 10 OR (nationkey >= 15 AND nationkey <= 24) ORDER BY name");
+    }
+
+    @Test
+    public void testMultipleUnionAllBranches()
+    {
+        // Test complex UNION ALL with 4 branches
+        assertQuery("SELECT type, COUNT(*) AS cnt " +
+                        "FROM (" +
+                        "  SELECT 'A' AS type, num FROM TABLE(sequence(0, 50, 1)) AS t(num) " +
+                        "  UNION ALL " +
+                        "  SELECT 'B' AS type, num FROM TABLE(sequence(0, 30, 1)) AS t(num) " +
+                        "  UNION ALL " +
+                        "  SELECT 'C' AS type, num FROM TABLE(sequence(0, 40, 1)) AS t(num) " +
+                        "  UNION ALL " +
+                        "  SELECT 'D' AS type, num FROM TABLE(sequence(0, 20, 1)) AS t(num)" +
+                        ") " +
+                        "GROUP BY type " +
+                        "ORDER BY type",
+                "VALUES ('A', BIGINT '51'), ('B', BIGINT '31'), ('C', BIGINT '41'), ('D', BIGINT '21')");
+    }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
```
SELECT 
    'Even Numbers' AS sequence_type,
    num AS value
FROM TABLE(sequence(0, 100, 2)) AS t(num)

UNION ALL

SELECT 
    'Multiples of 5' AS sequence_type,
    num AS value
FROM TABLE(sequence(0, 100, 5)) AS t(num)

UNION ALL

SELECT 
    'Multiples of 10' AS sequence_type,
    num AS value
FROM TABLE(sequence(0, 100, 10)) AS t(num)

ORDER BY sequence_type, value;
```

Error:
```
java.lang.IllegalArgumentException: expected one element but was: <0=system:com.facebook.presto.spi.FixedSplitSource@15989fd0, 5=system:com.facebook.presto.spi.FixedSplitSource@4fec0d31, 11=system:com.facebook.presto.spi.FixedSplitSource@7a1c313f>
	at com.google.common.collect.Iterators.getOnlyElement(Iterators.java:323)
	at com.google.common.collect.Iterables.getOnlyElement(Iterables.java:263)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createStageScheduler(SectionExecutionFactory.java:296)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createStreamingLinkedStageExecutions(SectionExecutionFactory.java:258)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createStreamingLinkedStageExecutions(SectionExecutionFactory.java:235)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createStreamingLinkedStageExecutions(SectionExecutionFactory.java:235)
	at com.facebook.presto.execution.scheduler.SectionExecutionFactory.createSectionExecutions(SectionExecutionFactory.java:179)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler.createStageExecutions(SqlQueryScheduler.java:380)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler.<init>(SqlQueryScheduler.java:248)
	at com.facebook.presto.execution.scheduler.SqlQueryScheduler.createSqlQueryScheduler(SqlQueryScheduler.java:178)
	at com.facebook.presto.execution.SqlQueryExecution.createQueryScheduler(SqlQueryExecution.java:685)
	at com.facebook.presto.execution.SqlQueryExecution.lambda$start$3(SqlQueryExecution.java:501)
	at com.facebook.presto.common.RuntimeStats.lambda$recordWallAndCpuTime$9(RuntimeStats.java:171)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:170)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:501)
	at com.facebook.presto.$gen.Presto_0_297_SNAPSHOT_2676aa3__0_297_SNAPSHOT____20260112_061124_1.run(Unknown Source)
	at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:326)
	at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$8(LocalDispatchQuery.java:210)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Union of table function leaf operators resulted in a multi split source, source distribution stage. We decided that the best fix would be to treat leaf operators like table scans, and not combine them into a single operation. This would keep the source distribution the same as before. 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
Now able to union leaf table function operations.

## Test Plan
<!---Please fill in how you tested your change-->
Added additional tests to TestSequenceFunction.java to cover these scenarios. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```
