### PR TITLE
fix: EXPLAIN CREATE TABLE to show IF NOT EXISTS clause

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CreateTableTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CreateTableTask.java
@@ -87,6 +87,9 @@ public class CreateTableTask
     @Override
     public String explain(CreateTable statement, List<Expression> parameters)
     {
+        if (statement.isNotExists()) {
+            return "CREATE TABLE IF NOT EXISTS " + statement.getName();
+        }
         return "CREATE TABLE " + statement.getName();
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2715,19 +2715,41 @@ public abstract class AbstractTestQueries
     @Test
     public void testExplainDdl()
     {
+        // CREATE TABLE
         assertExplainDdl("CREATE TABLE foo (pk bigint)", "CREATE TABLE foo");
+        assertExplainDdl("CREATE TABLE IF NOT EXISTS foo (pk bigint)", "CREATE TABLE IF NOT EXISTS foo");
+        assertExplainDdl("CREATE TABLE mycatalog.myschema.foo (pk bigint)", "CREATE TABLE mycatalog.myschema.foo");
+        assertExplainDdl("CREATE TABLE IF NOT EXISTS mycatalog.myschema.foo (pk bigint)", "CREATE TABLE IF NOT EXISTS mycatalog.myschema.foo");
+
+        // DROP TABLE
+        assertExplainDdl("DROP TABLE orders");
+        assertExplainDdl("DROP TABLE IF EXISTS orders");
+        assertExplainDdl("DROP TABLE IF EXISTS mycatalog.myschema.orders");
+
+        // CREATE VIEW
         assertExplainDdl("CREATE VIEW foo AS SELECT * FROM orders", "CREATE VIEW foo");
+
+        // DROP VIEW
+        assertExplainDdl("DROP VIEW view");
+
+        // CREATE/ALTER/DROP FUNCTION
         assertExplainDdl("CREATE OR REPLACE FUNCTION testing.default.tan (x int) RETURNS double COMMENT 'tangent trigonometric function' LANGUAGE SQL DETERMINISTIC CALLED ON NULL INPUT RETURN sin(x) / cos(x)", "CREATE FUNCTION testing.default.tan");
         assertExplainDdl("ALTER FUNCTION testing.default.tan CALLED ON NULL INPUT", "ALTER FUNCTION testing.default.tan");
         assertExplainDdl("DROP FUNCTION IF EXISTS testing.default.tan (int)", "DROP FUNCTION testing.default.tan");
-        assertExplainDdl("DROP TABLE orders");
-        assertExplainDdl("DROP VIEW view");
+
+        // ALTER TABLE
         assertExplainDdl("ALTER TABLE orders RENAME TO new_name");
         assertExplainDdl("ALTER TABLE orders RENAME COLUMN orderkey TO new_column_name");
+
+        // SESSION
         assertExplainDdl("SET SESSION foo = 'bar'");
+        assertExplainDdl("RESET SESSION foo");
+
+        // PREPARE/DEALLOCATE
         assertExplainDdl("PREPARE my_query FROM SELECT * FROM orders", "PREPARE my_query");
         assertExplainDdl("DEALLOCATE PREPARE my_query");
-        assertExplainDdl("RESET SESSION foo");
+
+        // TRANSACTION
         assertExplainDdl("START TRANSACTION");
         assertExplainDdl("COMMIT");
         assertExplainDdl("ROLLBACK");


### PR DESCRIPTION
Summary:
The existing special handling for EXPLAIN CREATE TABLE deliberately simplifies the output to just show CREATE TABLE <name> rather than the full DDL with columns, constraints, and properties. This is reasonable since the full column definitions can be quite verbose and aren't as useful for understanding what the statement will do.

However, the current implementation omits the IF NOT EXISTS clause, which is semantically important - it changes whether the statement will fail or succeed if the table already exists. This is inconsistent with EXPLAIN DROP TABLE IF EXISTS, which does show the IF EXISTS clause (since DROP TABLE uses the default SqlFormatter which includes it).

This change updates the custom explain() method to include IF NOT EXISTS when present, making the behavior consistent with DROP TABLE while still keeping the simplified output format.

With this, I'm open to suggestions on what the most helpful output for EXPLAIN CREATE TABLE would be. Some options:

- Keep the original abbreviated behavior (just CREATE TABLE <name>) - current behavior before this fix
- Abbreviated with IF NOT EXISTS included (this PR)
- Output the full DDL using SqlFormatter
ex)
```
EXPLAIN CREATE TABLE IF NOT EXISTS myschema.users (
    id bigint NOT NULL,
    PRIMARY KEY (id)
) WITH (format = 'ORC')
```
will output:
```
CREATE TABLE IF NOT EXISTS myschema.users (
   id bigint NOT NULL,
   PRIMARY KEY (id)
)
WITH (
   format = 'ORC'
)
```

Differential Revision: D93266866

## Summary by Sourcery

Include IF NOT EXISTS in EXPLAIN output for CREATE TABLE statements and expand DDL EXPLAIN coverage tests.

Bug Fixes:
- Ensure EXPLAIN for CREATE TABLE preserves the IF NOT EXISTS clause when present.

Tests:
- Expand EXPLAIN DDL tests to cover IF NOT EXISTS variants and additional DDL statements such as DROP TABLE/VIEW, RESET SESSION, and transaction commands.
```
== NO RELEASE NOTE ==
```