### PR TITLE
chore(connector): Upgarde  singlestore-jdbc-client to 1.2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1523,7 +1523,7 @@
             <dependency>
                 <groupId>com.singlestore</groupId>
                 <artifactId>singlestore-jdbc-client</artifactId>
-                <version>1.1.9</version>
+                <version>1.2.9</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

Upgarde singlestore-jdbc-client to 1.2.9

Key Behavioural Differences in JDBC Driver 1.2.9

1. Type Mapping: TINYINT(1) → BOOLEAN (was TINYINT)
2. VARCHAR Length: TEXT types report byte length instead of character length
3. Unbounded VARCHAR: VARCHAR(16777215) and LONGTEXT reported as unbounded VARCHAR
4. Date Handling: Pre-epoch dates have non-deterministic behavior
5. SQL Compatibility: SingleStore CREATE TABLE requires explicit VARCHAR size (cannot use bare VARCHAR)


## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade the SingleStore connector to use the newer singlestore-jdbc-client and align connector tests with the driver’s updated type and date behavior.

Build:
- Bump singlestore-jdbc-client dependency from 1.1.9 to 1.2.9.

Tests:
- Adjust SingleStore type mapping tests for new JDBC behavior around TINYINT(1) → BOOLEAN, VARCHAR/TEXT length reporting, unbounded VARCHAR handling, and skip pre-epoch date round-trip due to non-deterministic driver behavior.