### PR TITLE
fix: Do not add redundant exchange over remote function

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -282,7 +282,6 @@ public class AddExchanges
                         checkState(taskCount > 0, "taskCount should be larger than 0");
                         PlanNode newNode = roundRobinExchange(idAllocator.getNextId(), REMOTE_STREAMING, planWithProperties.getNode(), taskCount);
                         newNode = ChildReplacer.replaceChildren(node, ImmutableList.of(newNode));
-                        newNode = roundRobinExchange(idAllocator.getNextId(), REMOTE_STREAMING, newNode);
                         return new PlanWithProperties(newNode, derivePropertiesRecursively(newNode));
                     }
                 }


### PR DESCRIPTION
## Description
We added an option in https://github.com/prestodb/presto/pull/27044 to set the number of tasks for remote functions, however we observe that it will add an unnecessary exchange even when the remote function directly send data to output node. This PR will remove this unnecessary exchange node.

## Motivation and Context
Simplify plans

## Impact
Make the plan to streaming result out.

## Test Plan
Unit tests

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Adjust exchange planning for remote function projections to avoid adding unnecessary trailing exchanges when the plan is not required to be distributed.

Bug Fixes:
- Prevent insertion of a redundant trailing remote exchange for fixed-parallelism remote function projections when the preferred global properties are undistributed.

Tests:
- Update existing remote function fixed-parallelism plan tests to expect a gather exchange at the root where appropriate.
- Add tests covering when trailing exchanges are skipped or preserved for remote function projections under undistributed vs distributed plans.