### PR TITLE
misc: Remove unused includes

### DIFF
--- a/presto-native-execution/presto_cpp/main/Announcer.cpp
+++ b/presto-native-execution/presto_cpp/main/Announcer.cpp
@@ -16,8 +16,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <folly/futures/Retrying.h>
-#include <velox/common/memory/Memory.h>
 #include "presto_cpp/external/json/nlohmann/json.hpp"
 
 namespace facebook::presto {

--- a/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp
+++ b/presto-native-execution/presto_cpp/main/PeriodicHeartbeatManager.cpp
@@ -12,7 +12,6 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/PeriodicHeartbeatManager.h"
-#include <velox/common/memory/Memory.h>
 
 namespace facebook::presto {
 PeriodicHeartbeatManager::PeriodicHeartbeatManager(

--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -18,8 +18,8 @@
 #include <re2/re2.h>
 #include <sstream>
 
-#include "presto_cpp/main/QueryContextManager.h"
 #include "presto_cpp/main/common/Counters.h"
+#include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/testutil/TestValue.h"
 


### PR DESCRIPTION
Summary:
Clean up unused includes in presto_cpp/main to improve compilation times
and reduce unnecessary header dependencies:

1. Announcer.cpp:
   - Removed `folly/futures/Retrying.h` - no retrying symbols used
   - Removed `velox/common/memory/Memory.h` - no memory pool symbols used

2. PeriodicHeartbeatManager.cpp:
   - Removed `velox/common/memory/Memory.h` - no memory symbols used

3. PrestoExchangeSource.cpp:
   - Replaced `QueryContextManager.h` with the more specific
     `presto_protocol/core/presto_protocol_core.h` which directly provides
     the protocol namespace symbols (DataSize, Duration, PRESTO_*_HEADER
     constants) that are actually used. This avoids pulling in heavy
     transitive dependencies from QueryContextManager.h like
     folly/Synchronized, folly/executors/*, and velox/core/QueryCtx.h.

## Summary by Sourcery

Clean up unused and overly broad header dependencies in presto_cpp main sources to reduce compile-time and transitive includes.

Enhancements:
- Remove unused header includes from Announcer and PeriodicHeartbeatManager to simplify dependencies.
- Narrow PrestoExchangeSource's dependency from QueryContextManager to the specific presto_protocol_core header that provides the required protocol types and constants.

```
== NO RELEASE NOTE ==
```