### PR TITLE
fix: Add kMaxSpillBytes to system config -> velox query config mapping

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -137,6 +137,9 @@ void updateFromSystemConfigs(
            std::string(SystemConfig::kAggregationSpillEnabled),
        .veloxConfig = velox::core::QueryConfig::kAggregationSpillEnabled},
 
+      {.prestoSystemConfig = std::string(SystemConfig::kMaxSpillBytes),
+       .veloxConfig = velox::core::QueryConfig::kMaxSpillBytes},
+
       {.prestoSystemConfig =
            std::string(SystemConfig::kRequestDataSizesMaxWaitSec),
        .veloxConfig = velox::core::QueryConfig::kRequestDataSizesMaxWaitSec},

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -13,6 +13,8 @@
  */
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "presto_cpp/main/PrestoToVeloxQueryConfig.h"
 #include "presto_cpp/main/SessionProperties.h"
 #include "presto_cpp/main/common/Configs.h"
@@ -139,6 +141,18 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
               const std::string& expectedValue) {
              EXPECT_EQ(
                  expectedValue == "true", config.aggregationSpillEnabled());
+           }},
+
+      {.veloxConfigKey = core::QueryConfig::kMaxSpillBytes,
+       .sessionPropertyKey =
+           std::make_optional<std::string>(SessionProperties::kMaxSpillBytes),
+       .systemConfigKey = std::string(SystemConfig::kMaxSpillBytes),
+       .sessionValue = "214748364800",
+       .differentSessionValue = "107374182400",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) noexcept {
+             EXPECT_EQ(std::stoull(expectedValue), config.maxSpillBytes());
            }},
 
       {.veloxConfigKey = core::QueryConfig::kRequestDataSizesMaxWaitSec,
@@ -280,7 +294,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
   // CRITICAL: This count MUST match the exact number of entries in
   // veloxToPrestoConfigMapping If this assertion fails, it means a new
   // mapping was added and this test needs to be updated
-  const size_t kExpectedMappingCount = 14;
+  const size_t kExpectedMappingCount = 15;
   EXPECT_EQ(kExpectedMappingCount, testCases.size());
 
   // Test each mapping to ensure session properties override system configs
@@ -659,6 +673,8 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
        .systemConfigKey = std::string(SystemConfig::kOrderBySpillEnabled)},
       {.veloxConfigKey = core::QueryConfig::kAggregationSpillEnabled,
        .systemConfigKey = std::string(SystemConfig::kAggregationSpillEnabled)},
+      {.veloxConfigKey = core::QueryConfig::kMaxSpillBytes,
+       .systemConfigKey = std::string(SystemConfig::kMaxSpillBytes)},
       {.veloxConfigKey = core::QueryConfig::kRequestDataSizesMaxWaitSec,
        .systemConfigKey =
            std::string(SystemConfig::kRequestDataSizesMaxWaitSec)},
@@ -700,7 +716,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
            std::string(SystemConfig::kExchangeLazyFetchingEnabled)},
   };
 
-  const size_t kExpectedSystemConfigMappingCount = 20;
+  const size_t kExpectedSystemConfigMappingCount = 21;
   EXPECT_EQ(kExpectedSystemConfigMappingCount, expectedMappings.size())
       << "Update expectedMappings to match veloxToPrestoConfigMapping";
 


### PR DESCRIPTION
Summary:
max-spill-bytes from config.properties was not propagated to velox QueryConfig because it was missing from veloxToPrestoConfigMapping in updateFromSystemConfigs().

this caused queries to always use the hardcoded 100GB default spill limit regardless of the configured value, resulting in spurious "local spill limit exceeded" exceptions.

# Release Notes
```
== NO RELEASE NOTE ==
```

Differential Revision: D93147231

## Summary by Sourcery

Propagate the max spill bytes system configuration into the Velox query config and extend tests to cover this mapping.

Bug Fixes:
- Ensure the configured max spill bytes value is honored instead of always using the hardcoded default spill limit.

Tests:
- Add and update query config mapping tests to validate propagation of max spill bytes from system configs and session properties.