### PR TITLE
feat: Add TEXTFILE custom serde parameters support

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -291,6 +291,33 @@ Add the ``metastore.storage.schema.reader.impl`` property to ``hive-site.xml`` w
 
 You must restart the metastore service for this configuration to take effect. This setting allows the metastore to read storage schemas for Avro tables and avoids ``Storage schema reading not supported`` errors.
 
+Textfile Configuration Properties
+---------------------------------
+
+Table Properties
+^^^^^^^^^^^^^^^^
+
+These properties can be used when creating TEXTFILE tables in Presto:
+
+======================================================== ============================================================================== =============================
+Property Name                                            Description                                                                    Default
+======================================================== ============================================================================== =============================
+``textfile_field_delim``                                 A custom single-character delimiter to separate fields.                        NONE
+
+``textfile_escape_delim``                                A custom single-character delimiter to escape characters.                      NONE
+
+``textfile_collection_delim``                            A custom single-character delimiter to separate collection elements.           NONE
+
+``textfile_mapkey_delim``                                A custom single-character delimiter to separate map keys.                      NONE
+
+======================================================== ============================================================================== =============================
+
+.. note::
+These properties are mapped to the corresponding properties in Hive ``LazySerDeParameters`` during serialization and
+follow the same behaviors with ``LazySimpleSerDe``.
+If they are not defined, the Hive defaults are used, which are typically ``\001`` for field delimiter, ``\002`` for
+collection delimiter, ``\003`` for map key delimiter, and escape character is disabled.
+
 Metastore Configuration Properties
 ----------------------------------
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableProperties.java
@@ -57,6 +57,11 @@ public class HiveTableProperties
     public static final String CSV_SEPARATOR = "csv_separator";
     public static final String CSV_QUOTE = "csv_quote";
     public static final String CSV_ESCAPE = "csv_escape";
+    public static final String TEXTFILE_FIELD_DELIM = "textfile_field_delim";
+    public static final String TEXTFILE_MAPKEY_DELIM = "textfile_mapkey_delim";
+    public static final String TEXTFILE_COLLECTION_DELIM = "textfile_collection_delim";
+    public static final String TEXTFILE_ESCAPE_DELIM = "textfile_escape_delim";
+
     public static final String SKIP_HEADER_LINE_COUNT = "skip_header_line_count";
     public static final String SKIP_FOOTER_LINE_COUNT = "skip_footer_line_count";
 
@@ -157,6 +162,10 @@ public class HiveTableProperties
                 stringProperty(CSV_SEPARATOR, "CSV separator character", null, false),
                 stringProperty(CSV_QUOTE, "CSV quote character", null, false),
                 stringProperty(CSV_ESCAPE, "CSV escape character", null, false),
+                stringProperty(TEXTFILE_FIELD_DELIM, "Textfile field delimiter character", null, false),
+                stringProperty(TEXTFILE_ESCAPE_DELIM, "Textfile escape delimiter character", null, false),
+                stringProperty(TEXTFILE_COLLECTION_DELIM, "Textfile collection delimiter character", null, false),
+                stringProperty(TEXTFILE_MAPKEY_DELIM, "Textfile map key delimiter character", null, false),
                 integerProperty(SKIP_HEADER_LINE_COUNT, "Number of header lines", null, false),
                 integerProperty(SKIP_FOOTER_LINE_COUNT, "Number of footer lines", null, false),
                 new PropertyMetadata<>(
@@ -248,17 +257,17 @@ public class HiveTableProperties
         return (Double) tableProperties.get(ORC_BLOOM_FILTER_FPP);
     }
 
-    public static Optional<Character> getCsvProperty(Map<String, Object> tableProperties, String key)
+    public static Optional<Character> getSingleCharacterProperty(Map<String, Object> tableProperties, String key)
     {
         Object value = tableProperties.get(key);
         if (value == null) {
             return Optional.empty();
         }
-        String csvValue = (String) value;
-        if (csvValue.length() != 1) {
-            throw new PrestoException(INVALID_TABLE_PROPERTY, format("%s must be a single character string, but was: '%s'", key, csvValue));
+        String stringValue = (String) value;
+        if (stringValue.length() != 1) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, format("%s must be a single character string, but was: '%s'", key, stringValue));
         }
-        return Optional.of(csvValue.charAt(0));
+        return Optional.of(stringValue.charAt(0));
     }
 
     @SuppressWarnings("unchecked")

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -420,60 +420,10 @@ public abstract class AbstractTestNativeGeneralQueries
 
         String tmpTableName = generateRandomTableName();
         try {
-            getExpectedQueryRunner().execute(getSession(), format(
-                    "CREATE TABLE %s (" +
-                            "id BIGINT," +
-                            "name VARCHAR," +
-                            "is_active BOOLEAN," +
-                            "score DOUBLE," +
-                            "created_at TIMESTAMP," +
-                            "tags ARRAY<VARCHAR>," +
-                            "metrics ARRAY<DOUBLE>," +
-                            "properties MAP<VARCHAR, VARCHAR>," +
-                            "flags MAP<TINYINT, BOOLEAN>," +
-                            "nested_struct ROW(sub_id INTEGER, sub_name VARCHAR, sub_scores ARRAY<REAL>, sub_map MAP<SMALLINT, VARCHAR>)," +
-                            "price DECIMAL(15,2)," +
-                            "amount DECIMAL(21,6)," +
-                            "event_date DATE," +
-                            "ds VARCHAR" +
-                            ") WITH (format = 'TEXTFILE', partitioned_by = ARRAY['ds'])", tmpTableName), ImmutableList.of(BIGINT));
-            getExpectedQueryRunner().execute(getSession(), format(
-                    "INSERT INTO %s (" +
-                            "id," +
-                            "name," +
-                            "is_active," +
-                            "score," +
-                            "created_at," +
-                            "tags," +
-                            "metrics," +
-                            "properties," +
-                            "flags," +
-                            "nested_struct," +
-                            "price," +
-                            "amount," +
-                            "event_date," +
-                            "ds" +
-                            ") VALUES (" +
-                            "1001," +
-                            "'Jane Doe'," +
-                            "TRUE," +
-                            "88.5," +
-                            "TIMESTAMP '2025-07-23 10:00:00'," +
-                            "ARRAY['alpha', 'beta', 'gamma']," +
-                            "ARRAY[3.14, 2.71, 1.41]," +
-                            "MAP(ARRAY['color', 'size'], ARRAY['blue', 'large'])," +
-                            "MAP(ARRAY[TINYINT '1', TINYINT '2'], ARRAY[TRUE, FALSE])," +
-                            "ROW(" +
-                            "42," +
-                            "'sub_jane'," +
-                            "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']," +
-                            "MAP(ARRAY[SMALLINT '10', SMALLINT '20'], ARRAY['foo', 'bar'])" +
-                            ")," +
-                            "DECIMAL '12.34'," +
-                            "CAST('-123456789012345.123456' as DECIMAL(21,6))," +
-                            "DATE '2024-02-29'," +
-                            "'2025-07-01'" +
-                            ")", tmpTableName), ImmutableList.of(BIGINT));
+            getExpectedQueryRunner().execute(getSession(),
+                    createTextFileTableSql(tmpTableName, ImmutableList.of()),
+                    ImmutableList.of(BIGINT));
+            getExpectedQueryRunner().execute(getSession(), insertTextFileTableSql(tmpTableName), ImmutableList.of(BIGINT));
             // created_at is skipped because of the inconsistency in TIMESTAMP columns between Presto and Velox.
             // https://github.com/facebookincubator/velox/issues/8127
             assertQuery(format("SELECT id, name, is_active, score, tags, metrics, properties, flags, nested_struct, price, amount, event_date, ds FROM %s", tmpTableName));
@@ -481,6 +431,94 @@ public abstract class AbstractTestNativeGeneralQueries
         finally {
             dropTableIfExists(tmpTableName);
         }
+    }
+
+    @Test(groups = {"textfile"})
+    public void testReadTableWithCustomSerdeTextfile()
+    {
+        String tmpTableName = generateRandomTableName();
+        List<String> serdeParams = ImmutableList.of(
+                "textfile_field_delim='|'",
+                "textfile_escape_delim='\u0001'",
+                "textfile_collection_delim=';'",
+                "textfile_mapkey_delim=':'");
+        try {
+            getExpectedQueryRunner().execute(getSession(),
+                    createTextFileTableSql(tmpTableName, serdeParams),
+                    ImmutableList.of(BIGINT));
+            getExpectedQueryRunner().execute(getSession(), insertTextFileTableSql(tmpTableName), ImmutableList.of(BIGINT));
+            // created_at is skipped because of the inconsistency in TIMESTAMP columns between Presto and Velox.
+            // https://github.com/facebookincubator/velox/issues/8127
+            assertQuery(format("SELECT id, name, is_active, score, tags, metrics, properties, flags, nested_struct, price, amount, event_date, ds FROM %s", tmpTableName));
+        }
+        finally {
+            dropTableIfExists(tmpTableName);
+        }
+    }
+
+    private String createTextFileTableSql(String tableName, List<String> serdeParams)
+    {
+        String serde = serdeParams.isEmpty() ? "" : ", " + String.join(", ", serdeParams);
+        return format(
+                "CREATE TABLE %s (" +
+                        "id BIGINT," +
+                        "name VARCHAR," +
+                        "is_active BOOLEAN," +
+                        "score DOUBLE," +
+                        "created_at TIMESTAMP," +
+                        "tags ARRAY<VARCHAR>," +
+                        "metrics ARRAY<DOUBLE>," +
+                        "properties MAP<VARCHAR, VARCHAR>," +
+                        "flags MAP<TINYINT, BOOLEAN>," +
+                        "nested_struct ROW(sub_id INTEGER, sub_name VARCHAR, sub_scores ARRAY<REAL>, sub_map MAP<SMALLINT, VARCHAR>)," +
+                        "price DECIMAL(15,2)," +
+                        "amount DECIMAL(21,6)," +
+                        "event_date DATE," +
+                        "ds VARCHAR" +
+                        ") WITH (format = 'TEXTFILE'%s, partitioned_by = ARRAY['ds'])",
+                tableName,
+                serde);
+    }
+
+    private String insertTextFileTableSql(String tableName)
+    {
+        return format(
+                "INSERT INTO %s (" +
+                        "id," +
+                        "name," +
+                        "is_active," +
+                        "score," +
+                        "created_at," +
+                        "tags," +
+                        "metrics," +
+                        "properties," +
+                        "flags," +
+                        "nested_struct," +
+                        "price," +
+                        "amount," +
+                        "event_date," +
+                        "ds" +
+                        ") VALUES (" +
+                        "1001," +
+                        "'Jane Doe'," +
+                        "TRUE," +
+                        "88.5," +
+                        "TIMESTAMP '2025-07-23 10:00:00'," +
+                        "ARRAY['alpha', 'beta', 'gamma']," +
+                        "ARRAY[3.14, 2.71, 1.41]," +
+                        "MAP(ARRAY['color', 'size'], ARRAY['blue', 'large'])," +
+                        "MAP(ARRAY[TINYINT '1', TINYINT '2'], ARRAY[TRUE, FALSE])," +
+                        "ROW(" +
+                        "42," +
+                        "'sub_jane'," +
+                        "ARRAY[REAL '1.1', REAL '2.2', REAL '3.3']," +
+                        "MAP(ARRAY[SMALLINT '10', SMALLINT '20'], ARRAY['foo', 'bar'])" +
+                        ")," +
+                        "DECIMAL '12.34'," +
+                        "CAST('-123456789012345.123456' as DECIMAL(21,6))," +
+                        "DATE '2024-02-29'," +
+                        "'2025-07-01'" +
+                        ")", tableName);
     }
 
     @Test


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Add serde parameters support for Textfile format for both Presto and Prestissimo. The parameters includes:
- textfile_field_delim
- textfile_collection_delim
- textfile_mapkey_delim
- textfile_escape_delim

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Add support for custom TEXTFILE SerDe parameters ``textfile_field_delim``, ``textfile_escape_delim``, ``textfile_collection_delim``, and ``textfile_mapkey_delim``.
```

## Summary by Sourcery

Add Hive TEXTFILE SerDe table properties and wire them through Hive metadata so custom delimiters can be used for TEXTFILE tables, with coverage in both Hive and native execution tests.

New Features:
- Introduce Hive table properties to configure TEXTFILE field, collection, map key, and escape delimiters.
- Support propagating TEXTFILE SerDe delimiter settings between Presto and the Hive metastore when creating TEXTFILE tables.

Enhancements:
- Refactor native TEXTFILE table creation and insertion SQL into reusable helpers to simplify tests.
- Generalize single-character table property validation for reuse across CSV and TEXTFILE properties.

Tests:
- Add Hive integration tests validating read and write behavior of TEXTFILE tables using custom SerDe delimiters.
- Extend native execution tests to verify reading TEXTFILE tables with and without custom SerDe parameters.