### PR TITLE
fix(planner): Fix size estimate used in TextRenderer

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/PlanNodeStatsEstimate.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.statistics.PlanStatisticsWithSourceInfo;
 import com.facebook.presto.spi.statistics.SourceInfo;
 import com.facebook.presto.spi.statistics.TableWriterNodeStatistics;
 import com.facebook.presto.sql.Serialization;
+import com.facebook.presto.sql.planner.planPrinter.NodeRepresentation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -178,6 +179,17 @@ public class PlanNodeStatsEstimate
         }
 
         return getOutputSizeForVariables(planNode.getOutputVariables());
+    }
+
+    public double getOutputSizeInBytes(NodeRepresentation nodeRepresentation)
+    {
+        requireNonNull(nodeRepresentation, "nodeRepresentation is null");
+
+        if (!sourceInfo.estimateSizeUsingVariables() && !isNaN(totalSize)) {
+            return totalSize;
+        }
+
+        return getOutputSizeForVariables(nodeRepresentation.getOutputs());
     }
 
     /**

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -247,7 +247,7 @@ public class TextRenderer
             output.append(format(formatStr,
                     stats.getSourceInfo().getClass().getSimpleName(),
                     formatAsLong(stats.getOutputRowCount()),
-                    formatEstimateAsDataSize(stats.getOutputSizeInBytes(plan.getPlanNodeRoot())),
+                    formatEstimateAsDataSize(stats.getOutputSizeInBytes(node)),
                     formatDouble(cost.getCpuCost()),
                     formatDouble(cost.getMaxMemory()),
                     formatDouble(cost.getNetworkCost()),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/sanity/TestPlanPrinterSmoke.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/sanity/TestPlanPrinterSmoke.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.cost.CachingCostProvider;
+import com.facebook.presto.cost.CachingStatsProvider;
+import com.facebook.presto.cost.CostProvider;
+import com.facebook.presto.cost.StatsAndCosts;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPlanPrinterSmoke
+        extends BasePlanTest
+{
+    @Test
+    public void testLogicalPlanTextSizeEstimates()
+    {
+        String testSql = "SELECT \n" +
+                "  *\n" +
+                "FROM \n" +
+                "  supplier s,\n" +
+                "  lineitem l1,\n" +
+                "  orders o,\n" +
+                "  nation n\n" +
+                "WHERE \n" +
+                "  s.suppkey = l1.suppkey \n" +
+                "  AND o.orderkey = l1.orderkey\n" +
+                "  AND s.nationkey = n.nationkey \n" +
+                "\n";
+        try (LocalQueryRunner localQueryRunner = createQueryRunner(ImmutableMap.of())) {
+            localQueryRunner.inTransaction(localQueryRunner.getDefaultSession(), transactionSession -> {
+                Plan actualPlan = localQueryRunner.createPlan(
+                        transactionSession,
+                        testSql,
+                        WarningCollector.NOOP);
+
+                StatsProvider statsProvider = new CachingStatsProvider(localQueryRunner.getStatsCalculator(), transactionSession, actualPlan.getTypes());
+                CostProvider costProvider = new CachingCostProvider(localQueryRunner.getEstimatedExchangesCostCalculator(), statsProvider, transactionSession);
+
+                String textLogicalPlan = PlanPrinter.textLogicalPlan(actualPlan.getRoot(),
+                        actualPlan.getTypes(),
+                        StatsAndCosts.create(actualPlan.getRoot(), statsProvider, costProvider, transactionSession),
+                        localQueryRunner.getFunctionAndTypeManager(),
+                        transactionSession,
+                        1);
+
+                // `nation` scan
+                assertThat(textLogicalPlan).contains("Estimates: {source: CostBasedSourceInfo, rows: 25 (2.89kB), cpu: 2,734.00, memory: 0.00, network: 0.00}");
+                // `supplier` scan
+                assertThat(textLogicalPlan).contains("Estimates: {source: CostBasedSourceInfo, rows: 100 (17.14kB), cpu: 16,652.00, memory: 0.00, network: 0.00}");
+                // `orders` scan
+                assertThat(textLogicalPlan).contains("Estimates: {source: CostBasedSourceInfo, rows: 15,000 (1.99MB), cpu: 1,948,552.00, memory: 0.00, network: 0.00}");
+                // `lineitem` scan
+                assertThat(textLogicalPlan).contains("Estimates: {source: CostBasedSourceInfo, rows: 60,175 (9.29MB), cpu: 9,197,910.00, memory: 0.00, network: 0.00}");
+
+                // JOINs
+                assertThat(textLogicalPlan).contains("Estimates: {source: CostBasedSourceInfo, rows: 60,175 (15.71MB), cpu: 53,349,364.11, memory: 2,083,552.00, network: 2,083,552.00}");
+                assertThat(textLogicalPlan).contains("Estimates: {source: CostBasedSourceInfo, rows: 60,175 (30.51MB), cpu: 119,543,090.43, memory: 2,114,099.00, network: 2,114,099.00}");
+                assertThat(textLogicalPlan).contains("Estimates: {source: CostBasedSourceInfo, rows: 100 (26.06kB), cpu: 90,055.00, memory: 2,959.00, network: 2,959.00}");
+
+                return null;
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Description, Motivation and Context
The size estimate on text plans (EXPLAIN plans e.g) was incorrectly changed to use the plan root instead of the actual node's outputs in https://github.com/prestodb/presto/commit/7f5f2192f0da2bc95889ce38e320b16ba1d753c6

We fix this bug

## Test Plan
CI + new test to assert on `Estimates` strings in the text plan

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Correct the size estimate used when rendering text query plans to rely on each node's own outputs instead of the plan root.

Bug Fixes:
- Fix incorrect output size estimation in TextRenderer by basing it on the node representation outputs rather than the plan root.

Enhancements:
- Expose a size-estimation helper on PlanNodeStatsEstimate that operates on NodeRepresentation outputs.

## Summary by Sourcery

Correct size estimation used when rendering textual query plans so estimates are based on each node representation rather than the plan root.

Bug Fixes:
- Fix incorrect output size calculation in TextRenderer by using the node representation outputs instead of the plan root when computing size estimates.

Enhancements:
- Add a NodeRepresentation-based output size helper to PlanNodeStatsEstimate for reuse by plan printers and related components.