### PR TITLE
fix(spi): Typo in the comment of MaterializedViewDefinition.TableColumn

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewDefinition.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewDefinition.java
@@ -293,7 +293,7 @@ public final class MaterializedViewDefinition
         private final String columnName;
         // This signifies whether the mapping is direct or not.
         // Mapping is always direct in inner join case. In the outer join case, only the mapping from a column to its source column in the join input table is direct.
-        // For e.g. in case of SELECT t1_a as t1.a, t2_a as t2.a FROM t1 LEFT JOIN t2 ON t1.a = t2.a
+        // For e.g. in case of SELECT t1.a as t1_a, t2.a as t2_a FROM t1 LEFT JOIN t2 ON t1.a = t2.a
         // t1_a -> t1.a is direct mapped
         // t1_a -> t2.a is NOT direct mapped(as t1,t2 are in outer join)
         // t2_a -> t2.a is direct mapped(value can become null but column mapping is not altered)


### PR DESCRIPTION
## Description

This PR fix a typo in the comment of `MaterializedViewDefinition.TableColumn`. The correct SQL grammar should be:

```
SELECT t1.a as t1_a, t2.a as t2_a FROM t1 LEFT JOIN t2 ON t1.a = t2.a
```

Previously it was incorrectly written as:

```
SELECT t1_a as t1.a, t2_a as t2.a FROM t1 LEFT JOIN t2 ON t1.a = t2.a
```

## Motivation and Context

N/A

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Fix incorrect SQL example in MaterializedViewDefinition.TableColumn Javadoc comment to reflect proper alias usage.