### PR TITLE
feat(ci): Expand CVE reporting to med and low

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -18,7 +18,7 @@ jobs:
       group: ${{ github.workflow }}-owasp-dependency-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     env:
-      CVSS_THRESHOLD: ${{ github.event.inputs.cvss-threshold || '7.0' }}
+      CVSS_THRESHOLD: ${{ github.event.inputs.cvss-threshold || '0.1' }}
       OWASP_VERSION: 12.1.3
     steps:
       # Checkout PR branch first to get access to the composite action


### PR DESCRIPTION
Currently, only CVEs with a score about 7.0 are reported in the OWASP job. This helps getting alerted to high and critical CVEs. But even medium and low ranked CVEs have to be mitigated even if the timeline for them is longer. This helps to have the upstream project as free of CVEs as possible.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

CI:
- Lower the default CVSS threshold in the OWASP dependency-check workflow so that medium and low severity CVEs are also reported.