### PR TITLE
fix: Allow view querying with Mongo connector

### DIFF
--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -126,6 +126,20 @@
         </dependency>
 
         <!-- for testing -->
+        <!-- NOTE: creating views was only working with a GenericContainer, should move to use org.testcontainers.mongodb.MongoDBContainer -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mongodb</artifactId>
+            <version>${dep.testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-testng-services</artifactId>

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -36,6 +36,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.mongodb.MongoClient;
@@ -88,9 +89,11 @@ public class MongoSession
     private static final String TABLE_NAME_KEY = "table";
     private static final String COMMENT_KEY = "comment";
     private static final String FIELDS_KEY = "fields";
-    private static final String FIELDS_NAME_KEY = "name";
-    private static final String FIELDS_TYPE_KEY = "type";
+    private static final String NAME_KEY = "name";
+    private static final String TYPE_KEY = "type";
     private static final String FIELDS_HIDDEN_KEY = "hidden";
+    private static final String VIEW_TYPE_NAME = "view";
+    private static final String COLLECTION_TYPE_NAME = "collection";
 
     private static final String OR_OP = "$or";
     private static final String AND_OP = "$and";
@@ -193,13 +196,21 @@ public class MongoSession
         }
 
         MongoTableHandle tableHandle = new MongoTableHandle(tableName);
-        return new MongoTable(tableHandle, columnHandles.build(), getIndexes(tableName));
+        return new MongoTable(
+                tableHandle,
+                columnHandles.build(),
+                isView(tableMeta) ? ImmutableList.of() : getIndexes(tableName));
+    }
+
+    private static boolean isView(Document tableMeta)
+    {
+        return VIEW_TYPE_NAME.equals(tableMeta.get(TYPE_KEY));
     }
 
     private MongoColumnHandle buildColumnHandle(Document columnMeta)
     {
-        String name = columnMeta.getString(FIELDS_NAME_KEY);
-        String typeString = columnMeta.getString(FIELDS_TYPE_KEY);
+        String name = columnMeta.getString(NAME_KEY);
+        String typeString = columnMeta.getString(TYPE_KEY);
         boolean hidden = columnMeta.getBoolean(FIELDS_HIDDEN_KEY, false);
 
         Type type = typeManager.getType(TypeSignature.parseTypeSignature(typeString));
@@ -390,6 +401,7 @@ public class MongoSession
             else {
                 Document metadata = new Document(TABLE_NAME_KEY, tableName);
                 metadata.append(FIELDS_KEY, guessTableFields(schemaTableName));
+                metadata.append(TYPE_KEY, guessTableType(schemaName, tableName));
 
                 schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
                 schema.insertOne(metadata);
@@ -482,8 +494,8 @@ public class MongoSession
             Optional<TypeSignature> fieldType = guessFieldType(value);
             if (fieldType.isPresent()) {
                 Document metadata = new Document();
-                metadata.append(FIELDS_NAME_KEY, key);
-                metadata.append(FIELDS_TYPE_KEY, fieldType.get().toString());
+                metadata.append(NAME_KEY, key);
+                metadata.append(TYPE_KEY, fieldType.get().toString());
                 metadata.append(FIELDS_HIDDEN_KEY,
                         key.equals("_id") && fieldType.get().equals(OBJECT_ID.getTypeSignature()));
 
@@ -495,6 +507,20 @@ public class MongoSession
         }
 
         return builder.build();
+    }
+
+    private String guessTableType(String schema, String table)
+    {
+        MongoDatabase database = client.getDatabase(schema);
+        Document doc = database.listCollections().filter(
+                new Document(ImmutableMap.of(
+                        NAME_KEY, table,
+                        TYPE_KEY, VIEW_TYPE_NAME))).first();
+
+        if (doc != null) {
+            return VIEW_TYPE_NAME;
+        }
+        return COLLECTION_TYPE_NAME;
     }
 
     private Optional<TypeSignature> guessFieldType(Object value)
@@ -577,8 +603,8 @@ public class MongoSession
         List<Document> columns = new ArrayList<>(getColumnMetadata(metadata));
 
         Document newColumn = new Document()
-                .append(FIELDS_NAME_KEY, columnMetadata.getName())
-                .append(FIELDS_TYPE_KEY, columnMetadata.getType().getTypeSignature().toString())
+                .append(NAME_KEY, columnMetadata.getName())
+                .append(TYPE_KEY, columnMetadata.getType().getTypeSignature().toString())
                 .append(FIELDS_HIDDEN_KEY, false);
         columnMetadata.getComment().ifPresent(comment -> newColumn.append(COMMENT_KEY, comment));
         columns.add(newColumn);
@@ -602,8 +628,8 @@ public class MongoSession
 
         List<Document> columns = getColumnMetadata(metadata).stream()
                 .map(document -> {
-                    if (document.getString(FIELDS_NAME_KEY).equals(source)) {
-                        document.put(FIELDS_NAME_KEY, target);
+                    if (document.getString(NAME_KEY).equals(source)) {
+                        document.put(NAME_KEY, target);
                     }
                     return document;
                 })
@@ -630,7 +656,7 @@ public class MongoSession
         Document metadata = getTableMetadata(schemaTableName);
 
         List<Document> columns = getColumnMetadata(metadata).stream()
-                .filter(document -> !document.getString(FIELDS_NAME_KEY).equals(columnName))
+                .filter(document -> !document.getString(NAME_KEY).equals(columnName))
                 .collect(toImmutableList());
 
         metadata.append(FIELDS_KEY, columns);

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoViews.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoViews.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mongodb;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestMongoViews
+        extends AbstractTestQueryFramework
+{
+    private static GenericContainer<?> mongoContainer;
+    private static MongoClient mongoClient;
+    private final int mongoContainerInternalPort = 27017;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        mongoContainer = new GenericContainer<>(DockerImageName.parse("mongo:5.0"))
+                .withExposedPorts(mongoContainerInternalPort)
+                .withCommand("mongod", "--bind_ip_all");
+        mongoContainer.start();
+
+        String host = mongoContainer.getContainerIpAddress();
+        Integer port = mongoContainer.getMappedPort(mongoContainerInternalPort);
+
+        mongoClient = new MongoClient(host, port);
+        super.init();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public final void close()
+    {
+        if (mongoClient != null) {
+            mongoClient.close();
+            mongoClient = null;
+        }
+        if (mongoContainer != null) {
+            mongoContainer.stop();
+            mongoContainer = null;
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner() throws Exception
+    {
+        String mongoUrl = mongoContainer.getHost() + ":" + mongoContainer.getMappedPort(mongoContainerInternalPort);
+
+        Session session = testSessionBuilder()
+                .setCatalog("mongodb")
+                .setSchema("test")
+                .build();
+
+        QueryRunner queryRunner = com.facebook.presto.tests.DistributedQueryRunner.builder(session)
+                .setNodeCount(1)
+                .build();
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("mongodb.seeds", mongoUrl)
+                .put("mongodb.schema-collection", "_schema")
+                .build();
+
+        queryRunner.installPlugin(new MongoPlugin());
+        queryRunner.createCatalog("mongodb", "mongodb", properties);
+
+        return queryRunner;
+    }
+
+    private MongoDatabase getTestDatabase()
+    {
+        return mongoClient.getDatabase("test");
+    }
+
+    @Test
+    public void testQueryView()
+    {
+        assertUpdate("CREATE TABLE test.test_json (id INT, col VARCHAR)");
+        assertUpdate("INSERT INTO test.test_json VALUES (1, 'alice'), (2, 'bob')", 2);
+
+        MongoDatabase database = getTestDatabase();
+
+        database.runCommand(new Document("create", "test_view")
+                .append("viewOn", "test_json")
+                .append("pipeline", Arrays.asList(
+                        new Document("$project", new Document()
+                                .append("id", 1)
+                                .append("col", 1)))));
+
+        boolean foundView = false;
+        for (Document doc : database.listCollections()) {
+            if ("test_view".equals(doc.getString("name"))) {
+                assertEquals(doc.getString("type"), "view", "test_view should be a view, not a collection");
+                foundView = true;
+                break;
+            }
+        }
+        assertEquals(foundView, true, "test_view should exist");
+
+        assertQuery("SELECT * FROM test.test_view ORDER BY id",
+                "VALUES (1, 'alice'), (2, 'bob')");
+
+        assertQuery("SELECT col FROM test.test_view WHERE id = 1",
+                "VALUES ('alice')");
+
+        assertUpdate("DROP TABLE test.test_json");
+        database.getCollection("test_view").drop();
+    }
+
+    @Test
+    public void testViewWithAggregation()
+    {
+        assertUpdate("CREATE TABLE test.sales (product VARCHAR, quantity INT, price DOUBLE)");
+        assertUpdate("INSERT INTO test.sales VALUES " +
+                "('apple', 10, 1.5), " +
+                "('banana', 20, 0.5), " +
+                "('apple', 5, 1.5)", 3);
+
+        MongoDatabase database = getTestDatabase();
+
+        database.runCommand(new Document("create", "sales_summary")
+                .append("viewOn", "sales")
+                .append("pipeline", Arrays.asList(
+                        new Document("$group", new Document()
+                                .append("_id", "$product")
+                                .append("total_quantity", new Document("$sum", "$quantity"))
+                                .append("avg_price", new Document("$avg", "$price"))),
+                        new Document("$project", new Document()
+                                .append("product", "$_id")
+                                .append("total_quantity", 1)
+                                .append("avg_price", 1)
+                                .append("_id", 0)))));
+
+        assertQuery("SELECT product, total_quantity FROM test.sales_summary WHERE product = 'apple'",
+                "VALUES ('apple', 15)");
+
+        assertUpdate("DROP TABLE test.sales");
+        database.getCollection("sales_summary").drop();
+    }
+
+    @Test
+    public void testViewDoesNotHaveIndexes()
+    {
+        assertUpdate("CREATE TABLE test.indexed_table (id INT, name VARCHAR)");
+        assertUpdate("INSERT INTO test.indexed_table VALUES (1, 'test')", 1);
+
+        MongoDatabase database = getTestDatabase();
+
+        database.runCommand(new Document("create", "indexed_view")
+                .append("viewOn", "indexed_table")
+                .append("pipeline", Arrays.asList(
+                        new Document("$project", new Document()
+                                .append("id", 1)
+                                .append("name", 1)))));
+
+        assertQuery("SELECT * FROM test.indexed_view", "VALUES (1, 'test')");
+
+        boolean isView = false;
+        for (Document doc : database.listCollections()) {
+            if ("indexed_view".equals(doc.getString("name"))) {
+                isView = "view".equals(doc.getString("type"));
+                break;
+            }
+        }
+        assertEquals(isView, true, "indexed_view should be a view");
+
+        assertUpdate("DROP TABLE test.indexed_table");
+        database.getCollection("indexed_view").drop();
+    }
+
+    @Test
+    public void testViewWithFilter()
+    {
+        assertUpdate("CREATE TABLE test.all_items (id INT, category VARCHAR, active BOOLEAN)");
+        assertUpdate("INSERT INTO test.all_items VALUES " +
+                "(1, 'A', true), " +
+                "(2, 'B', false), " +
+                "(3, 'A', true), " +
+                "(4, 'C', true)", 4);
+
+        MongoDatabase database = getTestDatabase();
+
+        database.runCommand(new Document("create", "active_a_items")
+                .append("viewOn", "all_items")
+                .append("pipeline", Arrays.asList(
+                        new Document("$match", new Document()
+                                .append("category", "A")
+                                .append("active", true)),
+                        new Document("$project", new Document()
+                                .append("id", 1)
+                                .append("category", 1)
+                                .append("active", 1)))));
+
+        assertQuery("SELECT id FROM test.active_a_items ORDER BY id",
+                "VALUES (1), (3)");
+
+        assertUpdate("DROP TABLE test.all_items");
+        database.getCollection("active_a_items").drop();
+    }
+}


### PR DESCRIPTION
## Description
Since Mongo treats views as regular documents, the find function that's used in the connector works fine. The change here is to prevent mongo from using functions that are not allowed on views when querying a view. In this instance, get indexes

Previous behavior...

```
presto> select * from mongodb.testdb.users_view;

Query 20260210_185340_00000_mcpfd, FAILED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 251ms, server-side: 64ms] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20260210_185340_00000_mcpfd failed: com.mongodb.MongoCommandException: Command failed with error 166 (CommandNotSupportedOnView): 'Namespace testdb.users_view is a view, not a collection' on server localhost:27017. The full response is {"ok": 0.0, "errmsg": "Namespace testdb.users_view is a view, not a collection", "code": 166, "codeName": "CommandNotSupportedOnView"}
```

Fix...

```
presto> select * from mongodb.testdb.users_view;
  name   | age
---------+-----
 Alice   |  30
 Charlie |  35
(2 rows)

Query 20260210_192143_00000_tm4np, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 482ms, server-side: 316ms] [2 rows, 40B] [6 rows/s, 126B/s]
```

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

MongoDB Connector
* Add view querying capabilities in the Mongo connector
```