### PR TITLE
fix: Fix isNativeExecutionEnabled to be based on session property

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -72,6 +72,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.classTag;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.serializeZstdCompressed;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -250,7 +251,7 @@ public class PrestoSparkRddFactory
             taskSourceRdd = Optional.empty();
         }
 
-        if (featuresConfig.isNativeExecutionEnabled()) {
+        if (isNativeExecutionEnabled(session)) {
             return JavaPairRDD.fromRDD(
                     PrestoSparkNativeTaskRdd.create(
                             sparkContext.sc(),


### PR DESCRIPTION
Summary: fix isNativeExecutionEnabled to be based on session property.

## Releas Notes

== NO RELEASE NOTE ==

Differential Revision: D92990724

## Summary by Sourcery

Base native execution enablement in PrestoSpark RDD creation on session properties instead of global feature configuration and add coverage around session-driven behavior and factory utilities.

Bug Fixes:
- Ensure PrestoSparkRddFactory uses the session-based native execution flag when deciding whether to create native task RDDs.

Tests: unit tests for SystemSessionProperties cover the functionality, hence no tests added