### PR TITLE
build(deps): Bump CUDA from 12.8 to 12.9

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -16,6 +16,9 @@ FROM quay.io/centos/centos:stream9
 # from https://github.com/facebookincubator/velox/pull/14366
 ARG ARM_BUILD_TARGET
 
+# This defaults to 12.9 but can be overridden with a build arg
+ARG CUDA_VERSION
+
 ENV PROMPT_ALWAYS_RESPOND=y
 ENV CC=/opt/rh/gcc-toolset-12/root/bin/gcc
 ENV CXX=/opt/rh/gcc-toolset-12/root/bin/g++


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context

12.9 will soon be the minimum for latest CUDF, and has several compiler fixes.

## Impact

None known.

## Test Plan

Tested locally at NVIDIA.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Build:
- Bump CUDA toolkit version from 12.8 to 12.9 in the CentOS dependency Dockerfile for native execution.