### PR TITLE
fix(connector): Enable NDV stats collection for Iceberg in native mode

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -625,8 +625,7 @@ public class IcebergHiveMetadata
         Set<ColumnStatisticMetadata> supportedStatistics = ImmutableSet.<ColumnStatisticMetadata>builder()
                 .addAll(hiveColumnStatistics)
                 // iceberg table-supported statistics
-                .addAll(!connectorSystemConfig.isNativeExecution() ?
-                        super.getStatisticsCollectionMetadata(session, tableMetadata).getColumnStatistics() : ImmutableSet.of())
+                .addAll(super.getStatisticsCollectionMetadata(session, tableMetadata).getColumnStatistics())
                 .build();
         Set<TableStatisticType> tableStatistics = ImmutableSet.of(ROW_COUNT);
         return new TableStatisticsMetadata(supportedStatistics, tableStatistics, emptyList());


### PR DESCRIPTION
## Description
This change enables the collection of these NDV stats for Iceberg tables in Prestissimo.


## Motivation and Context
We disabled collection of NDV stats for Iceberg tables in Prestissimo because the sketch theta functions were not implemented. Now the functions are implemented as part of PR https://github.com/prestodb/presto/pull/25685. 

## Impact
No impact

## Test Plan
There is an existing test in TestPrestoNativeIcebergGeneralQueries.java 

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enhancements:
- Allow Iceberg connector to collect NDV-related column statistics in native execution mode alongside existing Hive statistics.