### PR TITLE
fix(planner): Fix failing isDistinct for equivalent variables for logical properties

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/properties/LogicalPropertiesImpl.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/properties/LogicalPropertiesImpl.java
@@ -190,13 +190,7 @@ public class LogicalPropertiesImpl
         if (maxCardProperty.isAtMostOne()) {
             return true;
         }
-        Optional<Key> normalizedKeyRequirement = getNormalizedKey(keyRequirement, equivalenceClassProperty);
-        if (normalizedKeyRequirement.isPresent()) {
-            return keyProperty.satisfiesKeyRequirement(keyRequirement);
-        }
-        else {
-            return false;
-        }
+        return getNormalizedKey(keyRequirement, equivalenceClassProperty).filter(keyProperty::satisfiesKeyRequirement).isPresent();
     }
 
     @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLogicalPropertyPropagation.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestLogicalPropertyPropagation.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.constraints.PrimaryKeyConstraint;
 import com.facebook.presto.spi.constraints.TableConstraint;
 import com.facebook.presto.spi.constraints.UniqueConstraint;
+import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.EquiJoinClause;
 import com.facebook.presto.spi.plan.FilterNode;
@@ -71,6 +72,7 @@ import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Collections.emptyList;
+import static org.testng.Assert.assertTrue;
 
 public class TestLogicalPropertyPropagation
         extends BaseRuleTest
@@ -198,6 +200,58 @@ public class TestLogicalPropertyPropagation
                                 ImmutableList.of(constant(2L, BIGINT)),
                                 ImmutableList.of(constant(3L, BIGINT)))))
                 .matches(expectedLogicalProperties);
+    }
+
+    @Test
+    public void testKeyNormalization()
+    {
+        tester().assertThat(new NoOpRule(), logicalPropertiesProvider)
+                .on(p -> {
+                    TableScanNode customerTableScan = p.tableScan(
+                            customerTableHandle,
+                            ImmutableList.of(customerCustKeyVariable),
+                            ImmutableMap.of(customerCustKeyVariable, customerCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(customerTableHandle));
+
+                    TableScanNode ordersTableScan = p.tableScan(
+                            ordersTableHandle,
+                            ImmutableList.of(ordersCustKeyVariable),
+                            ImmutableMap.of(ordersCustKeyVariable, ordersCustKeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(ordersTableHandle));
+
+                    TableScanNode lineitemTableScan = p.tableScan(
+                            lineitemTableHandle,
+                            ImmutableList.of(lineitemOrderkeyVariable),
+                            ImmutableMap.of(lineitemOrderkeyVariable, lineitemOrderkeyColumn),
+                            TupleDomain.none(),
+                            TupleDomain.none(),
+                            tester().getTableConstraints(lineitemTableHandle));
+
+                    JoinNode ordersCustomerJoin = p.join(JoinType.INNER,
+                            ordersTableScan,
+                            customerTableScan,
+                            new EquiJoinClause(ordersCustKeyVariable, customerCustKeyVariable));
+
+                    AggregationNode aggregation = p.aggregation(builder -> builder
+                            .singleGroupingSet(ordersCustKeyVariable)
+                            .source(p.join(JoinType.INNER,
+                                    ordersCustomerJoin,
+                                    lineitemTableScan,
+                                    new EquiJoinClause(customerCustKeyVariable, lineitemOrderkeyVariable))));
+                    return aggregation;
+                }).assertLogicalProperties(groupProperties -> {
+                    // SINGLE aggregation on ordersCustKeyVariable => this is a key
+                    assertTrue(groupProperties.isDistinct(ImmutableSet.of(ordersCustKeyVariable)));
+                    // Since ordersCustKeyVariable == customerCustKeyVariable, customerCustKeyVariable is a key as well
+                    // This is derived through the equivalence classes
+                    assertTrue(groupProperties.isDistinct(ImmutableSet.of(customerCustKeyVariable)));
+                    // Same holds true for lineitemOrderkeyVariable
+                    assertTrue(groupProperties.isDistinct(ImmutableSet.of(lineitemOrderkeyVariable)));
+                });
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/RuleAssert.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -58,6 +59,7 @@ import static com.facebook.presto.sql.planner.assertions.PlanAssert.assertPlan;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textLogicalPlan;
 import static com.facebook.presto.transaction.TransactionBuilder.transaction;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.fail;
 
@@ -131,7 +133,7 @@ public class RuleAssert
         TypeProvider types = ruleApplication.types;
 
         if (!ruleApplication.wasRuleApplied()) {
-            fail(String.format(
+            fail(format(
                     "%s did not fire for:\n%s",
                     rule.getClass().getName(),
                     formatPlan(plan, types)));
@@ -145,7 +147,7 @@ public class RuleAssert
         RuleApplication ruleApplication = applyRule();
 
         if (ruleApplication.wasRuleApplied()) {
-            fail(String.format(
+            fail(format(
                     "Expected %s to not fire for:\n%s",
                     rule.getClass().getName(),
                     inTransaction(session -> textLogicalPlan(plan, ruleApplication.types, StatsAndCosts.empty(), metadata.getFunctionAndTypeManager(), session, 2))));
@@ -158,7 +160,7 @@ public class RuleAssert
         TypeProvider types = ruleApplication.types;
 
         if (!ruleApplication.wasRuleApplied()) {
-            fail(String.format(
+            fail(format(
                     "%s did not fire for:\n%s",
                     rule.getClass().getName(),
                     formatPlan(plan, types)));
@@ -167,14 +169,14 @@ public class RuleAssert
         PlanNode actual = ruleApplication.getTransformedPlan();
 
         if (actual == plan) { // plans are not comparable, so we can only ensure they are not the same instance
-            fail(String.format(
+            fail(format(
                     "%s: rule fired but return the original plan:\n%s",
                     rule.getClass().getName(),
                     formatPlan(plan, types)));
         }
 
         if (!ImmutableSet.copyOf(plan.getOutputVariables()).equals(ImmutableSet.copyOf(actual.getOutputVariables()))) {
-            fail(String.format(
+            fail(format(
                     "%s: output schema of transformed and original plans are not equivalent\n" +
                             "\texpected: %s\n" +
                             "\tactual:   %s",
@@ -189,28 +191,35 @@ public class RuleAssert
         });
     }
 
-    public void matches(LogicalProperties expectedLogicalProperties)
+    public void assertLogicalProperties(Consumer<LogicalProperties> matcher)
     {
         RuleApplication ruleApplication = applyRule();
         TypeProvider types = ruleApplication.types;
 
         if (!ruleApplication.wasRuleApplied()) {
-            fail(String.format(
+            fail(format(
                     "%s did not fire for:\n%s",
                     rule.getClass().getName(),
                     formatPlan(plan, types)));
         }
 
-        // ensure that the logical properties of the root group are equivalent to the expected logical properties
         LogicalProperties rootNodeLogicalProperties = ruleApplication.getMemo().getLogicalProperties(ruleApplication.getMemo().getRootGroup()).get();
-        if (!((LogicalPropertiesImpl) rootNodeLogicalProperties).equals((LogicalPropertiesImpl) expectedLogicalProperties)) {
-            fail(String.format(
-                    "Logical properties of root node doesn't match expected logical properties\n" +
-                            "\texpected: %s\n" +
-                            "\tactual:   %s",
-                    expectedLogicalProperties,
-                    rootNodeLogicalProperties));
-        }
+        matcher.accept(rootNodeLogicalProperties);
+    }
+
+    public void matches(LogicalProperties expectedLogicalProperties)
+    {
+        // Ensure that the logical properties of the root group are equivalent to the expected logical properties
+        assertLogicalProperties(rootNodeLogicalProperties -> {
+            if (!((LogicalPropertiesImpl) rootNodeLogicalProperties).equals((LogicalPropertiesImpl) expectedLogicalProperties)) {
+                fail(format(
+                        "Logical properties of root node doesn't match expected logical properties\n" +
+                                "\texpected: %s\n" +
+                                "\tactual:   %s",
+                        expectedLogicalProperties,
+                        rootNodeLogicalProperties));
+            }
+        });
     }
 
     private RuleApplication applyRule()


### PR DESCRIPTION
## Description, Motivation and Context
When using logical properties and the Iterative optimizer, the `KeyProperty` for a Group may not always use the top-most output variables. It may be using a equivalent variable; which is why we should be normalized the test key using the equivalence classes before doing the comparison

## Impact
The [TransformDistinctInnerJoinToRightEarlyOutJoin](https://github.com/prestodb/presto/blob/47a708022aba003ebfda483ea3c940231fdbd282/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformDistinctInnerJoinToRightEarlyOutJoin.java#L167-L169) rule was stuck in a loop for TPCDS Q95 when constraints are turned on

The underlying Group node's Key's do not directly refer to the newly added aggregation node's output variables, 
so the `isDistinct` check was failing causing the rule to re-apply and get stuck

## Test Plan
New test added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Correct key requirement satisfaction check to use the normalized key requirement instead of the original key.

## Summary by Sourcery

Ensure logical key distinctness checks respect normalized equivalence classes and expand logical property testing to cover key normalization behavior.

Bug Fixes:
- Correct key requirement satisfaction to use normalized keys derived from equivalence classes when evaluating distinctness.

Enhancements:
- Refactor RuleAssert to allow custom logical property assertions via a consumer-based helper in addition to exact equality checks.

Tests:
- Add a logical property propagation test that validates key normalization across equivalent join variables and aggregations.