### PR TITLE
feat: Add session property aggregation_memory_compaction_reclaim_enabled

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -589,6 +589,17 @@ Native Execution only. Ratio of unused (evicted) bytes to total bytes that trigg
 compaction. The value is in the range of [0, 1). Currently only applies to
 approx_most_frequent aggregate with StringView type during global aggregation.
 
+``native_aggregation_memory_compaction_reclaim_enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Native Execution only. If true, enables lightweight memory compaction before
+spilling during memory reclaim in aggregation. When enabled, the aggregation
+operator will try to compact aggregate function state (for example, free dead strings)
+before resorting to spilling.
+
 ``optimizer.optimize_top_n_rank``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sessionpropertyproviders/NativeWorkerSessionPropertyProvider.java
@@ -91,6 +91,7 @@ public class NativeWorkerSessionPropertyProvider
     public static final String NATIVE_USE_VELOX_GEOSPATIAL_JOIN = "native_use_velox_geospatial_join";
     public static final String NATIVE_AGGREGATION_COMPACTION_BYTES_THRESHOLD = "native_aggregation_compaction_bytes_threshold";
     public static final String NATIVE_AGGREGATION_COMPACTION_UNUSED_MEMORY_RATIO = "native_aggregation_compaction_unused_memory_ratio";
+    public static final String NATIVE_AGGREGATION_MEMORY_COMPACTION_RECLAIM_ENABLED = "native_aggregation_memory_compaction_reclaim_enabled";
     public static final String NATIVE_MERGE_JOIN_OUTPUT_BATCH_START_SIZE = "native_merge_join_output_batch_start_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
@@ -457,6 +458,13 @@ public class NativeWorkerSessionPropertyProvider
                                 "The value is in the range of [0, 1). NOTE: Currently only applies to approx_most_frequent " +
                                 "aggregate with StringView type during global aggregation.",
                         0.25,
+                        !nativeExecution),
+                booleanProperty(
+                        NATIVE_AGGREGATION_MEMORY_COMPACTION_RECLAIM_ENABLED,
+                        "If true, enables lightweight memory compaction before spilling during " +
+                                "memory reclaim in aggregation. When enabled, the aggregation operator " +
+                                "will try to compact aggregate function state before resorting to spilling.",
+                        false,
                         !nativeExecution),
                 integerProperty(
                         NATIVE_MERGE_JOIN_OUTPUT_BATCH_START_SIZE,

--- a/presto-native-execution/presto_cpp/main/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.cpp
@@ -630,6 +630,17 @@ SessionProperties::SessionProperties() {
       false,
       QueryConfig::kAggregationCompactionUnusedMemoryRatio,
       std::to_string(c.aggregationCompactionUnusedMemoryRatio()));
+
+  addSessionProperty(
+      kAggregationMemoryCompactionReclaimEnabled,
+      "If true, enables lightweight memory compaction before spilling during "
+      "memory reclaim in aggregation. When enabled, the aggregation operator "
+      "will try to compact aggregate function state (for example, free dead strings) "
+      "before resorting to spilling. Disabled by default.",
+      BOOLEAN(),
+      false,
+      QueryConfig::kAggregationMemoryCompactionReclaimEnabled,
+      boolToString(c.aggregationMemoryCompactionReclaimEnabled()));
 }
 
 const std::string SessionProperties::toVeloxConfig(

--- a/presto-native-execution/presto_cpp/main/SessionProperties.h
+++ b/presto-native-execution/presto_cpp/main/SessionProperties.h
@@ -409,6 +409,13 @@ class SessionProperties {
   static constexpr const char* kAggregationCompactionUnusedMemoryRatio =
       "native_aggregation_compaction_unused_memory_ratio";
 
+  /// If true, enables lightweight memory compaction before spilling during
+  /// memory reclaim in aggregation. When enabled, the aggregation operator
+  /// will try to compact aggregate function state (e.g., free dead strings)
+  /// before resorting to spilling. Disabled by default.
+  static constexpr const char* kAggregationMemoryCompactionReclaimEnabled =
+      "native_aggregation_memory_compaction_reclaim_enabled";
+
   inline bool hasVeloxConfig(const std::string& key) {
     auto sessionProperty = sessionProperties_.find(key);
     if (sessionProperty == sessionProperties_.end()) {

--- a/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/SessionPropertiesTest.cpp
@@ -134,6 +134,8 @@ TEST_F(SessionPropertiesTest, validateMapping) {
        core::QueryConfig::kAggregationCompactionBytesThreshold},
       {SessionProperties::kAggregationCompactionUnusedMemoryRatio,
        core::QueryConfig::kAggregationCompactionUnusedMemoryRatio},
+      {SessionProperties::kAggregationMemoryCompactionReclaimEnabled,
+       core::QueryConfig::kAggregationMemoryCompactionReclaimEnabled},
       {SessionProperties::kMergeJoinOutputBatchStartSize,
        core::QueryConfig::kMergeJoinOutputBatchStartSize}};
 


### PR DESCRIPTION
Summary: Per title

Differential Revision: D94130609

## Summary by Sourcery

Add a configurable session property to control lightweight aggregation memory compaction during memory reclaim before spilling.

New Features:
- Introduce the native_aggregation_memory_compaction_reclaim_enabled session property to toggle lightweight aggregation memory compaction prior to spilling.

Tests:
- Extend SessionProperties mapping tests to cover the new aggregation memory compaction reclaim session property.

```
== NO RELEASE NOTE ==
```