### PR TITLE
fix(native): Fix Dereference expression index type in VeloxToPrestoExprConverter

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -319,7 +319,7 @@ SpecialFormExpressionPtr VeloxToPrestoExprConverter::getDereferenceExpression(
   const auto dereferenceInputs = std::vector<velox::core::TypedExprPtr>{
       dereferenceExpr->inputs().at(0),
       std::make_shared<velox::core::ConstantTypedExpr>(
-          velox::BIGINT(), static_cast<int64_t>(dereferenceExpr->index()))};
+          velox::INTEGER(), static_cast<int32_t>(dereferenceExpr->index()))};
   for (const auto& input : dereferenceInputs) {
     const auto rowExpr = getRowExpression(input);
     protocol::to_json(j, rowExpr);

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -689,6 +689,20 @@ public class TestNativeSidecarPlugin
         assertQuerySucceeds(session, "SELECT table_name, COALESCE(abs(ordinal_position), 0) as abs_pos FROM information_schema.columns WHERE table_catalog = 'hive' AND table_name IN ('nation', 'region') ORDER BY table_name, ordinal_position");
         assertQuerySucceeds(session, "SELECT table_name, ordinal_position FROM information_schema.columns  WHERE abs(ordinal_position) IN (1, 2, 3) AND table_catalog = 'hive' AND table_name != 'roles' ORDER BY table_name, ordinal_position");
         assertQuerySucceeds(session, "select lower(table_name) from information_schema.tables where table_name = 'lineitem' or table_name = 'LINEITEM'");
+
+        // Test dereference expression.
+        assertQuerySucceeds(session,
+                "select cast(row(row(row(random(10), if(random(10) >= 0, 2)), random(10)), random(100)) AS row(x row(y row(a int, b int), c int), d int))[1][1][2]");
+        assertQuerySucceeds(session,
+                "select cast(row(row(row(random(10), if(random(10) < 0, 2)), random(10)), random(100)) AS row(x row(y row(a int, b int), c int), d int))[1][2]");
+        assertQuerySucceeds(session,
+                "select cast(row(row(null, random(10)), random(100)) AS row(x row(y row(a int, b int), c int), d int))[1][1][1]");
+        assertQuerySucceeds(session,
+                "select cast(row(row(null, if(random(100) >= 0, 4)), random(10)) AS row(x row(y row(a int, b int), c int), d int))[2]");
+
+        // Test dereference expression with SQL invoked function, array_least_frequent.
+        assertQuerySucceeds(session, "SELECT array_least_frequent(array_agg(orderkey)) from orders");
+        assertQuerySucceeds(session, "SELECT array_least_frequent(array_agg(nationkey)) from nation");
     }
 
     @Test


### PR DESCRIPTION
## Description
Changes the type of index in `DEREFERENCE` expression from `BIGINT` to `INTEGER` to match the Presto `RowExpression` type.

## Motivation and Context
Resolves https://github.com/prestodb/presto/issues/27037.

## Impact
Sql invoked functions with dereference expression won't fail with native expression optimizer enabled.

## Test Plan
Added e2e tests.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Align DEREFERENCE expression index type with Presto RowExpression and add coverage for native optimizer queries using dereference.

Bug Fixes:
- Change DEREFERENCE expression index type from BIGINT to INTEGER in VeloxToPrestoExprConverter to match Presto RowExpression expectations and avoid failures in SQL-invoked functions when the native optimizer is enabled.

Tests:
- Extend native optimizer end-to-end tests to cover dereference expressions via array_least_frequent usage.