### PR TITLE
feat: Add CUBE limitation in Presto docs

### DIFF
--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -229,6 +229,11 @@ is equivalent to::
         (destination_state),
         ());
 
+.. note::
+
+    ``CUBE`` supports at most 30 columns. This is because CUBE generates 2^n
+    grouping sets, and 2^30 (approximately 1 billion) is the practical limit.
+
 .. code-block:: none
 
      origin_state | destination_state | _col0


### PR DESCRIPTION
## Documentation
- Clarify in the SELECT documentation that CUBE is limited to 30 columns (2^30 group sets).

## Motivation and Context
Add CUBE limitation in Presto docs
CUBE Is limited to n=30 (i.e 2^30 sets) and should be documented

https://github.com/prestodb/presto/blob/master/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java#L3913

Issue: https://github.com/prestodb/presto/issues/27096
## Impact
NA

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```


Differential Revision: D92542806