### PR TITLE
feat(plugin-iceberg): Push down min/max/count based on file stats

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -413,6 +413,9 @@ Property Name                                           Description             
                                                         are collected.
 ``iceberg.max-statistics-file-cache-size``              Maximum size in bytes that should be consumed by the          ``256MB``                          Yes                 Yes, only needed on coordinator
                                                         statistics file cache.
+
+``iceberg.aggregate-push-down-enabled``                 Controls whether to push down aggregate (MIN/MAX/COUNT) to    ``true``                           Yes                 No
+                                                        Iceberg based on data file stats.
 ======================================================= ============================================================= ================================== =================== =============================================
 
 Table Properties
@@ -625,6 +628,13 @@ Session properties set behavior changes for queries executed within the given se
        ``iceberg.max-partitions-per-writer`` in the current session.
      - Yes
      - No
+   * - .. _iceberg-sess-aggregate-push-down-enabled:
+
+       ``aggregate_push_down_enabled``
+     - Overrides the behavior of the connector property
+       ``iceberg.aggregate-push-down-enabled`` in the current session.
+     - Yes
+     - Yes
 
 Caching Support
 ---------------

--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -414,7 +414,7 @@ Property Name                                           Description             
 ``iceberg.max-statistics-file-cache-size``              Maximum size in bytes that should be consumed by the          ``256MB``                          Yes                 Yes, only needed on coordinator
                                                         statistics file cache.
 
-``iceberg.aggregate-push-down-enabled``                 Controls whether to push down aggregate (MIN/MAX/COUNT) to    ``true``                           Yes                 No
+``iceberg.aggregate-push-down-enabled``                 Controls whether to push down aggregate (MIN/MAX/COUNT) to    ``true``                           Yes                 Yes
                                                         Iceberg based on data file stats.
 ======================================================= ============================================================= ================================== =================== =============================================
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -80,6 +80,7 @@ public class IcebergConfig
     private String materializedViewDefaultStorageSchema;
     private int materializedViewMaxChangedPartitions = 100;
     private int materializedViewDefaultMaxSnapshotsPerRefresh;
+    private boolean aggregatePushDownEnabled = true;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -542,6 +543,19 @@ public class IcebergConfig
     public IcebergConfig setMaterializedViewDefaultMaxSnapshotsPerRefresh(int materializedViewDefaultMaxSnapshotsPerRefresh)
     {
         this.materializedViewDefaultMaxSnapshotsPerRefresh = materializedViewDefaultMaxSnapshotsPerRefresh;
+        return this;
+    }
+
+    public boolean isAggregatePushDownEnabled()
+    {
+        return aggregatePushDownEnabled;
+    }
+
+    @Config("iceberg.aggregate-push-down-enabled")
+    @ConfigDescription("Controls whether to push down aggregate (MIN/MAX/COUNT) to Iceberg based on data file stats.")
+    public IcebergConfig setAggregatePushDownEnabled(boolean aggregatePushDownEnabled)
+    {
+        this.aggregatePushDownEnabled = aggregatePushDownEnabled;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -77,6 +77,7 @@ public final class IcebergSessionProperties
     public static final String MAX_PARTITIONS_PER_WRITER = "max_partitions_per_writer";
     public static final String MATERIALIZED_VIEW_MAX_CHANGED_PARTITIONS = "materialized_view_max_changed_partitions";
     public static final String MATERIALIZED_VIEW_DEFAULT_MAX_SNAPSHOTS_PER_REFRESH = "materialized_view_default_max_snapshots_per_refresh";
+    public static final String AGGREGATE_PUSH_DOWN_ENABLED = "aggregate_push_down_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -265,6 +266,11 @@ public final class IcebergSessionProperties
                         "Default upper bound on snapshots consumed per base table per refresh when the materialized view " +
                                 "does not override it via the max_snapshots_per_refresh table property. 0 means unbounded.",
                         icebergConfig.getMaterializedViewDefaultMaxSnapshotsPerRefresh(),
+                        false))
+                .add(booleanProperty(
+                        AGGREGATE_PUSH_DOWN_ENABLED,
+                        "Controls whether to push down aggregate (MIN/MAX/COUNT) to Iceberg based on data file stats",
+                        icebergConfig.isAggregatePushDownEnabled(),
                         false));
 
         nessieConfig.ifPresent((config) -> propertiesBuilder
@@ -437,5 +443,10 @@ public final class IcebergSessionProperties
             return OptionalInt.empty();
         }
         return OptionalInt.of(value);
+    }
+
+    public static boolean isAggregatePushDownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(AGGREGATE_PUSH_DOWN_ENABLED, Boolean.class);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -24,7 +24,9 @@ import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.TimeType;
+import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.VarbinaryType;
@@ -122,6 +124,7 @@ import static com.facebook.presto.common.predicate.Domain.singleValue;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.Chars.isCharType;
+import static com.facebook.presto.common.type.DateTimeEncoding.packDateTimeWithZone;
 import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.common.type.Decimals.isLongDecimal;
@@ -179,7 +182,6 @@ import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.doubleToRawLongBits;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Double.parseDouble;
-import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Float.parseFloat;
@@ -1537,11 +1539,14 @@ public final class IcebergUtil
             if (type instanceof TimestampType || type instanceof TimeType) {
                 return MICROSECONDS.toMillis((long) value);
             }
+            else if (type instanceof TimestampWithTimeZoneType) {
+                return packDateTimeWithZone(MICROSECONDS.toMillis((long) value), TimeZoneKey.UTC_KEY);
+            }
             else if (value instanceof BigDecimal) {
                 return ((BigDecimal) value).unscaledValue().longValue();
             }
             else if (value instanceof Float && type instanceof RealType) {
-                return (long) floatToIntBits((Float) value);
+                return (long) floatToRawIntBits((Float) value);
             }
             else {
                 return ((Number) value).longValue();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -22,6 +22,8 @@ import com.facebook.presto.common.predicate.NullableValue;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.Decimals;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
@@ -53,6 +55,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
 import org.apache.iceberg.ContentFile;
@@ -96,6 +99,7 @@ import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -119,6 +123,7 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.Chars.isCharType;
 import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
 import static com.facebook.presto.common.type.Decimals.isLongDecimal;
 import static com.facebook.presto.common.type.Decimals.isShortDecimal;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -174,6 +179,7 @@ import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.doubleToRawLongBits;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.Double.parseDouble;
+import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Float.parseFloat;
@@ -1517,6 +1523,55 @@ public final class IcebergUtil
     public static DataSize getTargetSplitSize(ConnectorSession session, Scan<?, ?, ?> scan)
     {
         return getTargetSplitSize(IcebergSessionProperties.getTargetSplitSize(session), scan.targetSplitSize());
+    }
+
+    public static Object getNativeValue(Type type, Object value)
+    {
+        if (value == null) {
+            return null;
+        }
+        else if (type.getJavaType() == double.class) {
+            return ((Number) value).doubleValue();
+        }
+        else if (type.getJavaType() == long.class) {
+            if (type instanceof TimestampType || type instanceof TimeType) {
+                return MICROSECONDS.toMillis((long) value);
+            }
+            else if (value instanceof BigDecimal) {
+                return ((BigDecimal) value).unscaledValue().longValue();
+            }
+            else if (value instanceof Float && type instanceof RealType) {
+                return (long) floatToIntBits((Float) value);
+            }
+            else {
+                return ((Number) value).longValue();
+            }
+        }
+        else if (type.getJavaType() == Slice.class) {
+            Slice slice;
+            if (value instanceof byte[]) {
+                slice = Slices.wrappedBuffer((byte[]) value);
+            }
+            else if (value instanceof String) {
+                slice = Slices.utf8Slice((String) value);
+            }
+            else if (value instanceof BigDecimal) {
+                slice = encodeScaledValue((BigDecimal) value);
+            }
+            else if (value instanceof ByteBuffer) {
+                slice = Slices.wrappedBuffer(((ByteBuffer) value).array());
+            }
+            else if (value instanceof CharBuffer) {
+                slice = Slices.utf8Slice(((CharBuffer) value).toString());
+            }
+            else {
+                slice = (Slice) value;
+            }
+            return slice;
+        }
+        else {
+            return value;
+        }
     }
 
     // This code is copied from Iceberg

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
@@ -69,6 +69,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.isAggregatePushDownEnabled;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeValue;
 import static com.facebook.presto.iceberg.IcebergUtil.getNonMetadataColumnConstraints;
@@ -94,7 +95,7 @@ public class IcebergAggregationOptimizer
     @Override
     public PlanNode optimize(PlanNode maxSubplan, ConnectorSession session, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator)
     {
-        if (isPushdownFilterEnabled(session)) {
+        if (!isAggregatePushDownEnabled(session) || isPushdownFilterEnabled(session)) {
             return maxSubplan;
         }
         Optimizer optimizer = new Optimizer(session, idAllocator, icebergTransactionManager, functionResolution);
@@ -146,7 +147,7 @@ public class IcebergAggregationOptimizer
             }
 
             Expression filter = toIcebergExpression(predicate);
-            // Fold min/max aggregations to a constant value
+            // Fold min/max/count aggregations to a constant value
             return reduce(node, table.schema(), table, tableHandle.getIcebergTableName().getSnapshotId(), filter);
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.optimizer;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.iceberg.IcebergAbstractMetadata;
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.iceberg.IcebergTableHandle;
+import com.facebook.presto.iceberg.IcebergTableLayoutHandle;
+import com.facebook.presto.iceberg.IcebergUtil;
+import com.facebook.presto.iceberg.transaction.IcebergTransactionManager;
+import com.facebook.presto.iceberg.util.AggregateConverter;
+import com.facebook.presto.spi.ConnectorPlanOptimizer;
+import com.facebook.presto.spi.ConnectorPlanRewriter;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.AggregateEvaluator;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.BoundAggregate;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
+import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
+import static com.facebook.presto.iceberg.IcebergUtil.getNativeValue;
+import static com.facebook.presto.iceberg.IcebergUtil.getNonMetadataColumnConstraints;
+import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergAggregationOptimizer
+        implements ConnectorPlanOptimizer
+{
+    public static final Logger LOGGER = Logger.get(IcebergAggregationOptimizer.class);
+    private final IcebergTransactionManager icebergTransactionManager;
+    private final StandardFunctionResolution functionResolution;
+
+    public IcebergAggregationOptimizer(
+            IcebergTransactionManager icebergTransactionManager,
+            StandardFunctionResolution functionResolution)
+    {
+        this.icebergTransactionManager = requireNonNull(icebergTransactionManager, "icebergTransactionManager is null");
+        this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode maxSubplan, ConnectorSession session, VariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator)
+    {
+        if (isPushdownFilterEnabled(session)) {
+            return maxSubplan;
+        }
+        Optimizer optimizer = new Optimizer(session, idAllocator, icebergTransactionManager, functionResolution);
+        return ConnectorPlanRewriter.rewriteWith(optimizer, maxSubplan, null);
+    }
+
+    private static class Optimizer
+            extends ConnectorPlanRewriter<Void>
+    {
+        private final ConnectorSession connectorSession;
+        private final PlanNodeIdAllocator idAllocator;
+        private final IcebergTransactionManager icebergTransactionManager;
+        private final AggregateConverter aggregateConverter;
+        private final Map<Predicate<FunctionHandle>, Expression.Operation> allowedFunctions;
+
+        private Optimizer(ConnectorSession connectorSession,
+                          PlanNodeIdAllocator idAllocator,
+                          IcebergTransactionManager icebergTransactionManager,
+                          StandardFunctionResolution functionResolution)
+        {
+            this.connectorSession = connectorSession;
+            this.idAllocator = idAllocator;
+            this.icebergTransactionManager = icebergTransactionManager;
+            this.allowedFunctions = ImmutableMap.of(
+                    functionResolution::isCountFunction, Expression.Operation.COUNT,
+                    functionHandle -> functionHandle.getArgumentTypes().size() == 1 && functionResolution.isMinFunction(functionHandle), Expression.Operation.MIN,
+                    functionHandle -> functionHandle.getArgumentTypes().size() == 1 && functionResolution.isMaxFunction(functionHandle), Expression.Operation.MAX);
+            this.aggregateConverter = new AggregateConverter(allowedFunctions);
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Void> context)
+        {
+            Optional<TableScanNode> result = findTableScan(node.getSource());
+            if (result.isEmpty()) {
+                return context.defaultRewrite(node);
+            }
+
+            // verify all outputs of table scan are partition keys
+            TableScanNode tableScan = result.get();
+            IcebergTableHandle tableHandle = (IcebergTableHandle) tableScan.getTable().getConnectorHandle();
+            Table table = IcebergUtil.getIcebergTable(getConnectorMetadata(tableScan.getTable()),
+                    connectorSession, tableHandle.getSchemaTableName());
+            TupleDomain<IcebergColumnHandle> predicate = getNonMetadataColumnConstraints(((IcebergTableLayoutHandle) tableScan.getTable().getLayout().get())
+                    .getValidPredicate());
+
+            if (!isReducible(table, node)) {
+                return context.defaultRewrite(node);
+            }
+
+            Expression filter = toIcebergExpression(predicate);
+            // Fold min/max aggregations to a constant value
+            return reduce(node, table.schema(), table, tableHandle.getIcebergTableName().getSnapshotId(), filter);
+        }
+
+        private static Optional<TableScanNode> findTableScan(PlanNode source)
+        {
+            while (true) {
+                if (source instanceof ProjectNode) {
+                    source = ((ProjectNode) source).getSource();
+                }
+                else if (source instanceof TableScanNode) {
+                    return Optional.of((TableScanNode) source);
+                }
+                else {
+                    return Optional.empty();
+                }
+            }
+        }
+
+        private boolean isReducible(Table table, AggregationNode node)
+        {
+            if (!(table instanceof BaseTable)) {
+                return false;
+            }
+
+            // The aggregation is reducible when there is no group by key
+            if (node.getAggregations().isEmpty() || !node.getGroupingKeys().isEmpty()) {
+                return false;
+            }
+
+            // supported functions are only MIN/MAX/COUNT aggregates
+            for (AggregationNode.Aggregation aggregation : node.getAggregations().values()) {
+                if (aggregation.isDistinct() || aggregation.getMask().isPresent() || allowedFunctions.keySet().stream().noneMatch(
+                        pred -> pred.test(aggregation.getFunctionHandle())) && !aggregation.isDistinct()) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private PlanNode reduce(
+                AggregationNode node,
+                Schema schema,
+                Table table,
+                Optional<Long> snapshotId,
+                Expression filter)
+        {
+            AggregateEvaluator aggregateEvaluator;
+            List<BoundAggregate<?, ?>> expressions =
+                    Lists.newArrayListWithExpectedSize(node.getAggregations().size());
+
+            for (VariableReferenceExpression variable : node.getOutputVariables()) {
+                try {
+                    AggregationNode.Aggregation aggregation = node.getAggregations().get(variable);
+                    Expression expr = aggregateConverter.convert(aggregation);
+                    if (expr != null) {
+                        Expression bound = Binder.bind(schema.asStruct(), expr, false);
+                        expressions.add((BoundAggregate<?, ?>) bound);
+                    }
+                }
+                catch (UnsupportedOperationException e) {
+                    LOGGER.info(
+                            "Skipping aggregate pushdown: AggregateFunc %s can't be converted to iceberg Expression",
+                            variable,
+                            e);
+                    return node;
+                }
+                catch (IllegalArgumentException | ValidationException e) {
+                    LOGGER.info("Skipping aggregate pushdown: Bind failed for AggregateFunc %s", variable, e);
+                    return node;
+                }
+            }
+
+            aggregateEvaluator = AggregateEvaluator.create(expressions);
+            if (!metricsModeSupportsAggregatePushDown(table, aggregateEvaluator.aggregates())) {
+                return node;
+            }
+            TableScan scan = table.newScan().includeColumnStats();
+            Snapshot snapshot = snapshotId.map(table::snapshot).orElseGet(table::currentSnapshot);
+            if (snapshot == null) {
+                LOGGER.info("Skipping aggregate pushdown: table snapshot is null");
+                return node;
+            }
+            scan = scan.useSnapshot(snapshot.snapshotId());
+            scan = scan.filter(filter);
+
+            try (CloseableIterable<FileScanTask> fileScanTasks = scan.planFiles()) {
+                List<FileScanTask> tasks = ImmutableList.copyOf(fileScanTasks);
+                for (FileScanTask task : tasks) {
+                    if (!task.deletes().isEmpty()) {
+                        LOGGER.info("Skipping aggregate pushdown: detected row level deletes");
+                        return node;
+                    }
+
+                    aggregateEvaluator.update(task.file());
+                }
+            }
+            catch (IOException e) {
+                LOGGER.info("Skipping aggregate pushdown: ", e);
+                return node;
+            }
+
+            if (!aggregateEvaluator.allAggregatorsValid()) {
+                return node;
+            }
+
+            StructLike structLike = aggregateEvaluator.result();
+            List<Types.NestedField> fields = aggregateEvaluator.resultType().fields();
+            Assignments.Builder assignmentsBuilder = Assignments.builder();
+            for (int i = 0; i < node.getOutputVariables().size(); i++) {
+                VariableReferenceExpression outputVariable = node.getOutputVariables().get(i);
+                Class<?> javaClass = fields.get(i).type().typeId().javaClass();
+                Object value = structLike.get(i, javaClass);
+                RowExpression expression = new ConstantExpression(getNativeValue(outputVariable.getType(), value), outputVariable.getType());
+                assignmentsBuilder.put(outputVariable, expression);
+            }
+            Assignments assignments = assignmentsBuilder.build();
+            ValuesNode valuesNode = new ValuesNode(node.getSourceLocation(), idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of(new ArrayList<>(assignments.getExpressions())), Optional.empty());
+            return new ProjectNode(node.getSourceLocation(), idAllocator.getNextId(), valuesNode, assignments, LOCAL);
+        }
+
+        private ConnectorMetadata getConnectorMetadata(TableHandle tableHandle)
+        {
+            requireNonNull(icebergTransactionManager, "icebergTransactionManager is null");
+            ConnectorMetadata metadata = icebergTransactionManager.get(tableHandle.getTransaction());
+            checkState(metadata instanceof IcebergAbstractMetadata, "metadata must be IcebergAbstractMetadata");
+            return metadata;
+        }
+
+        private boolean metricsModeSupportsAggregatePushDown(Table table, List<BoundAggregate<?, ?>> aggregates)
+        {
+            MetricsConfig config = MetricsConfig.forTable(table);
+            for (BoundAggregate aggregate : aggregates) {
+                String colName = aggregate.columnName();
+                if (!colName.equals("*")) {
+                    MetricsModes.MetricsMode mode = config.columnMode(colName);
+                    if (mode instanceof MetricsModes.None) {
+                        LOGGER.info("Skipping aggregate pushdown: No metrics for column %s", colName);
+                        return false;
+                    }
+                    else if (mode instanceof MetricsModes.Counts) {
+                        if (aggregate.op() == Expression.Operation.MAX
+                                || aggregate.op() == Expression.Operation.MIN) {
+                            LOGGER.info(
+                                    "Skipping aggregate pushdown: Cannot produce min or max from count for column %s",
+                                    colName);
+                            return false;
+                        }
+                    }
+                    else if (mode instanceof MetricsModes.Truncate) {
+                        // lower_bounds and upper_bounds may be truncated, so disable push down
+                        if (aggregate.type().typeId() == Type.TypeID.STRING) {
+                            if (aggregate.op() == Expression.Operation.MAX
+                                    || aggregate.op() == Expression.Operation.MIN) {
+                                LOGGER.info(
+                                        "Skipping aggregate pushdown: Cannot produce min or max from truncated values for column %s",
+                                        colName);
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
@@ -134,7 +134,6 @@ public class IcebergAggregationOptimizer
                 return context.defaultRewrite(node);
             }
 
-            // verify all outputs of table scan are partition keys
             TableScanNode tableScan = result.get();
             IcebergTableHandle tableHandle = (IcebergTableHandle) tableScan.getTable().getConnectorHandle();
             Table table = IcebergUtil.getIcebergTable(getConnectorMetadata(tableScan.getTable()),
@@ -180,7 +179,7 @@ public class IcebergAggregationOptimizer
             // supported functions are only MIN/MAX/COUNT aggregates
             for (AggregationNode.Aggregation aggregation : node.getAggregations().values()) {
                 if (aggregation.isDistinct() || aggregation.getMask().isPresent() || allowedFunctions.keySet().stream().noneMatch(
-                        pred -> pred.test(aggregation.getFunctionHandle())) && !aggregation.isDistinct()) {
+                        pred -> pred.test(aggregation.getFunctionHandle()))) {
                     return false;
                 }
             }
@@ -299,7 +298,7 @@ public class IcebergAggregationOptimizer
                     }
                     else if (mode instanceof MetricsModes.Truncate) {
                         // lower_bounds and upper_bounds may be truncated, so disable push down
-                        if (aggregate.type().typeId() == Type.TypeID.STRING) {
+                        if (aggregate.type().typeId() == Type.TypeID.STRING || aggregate.type().typeId() == Type.TypeID.BINARY) {
                             if (aggregate.op() == Expression.Operation.MAX
                                     || aggregate.op() == Expression.Operation.MIN) {
                                 LOGGER.info(

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
@@ -296,16 +296,15 @@ public class IcebergAggregationOptimizer
                             return false;
                         }
                     }
-                    else if (mode instanceof MetricsModes.Truncate) {
-                        // lower_bounds and upper_bounds may be truncated, so disable push down
-                        if (aggregate.type().typeId() == Type.TypeID.STRING || aggregate.type().typeId() == Type.TypeID.BINARY) {
-                            if (aggregate.op() == Expression.Operation.MAX
-                                    || aggregate.op() == Expression.Operation.MIN) {
-                                LOGGER.info(
-                                        "Skipping aggregate pushdown: Cannot produce min or max from truncated values for column %s",
-                                        colName);
-                                return false;
-                            }
+                    else if (aggregate.type().typeId() == Type.TypeID.STRING || aggregate.type().typeId() == Type.TypeID.BINARY) {
+                        // lower_bounds and upper_bounds may have been truncated before, so disable push down
+                        // regardless of the current mode
+                        if (aggregate.op() == Expression.Operation.MAX
+                                || aggregate.op() == Expression.Operation.MIN) {
+                            LOGGER.info(
+                                    "Skipping aggregate pushdown: Cannot produce min or max from truncated values for column %s",
+                                    colName);
+                            return false;
                         }
                     }
                 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergAggregationOptimizer.java
@@ -22,6 +22,7 @@ import com.facebook.presto.iceberg.IcebergTableLayoutHandle;
 import com.facebook.presto.iceberg.IcebergUtil;
 import com.facebook.presto.iceberg.transaction.IcebergTransactionManager;
 import com.facebook.presto.iceberg.util.AggregateConverter;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.ConnectorPlanRewriter;
 import com.facebook.presto.spi.ConnectorSession;
@@ -147,7 +148,7 @@ public class IcebergAggregationOptimizer
 
             Expression filter = toIcebergExpression(predicate);
             // Fold min/max/count aggregations to a constant value
-            return reduce(node, table.schema(), table, tableHandle.getIcebergTableName().getSnapshotId(), filter);
+            return reduce(node, tableScan.getAssignments(), table.schema(), table, tableHandle.getIcebergTableName().getSnapshotId(), filter);
         }
 
         private static Optional<TableScanNode> findTableScan(PlanNode source)
@@ -189,6 +190,7 @@ public class IcebergAggregationOptimizer
 
         private PlanNode reduce(
                 AggregationNode node,
+                Map<VariableReferenceExpression, ColumnHandle> tableScanAssignments,
                 Schema schema,
                 Table table,
                 Optional<Long> snapshotId,
@@ -201,7 +203,7 @@ public class IcebergAggregationOptimizer
             for (VariableReferenceExpression variable : node.getOutputVariables()) {
                 try {
                     AggregationNode.Aggregation aggregation = node.getAggregations().get(variable);
-                    Expression expr = aggregateConverter.convert(aggregation);
+                    Expression expr = aggregateConverter.convert(aggregation, tableScanAssignments);
                     if (expr != null) {
                         Expression bound = Binder.bind(schema.asStruct(), expr, false);
                         expressions.add((BoundAggregate<?, ?>) bound);
@@ -234,8 +236,7 @@ public class IcebergAggregationOptimizer
             scan = scan.filter(filter);
 
             try (CloseableIterable<FileScanTask> fileScanTasks = scan.planFiles()) {
-                List<FileScanTask> tasks = ImmutableList.copyOf(fileScanTasks);
-                for (FileScanTask task : tasks) {
+                for (FileScanTask task : fileScanTasks) {
                     if (!task.deletes().isEmpty()) {
                         LOGGER.info("Skipping aggregate pushdown: detected row level deletes");
                         return node;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/optimizer/IcebergPlanOptimizerProvider.java
@@ -55,6 +55,7 @@ public class IcebergPlanOptimizerProvider
         this.logicalPlanOptimizers = ImmutableSet.of(
                 new IcebergPlanOptimizer(functionResolution, rowExpressionService, functionMetadataManager, transactionManager),
                 new IcebergFilterPushdown(rowExpressionService, functionResolution, functionMetadataManager, transactionManager, typeManager),
+                new IcebergAggregationOptimizer(transactionManager, functionResolution),
                 new IcebergMetadataOptimizer(functionMetadataManager, typeManager, transactionManager, rowExpressionService, functionResolution),
                 new IcebergParquetDereferencePushDown(transactionManager, rowExpressionService, typeManager, tableProperties),
                 new IcebergEqualityDeleteAsJoin(functionResolution, transactionManager, typeManager));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/AggregateConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/AggregateConverter.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.facebook.presto.iceberg.util;
+
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class AggregateConverter
+{
+    private final Map<Predicate<FunctionHandle>, Expression.Operation> allowedFunctions;
+
+    public AggregateConverter(Map<Predicate<FunctionHandle>, Expression.Operation> allowedFunctions)
+    {
+        this.allowedFunctions = allowedFunctions;
+    }
+
+    public Expression convert(AggregationNode.Aggregation aggregation)
+    {
+        Expression.Operation operation = this.allowedFunctions.entrySet().stream()
+                .filter(entry -> entry.getKey().test(aggregation.getFunctionHandle()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+
+        if (operation != null) {
+            switch (operation) {
+                case COUNT:
+                    if (!aggregation.getArguments().isEmpty()) {
+                        String columnName = ((VariableReferenceExpression) getOnlyElement(aggregation.getArguments())).getName();
+                        return Expressions.count(columnName);
+                    }
+                    else {
+                        return Expressions.countStar();
+                    }
+                case MAX:
+                    String columnName = ((VariableReferenceExpression) getOnlyElement(aggregation.getArguments())).getName();
+                    return Expressions.max(columnName);
+                case MIN:
+                    String columnName2 = ((VariableReferenceExpression) getOnlyElement(aggregation.getArguments())).getName();
+                    return Expressions.min(columnName2);
+            }
+        }
+
+        throw new UnsupportedOperationException("Unsupported aggregate: " + aggregation.getFunctionHandle().getName());
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/AggregateConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/AggregateConverter.java
@@ -18,6 +18,8 @@
  */
 package com.facebook.presto.iceberg.util;
 
+import com.facebook.presto.iceberg.IcebergColumnHandle;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -38,7 +40,8 @@ public class AggregateConverter
         this.allowedFunctions = allowedFunctions;
     }
 
-    public Expression convert(AggregationNode.Aggregation aggregation)
+    public Expression convert(AggregationNode.Aggregation aggregation,
+                              Map<VariableReferenceExpression, ColumnHandle> tableScanAssignments)
     {
         Expression.Operation operation = this.allowedFunctions.entrySet().stream()
                 .filter(entry -> entry.getKey().test(aggregation.getFunctionHandle()))
@@ -50,21 +53,29 @@ public class AggregateConverter
             switch (operation) {
                 case COUNT:
                     if (!aggregation.getArguments().isEmpty()) {
-                        String columnName = ((VariableReferenceExpression) getOnlyElement(aggregation.getArguments())).getName();
-                        return Expressions.count(columnName);
+                        return Expressions.count(getColumnNameOfAggregation(aggregation, tableScanAssignments));
                     }
                     else {
                         return Expressions.countStar();
                     }
                 case MAX:
-                    String columnName = ((VariableReferenceExpression) getOnlyElement(aggregation.getArguments())).getName();
-                    return Expressions.max(columnName);
+                    return Expressions.max(getColumnNameOfAggregation(aggregation, tableScanAssignments));
                 case MIN:
-                    String columnName2 = ((VariableReferenceExpression) getOnlyElement(aggregation.getArguments())).getName();
-                    return Expressions.min(columnName2);
+                    return Expressions.min(getColumnNameOfAggregation(aggregation, tableScanAssignments));
             }
         }
 
         throw new UnsupportedOperationException("Unsupported aggregate: " + aggregation.getFunctionHandle().getName());
+    }
+
+    private static String getColumnNameOfAggregation(AggregationNode.Aggregation aggregation,
+                                                     Map<VariableReferenceExpression, ColumnHandle> tableScanAssignments)
+    {
+        VariableReferenceExpression variable = (VariableReferenceExpression) getOnlyElement(aggregation.getArguments());
+        ColumnHandle columnHandle = tableScanAssignments.get(variable);
+        if (columnHandle == null) {
+            throw new IllegalArgumentException("Cannot find corresponding column for variable: " + variable.toString());
+        }
+        return ((IcebergColumnHandle) columnHandle).getName();
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergAggregatePushDown.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/BenchmarkIcebergAggregatePushDown.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.runner.options.WarmupMode;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkIcebergAggregatePushDown
+{
+    DistributedQueryRunner queryRunner;
+    Session writerSession;
+    Session aggregatePushDownEnabledSession;
+    Session aggregatePushDownDisabledSession;
+
+    @Setup
+    public void setup() throws Exception
+    {
+        queryRunner = IcebergQueryRunner.builder()
+                .build()
+                .getQueryRunner();
+        writerSession = Session.builder(queryRunner.getDefaultSession())
+                .setCatalogSessionProperty("iceberg", "max_partitions_per_writer", "1000")
+                .build();
+        queryRunner.execute(writerSession, "create table iceberg_lineitem with (partitioning = ARRAY['suppkey']) " +
+                "as select * from tpch.sf1.lineitem with no data");
+        for (int i = 0; i < 10; i++) {
+            queryRunner.execute(writerSession, "insert into iceberg_lineitem " +
+                    "select * from tpch.sf1.lineitem where suppkey > " + i * 1000 + " and suppkey <= " + (i + 1) * 1000);
+        }
+
+        aggregatePushDownEnabledSession = Session.builder(queryRunner.getDefaultSession())
+                .setCatalogSessionProperty("iceberg", "aggregate_push_down_enabled", "true")
+                .build();
+        aggregatePushDownDisabledSession = Session.builder(queryRunner.getDefaultSession())
+                .setCatalogSessionProperty("iceberg", "aggregate_push_down_enabled", "false")
+                .build();
+    }
+
+    @Benchmark
+    public void aggregatePushDownEnabledQuery(Blackhole bh)
+    {
+        MaterializedResult result = queryRunner.execute(aggregatePushDownEnabledSession,
+                "select count(*), min(orderkey), max(orderkey), min(commitdate), max(commitdate)" +
+                        " from iceberg_lineitem");
+        bh.consume(result.getRowCount());
+    }
+
+    @Benchmark
+    public void aggregatePushDownDisabledQuery(Blackhole bh)
+    {
+        MaterializedResult result = queryRunner.execute(aggregatePushDownDisabledSession,
+                "select count(*), min(orderkey), max(orderkey), min(commitdate), max(commitdate)" +
+                        " from iceberg_lineitem");
+        bh.consume(result.getRowCount());
+    }
+
+    @Benchmark
+    public void aggregatePushDownEnabledQueryWithFilter(Blackhole bh)
+    {
+        MaterializedResult result = queryRunner.execute(aggregatePushDownEnabledSession,
+                "select count(*), min(orderkey), max(orderkey), min(commitdate), max(commitdate)" +
+                        " from iceberg_lineitem" +
+                        " where suppkey > 1000 and suppkey <= 9000");
+        bh.consume(result.getRowCount());
+    }
+
+    @Benchmark
+    public void aggregatePushDownDisabledQueryWithFilter(Blackhole bh)
+    {
+        MaterializedResult result = queryRunner.execute(aggregatePushDownDisabledSession,
+                "select count(*), min(orderkey), max(orderkey), min(commitdate), max(commitdate)" +
+                        " from iceberg_lineitem" +
+                        " where suppkey > 1000 and suppkey <= 9000");
+        bh.consume(result.getRowCount());
+    }
+
+    @TearDown
+    public void finish()
+    {
+        queryRunner.execute("drop table iceberg_lineitem");
+        closeAllRuntimeException(queryRunner);
+        queryRunner = null;
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .warmupMode(WarmupMode.INDI)
+                .include(".*" + BenchmarkIcebergAggregatePushDown.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -2950,4 +2950,37 @@ public abstract class IcebergDistributedSmokeTestBase
             queryRunner.execute("DROP TABLE IF EXISTS test_pushdown_subfields_dml");
         }
     }
+
+    @Test
+    public void testAggregatePushDownForCountMinMax()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session aggregatePushDownEnabled = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "aggregate_push_down_enabled", "true")
+                .build();
+        Session aggregatePushDownDisabled = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "aggregate_push_down_enabled", "false")
+                .build();
+
+        String tableName = "test_lineitem_with_partition";
+        try {
+            queryRunner.execute("CREATE TABLE " + tableName +
+                    " with (partitioning = ARRAY['suppkey'])" +
+                    " as select * from tpch.tiny.lineitem");
+
+            @Language("SQL") String query = "select count(*), min(orderkey), max(orderkey), min(shipdate), max(commitdate) from " + tableName;
+            MaterializedResult resultWithAggregatePushDown = getQueryRunner().execute(aggregatePushDownEnabled, query);
+            MaterializedResult resultWithoutAggregatePushDown = getQueryRunner().execute(aggregatePushDownDisabled, query);
+            Assert.assertEquals(resultWithAggregatePushDown, resultWithoutAggregatePushDown);
+
+            @Language("SQL") String queryWithFilter = "select count(*), min(orderkey), max(orderkey), min(shipdate), max(commitdate) from " + tableName +
+                    " where suppkey > 50";
+            resultWithAggregatePushDown = getQueryRunner().execute(aggregatePushDownEnabled, queryWithFilter);
+            resultWithoutAggregatePushDown = getQueryRunner().execute(aggregatePushDownDisabled, queryWithFilter);
+            Assert.assertEquals(resultWithAggregatePushDown, resultWithoutAggregatePushDown);
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -77,7 +77,8 @@ public class TestIcebergConfig
                 .setMaterializedViewStoragePrefix("__mv_storage__")
                 .setMaterializedViewDefaultStorageSchema(null)
                 .setMaterializedViewMaxChangedPartitions(100)
-                .setMaterializedViewDefaultMaxSnapshotsPerRefresh(0));
+                .setMaterializedViewDefaultMaxSnapshotsPerRefresh(0)
+                .setAggregatePushDownEnabled(true));
     }
 
     @Test
@@ -117,6 +118,7 @@ public class TestIcebergConfig
                 .put("iceberg.materialized-view-default-storage-schema", "_mv_storage")
                 .put("iceberg.materialized-view-max-changed-partitions", "2000")
                 .put("iceberg.materialized-view-default-max-snapshots-per-refresh", "10")
+                .put("iceberg.aggregate-push-down-enabled", "false")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -152,7 +154,8 @@ public class TestIcebergConfig
                 .setMaterializedViewStoragePrefix("custom_mv_prefix")
                 .setMaterializedViewDefaultStorageSchema("_mv_storage")
                 .setMaterializedViewMaxChangedPartitions(2000)
-                .setMaterializedViewDefaultMaxSnapshotsPerRefresh(10);
+                .setMaterializedViewDefaultMaxSnapshotsPerRefresh(10)
+                .setAggregatePushDownEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -599,7 +599,7 @@ public class TestIcebergLogicalPlanner
     }
 
     @Test
-    public void testAggregateNotPushDownForVarcharType()
+    public void testMinMaxAggregateNotPushDownForVarcharType()
     {
         QueryRunner queryRunner = getQueryRunner();
         Session session = getSession();
@@ -607,7 +607,9 @@ public class TestIcebergLogicalPlanner
         String tableName = "aggregation_push_down_" + randomTableSuffix();
         try {
             assertUpdate(session, format("CREATE TABLE %s (id bigint, data varchar)", tableName));
-            assertUpdate(session, format("INSERT INTO %s VALUES (1, '1111'), (1, '2222'), (2, '3333'), (2, '4444'), (3, '5555'), (3, '6666') ",
+            queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
+                    schemaName, tableName, TableProperties.DEFAULT_WRITE_METRICS_MODE, "truncate(5)"));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, '111111'), (1, '2222'), (2, '3333'), (2, '4444'), (3, '5555'), (3, '666666') ",
                     tableName), 6);
             assertPlan(session, "SELECT MAX(id), MAX(data) FROM " + tableName,
                     anyTree(
@@ -621,6 +623,8 @@ public class TestIcebergLogicalPlanner
                                                                     "partial_max_data", functionCall("max", ImmutableList.of("data"))),
                                                             PARTIAL,
                                                             strictTableScan(tableName, identityMap("id", "data"))))))));
+            assertQuery(session, "SELECT MAX(id), MAX(data), MIN(data) FROM " + tableName,
+                    "VALUES (3, '666666', '111111')");
 
             assertPlan(session, "SELECT COUNT(data) FROM " + tableName,
                     anyNot(AggregationNode.class, strictProject(
@@ -630,10 +634,19 @@ public class TestIcebergLogicalPlanner
             queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
                     schemaName, tableName, TableProperties.DEFAULT_WRITE_METRICS_MODE, "full"));
             assertPlan(session, "SELECT COUNT(data), MAX(data) FROM " + tableName,
-                    anyNot(AggregationNode.class, strictProject(
-                            ImmutableMap.of("count", expression("6"),
-                                    "max", expression("6666")),
-                            anyTree(values()))));
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count_data", functionCall("count", ImmutableList.of("partial_count_data")),
+                                            "final_max_data", functionCall("max", ImmutableList.of("partial_max_data"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count_data", functionCall("count", ImmutableList.of("data")),
+                                                                    "partial_max_data", functionCall("max", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("data"))))))));
+            assertQuery(session, "SELECT COUNT(data), MAX(data), MIN(data) FROM " + tableName,
+                    "VALUES (6, '666666', '111111')");
         }
         finally {
             queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
@@ -641,7 +654,7 @@ public class TestIcebergLogicalPlanner
     }
 
     @Test
-    public void testAggregateNotPushDownForVarbinaryType()
+    public void testMinMaxAggregateNotPushDownForVarbinaryType()
     {
         QueryRunner queryRunner = getQueryRunner();
         Session session = getSession();
@@ -649,7 +662,9 @@ public class TestIcebergLogicalPlanner
         String tableName = "aggregation_push_down_" + randomTableSuffix();
         try {
             assertUpdate(session, format("CREATE TABLE %s (id bigint, data varbinary)", tableName));
-            assertUpdate(session, format("INSERT INTO %s VALUES (1, x'1111'), (1, x'2222'), (2, x'3333'), (2, x'4444'), (3, x'5555'), (3, x'6666') ",
+            queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
+                    schemaName, tableName, TableProperties.DEFAULT_WRITE_METRICS_MODE, "truncate(4)"));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, x'1111111111'), (1, x'2222'), (2, x'3333'), (2, x'4444'), (3, x'5555'), (3, x'6666666666') ",
                     tableName), 6);
             assertPlan(session, "SELECT MAX(id), MAX(data) FROM " + tableName,
                     anyTree(
@@ -663,6 +678,8 @@ public class TestIcebergLogicalPlanner
                                                                     "partial_max_data", functionCall("max", ImmutableList.of("data"))),
                                                             PARTIAL,
                                                             strictTableScan(tableName, identityMap("id", "data"))))))));
+            assertQuery(session, "SELECT MAX(id), MAX(data), MIN(data) FROM " + tableName,
+                    "VALUES (3, x'6666666666', x'1111111111')");
 
             assertPlan(session, "SELECT COUNT(data) FROM " + tableName,
                     anyNot(AggregationNode.class, strictProject(
@@ -672,10 +689,19 @@ public class TestIcebergLogicalPlanner
             queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
                     schemaName, tableName, TableProperties.DEFAULT_WRITE_METRICS_MODE, "full"));
             assertPlan(session, "SELECT COUNT(data), MAX(data) FROM " + tableName,
-                    anyNot(AggregationNode.class, strictProject(
-                            ImmutableMap.of("count", expression("6"),
-                                    "max", expression("X'66 66'")),
-                            anyTree(values()))));
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count_data", functionCall("count", ImmutableList.of("partial_count_data")),
+                                            "final_max_data", functionCall("max", ImmutableList.of("partial_max_data"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count_data", functionCall("count", ImmutableList.of("data")),
+                                                                    "partial_max_data", functionCall("max", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("data"))))))));
+            assertQuery(session, "SELECT COUNT(data), MAX(data), MIN(data) FROM " + tableName,
+                    "VALUES (6, x'6666666666', x'1111111111')");
         }
         finally {
             queryRunner.execute("DROP TABLE IF EXISTS " + tableName);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -425,8 +425,7 @@ public class TestIcebergLogicalPlanner
                             + "max(boolean_data), min(boolean_data), count(boolean_data), "
                             + "max(float_data), min(float_data), count(float_data), "
                             + "max(double_data), min(double_data), count(double_data), "
-                            + "max(decimal_data), min(decimal_data), count(decimal_data), "
-                            + "max(binary_data), min(binary_data), count(binary_data)"
+                            + "max(decimal_data), min(decimal_data), count(decimal_data)"
                             + " FROM " + tableName;
 
             ImmutableMap.Builder<String, ExpressionMatcher> assignmentsBuilder = ImmutableMap.<String, ExpressionMatcher>builder()
@@ -444,8 +443,6 @@ public class TestIcebergLogicalPlanner
                     .put("min(double_data)", expression("DOUBLE '2.222222'"))
                     .put("max(decimal_data)", expression("DECIMAL '66.66'"))
                     .put("min(decimal_data)", expression("DECIMAL '11.11'"))
-                    .put("max(binary_data)", expression("X'55 55'"))
-                    .put("min(binary_data)", expression("X'11 11'"))
                     .put("count_3", expression("5"));
             assertPlan(session, select,
                     anyNot(AggregationNode.class, strictProject(
@@ -466,25 +463,28 @@ public class TestIcebergLogicalPlanner
                 .build();
         String tableName = "aggregation_push_down_" + randomTableSuffix();
         try {
-            assertUpdate(session, format("CREATE TABLE %s (id bigint, data varchar, d date, ts timestamp) with(partitioning = ARRAY['id'])", tableName));
-            assertUpdate(session, format("INSERT INTO %s VALUES (1, '1', date '2021-11-10', null),"
-                            + "(1, '2', date '2021-11-11', timestamp '2021-11-11 22:22:22'), "
-                            + "(2, '3', date '2021-11-12', timestamp '2021-11-12 22:22:22'), "
-                            + "(2, '4', date '2021-11-13', timestamp '2021-11-13 22:22:22'), "
-                            + "(3, '5', null, timestamp '2021-11-14 22:22:22'), "
-                            + "(3, '6', date '2021-11-14', null)",
+            assertUpdate(session, format("CREATE TABLE %s (id bigint, data varchar, d date, ts timestamp, tz timestamp with time zone) with(partitioning = ARRAY['id'])", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, '1', date '2021-11-10', null, TIMESTAMP '1969-12-01 00:00:00.000000 UTC'),"
+                            + "(1, '2', date '2021-11-11', timestamp '2021-11-11 22:22:22', TIMESTAMP '1984-12-08 00:10:00 Asia/Shanghai'), "
+                            + "(2, '3', date '2021-11-12', timestamp '2021-11-12 22:22:22', TIMESTAMP '2001-09-01 10:10:00 America/Los_Angeles'), "
+                            + "(2, '4', date '2021-11-13', timestamp '2021-11-13 22:22:22', TIMESTAMP '2025-01-01 08:07:00 Asia/Shanghai'), "
+                            + "(3, '5', null, timestamp '2021-11-14 22:22:22', null), "
+                            + "(3, '6', date '2021-11-14', null, null)",
                     tableName), 6);
-            assertQuery(session, "select max(ts), max(data) from " + tableName, "values(timestamp '2021-11-14 22:22:22', '6')");
-            assertQuery(session, "select max(ts) from " + tableName, "values(timestamp '2021-11-14 22:22:22')");
+            assertQuery(session, "select max(ts), max(data), max(tz) from " + tableName, "values(timestamp '2021-11-14 22:22:22', '6', TIMESTAMP '2025-01-01 00:07:00.000 UTC')");
+            assertQuery(session, "select max(ts), min(tz) from " + tableName, "values(timestamp '2021-11-14 22:22:22', TIMESTAMP '1969-12-01 00:00:00.000 UTC')");
+            assertQuery(session, "select max(ts), min(tz) from " + tableName + " where id > 1", "values(timestamp '2021-11-14 22:22:22', TIMESTAMP '2001-09-01 17:10:00.000 UTC')");
 
-            @Language("SQL") String select = "SELECT max(d), min(d), count(d), max(ts), min(ts), count(ts) FROM " + tableName;
+            @Language("SQL") String select = "SELECT max(d), min(d), count(d), max(ts), min(ts), count(ts), max(tz), min(tz) FROM " + tableName;
             ImmutableMap.Builder<String, ExpressionMatcher> assignmentsBuilder = ImmutableMap.<String, ExpressionMatcher>builder()
                     .put("count", expression("5"))
                     .put("max(d)", expression("DATE '2021-11-14'"))
                     .put("min(d)", expression("DATE '2021-11-10'"))
                     .put("max(ts)", expression("TIMESTAMP '2021-11-14 22:22:22.000'"))
                     .put("min(ts)", expression("TIMESTAMP '2021-11-11 22:22:22.000'"))
-                    .put("count_2", expression("4"));
+                    .put("count_2", expression("4"))
+                    .put("max(tz)", expression("TIMESTAMP '2025-01-01 00:07:00.000 UTC'"))
+                    .put("min(tz)", expression("TIMESTAMP '1969-12-01 00:00:00.000 UTC'"));
             assertPlan(session, select,
                     anyNot(AggregationNode.class, strictProject(
                             assignmentsBuilder.build(),
@@ -633,6 +633,48 @@ public class TestIcebergLogicalPlanner
                     anyNot(AggregationNode.class, strictProject(
                             ImmutableMap.of("count", expression("6"),
                                     "max", expression("6666")),
+                            anyTree(values()))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregateNotPushDownForVarbinaryType()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String schemaName = session.getSchema().get();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id bigint, data varbinary)", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, x'1111'), (1, x'2222'), (2, x'3333'), (2, x'4444'), (3, x'5555'), (3, x'6666') ",
+                    tableName), 6);
+            assertPlan(session, "SELECT MAX(id), MAX(data) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_max_id", functionCall("max", ImmutableList.of("partial_max_id")),
+                                            "final_max_data", functionCall("max", ImmutableList.of("partial_max_data"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_max_id", functionCall("max", ImmutableList.of("id")),
+                                                                    "partial_max_data", functionCall("max", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("id", "data"))))))));
+
+            assertPlan(session, "SELECT COUNT(data) FROM " + tableName,
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of("count", expression("6")),
+                            anyTree(values()))));
+
+            queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
+                    schemaName, tableName, TableProperties.DEFAULT_WRITE_METRICS_MODE, "full"));
+            assertPlan(session, "SELECT COUNT(data), MAX(data) FROM " + tableName,
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of("count", expression("6"),
+                                    "max", expression("X'66 66'")),
                             anyTree(values()))));
         }
         finally {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.assertions.ExpressionMatcher;
 import com.facebook.presto.sql.planner.assertions.MatchResult;
 import com.facebook.presto.sql.planner.assertions.Matcher;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
@@ -46,6 +47,8 @@ import com.facebook.presto.sql.planner.assertions.SymbolAliases;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.base.Functions;
@@ -55,6 +58,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.apache.iceberg.TableProperties;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Ignore;
@@ -80,6 +84,7 @@ import static com.facebook.presto.common.predicate.TupleDomain.withColumnDomains
 import static com.facebook.presto.common.predicate.ValueSet.ofRanges;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DecimalType.DEFAULT_PRECISION;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -95,11 +100,14 @@ import static com.facebook.presto.iceberg.IcebergSessionProperties.PUSHDOWN_FILT
 import static com.facebook.presto.iceberg.IcebergSessionProperties.ROWS_FOR_METADATA_OPTIMIZATION_THRESHOLD;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.isPushdownFilterEnabled;
 import static com.facebook.presto.parquet.ParquetTypeUtils.pushdownColumnNameForSubfield;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.PARTIAL;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyNot;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.callDistributedProcedure;
@@ -107,7 +115,9 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchan
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filterWithDecimal;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.nullExpression;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.strictProject;
@@ -125,6 +135,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.NaN;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -211,6 +222,648 @@ public class TestIcebergLogicalPlanner
         }
         finally {
             queryRunner.execute("DROP TABLE IF EXISTS metadata_optimize");
+        }
+    }
+
+    @Test
+    public void testAggregationPushDownOptimizer()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            queryRunner.execute(format("create table %s(v1 int, v2 varchar, a int, b varchar)" +
+                    " with(partitioning = ARRAY['a', 'b'])", tableName));
+            queryRunner.execute(format("insert into %s values" +
+                    " (1, '1001', 5, '1001')," +
+                    " (2, '1002', 2, '1001')," +
+                    " (3, '1003', 9, '1002')," +
+                    " (4, '1004', 6, '1002')", tableName));
+            queryRunner.execute(format("insert into %s values" +
+                    " (5, '1005', 19, '1001')," +
+                    " (9, '1006', 21, '1001')," +
+                    " (13, '1007', 33, '1002')," +
+                    " (17, '1008', 37, '1002')", tableName));
+
+            assertQuery(session, "select min(v1), max(v1), count(v2), min(a), max(a) from " + tableName, "values(1, 17, 8, 2, 37)");
+            assertPlan(session, "select min(v1), max(v1), count(v2), min(a), max(a) from " + tableName,
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of(
+                                    "min(v1)", expression("1"),
+                                    "max(v1)", expression("17"),
+                                    "count(v2)", expression("8"),
+                                    "min(a)", expression("2"),
+                                    "max(a)", expression("37")),
+                            anyTree(values()))));
+
+            // Push down aggregations for query with filter which can be thoroughly pushed down
+            assertQuery(session, format("select min(v1), max(v1), count(v2), min(a), max(a) from %s where b > '1001'", tableName),
+                    "values(3, 17, 4, 6, 37)");
+            assertPlan(session, format("select min(v1), max(v1), count(v2), min(a), max(a) from %s where b > '1001'", tableName),
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of(
+                                    "min(v1)", expression("3"),
+                                    "max(v1)", expression("17"),
+                                    "count(v2)", expression("4"),
+                                    "min(a)", expression("6"),
+                                    "max(a)", expression("37")),
+                            anyTree(values()))));
+
+            // Couldn't push down aggregations for query with filter which cannot be thoroughly pushed down
+            assertQuery(session, format("select min(v1), count(v2), max(a) from %s where v2 > '1004'", tableName),
+                    "values(5, 4, 37)");
+            assertPlan(session, format("select min(v1), count(v2), max(a) from %s where v2 > '1004'", tableName),
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_min", functionCall("min", ImmutableList.of("partial_min")),
+                                            "final_count", functionCall("count", ImmutableList.of("partial_count")),
+                                            "final_max", functionCall("max", ImmutableList.of("partial_max"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_min", functionCall("min", ImmutableList.of("v1")),
+                                                                    "partial_count", functionCall("count", ImmutableList.of("v2")),
+                                                                    "partial_max", functionCall("max", ImmutableList.of("a"))),
+                                                            PARTIAL,
+                                                            anyTree(strictTableScan(tableName, identityMap("v1", "v2", "a")))))))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregationPushDownOptimizerWithDeletion()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            queryRunner.execute(format("create table %s(v1 int, v2 varchar, a int, b varchar)" +
+                    " with(partitioning = ARRAY['a', 'b'])", tableName));
+            queryRunner.execute(format("insert into %s values" +
+                    " (1, '1001', 5, '1001')," +
+                    " (2, '1002', 2, '1001')," +
+                    " (3, '1003', 9, '1002')," +
+                    " (4, '1004', 6, '1002')", tableName));
+            queryRunner.execute(format("insert into %s values" +
+                    " (5, '1005', 19, '1001')," +
+                    " (9, '1006', 21, '1001')," +
+                    " (13, '1007', 33, '1002')," +
+                    " (17, '1008', 37, '1002')", tableName));
+
+            // Push down aggregations for query on Iceberg table with metadata deletions
+            assertUpdate(format("delete from %s where b = '1001'", tableName), 4);
+            assertQuery(session, "select min(v1), max(v1), count(v2), min(a), max(a) from " + tableName, "values(3, 17, 4, 6, 37)");
+            assertPlan(session, "select min(v1), max(v1), count(v2), min(a), max(a) from " + tableName,
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of(
+                                    "min(v1)", expression("3"),
+                                    "max(v1)", expression("17"),
+                                    "count(v2)", expression("4"),
+                                    "min(a)", expression("6"),
+                                    "max(a)", expression("37")),
+                            anyTree(values()))));
+
+            // Couldn't push down aggregations for query on Iceberg table with delete files
+            assertUpdate(format("delete from %s where v1 < 4", tableName), 1);
+            assertPlan(session, "select min(v1), count(v2), max(a) from " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_min", functionCall("min", ImmutableList.of("partial_min")),
+                                            "final_count", functionCall("count", ImmutableList.of("partial_count")),
+                                            "final_max", functionCall("max", ImmutableList.of("partial_max"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_min", functionCall("min", ImmutableList.of("v1")),
+                                                                    "partial_count", functionCall("count", ImmutableList.of("v2")),
+                                                                    "partial_max", functionCall("max", ImmutableList.of("a"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("v1", "v2", "a"))))))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testDifferentDataTypesAggregatePushDown()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            String createTable =
+                    "CREATE TABLE %s (id BIGINT, int_data INTEGER, boolean_data BOOLEAN, float_data REAL, double_data DOUBLE, "
+                            + "decimal_data DECIMAL(14, 2), binary_data varbinary) WITH (partitioning = ARRAY['id'])";
+            queryRunner.execute(format(createTable, tableName));
+            assertUpdate(format("INSERT INTO %s VALUES "
+                    + "(1, null, false, null, null, 11.11, X'1111'),"
+                    + " (1, null, true, 2.222, 2.222222, 22.22, X'2222'),"
+                    + " (2, 33, false, 3.333, 3.333333, 33.33, X'3333'),"
+                    + " (2, 44, true, null, 4.444444, 44.44, X'4444'),"
+                    + " (3, 55, false, 5.555, 5.555555, 55.55, X'5555'),"
+                    + " (3, null, true, null, 6.666666, 66.66, null) ", tableName), 6);
+
+            @Language("SQL") String select =
+                    "SELECT count(*), max(id), min(id), count(id), "
+                            + "max(int_data), min(int_data), count(int_data), "
+                            + "max(boolean_data), min(boolean_data), count(boolean_data), "
+                            + "max(float_data), min(float_data), count(float_data), "
+                            + "max(double_data), min(double_data), count(double_data), "
+                            + "max(decimal_data), min(decimal_data), count(decimal_data), "
+                            + "max(binary_data), min(binary_data), count(binary_data)"
+                            + " FROM " + tableName;
+
+            ImmutableMap.Builder<String, ExpressionMatcher> assignmentsBuilder = ImmutableMap.<String, ExpressionMatcher>builder()
+                    .put("count", expression("6"))
+                    .put("max(id)", expression("3"))
+                    .put("min(id)", expression("1"))
+                    .put("max(int_data)", expression("55"))
+                    .put("min(int_data)", expression("33"))
+                    .put("count_2", expression("3"))
+                    .put("max(boolean_data)", expression("true"))
+                    .put("min(boolean_data)", expression("false"))
+                    .put("max(float_data)", expression("REAL '5.555'"))
+                    .put("min(float_data)", expression("REAL '2.222'"))
+                    .put("max(double_data)", expression("DOUBLE '6.666666'"))
+                    .put("min(double_data)", expression("DOUBLE '2.222222'"))
+                    .put("max(decimal_data)", expression("DECIMAL '66.66'"))
+                    .put("min(decimal_data)", expression("DECIMAL '11.11'"))
+                    .put("max(binary_data)", expression("X'55 55'"))
+                    .put("min(binary_data)", expression("X'11 11'"))
+                    .put("count_3", expression("5"));
+            assertPlan(session, select,
+                    anyNot(AggregationNode.class, strictProject(
+                            assignmentsBuilder.build(),
+                            anyTree(values()))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testDateAndTimestampWithPartition()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = Session.builder(getSession())
+                .setSystemProperty(LEGACY_TIMESTAMP, "false")
+                .build();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id bigint, data varchar, d date, ts timestamp) with(partitioning = ARRAY['id'])", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, '1', date '2021-11-10', null),"
+                            + "(1, '2', date '2021-11-11', timestamp '2021-11-11 22:22:22'), "
+                            + "(2, '3', date '2021-11-12', timestamp '2021-11-12 22:22:22'), "
+                            + "(2, '4', date '2021-11-13', timestamp '2021-11-13 22:22:22'), "
+                            + "(3, '5', null, timestamp '2021-11-14 22:22:22'), "
+                            + "(3, '6', date '2021-11-14', null)",
+                    tableName), 6);
+            assertQuery(session, "select max(ts), max(data) from " + tableName, "values(timestamp '2021-11-14 22:22:22', '6')");
+            assertQuery(session, "select max(ts) from " + tableName, "values(timestamp '2021-11-14 22:22:22')");
+
+            @Language("SQL") String select = "SELECT max(d), min(d), count(d), max(ts), min(ts), count(ts) FROM " + tableName;
+            ImmutableMap.Builder<String, ExpressionMatcher> assignmentsBuilder = ImmutableMap.<String, ExpressionMatcher>builder()
+                    .put("count", expression("5"))
+                    .put("max(d)", expression("DATE '2021-11-14'"))
+                    .put("min(d)", expression("DATE '2021-11-10'"))
+                    .put("max(ts)", expression("TIMESTAMP '2021-11-14 22:22:22.000'"))
+                    .put("min(ts)", expression("TIMESTAMP '2021-11-11 22:22:22.000'"))
+                    .put("count_2", expression("4"));
+            assertPlan(session, select,
+                    anyNot(AggregationNode.class, strictProject(
+                            assignmentsBuilder.build(),
+                            anyTree(values()))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregateNotPushDownIfOneCantPushDown()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id bigint, data double)", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, 1111), (1, 2222), (2, 3333), (2, 4444), (3, 5555), (3, 6666) ", tableName), 6);
+            assertPlan(session, "SELECT COUNT(data), SUM(data) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count")),
+                                            "final_sum", functionCall("sum", ImmutableList.of("partial_sum"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of("data")),
+                                                                    "partial_sum", functionCall("sum", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("data"))))))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregateNotPushDownForCountDistinct()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id bigint, data double)", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, 1111), (1, 2222), (2, 3333), (2, 4444), (3, 5555), (3, 6666) ", tableName), 6);
+            assertPlan(session, "SELECT COUNT(distinct id) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of("id"))),
+                                                            PARTIAL,
+                                                            anyTree(strictTableScan(tableName, identityMap("id")))))))));
+            assertQuery(session, "SELECT COUNT(distinct id) FROM " + tableName, "VALUES(3)");
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregatePushDownWithMetricsMode()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String schemaName = session.getSchema().get();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id bigint, data double)", tableName));
+            queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
+                    schemaName, tableName, TableProperties.DEFAULT_WRITE_METRICS_MODE, "none"));
+            queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
+                    schemaName, tableName, TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id", "counts"));
+            queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
+                    schemaName, tableName, TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "data", "none"));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, 1111), (1, 2222), (2, 3333), (2, 4444), (3, 5555), (3, 6666) ", tableName), 6);
+            assertPlan(session, "SELECT COUNT(data) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("data"))))))));
+
+            assertPlan(session, "SELECT COUNT(id) FROM " + tableName,
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of("count", expression("6")),
+                            anyTree(values()))));
+
+            assertPlan(session, "SELECT COUNT(id), MAX(id) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count")),
+                                            "final_max", functionCall("max", ImmutableList.of("partial_max"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of("id")),
+                                                                    "partial_max", functionCall("max", ImmutableList.of("id"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("id"))))))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregateNotPushDownForVarcharType()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String schemaName = session.getSchema().get();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id bigint, data varchar)", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, '1111'), (1, '2222'), (2, '3333'), (2, '4444'), (3, '5555'), (3, '6666') ",
+                    tableName), 6);
+            assertPlan(session, "SELECT MAX(id), MAX(data) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_max_id", functionCall("max", ImmutableList.of("partial_max_id")),
+                                            "final_max_data", functionCall("max", ImmutableList.of("partial_max_data"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_max_id", functionCall("max", ImmutableList.of("id")),
+                                                                    "partial_max_data", functionCall("max", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("id", "data"))))))));
+
+            assertPlan(session, "SELECT COUNT(data) FROM " + tableName,
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of("count", expression("6")),
+                            anyTree(values()))));
+
+            queryRunner.execute(format("call system.set_table_property('%s', '%s', '%s', '%s')",
+                    schemaName, tableName, TableProperties.DEFAULT_WRITE_METRICS_MODE, "full"));
+            assertPlan(session, "SELECT COUNT(data), MAX(data) FROM " + tableName,
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of("count", expression("6"),
+                                    "max", expression("6666")),
+                            anyTree(values()))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregatePushDownWithDataFilter()
+    {
+        testAggregatePushDownWithFilter(false);
+    }
+
+    @Test
+    public void testAggregatePushDownWithPartitionFilter()
+    {
+        testAggregatePushDownWithFilter(true);
+    }
+
+    private void testAggregatePushDownWithFilter(boolean partitionFilerOnly)
+    {
+        String createTable;
+        if (!partitionFilerOnly) {
+            createTable = "CREATE TABLE %s (id BIGINT, data INTEGER)";
+        }
+        else {
+            createTable = "CREATE TABLE %s (id BIGINT, data INTEGER) WITH (PARTITIONING = ARRAY['id'])";
+        }
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format(createTable, tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES"
+                            + " (1, 11), (1, 22), (2, 33),"
+                            + " (2, 44), (3, 55), (3, 66) ",
+                    tableName), 6);
+
+            @Language("SQL") String select = format("SELECT MIN(data) FROM %s WHERE id > 1", tableName);
+
+            if (!partitionFilerOnly) {
+                assertPlan(session, select,
+                        anyTree(
+                                aggregation(ImmutableMap.of("final_min", functionCall("min", ImmutableList.of("partial_min"))),
+                                        FINAL,
+                                        exchange(LOCAL, GATHER,
+                                                exchange(REMOTE_STREAMING, GATHER,
+                                                        aggregation(
+                                                                ImmutableMap.of("partial_min", functionCall("min", ImmutableList.of("data"))),
+                                                                PARTIAL,
+                                                                anyTree(strictTableScan(tableName, identityMap("id", "data")))))))));
+            }
+            else {
+                assertPlan(session, select,
+                        anyNot(AggregationNode.class, strictProject(
+                                ImmutableMap.of("min", expression("33")),
+                                anyTree(values()))));
+            }
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregateWithComplexType()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id INTEGER, complex ROW(c1 INTEGER, c2 VARCHAR))", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES(1, ROW(3, 'v1')), (2, ROW(2, 'v2'))", tableName), 2);
+
+            // count not pushed down for complex types
+            assertPlan(session, "SELECT count(complex), count(id) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count_complex", functionCall("count", ImmutableList.of("partial_count_complex")),
+                                            "final_count_id", functionCall("count", ImmutableList.of("partial_count_id"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count_complex", functionCall("count", ImmutableList.of("complex")),
+                                                                    "partial_count_id", functionCall("count", ImmutableList.of("id"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("id", "complex"))))))));
+
+            // max not pushed down for complex types
+            assertPlan(session, "SELECT max(complex) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_max", functionCall("max", ImmutableList.of("partial_max"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_max", functionCall("max", ImmutableList.of("complex"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("complex"))))))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAggregatePushDownForTimeTravel()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id BIGINT, data INTEGER)", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, 1111), (1, 2222), (2, 3333), (2, 4444), (3, 5555), (3, 6666) ",
+                    tableName), 6);
+            long snapshotId = (long) queryRunner.execute(session, format("SELECT snapshot_id FROM \"%s$snapshots\" order by committed_at desc limit 1", tableName))
+                    .getOnlyValue();
+
+            assertUpdate(session, format("INSERT INTO %s VALUES (4, 7777), (5, 8888)", tableName), 2);
+
+            // count pushed down
+            assertPlan(session, format("SELECT count(id) FROM %s FOR VERSION AS OF %s", tableName, snapshotId),
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of("count", expression("6")),
+                            anyTree(values()))));
+
+            // count pushed down
+            assertPlan(session, format("SELECT count(id) FROM %s", tableName),
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of("count", expression("8")),
+                            anyTree(values()))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAllNull()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id BIGINT, data INTEGER) WITH(PARTITIONING = ARRAY['id'])", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES "
+                            + "(1, null), (1, null), (2, null), "
+                            + "(2, null), (3, null), (3, null)",
+                    tableName), 6);
+
+            assertPlan(session, format("SELECT count(*), max(data), min(data), count(data) FROM %s", tableName),
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of(
+                                    "count_1", expression("6"),
+                                    "min_max", nullExpression(INTEGER),
+                                    "count_2", expression("0")),
+                            anyTree(values()))));
+            MaterializedResult result = queryRunner.execute(session, format("SELECT count(*), max(data), min(data), count(data) FROM %s", tableName));
+            assertEquals(result.getMaterializedRows().size(), 1);
+            assertEquals(result.getMaterializedRows().get(0), new MaterializedRow(DEFAULT_PRECISION, 6L, null, null, 0L));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testAllNaN()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id INTEGER, data REAL) WITH(PARTITIONING = ARRAY['id'])", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES "
+                            + "(1, cast(nan() as real)), (1, cast(nan() as real)), (2, cast(nan() as real)), "
+                            + "(2, cast(nan() as real)), (3, cast(nan() as real)), (3, cast(nan() as real))",
+                    tableName), 6);
+
+            assertPlan(session, "SELECT count(*), max(data), min(data), count(data) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count")),
+                                            "final_max_data", functionCall("max", ImmutableList.of("partial_max_data")),
+                                            "final_min_data", functionCall("min", ImmutableList.of("partial_min_data")),
+                                            "final_count_data", functionCall("count", ImmutableList.of("partial_count_data"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of()),
+                                                                    "partial_max_data", functionCall("max", ImmutableList.of("data")),
+                                                                    "partial_min_data", functionCall("min", ImmutableList.of("data")),
+                                                                    "partial_count_data", functionCall("count", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("data"))))))));
+            MaterializedResult result = queryRunner.execute(session, "SELECT count(*), max(data), min(data), count(data) FROM " + tableName);
+            assertEquals(result.getMaterializedRows().size(), 1);
+            assertEquals(result.getMaterializedRows().get(0), new MaterializedRow(DEFAULT_PRECISION, 6L, NaN, NaN, 6L));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testNaN()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id INTEGER, data REAL) WITH(PARTITIONING = ARRAY['id'])", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES "
+                            + "(1, cast(nan() as real)), (1, cast(nan() as real)), (2, 2), "
+                            + "(2, cast(nan() as real)), (3, cast(nan() as real)), (3, 1)",
+                    tableName), 6);
+
+            assertPlan(session, "SELECT count(*), max(data), min(data), count(data) FROM " + tableName,
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count")),
+                                            "final_max_data", functionCall("max", ImmutableList.of("partial_max_data")),
+                                            "final_min_data", functionCall("min", ImmutableList.of("partial_min_data")),
+                                            "final_count_data", functionCall("count", ImmutableList.of("partial_count_data"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of()),
+                                                                    "partial_max_data", functionCall("max", ImmutableList.of("data")),
+                                                                    "partial_min_data", functionCall("min", ImmutableList.of("data")),
+                                                                    "partial_count_data", functionCall("count", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("data"))))))));
+            MaterializedResult result = queryRunner.execute(session, "SELECT count(*), max(data), min(data), count(data) FROM " + tableName);
+            assertEquals(result.getMaterializedRows().size(), 1);
+            assertEquals(result.getMaterializedRows().get(0), new MaterializedRow(DEFAULT_PRECISION, 6L, NaN, 1.0F, 6L));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testInfinity()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(session, format("CREATE TABLE %s (id integer, data1 real, data2 double, data3 double) WITH(PARTITIONING = ARRAY['id'])", tableName));
+            assertUpdate(session, format("INSERT INTO %s VALUES (1, cast(-infinity() as real), infinity(), 1.23), "
+                            + "(1, cast(-infinity() as real), infinity(), -1.23), "
+                            + "(1, cast(-infinity() as real), infinity(), infinity()), "
+                            + "(1, cast(-infinity() as real), infinity(), 2.23), "
+                            + "(1, cast(-infinity() as real), infinity(), -infinity()), "
+                            + "(1, cast(-infinity() as real), infinity(), -2.23)",
+                    tableName), 6);
+            @Language("SQL") String select = "SELECT count(*), max(data1), min(data1), count(data1), max(data2), min(data2), " +
+                    "count(data2), max(data3), min(data3), count(data3) FROM " + tableName;
+            assertPlan(session, select,
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of(
+                                    "count", expression("6"),
+                                    "min_max_real", expression("real '-Infinity'"),
+                                    "max_double", expression("double 'Infinity'"),
+                                    "min_double", expression("double '-Infinity'")),
+                            anyTree(values()))));
+
+            MaterializedResult result = queryRunner.execute(session, select);
+            assertEquals(result.getMaterializedRows().size(), 1);
+            List<Object> fields = result.getMaterializedRows().get(0).getFields();
+            assertEquals(fields.get(0), 6L);
+            assertTrue(Float.isInfinite((Float) fields.get(1)));
+            assertTrue(Float.isInfinite((Float) fields.get(1)));
+            assertEquals(fields.get(3), 6L);
+            assertTrue(Double.isInfinite((Double) fields.get(4)));
+            assertTrue(Double.isInfinite((Double) fields.get(5)));
+            assertEquals(fields.get(6), 6L);
+            assertTrue(Double.isInfinite((Double) fields.get(4)));
+            assertTrue(Double.isInfinite((Double) fields.get(5)));
+            assertEquals(fields.get(9), 6L);
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
         }
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -348,6 +348,59 @@ public class TestIcebergLogicalPlanner
     }
 
     @Test
+    public void testAggregationPushDownOptimizerWithThoroughlyPushedDownFilter()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = getSession();
+        String tableName = "aggregation_push_down_with_filter_" + randomTableSuffix();
+        try {
+            queryRunner.execute(format("create table %s(v1 int, v2 varchar, a int, b varchar)" +
+                    " with(partitioning = ARRAY['a', 'b'])", tableName));
+            queryRunner.execute(format("insert into %s values" +
+                    " (1, '1001', 5, '1001')," +
+                    " (2, '1002', 2, '1001')," +
+                    " (3, '1003', 9, '1002')," +
+                    " (4, '1004', 6, '1002')", tableName));
+            queryRunner.execute(format("insert into %s values" +
+                    " (5, '1005', 19, '1001')," +
+                    " (9, '1006', 21, '1001')," +
+                    " (13, '1007', 33, '1002')," +
+                    " (17, '1008', 37, '1002')", tableName));
+
+            // Push down aggregations for query on Iceberg table with filters which can be thoroughly pushed down
+            assertQuery(session, "select min(v1), max(v1), count(v2), min(a), max(a) from " + tableName + " where a > 5 and b = '1002'", "values(3, 17, 4, 6, 37)");
+            assertPlan(session, "select min(v1), max(v1), count(v2), min(a), max(a) from " + tableName + " where a > 5 and b = '1002'",
+                    anyNot(AggregationNode.class, strictProject(
+                            ImmutableMap.of(
+                                    "min(v1)", expression("3"),
+                                    "max(v1)", expression("17"),
+                                    "count(v2)", expression("4"),
+                                    "min(a)", expression("6"),
+                                    "max(a)", expression("37")),
+                            anyTree(values()))));
+
+            // Couldn't push down aggregations for query on Iceberg table with filters which cannot be thoroughly pushed down
+            assertPlan(session, "select min(v1), count(v2), max(a) from " + tableName + " where v1 > 4",
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_min", functionCall("min", ImmutableList.of("partial_min")),
+                                            "final_count", functionCall("count", ImmutableList.of("partial_count")),
+                                            "final_max", functionCall("max", ImmutableList.of("partial_max"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_min", functionCall("min", ImmutableList.of("v1")),
+                                                                    "partial_count", functionCall("count", ImmutableList.of("v2")),
+                                                                    "partial_max", functionCall("max", ImmutableList.of("a"))),
+                                                            PARTIAL,
+                                                            filter(strictTableScan(tableName, identityMap("v1", "v2", "a")))))))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
     public void testDifferentDataTypesAggregatePushDown()
     {
         QueryRunner queryRunner = getQueryRunner();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergLogicalPlanner.java
@@ -523,6 +523,33 @@ public class TestIcebergLogicalPlanner
     }
 
     @Test
+    public void testAggregateNotPushDownWhenFilterPushdownEnabled()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session sessionWithFilterPushdown = pushdownFilterEnabled();
+        String tableName = "aggregation_push_down_" + randomTableSuffix();
+        try {
+            assertUpdate(getSession(), format("CREATE TABLE %s (id bigint, data double)", tableName));
+            assertUpdate(getSession(), format("INSERT INTO %s VALUES (1, 1111), (1, 2222), (2, 3333), (2, 4444), (3, 5555), (3, 6666) ", tableName), 6);
+            assertPlan(sessionWithFilterPushdown, "SELECT COUNT(data), MAX(data) FROM " + tableName + " WHERE id > 2",
+                    anyTree(
+                            aggregation(ImmutableMap.of("final_count", functionCall("count", ImmutableList.of("partial_count")),
+                                            "final_max", functionCall("max", ImmutableList.of("partial_max"))),
+                                    FINAL,
+                                    exchange(LOCAL, GATHER,
+                                            exchange(REMOTE_STREAMING, GATHER,
+                                                    aggregation(
+                                                            ImmutableMap.of("partial_count", functionCall("count", ImmutableList.of("data")),
+                                                                    "partial_max", functionCall("max", ImmutableList.of("data"))),
+                                                            PARTIAL,
+                                                            strictTableScan(tableName, identityMap("data"))))))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
     public void testAggregateNotPushDownForCountDistinct()
     {
         QueryRunner queryRunner = getQueryRunner();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -27,9 +27,11 @@ import com.facebook.presto.common.type.SmallintType;
 import com.facebook.presto.common.type.SqlDate;
 import com.facebook.presto.common.type.SqlTime;
 import com.facebook.presto.common.type.SqlTimestamp;
+import com.facebook.presto.common.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.common.type.SqlVarbinary;
 import com.facebook.presto.common.type.TimeType;
 import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
 import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
@@ -156,6 +158,9 @@ public final class LiteralInterpreter
             catch (RuntimeException e) {
                 throw new PrestoException(GENERIC_USER_ERROR, format("'%s' is not a valid timestamp literal", (String) node.getValue()));
             }
+        }
+        if (type instanceof TimestampWithTimeZoneType) {
+            return new SqlTimestampWithTimeZone((long) node.getValue());
         }
         if (type instanceof IntervalDayTimeType) {
             return new SqlIntervalDayTime((long) node.getValue());


### PR DESCRIPTION
## Description

This PR is inspired by the aggregate push down optimization from Spark on Iceberg, which pushes down min/max/count to Iceberg. See: https://github.com/apache/iceberg/pull/5872. After this change, MIN, MAX, COUNT will be calculated on Iceberg side using the statistics info in the manifest file.

For a detailed comparison between this optimization and the existing partition-based metadata optimization strategy, please see: https://github.com/prestodb/presto/pull/22080#issuecomment-1987724878.

Benchmark scenarios:

```
create table iceberg_lineitem with (partitioning = ARRAY['suppkey'])
	as select * from tpch.sf1.lineitem;

-- query count/min/max with aggregate push down disabled
set session iceberg.aggregate_push_down_enabled = false;
select count(*), min(orderkey), max(orderkey), min(commitdate), max(commitdate)
	from iceberg_lineitem;
select count(*), min(orderkey), max(orderkey), min(commitdate), max(commitdate)
	from iceberg_lineitem
	where suppkey > 1000 and suppkey <= 9000;

-- query count/min/max with aggregate push down enabled
set session iceberg.aggregate_push_down_enabled = true;
select count(*), min(orderkey), max(orderkey), min(commitdate), max(commitdate)
	from iceberg_lineitem;
select count(*), min(orderkey), max(orderkey), min(commitdate), max(commitdate)
	from iceberg_lineitem
	where suppkey > 1000 and suppkey <= 9000;
```

Benchmark result:

```
Benchmark                                                                   Mode  Cnt     Score     Error  Units
BenchmarkIcebergAggregatePushDown.aggregatePushDownDisabledQuery            avgt   10  1497.229 ± 557.160  ms/op
BenchmarkIcebergAggregatePushDown.aggregatePushDownDisabledQueryWithFilter  avgt   10  1273.857 ± 488.978  ms/op
BenchmarkIcebergAggregatePushDown.aggregatePushDownEnabledQuery             avgt   10    60.886 ±   3.636  ms/op
BenchmarkIcebergAggregatePushDown.aggregatePushDownEnabledQueryWithFilter   avgt   10    88.560 ±   1.729  ms/op
```

## Motivation and Context

Fix issue: #21885 

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Iceberg Connector Changes
 * Add support for ``min/max/count`` aggregation push down based on file stats.
    This can be toggled with the ``aggregate_push_down_enabled`` session property
    or the ``iceberg.aggregate-push-down-enabled`` configuration property.
```