### PR TITLE
[WIP DNR]- Test PR

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -84,7 +84,7 @@ public class TestSqlTaskManager
 
     public TestSqlTaskManager()
     {
-        localMemoryManager = new LocalMemoryManager(new NodeMemoryConfig());
+        localMemoryManager = new LocalMemoryManager(new NodeMemoryConfig(), new com.facebook.presto.server.ServerConfig(), new com.facebook.presto.execution.scheduler.NodeSchedulerConfig());
         localSpillManager = new LocalSpillManager(new NodeSpillConfig());
         taskExecutor = new TaskExecutor(8, 16, 3, 4, TASK_FAIR, Ticker.systemTicker());
         taskExecutor.start();

--- a/presto-main-base/src/test/java/com/facebook/presto/memory/TestLocalMemoryManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/memory/TestLocalMemoryManager.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.memory;
 
 import com.facebook.airlift.units.DataSize;
+import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.server.ServerConfig;
 import org.testng.annotations.Test;
 
 import static com.facebook.airlift.units.DataSize.Unit.GIGABYTE;
@@ -32,7 +34,9 @@ public class TestLocalMemoryManager
                 .setMaxQueryMemoryPerNode(new DataSize(20, GIGABYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(20, GIGABYTE));
 
-        LocalMemoryManager localMemoryManager = new LocalMemoryManager(config,
+        ServerConfig serverConfig = new ServerConfig().setCoordinator(false);
+        NodeSchedulerConfig schedulerConfig = new NodeSchedulerConfig();
+        LocalMemoryManager localMemoryManager = new LocalMemoryManager(config, serverConfig, schedulerConfig,
                 new DataSize(60, GIGABYTE).toBytes());
         assertFalse(localMemoryManager.getReservedPool().isPresent());
         assertEquals(localMemoryManager.getPools().size(), 1);
@@ -46,7 +50,9 @@ public class TestLocalMemoryManager
                 .setMaxQueryMemoryPerNode(new DataSize(20, GIGABYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(20, GIGABYTE));
 
-        LocalMemoryManager localMemoryManager = new LocalMemoryManager(config,
+        ServerConfig serverConfig = new ServerConfig().setCoordinator(false);
+        NodeSchedulerConfig schedulerConfig = new NodeSchedulerConfig();
+        LocalMemoryManager localMemoryManager = new LocalMemoryManager(config, serverConfig, schedulerConfig,
                 new DataSize(60, GIGABYTE).toBytes());
         assertTrue(localMemoryManager.getReservedPool().isPresent());
         assertEquals(localMemoryManager.getPools().size(), 2);
@@ -60,7 +66,9 @@ public class TestLocalMemoryManager
                 .setMaxQueryMemoryPerNode(new DataSize(200, GIGABYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(20, GIGABYTE));
 
-        new LocalMemoryManager(config, new DataSize(60, GIGABYTE).toBytes());
+        ServerConfig serverConfig = new ServerConfig().setCoordinator(false);
+        NodeSchedulerConfig schedulerConfig = new NodeSchedulerConfig();
+        new LocalMemoryManager(config, serverConfig, schedulerConfig, new DataSize(60, GIGABYTE).toBytes());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
@@ -74,6 +82,8 @@ public class TestLocalMemoryManager
                 .setMaxQueryMemoryPerNode(new DataSize(20, GIGABYTE))
                 .setMaxQueryTotalMemoryPerNode(new DataSize(20, GIGABYTE));
 
-        new LocalMemoryManager(config, new DataSize(10, GIGABYTE).toBytes());
+        ServerConfig serverConfig = new ServerConfig().setCoordinator(false);
+        NodeSchedulerConfig schedulerConfig = new NodeSchedulerConfig();
+        new LocalMemoryManager(config, serverConfig, schedulerConfig, new DataSize(10, GIGABYTE).toBytes());
     }
 }


### PR DESCRIPTION
Prevent coordinators from validating query.max-memory-per-node against JVM heap when they don't run query tasks

## Description
<!---Describe your changes in detail-->

## Motivation and Context


## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Relax query max-memory-per-node heap validation on coordinator-only nodes while wiring coordinator and scheduler configuration into the local memory manager.

Bug Fixes:
- Avoid failing heap headroom validation on coordinators that do not schedule or execute query tasks.

Enhancements:
- Inject ServerConfig and NodeSchedulerConfig into LocalMemoryManager to make memory validation aware of node roles.

Tests:
- Extend LocalMemoryManager and NodeMemoryConfig tests to cover coordinator-only behavior and updated constructor dependencies.