### PR TITLE
fix: Replace regex-based json_parse safety wrapper with AST-level rewriter

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
@@ -70,6 +70,8 @@ public class VerifierConfig
     private boolean extendedVerification;
     private String runningMode = CONTROL_TEST_MODE;
 
+    private boolean jsonParseSafetyWrapperEnabled;
+
     private Multimap<String, FunctionCallSubstitute> functionSubstitutes = ImmutableMultimap.of();
 
     @NotNull
@@ -452,6 +454,19 @@ public class VerifierConfig
         if (QUERY_BANK_MODE.toLowerCase(ENGLISH).equals(runningMode)) {
             skipControl = true;
         }
+        return this;
+    }
+
+    public boolean isJsonParseSafetyWrapperEnabled()
+    {
+        return jsonParseSafetyWrapperEnabled;
+    }
+
+    @ConfigDescription("Wrap bare json_parse() calls with TRY() during query rewriting to prevent failures on malformed JSON")
+    @Config("json-parse-safety-wrapper-enabled")
+    public VerifierConfig setJsonParseSafetyWrapperEnabled(boolean jsonParseSafetyWrapperEnabled)
+    {
+        this.jsonParseSafetyWrapperEnabled = jsonParseSafetyWrapperEnabled;
         return this;
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/VerificationQueryRewriterFactory.java
@@ -57,6 +57,7 @@ public class VerificationQueryRewriterFactory
     private final boolean testReuseTable;
 
     private final Multimap<String, FunctionCallSubstitute> functionSubstitutes;
+    private final boolean jsonParseSafetyWrapperEnabled;
 
     @Inject
     public VerificationQueryRewriterFactory(
@@ -77,6 +78,7 @@ public class VerificationQueryRewriterFactory
         this.controlReuseTable = controlConfig.isReuseTable();
         this.testReuseTable = testConfig.isReuseTable();
         this.functionSubstitutes = verifierConfig.getFunctionSubstitutes();
+        this.jsonParseSafetyWrapperEnabled = verifierConfig.isJsonParseSafetyWrapperEnabled();
     }
 
     @Override
@@ -90,7 +92,8 @@ public class VerificationQueryRewriterFactory
                 ImmutableMap.of(CONTROL, controlTablePrefix, TEST, testTablePrefix),
                 ImmutableMap.of(CONTROL, controlTableProperties, TEST, testTableProperties),
                 ImmutableMap.of(CONTROL, controlReuseTable, TEST, testReuseTable),
-                functionSubstitutes);
+                functionSubstitutes,
+                jsonParseSafetyWrapperEnabled);
     }
 
     private static List<Property> constructProperties(Map<String, Object> propertiesMap)

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -56,7 +56,8 @@ public class TestVerifierConfig
                 .setExtendedVerification(false)
                 .setSaveSnapshot(false)
                 .setFunctionSubstitutes(null)
-                .setValidateStringAsDouble(false));
+                .setValidateStringAsDouble(false)
+                .setJsonParseSafetyWrapperEnabled(false));
     }
 
     @Test
@@ -92,6 +93,7 @@ public class TestVerifierConfig
                 .put("save-snapshot", "true")
                 .put("function-substitutes", "/approx_distinct(c)/count(c)/")
                 .put("validate-string-as-double", "true")
+                .put("json-parse-safety-wrapper-enabled", "true")
                 .build();
         VerifierConfig expected = new VerifierConfig()
                 .setWhitelist("a,b,c")
@@ -122,7 +124,8 @@ public class TestVerifierConfig
                 .setExtendedVerification(true)
                 .setSaveSnapshot(true)
                 .setFunctionSubstitutes("/approx_distinct(c)/count(c)/")
-                .setValidateStringAsDouble(true);
+                .setValidateStringAsDouble(true)
+                .setJsonParseSafetyWrapperEnabled(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
testing infra fix: 
```
com.facebook.presto.verifier.framework.PrestoQueryException: com.facebook.presto.spi.PrestoException: Cannot convert '' to JSON
```
The previous applyJsonParseSafetyWrapper() used SqlFormatter.formatSql() -> regex ->
sqlParser.createStatement() round-trip that silently failed on complex queries with
lambdas and $internal$try(BIND(...)) patterns, leaving bare json_parse() calls that
crash on empty strings during verifier replay.

Replace with AST-level JsonParseTryWrapper using DefaultTreeRewriter +
ExpressionTreeRewriter<Boolean> (same pattern as FunctionCallRewriter). Wraps
json_parse FunctionCall nodes directly in TryExpression on the AST, eliminating the
fragile format/re-parse cycle.

# Releas Notes
```
== NO RELEASE NOTE ==
```

Differential Revision: D94175149

## Summary by Sourcery

Apply an AST-level rewriter to wrap json_parse() calls in TRY() during query rewriting, improving robustness over the previous regex-based approach and ensuring it works with function substitution and complex queries.

Bug Fixes:
- Ensure json_parse() calls are reliably wrapped in TRY() to prevent verifier failures on malformed or empty JSON, including in complex queries with lambdas, subqueries, and function substitutions.

Enhancements:
- Replace the SQL format/regex/re-parse json_parse safety wrapper with an AST-based JsonParseTryWrapper integrated into the query rewriting pipeline and applied consistently to CREATE TABLE AS, INSERT, and SELECT queries.

Tests:
- Add comprehensive verifier rewrite tests covering json_parse wrapping behavior across simple selects, expressions, lambdas, subqueries, WHERE clauses, function substitution, and multiple/mixed json_parse usages.