### PR TITLE
fix(connector): Java Scan operator raw input reported wrong

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/AggregatedOrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/AggregatedOrcPageSource.java
@@ -75,6 +75,19 @@ public class AggregatedOrcPageSource
     }
 
     @Override
+    public long getDecompressedBytes()
+    {
+        // For aggregated page source, there's no decompression - just return completed bytes
+        return completedBytes;
+    }
+
+    @Override
+    public long getDecompressedPositions()
+    {
+        return 0;
+    }
+
+    @Override
     public long getReadTimeNanos()
     {
         return readTimeNanos;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
@@ -158,6 +158,18 @@ public class OrcBatchPageSource
     }
 
     @Override
+    public long getDecompressedBytes()
+    {
+        return orcDataSource.getReadBytes();
+    }
+
+    @Override
+    public long getDecompressedPositions()
+    {
+        return completedPositions;
+    }
+
+    @Override
     public long getReadTimeNanos()
     {
         return orcDataSource.getReadTimeNanos();
@@ -199,7 +211,8 @@ public class OrcBatchPageSource
                     blocks[fieldId] = new LazyBlock(batchSize, new OrcBlockLoader(hiveColumnIndexes[fieldId]));
                 }
             }
-            return new Page(batchSize, blocks);
+            Page page = new Page(batchSize, blocks);
+            return page;
         }
         catch (PrestoException e) {
             closeWithSuppression(e);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
@@ -96,6 +96,18 @@ public class OrcSelectivePageSource
     }
 
     @Override
+    public long getDecompressedBytes()
+    {
+        return orcDataSource.getReadBytes();
+    }
+
+    @Override
+    public long getDecompressedPositions()
+    {
+        return recordReader.getReadPositions();
+    }
+
+    @Override
     public long getReadTimeNanos()
     {
         return orcDataSource.getReadTimeNanos();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFilePageSource.java
@@ -137,6 +137,21 @@ public class PageFilePageSource
     }
 
     @Override
+    public long getDecompressedBytes()
+    {
+        // PageFile format stores pages in a serialized format.
+        // The completedBytes already represents the decompressed data size
+        // since we're reading from the deserialized pages.
+        return completedBytes;
+    }
+
+    @Override
+    public long getDecompressedPositions()
+    {
+        return completedPositions;
+    }
+
+    @Override
     public void close()
             throws IOException
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/AggregatedParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/AggregatedParquetPageSource.java
@@ -60,6 +60,7 @@ public class AggregatedParquetPageSource
     private boolean completed;
     private long readTimeNanos;
     private long completedBytes;
+    private long decompressedPositions;
 
     public AggregatedParquetPageSource(List<HiveColumnHandle> columnHandles, ParquetMetadata parquetMetadata, TypeManager typeManager, StandardFunctionResolution functionResolution)
     {
@@ -243,6 +244,19 @@ public class AggregatedParquetPageSource
     public long getSystemMemoryUsage()
     {
         return 0;
+    }
+
+    @Override
+    public long getDecompressedBytes()
+    {
+        // For aggregated page source, there's no decompression - just return completed bytes
+        return completedBytes;
+    }
+
+    @Override
+    public long getDecompressedPositions()
+    {
+        return decompressedPositions;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -117,6 +117,18 @@ public class ParquetPageSource
     }
 
     @Override
+    public long getDecompressedBytes()
+    {
+        return parquetReader.getDataSource().getReadBytes();
+    }
+
+    @Override
+    public long getDecompressedPositions()
+    {
+        return completedPositions;
+    }
+
+    @Override
     public long getReadTimeNanos()
     {
         return parquetReader.getDataSource().getReadTimeNanos();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rcfile/RcFilePageSource.java
@@ -56,6 +56,7 @@ public class RcFilePageSource
 
     private int pageId;
     private long completedPositions;
+    private long decompressedPositions;
 
     private boolean closed;
 
@@ -191,6 +192,18 @@ public class RcFilePageSource
     public long getSystemMemoryUsage()
     {
         return GUESSED_MEMORY_USAGE;
+    }
+
+    @Override
+    public long getDecompressedBytes()
+    {
+        return rcFileReader.getBytesRead();
+    }
+
+    @Override
+    public long getDecompressedPositions()
+    {
+        return decompressedPositions;
     }
 
     private void closeWithSuppression(Throwable throwable)

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -361,7 +361,6 @@ public class ScanFilterAndProjectOperator
         long inputBytes = endCompletedBytes - completedBytes;
         long inputBytesReadTime = endReadTimeNanos - readTimeNanos;
         long positionCount = endCompletedPositions - completedPositions;
-        operatorContext.recordProcessedInput(inputBytes, positionCount);
         operatorContext.recordRawInputWithTiming(inputBytes, positionCount, inputBytesReadTime);
         RuntimeStats runtimeStats = pageSource.getRuntimeStats();
         if (runtimeStats != null) {
@@ -391,6 +390,14 @@ public class ScanFilterAndProjectOperator
                 blockSizeSum += block.getSizeInBytes();
             }
         }
+
+        // Record processed input: actual block sizes after filtering/projection
+        // If blocks is null, no lazy blocks were found, so use the original page size
+        long processedBytes = (blocks == null) ? page.getSizeInBytes() : blockSizeSum;
+        operatorContext.recordProcessedInput(processedBytes, page.getPositionCount());
+
+        // Record raw input: bytes read from storage before filtering (connector metrics)
+        recordInputStats();
 
         return (blocks == null) ? page : new Page(page.getPositionCount(), blocks);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSource.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSource.java
@@ -26,16 +26,42 @@ public interface ConnectorPageSource
     CompletableFuture<?> NOT_BLOCKED = CompletableFuture.completedFuture(null);
 
     /**
-     * Gets the number of input bytes processed by this page source so far.
+     * Gets the number of raw input bytes read from storage by this page source so far.
+     * This represents bytes read from physical storage (e.g., compressed ORC/Parquet files).
      * If size is not available, this method should return zero.
      */
     long getCompletedBytes();
 
     /**
-     * Gets the number of input rows processed by this page source so far.
+     * Gets the number of raw input rows read from storage by this page source so far.
+     * This represents rows before any filtering or processing.
      * If number is not available, this method should return zero.
      */
     long getCompletedPositions();
+
+    /**
+     * Gets the number of decompressed bytes processed by this page source so far.
+     * This represents bytes after decompression but before filtering/projection.
+     * For connectors without compression or that don't track this separately,
+     * the default implementation returns the same as getCompletedBytes().
+     * If size is not available, this method should return zero.
+     */
+    default long getDecompressedBytes()
+    {
+        return getCompletedBytes();
+    }
+
+    /**
+     * Gets the number of decompressed rows processed by this page source so far.
+     * This represents rows after decompression but before filtering/projection.
+     * For connectors that don't track this separately, the default implementation
+     * returns the same as getCompletedPositions().
+     * If number is not available, this method should return zero.
+     */
+    default long getDecompressedPositions()
+    {
+        return getCompletedPositions();
+    }
 
     /**
      * Gets the wall time this page source spent reading data from the input.


### PR DESCRIPTION
## Description
Java Scan operator raw input reported wrong

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Added new methods  getDecompressedBytes and getDecompressedPositions in ConnectorPageSource and added three-tier metrics to Correct raw input and processed input accounting for Java-based scan operators, especially for uncompressed sources and lazy block sources.