### PR TITLE
fix: Use namespaced GTest targets in arrow_flight tests

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/CMakeLists.txt
@@ -50,8 +50,8 @@ target_link_libraries(
   presto_flight_connector_test
   velox_exec_test_lib
   presto_flight_connector
-  gtest
-  gtest_main
+  GTest::gtest
+  GTest::gtest_main
   presto_flight_connector_test_lib
   presto_protocol
 )


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Fixed CMake linking error in Arrow Flight connector tests by using namespaced GTest imported targets (`GTest::gtest`,
`GTest::gtest_main`) instead of plain library names (`gtest`, `gtest_main`).

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
The Arrow Flight connector tests were failing to link with the error `ld: library 'gtest' not found` because the `CMakeLists.txt `was using old-style plain library names instead of modern CMake imported targets. This prevented building Presto with `-DPRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR=ON`.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
- Built Presto with `-DPRESTO_ENABLE_ARROW_FLIGHT_CONNECTOR=ON`
- Verified that `presto_flight_connector_test` executable links successfully
- Confirmed tests compile without linker errors

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix Arrow Flight connector test build by linking against the correct GoogleTest CMake targets.

Bug Fixes:
- Resolve linker failures in Arrow Flight connector tests caused by referencing non-namespaced GoogleTest libraries.

Build:
- Update Arrow Flight connector test CMake configuration to use namespaced GTest imported targets for linkage.