### PR TITLE
fix(docs): Iceberg connector reference in ANALYZE docs

### DIFF
--- a/presto-docs/src/main/sphinx/sql/analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/analyze.rst
@@ -35,6 +35,10 @@ Analyze table ``stores`` in catalog ``hive`` and schema ``default``::
 
     ANALYZE hive.default.stores;
 
+Analyze table ``stores`` in catalog ``iceberg`` and schema ``default``::
+
+    ANALYZE iceberg.default.stores;
+
 Analyze partitions ``'1992-01-01', '1992-01-02'`` from a Hive partitioned table ``sales``::
 
     ANALYZE hive.default.sales WITH (partitions = ARRAY[ARRAY['1992-01-01'], ARRAY['1992-01-02']]);


### PR DESCRIPTION
## Description
Earlier the Iceberg connector did not get linked to a valid page, and this change fixes the issue by correctly mapping it to the Iceberg connector documentation page.

## Motivation and Context
The previous documentation link for the Iceberg connector was invalid, which could confuse users trying to navigate to the correct connector documentation. This change ensures the link points to the correct and valid page.

## Impact
Documentation-only change. No public API, user-facing behavior, or performance impact.

## Test Plan
Verified the updated link points to the correct Iceberg connector documentation page.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
 == NO RELEASE NOTE == 
```