### PR TITLE
fix(build): Fully qualify yield call to avoid java 17 compilation error

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/PageBuffer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/PageBuffer.java
@@ -18,7 +18,6 @@ import jakarta.annotation.Nullable;
 
 import static com.facebook.presto.operator.WorkProcessor.ProcessState.finished;
 import static com.facebook.presto.operator.WorkProcessor.ProcessState.ofResult;
-import static com.facebook.presto.operator.WorkProcessor.ProcessState.yield;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -41,7 +40,7 @@ public class PageBuffer
                 return ofResult(result);
             }
 
-            return yield();
+            return WorkProcessor.ProcessState.yield();
         });
     }
 


### PR DESCRIPTION
## Description
Updates `yield` call to use fully-qualified call

## Motivation and Context
In java 14+, compilation will error if a restricted name is used and `yield` is a restricted in 14+.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

