### PR TITLE
misc(native): Refactor PrestoServer::run() into smaller methods for readability and testability

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.h
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.h
@@ -204,6 +204,45 @@ class PrestoServer {
 
   void addServerPeriodicTasks();
 
+  /// Loads config files, validates HTTPS/JWT settings, and populates member
+  /// variables from config. Called at the start of run().
+  void initializeConfigs();
+
+  /// Creates the HTTP server with appropriate socket bindings and
+  /// optional HTTPS configuration.
+  void initializeHttpServer();
+
+  /// Registers all HTTP API endpoints on the HTTP server.
+  void registerHttpEndpoints();
+
+  /// Registers exchange source factories for Presto exchange, shuffle, and
+  /// broadcast exchange.
+  void registerExchangeSources();
+
+  /// Creates memory pools, task manager, task resource, and related
+  /// components.
+  void initializeTaskResources();
+
+  /// Registers task, split, and expression set listeners based on config.
+  void registerListeners();
+
+  /// Starts the HTTP server (blocking), announcer, and heartbeat manager.
+  /// Returns when the server is stopped.
+  void startServer(const std::vector<std::string>& catalogNames);
+
+  /// Shuts down all server components in the correct order after the HTTP
+  /// server stops.
+  void shutdownServer();
+
+  /// Logs thread pool sizes for all executors.
+  void logExecutorInfo();
+
+  /// Stops announcer and heartbeat manager.
+  void stopAnnouncer();
+
+  /// Joins all thread pool executors in the correct shutdown order.
+  void joinExecutors();
+
   void reportMemoryInfo(proxygen::ResponseHandler* downstream);
 
   void reportServerInfo(proxygen::ResponseHandler* downstream);
@@ -322,6 +361,14 @@ class PrestoServer {
   std::string nodePoolType_;
   folly::SSLContextPtr sslContext_;
   std::string prestoBuiltinFunctionPrefix_;
+
+  // HTTP/HTTPS configuration populated by initializeConfigs() and consumed
+  // by initializeHttpServer() and startServer().
+  int httpPort_{0};
+  std::optional<int> httpsPort_;
+  std::string certPath_;
+  std::string keyPath_;
+  std::string ciphers_;
 };
 
 } // namespace facebook::presto


### PR DESCRIPTION
Summary:
`PrestoServer::run()` was ~580 lines performing config loading, HTTP server
setup, endpoint registration, task manager initialization, exchange source
registration, listener registration, server startup, and shutdown teardown
all in one monolithic method.

This change decomposes `run()` into focused helper methods:

- `initializeConfigs()`: Config file loading, HTTPS/JWT validation, member population
- `initializeHttpServer()`: Socket binding, HttpConfig/HttpsConfig, HttpServer construction
- `registerHttpEndpoints()`: All HTTP route registrations (/v1/memory, /v1/info, etc.)
- `registerExchangeSources()`: Exchange source factory registrations
- `initializeTaskResources()`: Memory pools, task manager, task resource, spill dir setup
- `registerListeners()`: Task, split, and expression set listener registration
- `logExecutorInfo()`: Executor thread count logging
- `startServer()`: Announcer, heartbeat manager, and blocking httpServer->start()
- `shutdownServer()`: Post-stop teardown orchestration
- `stopAnnouncer()`: Announcer and heartbeat manager stopping
- `joinExecutors()`: Thread pool joining in correct shutdown order

The refactored `run()` is now ~50 lines that clearly shows the server lifecycle
phases. All new methods are non-virtual and protected to avoid breaking the
existing subclass contract (FacebookPrestoBase, FacebookPrestoServer).

The HTTPS config variables (httpPort, httpsPort, certPath, keyPath, ciphers)
that previously were local to `run()` are now member variables, allowing them
to flow between `initializeConfigs()` and the methods that consume them.

No behavioral changes — the order of operations is preserved exactly.

## Summary by Sourcery

Refactor the native PrestoServer lifecycle so that run() delegates to smaller helper methods for configuration, HTTP server setup, task initialization, runtime registration, startup, and shutdown while preserving existing behavior.

Enhancements:
- Split PrestoServer::run() into focused lifecycle helpers for config loading, HTTP/HTTPS server setup, endpoint and exchange registration, task resources, listeners, logging, startup, and shutdown.
- Promote HTTP/HTTPS configuration (ports, cert, key, ciphers) from local variables in run() to member fields to be shared across initialization and startup helpers.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refactor the PrestoServer startup and shutdown lifecycle by decomposing the monolithic run() method into focused helper methods for configuration, HTTP server setup, runtime registration, startup, and teardown while preserving behavior.

Enhancements:
- Split PrestoServer::run() into dedicated lifecycle helpers for config initialization, HTTP/HTTPS server setup, endpoint registration, exchange source registration, task resource initialization, listener registration, logging, startup, and shutdown.
- Promote HTTP/HTTPS configuration (ports, certificate, key, ciphers) from local variables in run() to member fields so they can be shared across initialization and startup helpers.
- Encapsulate announcer and heartbeat startup/stop logic into startServer(), stopAnnouncer(), shutdownServer(), and joinExecutors() to clarify ownership and shutdown ordering.