### PR TITLE
misc: Fix RemoveCrossJoinWithConstantInput to use unknown locality

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.ProjectNode.Locality;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
@@ -183,6 +184,11 @@ public class PlannerUtils
 
     public static PlanNode addProjections(PlanNode source, PlanNodeIdAllocator planNodeIdAllocator, Map<VariableReferenceExpression, RowExpression> variableMap)
     {
+        return addProjections(source, planNodeIdAllocator, variableMap, LOCAL);
+    }
+
+    public static PlanNode addProjections(PlanNode source, PlanNodeIdAllocator planNodeIdAllocator, Map<VariableReferenceExpression, RowExpression> variableMap, Locality locality)
+    {
         Assignments.Builder assignments = Assignments.builder();
         for (VariableReferenceExpression variableReferenceExpression : source.getOutputVariables()) {
             assignments.put(variableReferenceExpression, variableReferenceExpression);
@@ -194,7 +200,7 @@ public class PlannerUtils
                 planNodeIdAllocator.getNextId(),
                 source,
                 assignments.build(),
-                LOCAL);
+                locality);
     }
 
     // Add a projection node, which assignment new value if output exists in variableMap, otherwise identity assignment

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveCrossJoinWithConstantInput.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveCrossJoinWithConstantInput.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.SystemSessionProperties.isRemoveCrossJoinWithConstantSingleRowInputEnabled;
+import static com.facebook.presto.spi.plan.ProjectNode.Locality.UNKNOWN;
 import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.google.common.base.Preconditions.checkState;
@@ -103,7 +104,7 @@ public class RemoveCrossJoinWithConstantInput
         if (!mapping.isPresent()) {
             return Result.empty();
         }
-        PlanNode resultNode = addProjections(joinInput, context.getIdAllocator(), mapping.get());
+        PlanNode resultNode = addProjections(joinInput, context.getIdAllocator(), mapping.get(), UNKNOWN);
         if (node.getFilter().isPresent()) {
             resultNode = new FilterNode(node.getSourceLocation(), context.getIdAllocator().getNextId(), resultNode, node.getFilter().get());
         }


### PR DESCRIPTION
## Description
Locality of a project is set in `PlanRemoteProjections` optimizer. `RemoveCrossJoinWithConstantInput` runs before PlanRemoteProjection, and we should not set the project locality to local, it should be unknown and wait for `PlanRemoteProjections` to set it.

## Motivation and Context
As in description

## Impact
Bug fix

## Test Plan
Unit tests

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure projections created when removing cross joins with constant inputs default to unknown locality so later optimizers can determine appropriate locality.

Bug Fixes:
- Prevent RemoveCrossJoinWithConstantInput from forcefully setting project locality to LOCAL by using UNKNOWN instead, allowing PlanRemoteProjections to assign locality correctly.

Enhancements:
- Extend PlannerUtils.addProjections to accept an explicit locality parameter for greater flexibility when constructing ProjectNodes.

Tests:
- Add planner rule tests verifying that ProjectNodes produced by RemoveCrossJoinWithConstantInput (with and without join filters) have UNKNOWN locality.