### PR TITLE
feat(analyzer): Add support for SELECT alias references in HAVING clause

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2967,7 +2967,10 @@ class StatementAnalyzer
             analysis.setOrderByExpressions(node, orderByExpressions);
 
             List<Expression> sourceExpressions = new ArrayList<>(outputExpressions);
-            node.getHaving().ifPresent(sourceExpressions::add);
+            // Use the rewritten HAVING expression (to resolve SELECT alias references)
+            if (node.getHaving().isPresent()) {
+                sourceExpressions.add(analysis.getHaving(node));
+            }
 
             analyzeGroupingOperations(node, sourceExpressions, orderByExpressions);
             List<FunctionCall> aggregates = analyzeAggregations(node, sourceExpressions, orderByExpressions);
@@ -3820,7 +3823,12 @@ class StatementAnalyzer
             if (node.getHaving().isPresent()) {
                 Expression predicate = node.getHaving().get();
 
-                ExpressionAnalysis expressionAnalysis = analyzeExpression(predicate, scope);
+                // Reuse OrderByExpressionRewriter to resolve SELECT aliases in HAVING
+                Multimap<QualifiedName, Expression> namedOutputExpressions = extractNamedOutputExpressions(node.getSelect());
+                Expression rewrittenPredicate = ExpressionTreeRewriter.rewriteWith(new OrderByExpressionRewriter(namedOutputExpressions, "HAVING"), predicate);
+
+                // Analyze the rewritten expression
+                ExpressionAnalysis expressionAnalysis = analyzeExpression(rewrittenPredicate, scope);
 
                 expressionAnalysis.getWindowFunctions().stream()
                         .findFirst()
@@ -3830,12 +3838,12 @@ class StatementAnalyzer
 
                 analysis.recordSubqueries(node, expressionAnalysis);
 
-                Type predicateType = expressionAnalysis.getType(predicate);
+                Type predicateType = expressionAnalysis.getType(rewrittenPredicate);
                 if (!predicateType.equals(BOOLEAN) && !predicateType.equals(UNKNOWN)) {
-                    throw new SemanticException(TYPE_MISMATCH, predicate, "HAVING clause must evaluate to a boolean: actual type %s", predicateType);
+                    throw new SemanticException(TYPE_MISMATCH, rewrittenPredicate, "HAVING clause must evaluate to a boolean: actual type %s", predicateType);
                 }
 
-                analysis.setHaving(node, predicate);
+                analysis.setHaving(node, rewrittenPredicate);
             }
         }
 
@@ -3886,10 +3894,17 @@ class StatementAnalyzer
                 extends ExpressionRewriter<Void>
         {
             private final Multimap<QualifiedName, Expression> assignments;
+            private final String clauseName;
 
             public OrderByExpressionRewriter(Multimap<QualifiedName, Expression> assignments)
             {
+                this(assignments, "ORDER BY");
+            }
+
+            public OrderByExpressionRewriter(Multimap<QualifiedName, Expression> assignments, String clauseName)
+            {
                 this.assignments = assignments;
+                this.clauseName = clauseName;
             }
 
             @Override
@@ -3902,7 +3917,7 @@ class StatementAnalyzer
                         .collect(Collectors.toSet());
 
                 if (expressions.size() > 1) {
-                    throw new SemanticException(AMBIGUOUS_ATTRIBUTE, reference, "'%s' in ORDER BY is ambiguous", name);
+                    throw new SemanticException(AMBIGUOUS_ATTRIBUTE, reference, "'%s' in '%s' is ambiguous", name, clauseName);
                 }
 
                 if (expressions.size() == 1) {


### PR DESCRIPTION
## Description
This change enables the `HAVING` clause to reference `SELECT` output aliases.

Previously, `HAVING` expressions were analyzed without resolving `SELECT` output aliases, which caused queries referencing projected aliases to fail semantic analysis.

This change rewrites the `HAVING` predicate by using existing `OrderByExpressionRewriter` prior to expression analysis, aligning alias resolution semantics with existing ORDER BY behavior.

Example:

**Before (this query would fail with a semantic analysis error):**

HAVING alias 'total' unresolved

> SELECT sum(a) AS total
FROM t1
GROUP BY b
HAVING total > 10;
-- Error: Column 'total' cannot be resolved

**After (this query works correctly)**

HAVING can reference SELECT alias 'total'

> SELECT sum(a) AS total
FROM t1
GROUP BY b
HAVING total > 10;

## Motivation and Context
Queries that reference `SELECT` output aliases in the `HAVING` clause currently fail during analysis due to unresolved aliases. This behavior is inconsistent with `ORDER BY`, which supports alias resolution.

This change improves SQL compatibility.

## Impact
`HAVING` clause can now reference `SELECT` output aliases.

No changes to public APIs.
No expected performance impact.
No changes to planning or execution logic.

## Test Plan
Updated test case which now also includes negative case. Local testing performed.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add support for SELECT alias references in HAVING clause
```

## Summary by Sourcery

Enable semantic analysis of HAVING clauses that reference SELECT output aliases by reusing the existing alias-rewriting logic shared with ORDER BY.

New Features:
- Allow HAVING clauses to reference SELECT output aliases for improved SQL compatibility.

Enhancements:
- Generalize the ORDER BY expression rewriter to be parameterized by clause name and reuse it for HAVING alias resolution, including clearer ambiguity error messages.
- Include rewritten HAVING expressions in grouping and aggregation analysis to keep semantics consistent.

Tests:
- Expand analyzer tests to cover successful HAVING references to SELECT aliases across grouped and aggregated queries.