### PR TITLE
misc(native): Decouple HttpServer and HttpClient from SystemConfig singleton

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h
@@ -287,6 +287,7 @@ class PrestoExchangeSource : public velox::exec::ExchangeSource {
   folly::CPUThreadPoolExecutor* const driverExecutor_;
 
   std::shared_ptr<http::HttpClient> httpClient_;
+  http::JwtOptions jwtOptions_;
   RetryState dataRequestRetryState_;
   RetryState abortRetryState_;
   int failedAttempts_;

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -378,6 +378,25 @@ bool SystemConfig::httpServerEnableGzipCompression() const {
   return optionalProperty<bool>(kHttpServerEnableGzipCompression).value();
 }
 
+http::HttpServerStartupOptions SystemConfig::httpServerStartupOptions() const {
+  http::HttpServerStartupOptions options;
+  options.idleTimeoutMs = httpServerIdleTimeoutMs();
+  options.http2InitialReceiveWindow = httpServerHttp2InitialReceiveWindow();
+  options.http2ReceiveStreamWindowSize =
+      httpServerHttp2ReceiveStreamWindowSize();
+  options.http2ReceiveSessionWindowSize =
+      httpServerHttp2ReceiveSessionWindowSize();
+  options.http2MaxConcurrentStreams = httpServerHttp2MaxConcurrentStreams();
+  options.enableContentCompression = httpServerEnableContentCompression();
+  options.contentCompressionLevel = httpServerContentCompressionLevel();
+  options.contentCompressionMinimumSize =
+      httpServerContentCompressionMinimumSize();
+  options.enableZstdCompression = httpServerEnableZstdCompression();
+  options.zstdContentCompressionLevel = httpServerZstdContentCompressionLevel();
+  options.enableGzipCompression = httpServerEnableGzipCompression();
+  return options;
+}
+
 std::string SystemConfig::httpsSupportedCiphers() const {
   return optionalProperty(kHttpsSupportedCiphers).value();
 }
@@ -963,6 +982,20 @@ bool SystemConfig::httpClientConnectionReuseCounterEnabled() const {
       .value();
 }
 
+http::HttpClientOptions SystemConfig::httpClientOptions() const {
+  http::HttpClientOptions options;
+  options.http2Enabled = httpClientHttp2Enabled();
+  options.http2MaxStreamsPerConnection =
+      httpClientHttp2MaxStreamsPerConnection();
+  options.http2InitialStreamWindow = httpClientHttp2InitialStreamWindow();
+  options.http2StreamWindow = httpClientHttp2StreamWindow();
+  options.http2SessionWindow = httpClientHttp2SessionWindow();
+  options.maxAllocateBytes = httpMaxAllocateBytes();
+  options.connectionReuseCounterEnabled =
+      httpClientConnectionReuseCounterEnabled();
+  return options;
+}
+
 std::chrono::duration<double> SystemConfig::exchangeMaxErrorDuration() const {
   return velox::config::toDuration(
       optionalProperty(kExchangeMaxErrorDuration).value());
@@ -1025,6 +1058,17 @@ std::string SystemConfig::internalCommunicationSharedSecret() const {
 int32_t SystemConfig::internalCommunicationJwtExpirationSeconds() const {
   return optionalProperty<int32_t>(kInternalCommunicationJwtExpirationSeconds)
       .value();
+}
+
+http::JwtOptions SystemConfig::jwtOptions() const {
+  http::JwtOptions options;
+  options.jwtEnabled = internalCommunicationJwtEnabled();
+  if (options.jwtEnabled) {
+    options.sharedSecret = internalCommunicationSharedSecret();
+    options.jwtExpirationSeconds = internalCommunicationJwtExpirationSeconds();
+    options.nodeId = NodeConfig::instance()->nodeId();
+  }
+  return options;
 }
 
 bool SystemConfig::useLegacyArrayAgg() const {

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -17,6 +17,9 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include "presto_cpp/main/http/HttpClientOptions.h" // @manual
+#include "presto_cpp/main/http/HttpServerStartupOptions.h" // @manual
+#include "presto_cpp/main/http/JwtOptions.h" // @manual
 #include "velox/common/config/Config.h"
 
 namespace facebook::presto {
@@ -936,6 +939,8 @@ class SystemConfig : public ConfigBase {
 
   bool httpServerEnableGzipCompression() const;
 
+  http::HttpServerStartupOptions httpServerStartupOptions() const;
+
   /// A list of ciphers (comma separated) that are supported by
   /// server and client. Note Java and folly::SSLContext use different names to
   /// refer to the same cipher. For e.g. TLS_RSA_WITH_AES_256_GCM_SHA384 in Java
@@ -1168,6 +1173,8 @@ class SystemConfig : public ConfigBase {
 
   bool httpClientConnectionReuseCounterEnabled() const;
 
+  http::HttpClientOptions httpClientOptions() const;
+
   std::chrono::duration<double> exchangeMaxErrorDuration() const;
 
   std::chrono::duration<double> exchangeRequestTimeoutMs() const;
@@ -1195,6 +1202,8 @@ class SystemConfig : public ConfigBase {
   std::string internalCommunicationSharedSecret() const;
 
   int32_t internalCommunicationJwtExpirationSeconds() const;
+
+  http::JwtOptions jwtOptions() const;
 
   bool useLegacyArrayAgg() const;
 

--- a/presto-native-execution/presto_cpp/main/functions/remote/client/RestRemoteClient.cpp
+++ b/presto-native-execution/presto_cpp/main/functions/remote/client/RestRemoteClient.cpp
@@ -17,6 +17,7 @@
 #include <folly/Uri.h>
 #include <proxygen/lib/http/HTTPMessage.h>
 
+#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/functions/remote/utils/ContentTypes.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/Memory.h"
@@ -39,6 +40,8 @@ RestRemoteClient::RestRemoteClient(const std::string& url) : url_(url) {
   folly::SocketAddress addr(uri.host().c_str(), uri.port(), true);
 
   evbThread_ = std::make_unique<folly::ScopedEventBaseThread>("rest-client");
+  auto systemConfig = SystemConfig::instance();
+  auto httpClientOptions = systemConfig->httpClientOptions();
   httpClient_ = std::make_shared<http::HttpClient>(
       evbThread_->getEventBase(),
       nullptr,
@@ -47,7 +50,8 @@ RestRemoteClient::RestRemoteClient(const std::string& url) : url_(url) {
       requestTimeoutMs,
       connectTimeoutMs,
       memPool_,
-      nullptr);
+      nullptr,
+      std::move(httpClientOptions));
 }
 
 RestRemoteClient::~RestRemoteClient() {

--- a/presto-native-execution/presto_cpp/main/http/HttpClientOptions.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpClientOptions.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::presto::http {
+
+struct HttpClientOptions {
+  // HTTP/2 transport settings (used in constructor)
+  bool http2Enabled{false};
+  uint32_t http2MaxStreamsPerConnection{8};
+  uint32_t http2InitialStreamWindow{1 << 23};
+  uint32_t http2StreamWindow{1 << 23};
+  uint32_t http2SessionWindow{1 << 26};
+  uint64_t maxAllocateBytes{65536};
+
+  // Metrics settings (used in ResponseHandler)
+  bool connectionReuseCounterEnabled{true};
+};
+
+} // namespace facebook::presto::http

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.cpp
@@ -14,9 +14,9 @@
 
 #include <algorithm>
 
-#include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "presto_cpp/main/http/HttpServer.h"
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::presto::http {
 
@@ -279,14 +279,13 @@ HttpServer::endpoints() const {
 }
 
 void HttpServer::start(
+    HttpServerStartupOptions startupOptions,
     std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>> filters,
     std::function<void(proxygen::HTTPServer* /*server*/)> onSuccess,
     std::function<void(std::exception_ptr)> onError) {
   proxygen::HTTPServerOptions options;
 
-  auto systemConfig = SystemConfig::instance();
-  options.idleTimeout =
-      std::chrono::milliseconds(systemConfig->httpServerIdleTimeoutMs());
+  options.idleTimeout = std::chrono::milliseconds(startupOptions.idleTimeoutMs);
 
   proxygen::RequestHandlerChain handlerFactories;
 
@@ -301,30 +300,24 @@ void HttpServer::start(
   options.handlerFactories = handlerFactories.build();
 
   // HTTP/2 flow control window sizes (configurable)
-  options.initialReceiveWindow =
-      systemConfig->httpServerHttp2InitialReceiveWindow();
-  options.receiveStreamWindowSize =
-      systemConfig->httpServerHttp2ReceiveStreamWindowSize();
+  options.initialReceiveWindow = startupOptions.http2InitialReceiveWindow;
+  options.receiveStreamWindowSize = startupOptions.http2ReceiveStreamWindowSize;
   options.receiveSessionWindowSize =
-      systemConfig->httpServerHttp2ReceiveSessionWindowSize();
+      startupOptions.http2ReceiveSessionWindowSize;
   options.maxConcurrentIncomingStreams =
-      systemConfig->httpServerHttp2MaxConcurrentStreams();
+      startupOptions.http2MaxConcurrentStreams;
   options.h2cEnabled = true;
 
   // Enable HTTP/2 responses compression for better performance
   // Supports both gzip and zstd (zstd preferred when client supports it)
-  options.enableContentCompression =
-      systemConfig->httpServerEnableContentCompression();
-  options.contentCompressionLevel =
-      systemConfig->httpServerContentCompressionLevel();
+  options.enableContentCompression = startupOptions.enableContentCompression;
+  options.contentCompressionLevel = startupOptions.contentCompressionLevel;
   options.contentCompressionMinimumSize =
-      systemConfig->httpServerContentCompressionMinimumSize();
-  options.enableZstdCompression =
-      systemConfig->httpServerEnableZstdCompression();
+      startupOptions.contentCompressionMinimumSize;
+  options.enableZstdCompression = startupOptions.enableZstdCompression;
   options.zstdContentCompressionLevel =
-      systemConfig->httpServerZstdContentCompressionLevel();
-  options.enableGzipCompression =
-      systemConfig->httpServerEnableGzipCompression();
+      startupOptions.zstdContentCompressionLevel;
+  options.enableGzipCompression = startupOptions.enableGzipCompression;
 
   // CRITICAL: Add Thrift content-types for Presto task updates
   // By default, proxygen only compresses text/* and some application/* types

--- a/presto-native-execution/presto_cpp/main/http/HttpServer.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServer.h
@@ -20,6 +20,7 @@
 #include <wangle/ssl/SSLContextConfig.h>
 #include "presto_cpp/external/json/nlohmann/json.hpp"
 #include "presto_cpp/main/http/HttpConstants.h"
+#include "presto_cpp/main/http/HttpServerStartupOptions.h" // @manual
 
 namespace facebook::presto::http {
 
@@ -288,6 +289,7 @@ class HttpServer {
       std::unique_ptr<HttpsConfig> httpsConfig = nullptr);
 
   void start(
+      HttpServerStartupOptions startupOptions = {},
       std::vector<std::unique_ptr<proxygen::RequestHandlerFactory>> filters =
           {},
       std::function<void(proxygen::HTTPServer* /*server*/)> onSuccess = nullptr,

--- a/presto-native-execution/presto_cpp/main/http/HttpServerStartupOptions.h
+++ b/presto-native-execution/presto_cpp/main/http/HttpServerStartupOptions.h
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::presto::http {
+
+struct HttpServerStartupOptions {
+  uint32_t idleTimeoutMs{60'000};
+  uint32_t http2InitialReceiveWindow{1 << 20};
+  uint32_t http2ReceiveStreamWindowSize{1 << 20};
+  uint32_t http2ReceiveSessionWindowSize{10 * (1 << 20)};
+  uint32_t http2MaxConcurrentStreams{100};
+  bool enableContentCompression{false};
+  uint32_t contentCompressionLevel{4};
+  uint32_t contentCompressionMinimumSize{3584};
+  bool enableZstdCompression{false};
+  uint32_t zstdContentCompressionLevel{8};
+  bool enableGzipCompression{false};
+};
+
+} // namespace facebook::presto::http

--- a/presto-native-execution/presto_cpp/main/http/JwtOptions.h
+++ b/presto-native-execution/presto_cpp/main/http/JwtOptions.h
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace facebook::presto::http {
+
+struct JwtOptions {
+  bool jwtEnabled{false};
+  std::string sharedSecret;
+  int32_t jwtExpirationSeconds{300};
+  std::string nodeId;
+};
+
+} // namespace facebook::presto::http

--- a/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.cpp
+++ b/presto-native-execution/presto_cpp/main/http/filters/InternalAuthenticationFilter.cpp
@@ -154,11 +154,11 @@ void InternalAuthenticationFilter::processAndVerifyJwt(
     }
     // Passed the verification, move the message along.
     Filter::onRequest(std::move(msg));
-  } catch (const jwt::error::token_verification_exception& e) {
+  } catch (const jwt::error::token_verification_exception&) {
     sendUnauthorizedResponse();
-  } catch (const jwt::error::signature_verification_exception& e) {
+  } catch (const jwt::error::signature_verification_exception&) {
     sendUnauthorizedResponse();
-  } catch (const std::system_error& e) {
+  } catch (const std::system_error&) {
     sendGenericErrorResponse();
   }
 #endif // PRESTO_ENABLE_JWT

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpJwtTest.cpp
@@ -104,8 +104,10 @@ class HttpJwtTestSuite : public ::testing::TestWithParam<bool> {
     auto [reqPromise, reqFuture] = folly::makePromiseContract<bool>();
     request->requestPromise = std::move(reqPromise);
 
+    auto jwtOpts = systemConfig->jwtOptions();
+
     auto responseFuture =
-        sendGet(client.get(), "/async/msg", sendDelayMs, "TestBody");
+        sendGet(client.get(), "/async/msg", sendDelayMs, "TestBody", jwtOpts);
 
     auto serverConfig = jwtSystemConfig(serverSystemConfigOverride);
     auto valuesMap = serverConfig->rawConfigsCopy();
@@ -133,7 +135,7 @@ class HttpJwtTestSuite : public ::testing::TestWithParam<bool> {
 TEST_P(HttpJwtTestSuite, basicJwtTest) {
   const bool useHttps = GetParam();
 
-  auto response = std::move(produceHttpResponse(useHttps));
+  auto response = produceHttpResponse(useHttps);
 
   EXPECT_EQ(response->headers()->getStatusCode(), http::kHttpOk);
 }
@@ -145,8 +147,7 @@ TEST_P(HttpJwtTestSuite, jwtSecretMismatch) {
 
   const bool useHttps = GetParam();
 
-  auto response =
-      std::move(produceHttpResponse(useHttps, {}, serverConfigOverride));
+  auto response = produceHttpResponse(useHttps, {}, serverConfigOverride);
 
   EXPECT_EQ(response->headers()->getStatusCode(), http::kHttpUnauthorized);
 }
@@ -162,8 +163,8 @@ TEST_P(HttpJwtTestSuite, jwtExpiredToken) {
 
   const bool useHttps = GetParam();
 
-  auto response = std::move(
-      produceHttpResponse(useHttps, clientConfigOverride, {}, kSendDelay));
+  auto response =
+      produceHttpResponse(useHttps, clientConfigOverride, {}, kSendDelay);
 
   EXPECT_EQ(response->headers()->getStatusCode(), http::kHttpUnauthorized);
 }
@@ -176,8 +177,7 @@ TEST_P(HttpJwtTestSuite, jwtServerVerificationDisabled) {
 
   const bool useHttps = GetParam();
 
-  auto response =
-      std::move(produceHttpResponse(useHttps, {}, serverConfigOverride));
+  auto response = produceHttpResponse(useHttps, {}, serverConfigOverride);
 
   EXPECT_EQ(response->headers()->getStatusCode(), http::kHttpUnauthorized);
 }
@@ -190,8 +190,7 @@ TEST_P(HttpJwtTestSuite, jwtClientMissingJwt) {
 
   const bool useHttps = GetParam();
 
-  auto response =
-      std::move(produceHttpResponse(useHttps, clientConfigOverride));
+  auto response = produceHttpResponse(useHttps, clientConfigOverride);
 
   EXPECT_EQ(response->headers()->getStatusCode(), http::kHttpUnauthorized);
 }

--- a/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
+++ b/presto-native-execution/presto_cpp/main/http/tests/HttpTest.cpp
@@ -160,7 +160,8 @@ TEST_P(HttpTestSuite, clientIdleSessions) {
         std::chrono::seconds(1),
         std::chrono::milliseconds(0),
         memoryPool,
-        useHttps ? makeSslContext() : nullptr);
+        useHttps ? makeSslContext() : nullptr,
+        http::HttpClientOptions{});
     auto response = sendGet(client.get(), "/ping").get(std::chrono::seconds(3));
     ASSERT_EQ(response->headers()->getStatusCode(), http::kHttpOk);
   }

--- a/presto-native-execution/presto_cpp/main/tests/HttpServerWrapper.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/HttpServerWrapper.cpp
@@ -21,7 +21,7 @@ folly::SemiFuture<folly::SocketAddress> HttpServerWrapper::start() {
   auto [promise, future] = folly::makePromiseContract<folly::SocketAddress>();
   promise_ = std::move(promise);
   serverThread_ = std::make_unique<std::thread>([this]() {
-    server_->start({}, [&](proxygen::HTTPServer* httpServer) {
+    server_->start({}, {}, [&](proxygen::HTTPServer* httpServer) {
       ASSERT_EQ(httpServer->addresses().size(), 1);
       promise_.setValue(httpServer->addresses()[0].address);
     });


### PR DESCRIPTION
Remove direct SystemConfig/NodeConfig singleton access from HttpServer.cpp
and HttpClient.cpp in the presto_http library. Instead, inject configuration
via option structs (HttpServerStartupOptions, HttpClientOptions, JwtOptions)
that callers populate from SystemConfig at construction/call sites.

This decouples the HTTP transport layer from Presto's configuration system,
making the HTTP components independently testable and reusable without
requiring a global SystemConfig singleton to be initialized.

Key changes:
- Add HttpServerStartupOptions struct for HttpServer::start() parameters
- Add HttpClientOptions struct for HttpClient constructor parameters
- Add JwtOptions struct for RequestBuilder JWT configuration
- Move SystemConfig access to caller sites (PrestoServer, PrestoExchangeSource,
  PeriodicServiceInventoryManager, RestRemoteClient)

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Decouple HTTP server/client components from global configuration singletons by injecting configuration via option structs, improving modularity and testability of the HTTP layer.

New Features:
- Introduce HttpClientOptions to configure HTTP client transport, resource limits, and metrics behavior at construction time.
- Introduce JwtOptions to configure request JWT signing on a per-client or per-request basis.
- Introduce HttpServerStartupOptions to configure HTTP server timeouts, HTTP/2 settings, and compression behavior at startup.

Enhancements:
- Move SystemConfig and NodeConfig access out of HttpClient, HttpServer, and RequestBuilder into higher-level callers such as PrestoServer, PrestoExchangeSource, PeriodicServiceInventoryManager, and RestRemoteClient.
- Update HTTP tests and helper wrappers to construct HttpServer and HttpClient with the new option-based interfaces.

Tests:
- Adjust HTTP server and client test utilities and test cases to use the new HttpServerStartupOptions and HttpClientOptions when starting servers and creating clients.

## Summary by Sourcery

Decouple HTTP server/client components and JWT handling from global configuration singletons by injecting configuration via dedicated option structs at construction/startup sites.

New Features:
- Introduce HttpServerStartupOptions to configure HTTP server timeouts, HTTP/2 settings, and compression behavior at startup.
- Introduce HttpClientOptions to configure HTTP client transport limits and metrics behavior at construction time.
- Introduce JwtOptions to configure internal JWT signing per client/request in the HTTP request builder.

Enhancements:
- Move SystemConfig and NodeConfig access for HTTP client, server, and JWT to higher-level callers such as PrestoServer, PrestoExchangeSource, PeriodicServiceInventoryManager, RestRemoteClient, and tests.
- Adjust HTTP utilities and tests to construct HttpServer, HttpClient, and RequestBuilder using the new option-based interfaces.
- Simplify internal authentication error handling by collapsing specific JWT verification exceptions into generic unauthorized/error responses.

Tests:
- Update HTTP client/server and JWT tests and helpers to pass the new options structs when creating clients, servers, and requests.