### PR TITLE
fix(function): ST_Equals should return true for same type empty geometries

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
@@ -139,11 +139,6 @@ public class SqlFunctionProperties
         return tryCatchableErrorCodes;
     }
 
-    public boolean isLegacyStEquals()
-    {
-        return legacyStEquals;
-    }
-
     @Override
     public boolean equals(Object o)
     {

--- a/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
@@ -41,6 +41,7 @@ public class SqlFunctionProperties
     private final Map<String, String> extraCredentials;
     private final boolean canonicalizedJsonExtract;
     private final Set<String> tryCatchableErrorCodes;
+    private final boolean legacyStEquals;
 
     private SqlFunctionProperties(
             boolean parseDecimalLiteralAsDouble,
@@ -55,7 +56,8 @@ public class SqlFunctionProperties
             boolean legacyJsonCast,
             Map<String, String> extraCredentials,
             boolean canonicalizedJsonExtract,
-            Set<String> tryCatchableErrorCodes)
+            Set<String> tryCatchableErrorCodes,
+            boolean legacyStEquals)
     {
         this.parseDecimalLiteralAsDouble = parseDecimalLiteralAsDouble;
         this.legacyRowFieldOrdinalAccessEnabled = legacyRowFieldOrdinalAccessEnabled;
@@ -70,6 +72,7 @@ public class SqlFunctionProperties
         this.extraCredentials = requireNonNull(extraCredentials, "extraCredentials is null");
         this.canonicalizedJsonExtract = canonicalizedJsonExtract;
         this.tryCatchableErrorCodes = requireNonNull(tryCatchableErrorCodes, "tryCatchableErrorCodes is null");
+        this.legacyStEquals = legacyStEquals;
     }
 
     public boolean isParseDecimalLiteralAsDouble()
@@ -136,6 +139,11 @@ public class SqlFunctionProperties
         return tryCatchableErrorCodes;
     }
 
+    public boolean isLegacyStEquals()
+    {
+        return legacyStEquals;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -157,7 +165,8 @@ public class SqlFunctionProperties
                 Objects.equals(extraCredentials, that.extraCredentials) &&
                 Objects.equals(legacyJsonCast, that.legacyJsonCast) &&
                 Objects.equals(canonicalizedJsonExtract, that.canonicalizedJsonExtract) &&
-                Objects.equals(tryCatchableErrorCodes, that.tryCatchableErrorCodes);
+                Objects.equals(tryCatchableErrorCodes, that.tryCatchableErrorCodes) &&
+                Objects.equals(legacyStEquals, that.legacyStEquals);
     }
 
     @Override
@@ -165,7 +174,7 @@ public class SqlFunctionProperties
     {
         return Objects.hash(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, timeZoneKey,
                 legacyTimestamp, legacyMapSubscript, sessionStartTime, sessionLocale, sessionUser,
-                extraCredentials, legacyJsonCast, canonicalizedJsonExtract, tryCatchableErrorCodes);
+                extraCredentials, legacyJsonCast, canonicalizedJsonExtract, tryCatchableErrorCodes, legacyStEquals);
     }
 
     public static Builder builder()
@@ -188,6 +197,7 @@ public class SqlFunctionProperties
         private Map<String, String> extraCredentials = emptyMap();
         private boolean canonicalizedJsonExtract;
         private Set<String> tryCatchableErrorCodes = emptySet();
+        private boolean legacyStEquals;
 
         private Builder() {}
 
@@ -269,6 +279,12 @@ public class SqlFunctionProperties
             return this;
         }
 
+        public Builder setLegacyStEquals(boolean legacyStEquals)
+        {
+            this.legacyStEquals = legacyStEquals;
+            return this;
+        }
+
         public SqlFunctionProperties build()
         {
             return new SqlFunctionProperties(
@@ -284,7 +300,8 @@ public class SqlFunctionProperties
                     legacyJsonCast,
                     extraCredentials,
                     canonicalizedJsonExtract,
-                    tryCatchableErrorCodes);
+                    tryCatchableErrorCodes,
+                    legacyStEquals);
         }
     }
 }

--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -881,10 +881,10 @@ The value represents the max background fetch threads for refreshing metadata.
 * **Type:** ``boolean``
 * **Default value:** ``false``
 
-When enabled, the JDBC driver executes a validation query (``SELECT 1``) immediately
-after establishing a connection to ensure it is working properly before returning it
-to the application. This is useful for applications using connection pooling or
-experiencing intermittent connectivity issues, as it allows early detection of failed
+When enabled, the JDBC driver executes a validation query (``SELECT 1``) immediately 
+after establishing a connection to ensure it is working properly before returning it 
+to the application. This is useful for applications using connection pooling or 
+experiencing intermittent connectivity issues, as it allows early detection of failed 
 connections rather than discovering connection problems during the first query execution.
 
 To enable connection validation, add ``validateConnection=true`` to the JDBC connection URL::
@@ -900,8 +900,8 @@ Or set it by using connection properties::
 
 .. note::
 
-    Enabling connection validation adds a small overhead during connection establishment
-    due to the execution of the validation query. This is typically negligible but should
+    Enabling connection validation adds a small overhead during connection establishment 
+    due to the execution of the validation query. This is typically negligible but should 
     be considered in high-frequency connection scenarios.
 
 

--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -881,10 +881,10 @@ The value represents the max background fetch threads for refreshing metadata.
 * **Type:** ``boolean``
 * **Default value:** ``false``
 
-When enabled, the JDBC driver executes a validation query (``SELECT 1``) immediately 
-after establishing a connection to ensure it is working properly before returning it 
-to the application. This is useful for applications using connection pooling or 
-experiencing intermittent connectivity issues, as it allows early detection of failed 
+When enabled, the JDBC driver executes a validation query (``SELECT 1``) immediately
+after establishing a connection to ensure it is working properly before returning it
+to the application. This is useful for applications using connection pooling or
+experiencing intermittent connectivity issues, as it allows early detection of failed
 connections rather than discovering connection problems during the first query execution.
 
 To enable connection validation, add ``validateConnection=true`` to the JDBC connection URL::
@@ -900,8 +900,8 @@ Or set it by using connection properties::
 
 .. note::
 
-    Enabling connection validation adds a small overhead during connection establishment 
-    due to the execution of the validation query. This is typically negligible but should 
+    Enabling connection validation adds a small overhead during connection establishment
+    due to the execution of the validation query. This is typically negligible but should
     be considered in high-frequency connection scenarios.
 
 
@@ -1079,3 +1079,17 @@ When partition-aware execution is not applicable (for example: non-partitioned t
 columns in join conditions), the query falls back to standard grouped execution automatically.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`partition-aware-grouped-execution-enabled\`\``.
+
+Geometry Properties
+-------------------
+
+``legacy_st_equals``
+^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Enable legacy behavior for the ``ST_Equals`` geospatial function.
+See ``ST_Equals`` in :ref:`functions/geospatial:Relationship Tests` for details on the behavior differences.
+
+The corresponding configuration property is :ref:`admin/properties:\`\`legacy-st-equals\`\``.

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1863,3 +1863,17 @@ fails.
 Optional values written into the sidecar's ``config.properties`` to satisfy
 required-property checks in deployment-specific native worker initialization paths.
 Leave unset if not required by your deployment.
+
+Geometry Properties
+-------------------
+
+``legacy-st-equals``
+^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Enable legacy behavior for the ``ST_Equals`` geospatial function.
+See ``ST_Equals`` in :ref:`functions/geospatial:Relationship Tests` for details on the behavior differences.
+
+The corresponding session property is :ref:`admin/properties-session:\`\`legacy_st_equals\`\``.

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -142,7 +142,9 @@ Relationship Tests
 
 .. function:: ST_Equals(Geometry, Geometry) -> boolean
 
-    Returns ``true`` if the given geometries represent the same geometry.
+    Returns ``true`` if the given geometries represent the same geometry
+    according to ISO SQL/MM semantics. Also returns ``true`` if both geometries are empty,
+    regardless of their geometry types.
 
 .. function:: ST_Intersects(Geometry, Geometry) -> boolean
 

--- a/presto-docs/src/main/sphinx/functions/geospatial.rst
+++ b/presto-docs/src/main/sphinx/functions/geospatial.rst
@@ -145,6 +145,9 @@ Relationship Tests
     Returns ``true`` if the given geometries represent the same geometry
     according to ISO SQL/MM semantics. Also returns ``true`` if both geometries are empty,
     regardless of their geometry types.
+    Note: A legacy implementation is available by using the ``legacy_st_equals`` session property
+    or ``legacy-st-equals`` configuration property. The legacy behavior returns ``false`` for
+    any two empty geometry comparisons, but otherwise behaves the same.
 
 .. function:: ST_Intersects(Geometry, Geometry) -> boolean
 

--- a/presto-main-base/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/Session.java
@@ -64,6 +64,7 @@ import static com.facebook.presto.SystemSessionProperties.isCanonicalizedJsonExt
 import static com.facebook.presto.SystemSessionProperties.isFieldNameInJsonCastEnabled;
 import static com.facebook.presto.SystemSessionProperties.isLegacyMapSubscript;
 import static com.facebook.presto.SystemSessionProperties.isLegacyRowFieldOrdinalAccessEnabled;
+import static com.facebook.presto.SystemSessionProperties.isLegacySTEquals;
 import static com.facebook.presto.SystemSessionProperties.isLegacyTimestamp;
 import static com.facebook.presto.SystemSessionProperties.isParseDecimalLiteralsAsDouble;
 import static com.facebook.presto.spi.ConnectorId.createInformationSchemaConnectorId;
@@ -539,6 +540,7 @@ public final class Session
                 .setExtraCredentials(identity.getExtraCredentials())
                 .setCanonicalizedJsonExtract(isCanonicalizedJsonExtract(this))
                 .setTryCatchableErrorCodes(parseTryCatchableErrorCodes(getTryFunctionCatchableErrors(this)))
+                .setLegacyStEquals(isLegacySTEquals(this))
                 .build();
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -413,6 +413,7 @@ public final class SystemSessionProperties
     public static final String PUSH_FILTER_THROUGH_SELECTING_AGGREGATION = "push_filter_through_selecting_aggregation";
     public static final String OPTIMIZE_ROW_IN_PREDICATE = "optimize_row_in_predicate";
     public static final String ALWAYS_ANALYZE_CREATE_TABLE_QUERY_ENABLED = "always_analyze_create_table_query_enabled";
+    public static final String LEGACY_ST_EQUALS = "legacy_st_equals";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -2349,6 +2350,11 @@ public final class SystemSessionProperties
                         OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS,
                         "Minimum number of non-sort-key columns required before TopN row_id optimization triggers",
                         10,
+                        false),
+                booleanProperty(
+                        LEGACY_ST_EQUALS,
+                        "Use legacy ST_Equals function (warning: this will be removed)",
+                        functionsConfig.isLegacyStEquals(),
                         false));
     }
 
@@ -2979,6 +2985,11 @@ public final class SystemSessionProperties
     public static boolean isLegacyUnnest(Session session)
     {
         return session.getSystemProperty(LEGACY_UNNEST, Boolean.class);
+    }
+
+    public static boolean isLegacySTEquals(Session session)
+    {
+        return session.getSystemProperty(LEGACY_ST_EQUALS, Boolean.class);
     }
 
     public static OptionalInt getMaxDriversPerTask(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -2355,7 +2355,7 @@ public final class SystemSessionProperties
                         LEGACY_ST_EQUALS,
                         "Use legacy ST_Equals function (warning: this will be removed)",
                         functionsConfig.isLegacyStEquals(),
-                        false));
+                        true));
     }
 
     public static int getMaxPrefixesCount(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
@@ -26,6 +26,7 @@ import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCLineString;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.KdbTreeType;
 import com.facebook.presto.common.type.StandardTypes;
@@ -1089,13 +1090,15 @@ public final class GeoFunctions
     @Description("Returns TRUE if the given geometries represent the same geometry")
     @ScalarFunction("ST_Equals")
     @SqlType(BOOLEAN)
-    public static Boolean stEquals(@SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
+    public static Boolean stEquals(SqlFunctionProperties properties, @SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
     {
         OGCGeometry leftGeometry = EsriGeometrySerde.deserialize(left);
         OGCGeometry rightGeometry = EsriGeometrySerde.deserialize(right);
         verifySameSpatialReference(leftGeometry, rightGeometry);
-        if (leftGeometry.isEmpty() && rightGeometry.isEmpty()) {
-            return true;
+        if (!properties.isLegacyStEquals()) {
+            if (leftGeometry.isEmpty() && rightGeometry.isEmpty()) {
+                return true;
+            }
         }
         return leftGeometry.Equals(rightGeometry);
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
@@ -1094,6 +1094,9 @@ public final class GeoFunctions
         OGCGeometry leftGeometry = EsriGeometrySerde.deserialize(left);
         OGCGeometry rightGeometry = EsriGeometrySerde.deserialize(right);
         verifySameSpatialReference(leftGeometry, rightGeometry);
+        if (leftGeometry.isEmpty() && rightGeometry.isEmpty()) {
+            return true;
+        }
         return leftGeometry.Equals(rightGeometry);
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/geospatial/GeoFunctions.java
@@ -26,7 +26,6 @@ import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCLineString;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
-import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.KdbTreeType;
 import com.facebook.presto.common.type.StandardTypes;
@@ -1087,23 +1086,6 @@ public final class GeoFunctions
     }
 
     @SqlNullable
-    @Description("Returns TRUE if the given geometries represent the same geometry")
-    @ScalarFunction("ST_Equals")
-    @SqlType(BOOLEAN)
-    public static Boolean stEquals(SqlFunctionProperties properties, @SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
-    {
-        OGCGeometry leftGeometry = EsriGeometrySerde.deserialize(left);
-        OGCGeometry rightGeometry = EsriGeometrySerde.deserialize(right);
-        verifySameSpatialReference(leftGeometry, rightGeometry);
-        if (!properties.isLegacyStEquals()) {
-            if (leftGeometry.isEmpty() && rightGeometry.isEmpty()) {
-                return true;
-            }
-        }
-        return leftGeometry.Equals(rightGeometry);
-    }
-
-    @SqlNullable
     @Description("Returns TRUE if the Geometries spatially intersect in 2D - (share any portion of space) and FALSE if they don't (they are Disjoint)")
     @ScalarFunction("ST_Intersects")
     @SqlType(BOOLEAN)
@@ -1309,7 +1291,7 @@ public final class GeoFunctions
         }
     }
 
-    private static void verifySameSpatialReference(OGCGeometry leftGeometry, OGCGeometry rightGeometry)
+    static void verifySameSpatialReference(OGCGeometry leftGeometry, OGCGeometry rightGeometry)
     {
         checkArgument(Objects.equals(leftGeometry.getEsriSpatialReference(), rightGeometry.getEsriSpatialReference()), "Input geometries must have the same spatial reference");
     }
@@ -1458,5 +1440,44 @@ public final class GeoFunctions
             delta >>= 5;
         }
         stringBuilder.append(Character.toChars((int) (delta + 0x3f)));
+    }
+
+    @ScalarFunction("ST_Equals")
+    @Description("Returns TRUE if the given geometries represent the same geometry")
+    public static final class LegacyStEquals
+    {
+        private LegacyStEquals() {}
+
+        @SqlNullable
+        @SqlType(BOOLEAN)
+        public static Boolean stEquals(@SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
+        {
+            OGCGeometry leftGeometry = EsriGeometrySerde.deserialize(left);
+            OGCGeometry rightGeometry = EsriGeometrySerde.deserialize(right);
+            verifySameSpatialReference(leftGeometry, rightGeometry);
+            return leftGeometry.Equals(rightGeometry);
+        }
+    }
+
+    @ScalarFunction("ST_Equals")
+    @Description("Returns TRUE if the given geometries represent the same geometry or both are empty")
+    public static final class StEquals
+    {
+        private StEquals() {}
+
+        @SqlNullable
+        @SqlType(BOOLEAN)
+        public static Boolean stEquals(@SqlType(GEOMETRY_TYPE_NAME) Slice left, @SqlType(GEOMETRY_TYPE_NAME) Slice right)
+        {
+            OGCGeometry leftGeometry = EsriGeometrySerde.deserialize(left);
+            OGCGeometry rightGeometry = EsriGeometrySerde.deserialize(right);
+            verifySameSpatialReference(leftGeometry, rightGeometry);
+
+            if (leftGeometry.isEmpty() && rightGeometry.isEmpty()) {
+                return true;
+            }
+
+            return leftGeometry.Equals(rightGeometry);
+        }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -1015,6 +1015,13 @@ public class BuiltInTypeAndFunctionNamespaceManager
             builder.scalar(LegacyLogFunction.class);
         }
 
+        if (functionsConfig.isLegacyStEquals()) {
+            builder.scalar(GeoFunctions.LegacyStEquals.class);
+        }
+        else {
+            builder.scalar(GeoFunctions.StEquals.class);
+        }
+
         // Replace some aggregations for Velox to override intermediate aggregation type.
         if (functionsConfig.isUseAlternativeFunctionSignatures()) {
             builder.override(ARBITRARY_AGGREGATION, ALTERNATIVE_ARBITRARY_AGGREGATION);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FunctionsConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FunctionsConfig.java
@@ -50,6 +50,8 @@ public class FunctionsConfig
     private boolean canonicalizedJsonExtract;
     private String defaultNamespacePrefix = JAVA_BUILTIN_NAMESPACE.toString();
 
+    private boolean legacyStEquals;
+
     @Config("deprecated.legacy-array-agg")
     public FunctionsConfig setLegacyArrayAgg(boolean legacyArrayAgg)
     {
@@ -307,5 +309,17 @@ public class FunctionsConfig
     public String getDefaultNamespacePrefix()
     {
         return defaultNamespacePrefix;
+    }
+
+    @Config("legacy-st-equals")
+    public FunctionsConfig setLegacyStEquals(boolean value)
+    {
+        this.legacyStEquals = value;
+        return this;
+    }
+
+    public boolean isLegacyStEquals()
+    {
+        return legacyStEquals;
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestGeoRelations.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestGeoRelations.java
@@ -155,6 +155,9 @@ public class TestGeoRelations
         assertRelation("ST_Equals", "'MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))'", "'MULTILINESTRING ((3 4, 6 4), (5 0, 5 4))'", false);
         assertRelation("ST_Equals", "'POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))'", "'POLYGON ((3 3, 3 1, 1 1, 1 3, 3 3))'", true);
         assertRelation("ST_Equals", "'MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1, 1 1)), ((0 0, 0 2, 2 2, 2 0, 0 0)))'", "'POLYGON ((0 1, 3 1, 3 3, 0 3, 0 1))'", false);
+        assertRelation("ST_Equals", "'LINESTRING (0 0, 0 1)'", "'POINT EMPTY'", false);
+        assertRelation("ST_Equals", "'POINT EMPTY'", "'POINT EMPTY'", true);
+        assertRelation("ST_Equals", "'POINT EMPTY'", "'LINESTRING EMPTY'", true);
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestGeoRelations.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestGeoRelations.java
@@ -14,7 +14,6 @@
 
 package com.facebook.presto.geospatial;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.operator.scalar.AbstractTestFunctions;
 import com.facebook.presto.operator.scalar.FunctionAssertions;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -167,13 +166,13 @@ public class TestGeoRelations
     @Test
     public void testSTEqualsLegacyBehavior()
     {
-        Session legacySession = Session.builder(session)
-                .setSystemProperty("legacy_st_equals", "true")
-                .build();
+        FunctionsConfig legacyFunctionsConfig = new FunctionsConfig();
+        legacyFunctionsConfig.setLegacyStEquals(true);
+
         FunctionAssertions legacyAssertions = new FunctionAssertions(
-                legacySession,
+                session,
                 new FeaturesConfig(),
-                new FunctionsConfig(),
+                legacyFunctionsConfig,
                 false);
 
         try {

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFunctionsConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFunctionsConfig.java
@@ -53,7 +53,8 @@ public class TestFunctionsConfig
                 .setLegacyCharToVarcharCoercion(false)
                 .setLegacyJsonCast(true)
                 .setCanonicalizedJsonExtract(false)
-                .setDefaultNamespacePrefix(JAVA_BUILTIN_NAMESPACE.toString()));
+                .setDefaultNamespacePrefix(JAVA_BUILTIN_NAMESPACE.toString())
+                .setLegacyStEquals(false));
     }
 
     @Test
@@ -81,6 +82,7 @@ public class TestFunctionsConfig
                 .put("legacy-json-cast", "false")
                 .put("presto.default-namespace", "native.default")
                 .put("canonicalized-json-extract", "true")
+                .put("legacy-st-equals", "true")
                 .build();
 
         FunctionsConfig expected = new FunctionsConfig()
@@ -104,7 +106,8 @@ public class TestFunctionsConfig
                 .setLegacyCharToVarcharCoercion(true)
                 .setLegacyJsonCast(false)
                 .setDefaultNamespacePrefix("native.default")
-                .setCanonicalizedJsonExtract(true);
+                .setCanonicalizedJsonExtract(true)
+                .setLegacyStEquals(true);
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Presto ST_Equals function for empty geometries should return true regardless of geometry types. 

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Closes #26253 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Added in tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
General Changes
* Update ST_Equals function for empty geometries to return true regardless of geometry types. 
* Add config properties for legacy ST_Equals behavior.
```

## Summary by Sourcery

Adjust ST_Equals geometry comparison semantics for empty geometries of the same or different types.

Bug Fixes:
- Ensure ST_Equals returns true for empty geometries of the same type and false for empty geometries of different types.

Tests:
- Add ST_Equals relation tests covering empty geometries of matching and differing types.