### PR TITLE
perf(native): Fix unnecessary copy in shuffle operators

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalShuffle.cpp
@@ -108,7 +108,7 @@ class SortedFileInputStream final : public velox::common::FileInputStream,
 class LocalShuffleSerializedPage : public ShuffleSerializedPage {
  public:
   LocalShuffleSerializedPage(
-      const std::vector<std::string_view>& rows,
+      std::vector<std::string_view> rows,
       velox::BufferPtr buffer)
       : rows_{std::move(rows)}, buffer_{std::move(buffer)} {}
 

--- a/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
+++ b/presto-native-execution/presto_cpp/main/operators/PartitionAndSerialize.h
@@ -112,7 +112,7 @@ class PartitionAndSerializeNode : public velox::core::PlanNode {
     Builder& sortingKeys(
         std::optional<std::vector<velox::core::FieldAccessTypedExprPtr>>
             sortingKeys) {
-      sortingKeys_ = sortingKeys;
+      sortingKeys_ = std::move(sortingKeys);
       return *this;
     }
 

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -36,7 +36,7 @@ ShuffleRead::ShuffleRead(
               shuffleReadNode->id(),
               shuffleReadNode->outputType(),
               VectorSerde::Kind::kCompactRow),
-          exchangeClient,
+          std::move(exchangeClient),
           "ShuffleRead") {
   initStats();
 }

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.h
@@ -21,7 +21,7 @@ namespace facebook::presto::operators {
 class ShuffleReadNode : public velox::core::PlanNode {
  public:
   ShuffleReadNode(const velox::core::PlanNodeId& id, velox::RowTypePtr type)
-      : PlanNode(id), outputType_(type) {}
+      : PlanNode(id), outputType_(std::move(type)) {}
 
   class Builder {
    public:


### PR DESCRIPTION
Summary:
Fix unnecessary copy:
- ShuffleReadNode: Use std::move for outputType_ initialization
- ShuffleRead: Use std::move for exchangeClient parameter
- LocalShuffleSerializedPage: Change const ref to value parameter to enable proper move semantics
- PartitionAndSerializeNode::Builder: Use std::move for sortingKeys assignment

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Optimize shuffle-related operators to avoid unnecessary data copies and improve move semantics.

Enhancements:
- Adjust LocalShuffleSerializedPage to take row views by value to enable moving the underlying container.
- Move the ShuffleReadNode output type and ShuffleRead exchange client instead of copying them.
- Move sorting key metadata into PartitionAndSerializeNode::Builder instead of copying it.