### PR TITLE
fix(native): Fix TRY expression handling in NativeExpressionOptimizer

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -301,9 +301,16 @@ public final class FunctionResolution
         return functionAndTypeResolver.lookupFunction("$internal$try", fromTypes(returnType));
     }
 
+    @Override
     public boolean isTryFunction(FunctionHandle functionHandle)
     {
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().getObjectName().equals("$internal$try");
+    }
+
+    @Override
+    public boolean isFailFunction(FunctionHandle functionHandle)
+    {
+        return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().getObjectName().equalsIgnoreCase("fail");
     }
 
     public boolean isJavaBuiltInFailFunction(FunctionHandle functionHandle)

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -101,6 +101,18 @@ const std::unordered_map<std::string, std::string>& veloxToPrestoOperatorMap() {
   return veloxToPrestoOperatorMap;
 }
 
+const std::unordered_map<std::string, std::string>&
+veloxToPrestoInternalFunctionMap() {
+  // Maps Velox internal function names to Presto internal/native function
+  // names used when constructing function signatures.
+  static const std::unordered_map<std::string, std::string>
+      veloxToPrestoInternalFunctionMap = {
+          {"try", "presto.default.$internal$try"},
+          {"try_cast", "presto.default.try_cast"},
+      };
+  return veloxToPrestoInternalFunctionMap;
+}
+
 // If the function name prefix starts from "presto.default", then it is a built
 // in function handle. Otherwise, it is a native function handle.
 std::shared_ptr<protocol::FunctionHandle> getFunctionHandle(
@@ -117,12 +129,12 @@ std::shared_ptr<protocol::FunctionHandle> getFunctionHandle(
     handle->_type = kStatic;
     handle->signature = signature;
     return handle;
-  } else {
-    auto handle = std::make_shared<protocol::NativeFunctionHandle>();
-    handle->_type = kNativeFunctionHandle;
-    handle->signature = signature;
-    return handle;
   }
+
+  auto handle = std::make_shared<protocol::NativeFunctionHandle>();
+  handle->_type = kNativeFunctionHandle;
+  handle->signature = signature;
+  return handle;
 }
 } // namespace
 
@@ -409,34 +421,61 @@ CallExpressionPtr VeloxToPrestoExprConverter::getCallExpression(
   json result;
   result["@type"] = kCall;
   protocol::Signature signature;
-  std::string exprName = expr->name();
+  std::string veloxExprName = expr->name();
+  std::string prestoExprName;
+
+  // Map Velox expression to the right Presto expression name when constructing
+  // the Presto function signature.
   const auto& opMap = veloxToPrestoOperatorMap();
-  auto mapIter = opMap.find(exprName);
+  auto mapIter = opMap.find(veloxExprName);
   if (mapIter != opMap.end()) {
-    exprName = mapIter->second;
+    prestoExprName = mapIter->second;
+  } else {
+    const auto& internalFunctionMap = veloxToPrestoInternalFunctionMap();
+    auto internalMapIter = internalFunctionMap.find(veloxExprName);
+    if (internalMapIter != internalFunctionMap.end()) {
+      prestoExprName = internalMapIter->second;
+    } else {
+      prestoExprName = veloxExprName;
+    }
   }
-  signature.name = exprName;
-  result["displayName"] = exprName;
+
+  signature.name = prestoExprName;
+  result["displayName"] = prestoExprName;
   signature.kind = protocol::FunctionKind::SCALAR;
   signature.typeVariableConstraints = {};
   signature.longVariableConstraints = {};
+  signature.variableArity = false;
   signature.returnType = getTypeSignature(expr->type());
 
   std::vector<protocol::TypeSignature> argumentTypes;
   auto exprInputs = expr->inputs();
   argumentTypes.reserve(exprInputs.size());
-  for (const auto& input : exprInputs) {
-    argumentTypes.emplace_back(getTypeSignature(input->type()));
+  bool isTryExpression = (veloxExprName == velox::expression::kTry);
+  result["arguments"] = json::array();
+  if (isTryExpression) {
+    VELOX_CHECK_EQ(
+        exprInputs.size(),
+        1,
+        "Velox TRY expression should have exactly 1 input, but got {}.",
+        exprInputs.size());
+
+    // Presto '$internal$try' expects a lambda with no arguments: () -> T.
+    // Construct a "function(T)" type signature for the lambda argument.
+    const auto lambdaExpr = std::make_shared<velox::core::LambdaTypedExpr>(
+        velox::ROW({}), exprInputs.at(0));
+    argumentTypes.emplace_back(getTypeSignature(lambdaExpr->type()));
+    result["arguments"].push_back(getLambdaExpression(lambdaExpr.get()));
+  } else {
+    for (const auto& input : exprInputs) {
+      argumentTypes.emplace_back(getTypeSignature(input->type()));
+      result["arguments"].push_back(getRowExpression(input));
+    }
   }
   signature.argumentTypes = argumentTypes;
-  signature.variableArity = false;
 
-  result["functionHandle"] = getFunctionHandle(exprName, signature);
+  result["functionHandle"] = getFunctionHandle(prestoExprName, signature);
   result["returnType"] = getTypeSignature(expr->type());
-  result["arguments"] = json::array();
-  for (const auto& exprInput : exprInputs) {
-    result["arguments"].push_back(getRowExpression(exprInput));
-  }
 
   return result;
 }
@@ -466,9 +505,14 @@ RowExpressionPtr VeloxToPrestoExprConverter::getRowExpression(
     }
     case velox::core::ExprKind::kCast: {
       // Velox CastTypedExpr maps to Presto CallExpression.
+      // Preserve nullOnFailure (isTryCast) so that TryCast round-trips
+      // correctly as "presto.default.try_cast" rather than "cast".
       const auto* castExpr = expr->asUnchecked<velox::core::CastTypedExpr>();
       auto call = std::make_shared<velox::core::CallTypedExpr>(
-          expr->type(), castExpr->inputs(), velox::expression::kCast);
+          expr->type(),
+          castExpr->inputs(),
+          castExpr->isTryCast() ? velox::expression::kTryCast
+                                : velox::expression::kCast);
       return getCallExpression(call.get());
     }
     case velox::core::ExprKind::kCall: {

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUAT
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.newSetFromMap;
 import static java.util.Objects.requireNonNull;
 
@@ -86,7 +87,7 @@ public class NativeExpressionOptimizer
                         return replacement != null
                                 ? toRowExpression(variable.getSourceLocation(), replacement, variable.getType())
                                 : variable;
-                    }),
+                    }, resolution),
                     null));
         }
         if (expressions.isEmpty()) {
@@ -120,8 +121,10 @@ public class NativeExpressionOptimizer
         // Add back in the constants
         replacements.putAll(constants);
 
-        // Replace all the expressions in the original expression with the optimized expressions
-        return toRowExpression(expression.getSourceLocation(), expression.accept(new ReplacingVisitor(replacements), null), expression.getType());
+        // Replace all the expressions in the original expression with the optimized expressions. Perform optimization
+        // to rewrite TRY-wrapping-FAIL sub-expressions into NULLs; since `try` is neither an expression type nor a
+        // function registered in Velox, the sidecar can not perform this optimization.
+        return toRowExpression(expression.getSourceLocation(), expression.accept(new ReplacingVisitor(replacements, resolution), null), expression.getType());
     }
 
     /**
@@ -315,17 +318,25 @@ public class NativeExpressionOptimizer
     private static class ReplacingVisitor
             implements RowExpressionVisitor<RowExpression, Void>
     {
+        private final Map<RowExpression, RowExpression> replacements;
         private final Function<RowExpression, RowExpression> resolver;
+        private final StandardFunctionResolution resolution;
 
-        public ReplacingVisitor(Map<RowExpression, RowExpression> replacements)
+        public ReplacingVisitor(Map<RowExpression, RowExpression> replacements, StandardFunctionResolution resolution)
         {
             requireNonNull(replacements, "replacements is null");
+            requireNonNull(resolution, "resolution is null");
+            this.resolution = resolution;
+            this.replacements = replacements;
             this.resolver = i -> replacements.getOrDefault(i, i);
         }
 
-        public ReplacingVisitor(Function<VariableReferenceExpression, RowExpression> variableResolver)
+        public ReplacingVisitor(Function<VariableReferenceExpression, RowExpression> variableResolver, StandardFunctionResolution resolution)
         {
             requireNonNull(variableResolver, "variableResolver is null");
+            requireNonNull(resolution, "resolution is null");
+            this.resolution = resolution;
+            this.replacements = emptyMap();
             this.resolver = i -> i instanceof VariableReferenceExpression ? variableResolver.apply((VariableReferenceExpression) i) : i;
         }
 
@@ -359,9 +370,19 @@ public class NativeExpressionOptimizer
         @Override
         public RowExpression visitCall(CallExpression call, Void context)
         {
-            if (canBeReplaced(call)) {
-                return resolver.apply(call);
+            if (isTryWrappingFail(call, resolution)) {
+                return toRowExpression(call.getSourceLocation(), null, call.getType());
             }
+
+            if (canBeReplaced(call)) {
+                RowExpression replacement = resolver.apply(call);
+                if (replacements.containsKey(replacement)) {
+                    return replacement;
+                }
+                // Replacement tree can be optimized further, such as rewriting TRY-wrapping-FAIL patterns with NULL.
+                return replacement.accept(this, context);
+            }
+
             List<RowExpression> updatedArguments = call.getArguments().stream()
                     .map(argument -> toRowExpression(argument.getSourceLocation(), argument.accept(this, context), argument.getType()))
                     .collect(toImmutableList());
@@ -372,8 +393,14 @@ public class NativeExpressionOptimizer
         public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
         {
             if (canBeReplaced(specialForm)) {
-                return resolver.apply(specialForm);
+                RowExpression replacement = resolver.apply(specialForm);
+                if (replacements.containsKey(replacement)) {
+                    return replacement;
+                }
+                // Replacement tree can be optimized further, such as rewriting TRY-wrapping-FAIL patterns with NULL.
+                return replacement.accept(this, context);
             }
+
             List<RowExpression> updatedArguments = specialForm.getArguments().stream()
                     .map(argument -> toRowExpression(argument.getSourceLocation(), argument.accept(this, context), argument.getType()))
                     .collect(toImmutableList());
@@ -397,5 +424,44 @@ public class NativeExpressionOptimizer
     public NativeSidecarExpressionInterpreter getRowExpressionInterpreterService()
     {
         return rowExpressionInterpreterService;
+    }
+
+    // This method checks if the given expression is a TRY function that wraps a FAIL function, so it can be optimized
+    // to NULL. Expressions of form 'try(fail(...))' and 'try(cast(fail(...) AS T)' will be optimized to NULL.
+    private static boolean isTryWrappingFail(RowExpression expr, StandardFunctionResolution resolution)
+    {
+        if (!(expr instanceof CallExpression)) {
+            return false;
+        }
+        CallExpression call = (CallExpression) expr;
+
+        if (!resolution.isTryFunction(call.getFunctionHandle()) || call.getArguments().isEmpty()) {
+            return false;
+        }
+
+        RowExpression tryArg = call.getArguments().get(0);
+        if (!(tryArg instanceof LambdaDefinitionExpression)) {
+            return false;
+        }
+        LambdaDefinitionExpression lambdaArg = (LambdaDefinitionExpression) tryArg;
+        RowExpression tryBody = lambdaArg.getBody();
+        if (!(tryBody instanceof CallExpression)) {
+            return false;
+        }
+        CallExpression callArg = (CallExpression) tryBody;
+        if (resolution.isFailFunction(callArg.getFunctionHandle())) {
+            return true;
+        }
+
+        if (resolution.isCastFunction(callArg.getFunctionHandle()) && !callArg.getArguments().isEmpty()) {
+            RowExpression inner = callArg.getArguments().get(0);
+            if (!(inner instanceof CallExpression)) {
+                return false;
+            }
+            CallExpression innerCall = (CallExpression) inner;
+            return resolution.isFailFunction(innerCall.getFunctionHandle());
+        }
+
+        return false;
     }
 }

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -777,6 +777,26 @@ public class TestNativeSidecarPlugin
         assertQueryWithSameQueryRunner(session,
                 "SELECT IF (0 = 0, NULL, ROW(regionkey, 1)) FROM region",
                 "VALUES (NULL), (NULL), (NULL), (NULL), (NULL)");
+
+        // Verify try(failing_function()) returns NULL with try and try_cast.
+        assertQueryWithSameQueryRunner(session, "SELECT TRY(CAST(abs(-1234567890) AS TINYINT))", "SELECT NULL");
+        assertQueryWithSameQueryRunner(session, "SELECT TRY_CAST(abs(-1234567890) AS TINYINT)", "SELECT NULL");
+        assertQueryWithSameQueryRunner(session, "SELECT COALESCE(TRY(CAST(abs(-1234567890) AS TINYINT)), 0)", "SELECT 0");
+        assertQueryWithSameQueryRunner(session, "SELECT COALESCE(TRY_CAST(abs(-1234567890) AS TINYINT), 0)", "SELECT 0");
+        assertQueryWithSameQueryRunner(session, "SELECT TRY(fail(VARCHAR 'error message'))", "SELECT NULL");
+        assertQueryWithSameQueryRunner(session, "SELECT COALESCE(TRY(fail(VARCHAR 'error message')), 1)", "SELECT 1");
+        assertQueryWithSameQueryRunner(session, "SELECT TRY(CAST(TRY(fail(VARCHAR 'error message')) AS BIGINT))", "SELECT NULL");
+        assertQueryWithSameQueryRunner(session, "SELECT COALESCE(TRY(CAST(TRY(fail(VARCHAR 'error message')) AS INTEGER)), 2)", "SELECT 2");
+        /// TODO: Enable test once Varchar(N) is supported in Velox.
+        // assertQueryWithSameQueryRunner(session, "SELECT coalesce(try_cast(clerk AS BIGINT), 456) FROM orders", "SELECT 456 FROM orders");
+
+        // Test TRY with CAST expression.
+        assertQuerySucceeds(session, "SELECT TRY(CAST(orderkey AS TINYINT)) FROM orders");
+        assertQuerySucceeds(session, "SELECT TRY(CAST(comment AS BIGINT)) FROM orders");
+        assertQuerySucceeds(session, "SELECT TRY(CAST(orderkey AS DOUBLE)) FROM orders");
+        assertQuerySucceeds(session, "SELECT TRY_CAST(orderkey AS TINYINT) FROM orders");
+        assertQuerySucceeds(session, "SELECT TRY_CAST(comment AS BIGINT) FROM orders");
+        assertQuerySucceeds(session, "SELECT TRY_CAST(orderkey AS DOUBLE) FROM orders");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -62,6 +62,10 @@ public interface StandardFunctionResolution
 
     FunctionHandle lookupCast(String castType, Type fromType, Type toType);
 
+    boolean isTryFunction(FunctionHandle functionHandle);
+
+    boolean isFailFunction(FunctionHandle functionHandle);
+
     boolean isCountFunction(FunctionHandle functionHandle);
 
     boolean isCountIfFunction(FunctionHandle functionHandle);


### PR DESCRIPTION
## Description

Resolves #27317.

Fixes TRY expression handling in the native sidecar expression optimizer and Velox-to-Presto expression conversion path. When TRY expressions wrap fail() calls or cast-wrapped fail statements, they are not properly converted back to Presto's expected shape after optimization, causing function resolution failures.

## Motivation and Context

In the sidecar execution path with native expression optimization enabled, there are a couple of bugs in the way TRY expressions are handled:

1. TRY is an internal function in Presto but it is a special form expression in Velox that is not registered as a function, and therefore is not registered with the function namespace prefix. The Velox to Presto TRY expression conversion must be mindful of this corner case. from  

2. Presto TRY expressions are converted to Velox equivalent for optimization i.e `$internal$try(lambda)` → Velox `try(body)`, optimized in Velox, then converted back to Presto expression. In this codepath, the Velox to Presto expression conversion was not re-wrapping the optimized body into a lambda, resulting in a Presto `try(body)` shape that Presto's function registry cannot resolve.

The issue manifests specifically because:
- Presto's `$internal$try` function expects a 0-argument lambda: `$internal$try(() -> body)`
- The native converter intentionally unwraps lambdas during Presto→Velox conversion to allow Velox's native optimizer to run
- The converter must rebuild the lambda structure on the way back so Presto can resolve the internal function by its proper signature
Without this, queries like `COALESCE(TRY(CAST(...) AS INTEGER), 0)` fail with "presto.default.$internal$try(T):T not found".

The `NativeExpressionOptimizer` in sidecar plugin should rewrite try wrapping fail sub-expressions in the optimized expressions to NULL. The sidecar cannot do it because it leverages the Velox `ExprOptimizer` for optimizing sub-trees and Velox cannot identify such expression shapes, since TRY is not a distinct expression type or a registered function in Velox.

## Impact

- Enables safe optimization of TRY expressions with the sidecar's native expression optimizer
- Allows queries with TRY-wrapped fail patterns and casts to execute correctly
- Fixes correctness bug in the code path by handling TRY shape mismatch

## Test Plan

Verified with sidecar integration tests that TRY expressions are correctly optimized by the native expression optimizer.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Improve native expression optimization and function mapping for TRY/fail patterns across Java and C++ components.

Bug Fixes:
- Correctly detect and replace TRY-wrapped fail expressions (including casted variants) with NULL in the native expression optimizer.
- Ensure SpecialFormExpression arguments containing TRY-wrapped fail are normalized to NULL results.
- Fix function handle resolution for internal TRY by treating it as a native internal function and mapping it correctly from Velox to Presto.

Enhancements:
- Add recursive sanitization of child expressions to normalize nested TRY(fail(...)) patterns in the native expression optimizer.

Tests:
- Extend native sidecar plugin tests to cover COALESCE/TRY with cast failures and TRY(cast) returning NULL behavior.

## Summary by Sourcery

Fix handling of TRY expressions in native optimization and Velox-to-Presto conversion so they preserve Presto’s expected internal function shape and semantics.

Bug Fixes:
- Rewrite TRY-wrapped FAIL (and casted FAIL) sub-expressions to NULL in the native expression optimizer so sidecar queries behave correctly.
- Ensure Velox TRY expressions are converted back to Presto’s $internal$try with a zero-argument lambda and correct function handle resolution.
- Prevent incorrect reuse of partially optimized replacement trees by recursively visiting replacements during expression rebuilding.

Enhancements:
- Extend Velox-to-Presto type signature serialization to support lambda/function types for internal functions like TRY.
- Add internal function name mapping from Velox TRY to Presto’s $internal$try during expression conversion.

Tests:
- Add sidecar plugin integration tests covering TRY with failing casts, TRY(fail(...)) patterns, COALESCE with TRY, and general TRY(CAST(...)) behavior.

## Summary by Sourcery

Fix TRY expression handling in native sidecar optimization and Velox-to-Presto conversion to ensure correct mapping of TRY/fail patterns and internal function resolution.

Bug Fixes:
- Normalize TRY-wrapped fail and cast-fail sub-expressions to NULL during native expression replacement so optimized trees remain semantically correct.
- Prevent repeated or stale replacements in the native expression optimizer by recursively re-visiting replacement subtrees.
- Correct Velox-to-Presto conversion of TRY expressions by mapping Velox try to Presto's $internal$try with the expected 0-argument lambda signature and function handle type.
- Expose isTryFunction and isFailFunction checks via StandardFunctionResolution to reliably detect TRY and FAIL calls during optimization.

Enhancements:
- Extend Velox type-to-Presto TypeSignature serialization to support function (lambda) types used by internal TRY.
- Improve native-to-Presto function handle construction and internal function mapping infrastructure for native execution.

Tests:
- Expand native sidecar plugin tests to cover TRY with failing casts, fail() calls, nested TRY(fail) patterns, COALESCE/TRY interactions, and general TRY CAST usage.