### PR TITLE
docs: Remove redundant table of contents

### DIFF
--- a/presto-docs/src/main/sphinx/admin/spill.rst
+++ b/presto-docs/src/main/sphinx/admin/spill.rst
@@ -2,11 +2,6 @@
 Spill to Disk
 =============
 
-.. contents::
-    :local:
-    :backlinks: none
-    :depth: 1
-
 Overview
 --------
 

--- a/presto-docs/src/main/sphinx/cache/local.rst
+++ b/presto-docs/src/main/sphinx/cache/local.rst
@@ -2,11 +2,6 @@
 Alluxio SDK Cache
 =================
 
-.. contents::
-    :local:
-    :backlinks: none
-    :depth: 1
-
 Overview
 --------
 

--- a/presto-docs/src/main/sphinx/cache/service.rst
+++ b/presto-docs/src/main/sphinx/cache/service.rst
@@ -2,11 +2,6 @@
 Alluxio Cache Service
 =====================
 
-.. contents::
-    :local:
-    :backlinks: none
-    :depth: 1
-
 Overview
 --------
 

--- a/presto-docs/src/main/sphinx/ecosystem/list.rst
+++ b/presto-docs/src/main/sphinx/ecosystem/list.rst
@@ -2,11 +2,6 @@
 Ecosystem
 =========
 
-.. contents::
-    :local:
-    :backlinks: none
-    :depth: 1
-
 Overview
 --------
 

--- a/presto-docs/src/main/sphinx/presto_cpp/metrics.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/metrics.rst
@@ -5,7 +5,7 @@ Presto C++ Runtime Metrics
 .. contents::
     :local:
     :backlinks: none
-    :depth: 2
+    :depth: 1
 
 Overview
 ========

--- a/presto-docs/src/main/sphinx/router/deployment.rst
+++ b/presto-docs/src/main/sphinx/router/deployment.rst
@@ -2,11 +2,6 @@
 Deploying Presto Router
 =======================
 
-.. contents::
-    :local:
-    :backlinks: none
-    :depth: 1
-
 Installing Router
 -----------------
 

--- a/presto-docs/src/main/sphinx/router/scheduler.rst
+++ b/presto-docs/src/main/sphinx/router/scheduler.rst
@@ -2,11 +2,6 @@
 Router Schedulers
 =================
 
-.. contents::
-    :local:
-    :backlinks: none
-    :depth: 1
-
 Presto router provides multiple scheduling algorithms for load balancing across
 multiple clusters.
 


### PR DESCRIPTION
## Description
Remove redundant table of contents from some documentation pages.

## Motivation and Context
The Presto documentation layout features a table of contents on the right side of all pages.
On pages where this sidebar remains visible within the screen view, the identical (or nearly identical) table of contents at the top can be removed as redundant.

0. Pages where the table of contents at the top has depth 2 (changed to 1 in the PR):
- (0.297-SNAPSHOT) ./presto/presto-docs/target/html/presto_cpp/metrics.html

1. Pages with identical table of contents:
- https://prestodb.github.io/docs/0.296/cache/local.html
- https://prestodb.github.io/docs/0.296/clients/presto-console.html
- https://prestodb.github.io/docs/0.296/connector/accumulo.html
- https://prestodb.github.io/docs/0.296/ecosystem/list.html
- https://prestodb.github.io/docs/0.296/router/scheduler.html - empty table of contents

2. Pages where the right sidebar fits the screen:
- https://prestodb.github.io/docs/0.296/admin/spill.html
- https://prestodb.github.io/docs/0.296/cache/service.html
- https://prestodb.github.io/docs/0.296/clients/presto-cli.html
- https://prestodb.github.io/docs/0.296/presto_cpp/sidecar.html
- https://prestodb.github.io/docs/0.296/router/deployment.html
- https://prestodb.github.io/docs/0.296/troubleshoot/deploy.html - can grow and may be excluded from the group
- https://prestodb.github.io/docs/0.296/troubleshoot/query.html - can grow and may be excluded from the group

3. Pages where the right sidebar **_almost_** fits the screen:
- https://prestodb.github.io/docs/0.296/connector/kafka-tutorial.html
- https://prestodb.github.io/docs/0.296/installation/deployment.html

4. Pages that require some scrolling in the right sidebar:
- https://prestodb.github.io/docs/0.296/connector/kudu.html
- https://prestodb.github.io/docs/0.296/overview/concepts.html

5. Pages that require scrolling in the right sidebar should remain unchanged:
- https://prestodb.github.io/docs/0.296/admin/properties.html
- https://prestodb.github.io/docs/0.296/admin/properties-session.html
- https://prestodb.github.io/docs/0.296/connector/elasticsearch.html
- https://prestodb.github.io/docs/0.296/connector/hive-security.html
- https://prestodb.github.io/docs/0.296/connector/hive.html
- https://prestodb.github.io/docs/0.296/connector/kafka.html
- https://prestodb.github.io/docs/0.296/functions/aggregate.html
- https://prestodb.github.io/docs/0.296/functions/noisy.html
- https://prestodb.github.io/docs/0.296/language/types.html
- https://prestodb.github.io/docs/0.296/presto_cpp/features.html
- https://prestodb.github.io/docs/0.296/presto_cpp/properties.html
- (0.297-SNAPSHOT) ./presto/presto-docs/target/html/presto_cpp/limitations.html

## Impact
No

Build the documentation and check that the pages are correct:
```shell
presto-docs/build
open target/html/overview/concepts.html
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Clean up multiple documentation pages by deleting duplicated top-of-page tables of contents while keeping the layout sidebar TOC as the single source of navigation.