### PR TITLE
feat(plugin-delta): Add support to show the external table location of Delta tables when running the SHOW CREATE TABLE command

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaMetadata.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaMetadata.java
@@ -46,6 +46,7 @@ import com.google.common.collect.ImmutableMultimap;
 import jakarta.inject.Inject;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -331,11 +332,19 @@ public class DeltaMetadata
             return null;
         }
 
-        List<ColumnMetadata> columnMetadata = tableHandle.getDeltaTable().getColumns().stream()
+        DeltaTable deltaTable = tableHandle.getDeltaTable();
+
+        // External location property
+        Map<String, Object> properties = new HashMap<>(1);
+        if (deltaTable.getTableLocation() != null) {
+            properties.put(DeltaTableProperties.EXTERNAL_LOCATION_PROPERTY, deltaTable.getTableLocation());
+        }
+
+        List<ColumnMetadata> columnMetadata = deltaTable.getColumns().stream()
                 .map(column -> getColumnMetadata(session, column))
                 .collect(Collectors.toList());
 
-        return new ConnectorTableMetadata(tableName, columnMetadata);
+        return new ConnectorTableMetadata(tableName, columnMetadata, properties);
     }
 
     @Override

--- a/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaIntegration.java
+++ b/presto-delta/src/test/java/com/facebook/presto/delta/TestDeltaIntegration.java
@@ -338,4 +338,33 @@ public class TestDeltaIntegration
                 Paths.get(URI.create(tableLocation)).resolve("_delta_log/").resolve(format("%020d.json", commitId)),
                 FileTime.from(commitTimeMillis, TimeUnit.MILLISECONDS));
     }
+
+    @Test(dataProvider = "deltaReaderVersions")
+    public void testShowCreateTable(String deltaVersion)
+    {
+        String tableName = deltaVersion + "/data-reader-primitives";
+        String fullTableName = format("%s.%s.\"%s\"", DELTA_CATALOG, DELTA_SCHEMA.toLowerCase(), tableName);
+
+        String createTableQueryTemplate = "CREATE TABLE %s (\n" +
+                "   \"as_int\" integer,\n" +
+                "   \"as_long\" bigint,\n" +
+                "   \"as_byte\" tinyint,\n" +
+                "   \"as_short\" smallint,\n" +
+                "   \"as_boolean\" boolean,\n" +
+                "   \"as_float\" real,\n" +
+                "   \"as_double\" double,\n" +
+                "   \"as_string\" varchar,\n" +
+                "   \"as_binary\" varbinary,\n" +
+                "   \"as_big_decimal\" decimal(1,0)\n" +
+                ")\n" +
+                "WITH (\n" +
+                "   external_location = '%s'\n" +
+                ")";
+
+        String expectedSqlCommand = format(createTableQueryTemplate, fullTableName, goldenTablePath(tableName));
+
+        String showCreateTableCommandResult = (String) computeActual("SHOW CREATE TABLE " + fullTableName).getOnlyValue();
+
+        assertEquals(showCreateTableCommandResult, expectedSqlCommand);
+    }
 }


### PR DESCRIPTION
## Description
Add support to show the external table location of Delta tables when running the SHOW CREATE TABLE command.

## Motivation and Context
* Some tools need to know the data and metadata location of Delta tables.
* After this change, users will be able to recreate a Delta table at the same location where it was previously created.

## Test Plan
Integration test added

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Delta Connector Changes
* Add support to show the external table location of Delta tables when running the SHOW CREATE TABLE command.
```