### PR TITLE
[WIP] Support multi-file broadcast writing via targetFileSize

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1919,6 +1919,7 @@ void PrestoServer::registerTraceNodeFactories() {
               nodeId,
               broadcastWriteNode->basePath(),
               broadcastWriteNode->maxBroadcastBytes(),
+              broadcastWriteNode->targetFileSize(),
               broadcastWriteNode->serdeRowType(),
               std::make_shared<velox::exec::trace::DummySourceNode>(
                   broadcastWriteNode->sources().front()->outputType()));

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFile.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFile.h
@@ -35,12 +35,13 @@ struct BroadcastFileInfo {
       const std::string& info);
 };
 
-/// Writes broadcast data to a single file.
+/// Writes broadcast data to one or more files.
 class BroadcastFileWriter : velox::serializer::SerializedPageFileWriter {
  public:
   BroadcastFileWriter(
       const std::string& pathPrefix,
       uint64_t maxBroadcastBytes,
+      uint64_t targetFileSize,
       uint64_t writeBufferSize,
       std::unique_ptr<velox::VectorSerde::Options> serdeOptions,
       velox::memory::MemoryPool* pool);

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.h
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.h
@@ -29,11 +29,13 @@ class BroadcastWriteNode : public velox::core::PlanNode {
       const velox::core::PlanNodeId& id,
       const std::string& basePath,
       uint64_t maxBroadcastBytes,
+      uint64_t targetFileSize,
       velox::RowTypePtr serdeRowType,
       velox::core::PlanNodePtr source)
       : velox::core::PlanNode(id),
         basePath_{basePath},
         maxBroadcastBytes_{maxBroadcastBytes},
+        targetFileSize_{targetFileSize},
         serdeRowType_{std::move(serdeRowType)},
         sources_{std::move(source)} {}
 
@@ -64,6 +66,10 @@ class BroadcastWriteNode : public velox::core::PlanNode {
     return maxBroadcastBytes_;
   }
 
+  uint64_t targetFileSize() const {
+    return targetFileSize_;
+  }
+
   /// The desired schema of the serialized data. May include a subset of input
   /// columns, some columns may be duplicated, some columns may be missing,
   /// columns may appear in different order.
@@ -80,6 +86,7 @@ class BroadcastWriteNode : public velox::core::PlanNode {
 
   const std::string basePath_;
   const uint64_t maxBroadcastBytes_;
+  const uint64_t targetFileSize_;
   const velox::RowTypePtr serdeRowType_;
   const std::vector<velox::core::PlanNodePtr> sources_;
 };

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.cpp
@@ -91,6 +91,7 @@ std::function<PlanNodePtr(std::string nodeId, PlanNodePtr)> addShuffleWriteNode(
 std::function<PlanNodePtr(std::string, PlanNodePtr)> addBroadcastWriteNode(
     const std::string& basePath,
     uint64_t maxBroadcastBytes,
+    uint64_t targetFileSize,
     const std::optional<std::vector<std::string>>& outputLayout) {
   return [=](core::PlanNodeId nodeId,
              core::PlanNodePtr source) -> core::PlanNodePtr {
@@ -106,7 +107,7 @@ std::function<PlanNodePtr(std::string, PlanNodePtr)> addBroadcastWriteNode(
     }
 
     return std::make_shared<BroadcastWriteNode>(
-        nodeId, basePath, maxBroadcastBytes, outputType, std::move(source));
+        nodeId, basePath, maxBroadcastBytes, targetFileSize, outputType, std::move(source));
   };
 }
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanBuilder.h
@@ -53,5 +53,6 @@ std::function<velox::core::PlanNodePtr(std::string, velox::core::PlanNodePtr)>
 addBroadcastWriteNode(
     const std::string& basePath,
     uint64_t maxBroadcastBytes = std::numeric_limits<uint64_t>::max(),
+    uint64_t targetFileSize = std::numeric_limits<uint64_t>::max(),
     const std::optional<std::vector<std::string>>& outputLayout = std::nullopt);
 } // namespace facebook::presto::operators

--- a/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeBuilderTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/PlanNodeBuilderTest.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <limits>
 #include "presto_cpp/main/operators/BroadcastWrite.h"
 #include "presto_cpp/main/operators/PartitionAndSerialize.h"
 #include "presto_cpp/main/operators/ShuffleRead.h"
@@ -49,7 +50,7 @@ TEST(PlanNodeBuilderTest, testBroadcastWrite) {
       };
 
   const auto node = std::make_shared<BroadcastWriteNode>(
-      id, basePath, maxBroadcastBytes, serdeRowType, kShuffleRead);
+      id, basePath, maxBroadcastBytes, std::numeric_limits<uint64_t>::max(), serdeRowType, kShuffleRead);
 
   verify(node);
 }

--- a/presto-native-execution/presto_cpp/main/tool/trace/BroadcastWriteReplayer.cpp
+++ b/presto-native-execution/presto_cpp/main/tool/trace/BroadcastWriteReplayer.cpp
@@ -60,6 +60,7 @@ core::PlanNodePtr BroadcastWriteReplayer::createPlanNode(
       nodeId,
       replayOutputDir_,
       broadcastWriteNode->maxBroadcastBytes(),
+      broadcastWriteNode->targetFileSize(),
       broadcastWriteNode->serdeRowType(),
       source);
 }

--- a/presto-native-execution/presto_cpp/main/tool/trace/tests/BroadcastWriteReplayerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tool/trace/tests/BroadcastWriteReplayerTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 #include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
+#include <limits>
 
 #include "presto_cpp/main/operators/BroadcastWrite.h"
 #include "presto_cpp/main/tool/trace/BroadcastWriteReplayer.h"
@@ -297,6 +298,7 @@ class BroadcastWriteReplayerTest : public HiveConnectorTestBase {
                 nodeId,
                 broadcastWriteNode->basePath(),
                 broadcastWriteNode->maxBroadcastBytes(),
+                broadcastWriteNode->targetFileSize(),
                 broadcastWriteNode->serdeRowType(),
                 std::make_shared<exec::trace::DummySourceNode>(
                     broadcastWriteNode->sources().front()->outputType()));
@@ -371,7 +373,7 @@ TEST_F(BroadcastWriteReplayerTest, basic) {
           .addNode([&](const std::string& id, core::PlanNodePtr input) {
             broadcastWriteNodeId = id;
             return std::make_shared<BroadcastWriteNode>(
-                id, originalBasePath, maxBroadcastBytes, outputType, input);
+                id, originalBasePath, maxBroadcastBytes, std::numeric_limits<uint64_t>::max(), outputType, input);
           })
           .planNode();
 
@@ -492,7 +494,7 @@ TEST_F(BroadcastWriteReplayerTest, multipleDrivers) {
           .addNode([&](std::string id, core::PlanNodePtr input) {
             broadcastWriteNodeId = id;
             return std::make_shared<BroadcastWriteNode>(
-                id, originalBasePath, maxBroadcastBytes, outputType, input);
+                id, originalBasePath, maxBroadcastBytes, std::numeric_limits<uint64_t>::max(), outputType, input);
           })
           .planNode();
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -2321,6 +2321,7 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
         *broadcastBasePath_,
         maxBroadcastBytesOpt.has_value() ? maxBroadcastBytesOpt.value()
                                          : std::numeric_limits<uint64_t>::max(),
+        std::numeric_limits<uint64_t>::max(),
         partitionedOutputNode->outputType(),
         core::LocalPartitionNode::gather(
             "broadcast-write-gather",


### PR DESCRIPTION
Summary:
The broadcast writer was hardcoded to write all data into a single file,
creating I/O inefficiency for large broadcast joins. The parent class
SerializedPageFileWriter already supports file rotation via targetFileSize,
but BroadcastFileWriter was passing uint64_t::max, forcing single-file mode.

Plumb targetFileSize through BroadcastWriteNode, BroadcastWriteOperator,
and BroadcastFileWriter. When set to a finite value, the writer rotates
to a new file once the current file exceeds the target size. Each file
gets its own footer with page sizes, and the reader works as-is since it
already processes individual files independently.

Default remains uint64_t::max (single file) for backward compatibility.

Differential Revision: D93673529

## Summary by Sourcery

Add support for multi-file broadcast writing controlled by a configurable target file size and verify end-to-end behavior and backward compatibility.

New Features:
- Allow BroadcastFileWriter to split broadcast data across multiple files based on a configurable target file size.
- Expose targetFileSize on BroadcastWriteNode and plumb it through operators, plan builders, and replay/server wiring so broadcast writes can be configured for multi-file output.

Enhancements:
- Extend broadcast file statistics to report per-file metadata when multiple broadcast files are produced.

Tests:
- Add unit and end-to-end tests covering multi-file broadcast writing, read-back correctness, and single-file backward compatibility behavior.