### PR TITLE
fix(plugin-iceberg): Avoid relying solely on manifest_length for cached manifests

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HdfsFileIO.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HdfsFileIO.java
@@ -62,7 +62,7 @@ public class HdfsFileIO
                 manifest.keyMetadata() == null,
                 "Cannot decrypt manifest: %s (use EncryptingFileIO)",
                 manifest.path());
-        InputFile inputFile = new HdfsInputFile(new Path(manifest.path()), environment, context, Optional.of(manifest.length()));
+        InputFile inputFile = new HdfsInputFile(new Path(manifest.path()), environment, context, Optional.empty());
         return manifestFileCache.isEnabled() ?
                 new HdfsCachedInputFile(inputFile, new ManifestFileCacheKey(manifest.path()), manifestFileCache) :
                 inputFile;


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

See #26998 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
No user-facing impact. 

When Manifest File Caching is enabled, Presto will not rely on `manifest_length` attribute of iceberg's snapshot metadata but fetch it from filesystem.

## Test Plan
<!---Please fill in how you tested your change-->

Table re-written using Spark's `rewrite_table_path` procedure

Before:

```
presto:iceberg> select * from "test_rewritten_table$files";

Query 20260120_233600_00000_8zt7x, FAILED, 1 node
Splits: 17 total, 0 done (0.00%)
[Latency: client-side: 1:27, server-side: 1:26] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20260120_233600_00000_8zt7x failed: Failed to open file: com.facebook.presto.iceberg.HdfsCachedInputFile@59768622
```

After:

```
presto:iceberg> select * from "test_rewritten_table$files";
 content |                                               file_path                                                | file_format | record_count | file_size_in_bytes | column_sizes | value_counts | null_v>
---------+--------------------------------------------------------------------------------------------------------+-------------+--------------+--------------------+--------------+--------------+------->
       0 | s3a://bucket/test_new_rewritten/data/6d762054-27e7-4161-99a7-fb31ef0a71fb.parquet | PARQUET     |            3 |                284 | {1=48}       | {1=3}        | {1=0} >
(1 row)

Query 20260120_234710_00000_s6uhc, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:12, server-side: 0:11] [1 rows, 319B] [0 rows/s, 29B/s]

presto:iceberg> select * from test_rewritten_table;
 id 
----
  1 
  2 
  3 
(3 rows)

Query 20260120_234747_00002_s6uhc, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:03, server-side: 0:03] [3 rows, 284B] [1 rows/s, 107B/s]

```

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix failures when reading Iceberg tables with manifest file caching enabled if snapshot metadata contains an incorrect manifest_length.
```

