### PR TITLE
feat: Add 'native_partitioned_output_eager_flush' session property

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -300,6 +300,15 @@ The maximum bytes to buffer per PartitionedOutput operator to avoid creating tin
 For PartitionedOutputNode::Kind::kPartitioned, PartitionedOutput operator would buffer up to that number of
 bytes / number of destinations for each destination before producing a SerializedPage. Default is 32MB.
 
+``native_partitioned_output_eager_flush``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Native Execution only. If true, the PartitionedOutput operator will flush rows eagerly, without waiting
+until buffers reach a certain size. Default is false.
+
 ``native_max_local_exchange_partition_count``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -62,6 +62,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_MAX_EXTENDED_PARTIAL_AGGREGATION_MEMORY = "native_max_extended_partial_aggregation_memory";
     public static final String NATIVE_MAX_SPILL_BYTES = "native_max_spill_bytes";
     public static final String NATIVE_MAX_PAGE_PARTITIONING_BUFFER_SIZE = "native_max_page_partitioning_buffer_size";
+    public static final String NATIVE_PARTITIONED_OUTPUT_EAGER_FLUSH = "native_partitioned_output_eager_flush";
     public static final String NATIVE_MAX_OUTPUT_BUFFER_SIZE = "native_max_output_buffer_size";
     public static final String NATIVE_QUERY_TRACE_ENABLED = "native_query_trace_enabled";
     public static final String NATIVE_QUERY_TRACE_DIR = "native_query_trace_dir";
@@ -316,6 +317,11 @@ public class NativeWorkerSessionPropertyProvider
                                 "would buffer up to that number of bytes / number of destinations for each destination before " +
                                 "producing a SerializedPage.",
                         24L << 20,
+                        !nativeExecution),
+                booleanProperty(NATIVE_PARTITIONED_OUTPUT_EAGER_FLUSH,
+                        "Native Execution only. If true, the PartitionedOutput operator will flush rows eagerly, without " +
+                                "waiting until buffers reach certain size. Default is false.",
+                        false,
                         !nativeExecution),
                 integerProperty(
                         NATIVE_MAX_LOCAL_EXCHANGE_PARTITION_COUNT,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -351,6 +351,15 @@ SessionProperties::SessionProperties() {
       QueryConfig::kMaxPartitionedOutputBufferSize,
       std::to_string(c.maxPartitionedOutputBufferSize()));
 
+  addSessionProperty(
+      kPartitionedOutputEagerFlush,
+      "If true, the PartitionedOutput operator will flush rows eagerly, without"
+      " waiting until buffers reach a certain size. Default is false.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kPartitionedOutputEagerFlush,
+      "false");
+
   // If `legacy_timestamp` is true, the coordinator expects timestamp
   // conversions without a timezone to be converted to the user's
   // session_timezone.

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -272,6 +272,11 @@ class SessionProperties {
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "native_max_page_partitioning_buffer_size";
 
+  /// If true, the PartitionedOutput operator will flush rows eagerly, without
+  /// waiting until buffers reach certain size. Default is false.
+  static constexpr const char* kPartitionedOutputEagerFlush =
+      "native_partitioned_output_eager_flush";
+
   /// Maximum number of partitions created by a local exchange.
   /// Affects concurrency for pipelines containing LocalPartitionNode.
   static constexpr const char* kMaxLocalExchangePartitionCount =

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -86,6 +86,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
        core::QueryConfig::kMaxOutputBufferSize},
       {SessionProperties::kMaxPartitionedOutputBufferSize,
        core::QueryConfig::kMaxPartitionedOutputBufferSize},
+      {SessionProperties::kPartitionedOutputEagerFlush,
+       core::QueryConfig::kPartitionedOutputEagerFlush},
       {SessionProperties::kLegacyTimestamp,
        core::QueryConfig::kAdjustTimestampToTimezone},
       {SessionProperties::kDriverCpuTimeSliceLimitMs,


### PR DESCRIPTION
## Description
The news session property would allow Partitioned Output Velox operators to flush (return) data eagerly, as soon as it arrives.
This would match default Presto Java behavior of returning results eagerly to the caller, while the query is still running (scanning).

## Motivation and Context
For "needle in a haystack" type of queries running in various UIs this early return functionality is crucial.

## Test Plan
Existing session property test.
Ran the custom build in a Prestissimo cluster to ensure session property changes query behavior accordingly.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add a native session property to control eager flushing behavior of partitioned output operators.

New Features:
- Introduce the native_partitioned_output_eager_flush session property to enable eager flushing of PartitionedOutput operator rows in native execution.

Documentation:
- Document the native_partitioned_output_eager_flush session property in the Presto native session properties reference.

Tests:
- Extend session property mapping tests to cover the new native_partitioned_output_eager_flush property.