### PR TITLE
fix: Revised the principal field retrieval

### DIFF
--- a/presto-docs/src/main/sphinx/security/oauth2.rst
+++ b/presto-docs/src/main/sphinx/security/oauth2.rst
@@ -38,6 +38,8 @@ Below are the key configuration properties for enabling OAuth2 authentication in
     http-server.authentication.oauth2.state-key=your-hmac-secret
     http-server.authentication.oauth2.additional-audiences=your-client-id,another-audience
     http-server.authentication.oauth2.user-mapping.pattern=(.*)
+    http-server.authentication.oauth2.userinfo-cache=false
+    http-server.authentication.oauth2.userinfo-cache-ttl=10m
 
 It is worth noting that ``configuration-based-authorizer.role-regex-map.file-path`` must be configured if
 authentication type is set to ``OAUTH2``.
@@ -58,11 +60,13 @@ If your IdP uses a custom or self-signed certificate, import it into the Java tr
 Notes
 -----
 
-- **Issuer**: The base URL of your IdP’s OIDC discovery endpoint.
+- **Issuer**: The base URL of your IdP's OIDC discovery endpoint.
 - **Client ID/Secret**: Registered credentials for Presto in your IdP.
 - **Scopes**: Must include ``openid``; others like ``email``, ``profile``, or ``groups`` are optional.
-- **Principal Field**: The claim in the ID token used as the Presto username.
+- **Principal Field**: The claim used as the Presto username. For OIDC flows (when ``openid`` scope is included), this is extracted from the ID token. If the claim is not present in the ID token, Presto will query the UserInfo endpoint as a fallback. For pure OAuth2 flows (without ``openid`` scope), the UserInfo endpoint is queried first, with the access token as a last resort.
 - **Groups Field**: Optional claim used for role-based access control.
 - **State Key**: A secret used to sign the OAuth2 state parameter (HMAC).
 - **Refresh Tokens**: Enable if your IdP supports issuing refresh tokens.
+- **UserInfo Cache**: Enable caching of UserInfo endpoint responses to reduce load on the IdP and improve performance. When enabled, responses are cached using a SHA-256 hash of the access token as the key. Default is ``false``.
+- **UserInfo Cache TTL**: Time-to-live for cached UserInfo entries. Only applicable when ``userinfo-cache`` is enabled. Default is ``10m`` (10 minutes). Minimum value is ``1m``.
 - **Callback**: When configuring your IdP the callback URI must be set to ``[presto]/oauth2/callback``

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Client.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Client.java
@@ -60,14 +60,20 @@ public interface OAuth2Client
     {
         private final String accessToken;
         private final Instant expiration;
-
         private final Optional<String> refreshToken;
+        private final Map<String, Object> claims;
 
         public Response(String accessToken, Instant expiration, Optional<String> refreshToken)
+        {
+            this(accessToken, expiration, refreshToken, null);
+        }
+
+        public Response(String accessToken, Instant expiration, Optional<String> refreshToken, Map<String, Object> claims)
         {
             this.accessToken = requireNonNull(accessToken, "accessToken is null");
             this.expiration = requireNonNull(expiration, "expiration is null");
             this.refreshToken = requireNonNull(refreshToken, "refreshToken is null");
+            this.claims = claims;
         }
 
         public String getAccessToken()
@@ -83,6 +89,17 @@ public interface OAuth2Client
         public Optional<String> getRefreshToken()
         {
             return refreshToken;
+        }
+
+        /**
+         * Returns the user claims from ID token (for OIDC) or UserInfo endpoint (for OAuth2).
+         * These claims should be used for extracting the principal field, not the access token.
+         *
+         * @return Optional containing claims map, or empty if not available
+         */
+        public Optional<Map<String, Object>> getClaims()
+        {
+            return Optional.ofNullable(claims);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Config.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Config.java
@@ -49,6 +49,8 @@ public class OAuth2Config
     private Optional<File> userMappingFile = Optional.empty();
     private boolean enableRefreshTokens;
     private boolean enableDiscovery = true;
+    private boolean userinfoCacheEnabled;
+    private Duration userinfoCacheTtl = new Duration(10, TimeUnit.MINUTES);
 
     public Optional<String> getStateKey()
     {
@@ -248,6 +250,34 @@ public class OAuth2Config
     public OAuth2Config setEnableDiscovery(boolean enableDiscovery)
     {
         this.enableDiscovery = enableDiscovery;
+        return this;
+    }
+
+    public boolean isUserinfoCacheEnabled()
+    {
+        return userinfoCacheEnabled;
+    }
+
+    @Config("http-server.authentication.oauth2.userinfo-cache")
+    @ConfigDescription("Enable caching of userinfo endpoint responses")
+    public OAuth2Config setUserinfoCacheEnabled(boolean userinfoCacheEnabled)
+    {
+        this.userinfoCacheEnabled = userinfoCacheEnabled;
+        return this;
+    }
+
+    @MinDuration("1m")
+    @NotNull
+    public Duration getUserinfoCacheTtl()
+    {
+        return userinfoCacheTtl;
+    }
+
+    @Config("http-server.authentication.oauth2.userinfo-cache-ttl")
+    @ConfigDescription("TTL for userinfo cache entries")
+    public OAuth2Config setUserinfoCacheTtl(Duration userinfoCacheTtl)
+    {
+        this.userinfoCacheTtl = userinfoCacheTtl;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2ServiceModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2ServiceModule.java
@@ -27,7 +27,7 @@ import static com.facebook.airlift.configuration.ConditionalModule.installModule
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
-import static com.facebook.presto.server.security.oauth2.TokenPairSerializer.ACCESS_TOKEN_ONLY_SERIALIZER;
+import static com.facebook.presto.server.security.oauth2.TokenPairSerializer.ACCESS_TOKEN_CLAIMS_ONLY_SERIALIZER;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 
 public class OAuth2ServiceModule
@@ -67,7 +67,7 @@ public class OAuth2ServiceModule
 
     private void disableRefreshTokens(Binder binder)
     {
-        binder.bind(TokenPairSerializer.class).toInstance(ACCESS_TOKEN_ONLY_SERIALIZER);
+        binder.bind(TokenPairSerializer.class).toInstance(ACCESS_TOKEN_CLAIMS_ONLY_SERIALIZER);
         newOptionalBinder(binder, Key.get(Duration.class, ForRefreshTokens.class));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/TokenPairSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/TokenPairSerializer.java
@@ -14,28 +14,82 @@
 
 package com.facebook.presto.server.security.oauth2;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.server.security.oauth2.OAuth2Client.Response;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nullable;
 
+import java.io.IOException;
+import java.util.Base64;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.Long.MAX_VALUE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public interface TokenPairSerializer
 {
-    TokenPairSerializer ACCESS_TOKEN_ONLY_SERIALIZER = new TokenPairSerializer()
+    /**
+     * Serializer that stores access token and claims in a simple JSON format.
+     * Used when refresh tokens are disabled but we still need to preserve claims for authentication.
+     */
+    TokenPairSerializer ACCESS_TOKEN_CLAIMS_ONLY_SERIALIZER = new TokenPairSerializer()
     {
+        private static final Logger LOG = Logger.get(TokenPairSerializer.class);
+        private final ObjectMapper objectMapper = new ObjectMapper();
+
         @Override
         public TokenPair deserialize(String token)
         {
+            // Try to decode from Base64 and parse as JSON (new format with claims)
+            try {
+                // First try to decode from Base64
+                byte[] decodedBytes = Base64.getDecoder().decode(token);
+                String decodedJson = new String(decodedBytes, UTF_8);
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> data = objectMapper.readValue(decodedJson, Map.class);
+                if (data.containsKey("accessToken") && data.containsKey("claims")) {
+                    String accessToken = (String) data.get("accessToken");
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> claims = (Map<String, Object>) data.get("claims");
+                    LOG.debug("Deserialized token with claims from new Base64-encoded JSON format");
+                    return new TokenPair(accessToken, new Date(MAX_VALUE), Optional.empty(), Optional.of(claims));
+                }
+            }
+            catch (IllegalArgumentException | IOException e) {
+                // Not Base64-encoded JSON, treat as plain access token (backward compatibility)
+                LOG.debug("Token is not in new Base64-encoded JSON format, treating as plain access token (old format or migration in progress)");
+            }
+
+            // Fallback: treat as plain access token (backward compatibility)
+            LOG.debug("Using plain access token format (no claims available, will need to query on authentication)");
             return TokenPair.accessToken(token);
         }
 
         @Override
         public String serialize(TokenPair tokenPair)
         {
+            // If claims are present, serialize as Base64-encoded JSON with access token and claims
+            if (tokenPair.getClaims().isPresent()) {
+                try {
+                    Map<String, Object> data = new HashMap<>();
+                    data.put("accessToken", tokenPair.getAccessToken());
+                    data.put("claims", tokenPair.getClaims().get());
+                    String json = objectMapper.writeValueAsString(data);
+                    // Base64 encode to ensure cookie compatibility
+                    return Base64.getEncoder().encodeToString(json.getBytes(UTF_8));
+                }
+                catch (JsonProcessingException e) {
+                    throw new IllegalStateException("Failed to serialize token with claims", e);
+                }
+            }
+
+            // Fallback: serialize as plain access token (backward compatibility)
             return tokenPair.getAccessToken();
         }
     };
@@ -49,12 +103,19 @@ public interface TokenPairSerializer
         private final String accessToken;
         private final Date expiration;
         private final Optional<String> refreshToken;
+        private final Optional<Map<String, Object>> claims;
 
         private TokenPair(String accessToken, Date expiration, Optional<String> refreshToken)
+        {
+            this(accessToken, expiration, refreshToken, Optional.empty());
+        }
+
+        private TokenPair(String accessToken, Date expiration, Optional<String> refreshToken, Optional<Map<String, Object>> claims)
         {
             this.accessToken = requireNonNull(accessToken, "accessToken is nul");
             this.expiration = requireNonNull(expiration, "expiration is null");
             this.refreshToken = requireNonNull(refreshToken, "refreshToken is null");
+            this.claims = requireNonNull(claims, "claims is null");
         }
 
         public static TokenPair accessToken(String accessToken)
@@ -65,7 +126,11 @@ public interface TokenPairSerializer
         public static TokenPair fromOAuth2Response(Response tokens)
         {
             requireNonNull(tokens, "tokens is null");
-            return new TokenPair(tokens.getAccessToken(), Date.from(tokens.getExpiration()), tokens.getRefreshToken());
+            return new TokenPair(
+                    tokens.getAccessToken(),
+                    Date.from(tokens.getExpiration()),
+                    tokens.getRefreshToken(),
+                    tokens.getClaims());
         }
 
         public static TokenPair accessAndRefreshTokens(String accessToken, Date expiration, @Nullable String refreshToken)
@@ -86,6 +151,17 @@ public interface TokenPairSerializer
         public Optional<String> getRefreshToken()
         {
             return refreshToken;
+        }
+
+        /**
+         * Returns the user claims from ID token (for OIDC) or UserInfo endpoint (for OAuth2).
+         * These claims should be used for extracting the principal field, not the access token.
+         *
+         * @return Optional containing claims map, or empty if not available
+         */
+        public Optional<Map<String, Object>> getClaims()
+        {
+            return claims;
         }
 
         public static TokenPair withAccessAndRefreshTokens(String accessToken, Date expiration, @Nullable String refreshToken)

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestNimbusOAuth2ClientUserInfoParser.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestNimbusOAuth2ClientUserInfoParser.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.security.oauth2;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.airlift.units.Duration;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
+import com.nimbusds.openid.connect.sdk.UserInfoResponse;
+import com.nimbusds.openid.connect.sdk.UserInfoSuccessResponse;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestNimbusOAuth2ClientUserInfoParser
+{
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String ADDITIONAL_AUDIENCE = "additional-audience";
+
+    private NimbusOAuth2Client createClient(String principalField, String additionalAudiences)
+    {
+        OAuth2Config config = new OAuth2Config()
+                .setIssuer("https://issuer.example.com")
+                .setClientId(CLIENT_ID)
+                .setClientSecret("test-secret")
+                .setPrincipalField(principalField)
+                .setAdditionalAudiences(additionalAudiences)
+                .setMaxClockSkew(new Duration(1, MINUTES));
+
+        OAuth2ServerConfigProvider configProvider = new OAuth2ServerConfigProvider()
+        {
+            @Override
+            public OAuth2ServerConfig get()
+            {
+                return new OAuth2ServerConfig(
+                        Optional.empty(),
+                        URI.create("https://issuer.example.com/auth"),
+                        URI.create("https://issuer.example.com/token"),
+                        URI.create("https://issuer.example.com/jwks"),
+                        Optional.empty());
+            }
+        };
+
+        HttpClient httpClient = new TestingHttpClient(request -> {
+            throw new UnsupportedOperationException("HTTP client should not be called in these tests");
+        });
+        NimbusHttpClient nimbusHttpClient = new NimbusAirliftHttpClient(httpClient);
+
+        return new NimbusOAuth2Client(config, configProvider, nimbusHttpClient);
+    }
+
+    @Test
+    public void testParseSuccessWithStandardSubClaim()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        body.put("email", "user@example.com");
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+        UserInfoSuccessResponse successResponse = response.toSuccessResponse();
+        assertThat(successResponse.getUserInfo().getSubject().getValue()).isEqualTo("user@example.com");
+    }
+
+    @Test
+    public void testParseSuccessWithCustomPrincipalField()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("email", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        httpResponse.setContentType("application/json");
+        JSONObject body = new JSONObject();
+        body.put("email", "custom@example.com");
+        body.put("name", "Custom User");
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+        UserInfoSuccessResponse successResponse = response.toSuccessResponse();
+        // The parser should add "sub" claim with the value from "email"
+        assertThat(successResponse.getUserInfo().getSubject().getValue()).isEqualTo("custom@example.com");
+    }
+
+    @Test
+    public void testParseSuccessWithCustomPrincipalFieldAndExistingSub()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("email", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "original-sub");
+        body.put("email", "custom@example.com");
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+        UserInfoSuccessResponse successResponse = response.toSuccessResponse();
+        // Should keep the original "sub" claim
+        assertThat(successResponse.getUserInfo().getSubject().getValue()).isEqualTo("original-sub");
+    }
+
+    @Test
+    public void testParseMissingPrincipalField()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("email", "user@example.com");
+        // Missing "sub" field
+        httpResponse.setBody(body.toJSONString());
+
+        assertThatThrownBy(() -> client.parse(httpResponse))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("/userinfo response missing principal field sub");
+    }
+
+    @Test
+    public void testParseMissingCustomPrincipalField()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("custom_field", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        // Missing "custom_field"
+        httpResponse.setBody(body.toJSONString());
+
+        assertThatThrownBy(() -> client.parse(httpResponse))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("/userinfo response missing principal field custom_field");
+    }
+
+    @Test
+    public void testParseWithValidAudienceString()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        body.put("aud", CLIENT_ID);
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+    }
+
+    @Test
+    public void testParseWithValidAudienceArray()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        JSONArray audiences = new JSONArray();
+        audiences.add(CLIENT_ID);
+        audiences.add("other-audience");
+        body.put("aud", audiences);
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+    }
+
+    @Test
+    public void testParseWithValidAdditionalAudience()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        body.put("aud", ADDITIONAL_AUDIENCE);
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+    }
+
+    @Test
+    public void testParseWithInvalidAudienceString()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        body.put("aud", "invalid-audience");
+        httpResponse.setBody(body.toJSONString());
+
+        assertThatThrownBy(() -> client.parse(httpResponse))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("Invalid audience in /userinfo response");
+    }
+
+    @Test
+    public void testParseWithInvalidAudienceArray()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        JSONArray audiences = new JSONArray();
+        audiences.add("invalid-audience-1");
+        audiences.add("invalid-audience-2");
+        body.put("aud", audiences);
+        httpResponse.setBody(body.toJSONString());
+
+        assertThatThrownBy(() -> client.parse(httpResponse))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("Invalid audience in /userinfo response");
+    }
+
+    @Test
+    public void testParseWithMixedAudienceArrayContainingValid()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        JSONArray audiences = new JSONArray();
+        audiences.add("invalid-audience");
+        audiences.add(CLIENT_ID);
+        body.put("aud", audiences);
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+    }
+
+    @Test
+    public void testParseWithUnsupportedAudienceType()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        body.put("aud", 12345); // Integer instead of String or Array
+        httpResponse.setBody(body.toJSONString());
+
+        assertThatThrownBy(() -> client.parse(httpResponse))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("Unsupported 'aud' claim type in /userinfo response");
+    }
+
+    @Test
+    public void testParseWithNoAudienceClaim()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        // No "aud" claim - should be allowed
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+    }
+
+    @Test
+    public void testParseWithAudienceArrayContainingNonStrings()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        JSONArray audiences = new JSONArray();
+        audiences.add(CLIENT_ID);
+        audiences.add(123); // Non-string element should be filtered out
+        audiences.add(null); // Null element should be filtered out
+        body.put("aud", audiences);
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+    }
+
+    @Test
+    public void testParseErrorResponse()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = new HTTPResponse(401);
+        httpResponse.setContentType("application/json");
+        JSONObject body = new JSONObject();
+        body.put("error", "invalid_token");
+        body.put("error_description", "The access token is invalid");
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+        assertThat(response.indicatesSuccess()).isFalse();
+        UserInfoErrorResponse errorResponse = response.toErrorResponse();
+        assertThat(errorResponse.getErrorObject().getCode()).isEqualTo("invalid_token");
+        assertThat(errorResponse.getErrorObject().getDescription()).isEqualTo("The access token is invalid");
+    }
+
+    @Test
+    public void testParseWithEmptyAudienceArray()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", ADDITIONAL_AUDIENCE);
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        body.put("aud", new JSONArray()); // Empty array
+        httpResponse.setBody(body.toJSONString());
+
+        assertThatThrownBy(() -> client.parse(httpResponse))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("Invalid audience in /userinfo response");
+    }
+
+    @Test
+    public void testParseWithMultipleAdditionalAudiences()
+            throws Exception
+    {
+        NimbusOAuth2Client client = createClient("sub", "aud1,aud2,aud3");
+        HTTPResponse httpResponse = createSuccessResponse();
+        JSONObject body = new JSONObject();
+        body.put("sub", "user@example.com");
+        body.put("aud", "aud2"); // One of the additional audiences
+        httpResponse.setBody(body.toJSONString());
+
+        UserInfoResponse response = client.parse(httpResponse);
+
+        assertThat(response.indicatesSuccess()).isTrue();
+    }
+
+    private HTTPResponse createSuccessResponse() throws ParseException
+    {
+        HTTPResponse response = new HTTPResponse(200);
+        response.setContentType("application/json");
+        return response;
+    }
+}
+
+// Made with Bob

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestOAuth2Config.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestOAuth2Config.java
@@ -47,7 +47,9 @@ public class TestOAuth2Config
                 .setUserMappingPattern(null)
                 .setUserMappingFile(null)
                 .setEnableRefreshTokens(false)
-                .setEnableDiscovery(true));
+                .setEnableDiscovery(true)
+                .setUserinfoCacheEnabled(false)
+                .setUserinfoCacheTtl(new Duration(10, MINUTES)));
     }
 
     @Test
@@ -70,6 +72,8 @@ public class TestOAuth2Config
                 .put("http-server.authentication.oauth2.user-mapping.file", userMappingFile.toString())
                 .put("http-server.authentication.oauth2.refresh-tokens", "true")
                 .put("http-server.authentication.oauth2.oidc.discovery", "false")
+                .put("http-server.authentication.oauth2.userinfo-cache", "true")
+                .put("http-server.authentication.oauth2.userinfo-cache-ttl", "5m")
                 .build();
 
         OAuth2Config expected = new OAuth2Config()
@@ -86,7 +90,9 @@ public class TestOAuth2Config
                 .setUserMappingPattern("(.*)@something")
                 .setUserMappingFile(userMappingFile.toFile())
                 .setEnableRefreshTokens(true)
-                .setEnableDiscovery(false);
+                .setEnableDiscovery(false)
+                .setUserinfoCacheEnabled(true)
+                .setUserinfoCacheTtl(new Duration(5, MINUTES));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

    Enhance OAuth2/OIDC authentication to be more standards-compliant and efficient:
    
    Features:
    - Extract principal from ID token per OIDC specification
    - Preserve user claims in cookies without refresh tokens
    - Add configurable UserInfo response caching
    - Serialize cookies as Base64-encoded JSON for safety
    
    Improvements:
    - Reduce redundant UserInfo endpoint queries
    - Better performance and lower IdP load
    - Enhanced debug logging for troubleshooting
    - Improved error handling and validation
    
    Configuration:
    - Add http-server.authentication.oauth2.userinfo-cache (default: false)
    - Add http-server.authentication.oauth2.userinfo-cache-ttl (default: 10m)

## Motivation and Context
- `aud` claim is not mandatory in the userinfo response. This change makes the `aud` validation in the userinfo optional.
- To comply with OIDC/OAuth standard, retrieve the `principal field` from ID token if it's OIDC flow. For the OAuth2 flow, retrieve the `principal field` from userinfo and fallback to the access token.

## Impact
Make the OAuth flow comply with the spec and correctly verify the `aud` claim and handle the principal field that the user specified.

## Test Plan
Make sure no regression and existing integration tests pass. Add test cases for the userinfo parsing.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Relax OAuth2 user info audience and principal handling while enforcing JWT access token validation and improving error handling.

Bug Fixes:
- Stop requiring the configured principal claim in JWT access tokens and instead resolve it from the access token or userinfo response with clear logging when missing.
- Treat non-200 /userinfo responses as error responses rather than attempting to parse them as successful user info.
- Make audience validation for /userinfo responses conditional on the presence of an aud claim and reject only invalid values or unsupported claim types.

Enhancements:
- Adjust JWT access token claim verification to rely on standard issuer and audience checks while leaving principal claim validation to higher-level logic.
- Improve /userinfo parsing robustness by handling string and array aud claims, filtering non-string entries, and simplifying success parsing for valid responses.

Tests:
- Add comprehensive unit tests for NimbusOAuth2Client userinfo parsing, covering principal field handling, optional/invalid audience combinations, additional audiences, and error responses.

## Summary by Sourcery

Align OAuth2/OIDC authentication with spec by deriving principals from ID tokens or userinfo, caching userinfo responses, and preserving user claims in cookies for flows without refresh tokens.

New Features:
- Support extracting principal and user claims from ID tokens for OIDC flows with fallback to the UserInfo endpoint.
- Introduce optional caching of UserInfo endpoint responses, configurable via new OAuth2 properties.
- Preserve user claims in cookies by serializing access tokens plus claims into a Base64-encoded JSON structure when refresh tokens are disabled.

Bug Fixes:
- Stop requiring the configured principal claim to be present in JWT access tokens and resolve it from ID tokens or UserInfo responses instead.
- Treat non-200 UserInfo HTTP responses as error responses and avoid parsing them as successful user info.
- Make /userinfo audience validation conditional on the presence of an aud claim and reject only invalid values or unsupported claim types.

Enhancements:
- Relax JWT access token claim verification to rely on standard issuer and audience checks while moving principal validation to higher-level logic.
- Improve UserInfo parsing robustness, including support for string or array aud claims and better logging and error handling.
- Prefer claims from ID tokens or UserInfo over access tokens when authenticating requests and building internal JWTs.
- Add a hashed, size-limited cache for UserInfo responses to reduce repeated IdP calls and improve performance.

Documentation:
- Document new OAuth2 configuration properties for enabling and tuning UserInfo response caching.

Tests:
- Add comprehensive unit tests for UserInfo parsing and audience/principal handling, and update existing tests to cover the new cookie serialization format.