### PR TITLE
feat(planner): Improve TextRenderer to show input totals

### DIFF
--- a/presto-docs/src/main/sphinx/sql/explain-analyze.rst
+++ b/presto-docs/src/main/sphinx/sql/explain-analyze.rst
@@ -36,43 +36,91 @@ relevant plan nodes). Such statistics are useful when one wants to detect data a
 
 .. code-block:: none
 
-    presto:sf1> EXPLAIN ANALYZE SELECT count(*), clerk FROM orders WHERE orderdate > date '1995-01-01' GROUP BY clerk;
+    presto:tiny> EXPLAIN ANALYZE SELECT
+          ->     s.acctbal,
+          ->     s.name,
+          ->     n.name,
+          ->     p.partkey,
+          ->     p.mfgr,
+          ->     s.address,
+          ->     s.phone,
+          ->     s.comment
+          -> FROM
+          ->     part p,
+          ->     supplier s,
+          ->     partsupp ps,
+          ->     nation n,
+          ->     region r
+          -> WHERE
+          ->     p.partkey = ps.partkey
+          ->   AND s.suppkey = ps.suppkey
+          ->   AND p.size = 15
+          ->   AND p.type like '%BRASS'
+          ->   AND s.nationkey = n.nationkey
+          ->   AND n.regionkey = r.regionkey
+          ->   AND r.name = 'EUROPE'
+          ->   AND ps.supplycost = (
+          ->     SELECT
+          ->         min(ps.supplycost)
+          ->     FROM
+          ->         partsupp ps,
+          ->         supplier s,
+          ->         nation n,
+          ->         region r
+          ->     WHERE
+          ->         p.partkey = ps.partkey
+          ->       AND s.suppkey = ps.suppkey
+          ->       AND s.nationkey = n.nationkey
+          ->       AND n.regionkey = r.regionkey
+          ->       AND r.name = 'EUROPE'
+          -> )
+          -> ORDER BY
+          ->     s.acctbal desc,
+          ->     n.name,
+          ->     s.name,
+          ->     p.partkey
+          ->     LIMIT 100;
+
+
 
                                               Query Plan
     -----------------------------------------------------------------------------------------------
-    Fragment 1 [HASH]
-        Cost: CPU 88.57ms, Input: 4000 rows (148.44kB), Output: 1000 rows (28.32kB)
-        Output layout: [count, clerk]
-        Output partitioning: SINGLE []
-        - Project[] => [count:bigint, clerk:varchar(15)]
-                Cost: 26.24%, Input: 1000 rows (37.11kB), Output: 1000 rows (28.32kB), Filtered: 0.00%
-                Input avg.: 62.50 lines, Input std.dev.: 14.77%
-            - Aggregate(FINAL)[clerk][$hashvalue] => [clerk:varchar(15), $hashvalue:bigint, count:bigint]
-                    Cost: 16.83%, Output: 1000 rows (37.11kB)
-                    Input avg.: 250.00 lines, Input std.dev.: 14.77%
-                    count := "count"("count_8")
-                - LocalExchange[HASH][$hashvalue] ("clerk") => clerk:varchar(15), count_8:bigint, $hashvalue:bigint
-                        Cost: 47.28%, Output: 4000 rows (148.44kB)
-                        Input avg.: 4000.00 lines, Input std.dev.: 0.00%
-                    - RemoteSource[2] => [clerk:varchar(15), count_8:bigint, $hashvalue_9:bigint]
-                            Cost: 9.65%, Output: 4000 rows (148.44kB)
-                            Input avg.: 4000.00 lines, Input std.dev.: 0.00%
+    ...
+    Fragment 4 [SOURCE]
+     CPU: 31.55ms, Scheduled: 38.34ms, Input: 8,020 rows (260B); per task: avg.: 8,020.00 std.dev.: 0.00, Output: 1,196 rows (21.02kB), 1 tasks
+     Output layout: [partkey_15, min_73]
+     Output partitioning: HASH [partkey_15]
+     Output encoding: COLUMNAR
+     Stage Execution Strategy: UNGROUPED_EXECUTION
+     - Aggregate(PARTIAL)[partkey_15][PlanNodeId 3023] => [partkey_15:bigint, min_73:double]
+             CPU: 3.00ms (1.74%), Scheduled: 4.00ms (0.54%), Output: 1,196 rows (21.02kB)
+             Input total: 1,600 rows (40.63kB), avg.: 400.00 rows, std.dev.: 0.00%
+             Collisions avg.: 4.50 (160.41% est.), Collisions std.dev.: 86.78%
+             min_73 := "presto.default.min"((supplycost_18)) (1:365)
+         - InnerJoin[PlanNodeId 2455][("suppkey_16" = "suppkey_21")] => [partkey_15:bigint, supplycost_18:double]
+                 Estimates: {source: CostBasedSourceInfo, rows: 1,600 (28.13kB), cpu: 684,460.00, memory: 225.00, network: 234.00}
+                 CPU: 11.00ms (6.40%), Scheduled: 13.00ms (1.77%), Output: 1,600 rows (40.63kB)
+                 Left (probe) Input total: 8,000 rows (210.94kB), avg.: 2,000.00 rows, std.dev.: 0.00%
+                 Right (build) Input total: 20 rows (260B), avg.: 1.25 rows, std.dev.: 60.00%
+                         Collisions avg.: 0.40 (30.84% est.), Collisions std.dev.: 183.71%
+                 Distribution: REPLICATED
+             - ScanFilter[PlanNodeId 9,2699][table = TableHandle {connectorId='tpch', connectorHandle='partsupp:sf0.01', layout='Optional[partsupp:sf0.01]'}, grouped = false, filterPredicate = (not(IS_NULL(partkey_15))) AND (not(IS_NULL(suppkey_16)))] => [partkey_15:bigint, suppkey_16:bigint, supplycost_18:double]
+                     Estimates: {source: CostBasedSourceInfo, rows: 8,000 (210.94kB), cpu: 216,000.00, memory: 0.00, network: 0.00}/{source: CostBasedSourceInfo, rows: 8,000 (210.94kB), cpu: 432,000.00, memory: 0.00, network: 0.00}
+                     CPU: 14.00ms (8.14%), Scheduled: 16.00ms (2.17%), Output: 8,000 rows (210.94kB)
+                     Input total: 8,000 rows (0B), avg.: 2,000.00 rows, std.dev.: 0.00%
+                     partkey_15 := tpch:partkey (1:389)
+                     supplycost_18 := tpch:supplycost (1:389)
+                     suppkey_16 := tpch:suppkey (1:389)
+                     Input: 8,000 rows (0B), Filtered: 0.00%
+             - LocalExchange[PlanNodeId 2949][HASH] (suppkey_21) => [suppkey_21:bigint]
+                     Estimates: {source: CostBasedSourceInfo, rows: 20 (180B), cpu: 7,480.00, memory: 54.00, network: 234.00}
+                     CPU: 0.00ns (0.00%), Scheduled: 0.00ns (0.00%), Output: 20 rows (260B)
+                     Input total: 20 rows (260B), avg.: 1.25 rows, std.dev.: 225.39%
+                 - RemoteSource[5]  => [suppkey_21:bigint]
+                         CPU: 0.00ns (0.00%), Scheduled: 0.00ns (0.00%), Output: 20 rows (260B)
+                         Input total: 20 rows (260B), avg.: 1.25 rows, std.dev.: 225.39%
+    ...
 
-    Fragment 2 [tpch:orders:1500000]
-        Cost: CPU 14.00s, Input: 818058 rows (22.62MB), Output: 4000 rows (148.44kB)
-        Output layout: [clerk, count_8, $hashvalue_10]
-        Output partitioning: HASH [clerk][$hashvalue_10]
-        - Aggregate(PARTIAL)[clerk][$hashvalue_10] => [clerk:varchar(15), $hashvalue_10:bigint, count_8:bigint]
-                Cost: 4.47%, Output: 4000 rows (148.44kB)
-                Input avg.: 204514.50 lines, Input std.dev.: 0.05%
-                Collisions avg.: 5701.28 (17569.93% est.), Collisions std.dev.: 1.12%
-                count_8 := "count"(*)
-            - ScanFilterProject[table = tpch:tpch:orders:sf1.0, originalConstraint = ("orderdate" > "$literal$date"(BIGINT '9131')), filterPredicate = ("orderdate" > "$literal$date"(BIGINT '9131'))] => [cler
-                    Cost: 95.53%, Input: 1500000 rows (0B), Output: 818058 rows (22.62MB), Filtered: 45.46%
-                    Input avg.: 375000.00 lines, Input std.dev.: 0.00%
-                    $hashvalue_10 := "combine_hash"(BIGINT '0', COALESCE("$operator$hash_code"("clerk"), 0))
-                    orderdate := tpch:orderdate
-                    clerk := tpch:clerk
 
 When the ``VERBOSE`` option is used, some operators may report additional information.
 For example, the window function operator will output the following:

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/OperatorInputStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/OperatorInputStats.java
@@ -20,16 +20,19 @@ public class OperatorInputStats
 {
     private final long totalDrivers;
     private final long inputPositions;
+    private final long inputDataSizeInBytes;
     private final double sumSquaredInputPositions;
 
     @JsonCreator
     public OperatorInputStats(
             @JsonProperty("totalDrivers") long totalDrivers,
             @JsonProperty("inputPositions") long inputPositions,
+            @JsonProperty("inputDataSizeInBytes") long inputDataSizeInBytes,
             @JsonProperty("sumSquaredInputPositions") double sumSquaredInputPositions)
     {
         this.totalDrivers = totalDrivers;
         this.inputPositions = inputPositions;
+        this.inputDataSizeInBytes = inputDataSizeInBytes;
         this.sumSquaredInputPositions = sumSquaredInputPositions;
     }
 
@@ -46,6 +49,12 @@ public class OperatorInputStats
     }
 
     @JsonProperty
+    public long getInputDataSizeInBytes()
+    {
+        return inputDataSizeInBytes;
+    }
+
+    @JsonProperty
     public double getSumSquaredInputPositions()
     {
         return sumSquaredInputPositions;
@@ -56,6 +65,7 @@ public class OperatorInputStats
         return new OperatorInputStats(
                 first.totalDrivers + second.totalDrivers,
                 first.inputPositions + second.inputPositions,
+                first.inputDataSizeInBytes + second.inputDataSizeInBytes,
                 first.sumSquaredInputPositions + second.sumSquaredInputPositions);
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanNodeStatsSummarizer.java
@@ -139,6 +139,7 @@ public class PlanNodeStatsSummarizer
                                 new OperatorInputStats(
                                         operatorStats.getTotalDrivers(),
                                         operatorStats.getInputPositions(),
+                                        operatorStats.getInputDataSizeInBytes(),
                                         operatorStats.getSumSquaredInputPositions())),
                         (map1, map2) -> mergeMaps(map1, map2, OperatorInputStats::merge));
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.planner.planPrinter;
 
+import com.facebook.airlift.units.DataSize;
 import com.facebook.presto.cost.PlanCostEstimate;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
 import com.facebook.presto.cost.TableWriterNodeStatsEstimate;
@@ -147,6 +148,7 @@ public class TextRenderer
     {
         Map<String, Double> inputAverages = stats.getOperatorInputPositionsAverages();
         Map<String, Double> inputStdDevs = stats.getOperatorInputPositionsStdDevs();
+        Map<String, OperatorInputStats> inputStats = stats.getOperatorInputStats();
 
         Map<String, Double> hashCollisionsAverages = emptyMap();
         Map<String, Double> hashCollisionsStdDevs = emptyMap();
@@ -162,10 +164,15 @@ public class TextRenderer
         for (String operator : translatedOperatorTypes.keySet()) {
             String translatedOperatorType = translatedOperatorTypes.get(operator);
             double inputAverage = inputAverages.get(operator);
+            long inputTotalRowCount = inputStats.get(operator).getInputPositions();
+            long inputDataSizeInBytes = inputStats.get(operator).getInputDataSizeInBytes();
 
             output.append(translatedOperatorType);
-            output.append(format(Locale.US, "Input avg.: %s rows, Input std.dev.: %s%%%n",
-                    formatDouble(inputAverage), formatDouble(100.0d * inputStdDevs.get(operator) / inputAverage)));
+            output.append(format(Locale.US, "Input total: %s (%s), avg.: %s rows, std.dev.: %s%%%n",
+                    formatPositions(inputTotalRowCount),
+                    DataSize.succinctBytes(inputDataSizeInBytes).toString(),
+                    formatDouble(inputAverage),
+                    formatDouble(100.0d * inputStdDevs.get(operator) / inputAverage)));
 
             double hashCollisionsAverage = hashCollisionsAverages.getOrDefault(operator, 0.0d);
             double expectedHashCollisionsAverage = expectedHashCollisionsAverages.getOrDefault(operator, 0.0d);


### PR DESCRIPTION
## Description, Motivation and Context
This makes it much easier to gork what a nodes input were (especially for join nodes)
An example -
```
- InnerJoin[PlanNodeId 2455][("suppkey_16" = "suppkey_21")] => [partkey_15:bigint, supplycost_18:double]
                 Estimates: {source: CostBasedSourceInfo, rows: 1,600 (28.13kB), cpu: 684,460.00, memory: 225.00, network: 234.00}
                 CPU: 11.00ms (6.40%), Scheduled: 13.00ms (1.77%), Output: 1,600 rows (40.63kB)
                 Left (probe) Input total: 8,000 rows (210.94kB), avg.: 2,000.00 rows, std.dev.: 0.00%
                 Right (build) Input total: 20 rows (260B), avg.: 1.25 rows, std.dev.: 60.00%
                         Collisions avg.: 0.40 (30.84% est.), Collisions std.dev.: 183.71%
                 Distribution: REPLICATED
```

## Test Plan
CI

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enhance plan text rendering to include total input row counts and data sizes alongside existing input distribution statistics for operators in EXPLAIN ANALYZE output.

New Features:
- Add tracking of input data size to operator input statistics and propagate it through plan node statistics summarization.
- Display per-operator total input rows and input data size in the text plan renderer to improve readability of join and other node inputs.