### PR TITLE
misc(native): Fix lint issues in presto_cpp types/ directory

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
+++ b/presto-native-execution/presto_cpp/main/types/PrestoTaskId.h
@@ -12,8 +12,13 @@
  * limitations under the License.
  */
 #pragma once
-#include <folly/Conv.h>
+
+#include <cstdint>
 #include <string>
+#include <vector>
+
+#include <folly/Conv.h>
+
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::presto {

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -918,7 +918,8 @@ VeloxQueryPlanConverterBase::generateOutputVariables(
   if (statisticsAggregation == nullptr) {
     return outputVariables;
   }
-  const auto statisticsOutputVariables = statisticsAggregation->outputVariables;
+  const auto& statisticsOutputVariables =
+      statisticsAggregation->outputVariables;
   auto statisticsGroupingVariables = statisticsAggregation->groupingVariables;
   outputVariables.insert(
       outputVariables.end(),
@@ -1752,7 +1753,7 @@ toSortFieldsAndOrders(
   std::vector<core::FieldAccessTypedExprPtr> sortFields;
   std::vector<core::SortOrder> sortOrders;
   if (orderingScheme != nullptr) {
-    auto nodeSpecOrdering = orderingScheme->orderBy;
+    const auto& nodeSpecOrdering = orderingScheme->orderBy;
     sortFields.reserve(nodeSpecOrdering.size());
     sortOrders.reserve(nodeSpecOrdering.size());
     for (const auto& [variable, sortOrder] : nodeSpecOrdering) {

--- a/presto-native-execution/presto_cpp/main/types/TypeParser.cpp
+++ b/presto-native-execution/presto_cpp/main/types/TypeParser.cpp
@@ -11,19 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <boost/algorithm/string.hpp>
-#include <iostream>
-
 #include "presto_cpp/main/types/TypeParser.h"
-#include "velox/functions/prestosql/types/parser/TypeParser.h"
 
 #include "presto_cpp/main/common/Configs.h"
+#include "velox/functions/prestosql/types/parser/TypeParser.h"
 
 namespace facebook::presto {
 
 velox::TypePtr TypeParser::parse(const std::string& text) const {
   if (SystemConfig::instance()->charNToVarcharImplicitCast()) {
-    if (text.find("char(") == 0 || text.find("CHAR(") == 0) {
+    if (text.starts_with("char(") || text.starts_with("CHAR(")) {
       return velox::VARCHAR();
     }
   }

--- a/presto-native-execution/presto_cpp/main/types/TypeParser.h
+++ b/presto-native-execution/presto_cpp/main/types/TypeParser.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <string>
+#include <unordered_map>
+
 #include "velox/type/Type.h"
 
 namespace facebook::presto {

--- a/presto-native-execution/presto_cpp/main/types/tests/TestUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/TestUtils.cpp
@@ -11,17 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
+#include <string>
 
-using namespace std;
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/filesystem/operations.hpp>
 
 namespace facebook::presto::test::utils {
 
 namespace {
-const std::string applyClionDirFix(
+std::string applyClionDirFix(
     std::string& currentPath,
-    const std::string& fileName) {
+    const std::string& fileName) noexcept {
   // CLion runs the tests from cmake-build-release/ or cmake-build-debug/
   // directory. Hard-coded json files are not copied there and test fails with
   // file not found. Fixing the path so that we can trigger these tests from
@@ -33,8 +34,8 @@ const std::string applyClionDirFix(
 }
 } // namespace
 
-const std::string getDataPath(const std::string& fileName) {
-  std::string currentPath = boost::filesystem::current_path().c_str();
+std::string getDataPath(const std::string& fileName) noexcept {
+  std::string currentPath = boost::filesystem::current_path().string();
   if (boost::algorithm::ends_with(currentPath, "fbcode")) {
     return currentPath +
         "/github/presto-trunk/presto-native-execution/presto_cpp/main/types/tests/data/" +
@@ -48,10 +49,10 @@ const std::string getDataPath(const std::string& fileName) {
   return applyClionDirFix(currentPath, fileName);
 }
 
-const std::string getDataPath(
+std::string getDataPath(
     const std::string& testDataDir,
-    const std::string& fileName) {
-  std::string currentPath = boost::filesystem::current_path().c_str();
+    const std::string& fileName) noexcept {
+  std::string currentPath = boost::filesystem::current_path().string();
   if (boost::algorithm::ends_with(currentPath, "fbcode")) {
     return currentPath + testDataDir + fileName;
   }

--- a/presto-native-execution/presto_cpp/main/types/tests/TestUtils.h
+++ b/presto-native-execution/presto_cpp/main/types/tests/TestUtils.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,9 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <string>
+
 namespace facebook::presto::test::utils {
-const std::string getDataPath(const std::string& fileName);
-const std::string getDataPath(
+std::string getDataPath(const std::string& fileName) noexcept;
+std::string getDataPath(
     const std::string& testDataDir,
-    const std::string& fileName);
+    const std::string& fileName) noexcept;
 } // namespace facebook::presto::test::utils


### PR DESCRIPTION
Summary:
Fix CLANGTIDY and INFERMINICPP lint warnings across the types/ directory:

TestUtils.cpp:
- Replace broad boost includes (string.hpp, filesystem.hpp) with specific headers
- Add missing #include <string>
- Remove unused `using namespace std;`
- Remove meaningless `const` qualifier on return-by-value types
- Replace redundant `.c_str()` with `.string()` on boost::filesystem::current_path()
- Add `noexcept` to function declarations and definitions

TestUtils.h:
- Add `#pragma once` header guard
- Add missing `#include <string>`
- Remove `const` from return types and add `noexcept`

TypeParser.cpp:
- Remove unused includes: `boost/algorithm/string.hpp` and `iostream`
- Fix include ordering (self-header first)
- Use `starts_with()` instead of `find() == 0` (modernize-use-starts-ends-with)

TypeParser.h:
- Add missing `#include <string>` and `#include <unordered_map>`

PrestoTaskId.h:
- Add missing `#include <cstdint>`, `#include <vector>`
- Fix include ordering (standard, then third-party, then project)

PrestoToVeloxQueryPlan.cpp:
- Fix unnecessary copies: use `const auto&` for `statisticsOutputVariables` and `nodeSpecOrdering`

```
== NO RELEASE NOTE ==
```


## Summary by Sourcery

Resolve static analysis and lint warnings in the presto_cpp types module and associated tests.

Enhancements:
- Tighten includes, header guards, and noexcept usage in TestUtils utilities and TypeParser interfaces to satisfy modern C++ and linting requirements.
- Adjust include ordering and add missing standard library headers in type-related components, including PrestoTaskId and TypeParser, for clearer dependencies and portability.
- Reduce unnecessary copying in PrestoToVeloxQueryPlan by binding to const references for existing aggregation and ordering structures.

Tests:
- Update TestUtils test helpers to use more precise includes, noexcept declarations, and simplified filesystem string handling while removing unused constructs.
