### PR TITLE
feat(native): Add config for asyc cache flush threshold

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1079,7 +1079,8 @@ void PrestoServer::initializeVeloxMemory() {
         systemConfig->asyncCacheMaxSsdWriteRatio(),
         systemConfig->asyncCacheSsdSavableRatio(),
         systemConfig->asyncCacheMinSsdSavableBytes(),
-        systemConfig->asyncCacheNumShards()};
+        systemConfig->asyncCacheNumShards(),
+        systemConfig->asyncCacheSsdFlushThresholdBytes()};
     cache_ = velox::cache::AsyncDataCache::create(
         velox::memory::memoryManager()->allocator(),
         std::move(ssd),

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -210,6 +210,7 @@ SystemConfig::SystemConfig() {
           NUM_PROP(kAsyncCacheSsdSavableRatio, 0.125),
           NUM_PROP(kAsyncCacheMinSsdSavableBytes, 1 << 24 /*16MB*/),
           NUM_PROP(kAsyncCacheNumShards, 4),
+          NUM_PROP(kAsyncCacheSsdFlushThresholdBytes, 0),
           STR_PROP(kAsyncCachePersistenceInterval, "0s"),
           BOOL_PROP(kAsyncCacheSsdDisableFileCow, false),
           BOOL_PROP(kSsdCacheChecksumEnabled, false),
@@ -717,6 +718,10 @@ int32_t SystemConfig::asyncCacheMinSsdSavableBytes() const {
 
 int32_t SystemConfig::asyncCacheNumShards() const {
   return optionalProperty<int32_t>(kAsyncCacheNumShards).value();
+}
+
+uint64_t SystemConfig::asyncCacheSsdFlushThresholdBytes() const {
+  return optionalProperty<uint64_t>(kAsyncCacheSsdFlushThresholdBytes).value();
 }
 
 std::chrono::duration<double> SystemConfig::asyncCachePersistenceInterval()

--- a/presto-native-execution/presto_cpp/main/common/Configs.h
+++ b/presto-native-execution/presto_cpp/main/common/Configs.h
@@ -438,6 +438,12 @@ class SystemConfig : public ConfigBase {
   static constexpr std::string_view kAsyncCacheNumShards{
       "async-cache-num-shards"};
 
+  /// The maximum threshold in bytes for triggering SSD flush. When the
+  /// accumulated SSD-savable bytes exceed this value, a flush to SSD is
+  /// triggered. Set to 0 to disable this threshold (default).
+  static constexpr std::string_view kAsyncCacheSsdFlushThresholdBytes{
+      "async-cache-ssd-flush-threshold-bytes"};
+
   /// The interval for persisting in-memory cache to SSD. Setting this config
   /// to a non-zero value will activate periodic cache persistence.
   static constexpr std::string_view kAsyncCachePersistenceInterval{
@@ -1078,6 +1084,8 @@ class SystemConfig : public ConfigBase {
   int32_t asyncCacheMinSsdSavableBytes() const;
 
   int32_t asyncCacheNumShards() const;
+
+  uint64_t asyncCacheSsdFlushThresholdBytes() const;
 
   std::chrono::duration<double> asyncCachePersistenceInterval() const;
 

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -241,6 +241,20 @@ TEST_F(ConfigTest, asyncCacheNumShards) {
   ASSERT_EQ(config.asyncCacheNumShards(), 8);
 }
 
+TEST_F(ConfigTest, asyncCacheSsdFlushThresholdBytes) {
+  SystemConfig config;
+  init(config, {});
+  // Test default value is 0
+  ASSERT_EQ(config.asyncCacheSsdFlushThresholdBytes(), 0);
+
+  // Test custom value
+  init(
+      config,
+      {{std::string(SystemConfig::kAsyncCacheSsdFlushThresholdBytes),
+        "134217728"}});
+  ASSERT_EQ(config.asyncCacheSsdFlushThresholdBytes(), 134217728);
+}
+
 TEST_F(ConfigTest, remoteFunctionServer) {
   SystemConfig config;
   init(config, {});


### PR DESCRIPTION
Differential Revision: D92323521

## Summary by Sourcery

Add configuration support for controlling the async cache SSD flush threshold and wire it through to the async data cache initialization.

New Features:
- Introduce a new system configuration option to set the async cache SSD flush threshold in bytes, with a default of zero.
- Expose the async cache SSD flush threshold from SystemConfig to the async data cache creation path.

Tests:
- Add unit coverage to validate the default and custom values of the async cache SSD flush threshold configuration.