### PR TITLE
test: Extend Iceberg schema evolution tests to cover PARQUET format

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -864,8 +864,7 @@ public abstract class IcebergDistributedSmokeTestBase
     @Test
     public void testSchemaEvolution()
     {
-        // TODO: Support schema evolution for PARQUET. Schema evolution should be id based.
-        testSchemaEvolution(getSession(), FileFormat.ORC);
+        testWithAllFileFormats(this::testSchemaEvolution);
     }
 
     private void testSchemaEvolution(Session session, FileFormat fileFormat)


### PR DESCRIPTION
## Description

This PR extends `IcebergDistributedSmokeTestBase.testSchemaEvolution()` to cover both `ORC` and `PARQUET` file formats.

## Motivation and Context

Expand test coverage.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Run the schema evolution smoke test for all Iceberg file formats instead of only ORC.