### PR TITLE
fix(ui): Avoid auto-applying LIMIT to non-SELECT statements

### DIFF
--- a/presto-ui/src/components/SQLInput.tsx
+++ b/presto-ui/src/components/SQLInput.tsx
@@ -67,30 +67,26 @@ class UpperCaseCharStream extends antlr4.CharStream {
 class SelectListener extends SqlBaseListener {
     limit = -1;
     fetchFirstNRows = -1;
-    isSelect = false;
     isTopLevelSelect = false;
-
-    enterStatement(ctx) {
-        // If the statement itself is a query (not CTAS / INSERT)
-        if (ctx.query()) {
-            this.isTopLevelSelect = true;
-        }
-    }
 
     constructor() {
         super();
     }
 
-    enterQueryNoWith(ctx) {
-        super.enterQueryNoWith(ctx);
-        this.isSelect = true;
+    enterStatement(ctx) {
+        // Top-level SELECT only (not CTAS / INSERT)
+        if (ctx.query()) {
+            this.isTopLevelSelect = true;
+        }
     }
+
     exitQueryNoWith(ctx) {
         super.exitQueryNoWith(ctx);
         this.limit = ctx.limit ? ctx.limit.text : -1;
         this.fetchFirstNRows = ctx.fetchFirstNRows ? ctx.fetchFirstNRows.text : -1;
     }
 }
+
 class SyntaxError extends antlr4.ErrorListener<Error> {
     error = undefined;
 


### PR DESCRIPTION
Description

This change fixes how the Presto Web UI applies its default row limit. Previously, the UI added a LIMIT 100 to any statement that contained a SELECT clause, even when the statement itself was not a SELECT.

Because statements like CREATE TABLE AS SELECT and INSERT INTO … SELECT includes a SELECT as part of their syntax, they were incorrectly treated as interactive queries and could be silently truncated when run from the Web UI. This update ensures the default limit is applied only to top-level SELECT statements.

Motivation and Context

The Web UI applies a default row limit to help prevent users from accidentally returning very large result sets. The existing logic only checked for the presence of a SELECT clause, which caused non-SELECT statements that embed a SELECT to be handled incorrectly.

This change refines the SQL detection logic so that only plain SELECT statements are subject to the automatic limit.

Fixes #26975.

Impact

Interactive SELECT queries in the Web UI behave the same as before. CREATE TABLE AS SELECT, INSERT, and other non-SELECT statements are no longer modified by the UI. There are no changes to public APIs, server-side behavior, or performance.

Test Plan

Tested manually using the Presto Web UI.

Ran a SELECT without an explicit LIMIT and confirmed the default limit is applied. Ran a SELECT with an explicit LIMIT and confirmed it is preserved. Ran CREATE TABLE AS SELECT and INSERT INTO … SELECT statements and confirmed no LIMIT was appended.

Automated tests were not added because this change affects UI-side SQL preprocessing and there is no existing test coverage in this area.

Contributor checklist

Follows the Presto contributing guide and code style
PR description clearly explains the problem and why the change is needed
Linked to the relevant GitHub issue
No new public APIs, SQL syntax, or configuration changes
Manual testing completed; automated tests not applicable
CI passed (pending)
No new dependencies added


