### PR TITLE
fix: Use relative epsilon in TDigest merge weight check

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -95,6 +95,9 @@ public class TDigest
     static final double MAX_COMPRESSION_FACTOR = 1_000;
     private static final double sizeFudge = 30;
     private static final double EPSILON = 0.001;
+    // Relative error epsilon to handle floating-point precision issues
+    // with large totalWeight values.
+    private static final double RELATIVE_ERROR_EPSILON = 1e-4;
 
     private double min = Double.POSITIVE_INFINITY;
     private double max = Double.NEGATIVE_INFINITY;
@@ -360,7 +363,10 @@ public class TDigest
             sumWeights += weight[i];
         }
 
-        checkArgument(Math.abs(sumWeights - totalWeight) < EPSILON, "Sum must equal the total weight, but sum:%s != totalWeight:%s", sumWeights, totalWeight);
+        // Use relative epsilon to handle floating-point precision issues
+        // with large totalWeight values.
+        double relativeEpsilon = Math.max(EPSILON, Math.abs(totalWeight) * RELATIVE_ERROR_EPSILON);
+        checkArgument(Math.abs(sumWeights - totalWeight) < relativeEpsilon, "Sum must equal the total weight, but sum:%s != totalWeight:%s", sumWeights, totalWeight);
         if (runBackwards) {
             reverse(mean, 0, activeCentroids);
             reverse(weight, 0, activeCentroids);

--- a/presto-main-base/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -209,6 +209,26 @@ public class TestTDigest
     }
 
     @Test
+    public void testMergeWithLargeTotalWeight()
+    {
+        // Reproduces production failure where floating-point rounding at
+        // large totalWeight (~1E19) exceeded the fixed absolute epsilon (0.001) in merge().
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+
+        double largeWeight = 1e17;
+        for (int i = 0; i < 100; i++) {
+            tDigest.add(i * 0.01, largeWeight);
+        }
+
+        TDigest other = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        for (int i = 0; i < 100; i++) {
+            other.add(i * 0.01 + 50, largeWeight);
+        }
+
+        tDigest.merge(other);
+    }
+
+    @Test
     public void testLargeScalePreservesWeights()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);


### PR DESCRIPTION
Summary:
The TDigest.merge() sanity check uses a hard-coded absolute epsilon of 0.001 to validate that centroid weights sum to totalWeight after merging. When totalWeight is large (~9.8E18), normal IEEE 754 floating-point rounding produces differences of ~3E15, far exceeding the 0.001 threshold, causing IllegalArgumentException even though the relative error is only ~0.03%.

This ports the fix from Velox C++ (D71770400) to the Java TDigest: use max(EPSILON, totalWeight * RELATIVE_ERROR_EPSILON) so the tolerance scales with the magnitude of the weight.

Fixes: https://fb.workplace.com/groups/sapphire.users/permalink/1287081970144732/

== NO RELEASE NOTE ==

Differential Revision: D94468857

## Summary by Sourcery

Adjust TDigest merge weight validation to use a relative epsilon tolerance and add coverage for large totalWeight merges.

Bug Fixes:
- Prevent spurious merge failures in TDigest when validating centroid weights for very large totalWeight values by scaling the epsilon tolerance with totalWeight magnitude.

Tests:
- Add a regression test that merges TDigest instances with extremely large weights to verify the merge no longer fails due to floating-point precision limits.