### PR TITLE
feat: Add mysql getViews

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -22,7 +22,10 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import jakarta.annotation.Nullable;
 
@@ -30,8 +33,13 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 
 public interface JdbcClient
 {
@@ -104,4 +112,35 @@ public interface JdbcClient
     TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle, List<JdbcColumnHandle> columnHandles, TupleDomain<ColumnHandle> tupleDomain);
 
     String normalizeIdentifier(ConnectorSession session, String identifier);
+
+    /**
+     * View support is optional for a JDBC client. {@link JdbcMetadata} delegates the view
+     * operations here, and the defaults below mirror
+     * {@link com.facebook.presto.spi.connector.ConnectorMetadata}, so a client that does not
+     * override them behaves as if the underlying database exposed no views at all.
+     */
+    default List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return emptyList();
+    }
+
+    default Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        return emptyMap();
+    }
+
+    default void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support creating views");
+    }
+
+    default void renameView(ConnectorSession session, SchemaTableName viewName, SchemaTableName newViewName)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support renaming views");
+    }
+
+    default void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support dropping views");
+    }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.ConnectorTableLayout;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutResult;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
@@ -289,5 +290,35 @@ public class JdbcMetadata
     public Optional<Object> getInfo(ConnectorTableLayoutHandle tableHandle)
     {
         return Optional.of(new JdbcInputInfo(url));
+    }
+
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return jdbcClient.listViews(session, schemaName);
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        return jdbcClient.getViews(session, prefix);
+    }
+
+    @Override
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        jdbcClient.createView(session, viewMetadata, viewData, replace);
+    }
+
+    @Override
+    public void renameView(ConnectorSession session, SchemaTableName viewName, SchemaTableName newViewName)
+    {
+        jdbcClient.renameView(session, viewName, newViewName);
+    }
+
+    @Override
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        jdbcClient.dropView(session, viewName);
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.plugin.jdbc.TestingDatabase.CONNECTOR_ID;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.PERMISSION_DENIED;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
@@ -509,5 +510,32 @@ public class TestJdbcMetadata
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("example", "view_source"),
                 new SchemaTableName("example", "view")));
+    }
+
+    @Test
+    public void testViewOperationsAreUnsupportedWhenClientDoesNotImplementThem()
+    {
+        // TestingDatabase's client leaves the optional view methods on JdbcClient at their
+        // defaults, so a connector that has not opted into views reports none and refuses to
+        // create, rename or drop them.
+        SchemaTableName viewName = new SchemaTableName("example", "a_view");
+
+        assertEquals(metadata.listViews(SESSION, Optional.of("example")), ImmutableList.of());
+        assertEquals(metadata.getViews(SESSION, new SchemaTablePrefix("example")), ImmutableMap.of());
+
+        assertViewOperationNotSupported(() -> metadata.createView(SESSION, new ConnectorTableMetadata(viewName, ImmutableList.of()), "view data", false));
+        assertViewOperationNotSupported(() -> metadata.renameView(SESSION, viewName, new SchemaTableName("example", "another_view")));
+        assertViewOperationNotSupported(() -> metadata.dropView(SESSION, viewName));
+    }
+
+    private static void assertViewOperationNotSupported(Runnable operation)
+    {
+        try {
+            operation.run();
+            fail("expected exception");
+        }
+        catch (PrestoException e) {
+            assertEquals(e.getErrorCode(), NOT_SUPPORTED.toErrorCode());
+        }
     }
 }

--- a/presto-docs/src/main/sphinx/connector/mysql.rst
+++ b/presto-docs/src/main/sphinx/connector/mysql.rst
@@ -312,6 +312,39 @@ Create a new table ``page_views_new`` from an existing table ``page_views``:
 
  ``Query 20240321_103408_00015_kbd43 failed: line 1:67: mismatched input '('. Expecting: 'DATA', 'NO'``
 
+CREATE VIEW
+^^^^^^^^^^^
+
+Create a new view in the ``web`` schema:
+
+.. code-block:: sql
+
+    CREATE VIEW mysql.web.recent_orders AS
+    SELECT * FROM mysql.web.orders WHERE ds > current_date - interval '7' day;
+
+Replace an existing view:
+
+.. code-block:: sql
+
+    CREATE OR REPLACE VIEW mysql.web.recent_orders AS
+    SELECT * FROM mysql.web.orders WHERE ds > current_date - interval '30' day;
+
+ALTER VIEW
+^^^^^^^^^^
+
+Rename an existing view:
+
+.. code-block:: sql
+
+    ALTER VIEW mysql.web.recent_orders RENAME TO mysql.web.last_30_days_orders;
+
+DROP VIEW
+^^^^^^^^^
+
+.. code-block:: sql
+
+    DROP VIEW mysql.web.recent_orders;
+
 INSERT INTO
 ^^^^^^^^^^^
 
@@ -342,14 +375,11 @@ MySQL Connector Limitations
 
 The following SQL statements are not supported:
 
-* :doc:`/sql/alter-table`
 * :doc:`/sql/analyze`
 * :doc:`/sql/create-schema`
-* :doc:`/sql/create-view`
 * :doc:`/sql/delete`
 * :doc:`/sql/drop-schema`
 * :doc:`/sql/drop-table`
-* :doc:`/sql/drop-view`
 * :doc:`/sql/grant`
 * :doc:`/sql/revoke`
 * :doc:`/sql/show-grants`

--- a/presto-docs/src/main/sphinx/connector/mysql.rst
+++ b/presto-docs/src/main/sphinx/connector/mysql.rst
@@ -72,6 +72,11 @@ Property Name                                      Description                  
 ``case-sensitive-name-matching``                   Enable case sensitive identifier support for schema and table        ``false``
                                                    names for the connector. When disabled, names are matched
                                                    case-insensitively using lowercase normalization.
+
+``enable-datasource-managed-views``                Let MySQL resolve view definitions instead of Presto. When           ``false``
+                                                   enabled, the connector does not report views to Presto, so
+                                                   Presto never analyzes the stored view SQL. See
+                                                   :ref:`Views <mysql-views>`.
 ================================================== ==================================================================== ===========
 
 Querying MySQL
@@ -99,6 +104,53 @@ Finally, you can access the ``clicks`` table in the ``web`` database::
 
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``mysql`` in the above examples.
+
+.. _mysql-views:
+
+Views
+-----
+
+A MySQL view can be read in either of two modes, selected by the
+``enable-datasource-managed-views`` catalog property.
+
+With the default ``enable-datasource-managed-views=false``, Presto reads the
+stored view SQL from MySQL and analyzes it itself. The view is exposed as a
+Presto view, so it is listed in ``information_schema.views``. Because Presto
+analyzes the definition, a view whose SQL uses MySQL-only syntax or functions
+that Presto does not have fails at analysis time. For example, a view defined
+with the MySQL-specific ``IFNULL()`` function fails with an error similar to
+the following:
+
+.. code-block:: none
+
+    Failed analyzing stored view 'mysql.web.recent_orders': Function ifnull not registered
+
+With ``enable-datasource-managed-views=true``, the connector reports no views
+and Presto reads each view through the normal table flow, leaving MySQL to
+resolve the view definition. Views whose SQL Presto cannot analyze become
+queryable, at the cost of Presto no longer treating them as views:
+
+* They are listed in ``information_schema.tables`` rather than
+  ``information_schema.views``.
+* ``SHOW CREATE VIEW`` fails with ``Relation '...' is a table, not a view``.
+* ``ALTER VIEW ... RENAME TO`` and ``DROP VIEW`` fail with
+  ``View '...' does not exist``, because Presto resolves the view through the
+  connector before issuing the statement. ``DROP VIEW IF EXISTS`` silently
+  does nothing. Use :ref:`the execute procedure <mysql-execute-procedure>` to
+  rename or drop such a view in MySQL directly.
+
+``CREATE VIEW`` and ``CREATE OR REPLACE VIEW`` work in both modes.
+
+The property is set per catalog, so two catalogs over the same MySQL server
+can use different modes:
+
+.. code-block:: none
+
+    connector.name=mysql
+    connection-url=jdbc:mysql://example.net:3306
+    connection-user=root
+    connection-password=secret
+    enable-datasource-managed-views=true
 
 Type mapping
 ------------
@@ -226,6 +278,8 @@ Procedures
 
 Use the :doc:`/sql/call` statement to perform data manipulation or administrative tasks. Procedures are available in the ``system`` schema of the catalog.
 
+.. _mysql-execute-procedure:
+
 Execute Procedure
 ^^^^^^^^^^^^^^^^^
 
@@ -344,6 +398,10 @@ DROP VIEW
 .. code-block:: sql
 
     DROP VIEW mysql.web.recent_orders;
+
+.. note:: ``ALTER VIEW`` and ``DROP VIEW`` require the connector to report the
+ view to Presto, so they do not work when
+ ``enable-datasource-managed-views=true``. See :ref:`Views <mysql-views>`.
 
 INSERT INTO
 ^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/connector/mysql.rst
+++ b/presto-docs/src/main/sphinx/connector/mysql.rst
@@ -375,6 +375,7 @@ MySQL Connector Limitations
 
 The following SQL statements are not supported:
 
+* :doc:`/sql/alter-table`
 * :doc:`/sql/analyze`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/delete`

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -20,6 +20,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-base-jdbc</artifactId>
         </dependency>
@@ -57,6 +67,16 @@
         <dependency>
             <groupId>com.esri.geometry</groupId>
             <artifactId>esri-geometry-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Presto SPI -->

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -85,7 +85,7 @@ public class MySqlClient
      * @see <a href="https://dev.mysql.com/doc/connector-j/en/connector-j-reference-error-sqlstates.html">MySQL documentation</a>
      */
     private static final String SQL_STATE_ER_TABLE_EXISTS_ERROR = "42S01";
-    private static JsonCodec<ViewDefinition> viewCodec;
+    private final JsonCodec<ViewDefinition> viewCodec;
 
     @Inject
     public MySqlClient(
@@ -329,7 +329,7 @@ public class MySqlClient
                         ResultSet resultSet = statement.executeQuery(sql)) {
                     while (resultSet.next()) {
                         String owner = resultSet.getString("DEFINER");
-                        ViewDefinition viewDefinition = getViewDefinition(resultSet, session, connectorId, schemaTableName, schemaName, tableName, owner);
+                        ViewDefinition viewDefinition = getViewDefinition(resultSet, session, connectorId, schemaTableName, owner);
 
                         SchemaTableName viewName = new SchemaTableName(schemaName, tableName);
                         String viewData = viewCodec.toJson(viewDefinition);
@@ -348,12 +348,14 @@ public class MySqlClient
         return views.build();
     }
 
-    private ViewDefinition getViewDefinition(ResultSet resultSet, ConnectorSession session, String connectorId, SchemaTableName schemaTableName, String schemaName, String tableName, String owner)
+    private ViewDefinition getViewDefinition(ResultSet resultSet, ConnectorSession session, String connectorId, SchemaTableName schemaTableName, String owner)
             throws SQLException
     {
         boolean runAsInvoker = "INVOKER".equals(resultSet.getString("SECURITY_TYPE"));
         // StatementAnalyzer can't parse sql with back ticks, so we replace them here
         String viewSql = resultSet.getString("VIEW_DEFINITION").replace('`', '"');
+        String schemaName = schemaTableName.getSchemaName();
+        String tableName = schemaTableName.getTableName();
 
         List<JdbcColumnHandle> jdbcColumns = super.getColumns(session, new JdbcTableHandle(
                 connectorId,
@@ -416,9 +418,10 @@ public class MySqlClient
             String catalog = connection.getCatalog();
 
             if (!replace) {
-                ResultSet resultSet = getTables(connection, Optional.ofNullable(schema), Optional.ofNullable(view));
-                if (resultSet.next()) {
-                    throw new PrestoException(ALREADY_EXISTS, format("The view/table '%s' already exists", viewName.getTableName()));
+                try (ResultSet resultSet = getTables(connection, Optional.ofNullable(schema), Optional.ofNullable(view))) {
+                    if (resultSet.next()) {
+                        throw new PrestoException(ALREADY_EXISTS, format("The view/table '%s' already exists", viewName.getTableName()));
+                    }
                 }
             }
 

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.mysql;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
@@ -30,8 +31,12 @@ import com.facebook.presto.plugin.jdbc.QueryBuilder;
 import com.facebook.presto.plugin.jdbc.mapping.ReadMapping;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.mysql.cj.jdbc.JdbcStatement;
 import com.mysql.jdbc.Driver;
@@ -43,6 +48,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
+import java.sql.Statement;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -61,10 +67,12 @@ import static com.facebook.presto.plugin.jdbc.QueryBuilder.quote;
 import static com.facebook.presto.plugin.jdbc.mapping.StandardColumnMappings.geometryReadMapping;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
 public class MySqlClient
@@ -77,12 +85,18 @@ public class MySqlClient
      * @see <a href="https://dev.mysql.com/doc/connector-j/en/connector-j-reference-error-sqlstates.html">MySQL documentation</a>
      */
     private static final String SQL_STATE_ER_TABLE_EXISTS_ERROR = "42S01";
+    private static JsonCodec<ViewDefinition> viewCodec;
 
     @Inject
-    public MySqlClient(JdbcConnectorId connectorId, BaseJdbcConfig config, MySqlConfig mySqlConfig)
+    public MySqlClient(
+            JdbcConnectorId connectorId,
+            BaseJdbcConfig config,
+            MySqlConfig mySqlConfig,
+            JsonCodec<ViewDefinition> viewCodec)
             throws SQLException
     {
         super(connectorId, config, "`", connectionFactory(config, mySqlConfig));
+        this.viewCodec = requireNonNull(viewCodec, "viewCodec is null");
     }
 
     private static ConnectionFactory connectionFactory(BaseJdbcConfig config, MySqlConfig mySqlConfig)
@@ -294,5 +308,160 @@ public class MySqlClient
     public String normalizeIdentifier(ConnectorSession session, String identifier)
     {
         return caseSensitiveNameMatchingEnabled ? identifier : identifier.toLowerCase(ENGLISH);
+    }
+
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, List<SchemaTableName> tableNames)
+    {
+        JdbcIdentity identity = new JdbcIdentity(session.getUser(), session.getIdentity().getExtraCredentials());
+        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            for (SchemaTableName schemaTableName : tableNames) {
+                String schemaName = schemaTableName.getSchemaName();
+                String tableName = schemaTableName.getTableName();
+
+                String sql = format(
+                        "SELECT * FROM INFORMATION_SCHEMA.VIEWS " +
+                                "WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
+                        schemaName, tableName);
+
+                try (Statement statement = connection.createStatement();
+                        ResultSet resultSet = statement.executeQuery(sql)) {
+                    while (resultSet.next()) {
+                        String owner = resultSet.getString("DEFINER");
+                        ViewDefinition viewDefinition = getViewDefinition(resultSet, session, connectorId, schemaTableName, schemaName, tableName, owner);
+
+                        SchemaTableName viewName = new SchemaTableName(schemaName, tableName);
+                        String viewData = viewCodec.toJson(viewDefinition);
+
+                        views.put(viewName, new ConnectorViewDefinition(
+                                viewName,
+                                Optional.of(owner),
+                                viewData));
+                    }
+                }
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+        return views.build();
+    }
+
+    private ViewDefinition getViewDefinition(ResultSet resultSet, ConnectorSession session, String connectorId, SchemaTableName schemaTableName, String schemaName, String tableName, String owner)
+            throws SQLException
+    {
+        boolean runAsInvoker = "INVOKER".equals(resultSet.getString("SECURITY_TYPE"));
+        // StatementAnalyzer can't parse sql with back ticks, so we replace them here
+        String viewSql = resultSet.getString("VIEW_DEFINITION").replace('`', '"');
+
+        List<JdbcColumnHandle> jdbcColumns = super.getColumns(session, new JdbcTableHandle(
+                connectorId,
+                schemaTableName,
+                null,
+                schemaName,
+                tableName));
+
+        List<ViewDefinition.ViewColumn> columns = jdbcColumns.stream()
+                .map(jdbcColumn -> new ViewDefinition.ViewColumn(jdbcColumn.getColumnName(), jdbcColumn.getColumnType()))
+                .collect(toImmutableList());
+
+        return new ViewDefinition(
+                viewSql,
+                Optional.of(connectorId),
+                Optional.of(schemaName),
+                columns,
+                Optional.of(owner),
+                runAsInvoker);
+    }
+
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            DatabaseMetaData metadata = connection.getMetaData();
+            Optional<String> escape = Optional.ofNullable(metadata.getSearchStringEscape());
+            try (ResultSet resultSet = metadata.getTables(
+                    schemaName.orElse(null),
+                    null,
+                    escapeNamePattern(Optional.empty(), escape).orElse(null),
+                    new String[] {"VIEW"})) {
+                ImmutableList.Builder<SchemaTableName> builder = ImmutableList.builder();
+                while (resultSet.next()) {
+                    String tableName = resultSet.getString("TABLE_NAME");
+                    String schema = schemaName.orElse(resultSet.getString("TABLE_CAT"));
+                    builder.add(new SchemaTableName(
+                            normalizeIdentifier(session, schema),
+                            normalizeIdentifier(session, tableName)));
+                }
+                return builder.build();
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        SchemaTableName viewName = viewMetadata.getTable();
+        JdbcIdentity identity = JdbcIdentity.from(session);
+
+        // Deserialize the Presto-internal ViewDefinition JSON to extract originalSql
+        String originalSql = viewCodec.fromJson(viewData).getOriginalSql();
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String schema = toRemoteSchemaName(session, identity, connection, viewName.getSchemaName());
+            String view = toRemoteTableName(session, identity, connection, schema, viewName.getTableName());
+            String catalog = connection.getCatalog();
+
+            if (!replace) {
+                ResultSet resultSet = getTables(connection, Optional.ofNullable(schema), Optional.ofNullable(view));
+                if (resultSet.next()) {
+                    throw new PrestoException(ALREADY_EXISTS, format("The view/table '%s' already exists", viewName.getTableName()));
+                }
+            }
+
+            String sql = format(
+                    "%s VIEW %s AS %s",
+                    replace ? "CREATE OR REPLACE" : "CREATE",
+                    quoted(catalog, schema, view),
+                    originalSql);
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    public void renameView(ConnectorSession session, SchemaTableName viewName, SchemaTableName newViewName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String sql = format(
+                    "RENAME TABLE %s TO %s",
+                    quoted(null, viewName.getSchemaName(), viewName.getTableName()),
+                    quoted(null, newViewName.getSchemaName(), newViewName.getTableName()));
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String sql = format(
+                    "DROP VIEW %s",
+                    quoted(null, viewName.getSchemaName(), viewName.getTableName()));
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
     }
 }

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -34,6 +34,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -310,8 +311,20 @@ public class MySqlClient
         return caseSensitiveNameMatchingEnabled ? identifier : identifier.toLowerCase(ENGLISH);
     }
 
-    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, List<SchemaTableName> tableNames)
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
     {
+        List<SchemaTableName> tableNames;
+        if (prefix.getTableName() != null) {
+            tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        }
+        else {
+            // A prefix with no table name, and possibly no schema name either, comes from queries
+            // such as SELECT * FROM information_schema.views. Every matching schema has to be
+            // walked, so the cost grows with the number of views on the server.
+            tableNames = listViews(session, Optional.ofNullable(prefix.getSchemaName()));
+        }
+
         JdbcIdentity identity = new JdbcIdentity(session.getUser(), session.getIdentity().getExtraCredentials());
         ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
 
@@ -377,6 +390,7 @@ public class MySqlClient
                 runAsInvoker);
     }
 
+    @Override
     public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
     {
         JdbcIdentity identity = JdbcIdentity.from(session);
@@ -404,6 +418,7 @@ public class MySqlClient
         }
     }
 
+    @Override
     public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
     {
         SchemaTableName viewName = viewMetadata.getTable();
@@ -437,6 +452,7 @@ public class MySqlClient
         }
     }
 
+    @Override
     public void renameView(ConnectorSession session, SchemaTableName viewName, SchemaTableName newViewName)
     {
         JdbcIdentity identity = JdbcIdentity.from(session);
@@ -453,6 +469,7 @@ public class MySqlClient
         }
     }
 
+    @Override
     public void dropView(ConnectorSession session, SchemaTableName viewName)
     {
         JdbcIdentity identity = JdbcIdentity.from(session);

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClientModule.java
@@ -14,34 +14,116 @@
 package com.facebook.presto.plugin.mysql;
 
 import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.plugin.jdbc.DefaultTableLocationProvider;
 import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcConnector;
+import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCacheStats;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataConfig;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataFactory;
+import com.facebook.presto.plugin.jdbc.JdbcPageSinkProvider;
+import com.facebook.presto.plugin.jdbc.JdbcRecordSetProvider;
+import com.facebook.presto.plugin.jdbc.JdbcSessionPropertiesProvider;
+import com.facebook.presto.plugin.jdbc.JdbcSplitManager;
+import com.facebook.presto.plugin.jdbc.TableLocationProvider;
+import com.facebook.presto.plugin.jdbc.procedure.ExecuteProcedure;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import com.mysql.cj.conf.ConnectionUrl;
 import com.mysql.cj.conf.ConnectionUrlParser;
 import com.mysql.cj.util.StringUtils;
+import jakarta.inject.Inject;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class MySqlClientModule
         extends AbstractConfigurationAwareModule
 {
+    private final String connectorId;
+
+    public MySqlClientModule(String connectorId)
+    {
+        this.connectorId = requireNonNull(connectorId, "connector id is null");
+    }
+
     @Override
     protected void setup(Binder binder)
     {
+        newOptionalBinder(binder, ConnectorAccessControl.class);
+        newSetBinder(binder, Procedure.class).addBinding().toProvider(ExecuteProcedure.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcConnectorId.class).toInstance(new JdbcConnectorId(connectorId));
+
+        binder.bind(JdbcMetadataCache.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcMetadataCacheStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(JdbcMetadataCacheStats.class).as(generatedNameOf(JdbcMetadataCacheStats.class, connectorId));
+
+        binder.bind(JdbcMetadataFactory.class).to(MySqlMetadataFactory.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, JdbcSessionPropertiesProvider.class);
+        binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(JdbcMetadataConfig.class);
+        configBinder(binder).bindConfig(BaseJdbcConfig.class);
+        binder.bind(TableLocationProvider.class).to(DefaultTableLocationProvider.class).in(Scopes.SINGLETON);
+        binder.bind(MySqlClient.class).in(Scopes.SINGLETON);
         binder.bind(JdbcClient.class).to(MySqlClient.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfigDefaults(BaseJdbcConfig.class, baseJdbcConfig -> {
             baseJdbcConfig.setlistSchemasIgnoredSchemas("information_schema,mysql");
         });
         ensureCatalogIsEmpty(buildConfigObject(BaseJdbcConfig.class).getConnectionUrl());
         configBinder(binder).bindConfig(MySqlConfig.class);
+        binder.install(new JsonModule());
+
+        jsonCodecBinder(binder).bindJsonCodec(ViewDefinition.class);
+        jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
     }
 
     private static void ensureCatalogIsEmpty(String connectionUrl)
     {
         checkArgument(ConnectionUrlParser.isConnectionStringSupported(connectionUrl), "Invalid JDBC URL for MySQL connector");
         checkArgument(StringUtils.isNullOrEmpty(ConnectionUrl.getConnectionUrlInstance(connectionUrl, null).getDatabase()), "Database (catalog) must not be specified in JDBC URL for MySQL connector");
+    }
+
+    private static final class TypeDeserializer
+            extends FromStringDeserializer<Type>
+    {
+        private static final long serialVersionUID = 1L;
+
+        private final TypeManager typeManager;
+
+        @Inject
+        public TypeDeserializer(TypeManager typeManager)
+        {
+            super(Type.class);
+            this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        }
+
+        @Override
+        protected Type _deserialize(String value, DeserializationContext context)
+        {
+            Type type = typeManager.getType(parseTypeSignature(value));
+            checkArgument(type != null, "Unknown type %s", value);
+            return type;
+        }
     }
 }

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlConfig.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.mysql;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.airlift.units.Duration;
 import jakarta.validation.constraints.Min;
 
@@ -24,6 +25,7 @@ public class MySqlConfig
     private boolean autoReconnect = true;
     private int maxReconnects = 3;
     private Duration connectionTimeout = new Duration(10, TimeUnit.SECONDS);
+    private boolean datasourceManagedViewsEnabled;
 
     public boolean isAutoReconnect()
     {
@@ -59,6 +61,21 @@ public class MySqlConfig
     public MySqlConfig setConnectionTimeout(Duration connectionTimeout)
     {
         this.connectionTimeout = connectionTimeout;
+        return this;
+    }
+
+    public boolean isDatasourceManagedViewsEnabled()
+    {
+        return datasourceManagedViewsEnabled;
+    }
+
+    @Config("enable-datasource-managed-views")
+    @ConfigDescription("Enable datasource-managed handling for connector views. " +
+            "When disabled, Presto analyzes and processes underlying view SQL. " +
+            "When enabled, Presto does not analyze the underlying view definition and treats it as datasource-managed.")
+    public MySqlConfig setDatasourceManagedViewsEnabled(boolean datasourceManagedViewsEnabled)
+    {
+        this.datasourceManagedViewsEnabled = datasourceManagedViewsEnabled;
         return this;
     }
 }

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlConnectorFactory.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlConnectorFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.mysql;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.plugin.jdbc.JdbcConnector;
+import com.facebook.presto.plugin.jdbc.JdbcHandleResolver;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.RowExpressionService;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.util.Objects.requireNonNull;
+
+public class MySqlConnectorFactory
+        implements ConnectorFactory
+{
+    private final String name;
+    private final ClassLoader classLoader;
+
+    public MySqlConnectorFactory(String name, ClassLoader classLoader)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or empty");
+        this.name = name;
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new JdbcHandleResolver();
+    }
+
+    public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        requireNonNull(requiredConfig, "requiredConfig is null");
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(
+                    binder -> {
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());
+                        binder.bind(StandardFunctionResolution.class).toInstance(context.getStandardFunctionResolution());
+                        binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
+                    },
+                    new MySqlClientModule(catalogName));
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(requiredConfig)
+                    .initialize();
+
+            return injector.getInstance(JdbcConnector.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlMetadata.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlMetadata.java
@@ -17,72 +17,35 @@ import com.facebook.presto.plugin.jdbc.JdbcMetadata;
 import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
 import com.facebook.presto.plugin.jdbc.TableLocationProvider;
 import com.facebook.presto.spi.ConnectorSession;
-import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
 public class MySqlMetadata
         extends JdbcMetadata
 {
-    private final MySqlClient mySqlClient;
     private final boolean datasourceManagedViewsEnabled;
 
     public MySqlMetadata(JdbcMetadataCache jdbcMetadataCache, MySqlClient client, boolean allowDropTable, TableLocationProvider tableLocationProvider, MySqlConfig mySqlConfig)
     {
         super(jdbcMetadataCache, client, allowDropTable, tableLocationProvider);
-        this.mySqlClient = requireNonNull(client, "client is null");
         requireNonNull(mySqlConfig, "mySqlConfig is null");
         this.datasourceManagedViewsEnabled = mySqlConfig.isDatasourceManagedViewsEnabled();
     }
 
     @Override
-    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
-    {
-        mySqlClient.createView(session, viewMetadata, viewData, replace);
-    }
-
-    @Override
-    public void renameView(ConnectorSession session, SchemaTableName viewName, SchemaTableName newViewName)
-    {
-        mySqlClient.renameView(session, viewName, newViewName);
-    }
-
-    @Override
-    public void dropView(ConnectorSession session, SchemaTableName viewName)
-    {
-        mySqlClient.dropView(session, viewName);
-    }
-
-    @Override
-    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
-    {
-        return mySqlClient.listViews(session, schemaName);
-    }
-
-    @Override
     public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        // Skip view analysis, resolve via normal table flow.
+        // Reporting no views leaves MySQL to resolve the view definition itself: Presto never
+        // analyzes the stored SQL and reaches the view through the normal table flow instead.
         if (datasourceManagedViewsEnabled) {
             return ImmutableMap.of();
         }
-
-        List<SchemaTableName> tableNames;
-        if (prefix.getTableName() != null) {
-            tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
-        }
-        else {
-            tableNames = listViews(session, Optional.ofNullable(prefix.getSchemaName()));
-        }
-        return mySqlClient.getViews(session, tableNames);
+        return super.getViews(session, prefix);
     }
 }

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlMetadata.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlMetadata.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.mysql;
+
+import com.facebook.presto.plugin.jdbc.JdbcMetadata;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.TableLocationProvider;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class MySqlMetadata
+        extends JdbcMetadata
+{
+    private final MySqlClient mySqlClient;
+    private final boolean datasourceManagedViewsEnabled;
+
+    public MySqlMetadata(JdbcMetadataCache jdbcMetadataCache, MySqlClient client, boolean allowDropTable, TableLocationProvider tableLocationProvider, MySqlConfig mySqlConfig)
+    {
+        super(jdbcMetadataCache, client, allowDropTable, tableLocationProvider);
+        this.mySqlClient = requireNonNull(client, "client is null");
+        requireNonNull(mySqlConfig, "mySqlConfig is null");
+        this.datasourceManagedViewsEnabled = mySqlConfig.isDatasourceManagedViewsEnabled();
+    }
+
+    @Override
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        mySqlClient.createView(session, viewMetadata, viewData, replace);
+    }
+
+    @Override
+    public void renameView(ConnectorSession session, SchemaTableName viewName, SchemaTableName newViewName)
+    {
+        mySqlClient.renameView(session, viewName, newViewName);
+    }
+
+    @Override
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        mySqlClient.dropView(session, viewName);
+    }
+
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return mySqlClient.listViews(session, schemaName);
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        // Skip view analysis, resolve via normal table flow.
+        if (datasourceManagedViewsEnabled) {
+            return ImmutableMap.of();
+        }
+
+        List<SchemaTableName> tableNames;
+        if (prefix.getTableName() != null) {
+            tableNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        }
+        else {
+            tableNames = listViews(session, Optional.ofNullable(prefix.getSchemaName()));
+        }
+        return mySqlClient.getViews(session, tableNames);
+    }
+}

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlMetadataFactory.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlMetadataFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.mysql;
+
+import com.facebook.presto.plugin.jdbc.JdbcMetadata;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataConfig;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataFactory;
+import com.facebook.presto.plugin.jdbc.TableLocationProvider;
+import jakarta.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class MySqlMetadataFactory
+        extends JdbcMetadataFactory
+{
+    private final JdbcMetadataCache jdbcMetadataCache;
+    private final MySqlClient mySqlClient;
+    private final boolean allowDropTable;
+    private final TableLocationProvider tableLocationProvider;
+    private final MySqlConfig mySqlConfig;
+
+    @Inject
+    public MySqlMetadataFactory(JdbcMetadataCache jdbcMetadataCache, MySqlClient mySqlClient, JdbcMetadataConfig config, TableLocationProvider tableLocationProvider, MySqlConfig mySqlConfig)
+    {
+        super(jdbcMetadataCache, mySqlClient, config, tableLocationProvider);
+        this.jdbcMetadataCache = requireNonNull(jdbcMetadataCache, "jdbcMetadataCache is null");
+        this.mySqlClient = requireNonNull(mySqlClient, "mySqlClient is null");
+        requireNonNull(config, "config is null");
+        this.allowDropTable = config.isAllowDropTable();
+        this.tableLocationProvider = requireNonNull(tableLocationProvider, "tableLocationProvider is null");
+        this.mySqlConfig = requireNonNull(mySqlConfig, "mySqlConfig is null");
+    }
+
+    @Override
+    public JdbcMetadata create()
+    {
+        return new MySqlMetadata(
+                jdbcMetadataCache,
+                mySqlClient,
+                allowDropTable,
+                tableLocationProvider,
+                mySqlConfig);
+    }
+}

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlMetadataFactory.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlMetadataFactory.java
@@ -28,6 +28,8 @@ public class MySqlMetadataFactory
     private final JdbcMetadataCache jdbcMetadataCache;
     private final MySqlClient mySqlClient;
     private final boolean allowDropTable;
+    private final boolean metadataTransactionCacheEnabled;
+    private final long metadataTransactionCacheMaximumSize;
     private final TableLocationProvider tableLocationProvider;
     private final MySqlConfig mySqlConfig;
 
@@ -39,6 +41,8 @@ public class MySqlMetadataFactory
         this.mySqlClient = requireNonNull(mySqlClient, "mySqlClient is null");
         requireNonNull(config, "config is null");
         this.allowDropTable = config.isAllowDropTable();
+        this.metadataTransactionCacheEnabled = config.isMetadataTransactionCacheEnabled();
+        this.metadataTransactionCacheMaximumSize = config.getMetadataTransactionCacheMaximumSize();
         this.tableLocationProvider = requireNonNull(tableLocationProvider, "tableLocationProvider is null");
         this.mySqlConfig = requireNonNull(mySqlConfig, "mySqlConfig is null");
     }
@@ -46,8 +50,14 @@ public class MySqlMetadataFactory
     @Override
     public JdbcMetadata create()
     {
+        // Overriding create() bypasses the transaction cache that JdbcMetadataFactory sets up, so
+        // repeat it here. Without this, metadata-transaction-cache-enabled and
+        // metadata-transaction-cache-maximum-size would be silently ignored for MySQL catalogs.
+        JdbcMetadataCache transactionMetadataCache = metadataTransactionCacheEnabled ?
+                JdbcMetadataCache.createTransactionCache(jdbcMetadataCache, metadataTransactionCacheMaximumSize) :
+                jdbcMetadataCache;
         return new MySqlMetadata(
-                jdbcMetadataCache,
+                transactionMetadataCache,
                 mySqlClient,
                 allowDropTable,
                 tableLocationProvider,

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlPlugin.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlPlugin.java
@@ -13,13 +13,23 @@
  */
 package com.facebook.presto.plugin.mysql;
 
-import com.facebook.presto.plugin.jdbc.JdbcPlugin;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableList;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class MySqlPlugin
-        extends JdbcPlugin
+        implements Plugin
 {
-    public MySqlPlugin()
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        super("mysql", new MySqlClientModule());
+        return ImmutableList.of(new MySqlConnectorFactory("mysql", getClassLoader()));
+    }
+
+    private static ClassLoader getClassLoader()
+    {
+        return firstNonNull(Thread.currentThread().getContextClassLoader(), MySqlPlugin.class.getClassLoader());
     }
 }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/MySqlQueryRunner.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/MySqlQueryRunner.java
@@ -35,6 +35,8 @@ public final class MySqlQueryRunner
     }
 
     private static final String TPCH_SCHEMA = "tpch";
+    public static final String MYSQL_CATALOG = "mysql";
+    public static final String MYSQL_PASSTHROUGH_CATALOG = "mysql_passthrough";
 
     public static QueryRunner createMySqlQueryRunner(String jdbcUrl, Map<String, String> connectorProperties, Iterable<TpchTable<?>> tables)
             throws Exception
@@ -61,7 +63,12 @@ public final class MySqlQueryRunner
             connectorProperties.putIfAbsent("allow-drop-table", "true");
 
             queryRunner.installPlugin(new MySqlPlugin());
-            queryRunner.createCatalog("mysql", "mysql", connectorProperties);
+            queryRunner.createCatalog(MYSQL_CATALOG, "mysql", connectorProperties);
+
+            // Second catalog with enable-datasource-managed-views=true (passthrough)
+            Map<String, String> passthroughProperties = new HashMap<>(connectorProperties);
+            passthroughProperties.put("enable-datasource-managed-views", "true");
+            queryRunner.createCatalog(MYSQL_PASSTHROUGH_CATALOG, "mysql", passthroughProperties);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
 
@@ -76,7 +83,7 @@ public final class MySqlQueryRunner
     public static Session createSession()
     {
         return testSessionBuilder()
-                .setCatalog("mysql")
+                .setCatalog(MYSQL_CATALOG)
                 .setSchema(TPCH_SCHEMA)
                 .build();
     }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlConfig.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlConfig.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestMySqlConfig
 {
@@ -32,7 +34,8 @@ public class TestMySqlConfig
         assertRecordedDefaults(recordDefaults(MySqlConfig.class)
                 .setAutoReconnect(true)
                 .setMaxReconnects(3)
-                .setConnectionTimeout(new Duration(10, TimeUnit.SECONDS)));
+                .setConnectionTimeout(new Duration(10, TimeUnit.SECONDS))
+                .setDatasourceManagedViewsEnabled(false));
     }
 
     @Test
@@ -41,13 +44,26 @@ public class TestMySqlConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("mysql.auto-reconnect", "false")
                 .put("mysql.max-reconnects", "4")
-                .put("mysql.connection-timeout", "4s").build();
+                .put("mysql.connection-timeout", "4s")
+                .put("enable-datasource-managed-views", "true")
+                .build();
 
         MySqlConfig expected = new MySqlConfig()
                 .setAutoReconnect(false)
                 .setMaxReconnects(4)
-                .setConnectionTimeout(new Duration(4, TimeUnit.SECONDS));
+                .setConnectionTimeout(new Duration(4, TimeUnit.SECONDS))
+                .setDatasourceManagedViewsEnabled(true);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testDatasourceManagedViewsConfiguration()
+    {
+        MySqlConfig config = new MySqlConfig();
+        assertFalse(config.isDatasourceManagedViewsEnabled());
+
+        config.setDatasourceManagedViewsEnabled(true);
+        assertTrue(config.isDatasourceManagedViewsEnabled());
     }
 }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testcontainers.mysql.MySQLContainer;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.sql.Connection;
@@ -34,6 +35,8 @@ import java.util.Map;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.MYSQL_CATALOG;
+import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.MYSQL_PASSTHROUGH_CATALOG;
 import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.removeDatabaseFromJdbcUrl;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
@@ -73,9 +76,26 @@ public class TestMySqlIntegrationSmokeTest
         return createMySqlQueryRunner(mysqlContainer.getJdbcUrl(), ImmutableMap.of(), ImmutableList.of(ORDERS));
     }
 
+    @BeforeClass
+    public void setUpViews()
+            throws SQLException
+    {
+        // VIEW 1: uses IFNULL() — MySQL built-in, unknown to Presto analyzer
+        execute("CREATE OR REPLACE VIEW tpch.v_now AS " +
+                "SELECT orderkey, IFNULL(comment, 'none') AS safe_comment FROM tpch.orders");
+
+        // VIEW 2: standard view — no MySQL-native functions
+        // Should work correctly in BOTH managed and passthrough modes
+        execute("CREATE OR REPLACE VIEW tpch.v_standard AS " +
+                "SELECT orderkey, custkey, orderstatus FROM tpch.orders");
+    }
+
     @AfterClass(alwaysRun = true)
     public final void destroy()
+            throws SQLException
     {
+        execute("DROP VIEW IF EXISTS tpch.v_now");
+        execute("DROP VIEW IF EXISTS tpch.v_standard");
         mysqlContainer.stop();
     }
 
@@ -424,6 +444,81 @@ public class TestMySqlIntegrationSmokeTest
     {
         assertQueryFails("CALL system.execute('SELECT 1')", "(?s)Failed to execute query.*");
         assertQueryFails("CALL system.execute('invalid')", "(?s)Failed to execute query.*");
+    }
+
+    // PASSTHROUGH MODE (enable-datasource-managed-views=true)
+    // MySQL resolves all view SQL natively — IFNULL() and other MySQL-only built-ins work correctly
+    @Test
+    public void testPassthroughNowViewQueryable()
+            throws SQLException
+    {
+        // IFNULL() resolved natively by MySQL — Presto never analyzes the view SQL
+        assertQuerySucceeds("SELECT * FROM " + MYSQL_PASSTHROUGH_CATALOG + ".tpch.v_now");
+    }
+
+    @Test
+    public void testPassthroughStandardViewQueryable()
+    {
+        // Standard view works in passthrough mode
+        assertQuerySucceeds("SELECT * FROM " + MYSQL_PASSTHROUGH_CATALOG + ".tpch.v_standard");
+    }
+
+    @Test
+    public void testPassthroughViewNotExposedAsPrestoView()
+    {
+        // With flag=true, views surface as tables — not listed in information_schema.views
+        MaterializedResult result = computeActual(
+                "SELECT table_name FROM " + MYSQL_PASSTHROUGH_CATALOG + ".information_schema.views " +
+                        "WHERE table_schema = 'tpch'");
+        assertTrue(result.getMaterializedRows().isEmpty(),
+                "Views should not be exposed as Presto views when datasource-managed-views is enabled");
+    }
+
+    // MANAGED MODE (enable-datasource-managed-views=false)
+    // Presto fetches and analyzes view SQL — fails on MySQL-native functions unknown to Presto
+    @Test
+    public void testManagedNowViewFails()
+    {
+        // IFNULL() is MySQL-specific and not registered in Presto's function registry —
+        // the analyzer throws FUNCTION_NOT_FOUND, so the query must fail
+        assertQueryFails("SELECT * FROM " + MYSQL_CATALOG + ".tpch.v_now",
+                "(?s).*");
+    }
+
+    @Test
+    public void testManagedStandardViewQueryable()
+    {
+        // Standard view with no MySQL-native functions works in managed mode
+        assertQuerySucceeds("SELECT * FROM " + MYSQL_CATALOG + ".tpch.v_standard");
+    }
+
+    @Test
+    public void testManagedViewExposedAsPrestoView()
+    {
+        // With flag=false, views are listed in information_schema.views
+        MaterializedResult result = computeActual(
+                "SELECT table_name FROM " + MYSQL_CATALOG + ".information_schema.views " +
+                        "WHERE table_schema = 'tpch'");
+        assertFalse(result.getMaterializedRows().isEmpty(),
+                "Views should be exposed as Presto views when datasource-managed-views is disabled");
+    }
+
+    // CROSS-MODE: same MySQL view, different behavior per catalog
+    @Test
+    public void testStandardViewWorksInBothModes()
+    {
+        // Standard view with no MySQL-native functions should work in both modes
+        assertQuerySucceeds("SELECT * FROM " + MYSQL_CATALOG + ".tpch.v_standard");
+        assertQuerySucceeds("SELECT * FROM " + MYSQL_PASSTHROUGH_CATALOG + ".tpch.v_standard");
+    }
+
+    @Test
+    public void testResultsConsistentAcrossModes()
+    {
+        // Standard view results should be identical in both modes
+        MaterializedResult managed = computeActual("SELECT orderkey, custkey FROM " + MYSQL_CATALOG + ".tpch.v_standard ORDER BY orderkey");
+        MaterializedResult passthrough = computeActual("SELECT orderkey, custkey FROM " + MYSQL_PASSTHROUGH_CATALOG + ".tpch.v_standard ORDER BY orderkey");
+        assertEquals(managed.getMaterializedRows(), passthrough.getMaterializedRows());
     }
 
     private void execute(String sql)

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -472,6 +472,13 @@ public class TestMySqlIntegrationSmokeTest
                         "WHERE table_schema = 'tpch'");
         assertTrue(result.getMaterializedRows().isEmpty(),
                 "Views should not be exposed as Presto views when datasource-managed-views is enabled");
+
+        // Absent from information_schema.views only proves half of it: both views must still be
+        // reachable, listed as tables by name. MySqlClient.getTables asks MySQL for TABLE and VIEW.
+        assertQuery(
+                "SELECT table_name FROM " + MYSQL_PASSTHROUGH_CATALOG + ".information_schema.tables " +
+                        "WHERE table_schema = 'tpch' AND table_name IN ('v_now', 'v_standard')",
+                "VALUES ('v_now'), ('v_standard')");
     }
 
     // MANAGED MODE (enable-datasource-managed-views=false)
@@ -482,7 +489,7 @@ public class TestMySqlIntegrationSmokeTest
         // IFNULL() is MySQL-specific and not registered in Presto's function registry —
         // the analyzer throws FUNCTION_NOT_FOUND, so the query must fail
         assertQueryFails("SELECT * FROM " + MYSQL_CATALOG + ".tpch.v_now",
-                "(?s).*");
+                "(?s).*Failed analyzing stored view '" + MYSQL_CATALOG + "\\.tpch\\.v_now'.*ifnull.*");
     }
 
     @Test
@@ -501,6 +508,13 @@ public class TestMySqlIntegrationSmokeTest
                         "WHERE table_schema = 'tpch'");
         assertFalse(result.getMaterializedRows().isEmpty(),
                 "Views should be exposed as Presto views when datasource-managed-views is disabled");
+
+        // Both views from setUpViews must be listed by name, not just some non-empty set of rows.
+        // Restricted to those two names so a view left behind by another test cannot affect the comparison.
+        assertQuery(
+                "SELECT table_name FROM " + MYSQL_CATALOG + ".information_schema.views " +
+                        "WHERE table_schema = 'tpch' AND table_name IN ('v_now', 'v_standard')",
+                "VALUES ('v_now'), ('v_standard')");
     }
 
     // CROSS-MODE: same MySQL view, different behavior per catalog

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlMetadata.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlMetadata.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.mysql;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestMySqlMetadata
+        extends AbstractTestQueryFramework
+{
+    private final MySQLContainer mysqlContainer;
+
+    public TestMySqlMetadata()
+    {
+        this.mysqlContainer = new MySQLContainer("mysql:8.0")
+                .withDatabaseName("tpch")
+                .withUsername("testuser")
+                .withPassword("testpass");
+        this.mysqlContainer.start();
+        try {
+            this.mysqlContainer.execInContainer("mysql",
+                    "-u", "root",
+                    "-p" + mysqlContainer.getPassword(),
+                    "-e", "CREATE DATABASE IF NOT EXISTS test_database; GRANT ALL PRIVILEGES ON test_database.* TO 'testuser'@'%';");
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to set up test_database", e);
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createMySqlQueryRunner(mysqlContainer.getJdbcUrl(), ImmutableMap.of(), ImmutableList.of(ORDERS));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        mysqlContainer.stop();
+    }
+
+    @Test
+    public void testCreateView()
+            throws SQLException
+    {
+        String viewName = "test_create_view";
+        String viewDefinition = "SELECT orderkey, custkey FROM tpch.orders WHERE orderkey < 100";
+
+        dropViewIfExists(viewName);
+
+        assertUpdate("CREATE VIEW " + viewName + " AS " + viewDefinition);
+        assertTrue(viewExistsInMySQL(viewName), "View should exist in MySQL");
+        assertQuery("SELECT orderkey FROM " + viewName + " LIMIT 1", "VALUES 1");
+
+        dropViewIfExists(viewName);
+    }
+
+    @Test
+    public void testCreateOrReplaceView()
+            throws SQLException
+    {
+        String viewName = "test_replace_view";
+        String viewDefinition1 = "SELECT orderkey FROM tpch.orders WHERE orderkey < 50";
+        String viewDefinition2 = "SELECT orderkey, custkey FROM tpch.orders WHERE orderkey < 100";
+
+        dropViewIfExists(viewName);
+
+        assertUpdate("CREATE VIEW " + viewName + " AS " + viewDefinition1);
+        assertTrue(viewExistsInMySQL(viewName), "View should exist after creation");
+
+        assertUpdate("CREATE OR REPLACE VIEW " + viewName + " AS " + viewDefinition2);
+        assertTrue(viewExistsInMySQL(viewName), "View should still exist after replacement");
+
+        assertQuerySucceeds("SELECT * FROM " + viewName);
+
+        dropViewIfExists(viewName);
+    }
+
+    @Test
+    public void testCreateViewAlreadyExists()
+            throws SQLException
+    {
+        String viewName = "test_create_view_already_exists";
+        String viewDefinition = "SELECT orderkey FROM tpch.orders WHERE orderkey < 100";
+
+        dropViewIfExists(viewName);
+
+        assertUpdate("CREATE VIEW " + viewName + " AS " + viewDefinition);
+        assertTrue(viewExistsInMySQL(viewName), "View should exist after creation");
+
+        assertQueryFails(
+                "CREATE VIEW " + viewName + " AS " + viewDefinition,
+                ".*already exists.*");
+
+        dropViewIfExists(viewName);
+    }
+
+    @Test
+    public void testDropView()
+            throws SQLException
+    {
+        String viewName = "test_drop_view";
+        String viewDefinition = "SELECT orderkey FROM tpch.orders";
+
+        dropViewIfExists(viewName);
+
+        assertUpdate("CREATE VIEW " + viewName + " AS " + viewDefinition);
+        assertTrue(viewExistsInMySQL(viewName), "View should exist after creation");
+
+        assertUpdate("DROP VIEW " + viewName);
+        assertFalse(viewExistsInMySQL(viewName), "View should not exist after drop");
+    }
+
+    @Test
+    public void testRenameView()
+            throws SQLException
+    {
+        String oldViewName = "test_rename_view_old";
+        String newViewName = "test_rename_view_new";
+        String viewDefinition = "SELECT orderkey, custkey FROM tpch.orders";
+
+        dropViewIfExists(new String[]{oldViewName, newViewName});
+
+        assertUpdate("CREATE VIEW " + oldViewName + " AS " + viewDefinition);
+        assertTrue(viewExistsInMySQL(oldViewName), "Old view should exist after creation");
+
+        assertUpdate("ALTER VIEW " + oldViewName + " RENAME TO " + newViewName);
+        assertFalse(viewExistsInMySQL(oldViewName), "Old view should not exist after rename");
+        assertTrue(viewExistsInMySQL(newViewName), "New view should exist after rename");
+
+        assertQuerySucceeds("SELECT * FROM " + newViewName);
+
+        dropViewIfExists(newViewName);
+    }
+
+    @Test
+    public void testListViews()
+            throws SQLException
+    {
+        String view1 = "test_list_view_1";
+        String view2 = "test_list_view_2";
+        String viewDefinition = "SELECT orderkey FROM tpch.orders";
+
+        dropViewIfExists(new String[]{view1, view2});
+
+        assertUpdate("CREATE VIEW " + view1 + " AS " + viewDefinition);
+        assertUpdate("CREATE VIEW " + view2 + " AS " + viewDefinition);
+
+        List<Object> tables = getQueryRunner().execute(getSession(), "SHOW TABLES")
+                .getOnlyColumn()
+                .collect(ImmutableList.toImmutableList());
+
+        assertTrue(tables.contains(view1), "View 1 should be in the list");
+        assertTrue(tables.contains(view2), "View 2 should be in the list");
+
+        dropViewIfExists(new String[]{view1, view2});
+    }
+
+    @Test
+    public void testGetViews()
+            throws SQLException
+    {
+        String viewName = "test_get_views";
+        String viewDefinition = "SELECT orderkey, custkey, orderstatus FROM tpch.orders WHERE orderkey < 100";
+
+        dropViewIfExists(viewName);
+
+        assertUpdate("CREATE VIEW " + viewName + " AS " + viewDefinition);
+        assertTrue(viewExistsInMySQL(viewName), "View should be in results");
+
+        dropViewIfExists(viewName);
+    }
+
+    @Test
+    public void testViewWithComplexQuery()
+            throws SQLException
+    {
+        String viewName = "test_complex_view";
+        String viewDefinition = "SELECT o.orderkey, o.custkey, o.totalprice, o.orderdate " +
+                "FROM tpch.orders o WHERE o.totalprice > 100000 ORDER BY o.totalprice DESC";
+
+        dropViewIfExists(viewName);
+
+        assertUpdate("CREATE VIEW " + viewName + " AS " + viewDefinition);
+        assertTrue(viewExistsInMySQL(viewName), "Complex view should exist");
+        assertQuerySucceeds("SELECT * FROM " + viewName + " LIMIT 10");
+
+        dropViewIfExists(viewName);
+    }
+
+    @Test
+    public void testViewInExplicitSchema()
+            throws SQLException
+    {
+        String viewName = "test_schema_view";
+        String viewDefinition = "SELECT orderkey FROM tpch.orders";
+
+        Session tpchSession = testSessionBuilder()
+                .setCatalog("mysql")
+                .setSchema("tpch")
+                .build();
+
+        dropViewIfExists(viewName);
+
+        assertUpdate(tpchSession, "CREATE VIEW " + viewName + " AS " + viewDefinition);
+        assertTrue(viewExistsInMySQL(viewName), "View should exist in tpch schema");
+        assertQuerySucceeds(tpchSession, "SELECT * FROM " + viewName);
+
+        dropViewIfExists(viewName);
+    }
+
+    private boolean viewExistsInMySQL(String viewName)
+            throws SQLException
+    {
+        try (Connection connection = DriverManager.getConnection(
+                mysqlContainer.getJdbcUrl(),
+                mysqlContainer.getUsername(),
+                mysqlContainer.getPassword());
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(
+                        "SELECT COUNT(*) FROM information_schema.views " +
+                                "WHERE table_schema = 'tpch' AND table_name = '" + viewName + "'")) {
+            return rs.next() && rs.getInt(1) > 0;
+        }
+    }
+
+    private void dropViewIfExists(String[] viewNames)
+            throws SQLException
+    {
+        for (String viewName : viewNames) {
+            dropViewIfExists(viewName);
+        }
+    }
+
+    private void dropViewIfExists(String viewName)
+            throws SQLException
+    {
+        try (Connection connection = DriverManager.getConnection(
+                mysqlContainer.getJdbcUrl(),
+                mysqlContainer.getUsername(),
+                mysqlContainer.getPassword());
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP VIEW IF EXISTS tpch." + viewName);
+        }
+    }
+}

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlMetadata.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlMetadata.java
@@ -14,7 +14,20 @@
 package com.facebook.presto.plugin.mysql;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.plugin.jdbc.DefaultTableLocationProvider;
+import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
+import com.facebook.presto.plugin.jdbc.JdbcMetadata;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCacheStats;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataConfig;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.TestingConnectorSession;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -29,9 +42,14 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.MYSQL_CATALOG;
 import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
+import static com.facebook.presto.plugin.mysql.MySqlQueryRunner.removeDatabaseFromJdbcUrl;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static io.airlift.tpch.TpchTable.ORDERS;
+import static java.util.Locale.ENGLISH;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -198,7 +216,37 @@ public class TestMySqlMetadata
         dropViewIfExists(viewName);
 
         assertUpdate("CREATE VIEW " + viewName + " AS " + viewDefinition);
-        assertTrue(viewExistsInMySQL(viewName), "View should be in results");
+
+        // information_schema.views is served by Metadata.getViews, so reading it through Presto
+        // exercises MySqlMetadata.getViews -> MySqlClient.getViews and the ConnectorViewDefinition
+        // it builds, rather than only checking that MySQL recorded the view.
+        MaterializedResult views = computeActual(
+                "SELECT table_catalog, table_schema, table_name, view_owner, view_definition " +
+                        "FROM information_schema.views " +
+                        "WHERE table_schema = 'tpch' AND table_name = '" + viewName + "'");
+        assertEquals(views.getRowCount(), 1);
+
+        MaterializedRow view = views.getMaterializedRows().get(0);
+        assertEquals(view.getField(0), MYSQL_CATALOG);
+        assertEquals(view.getField(1), "tpch");
+        assertEquals(view.getField(2), viewName);
+        // the owner comes from MySQL's DEFINER column, which is the account that ran CREATE VIEW
+        assertTrue(((String) view.getField(3)).startsWith(mysqlContainer.getUsername() + "@"),
+                "View owner should be the MySQL DEFINER account, was: " + view.getField(3));
+
+        // MySQL stores its own canonical form of the definition, so assert on what has to survive:
+        // the projected columns, and no back ticks, which the Presto analyzer cannot parse.
+        String storedSql = (String) view.getField(4);
+        assertTrue(storedSql.toLowerCase(ENGLISH).startsWith("select"), "Unexpected view definition: " + storedSql);
+        assertFalse(storedSql.contains("`"), "Back ticks should be replaced in: " + storedSql);
+        for (String column : new String[] {"orderkey", "custkey", "orderstatus"}) {
+            assertTrue(storedSql.contains("\"" + column + "\""), "View definition should project " + column + ", was: " + storedSql);
+        }
+
+        // the columns reported by getViews also have to let the analyzer resolve the view
+        assertQuery(
+                "SELECT orderkey, custkey, orderstatus FROM " + viewName,
+                "SELECT orderkey, custkey, orderstatus FROM orders WHERE orderkey < 100");
 
         dropViewIfExists(viewName);
     }
@@ -239,6 +287,47 @@ public class TestMySqlMetadata
         assertQuerySucceeds(tpchSession, "SELECT * FROM " + viewName);
 
         dropViewIfExists(viewName);
+    }
+
+    @Test
+    public void testMetadataTransactionCacheIsHonored()
+            throws SQLException
+    {
+        BaseJdbcConfig baseConfig = new BaseJdbcConfig()
+                .setConnectionUrl(removeDatabaseFromJdbcUrl(mysqlContainer.getJdbcUrl()))
+                .setConnectionUser(mysqlContainer.getUsername())
+                .setConnectionPassword(mysqlContainer.getPassword());
+        MySqlClient client = new MySqlClient(
+                new JdbcConnectorId(MYSQL_CATALOG),
+                baseConfig,
+                new MySqlConfig(),
+                jsonCodec(ViewDefinition.class));
+
+        JdbcMetadataConfig metadataConfig = new JdbcMetadataConfig();
+        assertTrue(metadataConfig.isMetadataTransactionCacheEnabled(), "The transaction cache should be enabled by default");
+
+        // metadata-cache-ttl defaults to zero, so the shared cache never serves a repeat lookup and
+        // every miss counted below is a round trip that only the transaction cache can absorb
+        JdbcMetadataCacheStats cacheStats = new JdbcMetadataCacheStats();
+        MySqlMetadataFactory metadataFactory = new MySqlMetadataFactory(
+                new JdbcMetadataCache(client, metadataConfig, cacheStats),
+                client,
+                metadataConfig,
+                new DefaultTableLocationProvider(baseConfig),
+                new MySqlConfig());
+
+        SchemaTableName tableName = new SchemaTableName("tpch", "orders");
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+
+        // repeated lookups within one transaction are served by that transaction's cache
+        JdbcMetadata transaction = metadataFactory.create();
+        transaction.getTableHandle(session, tableName);
+        transaction.getTableHandle(session, tableName);
+        assertEquals(cacheStats.getTableHandleCacheMiss(), 1);
+
+        // a later transaction gets a cache of its own, so it goes back to MySQL
+        metadataFactory.create().getTableHandle(session, tableName);
+        assertEquals(cacheStats.getTableHandleCacheMiss(), 2);
     }
 
     private boolean viewExistsInMySQL(String viewName)


### PR DESCRIPTION
## Description
Allow for querying views in the MySql connector

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enable MySQL connectors to expose and manage database views, with an option to delegate view SQL processing to MySQL.

New Features:
- Add MySQL view discovery and metadata retrieval, including view definitions, owners, columns, and schema/table filtering.
- Support creating, replacing, renaming, and dropping views in MySQL.
- Add configurable datasource-managed view passthrough mode for MySQL catalogs.

Enhancements:
- Extend the shared JDBC metadata layer with optional view operation delegation while preserving unsupported-operation defaults for other JDBC connectors.
- Rework MySQL connector initialization and metadata creation to support view serialization, type deserialization, and metadata transaction caching.

Build:
- Add MySQL connector dependencies required for JSON serialization and connector bootstrapping.

Documentation:
- Document MySQL view support and datasource-managed view configuration.

Tests:
- Add unit and integration coverage for MySQL view lifecycle operations, discovery, definitions, schema filtering, passthrough behavior, and metadata caching.