### PR TITLE
fix: Add null check to UtilizedColumnAnalyzer

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -46,6 +46,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.StandardErrorCode;
+import com.facebook.presto.spi.StandardWarningCode;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.AccessControlInfoForTable;
@@ -763,6 +764,9 @@ class StatementAnalyzer
             if (metadataResolver.tableExists(targetTable)) {
                 if (node.isNotExists()) {
                     analysis.setCreateTableAsSelectNoOp(true);
+                    warningCollector.add(new PrestoWarning(
+                            StandardWarningCode.SEMANTIC_WARNING,
+                            format("Table '%s' already exists, skipping table creation", targetTable)));
                     return createAndAssignScope(node, scope, Field.newUnqualified(node.getLocation(), "rows", BIGINT));
                 }
                 throw new SemanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/UtilizedColumnsAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/UtilizedColumnsAnalyzer.java
@@ -247,16 +247,19 @@ public class UtilizedColumnsAnalyzer
 
             // Wildcards are unresolved in the QuerySpecification's list of SelectItem, so we use output expressions from analysis instead
             List<Expression> selectItems = analysis.getOutputExpressions(querySpec);
-            if (!context.prunable) {
-                // Examine all the output expressions
-                for (Expression expression : selectItems) {
-                    process(expression, context);
+            // selectItems can be null for statements like CREATE TABLE IF NOT EXISTS when the table already exists
+            if (selectItems != null) {
+                if (!context.prunable) {
+                    // Examine all the output expressions
+                    for (Expression expression : selectItems) {
+                        process(expression, context);
+                    }
                 }
-            }
-            else {
-                // Prune (Only examine output expressions that have been referenced)
-                for (FieldId fieldId : context.getFieldIdsToExploreInRelation(querySpec)) {
-                    process(selectItems.get(fieldId.getFieldIndex()), context);
+                else {
+                    // Prune (Only examine output expressions that have been referenced)
+                    for (FieldId fieldId : context.getFieldIdsToExploreInRelation(querySpec)) {
+                        process(selectItems.get(fieldId.getFieldIndex()), context);
+                    }
                 }
             }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -126,6 +126,13 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testCTASIfNotExistsWhenExists()
+    {
+        assertHasWarning(analyzeWithWarnings("CREATE TABLE IF NOT EXISTS t1 AS SELECT a, b FROM t1"),
+                SEMANTIC_WARNING, "Table 'tpch.s1.t1' already exists, skipping table creation");
+    }
+
+    @Test
     public void testNonComparableGroupBy()
     {
         assertFails(TYPE_MISMATCH, "SELECT * FROM (SELECT approx_set(1)) GROUP BY 1");


### PR DESCRIPTION
## Description
Previously when using create table if not exists, the error if the table exists would look like this...

```
presto> create table if not exists tpch.sf1.customer as select * from tpch.sf1.customer;
CREATE TABLE: 0 rows

WARNING: Error in analyzing utilized columns for access control, falling back to checking access on all columns: Cannot invoke "java.util.List.iterator()" because "selectItems" is null


Query 20260206_233041_00001_z5bwk, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 64ms, server-side: 35ms] [0 rows, 0B] [0 rows/s, 0B/s]
```

After these changes, we have a more descriptive and concise message...

```
presto> create table if not exists tpch.sf1.customer as select * from tpch.sf1.customer;
CREATE TABLE: 0 rows

WARNING: Table 'tpch.sf1.customer' already exists, skipping table creation


Query 20260206_233246_00000_bjt5x, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 377ms, server-side: 209ms] [0 rows, 0B] [0 rows/s, 0B/s]
```



## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
General Changes
* Add warning message on CTAS if not exists
```

## Summary by Sourcery

Bug Fixes:
- Prevent a potential null pointer error in UtilizedColumnsAnalyzer when analysis returns no output expressions for a query specification.

## Summary by Sourcery

Guard query specification column utilization analysis when CREATE TABLE AS SELECT with IF NOT EXISTS resolves to a no-op due to an existing table, and surface a semantic warning in that scenario.

Bug Fixes:
- Prevent a potential null pointer when analyzing utilized columns for query specifications that have no output expressions, such as no-op CREATE TABLE IF NOT EXISTS statements.

Enhancements:
- Emit a semantic warning when CREATE TABLE IF NOT EXISTS is a no-op because the target table already exists, indicating that table creation is skipped.