### PR TITLE
chore(deps): Upgrade Arrow to 18.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dep.j2objc.version>3.0.0</dep.j2objc.version>
         <dep.avro.version>1.12.0</dep.avro.version>
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>
-        <dep.protobuf-java.version>4.29.0</dep.protobuf-java.version>
+        <dep.protobuf-java.version>4.30.2</dep.protobuf-java.version>
         <dep.jetty.version>12.0.29</dep.jetty.version>
         <dep.netty.version>4.1.130.Final</dep.netty.version>
         <dep.reactor-netty.version>1.2.8</dep.reactor-netty.version>
@@ -89,7 +89,7 @@
         <dep.gson.version>2.12.1</dep.gson.version>
         <dep.commons.lang3.version>3.18.0</dep.commons.lang3.version>
         <dep.guice.version>6.0.0</dep.guice.version>
-        <dep.arrow.version>17.0.0</dep.arrow.version>
+        <dep.arrow.version>18.3.0</dep.arrow.version>
         <dep.mariadb.version>3.5.4</dep.mariadb.version>
         <dep.spark.version>2.0.2-6</dep.spark.version>
         <dep.hadoop.version>3.4.1-1</dep.hadoop.version>


### PR DESCRIPTION
## Description
Upgrades Apache Arrow dependencies to 18.3.0.

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
Inherited connectors must use protobuf-java 4.30.x to avoid potential gencode issues.

## Test Plan
Tested after upgrade and was able to connect to Flight server and fetch schemas

<img width="1078" height="584" alt="Screenshot 2026-02-13 at 5 23 05 PM" src="https://github.com/user-attachments/assets/5b99131e-7644-4f77-b24a-ee53487f1e86" />

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Upgrade Apache Arrow to 18.3.0 and protobuf-java to 4.30.2.
```

