### PR TITLE
refactor(testing): Move testMapBlockBug to TestExpressionInterpreter

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/sql/expressions/AbstractTestExpressionInterpreter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/expressions/AbstractTestExpressionInterpreter.java
@@ -1533,6 +1533,12 @@ public abstract class AbstractTestExpressionInterpreter
         assertEquals(optimize("X'1234'"), Slices.wrappedBuffer((byte) 0x12, (byte) 0x34));
     }
 
+    @Test
+    public void testMapBlockBug()
+    {
+        assertThrows(RuntimeException.class, () -> optimize("MAP_AGG(12345,123))"));
+    }
+
     public void assertExpressionAndRowExpressionEquals(Object expressionResult, Object rowExpressionResult)
     {
         if (rowExpressionResult instanceof RowExpression) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -7609,12 +7609,6 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testMapBlockBug()
-    {
-        assertQueryFails(" VALUES(MAP_AGG(12345,123))", "(?s).*Cannot evaluate non-scalar function.*");
-    }
-
-    @Test
     public void testReplaceConstantVariableReferencesWithConstants()
     {
         Session enableOptimization = Session.builder(getSession())


### PR DESCRIPTION
## Description
`testMapBlockBug` was added in https://github.com/prestodb/presto/commit/91efd78315826160f6fe4ec889fba8ec1884a8e6 and it tests expression interpreter functionality. Moves this test from `AbstractTestQueries` to `AbstractTestExpressionInterpreter`.

## Motivation and Context
Tests from `AbstractTestQueries` are used in external test suites like `presto-native-tests`, where this test is not relevant. This refactor will help cleanup the test suite for https://github.com/prestodb/presto/pull/23671.

## Impact
NA


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Relocate the map block bug regression test from AbstractTestQueries to AbstractTestExpressionInterpreter.