### PR TITLE
fix: Query rewriter truncate

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/JsonParseSafetyWrapper.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/JsonParseSafetyWrapper.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.airlift.log.Logger;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Post-processor to fix unsafe json_parse() calls in rewritten queries.
+ * <p>
+ * Problem: Some query rewrites (e.g., typeof() compatibility rewrites) generate
+ * json_parse() calls without TRY() wrappers, causing failures on malformed JSON.
+ * <p>
+ * This utility wraps json_parse() calls with TRY() to handle malformed JSON gracefully.
+ */
+public final class JsonParseSafetyWrapper
+{
+    private JsonParseSafetyWrapper()
+    {
+    }
+
+    private static final Logger log = Logger.get(JsonParseSafetyWrapper.class);
+
+    // Pattern to match json_parse( that is NOT already wrapped in TRY(
+    // Uses negative lookbehind to avoid double-wrapping.
+    // Handles case-insensitive TRY with optional whitespace between TRY and (.
+    private static final Pattern JSON_PARSE_PATTERN = Pattern.compile(
+            "(?<![Tt][Rr][Yy]\\s{0,10}\\(\\s{0,10})\\b(json_parse)\\s*\\(",
+            Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Wraps unsafe json_parse() calls with TRY() to handle malformed JSON.
+     * <p>
+     * Transforms:
+     *   json_extract(json_parse(field), path)
+     * Into:
+     *   json_extract(TRY(json_parse(field)), path)
+     *
+     * @param sql SQL query string that may contain unsafe json_parse() calls
+     * @return Fixed SQL with TRY() wrappers around json_parse()
+     */
+    public static String wrapUnsafeJsonParse(String sql)
+    {
+        if (sql == null || sql.isEmpty()) {
+            return sql;
+        }
+
+        Matcher matcher = JSON_PARSE_PATTERN.matcher(sql);
+        if (!matcher.find()) {
+            return sql;
+        }
+
+        matcher.reset();
+
+        StringBuilder result = new StringBuilder();
+        int lastEnd = 0;
+
+        while (matcher.find()) {
+            // Skip if match is inside a string literal
+            if (isInsideStringLiteral(sql, matcher.start())) {
+                result.append(sql, lastEnd, matcher.end());
+                lastEnd = matcher.end();
+                continue;
+            }
+
+            result.append(sql, lastEnd, matcher.start());
+
+            int parenStart = matcher.end();
+            int closingParen = findMatchingParen(sql, parenStart - 1);
+
+            if (closingParen == -1) {
+                log.warn("Could not find matching parenthesis for json_parse at position %d", matcher.start());
+                result.append(matcher.group());
+                lastEnd = matcher.end();
+                continue;
+            }
+
+            String jsonParseCall = sql.substring(matcher.start(), closingParen + 1);
+            result.append("TRY(").append(jsonParseCall).append(")");
+
+            lastEnd = closingParen + 1;
+        }
+
+        result.append(sql.substring(lastEnd));
+
+        String fixedSql = result.toString();
+
+        if (!fixedSql.equals(sql)) {
+            log.debug("Wrapped json_parse() calls with TRY()");
+        }
+
+        return fixedSql;
+    }
+
+    /**
+     * Finds the matching closing parenthesis for an opening parenthesis.
+     *
+     * @param sql SQL string
+     * @param openParenPos Position of the opening parenthesis
+     * @return Position of matching closing parenthesis, or -1 if not found
+     */
+    private static int findMatchingParen(String sql, int openParenPos)
+    {
+        if (openParenPos < 0 || openParenPos >= sql.length() || sql.charAt(openParenPos) != '(') {
+            return -1;
+        }
+
+        int depth = 1;
+        int pos = openParenPos + 1;
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+
+        while (pos < sql.length() && depth > 0) {
+            char c = sql.charAt(pos);
+
+            // Handle escaped characters by counting consecutive backslashes
+            if (c == '\'' && !inDoubleQuote) {
+                if (!isEscaped(sql, pos)) {
+                    inSingleQuote = !inSingleQuote;
+                }
+            }
+            else if (c == '"' && !inSingleQuote) {
+                if (!isEscaped(sql, pos)) {
+                    inDoubleQuote = !inDoubleQuote;
+                }
+            }
+            else if (!inSingleQuote && !inDoubleQuote) {
+                if (c == '(') {
+                    depth++;
+                }
+                else if (c == ')') {
+                    depth--;
+                }
+            }
+
+            if (depth == 0) {
+                return pos;
+            }
+
+            pos++;
+        }
+
+        return -1;
+    }
+
+    /**
+     * Checks if the character at the given position is escaped by counting
+     * consecutive backslashes before it. An odd number of backslashes means escaped.
+     */
+    private static boolean isEscaped(String sql, int pos)
+    {
+        int backslashCount = 0;
+        int checkPos = pos - 1;
+        while (checkPos >= 0 && sql.charAt(checkPos) == '\\') {
+            backslashCount++;
+            checkPos--;
+        }
+        return backslashCount % 2 == 1;
+    }
+
+    /**
+     * Checks if the given position is inside a string literal (single or double quoted).
+     */
+    private static boolean isInsideStringLiteral(String sql, int pos)
+    {
+        boolean inSingleQuote = false;
+        boolean inDoubleQuote = false;
+
+        for (int i = 0; i < pos && i < sql.length(); i++) {
+            char c = sql.charAt(i);
+            if (c == '\'' && !inDoubleQuote && !isEscaped(sql, i)) {
+                inSingleQuote = !inSingleQuote;
+            }
+            else if (c == '"' && !inSingleQuote && !isEscaped(sql, i)) {
+                inDoubleQuote = !inDoubleQuote;
+            }
+        }
+
+        return inSingleQuote || inDoubleQuote;
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestJsonParseSafetyWrapper.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestJsonParseSafetyWrapper.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.verifier.framework.JsonParseSafetyWrapper.wrapUnsafeJsonParse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestJsonParseSafetyWrapper
+{
+    @Test
+    public void testWrapUnsafeJsonParse()
+    {
+        // Null and empty input
+        assertNull(wrapUnsafeJsonParse(null));
+        assertEquals(wrapUnsafeJsonParse(""), "");
+
+        // No json_parse present - should return unchanged
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT * FROM table1 WHERE id = 1"),
+                "SELECT * FROM table1 WHERE id = 1");
+
+        // Simple json_parse wrapping
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse(column1) FROM table1"),
+                "SELECT TRY(json_parse(column1)) FROM table1");
+
+        // Nested inside another function
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_extract(json_parse(data), '$.key') FROM table1"),
+                "SELECT json_extract(TRY(json_parse(data)), '$.key') FROM table1");
+
+        // Multiple json_parse calls in same query
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse(a), json_parse(b) FROM table1"),
+                "SELECT TRY(json_parse(a)), TRY(json_parse(b)) FROM table1");
+
+        // Already wrapped in TRY - should NOT double-wrap
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT TRY(json_parse(column1)) FROM table1"),
+                "SELECT TRY(json_parse(column1)) FROM table1");
+
+        // Mixed: some wrapped, some not
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT TRY(json_parse(a)), json_parse(b) FROM table1"),
+                "SELECT TRY(json_parse(a)), TRY(json_parse(b)) FROM table1");
+
+        // json_parse with CAST
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT CAST(json_parse(data) AS MAP(VARCHAR, VARCHAR)) FROM table1"),
+                "SELECT CAST(TRY(json_parse(data)) AS MAP(VARCHAR, VARCHAR)) FROM table1");
+
+        // Nested parentheses inside json_parse argument
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse(concat(a, b, (SELECT c FROM t))) FROM table1"),
+                "SELECT TRY(json_parse(concat(a, b, (SELECT c FROM t)))) FROM table1");
+
+        // Case-insensitive json_parse (JSON_PARSE, Json_Parse)
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT JSON_PARSE(data), Json_Parse(data2) FROM table1"),
+                "SELECT TRY(JSON_PARSE(data)), TRY(Json_Parse(data2)) FROM table1");
+
+        // String literal containing parentheses
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse('test(value)') FROM table1"),
+                "SELECT TRY(json_parse('test(value)')) FROM table1");
+
+        // Complex query with multiple json_parse in different clauses
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT a, json_extract(json_parse(data), '$.field'), b FROM table1 WHERE json_parse(filter) IS NOT NULL"),
+                "SELECT a, json_extract(TRY(json_parse(data)), '$.field'), b FROM table1 WHERE TRY(json_parse(filter)) IS NOT NULL");
+
+        // Double-quoted identifier
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse(\"column\") FROM table1"),
+                "SELECT TRY(json_parse(\"column\")) FROM table1");
+
+        // json_parse text inside string literal should NOT be wrapped (only the real function call)
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse(data), 'json_parse(not_a_function)' FROM table1"),
+                "SELECT TRY(json_parse(data)), 'json_parse(not_a_function)' FROM table1");
+
+        // Whitespace between json_parse and opening paren
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse  (  data  ) FROM table1"),
+                "SELECT TRY(json_parse  (  data  )) FROM table1");
+
+        // json_parse in subquery
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT * FROM (SELECT json_parse(data) AS parsed FROM table1) t"),
+                "SELECT * FROM (SELECT TRY(json_parse(data)) AS parsed FROM table1) t");
+
+        // Case-insensitive TRY (lowercase try, mixed case Try) - should NOT double-wrap
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT try(json_parse(column1)) FROM table1"),
+                "SELECT try(json_parse(column1)) FROM table1");
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT Try(json_parse(column1)), TRY(json_parse(column2)) FROM table1"),
+                "SELECT Try(json_parse(column1)), TRY(json_parse(column2)) FROM table1");
+
+        // Whitespace AFTER TRY( before json_parse - should NOT double-wrap
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT TRY( json_parse(column1)) FROM table1"),
+                "SELECT TRY( json_parse(column1)) FROM table1");
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT TRY(   json_parse(column1)) FROM table1"),
+                "SELECT TRY(   json_parse(column1)) FROM table1");
+
+        // Whitespace BETWEEN TRY and ( - should NOT double-wrap
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT TRY (json_parse(column1)) FROM table1"),
+                "SELECT TRY (json_parse(column1)) FROM table1");
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT TRY   (  json_parse(column1)) FROM table1"),
+                "SELECT TRY   (  json_parse(column1)) FROM table1");
+
+        // Escaped backslash in string - should handle correctly
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse('{\"path\": \"c:\\\\\"}') FROM table1"),
+                "SELECT TRY(json_parse('{\"path\": \"c:\\\\\"}')) FROM table1");
+
+        // Escaped quote in string
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse('{\"name\": \"test\\'s value\"}') FROM table1"),
+                "SELECT TRY(json_parse('{\"name\": \"test\\'s value\"}')) FROM table1");
+
+        // Mixed: various TRY variants with whitespace, some wrapped some not
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT TRY( json_parse(a)), json_parse(b), try(json_parse(c)) FROM table1"),
+                "SELECT TRY( json_parse(a)), TRY(json_parse(b)), try(json_parse(c)) FROM table1");
+
+        // Malformed SQL - missing closing paren (graceful degradation, return unchanged)
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse(data"),
+                "SELECT json_parse(data");
+
+        // Malformed SQL - unbalanced parens
+        assertEquals(
+                wrapUnsafeJsonParse("SELECT json_parse((data"),
+                "SELECT json_parse((data");
+    }
+}


### PR DESCRIPTION
Summary:
Some query rewrites (e.g., typeof() compatibility rewrites) generate json_parse() calls without TRY() wrappers, causing skip_control_failures on malformed/truncated JSON strings.

Adds JsonParseSafetyWrapper utility that wraps unprotected json_parse() calls with TRY() as a post-processing step in QueryRewriter. Handles nested parentheses, quoted strings, escaped characters, case-insensitive TRY matching, and whitespace between TRY( and json_parse.

# Releas Notes
```
== NO RELEASE NOTE ==
```

Differential Revision: D92548510

## Summary by Sourcery

Add a post-processing step in the query rewriter to safely wrap json_parse() calls with TRY(), preventing query failures on malformed JSON in rewritten queries.

Bug Fixes:
- Prevent verifier query failures caused by rewritten json_parse() calls on malformed or truncated JSON by wrapping them in TRY().

Enhancements:
- Introduce JsonParseSafetyWrapper utility to detect unsafe json_parse() usages in SQL strings and wrap them in TRY() while handling nesting, quoting, escaping, and whitespace.
- Apply the json_parse safety wrapper to CREATE TABLE AS SELECT, INSERT, and plain SELECT rewrites in QueryRewriter.
- Add logging around failures to apply the json_parse safety wrapper during query rewriting.

Tests:
- Add comprehensive unit tests for JsonParseSafetyWrapper covering multiple json_parse() patterns, nested expressions, case variations, string literals, escaping, and mixed TRY-wrapped and unwrapped calls.