### PR TITLE
chore(analyzer): Add runtime stats for materialized view usage

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -30,6 +30,9 @@ public class RuntimeMetricName
     public static final String OPTIMIZED_WITH_MATERIALIZED_VIEW_SUBQUERY_COUNT = "optimizedWithMaterializedViewSubqueryCount";
     public static final String MANY_PARTITIONS_MISSING_IN_MATERIALIZED_VIEW_COUNT = "manyPartitionsMissingInMaterializedViewCount";
     public static final String SKIP_READING_FROM_MATERIALIZED_VIEW_COUNT = "skipReadingFromMaterializedViewCount";
+    public static final String MATERIALIZED_VIEW_USED_COUNT = "materializedViewUsedCount";
+    public static final String MATERIALIZED_VIEW_STATUS = "materializedViewStatus";
+    public static final String MATERIALIZED_VIEW_STALE_PARTITIONS_COUNT = "materializedViewStalePartitionsCount";
     public static final String FRAGMENT_RESULT_CACHE_HIT = "fragmentResultCacheHitCount";
     public static final String FRAGMENT_RESULT_CACHE_MISS = "fragmentResultCacheMissCount";
     public static final String GET_VIEW_TIME_NANOS = "getViewTimeNanos";


### PR DESCRIPTION
Summary:
Add runtime stats to track materialized view usage details in the legacy
MV optimization path. Three new metrics are added:

- `materializedViewUsedCount`: Incremented when a materialized view's data
  table is actually read (i.e., MV is partially or fully materialized).
- `materializedViewStatus`: Records the ordinal of the MaterializedViewState
  enum (NOT_MATERIALIZED=0, TOO_MANY_PARTITIONS_MISSING=1,
  PARTIALLY_MATERIALIZED=2, FULLY_MATERIALIZED=3).
- `materializedViewStalePartitionsCount`: Number of stale partitions across
  all base tables, computed from the partition predicate disjuncts.

Stats are recorded in both legacy path entry points:
- `StatementAnalyzer.getMaterializedViewSQL()` (SQL stitching path)
- `MaterializedViewQueryOptimizer.QuerySpecificationRewriter.rewrite()`
  (AST rewrite path with data consistency enabled)

Wall time for getMaterializedViewStatus is already tracked via
GET_MATERIALIZED_VIEW_STATUS_TIME_NANOS in MetadataManager.

Differential Revision: D94621963

## Summary by Sourcery

Track materialized view usage and health via new runtime statistics in both legacy optimization paths.

Enhancements:
- Add runtime metrics for materialized view usage, status, and stale partition counts in the query optimizer and statement analyzer.
- Record materialized view optimization events separately for cases with and without data consistency checks.

Tests:
- Add tests verifying runtime stats are populated when a materialized view is used and remain unset when it is not used.


```
== RELEASE NOTES ==

General Changes
* Add runtime stats for materialized view usage

```