### PR TITLE
fix(optimizer): Fix hash function for prefilter groupby limit

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PrefilterForLimitingAggregation.java
@@ -57,8 +57,8 @@ import static com.facebook.presto.sql.planner.PlannerUtils.addAggregation;
 import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
 import static com.facebook.presto.sql.planner.PlannerUtils.clonePlanNode;
 import static com.facebook.presto.sql.planner.PlannerUtils.createMapType;
-import static com.facebook.presto.sql.planner.PlannerUtils.getHashExpression;
 import static com.facebook.presto.sql.planner.PlannerUtils.getTableScanNodeWithOnlyFilterAndProject;
+import static com.facebook.presto.sql.planner.PlannerUtils.getVariableHash;
 import static com.facebook.presto.sql.planner.PlannerUtils.projectExpressions;
 import static com.facebook.presto.sql.planner.optimizations.JoinNodeUtils.typeConvert;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
@@ -223,8 +223,8 @@ public class PrefilterForLimitingAggregation
                     SystemSessionProperties.getPrefilterForGroupbyLimitTimeoutMS(session));
 
             FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
-            RowExpression leftHashExpression = getHashExpression(functionAndTypeManager, keys).get();
-            RowExpression rightHashExpression = getHashExpression(functionAndTypeManager, timedDistinctLimitNode.getOutputVariables()).get();
+            RowExpression leftHashExpression = getVariableHash(keys, functionAndTypeManager);
+            RowExpression rightHashExpression = getVariableHash(timedDistinctLimitNode.getOutputVariables(), functionAndTypeManager);
 
             Type mapType = createMapType(functionAndTypeManager, BIGINT, BOOLEAN);
             PlanNode rightProjectNode = projectExpressions(timedDistinctLimitNode, idAllocator, variableAllocator, ImmutableList.of(rightHashExpression, constant(TRUE, BOOLEAN)), ImmutableList.of());


### PR DESCRIPTION
Fixup the hash code used for this optimization

## Description
We were using hashcode which is avialble only in java. Changed it to use the same function that we use for join prefilter which works for both java and cpp.



If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Use a shared hash computation utility for join and aggregation prefilters to ensure consistent hashing across Java and C++ implementations.

Bug Fixes:
- Fix incorrect or incompatible hash computation used for prefiltering group-by limit aggregations by switching to a working XX_HASH_64-based hash.

Enhancements:
- Extract variable hash computation into a reusable PlannerUtils helper and reuse it in join and aggregation prefilter optimizations.