### PR TITLE
feat(plugin-hive): Session property to control file size for presto writer

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -236,6 +236,18 @@ Property Name                                            Description            
 
 .. _constructor: https://github.com/apache/hadoop/blob/02a9190af5f8264e25966a80c8f9ea9bb6677899/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/conf/Configuration.java#L844-L875
 
+Hive Session Properties
+-----------------------
+
+======================================================== ============================================================ ============
+Property Name                                            Description                                                  Default
+======================================================== ============================================================ ============
+``native_max_target_file_size``                          Native Execution only. Maximum target file size. When a      ``0B``
+                                                         file exceeds this size during writing, the writer will
+                                                         close the current file and start writing to a new file.
+                                                         Zero means no limit.
+======================================================== ============================================================ ============
+
 Avro Configuration Properties
 -----------------------------
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -139,6 +139,8 @@ public final class HiveSessionProperties
 
     public static final String NATIVE_STATS_BASED_FILTER_REORDER_DISABLED = "native_stats_based_filter_reorder_disabled";
 
+    public static final String NATIVE_MAX_TARGET_FILE_SIZE = "native_max_target_file_size";
+
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -676,7 +678,12 @@ public final class HiveSessionProperties
                         NATIVE_STATS_BASED_FILTER_REORDER_DISABLED,
                         "Native Execution only. Disable stats based filter reordering.",
                         false,
-                        true));
+                        true),
+                dataSizeSessionProperty(
+                        NATIVE_MAX_TARGET_FILE_SIZE,
+                       "Native Execution only. Maximum target file size. When a file exceeds this size during writing, the writer will close the current file and start writing to a new file. Zero means no limit.",
+                        new DataSize(0, DataSize.Unit.BYTE),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()


### PR DESCRIPTION
Summary: Session property to control the file size for presto writers

Differential Revision: D91361183

## Summary by Sourcery

New Features:
- Introduce a NATIVE_MAX_TARGET_FILE_SIZE session property to control when writers roll over to a new output file based on size.


### Release Notes

```
== RELEASE NOTES ==

Prestissimo (Native Execution) Changes
* Add ``native_max_target_file_size`` session property to control the maximum target file size for writers. When a file exceeds this size during writing, the writer will close the current file and start writing to a new file.
```
