### PR TITLE
misc(native): Minor warning fixes

### DIFF
--- a/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpClient.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<folly::IOBuf> HttpResponse::consumeBody(
   for (auto& iobuf : bodyChain_) {
     const auto length = iobuf->length();
     ::memcpy(curr, iobuf->data(), length);
-    curr = (char*)curr + length;
+    curr = static_cast<char*>(curr) + length;
     iobuf.reset();
   }
   bodyChain_.clear();

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -63,13 +63,13 @@ class AbstractRequestHandler : public proxygen::RequestHandler {
     body_.emplace_back(std::move(body));
   }
 
-  void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override {}
+  void onUpgrade(proxygen::UpgradeProtocol /*proto*/) noexcept override {}
 
   void requestComplete() noexcept override {
     delete this;
   }
 
-  void onError(proxygen::ProxygenError err) noexcept override {
+  void onError(proxygen::ProxygenError /*err*/) noexcept override {
     delete this;
   }
 

--- a/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.cpp
+++ b/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.cpp
@@ -103,7 +103,7 @@ void InternalAuthenticationFilter::onError(
   delete this;
 }
 
-void InternalAuthenticationFilter::sendGenericErrorResponse(void) {
+void InternalAuthenticationFilter::sendGenericErrorResponse() {
   /// Indicate to upstream an error occurred and make sure
   /// no further forwarding occurs.
   upstream_->onError(proxygen::kErrorUnsupportedExpectation);

--- a/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.h
+++ b/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.h
@@ -47,9 +47,9 @@ class InternalAuthenticationFilter : public proxygen::Filter {
   void onError(proxygen::ProxygenError err) noexcept override;
 
  private:
-  void sendGenericErrorResponse(void);
+  void sendGenericErrorResponse();
 
-  void sendUnauthorizedResponse(void);
+  void sendUnauthorizedResponse();
 
   void processAndVerifyJwt(
       const std::string& token,

--- a/presto-native-execution/presto_cpp/main/http/filters/StatsFilter.h
+++ b/presto-native-execution/presto_cpp/main/http/filters/StatsFilter.h
@@ -46,7 +46,7 @@ class StatsFilterFactory : public proxygen::RequestHandlerFactory {
 
   proxygen::RequestHandler* onRequest(
       proxygen::RequestHandler* handler,
-      proxygen::HTTPMessage* msg) noexcept override {
+      proxygen::HTTPMessage* /*msg*/) noexcept override {
     return new StatsFilter(handler);
   }
 };


### PR DESCRIPTION
Summary:
Fix warnings identified by clang-tidy in the presto_cpp http/ directory:

- Replace C-style cast with static_cast in HttpClient.cpp (HttpResponse::consumeBody)
- Remove C-style `(void)` parameter declarations in InternalAuthenticationFilter (use empty parens instead)
- Comment out unused parameters in AbstractRequestHandler (onUpgrade, onError) and StatsFilterFactory (onRequest) to suppress -Wunused-parameter warnings

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Resolve clang-tidy and compiler warnings in the native HTTP components.

Bug Fixes:
- Fix potential type-safety issue in HttpResponse body consumption by replacing a C-style cast with a C++ static_cast.
- Suppress unused-parameter warnings in HTTP request handlers and filters by marking parameters as intentionally unused.
- Modernize InternalAuthenticationFilter method declarations by removing legacy C-style void parameter lists to satisfy lint checks.