### PR TITLE
chore(native): Remove unused variable in VeloxToPrestoExprConverter

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -280,7 +280,6 @@ LambdaDefinitionExpressionPtr VeloxToPrestoExprConverter::getLambdaExpression(
 CallExpressionPtr VeloxToPrestoExprConverter::getCallExpression(
     const velox::core::CallTypedExpr* expr) const {
   static constexpr char const* kCall = "call";
-  static constexpr char const* kStatic = "$static";
 
   json result;
   result["@type"] = kCall;


### PR DESCRIPTION
## Description
Removes unused `$static` variable from `VeloxToPresto` expression converter.

## Motivation and Context
Cleanup code.

## Impact
N/A.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Chores:
- Clean up an unused static variable definition in the VeloxToPresto expression converter code.