### PR TITLE
feat(plugin-iceberg): WIP support partitioned writer

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -37,6 +37,7 @@ import com.facebook.presto.hive.PartitionSet;
 import com.facebook.presto.hive.UnknownTableTypeException;
 import com.facebook.presto.iceberg.changelog.ChangelogOperation;
 import com.facebook.presto.iceberg.changelog.ChangelogUtil;
+import com.facebook.presto.iceberg.partitioning.IcebergPartitioningHandle;
 import com.facebook.presto.iceberg.procedure.context.IcebergCommonProcedureContext;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
 import com.facebook.presto.iceberg.transaction.IcebergTransactionContext;
@@ -64,6 +65,7 @@ import com.facebook.presto.spi.MaterializedViewRefreshType;
 import com.facebook.presto.spi.MaterializedViewStaleReadBehavior;
 import com.facebook.presto.spi.MaterializedViewStalenessConfig;
 import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.PartitionedTableWritePolicy;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.SchemaTableName;
@@ -150,6 +152,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -166,6 +169,9 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static com.facebook.presto.common.type.StandardTypes.ARRAY;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZED;
@@ -219,6 +225,7 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFil
 import static com.facebook.presto.iceberg.IcebergTableProperties.LOCATION_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
 import static com.facebook.presto.iceberg.IcebergTableType.CHANGELOG;
 import static com.facebook.presto.iceberg.IcebergTableType.DATA;
 import static com.facebook.presto.iceberg.IcebergTableType.EQUALITY_DELETES;
@@ -256,6 +263,7 @@ import static com.facebook.presto.iceberg.IcebergWarningCode.SORT_COLUMN_TRANSFO
 import static com.facebook.presto.iceberg.IcebergWarningCode.USE_OF_DEPRECATED_TABLE_PROPERTY;
 import static com.facebook.presto.iceberg.PartitionFields.getPartitionColumnName;
 import static com.facebook.presto.iceberg.PartitionFields.getTransformTerm;
+import static com.facebook.presto.iceberg.PartitionFields.parsePartitionFields;
 import static com.facebook.presto.iceberg.PartitionFields.toPartitionFields;
 import static com.facebook.presto.iceberg.PartitionSpecConverter.toPrestoPartitionSpec;
 import static com.facebook.presto.iceberg.SchemaConverter.toPrestoSchema;
@@ -687,6 +695,44 @@ public abstract class IcebergAbstractMetadata
         finishCreateTable(session, beginCreateTable(session, tableMetadata, layout), ImmutableList.of(), ImmutableList.of());
     }
 
+    public static Schema schemaFromMetadata(List<ColumnMetadata> columns)
+    {
+        List<NestedField> icebergColumns = new ArrayList<>();
+        AtomicInteger subFieldIndex = new AtomicInteger(columns.size() + 1);
+        for (int index = 0; index < columns.size(); index++) {
+            ColumnMetadata column = columns.get(index);
+            String baseTypeName = column.getType().getTypeSignature().getBase();
+            org.apache.iceberg.types.Type type;
+            if (baseTypeName.equals(ROW) || baseTypeName.equals(MAP) || baseTypeName.equals(ARRAY)) {
+                type = Types.ListType.ofOptional(subFieldIndex.getAndIncrement(), Types.BooleanType.get());
+            }
+            else {
+                type = toIcebergType(column.getType());
+            }
+            NestedField field = NestedField.of(index + 1, column.isNullable(), column.getName(), type);
+            icebergColumns.add(field);
+        }
+        org.apache.iceberg.types.Type icebergSchema = Types.StructType.of(icebergColumns);
+        return new Schema(icebergSchema.asStructType().fields());
+    }
+
+    @Override
+    public Optional<ConnectorNewTableLayout> getNewTableLayout(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        Schema schema = schemaFromMetadata(tableMetadata.getColumns());
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
+        return createNewTableLayout(schema, partitionSpec);
+    }
+
+    @Override
+    public Optional<ConnectorNewTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        Table icebergTable = getIcebergTable(session, ((IcebergTableHandle) tableHandle).getSchemaTableName());
+        Schema schema = icebergTable.schema();
+        PartitionSpec partitionSpec = icebergTable.spec();
+        return createNewTableLayout(schema, partitionSpec);
+    }
+
     @Override
     public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
@@ -848,6 +894,29 @@ public abstract class IcebergAbstractMetadata
             default:
                 throw new UnsupportedOperationException("Unsupported task content: " + task.getContent());
         }
+    }
+
+    private Optional<ConnectorNewTableLayout> createNewTableLayout(Schema schema, PartitionSpec partitionSpec)
+    {
+        if (partitionSpec.isUnpartitioned()) {
+            return Optional.empty();
+        }
+
+        List<String> partitioningColumnNames = partitionSpec.fields().stream()
+                .sorted(Comparator.comparingInt(PartitionField::sourceId))
+                .map(field -> {
+                    return schema.findColumnName(field.sourceId());
+                })
+                .distinct()
+                .collect(toImmutableList());
+
+        if (partitionSpec.fields().stream().allMatch(field -> field.transform().isIdentity())) {
+            // Use the default fixed hash distribution
+            return Optional.of(new ConnectorNewTableLayout(partitioningColumnNames));
+        }
+
+        IcebergPartitioningHandle partitioningHandle = IcebergPartitioningHandle.create(partitionSpec, typeManager);
+        return Optional.of(new ConnectorNewTableLayout(partitioningHandle, partitioningColumnNames, PartitionedTableWritePolicy.SINGLE_WRITER_PER_PARTITION_REQUIRED));
     }
 
     private void handleFinishPositionDeletes(CommitTaskData task, PartitionSpec partitionSpec, Type[] partitionColumnTypes, RowDelta rowDelta, ImmutableSet.Builder<String> writtenFiles, ImmutableSet.Builder<String> referencedDataFiles)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -52,6 +52,7 @@ import com.facebook.presto.spi.ConnectorMergeTableHandle;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayout;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -356,6 +357,7 @@ public abstract class IcebergAbstractMetadata
     protected final IcebergTransactionContext transactionContext;
     protected final StatisticsFileCache statisticsFileCache;
     protected final IcebergTableProperties tableProperties;
+    private final ConnectorSystemConfig connectorSystemConfig;
     private final StandardFunctionResolution functionResolution;
     private static final JsonCodec<List<String>> STRING_LIST_CODEC = JsonCodec.listJsonCodec(String.class);
 
@@ -371,6 +373,7 @@ public abstract class IcebergAbstractMetadata
             FilterStatsCalculatorService filterStatsCalculatorService,
             StatisticsFileCache statisticsFileCache,
             IcebergTableProperties tableProperties,
+            ConnectorSystemConfig connectorSystemConfig,
             com.facebook.presto.spi.transaction.IsolationLevel isolationLevel,
             boolean autoCommitContext)
     {
@@ -385,6 +388,7 @@ public abstract class IcebergAbstractMetadata
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
+        this.connectorSystemConfig = requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
         this.transactionContext = new IcebergTransactionContext(isolationLevel, autoCommitContext);
     }
 
@@ -898,7 +902,7 @@ public abstract class IcebergAbstractMetadata
 
     private Optional<ConnectorNewTableLayout> createNewTableLayout(Schema schema, PartitionSpec partitionSpec)
     {
-        if (partitionSpec.isUnpartitioned()) {
+        if (connectorSystemConfig.isNativeExecution() || partitionSpec.isUnpartitioned()) {
             return Optional.empty();
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -29,7 +29,6 @@ import com.facebook.presto.hive.HdfsConfigurationInitializer;
 import com.facebook.presto.hive.HdfsEnvironment;
 import com.facebook.presto.hive.HiveDwrfEncryptionProvider;
 import com.facebook.presto.hive.HiveHdfsConfiguration;
-import com.facebook.presto.hive.HiveNodePartitioningProvider;
 import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.OrcFileWriterConfig;
 import com.facebook.presto.hive.OrcFileWriterFactory;
@@ -44,6 +43,7 @@ import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
 import com.facebook.presto.hive.metastore.InvalidateMetastoreCacheProcedure;
 import com.facebook.presto.iceberg.nessie.IcebergNessieConfig;
 import com.facebook.presto.iceberg.optimizer.IcebergPlanOptimizerProvider;
+import com.facebook.presto.iceberg.partitioning.IcebergNodePartitioningProvider;
 import com.facebook.presto.iceberg.procedure.ExpireSnapshotsProcedure;
 import com.facebook.presto.iceberg.procedure.FastForwardBranchProcedure;
 import com.facebook.presto.iceberg.procedure.ManifestFileCacheInvalidationProcedure;
@@ -169,7 +169,7 @@ public class IcebergCommonModule
         binder.bind(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
         binder.bind(SortParameters.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).to(IcebergPageSinkProvider.class).in(Scopes.SINGLETON);
-        binder.bind(ConnectorNodePartitioningProvider.class).to(HiveNodePartitioningProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorNodePartitioningProvider.class).to(IcebergNodePartitioningProvider.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(ParquetFileWriterConfig.class);
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHandleResolver.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHandleResolver.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.facebook.presto.hive.HiveTransactionHandle;
+import com.facebook.presto.iceberg.partitioning.IcebergPartitioningHandle;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorDeleteTableHandle;
 import com.facebook.presto.spi.ConnectorDistributedProcedureHandle;
@@ -24,6 +25,7 @@ import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 
 public class IcebergHandleResolver
@@ -86,5 +88,11 @@ public class IcebergHandleResolver
     public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
     {
         return HiveTransactionHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass()
+    {
+        return IcebergPartitioningHandle.class;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -166,7 +166,6 @@ public class IcebergHiveMetadata
     private final HdfsEnvironment hdfsEnvironment;
     private final DateTimeZone timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(TimeZone.getDefault().getID())));
     private final IcebergHiveTableOperationsConfig hiveTableOperationsConfig;
-    private final ConnectorSystemConfig connectorSystemConfig;
     private final ManifestFileCache manifestFileCache;
 
     public IcebergHiveMetadata(
@@ -191,13 +190,12 @@ public class IcebergHiveMetadata
             boolean autoCommitContext)
     {
         super(typeManager, procedureRegistry, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec,
-                nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext);
+                nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties, connectorSystemConfig, isolationLevel, autoCommitContext);
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hiveTableOperationsConfig = requireNonNull(hiveTableOperationsConfig, "hiveTableOperationsConfig is null");
         this.manifestFileCache = requireNonNull(manifestFileCache, "manifestFileCache is null");
-        this.connectorSystemConfig = requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
     }
 
     public ExtendedHiveMetastore getMetastore()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.ConnectorViewDefinition;
@@ -124,11 +125,12 @@ public class IcebergNativeMetadata
             FilterStatsCalculatorService filterStatsCalculatorService,
             StatisticsFileCache statisticsFileCache,
             IcebergTableProperties tableProperties,
+            ConnectorSystemConfig connectorSystemConfig,
             IsolationLevel isolationLevel,
             boolean autoCommitContext)
     {
         super(typeManager, procedureRegistry, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec,
-                nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext);
+                nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties, connectorSystemConfig, isolationLevel, autoCommitContext);
         this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
         this.catalogType = requireNonNull(catalogType, "catalogType is null");
         this.warehouseDataDir = Optional.ofNullable(catalogFactory.getCatalogWarehouseDataDir());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.iceberg.statistics.StatisticsFileCache;
 import com.facebook.presto.iceberg.transaction.IcebergTransactionMetadata;
+import com.facebook.presto.spi.ConnectorSystemConfig;
 import com.facebook.presto.spi.MaterializedViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
@@ -48,6 +49,7 @@ public class IcebergNativeMetadataFactory
     final FilterStatsCalculatorService filterStatsCalculatorService;
     final StatisticsFileCache statisticsFileCache;
     final IcebergTableProperties tableProperties;
+    final ConnectorSystemConfig connectorSystemConfig;
 
     @Inject
     public IcebergNativeMetadataFactory(
@@ -63,7 +65,8 @@ public class IcebergNativeMetadataFactory
             NodeVersion nodeVersion,
             FilterStatsCalculatorService filterStatsCalculatorService,
             StatisticsFileCache statisticsFileCache,
-            IcebergTableProperties tableProperties)
+            IcebergTableProperties tableProperties,
+            ConnectorSystemConfig connectorSystemConfig)
     {
         this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -78,6 +81,7 @@ public class IcebergNativeMetadataFactory
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
+        this.connectorSystemConfig = requireNonNull(connectorSystemConfig, "connectorSystemConfig is null");
     }
 
     public IcebergTransactionMetadata create()
@@ -89,6 +93,6 @@ public class IcebergNativeMetadataFactory
     {
         return new IcebergNativeMetadata(catalogFactory, typeManager, procedureRegistry, functionResolution,
                 rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec, catalogType, nodeVersion,
-                filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext);
+                filterStatsCalculatorService, statisticsFileCache, tableProperties, connectorSystemConfig, isolationLevel, autoCommitContext);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
@@ -62,8 +62,8 @@ public final class PartitionFields
 
     private static final Pattern COLUMN_BUCKET_PATTERN = Pattern.compile("bucket\\((\\d+)\\)");
     private static final Pattern COLUMN_TRUNCATE_PATTERN = Pattern.compile("truncate\\((\\d+)\\)");
-    private static final Pattern ICEBERG_BUCKET_PATTERN = Pattern.compile("bucket\\[(\\d+)]");
-    private static final Pattern ICEBERG_TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
+    public static final Pattern ICEBERG_BUCKET_PATTERN = Pattern.compile("bucket\\[(\\d+)]");
+    public static final Pattern ICEBERG_TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
 
     private PartitionFields() {}
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTransforms.java
@@ -74,7 +74,11 @@ public final class PartitionTransforms
      */
     public static ColumnTransform getColumnTransform(PartitionField field, Type type)
     {
-        String transform = field.transform().toString();
+        return getColumnTransform(field.transform().toString(), type, field.toString());
+    }
+
+    public static ColumnTransform getColumnTransform(String transform, Type type, String partitionFieldMessage)
+    {
         switch (transform) {
             case "identity":
                 return new ColumnTransform(transform, type, Function.identity(), ValueTransform.identity(type));
@@ -97,7 +101,7 @@ public final class PartitionTransforms
                             block -> transformBlock(TIMESTAMP_WITH_TIME_ZONE, block, transformYear),
                             ValueTransform.from(TIMESTAMP_WITH_TIME_ZONE, transformYear));
                 }
-                throw new UnsupportedOperationException("Unsupported type for 'year': " + field);
+                throw new UnsupportedOperationException("Unsupported type for 'year': " + partitionFieldMessage);
             case "month":
                 if (type.equals(DATE)) {
                     LongUnaryOperator transformMonth = value -> epochMonth(DAYS.toMillis(value));
@@ -117,7 +121,7 @@ public final class PartitionTransforms
                             block -> transformBlock(TIMESTAMP_WITH_TIME_ZONE, block, transformMonth),
                             ValueTransform.from(TIMESTAMP_WITH_TIME_ZONE, transformMonth));
                 }
-                throw new UnsupportedOperationException("Unsupported type for 'month': " + field);
+                throw new UnsupportedOperationException("Unsupported type for 'month': " + partitionFieldMessage);
             case "day":
                 if (type.equals(DATE)) {
                     LongUnaryOperator transformDay = value -> epochDay(DAYS.toMillis(value));
@@ -137,7 +141,7 @@ public final class PartitionTransforms
                             block -> transformBlock(TIMESTAMP_WITH_TIME_ZONE, block, transformDay),
                             ValueTransform.from(TIMESTAMP_WITH_TIME_ZONE, transformDay));
                 }
-                throw new UnsupportedOperationException("Unsupported type for 'day': " + field);
+                throw new UnsupportedOperationException("Unsupported type for 'day': " + partitionFieldMessage);
             case "hour":
                 if (type.equals(TIMESTAMP)) {
                     LongUnaryOperator transformHour = value -> epochHour(value);
@@ -151,7 +155,7 @@ public final class PartitionTransforms
                             block -> transformBlock(TIMESTAMP_WITH_TIME_ZONE, block, transformHour),
                             ValueTransform.from(TIMESTAMP_WITH_TIME_ZONE, transformHour));
                 }
-                throw new UnsupportedOperationException("Unsupported type for 'hour': " + field);
+                throw new UnsupportedOperationException("Unsupported type for 'hour': " + partitionFieldMessage);
         }
 
         Matcher matcher = BUCKET_PATTERN.matcher(transform);
@@ -199,7 +203,7 @@ public final class PartitionTransforms
                         block -> bucketVarbinary(block, count),
                         (block, position) -> bucketValueVarbinary(block, position, count));
             }
-            throw new UnsupportedOperationException("Unsupported type for 'bucket': " + field);
+            throw new UnsupportedOperationException("Unsupported type for 'bucket': " + partitionFieldMessage);
         }
 
         matcher = TRUNCATE_PATTERN.matcher(transform);
@@ -269,10 +273,10 @@ public final class PartitionTransforms
                             return truncateVarbinary(VARBINARY.getSlice(block, position), width);
                         });
             }
-            throw new UnsupportedOperationException("Unsupported type for 'truncate': " + field);
+            throw new UnsupportedOperationException("Unsupported type for 'truncate': " + partitionFieldMessage);
         }
 
-        throw new UnsupportedOperationException("Unsupported partition transform: " + field);
+        throw new UnsupportedOperationException("Unsupported partition transform: " + partitionFieldMessage);
     }
 
     private static Block bucketInteger(Block block, int count)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergBucketFunction.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergBucketFunction.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.partitioning;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.iceberg.PartitionTransforms;
+import com.facebook.presto.spi.BucketFunction;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergBucketFunction
+        implements BucketFunction
+{
+    private final int bucketCount;
+    private final List<PartitionHashCalculator> calculators;
+    private final List<Type> partitionChannelTypes;
+
+    public IcebergBucketFunction(IcebergPartitioningHandle partitioningHandle, List<Type> partitionChannelTypes, int bucketCount)
+    {
+        requireNonNull(partitioningHandle, "partitioningHandle is null");
+        checkArgument(bucketCount > 0, "Invalid bucketCount: %s", bucketCount);
+
+        this.bucketCount = bucketCount;
+        List<IcebergPartitionFieldHandle> partitionFieldHandles = partitioningHandle.getPartitionFieldHandles();
+        this.calculators = partitionFieldHandles.stream()
+                .map(PartitionHashCalculator::create)
+                .collect(toImmutableList());
+        this.partitionChannelTypes = requireNonNull(partitionChannelTypes, "partitionChannelTypes  is null");
+    }
+
+    @Override
+    public int getBucket(Page page, int position)
+    {
+        long hash = 0;
+        for (int i = 0; i < calculators.size(); i++) {
+            PartitionHashCalculator function = calculators.get(i);
+            Type type = partitionChannelTypes.get(function.sourceColumnChannel);
+            long valueHash = function.computeHash(page, position, type);
+            hash = (31 * hash) + valueHash;
+        }
+
+        return (int) ((hash & Long.MAX_VALUE) % bucketCount);
+    }
+
+    public static class PartitionHashCalculator
+    {
+        Integer sourceColumnChannel;
+        PartitionTransforms.ColumnTransform columnTransform;
+        PartitionHashCalculator(Integer sourceColumnChannel,
+                                PartitionTransforms.ColumnTransform columnTransform)
+        {
+            this.sourceColumnChannel = sourceColumnChannel;
+            this.columnTransform = requireNonNull(columnTransform, "columnTransform is null");
+        }
+
+        public static PartitionHashCalculator create(IcebergPartitionFieldHandle partitionFieldHandle)
+        {
+            PartitionTransforms.ColumnTransform columnTransform = PartitionTransforms.getColumnTransform(
+                    partitionFieldHandle.getTransformString(),
+                    partitionFieldHandle.getType(),
+                    partitionFieldHandle.getPartitionFieldMessage());
+            return new PartitionHashCalculator(
+                    partitionFieldHandle.getSourceColumnChannel(),
+                    columnTransform);
+        }
+
+        public long computeHash(Page page, int position, Type type)
+        {
+            Block block = page.getBlock(sourceColumnChannel).getSingleValueBlock(position);
+            return columnTransform.getType().hash(columnTransform.getTransform().apply(block), 0);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergNodePartitioningProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergNodePartitioningProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.partitioning;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.BucketFunction;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.connector.ConnectorBucketNodeMap;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.common.primitives.Ints;
+
+import java.util.List;
+import java.util.function.ToIntFunction;
+
+import static com.facebook.presto.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
+
+public class IcebergNodePartitioningProvider
+        implements ConnectorNodePartitioningProvider
+{
+    public static final int DEFAULT_BUCKET_COUNT = 1024;
+
+    @Override
+    public ConnectorBucketNodeMap getBucketNodeMap(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorPartitioningHandle partitioningHandle,
+            List<Node> sortedNodes)
+    {
+        IcebergPartitioningHandle handle = (IcebergPartitioningHandle) partitioningHandle;
+
+        List<IcebergPartitionFieldHandle> partitionFieldHandles = handle.getPartitionFieldHandles();
+
+        // Heuristic bucket count estimation based on partition transforms and nodes size.
+        boolean allBucketTransform = true;
+        long bucketMultipleCount = 1L;
+        for (IcebergPartitionFieldHandle partitionFieldHandle : partitionFieldHandles) {
+            if (partitionFieldHandle.isBucketTransform()) {
+                bucketMultipleCount *= partitionFieldHandle.getSize().orElseThrow();
+            }
+            else {
+                allBucketTransform = false;
+            }
+        }
+
+        int bucketCount = Ints.saturatedCast(bucketMultipleCount);
+        int targetBucketCount = allBucketTransform ? bucketCount : Math.max(bucketCount, sortedNodes.size() * 2);
+
+        return createBucketNodeMap(Math.min(targetBucketCount, DEFAULT_BUCKET_COUNT));
+    }
+
+    @Override
+    public BucketFunction getBucketFunction(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorPartitioningHandle partitioningHandle,
+            List<Type> partitionChannelTypes,
+            int bucketCount)
+    {
+        IcebergPartitioningHandle handle = (IcebergPartitioningHandle) partitioningHandle;
+        return new IcebergBucketFunction(handle, partitionChannelTypes, bucketCount);
+    }
+
+    @Override
+    public int getBucketCount(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+    {
+        // Partitioned read is not currently supported.
+        // This return value will not actually be used, so return an invalid value to catch unintended usage.
+        return -1;
+    }
+
+    @Override
+    public ToIntFunction<ConnectorSplit> getSplitBucketFunction(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorPartitioningHandle partitioningHandle)
+    {
+        return (split) -> {
+            throw new UnsupportedOperationException("This connector does not support partitioned read");
+        };
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitionFieldHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitionFieldHandle.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.partitioning;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.iceberg.PartitionTransformType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.iceberg.PartitionField;
+
+import java.util.OptionalInt;
+import java.util.regex.Matcher;
+
+import static com.facebook.presto.iceberg.PartitionFields.ICEBERG_BUCKET_PATTERN;
+import static com.facebook.presto.iceberg.PartitionFields.ICEBERG_TRUNCATE_PATTERN;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergPartitionFieldHandle
+{
+    final int sourceColumnChannel;
+    final PartitionTransformType transform;
+    final Type type;
+    final OptionalInt size;
+    final String partitionFieldMessage;
+
+    public IcebergPartitionFieldHandle(int sourceColumnChannel, PartitionField partitionField, Type type)
+    {
+        this(sourceColumnChannel, partitionField, type, OptionalInt.empty());
+    }
+
+    public IcebergPartitionFieldHandle(
+            int sourceColumnChannel,
+            PartitionField partitionField,
+            Type type,
+            OptionalInt size)
+    {
+        this(sourceColumnChannel, PartitionTransformType.fromStringOrFail(partitionField.transform().toString()), partitionField.toString(), type, size);
+    }
+
+    @JsonCreator
+    public IcebergPartitionFieldHandle(
+            @JsonProperty("sourceColumnChannel") int sourceColumnChannel,
+            @JsonProperty("transform") PartitionTransformType transform,
+            @JsonProperty("partitionFieldMessage") String partitionFieldMessage,
+            @JsonProperty("type") Type type,
+            @JsonProperty("size") OptionalInt size)
+    {
+        checkArgument(sourceColumnChannel >= 0, "sourceColumnChannel must be greater than or equal to zero");
+        this.sourceColumnChannel = sourceColumnChannel;
+        this.transform = requireNonNull(transform, "transform is null");
+        this.partitionFieldMessage = requireNonNull(partitionFieldMessage, "partitionFieldMessage is null");
+        this.type = requireNonNull(type, "type is null");
+        this.size = requireNonNull(size, "size is null");
+        checkArgument(size.isEmpty() || size.getAsInt() >= 0, "size must be greater than or equal to zero");
+        checkArgument(size.isPresent() && isParameterizedTransform() || size.isEmpty() && !isParameterizedTransform(), "size is only valid for BUCKET and TRUNCATE transforms");
+    }
+
+    @JsonProperty
+    public int getSourceColumnChannel()
+    {
+        return sourceColumnChannel;
+    }
+
+    @JsonProperty
+    public PartitionTransformType getTransform()
+    {
+        return transform;
+    }
+
+    @JsonProperty
+    public String getPartitionFieldMessage()
+    {
+        return partitionFieldMessage;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public OptionalInt getSize()
+    {
+        return size;
+    }
+
+    @JsonIgnore
+    public boolean isBucketTransform()
+    {
+        return transform == PartitionTransformType.BUCKET;
+    }
+
+    @JsonIgnore
+    public boolean isParameterizedTransform()
+    {
+        return transform == PartitionTransformType.BUCKET || transform == PartitionTransformType.TRUNCATE;
+    }
+
+    @JsonIgnore
+    public String getTransformString()
+    {
+        switch (transform) {
+            case IDENTITY :
+            case YEAR:
+            case MONTH:
+            case DAY:
+            case HOUR:
+                return transform.getTransform();
+            case BUCKET:
+            case TRUNCATE:
+                checkArgument(size.isPresent(), "size must be present for BUCKET and TRUNCATE transforms");
+                return transform.getTransform() + "[" + size.getAsInt() + "]";
+            default:
+                throw new UnsupportedOperationException("Unsupported partition transform: " + transform);
+        }
+    }
+
+    public static IcebergPartitionFieldHandle create(int sourceColumnChannel, PartitionField partitionField, String transform, Type type)
+    {
+        switch (transform) {
+            case "identity":
+            case "year":
+            case "month":
+            case "day":
+            case "hour":
+            case "void":
+                return new IcebergPartitionFieldHandle(sourceColumnChannel, partitionField, type);
+            default:
+                Matcher matcher = ICEBERG_BUCKET_PATTERN.matcher(transform);
+                if (matcher.matches()) {
+                    return new IcebergPartitionFieldHandle(
+                            sourceColumnChannel,
+                            partitionField,
+                            type,
+                            OptionalInt.of(Integer.parseInt(matcher.group(1))));
+                }
+
+                matcher = ICEBERG_TRUNCATE_PATTERN.matcher(transform);
+                if (matcher.matches()) {
+                    return new IcebergPartitionFieldHandle(
+                            sourceColumnChannel,
+                            partitionField,
+                            type,
+                            OptionalInt.of(Integer.parseInt(matcher.group(1))));
+                }
+                throw new UnsupportedOperationException("Unsupported partition transform: " + transform);
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitionFieldHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitionFieldHandle.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.iceberg.PartitionField;
 
+import java.util.Objects;
 import java.util.OptionalInt;
 import java.util.regex.Matcher;
 
@@ -159,5 +160,42 @@ public class IcebergPartitionFieldHandle
                 }
                 throw new UnsupportedOperationException("Unsupported partition transform: " + transform);
         }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IcebergPartitionFieldHandle that = (IcebergPartitionFieldHandle) o;
+        return Objects.equals(sourceColumnChannel, that.sourceColumnChannel) &&
+                Objects.equals(transform, that.transform) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(size, that.size) &&
+                Objects.equals(partitionFieldMessage, that.partitionFieldMessage);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sourceColumnChannel, transform, type, size, partitionFieldMessage);
+    }
+
+    @Override
+    public String toString()
+    {
+        String transformString = size.isPresent()
+                ? transform + "[" + size.getAsInt() + "]"
+                : transform.toString();
+
+        return String.format(
+                "field(channel=%d, %s, %s)",
+                sourceColumnChannel,
+                transformString,
+                type);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitioningHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitioningHandle.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.partitioning;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.types.Types;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergPartitioningHandle
+        implements ConnectorPartitioningHandle
+{
+    private final List<IcebergPartitionFieldHandle> partitionFieldHandles;
+
+    @JsonCreator
+    public IcebergPartitioningHandle(@JsonProperty("partitionFieldHandles") List<IcebergPartitionFieldHandle> partitionFieldHandles)
+    {
+        this.partitionFieldHandles = ImmutableList.copyOf(requireNonNull(partitionFieldHandles, "partitionFieldHandles is null"));
+    }
+
+    @JsonProperty
+    public List<IcebergPartitionFieldHandle> getPartitionFieldHandles()
+    {
+        return partitionFieldHandles;
+    }
+
+    public static IcebergPartitioningHandle create(PartitionSpec spec, TypeManager typeManager)
+    {
+        Set<Integer> sourceColumnIdSet = spec.fields().stream().map(PartitionField::sourceId).collect(Collectors.toSet());
+        Map<Integer, Integer> sourceColumnIdToIndex = new HashMap<>();
+        List<Types.NestedField> fields = spec.schema().columns();
+        AtomicInteger index = new AtomicInteger(0);
+        for (Types.NestedField field : fields) {
+            if (sourceColumnIdSet.contains(field.fieldId()) && !sourceColumnIdToIndex.containsKey(field.fieldId())) {
+                sourceColumnIdToIndex.put(field.fieldId(), index.getAndIncrement());
+            }
+        }
+        List<IcebergPartitionFieldHandle> partitionFields = spec.fields().stream()
+                .map(field -> IcebergPartitionFieldHandle.create(sourceColumnIdToIndex.get(field.sourceId()),
+                        field, field.transform().toString(),
+                        toPrestoType(spec.schema().findType(field.sourceId()), typeManager)))
+                .collect(toImmutableList());
+
+        return new IcebergPartitioningHandle(partitionFields);
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitioningHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitioningHandle.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.types.Types;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -68,5 +69,30 @@ public class IcebergPartitioningHandle
                 .collect(toImmutableList());
 
         return new IcebergPartitioningHandle(partitionFields);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IcebergPartitioningHandle that = (IcebergPartitioningHandle) o;
+        return Objects.equals(partitionFieldHandles, that.partitionFieldHandles);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(partitionFieldHandles);
+    }
+
+    @Override
+    public String toString()
+    {
+        return partitionFieldHandles.toString();
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1569,6 +1569,42 @@ public abstract class IcebergDistributedSmokeTestBase
     }
 
     @Test
+    public void testPlanFragmentPartitioningOfCTAS()
+    {
+        String tableName = "test_plan_fragment_partitioning_of_ctas";
+        try {
+            // For non-partitioned target tables, the plan fragment containing the writer node is of SCALED distributed type.
+            String distributedPlanForUnpartitionedTable = getQueryRunner().execute(
+                    format("EXPLAIN (TYPE DISTRIBUTED) CREATE TABLE %s AS SELECT * FROM %s", tableName, "lineitem"))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 1 [SCALED]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 2 [SOURCE]"));
+
+            // For partitioned target tables, the plan fragment containing the writer node is of IcebergPartitioningHandle distributed type.
+            String distributedPlanForPartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 1000)'])" +
+                                    " AS SELECT * FROM %s", tableName, "lineitem"))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 1 [iceberg:[field(channel=0, bucket[1000], bigint)]]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 2 [SOURCE]"));
+
+            // IcebergPartitioningHandle distributed type with multiple partition fields.
+            distributedPlanForPartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 1000)', 'orderkey', 'suppkey'])" +
+                                    " AS SELECT * FROM %s", tableName, "lineitem"))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 1 [iceberg:[field(channel=0, bucket[1000], bigint), field(channel=0, identity, bigint), field(channel=1, identity, bigint)]]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 2 [SOURCE]"));
+        }
+        finally {
+            dropTable(getSession(), tableName);
+        }
+    }
+
+    @Test
     public void testPartitionedInsertIntoTableWithLargeAmountOfPartitions()
     {
         String tableName = "test_partitioned_insert_with_many_partitions";
@@ -1604,6 +1640,48 @@ public abstract class IcebergDistributedSmokeTestBase
         }
         finally {
             dropTable(getSession(), tableName);
+        }
+    }
+
+    @Test
+    public void testPlanFragmentPartitioningOfInsertIntoTable()
+    {
+        String unpartitionedTableName = "plan_fragment_partitioning_of_unpartitioned_insert";
+        String partitionedTableName = "plan_fragment_partitioning_of_partitioned_insert";
+        try {
+            // For non-partitioned target tables, the plan fragment containing the writer node is of SCALED distributed type.
+            assertUpdate(format("CREATE TABLE %s AS SELECT * FROM %s WITH NO DATA", unpartitionedTableName, "lineitem"), 0);
+            String distributedPlanForUnpartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) INSERT INTO %s SELECT * FROM %s", unpartitionedTableName, "lineitem"))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 1 [SCALED]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 2 [SOURCE]"));
+
+            // For partitioned target tables, the plan fragment containing the writer node is of IcebergPartitioningHandle distributed type.
+            assertUpdate(format("CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 1000)']) AS SELECT * FROM %s WITH NO DATA",
+                    partitionedTableName, "lineitem"), 0);
+            String distributedPlanForPartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) INSERT INTO %s SELECT * FROM %s", partitionedTableName, "lineitem"))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 1 [iceberg:[field(channel=0, bucket[1000], bigint)]]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 2 [SOURCE]"));
+
+            // IcebergPartitioningHandle distributed type with multiple partition fields.
+            dropTable(getSession(), partitionedTableName);
+            assertUpdate(format("CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 1000)', 'orderkey', 'suppkey']) AS SELECT * FROM %s WITH NO DATA",
+                    partitionedTableName, "lineitem"), 0);
+            distributedPlanForPartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) INSERT INTO %s SELECT * FROM %s", partitionedTableName, "lineitem"))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 1 [iceberg:[field(channel=0, bucket[1000], bigint), field(channel=0, identity, bigint), field(channel=1, identity, bigint)]]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 2 [SOURCE]"));
+        }
+        finally {
+            dropTable(getSession(), partitionedTableName);
+            dropTable(getSession(), unpartitionedTableName);
         }
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -1534,6 +1534,79 @@ public abstract class IcebergDistributedSmokeTestBase
         }
     }
 
+    @Test
+    public void testPartitionedCTASWithLargeAmountOfPartitions()
+    {
+        String tableName = "test_partitioned_ctas_with_many_partitions";
+        try {
+            // 4 worker nodes, default `max_partitions_per_writer` is 100.
+            // Creating a table with data from 1000 partitions would fail.
+            assertQueryFails(format("CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 1000)']) AS SELECT * FROM tpch.tiny.lineitem", tableName),
+                    "Exceeded limit of 100 open writers for partitions");
+
+            // 4 worker nodes, set `max_partitions_per_writer` to 200, which is insufficient for 1000 partitions.
+            // Creating a table with data from 1000 partitions would fail as well.
+            Session sessionWithInsufficientPartitionsPerWriter = Session.builder(getSession())
+                    .setCatalogSessionProperty("iceberg", "max_partitions_per_writer", "200")
+                    .build();
+            assertQueryFails(sessionWithInsufficientPartitionsPerWriter, format("CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 1000)']) AS SELECT * FROM tpch.tiny.lineitem", tableName),
+                    "Exceeded limit of 200 open writers for partitions");
+
+            // 4 worker nodes, set `max_partitions_per_writer` to 300, which is sufficient for 1000 partitions.
+            // Creating a table with data from 1000 partitions would succeed.
+            Session sessionWithSufficientPartitionsPerWriter = Session.builder(getSession())
+                    .setCatalogSessionProperty("iceberg", "max_partitions_per_writer", "300")
+                    .build();
+            assertUpdate(sessionWithSufficientPartitionsPerWriter,
+                    format("CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 1000)']) AS SELECT * FROM tpch.tiny.lineitem", tableName), 60175);
+
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 60175");
+            assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 1000");
+        }
+        finally {
+            dropTable(getSession(), tableName);
+        }
+    }
+
+    @Test
+    public void testPartitionedInsertIntoTableWithLargeAmountOfPartitions()
+    {
+        String tableName = "test_partitioned_insert_with_many_partitions";
+        try {
+            assertUpdate(format("CREATE TABLE %s WITH(PARTITIONING = ARRAY['partkey']) AS SELECT * FROM tpch.tiny.lineitem WITH NO DATA", tableName), 0);
+
+            // 4 worker nodes, default `max_partitions_per_writer` is 100.
+            // Inserting into a table with data from 2000 partitions would fail.
+            assertQueryFails(format("INSERT INTO %s SELECT * FROM tpch.tiny.lineitem", tableName),
+                    "Exceeded limit of 100 open writers for partitions");
+
+            // 4 worker nodes, set `max_partitions_per_writer` to 400, which is insufficient for 2000 partitions.
+            // Inserting into a table with data from 2000 partitions would fail as well.
+            Session sessionWithInsufficientPartitionsPerWriter = Session.builder(getSession())
+                    .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "100kB")
+                    .setCatalogSessionProperty("iceberg", "parquet_writer_page_size", "10kB")
+                    .setCatalogSessionProperty("iceberg", "max_partitions_per_writer", "400")
+                    .build();
+            assertQueryFails(sessionWithInsufficientPartitionsPerWriter, format("INSERT INTO %s SELECT * FROM tpch.tiny.lineitem", tableName),
+                    "Exceeded limit of 400 open writers for partitions");
+
+            // 4 worker nodes, set `max_partitions_per_writer` to 600, which is sufficient for 2000 partitions.
+            // Inserting into a table with data from 2000 partitions would succeed.
+            Session sessionWithSufficientPartitionsPerWriter = Session.builder(getSession())
+                    .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "100kB")
+                    .setCatalogSessionProperty("iceberg", "parquet_writer_page_size", "10kB")
+                    .setCatalogSessionProperty("iceberg", "max_partitions_per_writer", "600")
+                    .build();
+            assertUpdate(sessionWithSufficientPartitionsPerWriter,
+                    format("INSERT INTO %s SELECT * FROM tpch.tiny.lineitem", tableName), 60175);
+            assertQuery("SELECT count(*) FROM " + tableName, "SELECT 60175");
+            assertQuery(format("SELECT count(*) from \"%s$partitions\"", tableName), "SELECT 2000");
+        }
+        finally {
+            dropTable(getSession(), tableName);
+        }
+    }
+
     @DataProvider
     public Object[][] compressionCodecTestData()
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewOptimizer.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewOptimizer.java
@@ -251,9 +251,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(project(staleDsBranch)))),
-                                                    node(TableWriterNode.class, exchange(exchange(project(staleRegDateBranch)))))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(project(staleDsBranch), project(staleRegDateBranch)))))))));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
@@ -422,9 +420,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, anyTree(firstBranch)),
-                                                    node(TableWriterNode.class, anyTree(secondBranch)))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(firstBranch, secondBranch))))))));
 
             Session skipStorageSession = Session.builder(getQueryRunner().getDefaultSession())
                     .setSystemProperty("materialized_view_force_stale", "true")
@@ -514,9 +510,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, anyTree(deltaBranchOrders)),
-                                                    node(TableWriterNode.class, anyTree(deltaBranchCustomers)))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(anyTree(deltaBranchOrders), anyTree(deltaBranchCustomers)))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_active_orders");
@@ -803,9 +797,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(staleBranchJan02))),
-                                                    node(TableWriterNode.class, exchange(exchange(staleBranchJan01))))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(staleBranchJan02, staleBranchJan01))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_passthrough");
@@ -917,9 +909,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(intersectBranchBoth))),
-                                                    node(TableWriterNode.class, exchange(exchange(intersectBranchTable2Only))))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(intersectBranchBoth, intersectBranchTable2Only))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_intersect");
@@ -1025,9 +1015,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(intersectBranchBoth))),
-                                                    node(TableWriterNode.class, exchange(exchange(intersectBranchTable2Only))))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(intersectBranchBoth, intersectBranchTable2Only))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_intersect_left");
@@ -1124,9 +1112,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(intersectBranch1))),
-                                                    node(TableWriterNode.class, exchange(exchange(intersectBranch2))))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(intersectBranch1, intersectBranch2))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_intersect_right");
@@ -1424,9 +1410,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(firstStaleBranch))),
-                                                    node(TableWriterNode.class, exchange(exchange(secondStaleBranch))))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(firstStaleBranch, secondStaleBranch))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_except");
@@ -1680,9 +1664,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch1))),
-                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch2))))))));
+                                                    node(TableWriterNode.class, exchange(exchange(exchange(exceptBranch1, exceptBranch2))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_jexj");
@@ -1770,9 +1752,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch))),
-                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch))))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(exceptBranch, exceptBranch))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_jexjr");
@@ -1884,9 +1864,7 @@ public class TestIcebergMaterializedViewOptimizer
                     output(
                             tableFinish(
                                     exchange(
-                                            exchange(
-                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch1))),
-                                                    node(TableWriterNode.class, exchange(exchange(exceptBranch2))))))));
+                                            node(TableWriterNode.class, exchange(exchange(exchange(exceptBranch1, exceptBranch2))))))));
         }
         finally {
             assertUpdate("DROP MATERIALIZED VIEW IF EXISTS mv_jexjb");

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -23,6 +23,7 @@
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/exec/RoundRobinPartitionFunction.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
 namespace facebook::presto {
@@ -664,6 +665,24 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
       std::unordered_map<std::string, std::string>{},
       velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
           kMerge);
+}
+
+std::unique_ptr<velox::core::PartitionFunctionSpec>
+IcebergPrestoToVeloxConnector::createVeloxPartitionFunctionSpec(
+    const protocol::ConnectorPartitioningHandle* partitioningHandle,
+    const std::vector<int>& bucketToPartition,
+    const std::vector<velox::column_index_t>& channels,
+    const std::vector<velox::VectorPtr>& constValues,
+    bool& effectivelyGather) const {
+  auto icebergPartitioningHandle =
+      dynamic_cast<const protocol::iceberg::IcebergPartitioningHandle*>(
+          partitioningHandle);
+  VELOX_CHECK_NOT_NULL(
+      icebergPartitioningHandle,
+      "Unexpected partitioning handle type {}",
+      partitioningHandle->_type);
+  effectivelyGather = true;
+  return std::make_unique<velox::exec::RoundRobinPartitionFunctionSpec>();
 }
 
 } // namespace facebook::presto

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
@@ -71,6 +71,14 @@ class IcebergPrestoToVeloxConnector final : public PrestoToVeloxConnector {
       const protocol::MergeHandle* mergeHandle,
       const TypeParser& typeParser) const final;
 
+  std::unique_ptr<velox::core::PartitionFunctionSpec>
+  createVeloxPartitionFunctionSpec(
+      const protocol::ConnectorPartitioningHandle* partitioningHandle,
+      const std::vector<int>& bucketToPartition,
+      const std::vector<velox::column_index_t>& channels,
+      const std::vector<velox::VectorPtr>& constValues,
+      bool& effectivelyGather) const final;
+
  private:
   std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
   toIcebergColumns(

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
@@ -25,7 +25,7 @@ using IcebergConnectorProtocol = ConnectorProtocolTemplate<
     IcebergInsertTableHandle,
     IcebergOutputTableHandle,
     IcebergSplit,
-    NotImplemented,
+    IcebergPartitioningHandle,
     hive::HiveTransactionHandle,
     IcebergDistributedProcedureHandle,
     IcebergDeleteTableHandle,

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1984,6 +1984,91 @@ void from_json(const json& j, IcebergOutputTableHandle& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+
+void to_json(json& j, const IcebergPartitionFieldHandle& p) {
+  j = json::object();
+  to_json_key(
+      j,
+      "sourceColumnChannel",
+      p.sourceColumnChannel,
+      "IcebergPartitionFieldHandle",
+      "int",
+      "sourceColumnChannel");
+  to_json_key(
+      j,
+      "transform",
+      p.transform,
+      "IcebergPartitionFieldHandle",
+      "PartitionTransformType",
+      "transform");
+  to_json_key(
+      j,
+      "partitionFieldMessage",
+      p.partitionFieldMessage,
+      "IcebergPartitionFieldHandle",
+      "String",
+      "partitionFieldMessage");
+  to_json_key(j, "type", p.type, "IcebergPartitionFieldHandle", "Type", "type");
+  to_json_key(j, "size", p.size, "IcebergPartitionFieldHandle", "int", "size");
+}
+
+void from_json(const json& j, IcebergPartitionFieldHandle& p) {
+  from_json_key(
+      j,
+      "sourceColumnChannel",
+      p.sourceColumnChannel,
+      "IcebergPartitionFieldHandle",
+      "int",
+      "sourceColumnChannel");
+  from_json_key(
+      j,
+      "transform",
+      p.transform,
+      "IcebergPartitionFieldHandle",
+      "PartitionTransformType",
+      "transform");
+  from_json_key(
+      j,
+      "partitionFieldMessage",
+      p.partitionFieldMessage,
+      "IcebergPartitionFieldHandle",
+      "String",
+      "partitionFieldMessage");
+  from_json_key(
+      j, "type", p.type, "IcebergPartitionFieldHandle", "Type", "type");
+  from_json_key(
+      j, "size", p.size, "IcebergPartitionFieldHandle", "int", "size");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
+IcebergPartitioningHandle::IcebergPartitioningHandle() noexcept {
+  _type = "hive";
+}
+
+void to_json(json& j, const IcebergPartitioningHandle& p) {
+  j = json::object();
+  j["@type"] = "hive";
+  to_json_key(
+      j,
+      "partitionFieldHandles",
+      p.partitionFieldHandles,
+      "IcebergPartitioningHandle",
+      "List<IcebergPartitionFieldHandle>",
+      "partitionFieldHandles");
+}
+
+void from_json(const json& j, IcebergPartitioningHandle& p) {
+  p._type = j["@type"];
+  from_json_key(
+      j,
+      "partitionFieldHandles",
+      p.partitionFieldHandles,
+      "IcebergPartitioningHandle",
+      "List<IcebergPartitionFieldHandle>",
+      "partitionFieldHandles");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
 IcebergSplit::IcebergSplit() noexcept {
   _type = "hive-iceberg";
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -343,6 +343,26 @@ struct IcebergOutputTableHandle : public ConnectorOutputTableHandle {
 void to_json(json& j, const IcebergOutputTableHandle& p);
 void from_json(const json& j, IcebergOutputTableHandle& p);
 } // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
+struct IcebergPartitionFieldHandle {
+  int sourceColumnChannel = {};
+  PartitionTransformType transform = {};
+  String partitionFieldMessage = {};
+  Type type = {};
+  std::shared_ptr<int> size = {};
+};
+void to_json(json& j, const IcebergPartitionFieldHandle& p);
+void from_json(const json& j, IcebergPartitionFieldHandle& p);
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
+struct IcebergPartitioningHandle : public ConnectorPartitioningHandle {
+  List<IcebergPartitionFieldHandle> partitionFieldHandles = {};
+
+  IcebergPartitioningHandle() noexcept;
+};
+void to_json(json& j, const IcebergPartitioningHandle& p);
+void from_json(const json& j, IcebergPartitioningHandle& p);
+} // namespace facebook::presto::protocol::iceberg
 // IcebergSplit is special since it needs an usage of
 // hive::.
 

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -20,7 +20,7 @@ AbstractClasses:
   ConnectorPartitioningHandle:
     super: JsonEncodedSubclass
     subclasses:
-      - { name: HivePartitioningHandle,   key: hive }
+      - { name: IcebergPartitioningHandle,   key: hive }
 
   ConnectorTableHandle:
     super: JsonEncodedSubclass
@@ -90,3 +90,5 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogOperation.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitInfo.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/SortField.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitioningHandle.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitionFieldHandle.java

--- a/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/presto_protocol_core.yml
@@ -72,6 +72,7 @@ AbstractClasses:
     subclasses:
       - { name: SystemPartitioningHandle, key: $remote }
       - { name: HivePartitioningHandle,   key: hive }
+      - { name: IcebergPartitioningHandle,   key: hive-iceberg }
       - { name: TpchPartitioningHandle,   key: tpch }
 
   ConnectorTableHandle:

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -60,6 +60,7 @@ AbstractClasses:
     subclasses:
       - { name: SystemPartitioningHandle, key: $remote }
       - { name: HivePartitioningHandle,   key: hive }
+      - { name: IcebergPartitioningHandle,   key: hive-iceberg }
       - { name: TpchPartitioningHandle,   key: tpch }
 
   ConnectorTableHandle:
@@ -287,6 +288,7 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogOperation.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitInfo.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/partitioning/IcebergPartitioningHandle.java
   - presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplit.java
   - presto-tpch/src/main/java/com/facebook/presto/tpch/TpchTableHandle.java
   - presto-tpch/src/main/java/com/facebook/presto/tpch/TpchTableLayoutHandle.java

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestCreateTable.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestCreateTable.java
@@ -16,11 +16,16 @@ package com.facebook.presto.nativeworker.iceberg;
 import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.ICEBERG_DEFAULT_STORAGE_FORMAT;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder;
 import static com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestCreateTable
         extends AbstractTestQueryFramework
@@ -215,6 +220,78 @@ public class TestCreateTable
         finally {
             assertUpdate(String.format("DROP TABLE IF EXISTS %s", targetTable));
             assertUpdate(String.format("DROP TABLE IF EXISTS %s", sourceTable));
+        }
+    }
+
+    @Test
+    public void testPlanFragmentPartitioningOfCTAS()
+    {
+        String sourceTable = "test_line_item";
+        String targetTable = "test_plan_fragment_partitioning_of_ctas";
+        try {
+            long count = (long) getExpectedQueryRunner().execute(getSession(), "CREATE TABLE " + sourceTable + " AS SELECT * FROM tpch.tiny.lineitem", ImmutableList.of(BIGINT))
+                    .getOnlyValue();
+            assertEquals(count, 60175L);
+
+            // For non-partitioned target tables, the plan fragment containing the writer node is of SCALED distributed type.
+            String distributedPlanForUnpartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) CREATE TABLE %s AS SELECT * FROM %s", targetTable, sourceTable))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 1 [SCALED]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 2 [SOURCE]"));
+
+            // Native workers do not currently support partitioned writer.
+            // For partitioned target tables, the plan fragment containing the writer node is still of SCALED distributed type.
+            String distributedPlanForPartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 200)'])" +
+                                    " AS SELECT * FROM %s", targetTable, sourceTable))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 1 [SCALED]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 2 [SOURCE]"));
+        }
+        finally {
+            assertUpdate(getSession(), "DROP TABLE IF EXISTS " + targetTable);
+            assertUpdate(getSession(), "DROP TABLE IF EXISTS " + sourceTable);
+        }
+    }
+
+    @Test
+    public void testPlanFragmentPartitioningOfInsertIntoTable()
+    {
+        String sourceTable = "test_line_item_2";
+        String unpartitionedTableName = "plan_fragment_partitioning_of_unpartitioned_insert";
+        String partitionedTableName = "plan_fragment_partitioning_of_partitioned_insert";
+        try {
+            long count = (long) getExpectedQueryRunner().execute(getSession(), "CREATE TABLE " + sourceTable + " AS SELECT * FROM tpch.tiny.lineitem", ImmutableList.of(BIGINT))
+                    .getOnlyValue();
+            assertEquals(count, 60175L);
+
+            // For non-partitioned target tables, the plan fragment containing the writer node is of SCALED distributed type.
+            assertUpdate(format("CREATE TABLE %s AS SELECT * FROM %s WITH NO DATA", unpartitionedTableName, sourceTable), 0);
+            String distributedPlanForUnpartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) INSERT INTO %s SELECT * FROM %s", unpartitionedTableName, sourceTable))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 1 [SCALED]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 2 [SOURCE]"));
+
+            // Native workers do not currently support partitioned writer.
+            // For partitioned target tables, the plan fragment containing the writer node is still of SCALED distributed type.
+            assertUpdate(format("CREATE TABLE %s WITH(PARTITIONING = ARRAY['bucket(orderkey, 1000)']) AS SELECT * FROM %s WITH NO DATA",
+                    partitionedTableName, sourceTable), 0);
+            String distributedPlanForPartitionedTable = getQueryRunner().execute(
+                            format("EXPLAIN (TYPE DISTRIBUTED) INSERT INTO %s SELECT * FROM %s", partitionedTableName, sourceTable))
+                    .getOnlyValue().toString();
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 0 [COORDINATOR_ONLY]"));
+            assertTrue(distributedPlanForUnpartitionedTable.contains("Fragment 1 [SCALED]"));
+            assertTrue(distributedPlanForPartitionedTable.contains("Fragment 2 [SOURCE]"));
+        }
+        finally {
+            assertUpdate(getSession(), "DROP TABLE IF EXISTS " + partitionedTableName);
+            assertUpdate(getSession(), "DROP TABLE IF EXISTS " + unpartitionedTableName);
+            assertUpdate(getSession(), "DROP TABLE IF EXISTS " + sourceTable);
         }
     }
 }


### PR DESCRIPTION
## Description

[WIP]Support partitioned writer for Iceberg Connector

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add native partitioned write support for the Iceberg connector, including connector-specific partitioning handles and node partitioning integration.

New Features:
- Introduce Iceberg-specific partitioning handle, field handle, bucket function, and node partitioning provider to support partition-aware writes.
- Derive new table and insert layouts from Iceberg partition specs, exposing partitioning columns and enforcing per-partition single-writer policy.

Enhancements:
- Refactor partition transform handling to operate on raw transform strings and expose Iceberg bucket/truncate patterns for reuse.