### PR TITLE
feat: Add try_function_catchable_errors session property

### DIFF
--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -618,6 +618,15 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kAggregationCompactionUnusedMemoryRatio,
       std::to_string(c.aggregationCompactionUnusedMemoryRatio()));
+
+  addSessionProperty(
+      kTryFunctionCatchableErrors,
+      "Comma-separated list of error code names that TRY() should catch and "
+      "return NULL for. If empty (default), TRY() catches all user errors.",
+      VARCHAR(),
+      false,
+      QueryConfig::kTryCatchableErrorCodes,
+      c.tryCatchableErrorCodes());
 }
 
 const std::string SessionProperties::toVeloxConfig(

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -401,6 +401,11 @@ class SessionProperties {
   static constexpr const char* kAggregationCompactionUnusedMemoryRatio =
       "native_aggregation_compaction_unused_memory_ratio";
 
+  /// Comma-separated list of error code names that TRY() should catch and
+  /// return NULL for. If empty (default), TRY() catches all user errors.
+  static constexpr const char* kTryFunctionCatchableErrors =
+      "try_function_catchable_errors";
+
   inline bool hasVeloxConfig(const std::string& key) {
     auto sessionProperty = sessionProperties_.find(key);
     if (sessionProperty == sessionProperties_.end()) {


### PR DESCRIPTION
Summary:
Add `try_function_catchable_errors` session property in Prestissimo.
This maps to Velox's `try_catchable_error_codes` config to allow users
to specify which error codes TRY() should catch and return NULL for.

This is the C++ counterpart to the Java implementation in:
https://github.com/prestodb/presto/pull/26976

Differential Revision: D92117738

## Summary by Sourcery

New Features:
- Introduce the try_function_catchable_errors session property to configure TRY() catchable error codes in native execution.