### PR TITLE
build(native): Use cuda 12.9 in centos deps Dockerfile

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -35,7 +35,7 @@ RUN bash -c "mkdir build && \
                  source ../velox/scripts/setup-centos-adapters.sh && \
                  install_adapters && \
                  install_clang15 && \
-                 install_cuda 12.8) && \
+                 install_cuda 12.9) && \
     rm -rf build"
 
 # put CUDA binaries on the PATH


### PR DESCRIPTION
## Description
Bump cuda install from 12.8 to 12.9 in `presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile`.

## Motivation and Context
- https://github.com/facebookincubator/velox/pull/16131
- https://github.com/rapidsai/cudf/pull/21186

## Impact
N/A

## Test Plan
Tested via https://github.com/rapidsai/velox-testing

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Build:
- Bump CUDA version from 12.8 to 12.9 in the CentOS dependency Dockerfile used for native execution builds.