### PR TITLE
fix: Increase max-task-update-size for the test

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/StandaloneQueryRunner.java
@@ -293,7 +293,8 @@ public final class StandaloneQueryRunner
                 .put("query.client.timeout", "10m")
                 .put("exchange.http-client.idle-timeout", "1h")
                 .put("node-scheduler.min-candidates", "1")
-                .put("datasources", "system");
+                .put("datasources", "system")
+                .put("experimental.internal-communication.max-task-update-size", "32MB");
 
         return new TestingPrestoServer(true, properties.build(), null, null, new SqlParserOptions(), ImmutableList.of());
     }


### PR DESCRIPTION
## Description
`com.facebook.presto.verifier.framework.TestDataVerification.testLargeTableSelectStarCompiles` fails with `java.lang.AssertionError: expected [SUCCEEDED] but found [FAILED]` because `com.facebook.presto.spi.PrestoException: TaskUpdate size of 16.73MB has exceeded the limit of 16MB`
Default limit is 16Mb and with recent dependencies updates task update size started to cross it for test that generates many columns

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing
guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md),
in particular [code
style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style)
and [commit
standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If
the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax,
functions, or other functionality.
- [x] If release notes are required, they follow the [release notes
guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF
Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or
higher (or obtained explicit TSC approval for lower scores).


## Release Notes
Please follow [release notes
guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines)
and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

Differential Revision: D94558539