### PR TITLE
fix(build): Add library required for Velox as of 44e10f4

### DIFF
--- a/presto-native-execution/presto_cpp/main/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/CMakeLists.txt
@@ -93,6 +93,7 @@ target_link_libraries(
   velox_hive_connector
   velox_hive_iceberg_splitreader
   velox_hive_partition_function
+  velox_key_encoder
   velox_presto_serializer
   velox_presto_type_parser
   velox_s3fs


### PR DESCRIPTION
## Description

Added velox_key_encoder library to main presto_server link.

## Motivation and Context

Resolves link failure with Velox as of 44e10f4 (2026/2/13)

HiveIndexReader.cpp:(.text+0x1b37): undefined reference to facebook::velox::serializer::IndexBounds::set(facebook::velox::serializer::IndexBound, facebook::velox::serializer::IndexBound)

## Impact

None.

## Test Plan

Local builds so far.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Build:
- Add velox_key_encoder to the presto_cpp main target link libraries to satisfy new Velox linkage requirements.