### PR TITLE
chore(connector): Upgrade clickhouse-jdbc to 0.3.2

### DIFF
--- a/presto-clickhouse/pom.xml
+++ b/presto-clickhouse/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>ru.yandex.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.2.4</version>
+            <version>0.3.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/StandardReadMappings.java
+++ b/presto-clickhouse/src/main/java/com/facebook/presto/plugin/clickhouse/StandardReadMappings.java
@@ -48,7 +48,6 @@ import static com.facebook.presto.plugin.clickhouse.ClickHouseErrorCode.JDBC_ERR
 import static com.facebook.presto.plugin.clickhouse.DateTimeUtil.getMillisOfDay;
 import static com.facebook.presto.plugin.clickhouse.ReadMapping.longReadMapping;
 import static com.facebook.presto.plugin.clickhouse.ReadMapping.sliceReadMapping;
-import static com.facebook.presto.plugin.clickhouse.TimestampUtil.getMillisecondsFromTimestampString;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Float.floatToRawIntBits;
@@ -141,8 +140,9 @@ public final class StandardReadMappings
     {
         return longReadMapping(TIMESTAMP, (resultSet, columnIndex) -> {
             Timestamp timestamp = resultSet.getTimestamp(columnIndex);
-            // getTimestamp loses the milliseconds, but we can get them from the getString
-            return timestamp.getTime() + getMillisecondsFromTimestampString(resultSet.getString(columnIndex));
+            // In ClickHouse JDBC 0.3.2+, getTimestamp() properly includes milliseconds
+            // so we don't need to extract them separately from getString()
+            return timestamp.getTime();
         });
     }
 


### PR DESCRIPTION
## Description
Upgarde clickhouse-jdbc to 0.3.2

 Transaction Support: ClickHouse JDBC driver version 0.3.2 introduced stricter enforcement of transaction support. Since ClickHouse database doesn't support transactions, the driver now throws exceptions when transaction-related methods (setAutoCommit, commit, rollback) are called. The old version (0.2.4) silently ignored these calls.
https://github.com/ClickHouse/clickhouse-jdbc/commit/259682eaa8d5af741e4df57ca745f21ae3ae574c

Timestamp Precision: ClickHouse JDBC 0.3.2 fixed a bug where getTimestamp() was losing millisecond precision. The old code had a workaround to extract milliseconds from the string representation and add them back. This workaround is no longer needed and was actually causing incorrect results (double-counting milliseconds).


Test Result:

presto> CREATE TABLE "clickhouse"."tm_lakehouse_engine_db_1"."table12"(id int, name VARCHAR);
CREATE TABLE

Query 20260127_124940_00003_nde8t, FINISHED, 0 nodes
http://localhost:8080/ui/query.html?20260127_124940_00003_nde8t
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:04, server-side: 0:04] [0 rows, 0B] [0 rows/s, 0B/s]

presto> INSERT INTO  "clickhouse"."tm_lakehouse_engine_db_1"."table12"  VALUES (1,'Sinan');

INSERT: 1 row

Query 20260127_125234_00004_nde8t, FINISHED, 1 node
http://localhost:8080/ui/query.html?20260127_125234_00004_nde8t
Splits: 19 total, 19 done (100.00%)
[Latency: client-side: 0:16, server-side: 0:16] [0 rows, 0B] [0 rows/s, 0B/s]

presto> select * from "clickhouse"."tm_lakehouse_engine_db_1"."table12";

Query 20260127_125355_00005_nde8t, RUNNING, 1 node, 17 splits
http://localhost:8080/ui/query.html?20260127_125355_00005_nde8t
Splits:   0 queued, 17 running, 0 done
CPU Time: 0.0s total,     0 rows/s,     0B/s, 7% active
Per Node: 0.0 parallelism,     0 rows/s,     0B/s
Parallelism: 0.0
Peak Memory: 0B
Peak Total Memory: 0B
Peak Task Total Memory: 0B


 id | name  
----+-------
  1 | Sinan 
(1 row)

Query 20260127_125355_00005_nde8t, FINISHED, 1 node
http://localhost:8080/ui/query.html?20260127_125355_00005_nde8t
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:07, server-side: 0:07] [1 rows, 0B] [0 rows/s, 0B/s]

presto> 


## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade the ClickHouse connector to use clickhouse-jdbc 0.3.2 while adapting to its stricter transaction semantics and improved timestamp handling.

Enhancements:
- Guard transaction-related JDBC calls behind a helper that ignores expected exceptions when ClickHouse does not support transactions, keeping behavior compatible across driver versions.
- Simplify timestamp read mapping by relying on the driver’s corrected getTimestamp() millisecond precision instead of a manual string-based workaround.

Build:
- Bump the clickhouse-jdbc dependency version from 0.2.4 to 0.3.2 for the ClickHouse connector.