### PR TITLE
fix(ci): Fix no space error in arrow flight tests

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -70,6 +70,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.297-202601311423-22d722a9
+      volumes:
+        - /usr:/host_usr
+        - /opt:/host_opt
     concurrency:
       group: ${{ github.workflow }}-prestocpp-linux-build-for-test-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -80,6 +83,23 @@ jobs:
     permissions:
       actions: write
     steps:
+      # We cannot use the github action to free disk space from the runner
+      # because we are in the container and not on the runner anymore.
+      - name: Free Disk Space
+        run: |
+          # Re-used from free-disk-space github action.
+          getAvailableSpace() { echo $(df -a $1 | awk 'NR > 1 {avail+=$4} END {print avail}'); }
+          # Show before
+          echo "Original available disk space: " $(getAvailableSpace)
+          # Remove DotNet.
+          rm -rf /host_usr/share/dotnet || true
+          # Remove android
+          rm -rf /host_usr/local/lib/android || true
+          # Remove CodeQL
+          rm -rf /host_opt/hostedtoolcache/CodeQL || true
+          # Show after
+          echo "New available disk space: " $(getAvailableSpace)
+
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -164,6 +184,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.297-202601311423-22d722a9
+      volumes:
+        - /usr:/host_usr
+        - /opt:/host_opt
     env:
       INSTALL_PREFIX: "${{ github.workspace }}/adapter-deps/install"
     strategy:
@@ -178,6 +201,23 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      # We cannot use the github action to free disk space from the runner
+      # because we are in the container and not on the runner anymore.
+      - name: Free Disk Space
+        run: |
+          # Re-used from free-disk-space github action.
+          getAvailableSpace() { echo $(df -a $1 | awk 'NR > 1 {avail+=$4} END {print avail}'); }
+          # Show before
+          echo "Original available disk space: " $(getAvailableSpace)
+          # Remove DotNet.
+          rm -rf /host_usr/share/dotnet || true
+          # Remove android
+          rm -rf /host_usr/local/lib/android || true
+          # Remove CodeQL
+          rm -rf /host_opt/hostedtoolcache/CodeQL || true
+          # Show after
+          echo "New available disk space: " $(getAvailableSpace)
+
       - uses: actions/checkout@v4
         with:
           persist-credentials: false


### PR DESCRIPTION
## Description

https://github.com/prestodb/presto/actions/runs/21840481549/job/63032782954

```
/usr/lib64/libre2.so.9.0.0  /usr/lib64/libgtest.so.1.11.0 && :
/opt/rh/gcc-toolset-12/root/usr/libexec/gcc/x86_64-redhat-linux/12/ld: final link failed: No space left on device
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

## Motivation and Context

## Impact
Github actions

## Test Plan
Test with PR CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Adjust Arrow Flight CI workflow to free disk space in containerized builds to avoid linker failures.

CI:
- Mount host /usr and /opt into the Arrow Flight test container to allow disk space cleanup.
- Add a Free Disk Space step in Arrow Flight CI jobs to remove unnecessary SDKs and tools before building.