### PR TITLE
fix(build): Fix deps container dockerfile

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/centos-dependency.dockerfile
@@ -40,7 +40,7 @@ RUN bash -c "mkdir build && \
                  source ../velox/scripts/setup-centos-adapters.sh && \
                  install_adapters && \
                  install_clang15 && \
-                 install_cuda ${CUDA_VERSION}) && \
+                 install_cuda ${CUDA_VERSION} && \
                  install_ucx) && \
     rm -rf build"
 


### PR DESCRIPTION
## Description

PR #27118 broke this Dockerfile by leaving an extra closing parenthesis after `${CUDA_VERSION}`.

## Motivation and Context

Fixes build.

## Impact

Fixes build.

## Test Plan

None.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

== NO RELEASE NOTE ==

## Summary by Sourcery

Bug Fixes:
- Correct a syntax error in the CentOS dependency Dockerfile that prevented the build from running successfully.