### PR TITLE
fix(plugin-iceberg): UUID handling in HiveType

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -208,6 +208,9 @@ public final class HiveType
     {
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
+                if (typeInfo.getTypeName().equals(UUID)) {
+                    return true;
+                }
                 return getPrimitiveType((PrimitiveTypeInfo) typeInfo) != null;
             case MAP:
                 MapTypeInfo mapTypeInfo = (MapTypeInfo) typeInfo;
@@ -269,10 +272,10 @@ public final class HiveType
     {
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
-                Type primitiveType = getPrimitiveType((PrimitiveTypeInfo) typeInfo);
-                if (primitiveType == null && typeInfo.getTypeName().equals(UUID)) {
+                if (typeInfo.getTypeName().equals(UUID)) {
                     return UuidType.UUID.getTypeSignature();
                 }
+                Type primitiveType = getPrimitiveType((PrimitiveTypeInfo) typeInfo);
                 if (primitiveType == null) {
                     break;
                 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2779,6 +2779,7 @@ public abstract class IcebergDistributedTestBase
             UUID uuid = UUID.fromString("11111111-2222-3333-4444-555555555555");
             assertUpdate(format("INSERT INTO uuid_roundtrip VALUES CAST('%s' as uuid)", uuid), 1);
             assertQuery(session, "SELECT CAST(u as varchar) FROM uuid_roundtrip", format("VALUES '%s'", uuid));
+            assertQuerySucceeds(session, "SELECT u FROM uuid_roundtrip");
         }
         finally {
             assertQuerySucceeds("DROP TABLE uuid_roundtrip");


### PR DESCRIPTION
## Motivation and Context
Selecting a UUID column with the Hive catalog in Iceberg fails with this error:

```
  java.lang.RuntimeException: class com.facebook.presto.hive.HiveType$1 cannot be cast to class                                                                              
  org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo  
```

## Impact
Allow selecting UUIDs

## Test Plan
Fixed a unit test that would have caught this.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Fix UUID handling with Hive catalog
```

## Summary by Sourcery

Fix handling of UUID Hive types in Iceberg queries and extend UUID round-trip testing.

Bug Fixes:
- Prevent class cast exceptions when resolving UUID Hive types by treating UUID type names as supported primitive types.
- Correct type signature resolution for UUID Hive types so UUID columns can be selected via the Hive catalog.

Tests:
- Extend Iceberg UUID round-trip test to verify selecting UUID-typed columns directly.