### PR TITLE
refactor: Update TempDirectoryPath and TempFilePath path

### DIFF
--- a/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
@@ -28,10 +28,11 @@
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
-#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::common::testutil;
 using namespace facebook::presto;
 using namespace facebook::presto::operators;
 
@@ -189,7 +190,7 @@ class BroadcastTest : public exec::test::OperatorTestBase,
     exec::Operator::registerOperator(
         std::make_unique<BroadcastWriteTranslator>());
 
-    auto tempDirectoryPath = exec::test::TempDirectoryPath::create();
+    auto tempDirectoryPath = TempDirectoryPath::create();
     auto [serdeRowType, broadcastFilePaths] =
         executeBroadcastWrite(data, tempDirectoryPath->getPath(), serdeLayout);
 
@@ -264,7 +265,7 @@ TEST_P(BroadcastTest, endToEndSerdeLayout) {
 TEST_P(BroadcastTest, endToEndWithNoRows) {
   std::vector<RowVectorPtr> data = {makeRowVector(
       {makeFlatVector<double>({}), makeArrayVector<int32_t>({})})};
-  auto tempDirectoryPath = exec::test::TempDirectoryPath::create();
+  auto tempDirectoryPath = TempDirectoryPath::create();
   std::vector<std::string> broadcastFilePaths;
 
   // Execute write.
@@ -291,7 +292,7 @@ TEST_P(BroadcastTest, endToEndWithMultipleWriteNodes) {
           makeFlatVector<int32_t>({11, 21, 31, 41, 51, 61}),
           makeFlatVector<int64_t>({102, 203, 304, 405, 506, 607}),
       })};
-  auto tempDirectoryPath = exec::test::TempDirectoryPath::create();
+  auto tempDirectoryPath = TempDirectoryPath::create();
   std::vector<std::string> broadcastFilePaths;
 
   // Execute write.
@@ -380,7 +381,7 @@ TEST_P(BroadcastTest, malformedBroadcastInfoJson) {
 }
 
 TEST_P(BroadcastTest, broadcastFileWriter) {
-  auto tempDirectoryPath = exec::test::TempDirectoryPath::create();
+  auto tempDirectoryPath = TempDirectoryPath::create();
   auto fileSystem =
       velox::filesystems::getFileSystem(tempDirectoryPath->getPath(), nullptr);
   fileSystem->mkdir(tempDirectoryPath->getPath());
@@ -585,7 +586,7 @@ TEST_P(BroadcastTest, endToEndWithDifferentWriterPageSizes) {
   };
 
   for (size_t i = 0; i < kPageSizes.size(); ++i) {
-    auto tempDirectoryPath = exec::test::TempDirectoryPath::create();
+    auto tempDirectoryPath = TempDirectoryPath::create();
 
     // Create a modified factory that uses custom buffer size
     auto fileSystem = velox::filesystems::getFileSystem(
@@ -652,7 +653,7 @@ TEST_P(BroadcastTest, endToEndWithDifferentWriterPageSizes) {
 }
 
 TEST_P(BroadcastTest, exceedBroadcastFileWriterLimit) {
-  auto tempDirectoryPath = exec::test::TempDirectoryPath::create();
+  auto tempDirectoryPath = TempDirectoryPath::create();
   auto fileSystem =
       velox::filesystems::getFileSystem(tempDirectoryPath->getPath(), nullptr);
   fileSystem->mkdir(tempDirectoryPath->getPath());
@@ -693,7 +694,7 @@ TEST_P(BroadcastTest, exceedBroadcastFileWriterLimit) {
 }
 
 TEST_P(BroadcastTest, broadcastJoinExceedLimit) {
-  auto tempDirectoryPath = exec::test::TempDirectoryPath::create();
+  auto tempDirectoryPath = TempDirectoryPath::create();
 
   // Create build side data (data to broadcast)
   auto buildData = makeRowVector({

--- a/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/ShuffleTest.cpp
@@ -33,7 +33,7 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/row/CompactRow.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -191,7 +191,7 @@ class ShuffleTest : public exec::test::OperatorTestBase {
         std::make_unique<LocalPersistentShuffleFactory>());
     registerExchangeSource(std::string(shuffleName_));
     // Create a temporary directory for shuffle files
-    tempDir_ = exec::test::TempDirectoryPath::create();
+    tempDir_ = TempDirectoryPath::create();
   }
 
   void TearDown() override {
@@ -660,7 +660,7 @@ class ShuffleTest : public exec::test::OperatorTestBase {
         {"c16", MAP(TINYINT(), REAL())},
     });
 
-    auto rootDirectory = velox::exec::test::TempDirectoryPath::create();
+    auto rootDirectory = TempDirectoryPath::create();
     auto rootPath = rootDirectory->getPath();
     const std::string shuffleWriteInfo =
         localShuffleWriteInfo(rootPath, numPartitions);
@@ -701,7 +701,7 @@ class ShuffleTest : public exec::test::OperatorTestBase {
   }
 
   std::string_view shuffleName_;
-  std::shared_ptr<exec::test::TempDirectoryPath> tempDir_;
+  std::shared_ptr<TempDirectoryPath> tempDir_;
   enum class DataType {
     BASIC,
     BASIC_WITH_NULLS,
@@ -1412,10 +1412,10 @@ TEST_F(ShuffleTest, shuffleEndToEnd) {
   for (const auto& config : testSettings) {
     SCOPED_TRACE(config.debugString());
 
-    std::shared_ptr<exec::test::TempDirectoryPath> customTempDir;
+    std::shared_ptr<TempDirectoryPath> customTempDir;
     std::string rootPath;
     if (config.useCustomTempDir) {
-      customTempDir = exec::test::TempDirectoryPath::create();
+      customTempDir = TempDirectoryPath::create();
       rootPath = customTempDir->getPath();
     } else {
       rootPath = tempDir_->getPath();
@@ -1564,7 +1564,7 @@ TEST_F(ShuffleTest, shuffleWriterReader) {
   for (const auto& config : testSettings) {
     SCOPED_TRACE(config.debugString());
 
-    auto tempRootDir = velox::exec::test::TempDirectoryPath::create();
+    auto tempRootDir = TempDirectoryPath::create();
     const auto testRootPath = tempRootDir->getPath();
 
     LocalShuffleWriteInfo writeInfo = LocalShuffleWriteInfo::deserialize(

--- a/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/tests/CMakeLists.txt
@@ -90,7 +90,7 @@ if(PRESTO_ENABLE_REMOTE_FUNCTIONS)
     presto_server_remote_function_test
     presto_server_remote_function
     velox_expression
-    velox_temp_path
+    velox_test_util
     GTest::gmock
     GTest::gtest
     GTest::gtest_main

--- a/presto-native-execution/presto_cpp/main/tests/LinuxMemoryCheckerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/LinuxMemoryCheckerTest.cpp
@@ -17,9 +17,10 @@
 #include <gtest/gtest.h>
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/exec/tests/utils/TempFilePath.h"
+#include "velox/common/testutil/TempFilePath.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::common::testutil;
 
 namespace facebook::presto {
 class LinuxMemoryCheckerTest : public testing::Test {
@@ -31,11 +32,11 @@ class LinuxMemoryCheckerTest : public testing::Test {
   void checkAvailableMemoryOfDeployment(
       const std::string& content,
       int64_t expectedMemoryMax) {
-    auto tempMemInfoFile = exec::test::TempFilePath::create();
+    auto tempMemInfoFile = TempFilePath::create();
     tempMemInfoFile->append(kMemInfoText_);
     auto memInfoPath = tempMemInfoFile->getPath();
 
-    auto tempMemMaxFile = exec::test::TempFilePath::create();
+    auto tempMemMaxFile = TempFilePath::create();
     tempMemMaxFile->append(content);
     auto tempMemMaxFilePath = tempMemMaxFile->getPath();
 
@@ -47,7 +48,7 @@ class LinuxMemoryCheckerTest : public testing::Test {
   void checkMemoryUsage(
       const std::string& content,
       int64_t expectedMemoryUsage) {
-    auto tempTestFile = exec::test::TempFilePath::create();
+    auto tempTestFile = TempFilePath::create();
     tempTestFile->append(content);
     auto testFilePath = tempTestFile->getPath();
 
@@ -147,11 +148,11 @@ TEST_F(LinuxMemoryCheckerTest, basic) {
 }
 
 TEST_F(LinuxMemoryCheckerTest, sysMemLimitBytesCheck) {
-  auto tempMemInfoFile = exec::test::TempFilePath::create();
+  auto tempMemInfoFile = TempFilePath::create();
   tempMemInfoFile->append(kMemInfoText_);
   auto memInfoPath = tempMemInfoFile->getPath();
 
-  auto tempTestFile = exec::test::TempFilePath::create();
+  auto tempTestFile = TempFilePath::create();
   tempTestFile->append("131000000000\n");
   auto memMaxFilePath = tempTestFile->getPath();
 

--- a/presto-native-execution/presto_cpp/main/tests/RemoteFunctionRegistererTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/RemoteFunctionRegistererTest.cpp
@@ -16,11 +16,12 @@
 #include <gtest/gtest.h>
 #include <fstream>
 #include "velox/common/base/Fs.h"
-#include "velox/exec/tests/utils/TempDirectoryPath.h"
-#include "velox/exec/tests/utils/TempFilePath.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/common/testutil/TempFilePath.h"
 #include "velox/expression/VectorFunction.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::common::testutil;
 
 namespace facebook::presto::test {
 namespace {
@@ -56,7 +57,7 @@ TEST_F(RemoteFunctionRegistererTest, singleFile) {
   })";
 
   // Write to a single output file.
-  auto path = exec::test::TempFilePath::create();
+  auto path = TempFilePath::create();
   writeToFile(path->getPath(), json);
 
   // Check functions do not exist first.
@@ -86,7 +87,7 @@ TEST_F(RemoteFunctionRegistererTest, prefixes) {
   })";
 
   // Write to a single output file.
-  auto path = exec::test::TempFilePath::create();
+  auto path = TempFilePath::create();
   writeToFile(path->getPath(), json);
 
   EXPECT_TRUE(exec::getVectorFunctionSignatures("mock3") == std::nullopt);
@@ -124,7 +125,7 @@ std::string getJson(const std::string& functionName) {
 }
 
 TEST_F(RemoteFunctionRegistererTest, directory) {
-  auto tempDir = exec::test::TempDirectoryPath::create();
+  auto tempDir = TempDirectoryPath::create();
 
   // Create the following structure:
   //

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -36,7 +36,7 @@
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
-#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/type/Type.h"
 
 DECLARE_int32(old_task_ms);
@@ -45,6 +45,7 @@ DECLARE_bool(velox_memory_leak_check_enabled);
 static const std::string kHiveConnectorId = "test-hive";
 
 using namespace facebook::velox;
+using namespace facebook::velox::common::testutil;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
@@ -609,8 +610,8 @@ class TaskManagerTest : public exec::test::OperatorTestBase,
   // Setup the temporary spilling directory and initialize the system config
   // file (in the same temporary directory) to contain the spilling path
   // setting.
-  static std::shared_ptr<exec::test::TempDirectoryPath> setupSpillPath() {
-    auto spillDirectory = exec::test::TempDirectoryPath::create();
+  static std::shared_ptr<TempDirectoryPath> setupSpillPath() {
+    auto spillDirectory = TempDirectoryPath::create();
     auto sysConfigFilePath =
         fmt::format("{}/config.properties", spillDirectory->getPath());
     auto fileSystem = filesystems::getFileSystem(sysConfigFilePath, nullptr);
@@ -692,7 +693,7 @@ class TaskManagerTest : public exec::test::OperatorTestBase,
 // Runs "select * from t where c0 % 5 = 0" query.
 // Creates one task and provides all splits at once.
 TEST_P(TaskManagerTest, tableScanAllSplitsAtOnce) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {
@@ -720,7 +721,7 @@ TEST_P(TaskManagerTest, tableScanAllSplitsAtOnce) {
 }
 
 TEST_P(TaskManagerTest, addSplitsWithSameSourceNode) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {
@@ -755,7 +756,7 @@ TEST_P(TaskManagerTest, addSplitsWithSameSourceNode) {
 }
 
 TEST_P(TaskManagerTest, fecthFromFinishedTask) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {
@@ -872,7 +873,7 @@ TEST_P(TaskManagerTest, taskCleanupWithPendingResultData) {
   // Trigger old task cleanup immediately.
   taskManager_->setOldTaskCleanUpMs(0);
 
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {
@@ -977,7 +978,7 @@ TEST_P(TaskManagerTest, queuedEmptyGroupedExecutionTask) {
 // Runs "select * from t where c0 % 5 = 1" query.
 // Creates one task and provides splits one at a time.
 TEST_P(TaskManagerTest, tableScanOneSplitAtATime) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {
@@ -1013,7 +1014,7 @@ TEST_P(TaskManagerTest, tableScanOneSplitAtATime) {
 
 // Runs 2-stage tableScan: (1) multiple table scan tasks; (2) single output task
 TEST_P(TaskManagerTest, tableScanMultipleTasks) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {
@@ -1047,7 +1048,7 @@ TEST_P(TaskManagerTest, tableScanMultipleTasks) {
 }
 
 TEST_P(TaskManagerTest, countAggregation) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {
@@ -1061,7 +1062,7 @@ TEST_P(TaskManagerTest, countAggregation) {
 // Run distributed sort query that has 2 stages. First stage runs multiple
 // tasks with partial sort. Second stage runs single task with merge exchange.
 TEST_P(TaskManagerTest, distributedSort) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {
@@ -1136,7 +1137,7 @@ TEST_P(TaskManagerTest, distributedSort) {
 }
 
 TEST_P(TaskManagerTest, outOfQueryUserMemory) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (auto i = 0; i < filePaths.size(); i++) {
@@ -1175,7 +1176,7 @@ TEST_P(TaskManagerTest, outOfOrderRequests) {
   auto longWait = protocol::Duration("300s");
   auto shortWait = std::chrono::seconds(1);
 
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1000);
   duckDbQueryRunner_.createTable("tmp", vectors);
@@ -1261,7 +1262,7 @@ TEST_P(TaskManagerTest, aggregationSpill) {
   // trigger spill.
   const int numBatchesPerFile = 5;
   const int numFiles = 5;
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, numFiles);
   std::vector<std::vector<RowVectorPtr>> batches(numFiles);
   for (int i = 0; i < numFiles; ++i) {
@@ -1279,7 +1280,7 @@ TEST_P(TaskManagerTest, aggregationSpill) {
   int queryId = 0;
   for (const bool doSpill : {false, true}) {
     SCOPED_TRACE(fmt::format("doSpill: {}", doSpill));
-    std::shared_ptr<exec::test::TempDirectoryPath> spillDirectory;
+    std::shared_ptr<TempDirectoryPath> spillDirectory;
     std::map<std::string, std::string> queryConfigs;
 
     int32_t spillPct{0};
@@ -1655,7 +1656,7 @@ TEST_P(TaskManagerTest, buildSpillDirectoryFailure) {
 }
 
 TEST_P(TaskManagerTest, summarize) {
-  const auto tableDir = exec::test::TempDirectoryPath::create();
+  const auto tableDir = TempDirectoryPath::create();
   auto filePaths = makeFilePaths(tableDir, 5);
   auto vectors = makeVectors(filePaths.size(), 1'000);
   for (int i = 0; i < filePaths.size(); i++) {

--- a/presto-native-execution/presto_cpp/main/tool/trace/tests/BroadcastWriteReplayerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tool/trace/tests/BroadcastWriteReplayerTest.cpp
@@ -25,10 +25,11 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::common::testutil;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::tool::trace;

--- a/presto-native-execution/presto_cpp/main/tool/trace/tests/PartitionAndSerializeReplayerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tool/trace/tests/PartitionAndSerializeReplayerTest.cpp
@@ -27,9 +27,10 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::common::testutil;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::tool::trace;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axiom/pull/949

Since we have already moved TempDirectoryPath and TempFilePath to common/testutil, we need to update these paths in both Prestissmio and Axiom.

Differential Revision: D94236906

## Summary by Sourcery

Update Presto C++ tests to use the shared TempDirectoryPath and TempFilePath utilities from velox/common/testutil.

Enhancements:
- Switch test code to include TempDirectoryPath and TempFilePath from velox/common/testutil and update usages accordingly.

Build:
- Update test CMake target dependency from velox_temp_path to velox_test_util.