### PR TITLE
fix: Enable GPU build in CI and replace clang usage

### DIFF
--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -20,13 +20,13 @@ jobs:
             codechange:
               - '!presto-docs/**'
 
-  prestocpp-linux-build-engine:
+  prestocpp-linux-build-gpu-engine:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
     needs: changes
     container:
-      image: prestodb/presto-native-dependency:0.297-202601311423-22d722a9
+      image: prestodb/presto-native-dependency:0.297-202602190453-8d6d9543
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt
@@ -35,16 +35,20 @@ jobs:
       cancel-in-progress: true
     env:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
-      CC: /usr/bin/clang-15
-      CXX: /usr/bin/clang++-15
+      cudf_SOURCE: BUNDLED
+      CUDA_COMPILER: /usr/local/cuda-${CUDA_VERSION}/bin/nvcc
+      # Set compiler to GCC 14
+      CUDA_FLAGS: -ccbin /opt/rh/gcc-toolset-14/root/usr/bin
       BUILD_SCRIPT: |
+        unset CC && unset CXX
+        source /opt/rh/gcc-toolset-14/enable
         cd presto-native-execution
         cmake \
-          -B _build/debug \
+          -B _build/release \
           -GNinja \
           -DTREAT_WARNINGS_AS_ERRORS=1 \
           -DENABLE_ALL_WARNINGS=1 \
-          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_BUILD_TYPE=Release \
           -DPRESTO_ENABLE_S3=ON \
           -DPRESTO_ENABLE_GCS=ON \
           -DPRESTO_ENABLE_ABFS=OFF \
@@ -54,11 +58,13 @@ jobs:
           -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS \
           -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER \
           -DPRESTO_ENABLE_TESTING=OFF \
+          -DPRESTO_ENABLE_CUDF=ON \
+          -DCMAKE_CUDA_ARCHITECTURES=75 \
           -DCMAKE_PREFIX_PATH=/usr/local \
           -DThrift_ROOT=/usr/local \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DMAX_LINK_JOBS=4
-        ninja -C _build/debug -j 4
+        ninja -C _build/release -j 4
 
     steps:
       # We cannot use the github action to free disk space from the runner


### PR DESCRIPTION
We need to disable the clang-15 build for now because Velox will bring in code that is not comaptible.
Given that clang-15 is older we want to upgrade to a newer Clang and refactor the adapters build to use both clang and gcc.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enable GPU-based native build in CI and switch the Linux workflow from clang-15 to a GCC-based toolchain.

CI:
- Configure CUDA and cuDF options in the Linux native build workflow to exercise GPU support.
- Replace the clang-15 toolchain with GCC 14 in the CI native build job and adjust environment setup accordingly.

## Summary by Sourcery

Enable GPU-capable native engine build in the Linux CI workflow and switch the container toolchain from clang-15 to a GCC-based CUDA toolchain.

Build:
- Update the prestocpp Linux native build workflow to use a newer dependency image with GCC 14 and CUDA tooling instead of clang-15.
- Rename the native engine build job to a GPU-focused job and build the engine in Release mode.
- Enable CUDA/cuDF configuration and architecture settings in the native build to exercise GPU support in CI.