### PR TITLE
misc: Make theta_sketch configurable via PRESTO_ENABLE_THETA_SKETCH macro

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -236,6 +236,7 @@ if(PRESTO_ENABLE_JWT)
 endif()
 
 find_package(DataSketches)
+add_compile_definitions(PRESTO_ENABLE_THETA_SKETCH)
 
 if("${MAX_LINK_JOBS}")
   set_property(GLOBAL APPEND PROPERTY JOB_POOLS "presto_link_job_pool=${MAX_LINK_JOBS}")

--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -32,7 +32,6 @@
 #include "presto_cpp/main/connectors/SystemConnector.h"
 #include "presto_cpp/main/connectors/hive/functions/HiveFunctionRegistration.h"
 #include "presto_cpp/main/functions/FunctionMetadata.h"
-#include "presto_cpp/main/functions/theta_sketch/ThetaSketchRegistration.h"
 #include "presto_cpp/main/http/HttpConstants.h"
 #include "presto_cpp/main/http/filters/AccessLogFilter.h"
 #include "presto_cpp/main/http/filters/HttpEndpointLatencyFilter.h"
@@ -84,6 +83,10 @@
 
 #ifdef PRESTO_ENABLE_REMOTE_FUNCTIONS
 #include "presto_cpp/main/RemoteFunctionRegisterer.h"
+#endif
+
+#ifdef PRESTO_ENABLE_THETA_SKETCH
+#include "presto_cpp/main/functions/theta_sketch/ThetaSketchRegistration.h"
 #endif
 
 #ifdef __linux__
@@ -1496,8 +1499,10 @@ void PrestoServer::registerFunctions() {
     hive::functions::registerHiveNativeFunctions();
   }
 
+#ifdef PRESTO_ENABLE_THETA_SKETCH
   functions::aggregate::theta_sketch::registerAllThetaSketchFunctions(
       prestoBuiltinFunctionPrefix_);
+#endif
 }
 
 void PrestoServer::registerRemoteFunctions() {


### PR DESCRIPTION
## Description
Make theta_sketch configurable like remote functions as some deployments (e.g. Meta) may not use it. Enabled by default in OSS side

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).


## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Make theta sketch aggregation support conditionally compiled behind a configuration macro.

New Features:
- Allow enabling or disabling theta sketch aggregation functions via the PRESTO_ENABLE_THETA_SKETCH compile-time macro.

Build:
- Define the PRESTO_ENABLE_THETA_SKETCH macro in the native execution CMake configuration when DataSketches is available to control theta sketch support.