### PR TITLE
Add support for America/Coyhaique timezone

### DIFF
--- a/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
+++ b/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
@@ -2240,3 +2240,4 @@
 2231 Pacific/Kanton
 2232 Europe/Kyiv
 2233 America/Ciudad_Juarez
+2234 America/Coyhaique


### PR DESCRIPTION
## Description
This PR adds support for the `America/Coyhaique` timezone to Presto's timezone index by adding a new entry to the `zone-index.properties` file. solves #27075 

## Motivation and Context
This change addresses the need for comprehensive timezone support in Presto, particularly for South American regions


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

New Features:
- Introduce support for the America/Coyhaique timezone in the Presto timezone index.