### PR TITLE
feat(optimizer): Add option to set task count for remote functions

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -485,6 +485,43 @@ parallelism factor is below the ``table_scan_shuffle_parallelism_threshold``.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.table-scan-shuffle-strategy\`\``.
 
+``remote_function_names_for_fixed_parallelism``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``""`` (empty string, disabled)
+
+A regular expression pattern to match fully qualified remote function names, such as ``catalog.schema.function_name``,
+that should use fixed parallelism. When a remote function matches this pattern, the optimizer inserts
+round-robin shuffle exchanges before and after the projection containing the remote function call.
+This ensures that the remote function executes with a fixed degree of parallelism, which can be useful
+for controlling resource usage when calling external services.
+
+This property only applies to external/remote functions (functions where ``isExternalExecution()`` returns ``true``,
+such as functions using THRIFT, GRPC, or REST implementation types).
+
+Example patterns:
+
+* ``myschema.myfunction`` - matches an exact function name
+* ``catalog.schema.remote_.*`` - matches all functions starting with ``remote_`` in the specified catalog and schema
+* ``.*remote.*`` - matches any function containing ``remote`` in its fully qualified name
+
+The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.remote-function-names-for-fixed-parallelism\`\``.
+
+``remote_function_fixed_parallelism_task_count``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``null`` (uses the default hash partition count)
+
+The number of tasks to use for remote functions matching the ``remote_function_names_for_fixed_parallelism`` pattern.
+When set, this value determines the degree of parallelism for the round-robin shuffle exchanges inserted
+around matching remote function projections. If not set, the default hash partition count will be used.
+
+This property is only effective when ``remote_function_names_for_fixed_parallelism`` is set to a non-empty pattern.
+
+The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.remote-function-fixed-parallelism-task-count\`\``.
+
 
 JDBC Properties
 ---------------

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -1099,6 +1099,43 @@ parallelism factor is below the ``optimizer.table-scan-shuffle-parallelism-thres
 
 The corresponding session property is :ref:`admin/properties-session:\`\`table_scan_shuffle_strategy\`\``.
 
+``optimizer.remote-function-names-for-fixed-parallelism``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``string``
+* **Default value:** ``""`` (empty string, disabled)
+
+A regular expression pattern to match fully qualified remote function names, such as ``catalog.schema.function_name``,
+that should use fixed parallelism. When a remote function matches this pattern, the optimizer inserts
+round-robin shuffle exchanges before and after the projection containing the remote function call.
+This ensures that the remote function executes with a fixed degree of parallelism, which can be useful
+for controlling resource usage when calling external services.
+
+This property only applies to external/remote functions (functions where ``isExternalExecution()`` returns ``true``,
+such as functions using THRIFT, GRPC, or REST implementation types).
+
+Example patterns:
+
+* ``myschema.myfunction`` - matches an exact function name
+* ``catalog.schema.remote_.*`` - matches all functions starting with ``remote_`` in the specified catalog and schema
+* ``.*remote.*`` - matches any function containing ``remote`` in its fully qualified name
+
+The corresponding session property is :ref:`admin/properties-session:\`\`remote_function_names_for_fixed_parallelism\`\``.
+
+``optimizer.remote-function-fixed-parallelism-task-count``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Default value:** ``null`` (uses the default hash partition count)
+
+The number of tasks to use for remote functions matching the ``optimizer.remote-function-names-for-fixed-parallelism`` pattern.
+When set, this value determines the degree of parallelism for the round-robin shuffle exchanges inserted
+around matching remote function projections. If not set, the default hash partition count will be used.
+
+This property is only effective when ``optimizer.remote-function-names-for-fixed-parallelism`` is set to a non-empty pattern.
+
+The corresponding session property is :ref:`admin/properties-session:\`\`remote_function_fixed_parallelism_task_count\`\``.
+
 Planner Properties
 ------------------
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -361,6 +361,8 @@ public final class SystemSessionProperties
     public static final String TABLE_SCAN_SHUFFLE_PARALLELISM_THRESHOLD = "table_scan_shuffle_parallelism_threshold";
     public static final String TABLE_SCAN_SHUFFLE_STRATEGY = "table_scan_shuffle_strategy";
     public static final String SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION = "skip_pushdown_through_exchange_for_remote_projection";
+    public static final String REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM = "remote_function_names_for_fixed_parallelism";
+    public static final String REMOTE_FUNCTION_FIXED_PARALLELISM_TASK_COUNT = "remote_function_fixed_parallelism_task_count";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -2079,6 +2081,16 @@ public final class SystemSessionProperties
                         "Skip pushing down remote projection through exchange",
                         featuresConfig.isSkipPushdownThroughExchangeForRemoteProjection(),
                         false),
+                stringProperty(
+                        REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM,
+                        "Regex pattern to match remote function names that should use fixed parallelism",
+                        featuresConfig.getRemoteFunctionNamesForFixedParallelism(),
+                        false),
+                integerProperty(
+                        REMOTE_FUNCTION_FIXED_PARALLELISM_TASK_COUNT,
+                        "Number of tasks to use for remote functions matching the fixed parallelism pattern. If not set, the default hash partition count will be used.",
+                        featuresConfig.getRemoteFunctionFixedParallelismTaskCount(),
+                        false),
                 new PropertyMetadata<>(
                         QUERY_CLIENT_TIMEOUT,
                         "Configures how long the query runs without contact from the client application, such as the CLI, before it's abandoned",
@@ -3563,5 +3575,15 @@ public final class SystemSessionProperties
     public static boolean isSkipPushdownThroughExchangeForRemoteProjection(Session session)
     {
         return session.getSystemProperty(SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION, Boolean.class);
+    }
+
+    public static String getRemoteFunctionNamesForFixedParallelism(Session session)
+    {
+        return session.getSystemProperty(REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM, String.class);
+    }
+
+    public static int getRemoteFunctionFixedParallelismTaskCount(Session session)
+    {
+        return session.getSystemProperty(REMOTE_FUNCTION_FIXED_PARALLELISM_TASK_COUNT, Integer.class);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -330,6 +330,8 @@ public class FeaturesConfig
     private double tableScanShuffleParallelismThreshold = 0.1;
     private ShuffleForTableScanStrategy tableScanShuffleStrategy = ShuffleForTableScanStrategy.DISABLED;
     private boolean skipPushdownThroughExchangeForRemoteProjection;
+    private String remoteFunctionNamesForFixedParallelism = "";
+    private int remoteFunctionFixedParallelismTaskCount = 10;
 
     private boolean builtInSidecarFunctionsEnabled;
 
@@ -3358,5 +3360,32 @@ public class FeaturesConfig
     public boolean isBuiltInSidecarFunctionsEnabled()
     {
         return this.builtInSidecarFunctionsEnabled;
+    }
+
+    public String getRemoteFunctionNamesForFixedParallelism()
+    {
+        return remoteFunctionNamesForFixedParallelism;
+    }
+
+    @Config("optimizer.remote-function-names-for-fixed-parallelism")
+    @ConfigDescription("Regex pattern to match remote function names that should use fixed parallelism")
+    public FeaturesConfig setRemoteFunctionNamesForFixedParallelism(String remoteFunctionNamesForFixedParallelism)
+    {
+        this.remoteFunctionNamesForFixedParallelism = remoteFunctionNamesForFixedParallelism;
+        return this;
+    }
+
+    @Min(1)
+    public int getRemoteFunctionFixedParallelismTaskCount()
+    {
+        return remoteFunctionFixedParallelismTaskCount;
+    }
+
+    @Config("optimizer.remote-function-fixed-parallelism-task-count")
+    @ConfigDescription("Number of tasks to use for remote functions matching the fixed parallelism pattern. If not set (0), the default hash partition count will be used.")
+    public FeaturesConfig setRemoteFunctionFixedParallelismTaskCount(int remoteFunctionFixedParallelismTaskCount)
+    {
+        this.remoteFunctionFixedParallelismTaskCount = remoteFunctionFixedParallelismTaskCount;
+        return this;
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -21,6 +21,9 @@ import com.facebook.presto.spi.plan.PartitioningScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.SystemPartitioningHandle;
+import com.facebook.presto.sql.planner.SystemPartitioningHandle.SystemPartitionFunction;
+import com.facebook.presto.sql.planner.SystemPartitioningHandle.SystemPartitioning;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -257,6 +260,16 @@ public class ExchangeNode
                 scope,
                 child,
                 new PartitioningScheme(Partitioning.create(FIXED_ARBITRARY_DISTRIBUTION, ImmutableList.of()), child.getOutputVariables()));
+    }
+
+    public static ExchangeNode roundRobinExchange(PlanNodeId id, Scope scope, PlanNode child, int partitionCount)
+    {
+        checkArgument(partitionCount > 0, "partitionCount must be positive");
+        return partitionedExchange(
+                id,
+                scope,
+                child,
+                new PartitioningScheme(Partitioning.create(SystemPartitioningHandle.createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.ROUND_ROBIN, partitionCount), ImmutableList.of()), child.getOutputVariables()));
     }
 
     public static ExchangeNode mergingExchange(PlanNodeId id, Scope scope, PlanNode child, OrderingScheme orderingScheme)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -283,7 +283,9 @@ public class TestFeaturesConfig
                 .setTableScanShuffleParallelismThreshold(0.1)
                 .setTableScanShuffleStrategy(FeaturesConfig.ShuffleForTableScanStrategy.DISABLED)
                 .setSkipPushdownThroughExchangeForRemoteProjection(false)
-                .setUseConnectorProvidedSerializationCodecs(false));
+                .setUseConnectorProvidedSerializationCodecs(false)
+                .setRemoteFunctionNamesForFixedParallelism("")
+                .setRemoteFunctionFixedParallelismTaskCount(10));
     }
 
     @Test
@@ -513,6 +515,8 @@ public class TestFeaturesConfig
                 .put("optimizer.table-scan-shuffle-strategy", "ALWAYS_ENABLED")
                 .put("optimizer.skip-pushdown-through-exchange-for-remote-projection", "true")
                 .put("use-connector-provided-serialization-codecs", "true")
+                .put("optimizer.remote-function-names-for-fixed-parallelism", "remote_.*")
+                .put("optimizer.remote-function-fixed-parallelism-task-count", "100")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -740,7 +744,9 @@ public class TestFeaturesConfig
                 .setTableScanShuffleParallelismThreshold(0.3)
                 .setTableScanShuffleStrategy(FeaturesConfig.ShuffleForTableScanStrategy.ALWAYS_ENABLED)
                 .setSkipPushdownThroughExchangeForRemoteProjection(true)
-                .setUseConnectorProvidedSerializationCodecs(true);
+                .setUseConnectorProvidedSerializationCodecs(true)
+                .setRemoteFunctionNamesForFixedParallelism("remote_.*")
+                .setRemoteFunctionFixedParallelismTaskCount(100);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
## Description
For remote functions, sometimes we want to limit the concurrency to avoid throttling the remote service.
In this PR, I added session properties to set the number of tasks for a remote projection, so the plan will be like:

scan -> remote exchange (with specified number of tasks) -> remote project node -> remote exchange -> output

The remote project will run in a separate stage.

There are two session properties, `remote_function_fixed_parallelism_task_count` to specify how many tasks to use
`remote_function_names_for_fixed_parallelism` to specify the pattern of remote function names to match.

## Motivation and Context
As in description

## Impact
To control the number of tasks for a remote project node

## Test Plan
unit tests and local end to end test

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add options to control the number of tasks for remote project node
```

## Summary by Sourcery

Add configurable fixed-parallelism support for remote function projections and wire it through planning, partitioning, and session properties.

New Features:
- Introduce session and config properties to control fixed parallelism for selected remote functions via regex-matched names and an optional task count.
- Extend exchange planning to insert bounded round-robin remote exchanges around qualifying remote project nodes based on the configured properties.

Enhancements:
- Augment system partitioning handles and exchange nodes to carry an optional partition count for fixed distributions and honor it when selecting nodes.

Tests:
- Add planner and configuration tests covering regex matching behavior for remote-function fixed parallelism and property mappings for the new optimizer settings.