### PR TITLE
fix: Add createBranch method implementation in StatsRecordingMetadataManager

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManagerStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/MetadataManagerStats.java
@@ -117,6 +117,7 @@ public class MetadataManagerStats
     private final AtomicLong getMetadataResolverCalls = new AtomicLong();
     private final AtomicLong getConnectorCapabilitiesCalls = new AtomicLong();
     private final AtomicLong dropBranchCalls = new AtomicLong();
+    private final AtomicLong createBranchCalls = new AtomicLong();
     private final AtomicLong dropTagCalls = new AtomicLong();
     private final AtomicLong dropConstraintCalls = new AtomicLong();
     private final AtomicLong addConstraintCalls = new AtomicLong();
@@ -225,6 +226,7 @@ public class MetadataManagerStats
     private final TimeStat getMetadataResolverTime = new TimeStat(TimeUnit.NANOSECONDS);
     private final TimeStat getConnectorCapabilitiesTime = new TimeStat(TimeUnit.NANOSECONDS);
     private final TimeStat dropBranchTime = new TimeStat(TimeUnit.NANOSECONDS);
+    private final TimeStat createBranchTime = new TimeStat(TimeUnit.NANOSECONDS);
     private final TimeStat dropTagTime = new TimeStat(TimeUnit.NANOSECONDS);
     private final TimeStat dropConstraintTime = new TimeStat(TimeUnit.NANOSECONDS);
     private final TimeStat addConstraintTime = new TimeStat(TimeUnit.NANOSECONDS);
@@ -1723,6 +1725,12 @@ public class MetadataManagerStats
     {
         dropBranchCalls.incrementAndGet();
         dropBranchTime.add(duration, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordCreateBranchCall(long duration)
+    {
+        createBranchCalls.incrementAndGet();
+        createBranchTime.add(duration, TimeUnit.NANOSECONDS);
     }
 
     public void recordDropTagCall(long duration)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/StatsRecordingMetadataManager.java
@@ -1000,6 +1000,26 @@ public class StatsRecordingMetadataManager
     }
 
     @Override
+    public void createBranch(Session session,
+                      TableHandle tableHandle,
+                      String branchName,
+                      boolean replace,
+                      boolean ifNotExists,
+                      Optional<ConnectorTableVersion> tableVersion,
+                      Optional<Long> retainDays,
+                      Optional<Integer> minSnapshotsToKeep,
+                      Optional<Long> maxSnapshotAgeDays)
+    {
+        long startTime = System.nanoTime();
+        try {
+            delegate.createBranch(session, tableHandle, branchName, replace, ifNotExists, tableVersion, retainDays, minSnapshotsToKeep, maxSnapshotAgeDays);
+        }
+        finally {
+            stats.recordCreateBranchCall(System.nanoTime() - startTime);
+        }
+    }
+
+    @Override
     public void dropTag(Session session, TableHandle tableHandle, String tagName, boolean tagExists)
     {
         long startTime = System.nanoTime();


### PR DESCRIPTION
## Description
Add createBranch method implementation in StatsRecordingMetadataManager
This started failing master build after merging - https://github.com/prestodb/presto/pull/26875 (Since branch support was merged earlier https://github.com/prestodb/presto/pull/26898) 

## Motivation and Context
Build fix

## Impact
Add createBranch method implementation in StatsRecordingMetadataManager
This started failing master build after merging - https://github.com/prestodb/presto/pull/26875 (Since branch support was merged earlier https://github.com/prestodb/presto/pull/26898) 

## Test Plan
NA

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Summary by Sourcery

Bug Fixes:
- Fix master build failure by providing a concrete createBranch implementation in StatsRecordingMetadataManager to match the metadata interface.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```
