### PR TITLE
fix(ci): Add presto native docker image tests

### DIFF
--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -468,6 +468,14 @@ jobs:
             docker push $ORG_NAME/${{ env.IMAGE_NAME }}:latest
           fi
 
+  native-image-tests:
+    needs: publish-native-image
+    if: (!failure() && !cancelled())
+    name: Run Docker Image Tests
+    uses: prestodb/presto-release-tools/.github/workflows/docker-image-tests.yml@master
+    with:
+      image_tag: ${{ inputs.RELEASE_VERSION }}
+
   publish-docs:
     needs: publish-maven-artifacts
     if: (!failure() && !cancelled()) && github.event.inputs.publish_docs == 'true'


### PR DESCRIPTION
## Description
Add tests for released docker images, to avoid issue like https://github.com/prestodb/presto/issues/26996 for future changes about release actions.

This PR requires https://github.com/prestodb/presto-release-tools/pull/61 merge first.

## Motivation and Context
https://github.com/prestodb/presto/issues/27004

## Impact
Release

## Test Plan
https://github.com/unix280/presto/actions/runs/21278995747

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

