### PR TITLE
docs: Add CREATE/DROP TABLE docs to sql/explain.rst

### DIFF
--- a/presto-docs/src/main/sphinx/sql/explain.rst
+++ b/presto-docs/src/main/sphinx/sql/explain.rst
@@ -20,7 +20,7 @@ Description
 -----------
 
 Show the logical or distributed execution plan of a statement, or validate the statement.
-Use ``TYPE DISTRIBUTED`` option to display fragmented plan. Each
+Use ``TYPE DISTRIBUTED`` option to display a fragmented plan. Each
 `plan fragment <https://prestodb.io/docs/current/overview/concepts.html#plan-fragment>`_
 is executed by a single or multiple Presto nodes. Fragment type specifies how the fragment
 is executed by Presto nodes and how the data is distributed between fragments:


### PR DESCRIPTION
Summary: as title.

Differential Revision: D93814964

## Summary by Sourcery

Document CREATE TABLE and DROP TABLE usage in the SQL EXPLAIN reference.

Documentation:
- Add EXPLAIN documentation coverage for CREATE TABLE statements.
- Add EXPLAIN documentation coverage for DROP TABLE statements.

```
== NO RELEASE NOTE ==
```