### PR TITLE
refactor: Remove unused code

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/InMemoryCachingHiveMetastore.java
@@ -637,30 +637,6 @@ public class InMemoryCachingHiveMetastore
         return get(partitionFilterCache, getCachingKey(metastoreContext, partitionFilter(databaseName, tableName, partitionPredicates)));
     }
 
-    private void invalidateStalePartitions(
-            List<PartitionNameWithVersion> partitionNamesWithVersion,
-            String databaseName,
-            String tableName,
-            MetastoreContext metastoreContext)
-    {
-        for (PartitionNameWithVersion partitionNameWithVersion : partitionNamesWithVersion) {
-            HivePartitionName hivePartitionName = hivePartitionName(databaseName, tableName, partitionNameWithVersion.getPartitionName());
-            KeyAndContext<HivePartitionName> partitionNameKey = getCachingKey(metastoreContext, hivePartitionName);
-            Optional<Partition> partition = partitionCache.getIfPresent(partitionNameKey);
-            if (partition == null || !partition.isPresent()) {
-                partitionCache.invalidate(partitionNameKey);
-                partitionStatisticsCache.invalidate(partitionNameKey);
-            }
-            else {
-                Optional<Long> partitionVersion = partition.get().getPartitionVersion();
-                if (!partitionVersion.isPresent() || !partitionVersion.equals(partitionNameWithVersion.getPartitionVersion())) {
-                    partitionCache.invalidate(partitionNameKey);
-                    partitionStatisticsCache.invalidate(partitionNameKey);
-                }
-            }
-        }
-    }
-
     private void invalidatePartitionsWithHighColumnCount(Optional<Partition> partition, KeyAndContext<HivePartitionName> partitionCacheKey)
     {
         // Do NOT cache partitions with # of columns > partitionCacheColumnLimit


### PR DESCRIPTION
## Description
Remove unused code in `presto-hive-metastore` module

## Motivation and Context
Remove unused code in `presto-hive-metastore` module 

## Impact
Maintainance

## Test Plan
None

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enhancements:
- Clean up the in-memory caching Hive metastore by removing an unused method for invalidating stale partitions.