### PR TITLE
perf: Add strpos pre-filter optimization for json_extract_scalar equality predicates

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -331,6 +331,7 @@ public final class SystemSessionProperties
     public static final String CANONICALIZED_JSON_EXTRACT = "canonicalized_json_extract";
     public static final String PULL_EXPRESSION_FROM_LAMBDA_ENABLED = "pull_expression_from_lambda_enabled";
     public static final String REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION = "rewrite_constant_array_contains_to_in_expression";
+    public static final String REWRITE_JSON_EXTRACT_SCALAR_STRPOS_FILTER = "rewrite_json_extract_scalar_strpos_filter";
     public static final String INFER_INEQUALITY_PREDICATES = "infer_inequality_predicates";
     public static final String ENABLE_HISTORY_BASED_SCALED_WRITER = "enable_history_based_scaled_writer";
     public static final String USE_PARTIAL_AGGREGATION_HISTORY = "use_partial_aggregation_history";
@@ -1931,6 +1932,11 @@ public final class SystemSessionProperties
                         featuresConfig.isRewriteConstantArrayContainsToInEnabled(),
                         false),
                 booleanProperty(
+                        REWRITE_JSON_EXTRACT_SCALAR_STRPOS_FILTER,
+                        "Add strpos pre-filter for json_extract_scalar equality predicates to short-circuit expensive JSON parsing",
+                        featuresConfig.isRewriteJsonExtractScalarStrposFilterEnabled(),
+                        false),
+                booleanProperty(
                         INFER_INEQUALITY_PREDICATES,
                         "Infer nonequality predicates for joins",
                         featuresConfig.getInferInequalityPredicates(),
@@ -3443,6 +3449,11 @@ public final class SystemSessionProperties
     public static boolean isRewriteConstantArrayContainsToInExpressionEnabled(Session session)
     {
         return session.getSystemProperty(REWRITE_CONSTANT_ARRAY_CONTAINS_TO_IN_EXPRESSION, Boolean.class);
+    }
+
+    public static boolean isRewriteJsonExtractScalarStrposFilterEnabled(Session session)
+    {
+        return session.getSystemProperty(REWRITE_JSON_EXTRACT_SCALAR_STRPOS_FILTER, Boolean.class);
     }
 
     public static boolean shouldInferInequalityPredicates(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -291,6 +291,7 @@ public class FeaturesConfig
     private boolean inferInequalityPredicates;
     private boolean pullUpExpressionFromLambda;
     private boolean rewriteConstantArrayContainsToIn;
+    private boolean rewriteJsonExtractScalarStrposFilter;
     private boolean rewriteExpressionWithConstantVariable = true;
     private boolean optimizeConditionalApproxDistinct = true;
 
@@ -2956,6 +2957,19 @@ public class FeaturesConfig
     public FeaturesConfig setRewriteConstantArrayContainsToInEnabled(boolean rewriteConstantArrayContainsToIn)
     {
         this.rewriteConstantArrayContainsToIn = rewriteConstantArrayContainsToIn;
+        return this;
+    }
+
+    public boolean isRewriteJsonExtractScalarStrposFilterEnabled()
+    {
+        return this.rewriteJsonExtractScalarStrposFilter;
+    }
+
+    @Config("optimizer.rewrite-json-extract-scalar-strpos-filter")
+    @ConfigDescription("Add strpos pre-filter for json_extract_scalar equality predicates to short-circuit expensive JSON parsing")
+    public FeaturesConfig setRewriteJsonExtractScalarStrposFilterEnabled(boolean rewriteJsonExtractScalarStrposFilter)
+    {
+        this.rewriteJsonExtractScalarStrposFilter = rewriteJsonExtractScalarStrposFilter;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -141,6 +141,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RewriteAggregationIfToFilt
 import com.facebook.presto.sql.planner.iterative.rule.RewriteCaseExpressionPredicate;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteCaseToMap;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteConstantArrayContainsToInExpression;
+import com.facebook.presto.sql.planner.iterative.rule.RewriteJsonExtractScalarWithStrposFilter;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteExcludeColumnsFunctionToProjection;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteFilterWithExternalFunctionToProject;
 import com.facebook.presto.sql.planner.iterative.rule.RewriteRowExpressions;
@@ -392,6 +393,13 @@ public class PlanOptimizers
                 estimatedExchangesCostCalculator,
                 new RewriteConstantArrayContainsToInExpression(metadata.getFunctionAndTypeManager()).rules());
 
+        IterativeOptimizer jsonExtractScalarStrposRewriter = new IterativeOptimizer(
+                metadata,
+                ruleStats,
+                statsCalculator,
+                estimatedExchangesCostCalculator,
+                new RewriteJsonExtractScalarWithStrposFilter(metadata.getFunctionAndTypeManager()).rules());
+
         PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser, expressionOptimizerManager, featuresConfig.isNativeExecutionEnabled()));
         PlanOptimizer prefilterForLimitingAggregation = new StatsRecordingPlanOptimizer(optimizerStats, new PrefilterForLimitingAggregation(metadata, statsCalculator));
 
@@ -616,6 +624,7 @@ public class PlanOptimizers
                 caseToMapRewriter,
                 caseExpressionPredicateRewriter,
                 containsToInRewriter,
+                jsonExtractScalarStrposRewriter,
                 new IterativeOptimizer(
                         metadata,
                         ruleStats,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteJsonExtractScalarWithStrposFilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteJsonExtractScalarWithStrposFilter.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slice;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.isRewriteJsonExtractScalarStrposFilterEnabled;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.expressions.LogicalRowExpressions.and;
+import static com.facebook.presto.expressions.LogicalRowExpressions.extractConjuncts;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Optimization rule that adds a strpos pre-filter for json_extract_scalar equality predicates.
+ * <p>
+ * Transforms:
+ * <pre>
+ *   json_extract_scalar(col, '$.key') = 'some_value'
+ * </pre>
+ * Into:
+ * <pre>
+ *   strpos(col, 'some_value') &gt; 0 AND json_extract_scalar(col, '$.key') = 'some_value'
+ * </pre>
+ * <p>
+ * The strpos check is a cheap O(n) string scan that eliminates rows where the literal string
+ * cannot possibly exist in the JSON text, avoiding expensive JSON parsing on those rows.
+ * <p>
+ * Safety constraints:
+ * <ul>
+ *   <li>Only applies to equality comparisons (=) with a string constant</li>
+ *   <li>Only applies when the first argument to json_extract_scalar is VARCHAR (not JSON type)</li>
+ *   <li>Only applies when the constant string contains no characters that could be
+ *       JSON-escaped (", \, control chars U+0000-U+001F), which would cause the raw JSON
+ *       representation to differ from the extracted scalar value</li>
+ * </ul>
+ */
+public class RewriteJsonExtractScalarWithStrposFilter
+        extends RowExpressionRewriteRuleSet
+{
+    public RewriteJsonExtractScalarWithStrposFilter(FunctionAndTypeManager functionAndTypeManager)
+    {
+        super(new Rewriter(functionAndTypeManager));
+    }
+
+    @Override
+    public boolean isRewriterEnabled(Session session)
+    {
+        return isRewriteJsonExtractScalarStrposFilterEnabled(session);
+    }
+
+    @Override
+    public Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(filterRowExpressionRewriteRule());
+    }
+
+    private static class Rewriter
+            implements PlanRowExpressionRewriter
+    {
+        private final FunctionResolution functionResolution;
+        private final FunctionAndTypeManager functionAndTypeManager;
+
+        public Rewriter(FunctionAndTypeManager functionAndTypeManager)
+        {
+            requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.functionAndTypeManager = functionAndTypeManager;
+            this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+        }
+
+        @Override
+        public RowExpression rewrite(RowExpression expression, Rule.Context context)
+        {
+            // Extract all AND conjuncts from the filter expression.
+            // This avoids infinite recursion: we process top-level conjuncts and
+            // check for existing strpos guards before adding new ones.
+            List<RowExpression> conjuncts = extractConjuncts(expression);
+            List<RowExpression> newConjuncts = new ArrayList<>();
+            boolean changed = false;
+
+            for (RowExpression conjunct : conjuncts) {
+                RowExpression strposGuard = tryCreateStrposGuard(conjunct, conjuncts);
+                if (strposGuard != null) {
+                    newConjuncts.add(strposGuard);
+                    changed = true;
+                }
+                newConjuncts.add(conjunct);
+            }
+
+            if (!changed) {
+                return expression;
+            }
+
+            return and(newConjuncts);
+        }
+
+        /**
+         * If the given conjunct matches the pattern EQUALS(json_extract_scalar(varcharCol, path), stringLiteral),
+         * and no existing strpos guard is already present among the conjuncts, returns a new
+         * strpos(varcharCol, literal) &gt; 0 expression. Otherwise returns null.
+         */
+        private RowExpression tryCreateStrposGuard(RowExpression conjunct, List<RowExpression> allConjuncts)
+        {
+            if (!(conjunct instanceof CallExpression)) {
+                return null;
+            }
+
+            CallExpression callExpr = (CallExpression) conjunct;
+            if (!functionResolution.isEqualsFunction(callExpr.getFunctionHandle()) || callExpr.getArguments().size() != 2) {
+                return null;
+            }
+
+            RowExpression left = callExpr.getArguments().get(0);
+            RowExpression right = callExpr.getArguments().get(1);
+
+            // Try both operand orders: json_extract_scalar(...) = 'literal' or 'literal' = json_extract_scalar(...)
+            CallExpression jsonExtractCall = null;
+            ConstantExpression literalExpr = null;
+
+            if (isJsonExtractScalarCall(left) && isStringConstant(right)) {
+                jsonExtractCall = (CallExpression) left;
+                literalExpr = (ConstantExpression) right;
+            }
+            else if (isJsonExtractScalarCall(right) && isStringConstant(left)) {
+                jsonExtractCall = (CallExpression) right;
+                literalExpr = (ConstantExpression) left;
+            }
+
+            if (jsonExtractCall == null || literalExpr == null) {
+                return null;
+            }
+
+            RowExpression jsonInput = jsonExtractCall.getArguments().get(0);
+
+            // Only apply when the first argument is VARCHAR (not JSON type)
+            if (!(jsonInput.getType() instanceof VarcharType)) {
+                return null;
+            }
+
+            // Extract the literal string value
+            Slice literalSlice = (Slice) literalExpr.getValue();
+            if (literalSlice == null) {
+                return null;
+            }
+            String literalString = literalSlice.toStringUtf8();
+
+            // Only apply when the literal is safe (no JSON-escapable characters)
+            if (!isSafeForStrposOptimization(literalString)) {
+                return null;
+            }
+
+            // Check if a strpos guard already exists among the conjuncts for this column and literal
+            if (hasExistingStrposGuard(jsonInput, literalExpr, allConjuncts)) {
+                return null;
+            }
+
+            return buildStrposGreaterThanZero(jsonInput, literalExpr);
+        }
+
+        /**
+         * Checks if a strpos(jsonInput, literal) &gt; 0 conjunct already exists.
+         * This prevents the rule from firing again after a previous application.
+         */
+        private boolean hasExistingStrposGuard(RowExpression jsonInput, ConstantExpression literal, List<RowExpression> conjuncts)
+        {
+            for (RowExpression conjunct : conjuncts) {
+                if (isStrposGreaterThanZero(conjunct, jsonInput, literal)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Checks if the expression matches the pattern: strpos(jsonInput, literal) &gt; 0
+         */
+        private boolean isStrposGreaterThanZero(RowExpression expression, RowExpression expectedInput, ConstantExpression expectedLiteral)
+        {
+            if (!(expression instanceof CallExpression)) {
+                return false;
+            }
+
+            CallExpression call = (CallExpression) expression;
+            FunctionMetadata metadata = functionAndTypeManager.getFunctionMetadata(call.getFunctionHandle());
+
+            // Check for GREATER_THAN operator
+            if (!metadata.getOperatorType().isPresent()
+                    || metadata.getOperatorType().get() != GREATER_THAN
+                    || call.getArguments().size() != 2) {
+                return false;
+            }
+
+            RowExpression gtLeft = call.getArguments().get(0);
+            RowExpression gtRight = call.getArguments().get(1);
+
+            // Right side should be constant 0
+            if (!(gtRight instanceof ConstantExpression)
+                    || !BIGINT.equals(gtRight.getType())
+                    || !Long.valueOf(0L).equals(((ConstantExpression) gtRight).getValue())) {
+                return false;
+            }
+
+            // Left side should be strpos(expectedInput, expectedLiteral)
+            if (!(gtLeft instanceof CallExpression)) {
+                return false;
+            }
+
+            CallExpression strposCall = (CallExpression) gtLeft;
+            FunctionMetadata strposMetadata = functionAndTypeManager.getFunctionMetadata(strposCall.getFunctionHandle());
+            if (!strposMetadata.getName().getObjectName().equals("strpos") || strposCall.getArguments().size() != 2) {
+                return false;
+            }
+
+            return strposCall.getArguments().get(0).equals(expectedInput)
+                    && strposCall.getArguments().get(1).equals(expectedLiteral);
+        }
+
+        private boolean isJsonExtractScalarCall(RowExpression expression)
+        {
+            if (!(expression instanceof CallExpression)) {
+                return false;
+            }
+            CallExpression call = (CallExpression) expression;
+            FunctionMetadata metadata = functionAndTypeManager.getFunctionMetadata(call.getFunctionHandle());
+            return metadata.getName().getObjectName().equals("json_extract_scalar")
+                    && call.getArguments().size() == 2;
+        }
+
+        private static boolean isStringConstant(RowExpression expression)
+        {
+            return expression instanceof ConstantExpression
+                    && expression.getType() instanceof VarcharType
+                    && !((ConstantExpression) expression).isNull();
+        }
+
+        /**
+         * Checks if a string literal is safe for the strpos optimization.
+         * The string must not contain characters that could be escaped differently
+         * in JSON representation vs. the extracted scalar value:
+         * <ul>
+         *   <li>Double quote (")</li>
+         *   <li>Backslash (\)</li>
+         *   <li>Control characters (U+0000 through U+001F)</li>
+         * </ul>
+         */
+        private static boolean isSafeForStrposOptimization(String value)
+        {
+            if (value.isEmpty()) {
+                return false;
+            }
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '"' || c == '\\' || c <= 0x1F) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private RowExpression buildStrposGreaterThanZero(RowExpression jsonInput, ConstantExpression literal)
+        {
+            // Resolve strpos(varchar, varchar) -> bigint
+            FunctionHandle strposHandle = functionAndTypeManager.lookupFunction(
+                    "strpos",
+                    fromTypes(jsonInput.getType(), literal.getType()));
+
+            CallExpression strposCall = call(
+                    "strpos",
+                    strposHandle,
+                    BIGINT,
+                    ImmutableList.of(jsonInput, literal));
+
+            // Resolve GREATER_THAN(bigint, bigint)
+            FunctionHandle greaterThanHandle = functionAndTypeManager.resolveOperator(
+                    GREATER_THAN,
+                    fromTypes(BIGINT, BIGINT));
+
+            return call(
+                    GREATER_THAN.getOperator(),
+                    greaterThanHandle,
+                    BOOLEAN,
+                    ImmutableList.of(strposCall, constant(0L, BIGINT)));
+        }
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteJsonExtractScalarWithStrposFilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteJsonExtractScalarWithStrposFilter.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.SystemSessionProperties.REWRITE_JSON_EXTRACT_SCALAR_STRPOS_FILTER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRewriteJsonExtractScalarWithStrposFilter
+        extends BaseRuleTest
+{
+    private static final MetadataManager METADATA = createTestMetadataManager();
+    private static final Map<String, Type> TYPE_MAP = ImmutableMap.of("col", VARCHAR);
+
+    private final TestingRowExpressionTranslator testSqlToRowExpressionTranslator = new TestingRowExpressionTranslator();
+
+    @Test
+    public void testBasicRewrite()
+    {
+        assertRewrittenExpression(
+                "json_extract_scalar(col, '$.key') = 'some_value'",
+                "strpos(col, 'some_value') > 0 AND json_extract_scalar(col, '$.key') = 'some_value'");
+    }
+
+    @Test
+    public void testReversedOperands()
+    {
+        assertRewrittenExpression(
+                "'some_value' = json_extract_scalar(col, '$.key')",
+                "strpos(col, 'some_value') > 0 AND 'some_value' = json_extract_scalar(col, '$.key')");
+    }
+
+    @Test
+    public void testMultipleConjuncts()
+    {
+        assertRewrittenExpression(
+                "json_extract_scalar(col, '$.a') = 'foo' AND json_extract_scalar(col, '$.b') = 'bar'",
+                "strpos(col, 'foo') > 0 AND json_extract_scalar(col, '$.a') = 'foo' AND strpos(col, 'bar') > 0 AND json_extract_scalar(col, '$.b') = 'bar'");
+    }
+
+    @Test
+    public void testDoesNotFireForUnsafeStringWithQuote()
+    {
+        // Double quote is JSON-escapable — not safe for strpos optimization
+        assertRewriteDoesNotFire("json_extract_scalar(col, '$.key') = 'he\"llo'");
+    }
+
+    @Test
+    public void testDoesNotFireForUnsafeStringWithBackslash()
+    {
+        // Backslash is JSON-escapable — not safe for strpos optimization
+        assertRewriteDoesNotFire("json_extract_scalar(col, '$.key') = 'path\\to'");
+    }
+
+    @Test
+    public void testDoesNotFireForNonEqualityComparison()
+    {
+        assertRewriteDoesNotFire("json_extract_scalar(col, '$.key') > 'some_value'");
+        assertRewriteDoesNotFire("json_extract_scalar(col, '$.key') != 'some_value'");
+    }
+
+    @Test
+    public void testDoesNotFireForNonConstantComparison()
+    {
+        Map<String, Type> twoColTypes = ImmutableMap.of("col", VARCHAR, "other_col", VARCHAR);
+        RowExpression inputExpression = testSqlToRowExpressionTranslator.translate(
+                "json_extract_scalar(col, '$.key') = other_col",
+                twoColTypes);
+
+        tester().assertThat(new RewriteJsonExtractScalarWithStrposFilter(getFunctionManager()).filterRowExpressionRewriteRule())
+                .setSystemProperty(REWRITE_JSON_EXTRACT_SCALAR_STRPOS_FILTER, "true")
+                .on(p -> p.filter(inputExpression, p.values(p.variable("col", VARCHAR), p.variable("other_col", VARCHAR))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWithoutSessionProperty()
+    {
+        RowExpression inputExpression = testSqlToRowExpressionTranslator.translate(
+                "json_extract_scalar(col, '$.key') = 'some_value'",
+                TYPE_MAP);
+
+        tester().assertThat(new RewriteJsonExtractScalarWithStrposFilter(getFunctionManager()).filterRowExpressionRewriteRule())
+                .setSystemProperty(REWRITE_JSON_EXTRACT_SCALAR_STRPOS_FILTER, "false")
+                .on(p -> p.filter(inputExpression, p.values(p.variable("col", VARCHAR))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForNonJsonExtractScalar()
+    {
+        // Regular string equality should not be rewritten
+        assertRewriteDoesNotFire("col = 'some_value'");
+    }
+
+    @Test
+    public void testDoesNotFireForEmptyString()
+    {
+        assertRewriteDoesNotFire("json_extract_scalar(col, '$.key') = ''");
+    }
+
+    private void assertRewriteDoesNotFire(String expression)
+    {
+        RowExpression inputExpression = testSqlToRowExpressionTranslator.translate(expression, TYPE_MAP);
+
+        tester().assertThat(new RewriteJsonExtractScalarWithStrposFilter(getFunctionManager()).filterRowExpressionRewriteRule())
+                .setSystemProperty(REWRITE_JSON_EXTRACT_SCALAR_STRPOS_FILTER, "true")
+                .on(p -> p.filter(inputExpression, p.values(p.variable("col", VARCHAR))))
+                .doesNotFire();
+    }
+
+    private void assertRewrittenExpression(String inputExpressionStr, String expectedExpressionStr)
+    {
+        RowExpression inputExpression = testSqlToRowExpressionTranslator.translate(inputExpressionStr, TYPE_MAP);
+
+        tester().assertThat(new RewriteJsonExtractScalarWithStrposFilter(getFunctionManager()).filterRowExpressionRewriteRule())
+                .setSystemProperty(REWRITE_JSON_EXTRACT_SCALAR_STRPOS_FILTER, "true")
+                .on(p -> p.filter(inputExpression, p.values(p.variable("col", VARCHAR))))
+                .matches(filter(expectedExpressionStr, values("col")));
+    }
+}


### PR DESCRIPTION
Summary:
## Summary

Adds a new Presto query optimizer rule that prepends a `strpos` pre-filter for `json_extract_scalar` equality predicates in WHERE clauses.

### Transformation

```sql
-- Before:
WHERE json_extract_scalar(col, '$.key') = 'some_value'

-- After:
WHERE strpos(col, 'some_value') > 0 AND json_extract_scalar(col, '$.key') = 'some_value'
```

The `strpos` check is a cheap O(n) string scan that eliminates rows where the literal string cannot possibly exist in the JSON text, avoiding expensive JSON parsing + path extraction on those rows. This is a necessary-but-not-sufficient pre-filter: false positives are acceptable (strpos finds the string but json_extract_scalar doesn't match), but false negatives are not.

### Safety constraints

- **Equality only**: Only applies to `=` comparisons with a string constant literal
- **VARCHAR input only**: Only applies when the first argument to `json_extract_scalar` is VARCHAR (not JSON type), so `strpos` works directly on the raw column
- **JSON escaping safety**: Only applies when the literal contains no characters that could be JSON-escaped (`"`, `\`, control chars U+0000-U+001F), which would cause the raw JSON representation to differ from the extracted scalar value
- **Empty string excluded**: Empty literals are skipped since they trivially match everything
- **Idempotent**: Uses conjunct-based approach that checks for existing strpos guards, preventing infinite recursion in the IterativeOptimizer

### Implementation

- New `RewriteJsonExtractScalarWithStrposFilter` extending `RowExpressionRewriteRuleSet`
- Gated by session property `rewrite_json_extract_scalar_strpos_filter` (default **OFF**, opt-in)
- Config: `optimizer.rewrite-json-extract-scalar-strpos-filter`
- Only applies to filter expressions (WHERE clauses)
- Registered in `PlanOptimizers` alongside other expression rewrite rules
---
> Generated by [RACER], powered by [Confucius]

Differential Revision: D94798757

## Summary by Sourcery

Introduce an optimizer rule that adds an optional strpos-based pre-filter to json_extract_scalar string equality predicates in WHERE clauses to reduce JSON parsing overhead.

New Features:
- Add configurable optimizer rule RewriteJsonExtractScalarWithStrposFilter that injects a strpos guard for eligible json_extract_scalar string equality filters.

Enhancements:
- Wire the new rewrite rule into PlanOptimizers and gate it behind a new session/system property and corresponding feature config flag.

Tests:
- Add planner rule tests to validate the rewrite behavior, safety constraints, and session-property gating for the json_extract_scalar strpos pre-filter.