### PR TITLE
feat: Add  read support for row lineage columns in Iceberg connector

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -173,8 +173,12 @@ import static com.facebook.presto.iceberg.IcebergColumnHandle.DELETE_FILE_PATH_C
 import static com.facebook.presto.iceberg.IcebergColumnHandle.DELETE_FILE_PATH_COLUMN_METADATA;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.IS_DELETED_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.IS_DELETED_COLUMN_METADATA;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_METADATA;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.PATH_COLUMN_METADATA;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.ROW_ID_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.ROW_ID_COLUMN_METADATA;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_FORMAT_VERSION;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_MATERIALIZED_VIEW;
@@ -608,6 +612,8 @@ public abstract class IcebergAbstractMetadata
                 columns.add(DATA_SEQUENCE_NUMBER_COLUMN_METADATA);
                 columns.add(IS_DELETED_COLUMN_METADATA);
                 columns.add(DELETE_FILE_PATH_COLUMN_METADATA);
+                columns.add(ROW_ID_COLUMN_METADATA);
+                columns.add(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_METADATA);
             }
             return new ConnectorTableMetadata(table, columns.build(), createMetadataProperties(icebergTable, session), getTableComment(icebergTable));
         }
@@ -1332,6 +1338,8 @@ public abstract class IcebergAbstractMetadata
             columnHandles.put(DATA_SEQUENCE_NUMBER.getColumnName(), DATA_SEQUENCE_NUMBER_COLUMN_HANDLE);
             columnHandles.put(IS_DELETED.getColumnName(), IS_DELETED_COLUMN_HANDLE);
             columnHandles.put(DELETE_FILE_PATH.getColumnName(), DELETE_FILE_PATH_COLUMN_HANDLE);
+            columnHandles.put(ROW_ID_COLUMN_HANDLE.getName(), ROW_ID_COLUMN_HANDLE);
+            columnHandles.put(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE.getName(), LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE);
         }
         return columnHandles.build();
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.SYNTHESIZED;
 import static com.facebook.presto.iceberg.ColumnIdentity.createColumnIdentity;
@@ -44,6 +45,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER;
+import static org.apache.iceberg.MetadataColumns.ROW_ID;
 import static org.apache.iceberg.MetadataColumns.ROW_POSITION;
 
 public class IcebergColumnHandle
@@ -57,6 +60,20 @@ public class IcebergColumnHandle
     public static final ColumnMetadata IS_DELETED_COLUMN_METADATA = getColumnMetadata(IS_DELETED);
     public static final IcebergColumnHandle DELETE_FILE_PATH_COLUMN_HANDLE = getIcebergColumnHandle(DELETE_FILE_PATH);
     public static final ColumnMetadata DELETE_FILE_PATH_COLUMN_METADATA = getColumnMetadata(DELETE_FILE_PATH);
+    public static final IcebergColumnHandle ROW_ID_COLUMN_HANDLE = primitiveIcebergColumnHandle(
+            ROW_ID.fieldId(), ROW_ID.name(), BIGINT, Optional.ofNullable(ROW_ID.doc()));
+    public static final ColumnMetadata ROW_ID_COLUMN_METADATA = ColumnMetadata.builder()
+            .setName(ROW_ID.name())
+            .setType(BIGINT)
+            .setHidden(true)
+            .build();
+    public static final IcebergColumnHandle LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE = primitiveIcebergColumnHandle(
+            LAST_UPDATED_SEQUENCE_NUMBER.fieldId(), LAST_UPDATED_SEQUENCE_NUMBER.name(), BIGINT, Optional.ofNullable(LAST_UPDATED_SEQUENCE_NUMBER.doc()));
+    public static final ColumnMetadata LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_METADATA = ColumnMetadata.builder()
+            .setName(LAST_UPDATED_SEQUENCE_NUMBER.name())
+            .setType(BIGINT)
+            .setHidden(true)
+            .build();
 
     private final ColumnIdentity columnIdentity;
     private final Type type;
@@ -216,6 +233,16 @@ public class IcebergColumnHandle
     public boolean isDeleteFilePathColumn()
     {
         return getColumnIdentity().getId() == DELETE_FILE_PATH.getId();
+    }
+
+    public boolean isRowIdColumn()
+    {
+        return getColumnIdentity().getId() == ROW_ID.fieldId();
+    }
+
+    public boolean isLastUpdatedSequenceNumberColumn()
+    {
+        return getColumnIdentity().getId() == LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
     }
 
     public static IcebergColumnHandle primitiveIcebergColumnHandle(int id, String name, Type type, Optional<String> comment)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataColumn.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataColumn.java
@@ -46,7 +46,8 @@ public enum IcebergMetadataColumn
 
     private static final Set<Integer> COLUMN_IDS = Stream.concat(
             Stream.of(values()).map(IcebergMetadataColumn::getId),
-            Stream.of(MetadataColumns.SPEC_ID.fieldId())).collect(toImmutableSet());
+            Stream.of(
+                    MetadataColumns.SPEC_ID.fieldId())).collect(toImmutableSet());
     private final int id;
     private final String columnName;
     private final Type type;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -758,10 +758,22 @@ public class IcebergPageSourceProvider
         Map<Integer, HivePartitionKey> partitionKeys = split.getPartitionKeys();
 
         // The update row id and merge target table row id aren't valid columns that can be read from storage.
-        // Filter it out from columns passed to the storage page source.
+        // _row_id and _last_updated_sequence_number are kept in columnsToReadFromStorage so that
+        // the Parquet/ORC reader can read them from the data file when present.
+        // When absent, IcebergUpdateablePageSource applies fallback computation.
         Set<IcebergColumnHandle> columnsToReadFromStorage = icebergColumns.stream()
                 .filter(not(column -> column.isUpdateRowIdColumn() || column.isMergeTargetTableRowIdColumn()))
                 .collect(Collectors.toSet());
+
+        // If _row_id is requested and the file has a valid first_row_id, we need ROW_POSITION to
+        // compute _row_id = firstRowId + _pos as fallback when the file doesn't contain _row_id.
+        // Add it if not already present.
+        boolean rowIdRequested = icebergColumns.stream().anyMatch(IcebergColumnHandle::isRowIdColumn);
+        long firstRowId = split.getFirstRowId();
+        if (rowIdRequested && firstRowId >= 0) {
+            IcebergColumnHandle rowPositionHandle = IcebergColumnHandle.create(ROW_POSITION, typeManager, REGULAR);
+            columnsToReadFromStorage.add(rowPositionHandle);
+        }
 
         // add any additional columns which may need to be read from storage
         // by delete filters
@@ -926,7 +938,9 @@ public class IcebergPageSourceProvider
                 deleteFilters,
                 updatedRowPageSinkSupplier,
                 table.getUpdatedColumns(),
-                rowIdColumnHandle);
+                rowIdColumnHandle,
+                firstRowId,
+                split.getDataSequenceNumber());
 
         if (split.getChangelogSplitInfo().isPresent()) {
             dataSource = new ChangelogPageSource(dataSource, split.getChangelogSplitInfo().get(), (List<IcebergColumnHandle>) (List<?>) desiredColumns, icebergColumns);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
@@ -51,6 +51,7 @@ public class IcebergSplit
     private final List<DeleteFile> deletes;
     private final Optional<ChangelogSplitInfo> changelogSplitInfo;
     private final long dataSequenceNumber;
+    private final long firstRowId;
     private final long affinitySchedulingFileSectionSize;
     private final long affinitySchedulingFileSectionIndex;
 
@@ -69,6 +70,7 @@ public class IcebergSplit
             @JsonProperty("deletes") List<DeleteFile> deletes,
             @JsonProperty("changelogSplitInfo") Optional<ChangelogSplitInfo> changelogSplitInfo,
             @JsonProperty("dataSequenceNumber") long dataSequenceNumber,
+            @JsonProperty("firstRowId") long firstRowId,
             @JsonProperty("affinitySchedulingSectionSize") long affinitySchedulingFileSectionSize)
     {
         requireNonNull(nodeSelectionStrategy, "nodeSelectionStrategy is null");
@@ -85,6 +87,7 @@ public class IcebergSplit
         this.deletes = ImmutableList.copyOf(requireNonNull(deletes, "deletes is null"));
         this.changelogSplitInfo = requireNonNull(changelogSplitInfo, "changelogSplitInfo is null");
         this.dataSequenceNumber = dataSequenceNumber;
+        this.firstRowId = firstRowId;
         this.affinitySchedulingFileSectionSize = affinitySchedulingFileSectionSize;
         this.affinitySchedulingFileSectionIndex = start / affinitySchedulingFileSectionSize;
     }
@@ -176,6 +179,12 @@ public class IcebergSplit
     public long getDataSequenceNumber()
     {
         return dataSequenceNumber;
+    }
+
+    @JsonProperty
+    public long getFirstRowId()
+    {
+        return firstRowId;
     }
 
     @JsonProperty

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.hive.HiveCommonSessionProperties.getNodeSelect
 import static com.facebook.presto.iceberg.FileFormat.fromIcebergFileFormat;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
 import static com.facebook.presto.iceberg.IcebergUtil.getDataSequenceNumber;
+import static com.facebook.presto.iceberg.IcebergUtil.getFirstRowId;
 import static com.facebook.presto.iceberg.IcebergUtil.getPartitionKeys;
 import static com.facebook.presto.iceberg.IcebergUtil.getTargetSplitSize;
 import static com.facebook.presto.iceberg.IcebergUtil.metadataColumnsMatchPredicates;
@@ -152,6 +153,7 @@ public class IcebergSplitSource
                 task.deletes().stream().map(DeleteFile::fromIceberg).collect(toImmutableList()),
                 Optional.empty(),
                 getDataSequenceNumber(task.file()),
+                getFirstRowId(task.file()),
                 affinitySchedulingFileSectionSize);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUpdateablePageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUpdateablePageSource.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.block.ColumnarRow.toColumnarRow;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
@@ -97,6 +98,16 @@ public class IcebergUpdateablePageSource
     private final int[] outputColumnToDelegateMapping;
     private final int isDeletedColumnId;
     private final int deleteFilePathColumnId;
+    // The output index of the _row_id column, or -1 if not requested
+    private final int rowLineageRowIdOutputIndex;
+    // The delegate index of the ROW_POSITION column for computing _row_id fallback, or -1 if not needed
+    private final int rowPositionDelegateIndex;
+    // The first_row_id of the data file (from the manifest), or -1 if not a V3 table
+    private final long firstRowId;
+    // The output index of _last_updated_sequence_number, or -1 if not requested
+    private final int lastUpdatedSeqOutputIndex;
+    // The data sequence number of the file for _last_updated_sequence_number fallback
+    private final long dataSequenceNumber;
 
     public IcebergUpdateablePageSource(
             Schema tableSchema,
@@ -113,7 +124,9 @@ public class IcebergUpdateablePageSource
             Supplier<IcebergPageSink> updatedRowPageSinkSupplier,
             // the columns that this page source is supposed to update
             List<IcebergColumnHandle> updatedColumns,
-            Optional<IcebergColumnHandle> rowIdColumn)
+            Optional<IcebergColumnHandle> rowIdColumn,
+            long firstRowId,
+            long dataSequenceNumber)
     {
         requireNonNull(partitionKeys, "partitionKeys is null");
         this.tableSchema = requireNonNull(tableSchema, "tableSchema is null");
@@ -132,6 +145,8 @@ public class IcebergUpdateablePageSource
         this.updateRowIdChildColumnIndexes = rowIdColumn
                 .map(column -> new int[column.getColumnIdentity().getChildren().size()])
                 .orElse(new int[0]);
+        this.firstRowId = firstRowId;
+        this.dataSequenceNumber = dataSequenceNumber;
         Map<ColumnIdentity, Integer> columnToIndex = IntStream.range(0, delegateColumns.size())
                 .boxed()
                 .collect(toImmutableMap(index -> delegateColumns.get(index).getColumnIdentity(), identity()));
@@ -150,10 +165,24 @@ public class IcebergUpdateablePageSource
                 columnIdentityToUpdatedColumnIndex.put(updatedColumn.getColumnIdentity(), columnIndex);
             }
         }
-        for (int i = 0; i < outputColumnToDelegateMapping.length; i++) {
+
+        // Find the output index of _row_id (lineage), _last_updated_sequence_number, and the delegate index for ROW_POSITION
+        int rowLineageIdx = -1;
+        int lastUpdatedSeqIdx = -1;
+        int rowPosIdx = -1;
+        for (int i = 0; i < outputColumns.size(); i++) {
             IcebergColumnHandle outputColumn = outputColumns.get(i);
             if (outputColumn.isUpdateRowIdColumn() || outputColumn.isMergeTargetTableRowIdColumn()) {
                 continue;
+            }
+
+            if (outputColumn.isRowIdColumn()) {
+                // Map to delegate index for reading file values, but also track output index for fallback
+                rowLineageIdx = i;
+            }
+
+            if (outputColumn.isLastUpdatedSequenceNumberColumn()) {
+                lastUpdatedSeqIdx = i;
             }
 
             if (!columnToIndex.containsKey(outputColumn.getColumnIdentity())) {
@@ -163,6 +192,20 @@ public class IcebergUpdateablePageSource
                 outputColumnToDelegateMapping[i] = columnToIndex.get(outputColumn.getColumnIdentity());
             }
         }
+        this.rowLineageRowIdOutputIndex = rowLineageIdx;
+        this.lastUpdatedSeqOutputIndex = lastUpdatedSeqIdx;
+
+        // Find the delegate index for ROW_POSITION (needed for _row_id = firstRowId + _pos fallback)
+        if (rowLineageIdx >= 0 && firstRowId >= 0) {
+            for (int i = 0; i < delegateColumns.size(); i++) {
+                if (delegateColumns.get(i).isRowPositionColumn()) {
+                    rowPosIdx = i;
+                    break;
+                }
+            }
+        }
+        this.rowPositionDelegateIndex = rowPosIdx;
+
         this.isDeletedColumnId = getDelegateColumnId(IcebergColumnHandle::isDeletedColumn);
         this.deleteFilePathColumnId = getDelegateColumnId(IcebergColumnHandle::isDeleteFilePathColumn);
     }
@@ -321,6 +364,8 @@ public class IcebergUpdateablePageSource
     /**
      * The $row_id column used for updates and merge is a composite column of at least one other column in the Page.
      * The indexes of the columns needed for the $row_id are in the updateRowIdChildColumnIndexes array.
+     * Additionally, _row_id (row lineage) is computed with fallback from file values or firstRowId + _pos.
+     * _last_updated_sequence_number is computed with fallback from file values or dataSequenceNumber.
      *
      * @param page The raw Page from the Parquet/ORC reader.
      * @return A Page where the $row_id channel has been populated.
@@ -333,7 +378,17 @@ public class IcebergUpdateablePageSource
         boolean isMergeTargetTable = columns.stream().anyMatch(IcebergColumnHandle::isMergeTargetTableRowIdColumn);
 
         if ((updateRowIdColumnIndex == -1 || updatedColumns.isEmpty()) && !isMergeTargetTable) {
-            loopFunc = (channel) -> fullPage[channel] = page.getBlock(outputColumnToDelegateMapping[channel]);
+            loopFunc = (channel) -> {
+                if (channel == rowLineageRowIdOutputIndex) {
+                    fullPage[channel] = computeRowIdBlock(page);
+                }
+                else if (channel == lastUpdatedSeqOutputIndex) {
+                    fullPage[channel] = computeLastUpdatedSeqBlock(page);
+                }
+                else {
+                    fullPage[channel] = page.getBlock(outputColumnToDelegateMapping[channel]);
+                }
+            };
         }
         else {
             rowIdFields = new Block[updateRowIdChildColumnIndexes.length];
@@ -343,6 +398,12 @@ public class IcebergUpdateablePageSource
             loopFunc = (channel) -> {
                 if (channel == updateRowIdColumnIndex) {
                     fullPage[channel] = RowBlock.fromFieldBlocks(page.getPositionCount(), Optional.empty(), rowIdFields);
+                }
+                else if (channel == rowLineageRowIdOutputIndex) {
+                    fullPage[channel] = computeRowIdBlock(page);
+                }
+                else if (channel == lastUpdatedSeqOutputIndex) {
+                    fullPage[channel] = computeLastUpdatedSeqBlock(page);
                 }
                 else {
                     fullPage[channel] = page.getBlock(outputColumnToDelegateMapping[channel]);
@@ -355,6 +416,122 @@ public class IcebergUpdateablePageSource
         }
 
         return new Page(page.getPositionCount(), fullPage);
+    }
+
+    /**
+     * Computes the _row_id block. If the data file contains physical _row_id values,
+     * those are used. Null values within the block are replaced with firstRowId + _pos
+     * (per the Iceberg spec, null means "set by the commit").
+     * For V1/V2 tables (firstRowId &lt; 0), returns null for all rows.
+     */
+    private Block computeRowIdBlock(Page page)
+    {
+        // V1/V2 table: return null for all rows
+        if (firstRowId < 0) {
+            return RunLengthEncodedBlock.create(BIGINT, null, page.getPositionCount());
+        }
+
+        // Get the file-read block for _row_id
+        Block fileRowIdBlock = page.getBlock(outputColumnToDelegateMapping[rowLineageRowIdOutputIndex]);
+
+        // If the file provided all non-null values, use them directly (COW-rewritten files)
+        if (!hasAnyNull(fileRowIdBlock)) {
+            return fileRowIdBlock;
+        }
+
+        // Fallback needed: compute _row_id = firstRowId + _pos for null rows
+        if (rowPositionDelegateIndex < 0) {
+            // No ROW_POSITION available: return file values as-is (nulls remain)
+            return fileRowIdBlock;
+        }
+
+        // If the file provided all nulls, compute _row_id for all rows
+        Block rowPositionBlock = page.getBlock(rowPositionDelegateIndex);
+        if (isAllNull(fileRowIdBlock)) {
+            BlockBuilder builder = BIGINT.createBlockBuilder(null, page.getPositionCount());
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                BIGINT.writeLong(builder, firstRowId + BIGINT.getLong(rowPositionBlock, i));
+            }
+            return builder.build();
+        }
+
+        // Mixed case: COW file with some preserved values and some nulls.
+        // Replace nulls with firstRowId + _pos.
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, page.getPositionCount());
+        for (int i = 0; i < page.getPositionCount(); i++) {
+            if (fileRowIdBlock.isNull(i)) {
+                BIGINT.writeLong(builder, firstRowId + BIGINT.getLong(rowPositionBlock, i));
+            }
+            else {
+                BIGINT.writeLong(builder, BIGINT.getLong(fileRowIdBlock, i));
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Computes the _last_updated_sequence_number block. If the data file contains physical values
+     * those are used. Null values within the block are replaced with the file's dataSequenceNumber
+     * (per the Iceberg spec, null means "set by the commit").
+     * For V1/V2 tables (firstRowId &lt; 0), returns null for all rows.
+     */
+    private Block computeLastUpdatedSeqBlock(Page page)
+    {
+        // V1/V2 table: return null for all rows
+        if (firstRowId < 0) {
+            return RunLengthEncodedBlock.create(BIGINT, null, page.getPositionCount());
+        }
+
+        Block fileSeqBlock = page.getBlock(outputColumnToDelegateMapping[lastUpdatedSeqOutputIndex]);
+
+        // If the file provided all non-null values, use them directly
+        if (!hasAnyNull(fileSeqBlock)) {
+            return fileSeqBlock;
+        }
+
+        // If the file provided all nulls, use the file's data sequence number for all rows
+        if (isAllNull(fileSeqBlock)) {
+            return RunLengthEncodedBlock.create(BIGINT, dataSequenceNumber, page.getPositionCount());
+        }
+
+        // Mixed case: COW file with some preserved values and some nulls (updated rows).
+        // Replace nulls with the file's dataSequenceNumber per the Iceberg spec.
+        BlockBuilder builder = BIGINT.createBlockBuilder(null, page.getPositionCount());
+        for (int i = 0; i < page.getPositionCount(); i++) {
+            if (fileSeqBlock.isNull(i)) {
+                BIGINT.writeLong(builder, dataSequenceNumber);
+            }
+            else {
+                BIGINT.writeLong(builder, BIGINT.getLong(fileSeqBlock, i));
+            }
+        }
+        return builder.build();
+    }
+
+    private static boolean hasAnyNull(Block block)
+    {
+        if (block instanceof RunLengthEncodedBlock) {
+            return block.isNull(0);
+        }
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (block.isNull(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isAllNull(Block block)
+    {
+        if (block instanceof RunLengthEncodedBlock) {
+            return block.isNull(0);
+        }
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private int getDelegateColumnId(Predicate<IcebergColumnHandle> columnPredicate)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -643,9 +643,17 @@ public final class IcebergUtil
     }
 
     // Strip the constraints on metadata columns like "$path", "$data_sequence_number" from the list.
+    // Also strips row lineage columns (_row_id, _last_updated_sequence_number) which cannot be
+    // pushed to Iceberg's manifest filter because they are not part of the physical table schema.
     public static <U> TupleDomain<IcebergColumnHandle> getNonMetadataColumnConstraints(TupleDomain<U> allConstraints)
     {
-        return allConstraints.transform(c -> isMetadataColumnId(((IcebergColumnHandle) c).getId()) ? null : (IcebergColumnHandle) c);
+        return allConstraints.transform(c -> {
+            IcebergColumnHandle handle = (IcebergColumnHandle) c;
+            if (isMetadataColumnId(handle.getId()) || handle.isRowIdColumn() || handle.isLastUpdatedSequenceNumberColumn()) {
+                return null;
+            }
+            return handle;
+        });
     }
 
     public static <U> TupleDomain<IcebergColumnHandle> getMetadataColumnConstraints(TupleDomain<U> allConstraints)
@@ -901,6 +909,14 @@ public final class IcebergUtil
             return file.dataSequenceNumber();
         }
         return file.fileSequenceNumber();
+    }
+
+    public static long getFirstRowId(DataFile file)
+    {
+        if (file.firstRowId() != null) {
+            return file.firstRowId();
+        }
+        return -1L;
     }
 
     /**

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitSource.java
@@ -157,6 +157,7 @@ public class ChangelogSplitSource
                         changeTask.commitSnapshotId(),
                         columnHandles)),
                 getDataSequenceNumber(task.file()),
+                -1L,
                 affinitySchedulingSectionSize);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/equalitydeletes/EqualityDeletesSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/equalitydeletes/EqualityDeletesSplitSource.java
@@ -125,6 +125,7 @@ public class EqualityDeletesSplitSource
                 ImmutableList.of(),
                 Optional.empty(),
                 IcebergUtil.getDataSequenceNumber(deleteFile),
+                -1L,
                 affinitySchedulingSectionSize);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2760,6 +2760,57 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
+    public void testRowLineageHiddenColumns()
+    {
+        assertUpdate("DROP TABLE IF EXISTS test_row_lineage_hidden");
+        assertUpdate("CREATE TABLE test_row_lineage_hidden AS SELECT * FROM tpch.tiny.region WHERE regionkey=0", 1);
+        assertUpdate("INSERT INTO test_row_lineage_hidden SELECT * FROM tpch.tiny.region WHERE regionkey=1", 1);
+
+        // For non-V3 tables (format-version = 2, the default), _row_id and _last_updated_sequence_number return null
+        assertEquals(computeActual("SELECT \"_row_id\", * FROM test_row_lineage_hidden").getRowCount(), 2);
+        assertQuery("SELECT \"_row_id\" FROM test_row_lineage_hidden", "VALUES NULL, NULL");
+        assertQuery("SELECT \"_last_updated_sequence_number\" FROM test_row_lineage_hidden", "VALUES NULL, NULL");
+
+        assertUpdate("DROP TABLE IF EXISTS test_row_lineage_hidden");
+
+        // For V3 tables, _row_id and _last_updated_sequence_number must have actual values
+        String v3Table = "test_row_lineage_v3";
+        assertUpdate("DROP TABLE IF EXISTS " + v3Table);
+        // Each insert creates 1 row, so row IDs are deterministic: 0 (first commit), 1 (second commit)
+        assertUpdate("CREATE TABLE " + v3Table + " WITH (\"format-version\" = '3') AS SELECT * FROM tpch.tiny.region WHERE regionkey=0", 1);
+        assertUpdate("INSERT INTO " + v3Table + " SELECT * FROM tpch.tiny.region WHERE regionkey=1", 1);
+
+        // Both rows must have non-null row lineage values
+        assertEquals(computeActual("SELECT \"_row_id\", * FROM " + v3Table).getRowCount(), 2);
+        assertEquals(computeActual("SELECT \"_row_id\" FROM " + v3Table + " WHERE \"_row_id\" IS NULL").getRowCount(), 0);
+        assertEquals(computeActual("SELECT \"_last_updated_sequence_number\" FROM " + v3Table + " WHERE \"_last_updated_sequence_number\" IS NULL").getRowCount(), 0);
+
+        // _row_id must be unique across all rows in the table
+        long distinctRowIds = (Long) computeActual("SELECT count(DISTINCT \"_row_id\") FROM " + v3Table).getOnlyValue();
+        assertEquals(distinctRowIds, 2L);
+
+        // _last_updated_sequence_number must differ between the two commits
+        long distinctSeqNums = (Long) computeActual("SELECT count(DISTINCT \"_last_updated_sequence_number\") FROM " + v3Table).getOnlyValue();
+        assertEquals(distinctSeqNums, 2L);
+
+        // Rows from the first commit have a smaller sequence number than rows from the second commit
+        Long seqForFirst = (Long) computeActual("SELECT \"_last_updated_sequence_number\" FROM " + v3Table + " WHERE regionkey=0").getOnlyValue();
+        Long seqForSecond = (Long) computeActual("SELECT \"_last_updated_sequence_number\" FROM " + v3Table + " WHERE regionkey=1").getOnlyValue();
+        assertNotNull(seqForFirst);
+        assertNotNull(seqForSecond);
+        assertTrue(seqForFirst < seqForSecond, "_last_updated_sequence_number should be smaller for earlier commits");
+
+        // Row IDs must differ between the two rows (they are unique)
+        Long rowIdForFirst = (Long) computeActual("SELECT \"_row_id\" FROM " + v3Table + " WHERE regionkey=0").getOnlyValue();
+        Long rowIdForSecond = (Long) computeActual("SELECT \"_row_id\" FROM " + v3Table + " WHERE regionkey=1").getOnlyValue();
+        assertNotNull(rowIdForFirst);
+        assertNotNull(rowIdForSecond);
+        assertTrue(!rowIdForFirst.equals(rowIdForSecond), "_row_id should be unique per row");
+
+        assertUpdate("DROP TABLE IF EXISTS " + v3Table);
+    }
+
+    @Test
     public void testDeleteWithSpecialCharacterColumnName()
     {
         assertUpdate("CREATE TABLE test_special_character_column_name (\"<age>\" int, name varchar)");

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
@@ -32,9 +32,15 @@ import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.ARRAY;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
 import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.STRUCT;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.ROW_ID_COLUMN_HANDLE;
 import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static org.apache.iceberg.MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER;
+import static org.apache.iceberg.MetadataColumns.ROW_ID;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestIcebergColumnHandle
 {
@@ -59,6 +65,30 @@ public class TestIcebergColumnHandle
                 Optional.empty(),
                 REGULAR);
         testRoundTrip(nestedColumn);
+    }
+
+    @Test
+    public void testRowLineageColumnHandles()
+    {
+        // Verify ROW_ID column handle
+        assertEquals(ROW_ID_COLUMN_HANDLE.getName(), ROW_ID.name());
+        assertEquals(ROW_ID_COLUMN_HANDLE.getId(), ROW_ID.fieldId());
+        assertEquals(ROW_ID_COLUMN_HANDLE.getType(), BIGINT);
+        assertTrue(ROW_ID_COLUMN_HANDLE.isRowIdColumn());
+        assertFalse(ROW_ID_COLUMN_HANDLE.isLastUpdatedSequenceNumberColumn());
+
+        // Verify LAST_UPDATED_SEQUENCE_NUMBER column handle
+        assertEquals(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE.getName(), LAST_UPDATED_SEQUENCE_NUMBER.name());
+        assertEquals(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE.getId(), LAST_UPDATED_SEQUENCE_NUMBER.fieldId());
+        assertEquals(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE.getType(), BIGINT);
+        assertTrue(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE.isLastUpdatedSequenceNumberColumn());
+        assertFalse(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE.isRowIdColumn());
+
+        // Verify that _row_id and _last_updated_sequence_number are NOT treated as metadata column IDs
+        // so that IcebergPartitionInsertingPageSource passes them through to the Parquet reader.
+        // Predicate pushdown exclusion is handled separately in getNonMetadataColumnConstraints().
+        assertFalse(IcebergMetadataColumn.isMetadataColumnId(ROW_ID_COLUMN_HANDLE.getId()));
+        assertFalse(IcebergMetadataColumn.isMetadataColumnId(LAST_UPDATED_SEQUENCE_NUMBER_COLUMN_HANDLE.getId()));
     }
 
     private void testRoundTrip(IcebergColumnHandle expected)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineage.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergRowLineage.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.hadoop.HadoopOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.UUID;
+
+import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.getIcebergDataDirectoryPath;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests that row lineage values (_row_id and _last_updated_sequence_number) are consistent
+ * between the Iceberg API (used by Spark internally to create and read Iceberg V3 tables)
+ * and Presto (which reads the row lineage hidden columns).
+ *
+ * <p>This test creates V3 tables and writes data using the same Iceberg API that Spark uses
+ * under the hood (HadoopCatalog, GenericRecord, GenericParquetWriter), then verifies that
+ * Presto returns identical row lineage values to those derived from the Iceberg file metadata.
+ */
+public class TestIcebergRowLineage
+        extends AbstractTestQueryFramework
+{
+    private static final String TEST_SCHEMA = "tpch";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(HADOOP)
+                .setFormat(FileFormat.PARQUET)
+                .setNodeCount(OptionalInt.of(1))
+                .setCreateTpchTables(false)
+                .setAddJmxPlugin(false)
+                .build().getQueryRunner();
+    }
+
+    @Test
+    public void testSparkCreatedV3TableRowLineageMatchesPresto()
+            throws Exception
+    {
+        String tableName = "test_spark_row_lineage";
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+
+        try {
+            // Create V3 table using the Iceberg Catalog API (same API Spark's SparkCatalog uses)
+            Schema schema = new Schema(
+                    Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                    Types.NestedField.optional(2, "value", Types.StringType.get()));
+            Table table = catalog.createTable(tableId, schema,
+                    org.apache.iceberg.PartitionSpec.unpartitioned(),
+                    ImmutableMap.of("format-version", "3"));
+
+            // First commit: write one row using Iceberg's data writer (same API Spark uses internally)
+            writeRecords(table, schema, GenericRecord.create(schema).copy("id", 1, "value", "one"));
+
+            // Second commit: write another row in a separate commit
+            table.refresh();
+            writeRecords(table, schema, GenericRecord.create(schema).copy("id", 2, "value", "two"));
+
+            // Read expected row lineage values from Iceberg DataFile metadata
+            // This is the ground truth that both Spark and Presto should agree on
+            table.refresh();
+            List<long[]> expectedPairs = new ArrayList<>();
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    DataFile dataFile = task.file();
+                    Long firstRowId = dataFile.firstRowId();
+                    long seqNum = task.file().dataSequenceNumber();
+
+                    // Verify that V3 metadata was written correctly
+                    assertNotNull(firstRowId,
+                            "Iceberg should set firstRowId for V3 tables (same behavior as Spark)");
+
+                    for (long pos = 0; pos < dataFile.recordCount(); pos++) {
+                        expectedPairs.add(new long[] {firstRowId + pos, seqNum});
+                    }
+                }
+            }
+            expectedPairs.sort((a, b) -> Long.compare(a[0], b[0]));
+
+            // Read row lineage from Presto
+            MaterializedResult prestoResult = computeActual(
+                    "SELECT \"_row_id\", \"_last_updated_sequence_number\" FROM " + tableName +
+                            " ORDER BY \"_row_id\"");
+            List<MaterializedRow> prestoRows = prestoResult.getMaterializedRows();
+
+            // Assert same number of rows
+            assertEquals(prestoRows.size(), expectedPairs.size(),
+                    "Presto and Iceberg API should return the same number of rows");
+
+            // Assert row lineage values match between Iceberg API (Spark path) and Presto
+            for (int i = 0; i < prestoRows.size(); i++) {
+                Long prestoRowId = (Long) prestoRows.get(i).getField(0);
+                Long prestoSeqNum = (Long) prestoRows.get(i).getField(1);
+
+                assertNotNull(prestoRowId, "Presto _row_id should not be null for V3 table");
+                assertNotNull(prestoSeqNum, "Presto _last_updated_sequence_number should not be null");
+
+                assertEquals(prestoRowId.longValue(), expectedPairs.get(i)[0],
+                        "Presto _row_id should match expected value from Iceberg metadata");
+                assertEquals(prestoSeqNum.longValue(), expectedPairs.get(i)[1],
+                        "Presto _last_updated_sequence_number should match Iceberg metadata");
+            }
+
+            // Verify _row_id uniqueness
+            long distinctRowIds = (Long) computeActual(
+                    "SELECT count(DISTINCT \"_row_id\") FROM " + tableName).getOnlyValue();
+            assertEquals(distinctRowIds, 2L, "Row IDs must be unique across all rows");
+
+            // Verify sequence numbers differ between commits
+            long distinctSeqNums = (Long) computeActual(
+                    "SELECT count(DISTINCT \"_last_updated_sequence_number\") FROM " + tableName).getOnlyValue();
+            assertEquals(distinctSeqNums, 2L, "Sequence numbers should differ between commits");
+
+            // Verify ordering: earlier commits have smaller sequence numbers
+            Long seqForFirst = (Long) computeActual(
+                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName +
+                            " WHERE id = 1").getOnlyValue();
+            Long seqForSecond = (Long) computeActual(
+                    "SELECT \"_last_updated_sequence_number\" FROM " + tableName +
+                            " WHERE id = 2").getOnlyValue();
+            assertTrue(seqForFirst < seqForSecond,
+                    "_last_updated_sequence_number should be smaller for earlier commits");
+        }
+        finally {
+            catalog.dropTable(tableId, true);
+        }
+    }
+
+    @Test
+    public void testSparkCreatedV3TableRowLineageWithMultipleRowsPerCommit()
+            throws Exception
+    {
+        String tableName = "test_spark_row_lineage_multi";
+        Catalog catalog = loadCatalog();
+        TableIdentifier tableId = TableIdentifier.of(TEST_SCHEMA, tableName);
+
+        try {
+            // Create V3 table
+            Schema schema = new Schema(
+                    Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                    Types.NestedField.optional(2, "value", Types.StringType.get()));
+            Table table = catalog.createTable(tableId, schema,
+                    org.apache.iceberg.PartitionSpec.unpartitioned(),
+                    ImmutableMap.of("format-version", "3"));
+
+            // Write multiple rows in a single commit (same as Spark INSERT with multiple values)
+            writeRecords(table, schema,
+                    GenericRecord.create(schema).copy("id", 1, "value", "one"),
+                    GenericRecord.create(schema).copy("id", 2, "value", "two"),
+                    GenericRecord.create(schema).copy("id", 3, "value", "three"));
+
+            // Read file metadata from Iceberg API
+            table.refresh();
+            List<long[]> expectedPairs = new ArrayList<>();
+            try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    DataFile dataFile = task.file();
+                    Long firstRowId = dataFile.firstRowId();
+                    long seqNum = task.file().dataSequenceNumber();
+                    assertNotNull(firstRowId, "firstRowId should be set for V3 tables");
+                    for (long pos = 0; pos < dataFile.recordCount(); pos++) {
+                        expectedPairs.add(new long[] {firstRowId + pos, seqNum});
+                    }
+                }
+            }
+            expectedPairs.sort((a, b) -> Long.compare(a[0], b[0]));
+
+            // Read from Presto
+            MaterializedResult prestoResult = computeActual(
+                    "SELECT \"_row_id\", \"_last_updated_sequence_number\" FROM " +
+                            tableName + " ORDER BY \"_row_id\"");
+            List<MaterializedRow> prestoRows = prestoResult.getMaterializedRows();
+
+            assertEquals(prestoRows.size(), expectedPairs.size());
+
+            // All rows from the same commit should have the same sequence number
+            long firstSeqNum = expectedPairs.get(0)[1];
+            for (int i = 0; i < prestoRows.size(); i++) {
+                Long prestoRowId = (Long) prestoRows.get(i).getField(0);
+                Long prestoSeqNum = (Long) prestoRows.get(i).getField(1);
+
+                assertEquals(prestoRowId.longValue(), expectedPairs.get(i)[0],
+                        "Row ID should match expected value from Iceberg metadata");
+                assertEquals(prestoSeqNum.longValue(), expectedPairs.get(i)[1],
+                        "Sequence number should match expected value from Iceberg metadata");
+                assertEquals(prestoSeqNum.longValue(), firstSeqNum,
+                        "All rows in the same commit should have the same sequence number");
+            }
+
+            // Verify all row IDs are unique
+            long distinctRowIds = (Long) computeActual(
+                    "SELECT count(DISTINCT \"_row_id\") FROM " + tableName).getOnlyValue();
+            assertEquals(distinctRowIds, 3L);
+        }
+        finally {
+            catalog.dropTable(tableId, true);
+        }
+    }
+
+    private void writeRecords(Table table, Schema schema, Record... records)
+            throws Exception
+    {
+        String filename = "data-" + UUID.randomUUID() + ".parquet";
+        org.apache.hadoop.fs.Path filePath = new org.apache.hadoop.fs.Path(
+                table.location(), "data/" + filename);
+        Configuration conf = new Configuration();
+
+        DataWriter<Record> writer = Parquet.writeData(
+                        HadoopOutputFile.fromPath(filePath, conf))
+                .forTable(table)
+                .createWriterFunc(GenericParquetWriter::create)
+                .overwrite()
+                .build();
+        try {
+            for (Record record : records) {
+                writer.write(record);
+            }
+        }
+        finally {
+            writer.close();
+        }
+
+        table.newAppend()
+                .appendFile(writer.toDataFile())
+                .commit();
+    }
+
+    private Catalog loadCatalog()
+    {
+        return CatalogUtil.loadCatalog(
+                HadoopCatalog.class.getName(), ICEBERG_CATALOG,
+                getProperties(), new Configuration());
+    }
+
+    private Map<String, String> getProperties()
+    {
+        File metastoreDir = getCatalogDirectory();
+        return ImmutableMap.of("warehouse", metastoreDir.toURI().toString());
+    }
+
+    private File getCatalogDirectory()
+    {
+        Path dataDirectory = getDistributedQueryRunner()
+                .getCoordinator().getDataDirectory();
+        Path catalogDirectory = getIcebergDataDirectoryPath(
+                dataDirectory, HADOOP.name(),
+                new IcebergConfig().getFileFormat(), false);
+        return catalogDirectory.toFile();
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
@@ -577,7 +577,12 @@ public class TestIcebergHiveStatistics
     private static Map<String, ColumnHandle> getColumnHandles(QueryRunner queryRunner, String tableName, Session session)
     {
         return queryRunner.getMetadata().getColumnHandles(session, getTableHandle(queryRunner, tableName, session)).entrySet().stream()
-                .filter(entry -> !IcebergMetadataColumn.isMetadataColumnId(((IcebergColumnHandle) (entry.getValue())).getId()))
+                .filter(entry -> {
+                    IcebergColumnHandle handle = (IcebergColumnHandle) entry.getValue();
+                    return !IcebergMetadataColumn.isMetadataColumnId(handle.getId()) &&
+                            !handle.isRowIdColumn() &&
+                            !handle.isLastUpdatedSequenceNumberColumn();
+                })
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1720,6 +1720,8 @@ void to_json(json& j, const IcebergSplit& p) {
       "int64_t",
       "dataSequenceNumber");
   to_json_key(
+      j, "firstRowId", p.firstRowId, "IcebergSplit", "int64_t", "firstRowId");
+  to_json_key(
       j,
       "affinitySchedulingSectionSize",
       p.affinitySchedulingSectionSize,
@@ -1798,6 +1800,8 @@ void from_json(const json& j, IcebergSplit& p) {
       "IcebergSplit",
       "int64_t",
       "dataSequenceNumber");
+  from_json_key(
+      j, "firstRowId", p.firstRowId, "IcebergSplit", "int64_t", "firstRowId");
   from_json_key(
       j,
       "affinitySchedulingSectionSize",

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -315,6 +315,7 @@ struct IcebergSplit : public ConnectorSplit {
   List<DeleteFile> deletes = {};
   std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo = {};
   int64_t dataSequenceNumber = {};
+  int64_t firstRowId = -1;
   int64_t affinitySchedulingSectionSize = {};
 
   IcebergSplit() noexcept;

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergSplit.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergSplit.hpp.inc
@@ -30,6 +30,7 @@ struct IcebergSplit : public ConnectorSplit {
   List<DeleteFile> deletes = {};
   std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo = {};
   int64_t dataSequenceNumber = {};
+  int64_t firstRowId = -1;
   int64_t affinitySchedulingSectionSize = {};
 
   IcebergSplit() noexcept;


### PR DESCRIPTION
## Description
Add support in the Iceberg connector for reading row lineage columns.

## Motivation and Context
Fixes - https://github.com/prestodb/presto/issues/27197

## Release Notes
```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add read support for Iceberg V3 row lineage hidden columns `_row_id` and `_last_updated_sequence_number`.
```

## Summary by Sourcery

Add support in the Iceberg connector for exposing Iceberg V3 row lineage hidden columns and wiring through underlying file metadata needed to compute them with correct fallbacks.

New Features:
- Expose hidden row lineage columns _row_id and _last_updated_sequence_number in Iceberg table metadata and column handles.
- Support reading row lineage columns for Iceberg V3 tables by deriving values from physical file metadata and row positions when necessary.

Enhancements:
- Propagate first-row ID and data sequence number through Iceberg splits and page sources to enable lineage computation without altering existing storage readers.
- Exclude row lineage columns from metadata constraint pushdown and statistics handling where they are not part of the physical schema.

Tests:
- Add distributed and integration tests verifying row lineage behavior for V2 vs V3 tables, uniqueness and ordering of row IDs and sequence numbers, and consistency with tables written via the Iceberg (Spark) APIs.
- Extend unit tests for Iceberg column handles and statistics helpers to cover new row lineage hidden columns.