### PR TITLE
fix(testing): Check both type and data for GenericLiteral in verifier

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestExtractSpatialInnerJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/geospatial/TestExtractSpatialInnerJoin.java
@@ -261,7 +261,7 @@ public class TestExtractSpatialInnerJoin
                 .on(p ->
                         p.filter(
                                 sqlToRowExpression(
-                                        "ST_Distance(a, b) < 5000",
+                                        "ST_Distance(a, b) < BIGINT '5000'",
                                         ImmutableMap.of("a", SPHERICAL_GEOGRAPHY, "b", SPHERICAL_GEOGRAPHY)),
                                 p.join(INNER,
                                         p.values(p.variable("a", SPHERICAL_GEOGRAPHY)),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestLogicalPlanner.java
@@ -1816,6 +1816,30 @@ public class TestLogicalPlanner
                 output(tableScan("orders")));
     }
 
+    @Test
+    public void testInfinityAndNaNExpression()
+    {
+        assertPlan("select nan(), infinity(), cast (nan() as real), cast(infinity() as real)",
+                anyTree(strictProject(
+                        ImmutableMap.of(
+                                "col_1", expression("double 'NaN'"),
+                                "col_2", expression("double 'Infinity'"),
+                                "col_3", expression("real 'NaN'"),
+                                "col_4", expression("real 'Infinity'")),
+                        values())));
+    }
+
+    @Test
+    public void testBigintAndIntegerExpression()
+    {
+        assertPlan("select cast(123 as integer), cast(123 as bigint)",
+                anyTree(strictProject(
+                        ImmutableMap.of(
+                                "col_4", expression("bigint '123'"),
+                                "col_3", expression("integer '123'")),
+                        values())));
+    }
+
     private Session noJoinReordering()
     {
         return Session.builder(this.getQueryRunner().getDefaultSession())

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -424,6 +424,9 @@ public final class RowExpressionVerifier
     @Override
     protected Boolean visitGenericLiteral(GenericLiteral expected, RowExpression actual)
     {
+        if (!expected.getType().equalsIgnoreCase(actual.getType().getTypeSignature().getBase())) {
+            return false;
+        }
         return compareLiteral(expected, actual);
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteRowExpressions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteRowExpressions.java
@@ -211,7 +211,7 @@ public class TestRewriteRowExpressions
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", BIGINT);
                     return p.project(
-                            assignment(a, p.rowExpression("1 + 2")),
+                            assignment(a, p.rowExpression("bigint '1' + 2")),
                             p.values());
                 })
                 .matches(


### PR DESCRIPTION
## Description

Currently, when `UnaliasSymbolReferences` performs mapping and canonicalization to compare expression equality, it validates both the type and value for a `ConstantExpression`. However, in test framework, `RowExpressionVerifier` does not check the type when verifying if an expression equals a `GenericLiteral`—it validates only the value. This inconsistency can cause issues, as demonstrated by the following test case:

```
        assertPlan("select nan(), infinity(), cast (nan() as real), cast(infinity() as real)",
                anyTree(strictProject(
                        ImmutableMap.of(
                                "col_1", expression("double 'NaN'"),
                                "col_2", expression("double 'Infinity'"),
                                "col_3", expression("real 'NaN'"),
                                "col_4", expression("real 'Infinity'")),
                        values())));
```

The test fails with the exception:

```
java.lang.IllegalStateException: Ambiguous expression double 'NaN' matches multiple assignments [NaN, 2143289344]
```

This PR fixes the issue by ensuring `RowExpressionVerifier` checks both the type and data for a `GenericLiteral`, aligning its equality validation with the behavior in the core path.

## Motivation and Context

Fix the issues caused by inconsistency in constant expression equality checking between the test framework and the core path.

## Impact

N/A

## Test Plan

Newly added test cases in `TestLogicalPlanner` to verify the scenario in the PR description

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Align expression verification for generic literals with planner behavior and add coverage for NaN/Infinity and integer/bigint constants.

Bug Fixes:
- Ensure RowExpressionVerifier compares both type and value when matching GenericLiteral expressions to avoid ambiguous matches.

Tests:
- Add logical planner tests covering NaN/Infinity across double and real types.
- Add logical planner test covering bigint vs integer literals in projections.
- Adjust spatial join and rewrite-row-expressions tests to use typed bigint literals for numeric constants.