### PR TITLE
fix: Resolve table names in MV query optimizer for consistent matching

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.sql;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.predicate.NullableValue;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.metadata.Metadata;
@@ -40,7 +41,9 @@ import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.Relation;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.facebook.presto.sql.tree.Table;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -60,6 +63,7 @@ import static com.facebook.presto.SystemSessionProperties.isLegacyMaterializedVi
 import static com.facebook.presto.common.predicate.TupleDomain.extractFixedValues;
 import static com.facebook.presto.common.type.StandardTypes.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.StandardTypes.VARBINARY;
+import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.ExpressionUtils.combineDisjuncts;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.tree.ArithmeticBinaryExpression.Operator.DIVIDE;
@@ -397,6 +401,15 @@ public final class MaterializedViewUtils
         else {
             return combineDisjuncts(disjuncts);
         }
+    }
+
+    public static Relation resolveTableName(Relation relation, Session session, Metadata metadata)
+    {
+        if (!(relation instanceof Table)) {
+            return relation;
+        }
+        QualifiedObjectName qualifiedTableName = createQualifiedObjectName(session, relation, ((Table) relation).getName(), metadata);
+        return new Table(QualifiedName.of(qualifiedTableName.getSchemaName(), qualifiedTableName.getObjectName()));
     }
 
     private static Expression convertSymbolReferencesToIdentifiers(Expression expression)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -101,6 +101,7 @@ import static com.facebook.presto.sql.MaterializedViewUtils.ASSOCIATIVE_REWRITE_
 import static com.facebook.presto.sql.MaterializedViewUtils.COUNT;
 import static com.facebook.presto.sql.MaterializedViewUtils.NON_ASSOCIATIVE_REWRITE_FUNCTIONS;
 import static com.facebook.presto.sql.MaterializedViewUtils.SUM;
+import static com.facebook.presto.sql.MaterializedViewUtils.resolveTableName;
 import static com.facebook.presto.sql.analyzer.MaterializedViewInformationExtractor.MaterializedViewInfo;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_TABLE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
@@ -641,7 +642,8 @@ public class MaterializedViewQueryOptimizer
         @Override
         protected Node visitRelation(Relation node, Void context)
         {
-            if (materializedViewInfo.getBaseTable().isPresent() && node.equals(materializedViewInfo.getBaseTable().get())) {
+            if (materializedViewInfo.getBaseTable().isPresent() && resolveTableName(node, session, metadata)
+                        .equals(resolveTableName(materializedViewInfo.getBaseTable().get(), session, metadata))) {
                 return materializedView;
             }
             throw new IllegalStateException("Mismatching table or non-supporting relation format in base query");

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -451,6 +451,42 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testWithSchemaQualifiedTableName()
+    {
+        String schemaQualifiedTable = SESSION_SCHEMA + "." + BASE_TABLE_1;
+
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, b FROM %s", schemaQualifiedTable);
+        String expectedRewrittenSql = format("SELECT a, b FROM %s", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        originalViewSql = format("SELECT a, b FROM %s", schemaQualifiedTable);
+        baseQuerySql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT a, b FROM %s", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        originalViewSql = format("SELECT a, b FROM %s", schemaQualifiedTable);
+        baseQuerySql = format("SELECT a, b FROM %s", schemaQualifiedTable);
+        expectedRewrittenSql = format("SELECT a, b FROM %s", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, b FROM %s WHERE c > 10", schemaQualifiedTable);
+        expectedRewrittenSql = format("SELECT a, b FROM %s WHERE c > 10", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        originalViewSql = format("SELECT SUM(a) as sum_a, b FROM %s GROUP BY b", BASE_TABLE_1);
+        baseQuerySql = format("SELECT SUM(a), b FROM %s GROUP BY b", schemaQualifiedTable);
+        expectedRewrittenSql = format("SELECT SUM(sum_a), b FROM %s GROUP BY b", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testAggregationWithTableAlias()
     {
         String originalViewSql = format("SELECT SUM(a) AS sum_a, b FROM %s GROUP BY b", BASE_TABLE_1);


### PR DESCRIPTION
Summary:
MV query optimizer fails to rewrite queries when the specified table name differs between the MV definition and the incoming query (ex: `base_table` vs `schema.base_table`). 

This fix resolves table references to schema-qualified names, ensuring consistent table matching regardless of how the table was specified.

Reviewed By: zation99

Differential Revision: D91699496

## Summary by Sourcery

Ensure materialized view query optimization consistently matches base tables regardless of schema qualification in table names.

Bug Fixes:
- Fix materialized view rewrites failing when base tables are referenced with different schema qualifications between the MV definition and the incoming query.

Tests:
- Add coverage to verify materialized view query optimization works when base tables are referenced both with and without schema-qualified names in various query shapes.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Fix MV query optimizer by correctly resolving table references to schema-qualified names.
```