### PR TITLE
chore(deps): Upgrade avro to version 1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dep.guava.version>32.1.0-jre</dep.guava.version>
         <dep.jackson.version>2.15.4</dep.jackson.version>
         <dep.j2objc.version>3.0.0</dep.j2objc.version>
-        <dep.avro.version>1.12.0</dep.avro.version>
+        <dep.avro.version>1.12.1</dep.avro.version>
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>
         <dep.protobuf-java.version>4.30.2</dep.protobuf-java.version>
         <dep.jetty.version>12.0.29</dep.jetty.version>
@@ -1098,7 +1098,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.0.0-11</version>
+                <version>3.0.0-12</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
Upgrade avro to version 1.12.1 to fix the [CVE-2025-33042](https://github.com/advisories/GHSA-rp46-r563-jrc7)

## Motivation and Context
Using a more recent version helps avoid potential vulnerabilities and ensures we aren't relying on outdated or unsupported code.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<img width="713" height="604" alt="Screenshot 2026-02-19 at 1 12 20 PM" src="https://github.com/user-attachments/assets/2d2be2d2-fc2a-4762-9ae2-1f828c839dcf" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

