### PR TITLE
fix(build): Upgrade testconatiners to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
         <dep.jaxb.runtime.version>4.0.6</dep.jaxb.runtime.version>
         <dep.hudi.version>0.14.0</dep.hudi.version>
-        <dep.testcontainers.version>1.20.5</dep.testcontainers.version>
+        <dep.testcontainers.version>2.0.3</dep.testcontainers.version>
         <dep.docker-java.version>3.4.1</dep.docker-java.version>
         <dep.jayway.version>2.9.0</dep.jayway.version>
         <dep.ratis.version>3.1.3</dep.ratis.version>

--- a/presto-clickhouse/pom.xml
+++ b/presto-clickhouse/pom.xml
@@ -196,13 +196,13 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>clickhouse</artifactId>
+            <artifactId>testcontainers-clickhouse</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>jdbc</artifactId>
+            <artifactId>testcontainers-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/ClickHouseQueryRunner.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/ClickHouseQueryRunner.java
@@ -60,6 +60,8 @@ public final class ClickHouseQueryRunner
 
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
             connectorProperties.putIfAbsent("clickhouse.connection-url", server.getJdbcUrl());
+            connectorProperties.putIfAbsent("clickhouse.connection-user", server.getClickHouseContainer().getUsername());
+            connectorProperties.putIfAbsent("clickhouse.connection-password", server.getClickHouseContainer().getPassword());
             connectorProperties.putIfAbsent("clickhouse.allow-drop-table", String.valueOf(true));
             connectorProperties.putIfAbsent("clickhouse.map-string-as-varchar", String.valueOf(true));
 

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingClickHouseServer.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestingClickHouseServer.java
@@ -13,15 +13,12 @@
  */
 package com.facebook.presto.plugin.clickhouse;
 
-import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.clickhouse.ClickHouseContainer;
 
 import java.io.Closeable;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
-
-import static java.lang.String.format;
-import static org.testcontainers.containers.ClickHouseContainer.HTTP_PORT;
 
 public class TestingClickHouseServer
         implements Closeable
@@ -44,7 +41,10 @@ public class TestingClickHouseServer
     }
     public void execute(String sql)
     {
-        try (Connection connection = DriverManager.getConnection(getJdbcUrl());
+        try (Connection connection = DriverManager.getConnection(
+                getJdbcUrl(),
+                dockerContainer.getUsername(),
+                dockerContainer.getPassword());
                 Statement statement = connection.createStatement()) {
             statement.execute(sql);
         }
@@ -55,10 +55,7 @@ public class TestingClickHouseServer
 
     public String getJdbcUrl()
     {
-        String s = format("jdbc:clickhouse://%s:%s/", dockerContainer.getContainerIpAddress(),
-                dockerContainer.getMappedPort(HTTP_PORT));
-        return format("jdbc:clickhouse://%s:%s/", dockerContainer.getContainerIpAddress(),
-                dockerContainer.getMappedPort(HTTP_PORT));
+        return dockerContainer.getJdbcUrl();
     }
 
     @Override

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -247,7 +247,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <artifactId>testcontainers-elasticsearch</artifactId>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -472,10 +472,10 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestingHydraIdentityProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestingHydraIdentityProvider.java
@@ -44,10 +44,10 @@ import okhttp3.Response;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.Closeable;
@@ -75,7 +75,7 @@ public class TestingHydraIdentityProvider
 
     private final Network network = Network.newNetwork();
 
-    private final PostgreSQLContainer<?> databaseContainer = new PostgreSQLContainer<>()
+    private final PostgreSQLContainer databaseContainer = new PostgreSQLContainer("postgres:14")
             .withNetwork(network)
             .withNetworkAliases("database")
             .withUsername("hydra")

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -166,7 +166,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestCredentialPassthrough.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestCredentialPassthrough.java
@@ -18,7 +18,7 @@ import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableMap;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -40,13 +40,13 @@ public class TestCredentialPassthrough
     private static final String TEST_USER = "testuser";
     private static final String TEST_PASSWORD = "testpass";
 
-    private final MySQLContainer<?> mysqlContainer;
+    private final MySQLContainer mysqlContainer;
     private final QueryRunner mySqlQueryRunner;
 
     public TestCredentialPassthrough()
             throws Exception
     {
-        mysqlContainer = new MySQLContainer<>("mysql:8.0")
+        mysqlContainer = new MySQLContainer("mysql:8.0")
                 .withDatabaseName(TEST_SCHEMA)
                 .withUsername(TEST_USER)
                 .withPassword(TEST_PASSWORD);
@@ -77,7 +77,7 @@ public class TestCredentialPassthrough
         mySqlQueryRunner.execute(getSession(mysqlContainer), "CREATE TABLE test_create (a bigint, b double, c varchar)");
     }
 
-    public static QueryRunner createQueryRunner(MySQLContainer<?> mysqlContainer)
+    public static QueryRunner createQueryRunner(MySQLContainer mysqlContainer)
             throws Exception
     {
         DistributedQueryRunner queryRunner = null;
@@ -99,7 +99,7 @@ public class TestCredentialPassthrough
         }
     }
 
-    private static Session getSession(MySQLContainer<?> mysqlContainer)
+    private static Session getSession(MySQLContainer mysqlContainer)
     {
         Map<String, String> extraCredentials = ImmutableMap.of("mysql.user", mysqlContainer.getUsername(), "mysql.password", mysqlContainer.getPassword());
         return testSessionBuilder()
@@ -116,7 +116,7 @@ public class TestCredentialPassthrough
                 .build();
     }
 
-    private static String getConnectionUrl(MySQLContainer<?> mysqlContainer)
+    private static String getConnectionUrl(MySQLContainer mysqlContainer)
     {
         String jdbcUrlWithoutDatabase = removeDatabaseFromJdbcUrl(mysqlContainer.getJdbcUrl());
         return format("%s?useSSL=false&allowPublicKeyRetrieval=true", jdbcUrlWithoutDatabase.split("\\?")[0]);

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlDistributedQueries.java
@@ -18,7 +18,7 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
@@ -33,11 +33,11 @@ import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 public class TestMySqlDistributedQueries
         extends AbstractTestDistributedQueries
 {
-    private final MySQLContainer<?> mysqlContainer;
+    private final MySQLContainer mysqlContainer;
 
     public TestMySqlDistributedQueries()
     {
-        this.mysqlContainer = new MySQLContainer<>("mysql:8.0")
+        this.mysqlContainer = new MySQLContainer("mysql:8.0")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationMixedCaseTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationMixedCaseTest.java
@@ -19,7 +19,7 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -40,12 +40,12 @@ import static org.testng.Assert.assertTrue;
 public class TestMySqlIntegrationMixedCaseTest
         extends AbstractTestQueryFramework
 {
-    private final MySQLContainer<?> mysqlContainer;
+    private final MySQLContainer mysqlContainer;
 
     public TestMySqlIntegrationMixedCaseTest()
             throws Exception
     {
-        this.mysqlContainer = new MySQLContainer<>("mysql:8.0")
+        this.mysqlContainer = new MySQLContainer("mysql:8.0")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -22,7 +22,7 @@ import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -48,12 +48,12 @@ import static org.testng.Assert.assertTrue;
 public class TestMySqlIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final MySQLContainer<?> mysqlContainer;
+    private final MySQLContainer mysqlContainer;
 
     public TestMySqlIntegrationSmokeTest()
             throws Exception
     {
-        this.mysqlContainer = new MySQLContainer<>("mysql:8.0")
+        this.mysqlContainer = new MySQLContainer("mysql:8.0")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlTypeMapping.java
@@ -26,7 +26,7 @@ import com.facebook.presto.tests.sql.JdbcSqlExecutor;
 import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -66,11 +66,11 @@ public class TestMySqlTypeMapping
 {
     private static final String CHARACTER_SET_UTF8 = "CHARACTER SET utf8";
 
-    private final MySQLContainer<?> mysqlContainer;
+    private final MySQLContainer mysqlContainer;
 
     public TestMySqlTypeMapping()
     {
-        this.mysqlContainer = new MySQLContainer<>("mysql:8.0")
+        this.mysqlContainer = new MySQLContainer("mysql:8.0")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -175,7 +175,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -19,7 +19,7 @@ import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -93,7 +93,7 @@ public final class PostgreSqlQueryRunner
         }
     }
 
-    public static Properties createJdbcProperties(PostgreSQLContainer<?> container)
+    public static Properties createJdbcProperties(PostgreSQLContainer container)
     {
         Properties properties = new Properties();
         properties.setProperty("user", container.getUsername());

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
@@ -18,7 +18,7 @@ import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -37,11 +37,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestPostgreSqlCaseInsensitiveMapping
         extends AbstractTestQueryFramework
 {
-    private final PostgreSQLContainer<?> postgresContainer;
+    private final PostgreSQLContainer postgresContainer;
 
     public TestPostgreSqlCaseInsensitiveMapping()
     {
-        this.postgresContainer = new PostgreSQLContainer<>("postgres:14")
+        this.postgresContainer = new PostgreSQLContainer("postgres:14")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlCaseSensitiveMapping.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlCaseSensitiveMapping.java
@@ -17,7 +17,7 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestQueryFramework;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -31,11 +31,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestPostgreSqlCaseSensitiveMapping
         extends AbstractTestQueryFramework
 {
-    private final PostgreSQLContainer<?> postgresContainer;
+    private final PostgreSQLContainer postgresContainer;
 
     public TestPostgreSqlCaseSensitiveMapping()
     {
-        this.postgresContainer = new PostgreSQLContainer<>("postgres:14")
+        this.postgresContainer = new PostgreSQLContainer("postgres:14")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlDistributedQueries.java
@@ -17,7 +17,7 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -27,11 +27,11 @@ import static com.facebook.presto.plugin.postgresql.PostgreSqlQueryRunner.create
 public class TestPostgreSqlDistributedQueries
         extends AbstractTestDistributedQueries
 {
-    private final PostgreSQLContainer<?> postgresContainer;
+    private PostgreSQLContainer postgresContainer;
 
     public TestPostgreSqlDistributedQueries()
     {
-        this.postgresContainer = new PostgreSQLContainer<>("postgres:14")
+        this.postgresContainer = new PostgreSQLContainer("postgres:14")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -20,7 +20,7 @@ import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -42,11 +42,11 @@ import static org.testng.Assert.assertTrue;
 public class TestPostgreSqlIntegrationSmokeTest
         extends AbstractTestIntegrationSmokeTest
 {
-    private final PostgreSQLContainer<?> postgresContainer;
+    private PostgreSQLContainer postgresContainer;
 
     public TestPostgreSqlIntegrationSmokeTest()
     {
-        this.postgresContainer = new PostgreSQLContainer<>("postgres:14")
+        this.postgresContainer = new PostgreSQLContainer("postgres:14")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -26,7 +26,7 @@ import com.facebook.presto.tests.sql.JdbcSqlExecutor;
 import com.facebook.presto.tests.sql.PrestoSqlExecutor;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -70,12 +70,12 @@ import static org.testng.Assert.assertTrue;
 public class TestPostgreSqlTypeMapping
         extends AbstractTestQueryFramework
 {
-    private final PostgreSQLContainer<?> postgresContainer;
+    private final PostgreSQLContainer postgresContainer;
 
     public TestPostgreSqlTypeMapping()
             throws Exception
     {
-        this.postgresContainer = new PostgreSQLContainer<>("postgres:14")
+        this.postgresContainer = new PostgreSQLContainer("postgres:14")
                 .withDatabaseName("tpch")
                 .withUsername("testuser")
                 .withPassword("testpass");

--- a/presto-singlestore/pom.xml
+++ b/presto-singlestore/pom.xml
@@ -107,7 +107,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>jdbc</artifactId>
+            <artifactId>testcontainers-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Description
The current image that runs the CI builds is using the new Docker engine and requires the client version be higher than 1.44. The default client version that is used by the current testcontainer is 1.32 and causes build failures.

Upgrade the testcontainers to 2.0.3, related dependencies, and update test cases accordingly.

## Motivation and Context
The CI builds fail on lots of PRs, and the root cause is that the version of the `testcontainers` is using an old Docker client, which got rejected by the Docker engine that runs on the build image.

## Impact
Only on the build CI and running the testing locally for those projects that are using testcontainers.

## Test Plan
I manually ran projects using testcontainers, and all passed, including:
- presto-clickhouse
- presto-elasticsearch
- presto-main
- presto-mysql
- presto-postgresql
- presto-singlestore

Wait for the CI to run through all other test suites.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade Testcontainers to version 2.0.3 across the project and update dependent test modules to align with the new artifacts and APIs.

Enhancements:
- Align ClickHouse, MySQL, PostgreSQL, Elasticsearch, and SingleStore test modules with the new Testcontainers module artifact names.
- Adjust JDBC URL and credential handling for ClickHouse tests to use container-provided connection metadata.
- Simplify MySQL and PostgreSQL Testcontainers usage by removing unnecessary generics and standardizing container initialization in tests.

Build:
- Bump the global Testcontainers dependency version from 1.20.5 to 2.0.3 to support newer Docker client requirements in CI.