### PR TITLE
feat(native): Add config for asyc cache numShards

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1073,7 +1073,8 @@ void PrestoServer::initializeVeloxMemory() {
     velox::cache::AsyncDataCache::Options cacheOptions{
         systemConfig->asyncCacheMaxSsdWriteRatio(),
         systemConfig->asyncCacheSsdSavableRatio(),
-        systemConfig->asyncCacheMinSsdSavableBytes()};
+        systemConfig->asyncCacheMinSsdSavableBytes(),
+        systemConfig->asyncCacheNumShards()};
     cache_ = velox::cache::AsyncDataCache::create(
         velox::memory::memoryManager()->allocator(),
         std::move(ssd),

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -209,6 +209,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kAsyncCacheMaxSsdWriteRatio, 0.7),
           NUM_PROP(kAsyncCacheSsdSavableRatio, 0.125),
           NUM_PROP(kAsyncCacheMinSsdSavableBytes, 1 << 24 /*16MB*/),
+          NUM_PROP(kAsyncCacheNumShards, 4),
           STR_PROP(kAsyncCachePersistenceInterval, "0s"),
           BOOL_PROP(kAsyncCacheSsdDisableFileCow, false),
           BOOL_PROP(kSsdCacheChecksumEnabled, false),
@@ -693,6 +694,10 @@ double SystemConfig::asyncCacheSsdSavableRatio() const {
 
 int32_t SystemConfig::asyncCacheMinSsdSavableBytes() const {
   return optionalProperty<int32_t>(kAsyncCacheMinSsdSavableBytes).value();
+}
+
+int32_t SystemConfig::asyncCacheNumShards() const {
+  return optionalProperty<int32_t>(kAsyncCacheNumShards).value();
 }
 
 std::chrono::duration<double> SystemConfig::asyncCachePersistenceInterval()

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -429,6 +429,12 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kAsyncCacheMinSsdSavableBytes{
       "async-cache-min-ssd-savable-bytes"};
 
+  /// The number of shards for the async data cache. The cache is divided into
+  /// shards to decrease contention on the mutex for the key to entry mapping
+  /// and other housekeeping. Must be a power of 2.
+  static constexpr std::string_view kAsyncCacheNumShards{
+      "async-cache-num-shards"};
+
   /// The interval for persisting in-memory cache to SSD. Setting this config
   /// to a non-zero value will activate periodic cache persistence.
   static constexpr std::string_view kAsyncCachePersistenceInterval{
@@ -1065,6 +1071,8 @@ class SystemConfig : public ConfigBase {
   double asyncCacheSsdSavableRatio() const;
 
   int32_t asyncCacheMinSsdSavableBytes() const;
+
+  int32_t asyncCacheNumShards() const;
 
   std::chrono::duration<double> asyncCachePersistenceInterval() const;
 

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -230,6 +230,17 @@ TEST_F(ConfigTest, optionalSystemConfigsWithDefault) {
   ASSERT_EQ(config.maxDriversPerTask(), 1024);
 }
 
+TEST_F(ConfigTest, asyncCacheNumShards) {
+  SystemConfig config;
+  init(config, {});
+  // Test default value is 4
+  ASSERT_EQ(config.asyncCacheNumShards(), 4);
+
+  // Test custom value
+  init(config, {{std::string(SystemConfig::kAsyncCacheNumShards), "8"}});
+  ASSERT_EQ(config.asyncCacheNumShards(), 8);
+}
+
 TEST_F(ConfigTest, remoteFunctionServer) {
   SystemConfig config;
   init(config, {});


### PR DESCRIPTION
Differential Revision: D92009590

## Summary by Sourcery

Add configurable sharding for the async data cache and wire it through server initialization.

New Features:
- Introduce a system config option to control the number of shards used by the async data cache, with a default of 4.

Tests:
- Add unit coverage to verify the default and custom values for the async data cache shard count system config.