### PR TITLE
fix(planner): Set the size estimate for a ConstantExpression/Literal

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -2169,6 +2169,11 @@ public class TestHiveMaterializedViewLogicalPlanner
 
             assertPlan(queryOptimizationWithMaterializedView, baseQuery, anyTree(
                     node(JoinNode.class,
+                            exchange(
+                                    anyTree(
+                                            constrainedTableScan(table,
+                                                    ImmutableMap.of(),
+                                                    ImmutableMap.of()))),
                             anyTree(
                                     exchange(
                                             anyTree(
@@ -2178,12 +2183,7 @@ public class TestHiveMaterializedViewLogicalPlanner
                                             anyTree(
                                                     constrainedTableScan(view2,
                                                             ImmutableMap.of(),
-                                                            ImmutableMap.of("ds_42", "ds", "orderkey_41", "orderkey"))))),
-                            exchange(
-                                    anyTree(
-                                            constrainedTableScan(table,
-                                                    ImmutableMap.of(),
-                                                    ImmutableMap.of()))))));
+                                                            ImmutableMap.of("ds_42", "ds", "orderkey_41", "orderkey"))))))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view2);

--- a/presto-main-base/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/TestScalarStatsCalculator.java
@@ -114,10 +114,12 @@ public class TestScalarStatsCalculator
                 .highValue(75.5)
                 .nullsFraction(0.0);
 
-        assertCalculate(new StringLiteral("blah"))
+        VariableStatsAssertion blah = assertCalculate(new StringLiteral("blah"));
+        blah
                 .distinctValuesCount(1.0)
                 .lowValueUnknown()
                 .highValueUnknown()
+                .averageRowSize(4.0)
                 .nullsFraction(0.0);
 
         assertCalculate(new NullLiteral())
@@ -162,6 +164,7 @@ public class TestScalarStatsCalculator
                 .distinctValuesCount(1.0)
                 .lowValueUnknown()
                 .highValueUnknown()
+                .averageRowSize(11.0)
                 .nullsFraction(0.0);
     }
 


### PR DESCRIPTION
## Description, Motivation and Context
The planner generates constant variables which were missing a size estimate. These are needed for correctly estimating join sizes/ join costs (among other cost based comparisons)

## Impact
Improves build/prode side estimation during `DetermineJoinDistributionType`

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Improves size estimates for constant variables

```

## Summary by Sourcery

Set size estimates for constant and literal string expressions to improve planner cost estimation for joins and other operations.

Bug Fixes:
- Populate average row size for constant and literal Slice-backed expressions so planner statistics include size estimates.

Tests:
- Extend scalar stats calculator tests to cover average row size estimation for string literals.