### PR TITLE
fix: Add row field names for varchar/map types when registering function signatures

### DIFF
--- a/presto-built-in-worker-function-tools/src/main/java/com/facebook/presto/builtin/tools/WorkerFunctionUtil.java
+++ b/presto-built-in-worker-function-tools/src/main/java/com/facebook/presto/builtin/tools/WorkerFunctionUtil.java
@@ -17,6 +17,7 @@ package com.facebook.presto.builtin.tools;
 import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.NamedTypeSignature;
+import com.facebook.presto.common.type.RowFieldName;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -154,10 +155,12 @@ public class WorkerFunctionUtil
                                         parameterTypeSignature.getStandardTypeSignature(),
                                         parameterTypeSignature.getParameters()));
                 if (isNamedTypeSignature) {
+                    // Preserve the original field name if present, otherwise use Optional.empty()
+                    Optional<RowFieldName> fieldName = parameter.getNamedTypeSignature().getFieldName();
                     newParameterTypeList.add(
                             TypeSignatureParameter.of(
                                     new NamedTypeSignature(
-                                            Optional.empty(),
+                                            fieldName,
                                             newTypeSignature)));
                 }
                 else {


### PR DESCRIPTION
## Description
In SHOW FUNCTIONS output, the return type signatures for named field names only have the type name, but they do no show that name of the parameter. Note that the names of the fields are shown if the parameter type is a integer or real, but it seems to be hidden for varchar type params.

## Motivation and Context
SHOW FUNCTIONS output for return type can be inconsistent.

## Impact
Ensures that the named fields are displayed in the return types of funtion signatures shown in SHOW FUNCTIONS.

## Test Plan
Added unit tests for varchar and map type fields.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```




Differential Revision: D91268854
