### PR TITLE
perf(native): Fix unnecessary copy in http module

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -54,7 +54,7 @@ HttpClient::HttpClient(
       http2SessionWindow_(
           SystemConfig::instance()->httpClientHttp2SessionWindow()),
       pool_(std::move(pool)),
-      sslContext_(sslContext),
+      sslContext_(std::move(sslContext)),
       reportOnBodyStatsFunc_(std::move(reportOnBodyStatsFunc)),
       maxResponseAllocBytes_(SystemConfig::instance()->httpMaxAllocateBytes()) {
 }
@@ -207,7 +207,7 @@ class ResponseHandler : public proxygen::HTTPTransactionHandler {
 
   folly::SemiFuture<std::unique_ptr<HttpResponse>> initialize(
       std::shared_ptr<ResponseHandler> self) {
-    self_ = self;
+    self_ = std::move(self);
     return promise_.getSemiFuture();
   }
 
@@ -342,7 +342,7 @@ class ConnectionHandler : public proxygen::HTTPConnector::Callback {
       folly::SSLContextPtr sslContext)
       : responseHandler_(responseHandler),
         sessionPool_(sessionPool),
-        transactionTimer_(transactionTimeout),
+        transactionTimer_(std::move(transactionTimeout)),
         connectTimeout_(connectTimeout),
         http2Enabled_(http2Enabled),
         maxConcurrentStreams_(maxConcurrentStreams),

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -218,7 +218,7 @@ proxygen::RequestHandler* DispatchingRequestHandlerFactory::onRequest(
             message->getURL()));
   }
 
-  auto path = message->getPath();
+  const auto& path = message->getPath();
 
   // Allocate vector outside of loop to avoid repeated alloc/free.
   std::vector<std::string> matches(4);

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -106,7 +106,7 @@ class CallbackRequestHandlerState {
 
   // The function 'fn' will run on the thread that invoked onEOM()
   void runOnFinalization(std::function<void(void)> callback) {
-    onFinalizationCallback_ = callback;
+    onFinalizationCallback_ = std::move(callback);
   }
 
   bool requestExpired() const {
@@ -136,10 +136,11 @@ using AsyncRequestHandlerCallback = std::function<void(
 class CallbackRequestHandler : public AbstractRequestHandler {
  public:
   explicit CallbackRequestHandler(RequestHandlerCallback callback)
-      : callback_(wrap(callback)) {}
+      : callback_(wrap(std::move(callback))) {}
 
   explicit CallbackRequestHandler(AsyncRequestHandlerCallback callback)
-      : callback_(callback), state_{CallbackRequestHandlerState::create()} {}
+      : callback_(std::move(callback)),
+        state_{CallbackRequestHandlerState::create()} {}
 
   ~CallbackRequestHandler() override {
     if (state_) {


### PR DESCRIPTION
Summary:
Fix unnecessary copies in the Presto HTTP module:
- Use std::move() for shared_ptr, SSLContextPtr, and callback assignments
- Use const reference for path variable to avoid copy from getPath()

These changes eliminate unnecessary copy operations and improve performance.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Address performance-related cleanups in the Presto HTTP client and server by eliminating unnecessary copies of objects and strings.

Enhancements:
- Move HTTP client and server callbacks, timers, and context objects instead of copying to avoid redundant allocations and ownership transfers.
- Bind the HTTP request path as a const reference rather than copying the string when dispatching request handlers.