### PR TITLE
test: Add end to end test for key_sampling_percent

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1009,7 +1009,7 @@ public abstract class AbstractTestNativeGeneralQueries
         // Reverse
         assertQuery("SELECT comment, reverse(comment) FROM orders");
 
-        // Normalize
+        // Normalize, key_sampling_percent.
         String tmpTableName = generateRandomTableName();
         try {
             getQueryRunner().execute(String.format("CREATE TABLE %s (c0 VARCHAR)", tmpTableName));
@@ -1023,6 +1023,17 @@ public abstract class AbstractTestNativeGeneralQueries
             assertQuery("SELECT normalize(comment, NFD) FROM nation");
             assertQuery(String.format("SELECT normalize(c0) from %s", tmpTableName));
             assertQuery(String.format("SELECT normalize(c0, NFKD) from %s", tmpTableName));
+            getQueryRunner().execute(String.format("INSERT INTO %s VALUES " +
+                    "(NULL), " +
+                    "('abc'), " +
+                    "('abcdefghskwkjadhwd'), " +
+                    "('001yxzuj'), " +
+                    "('56wfythjhdhvgewuikwemn'), " +
+                    "('special_#@,$|%%/^~?{}+-'), " +
+                    "('     '), " +
+                    "(''), " +
+                    "('Hello World from Velox!')", tmpTableName));
+            assertQuery(String.format("SELECT key_sampling_percent(c0) FROM %s", tmpTableName));
         }
         finally {
             dropTableIfExists(tmpTableName);


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add E2E tests for key_sampling_percent

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
As part of testing for https://github.com/facebookincubator/velox/issues/16041
## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Added in E2E tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Summary by Sourcery

Tests:
- Extend native string function E2E tests to validate key_sampling_percent using a variety of VARCHAR inputs.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```