### PR TITLE
Dummy docker image tests

### DIFF
--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -27,7 +27,7 @@ function export_canonical_path() {
 source "${BASH_SOURCE%/*}/../../../bin/locations.sh"
 
 export DOCKER_IMAGES_VERSION=${DOCKER_IMAGES_VERSION:-11}
-export HADOOP_BASE_IMAGE=${HADOOP_BASE_IMAGE:-"prestodb/hdp3.1-hive"}
+export HADOOP_BASE_IMAGE=${HADOOP_BASE_IMAGE:-"unix280/hdp3.1-hive"}
 # This is the directory for the overriden JDK to use for starting Presto
 export OVERRIDE_JDK_DIR=${OVERRIDE_JDK_DIR:-"/dev/null"}
 

--- a/presto-product-tests/conf/docker/common/standard.yml
+++ b/presto-product-tests/conf/docker/common/standard.yml
@@ -1,7 +1,7 @@
 services:
 
   java-8-base:
-    image: 'prestodb/centos7-oj8:${DOCKER_IMAGES_VERSION}'
+    image: 'unix280/centos7-oj8:${DOCKER_IMAGES_VERSION}'
     platform: linux/amd64
     volumes:
       - ../..:/docker/volumes/conf

--- a/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
+++ b/presto-product-tests/conf/docker/singlenode-ldap/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   presto-master:
-    image: 'prestodb/centos7-oj8-openldap:${DOCKER_IMAGES_VERSION}'
+    image: 'unix280/centos7-oj8-openldap:${DOCKER_IMAGES_VERSION}'
     command: /docker/volumes/conf/docker/files/presto-launcher-wrapper.sh singlenode-ldap run
     extra_hosts:
        - "${LDAP_SERVER_HOST}:${LDAP_SERVER_IP}"
@@ -12,7 +12,7 @@ services:
       - ${OVERRIDE_JDK_DIR}:/docker/volumes/overridejdk
 
   application-runner:
-    image: 'prestodb/centos7-oj8-openldap:${DOCKER_IMAGES_VERSION}'
+    image: 'unix280/centos7-oj8-openldap:${DOCKER_IMAGES_VERSION}'
     volumes:
       - ${OVERRIDE_JDK_DIR}:/docker/volumes/overridejdk
     environment:
@@ -20,4 +20,4 @@ services:
       - CLI_ARGUMENTS=--server https://presto-master:8443 --keystore-path /etc/openldap/certs/coordinator.jks --keystore-password testldap
 
   ldapserver:
-    image: 'prestodb/centos7-oj8-openldap:${DOCKER_IMAGES_VERSION}'
+    image: 'unix280/centos7-oj8-openldap:${DOCKER_IMAGES_VERSION}'


### PR DESCRIPTION
Just for docker image testing, will close after tested.

Related PR: https://github.com/prestodb/docker-images/pull/61

## Summary by Sourcery

Update Docker image references for product tests to use alternative registry images.

Build:
- Change singlenode-ldap docker-compose services to use unix280 centos7-oj8-openldap images instead of prestodb equivalents.
- Update default HADOOP_BASE_IMAGE to unix280/hdp3.1-hive in common compose configuration.
- Switch standard java-8-base service image to unix280/centos7-oj8 in shared Docker configuration.