### PR TITLE
fix(build): Undefined Iceberg* symbols

### DIFF
--- a/presto-native-execution/presto_cpp/main/tool/trace/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tool/trace/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(
   velox_exec
   velox_exec_test_lib
   velox_hive_connector
+  velox_hive_iceberg_splitreader
   velox_query_trace_replayer_base
   gtest
   gtest_main

--- a/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/types/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   velox_dwio_common
   velox_dwio_orc_reader
   velox_hive_connector
+  velox_hive_iceberg_splitreader
   velox_tpch_connector
   velox_tpcds_connector
   velox_exec
@@ -70,6 +71,7 @@ target_link_libraries(
   velox_functions_prestosql
   velox_presto_type_parser
   velox_hive_connector
+  velox_hive_iceberg_splitreader
   velox_tpch_connector
   velox_type
   Boost::filesystem
@@ -123,6 +125,7 @@ target_link_libraries(
   velox_dwio_common
   velox_exec_test_lib
   velox_hive_connector
+  velox_hive_iceberg_splitreader
   velox_tpch_connector
   GTest::gtest
   GTest::gtest_main


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Fix build break.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Build:
- Link the velox_hive_iceberg_splitreader library into various native execution and trace test binaries to fix build-time undefined symbol errors.