### PR TITLE
test: Add Sequence and Exclude columns function tests with lateral

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestExcludeColumnsFunction.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestExcludeColumnsFunction.java
@@ -197,4 +197,28 @@ public class TestExcludeColumnsFunction
                         "                    columns => DESCRIPTOR(orderstatus, orderdate, orderpriority, clerk, shippriority, comment)))\n",
                 "SELECT orderkey, custkey, totalprice FROM tpch.tiny.orders");
     }
+
+    @Test
+    public void testExcludeColumnsLateralJoin()
+    {
+        // Test LATERAL join with exclude_columns function
+        // This tests using exclude_columns in a lateral join context with filtering
+        assertQuery("SELECT n.nationkey, filtered.* " +
+                        "FROM tpch.tiny.nation n " +
+                        "CROSS JOIN LATERAL (" +
+                        "    SELECT * " +
+                        "    FROM TABLE(" +
+                        "        system.builtin.exclude_columns(" +
+                        "            input => table(tpch.tiny.region)," +
+                        "            columns => descriptor(comment)" +
+                        "        )" +
+                        "    ) r " +
+                        "    WHERE r.regionkey = n.regionkey" +
+                        ") filtered " +
+                        "WHERE n.nationkey < 5",
+                "SELECT n.nationkey, r.regionkey, r.name " +
+                        "FROM tpch.tiny.nation n " +
+                        "JOIN tpch.tiny.region r ON r.regionkey = n.regionkey " +
+                        "WHERE n.nationkey < 5");
+    }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestSequenceFunction.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestSequenceFunction.java
@@ -288,4 +288,22 @@ public class TestSequenceFunction
                         "                    step => %s)) t(x)", start, stop, step),
                 format("SELECT %s, %s", start, Long.MAX_VALUE - 1));
     }
+
+    @Test
+    public void testSequenceLateralJoin()
+    {
+        // Test LATERAL join with sequence function
+        // This tests using sequence in a lateral join context with filtering
+        assertQuery("SELECT t.nationkey, s.seq " +
+                        "FROM tpch.tiny.nation t " +
+                        "CROSS JOIN LATERAL (" +
+                        "    SELECT * " +
+                        "    FROM TABLE(system.builtin.sequence(start => 1, stop => 5))" +
+                        ") AS s(seq) " +
+                        "WHERE t.nationkey < 3 AND s.seq <= t.regionkey",
+                "SELECT t.nationkey, s.seq " +
+                        "FROM tpch.tiny.nation t " +
+                        "CROSS JOIN UNNEST(sequence(1, 5)) AS s(seq) " +
+                        "WHERE t.nationkey < 3 AND s.seq <= t.regionkey");
+    }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Add examples for lateral calls with table function calls.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
Add more test coverage and show examples.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Ran ExcludeColumns and Sequence tests to verify they pass. 

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add test coverage for using table functions in lateral joins.

Tests:
- Add an exclude_columns lateral join test validating filtered results against a standard join.
- Add a sequence lateral join test comparing table function output with UNNEST(sequence(...)).