### PR TITLE
fix: Use relative epsilon in TDigest Java merge weight check

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -95,6 +95,9 @@ public class TDigest
     static final double MAX_COMPRESSION_FACTOR = 1_000;
     private static final double sizeFudge = 30;
     private static final double EPSILON = 0.001;
+    // Relative error epsilon to handle floating-point precision issues
+    // with large totalWeight values.
+    private static final double RELATIVE_ERROR_EPSILON = 1e-4;
 
     private double min = Double.POSITIVE_INFINITY;
     private double max = Double.NEGATIVE_INFINITY;
@@ -360,7 +363,10 @@ public class TDigest
             sumWeights += weight[i];
         }
 
-        checkArgument(Math.abs(sumWeights - totalWeight) < EPSILON, "Sum must equal the total weight, but sum:%s != totalWeight:%s", sumWeights, totalWeight);
+        // Use relative epsilon to handle floating-point precision issues
+        // with large totalWeight values.
+        double relativeEpsilon = Math.max(EPSILON, totalWeight * RELATIVE_ERROR_EPSILON);
+        checkArgument(Math.abs(sumWeights - totalWeight) < relativeEpsilon, "Sum must equal the total weight, but sum:%s != totalWeight:%s", sumWeights, totalWeight);
         if (runBackwards) {
             reverse(mean, 0, activeCentroids);
             reverse(weight, 0, activeCentroids);

--- a/presto-main-base/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -209,6 +209,30 @@ public class TestTDigest
     }
 
     @Test
+    public void testMergeWithLargeTotalWeight()
+    {
+        // Reproduces production failure where totalWeight ~9.8E18 causes
+        // the absolute epsilon check (0.001) to fail due to normal
+        // floating-point rounding at large magnitudes.
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+
+        // Add entries with large weights to push totalWeight past 1E18
+        double largeWeight = 1e15;
+        for (int i = 0; i < 10000; i++) {
+            tDigest.add(i * 0.01, largeWeight);
+        }
+
+        // Merge with another large-weight digest to trigger the merge() sanity check
+        TDigest other = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        for (int i = 0; i < 10000; i++) {
+            other.add(i * 0.01 + 50, largeWeight);
+        }
+
+        // This should not throw IllegalArgumentException
+        tDigest.merge(other);
+    }
+
+    @Test
     public void testLargeScalePreservesWeights()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);


### PR DESCRIPTION
Summary:
The TDigest.merge() sanity check uses a hard-coded absolute epsilon of
0.001 to validate that centroid weights sum to totalWeight after merging.
When totalWeight is large (~9.8E18), normal IEEE 754 floating-point
rounding produces differences of ~3E15, far exceeding the 0.001 threshold causing IllegalArgumentException even though the relative error is only ~0.03%.

This ports the fix from Velox C++ (D71770400) to the Java TDigest:
use max(EPSILON, totalWeight * RELATIVE_ERROR_EPSILON) so the tolerance scales with the magnitude of the weight.

Fixes: https://fb.workplace.com/groups/sapphire.users/permalink/1287081970144732/

Differential Revision: D94468686

## Summary by Sourcery

Adjust TDigest merge weight validation to use a relative tolerance that scales with totalWeight to avoid spurious failures at very large magnitudes.

Bug Fixes:
- Prevent IllegalArgumentException in TDigest.merge() when validating centroid weights for digests with extremely large total weights by switching to a relative epsilon check.

Tests:
- Add a regression test that merges TDigest instances with very large weights to ensure the merge sanity check no longer fails due to floating-point rounding.