### PR TITLE
fix: Fix typo in sidecar docs

### DIFF
--- a/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst
+++ b/presto-docs/src/main/sphinx/plugin/native-sidecar-plugin.rst
@@ -26,7 +26,7 @@ Property Name                                Description                        
 ``coordinator-sidecar-enabled``              Enables sidecar in the coordinator                                    true
 ``native-execution-enabled``                 Enables native execution                                              true
 ``presto.default-namespace``                 Sets the default function namespace                                   `native.default`
-``plugin.dir``                               Specifies which directory under installation root                     `{root-directory}/native-plugins/`
+``plugin.dir``                               Specifies which directory under installation root                     `{root-directory}/native-plugin/`
                                              to scan for plugins at startup.
 ============================================ ===================================================================== ==============================
 


### PR DESCRIPTION
## Description
The Provisio plugin dumps all the native plugins under `native-plugin/` and not` native-plugins/`.

## Motivation and Context
See attached screenshot for 
<img width="416" height="249" alt="Screenshot 2026-01-29 at 10 23 38 AM" src="https://github.com/user-attachments/assets/8edf2856-d61d-4b0c-8d27-20712c0ad044" />

## Impact
No user impact

## Test Plan
Docs only change

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

