### PR TITLE
feat(native-pos): Add capability for parallel shuffle checksum

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/LocalShuffle.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/LocalShuffle.cpp
@@ -112,7 +112,7 @@ class LocalShuffleSerializedPage : public ShuffleSerializedPage {
       velox::BufferPtr buffer)
       : rows_{std::move(rows)}, buffer_{std::move(buffer)} {}
 
-  const std::vector<std::string_view>& rows() override {
+  const std::vector<std::string_view>& rows(int32_t /*driverId*/) override {
     return rows_;
   }
 

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleInterface.h
@@ -63,7 +63,14 @@ class ShuffleSerializedPage : public velox::exec::SerializedPageBase {
     VELOX_UNSUPPORTED();
   }
 
-  virtual const std::vector<std::string_view>& rows() = 0;
+  /// Legacy single-consumer path that delegates to rows(0)..
+  /// retained for backward compatibility.
+  virtual const std::vector<std::string_view>& rows() {
+    return rows(0);
+  }
+
+  /// @param driverId Driver ID for per-consumer checksum tracking.
+  virtual const std::vector<std::string_view>& rows(int32_t driverId) = 0;
 };
 
 class ShuffleReader {

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -84,9 +84,10 @@ RowVectorPtr ShuffleRead::getOutput() {
       numRows += pageRows;
     }
     rows_.reserve(numRows);
+    const int32_t driverId = operatorCtx()->driverCtx()->driverId;
     for (const auto& page : currentPages_) {
       auto* batch = checkedPointerCast<ShuffleSerializedPage>(page.get());
-      const auto& rows = batch->rows();
+      const auto& rows = batch->rows(driverId);
       for (const auto& row : rows) {
         rows_.emplace_back(row);
       }


### PR DESCRIPTION
Differential Revision: D92208394

Introduce a driverId-aware rows() interface on shuffle serialized pages to enable per-consumer checksum tracking in parallel shuffle reads.


```
== NO RELEASE NOTES ==
```