### PR TITLE
fix(native): Fix copy-paste bug in veloxQueryConfigOperation log message and add tests

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServerOperations.cpp
@@ -174,7 +174,7 @@ std::string PrestoServerOperations::veloxQueryConfigOperation(
           ServerOperation::targetString(op.target),
           ServerOperation::actionString(op.action));
       return fmt::format(
-          "Have set system property value '{}' to '{}'. Old value was '{}'.\n",
+          "Have set velox query config property '{}' to '{}'. Old value was '{}'.\n",
           name,
           value,
           SystemConfig::instance()


### PR DESCRIPTION
Summary:
Fix a copy-paste bug in `PrestoServerOperations::veloxQueryConfigOperation()` where the `kSetProperty` handler's response message incorrectly said "system property" instead of "velox query config property". This was caused by the function being copied from `systemConfigOperation()` without updating the log message.

Add comprehensive tests for the `veloxQueryConfig` operation endpoint:
- URL path parsing for veloxQueryConfig/setProperty and veloxQueryConfig/getProperty
- Getting an unknown property returns "<default>" (unlike systemConfig which throws)
- Getting a known registered property returns its value
- Setting a property returns a message with correct "velox query config" wording
- Round-trip set + get verification
- Error cases: missing 'name' and missing 'value' parameters

```
== NO RELEASE NOTE ==
```


## Summary by Sourcery

Fix the velox query config server operation messaging and extend coverage of its HTTP endpoint behavior.

Bug Fixes:
- Correct the veloxQueryConfig setProperty response message to reference "velox query config" instead of "system" properties.

Tests:
- Add URL path parsing tests for veloxQueryConfig setProperty and getProperty operations.
- Add end-to-end tests for veloxQueryConfig behavior, including unknown property handling, value round-trips, and required parameter validation.