### PR TITLE
fix(security): Upgrade com.fasterxml.jackson.core:jackson-core from 2.15.4 to 2.18.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dep.ratis.version>3.1.3</dep.ratis.version>
         <dep.errorprone.version>2.37.0</dep.errorprone.version>
         <dep.guava.version>32.1.0-jre</dep.guava.version>
-        <dep.jackson.version>2.15.4</dep.jackson.version>
+        <dep.jackson.version>2.18.6</dep.jackson.version>
         <dep.j2objc.version>3.0.0</dep.j2objc.version>
         <dep.avro.version>1.12.0</dep.avro.version>
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -266,6 +266,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.planner.PlanCanonicalInfoProvider;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.Inject;
 
 import java.util.List;
@@ -52,7 +53,10 @@ public class HistoryBasedPlanStatisticsManager
         requireNonNull(objectMapper, "objectMapper is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.historyBasedStatisticsCacheManager = new HistoryBasedStatisticsCacheManager();
-        ObjectMapper newObjectMapper = objectMapper.copy().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        ObjectMapper newObjectMapper = objectMapper.copy()
+                .registerModule(new Jdk8Module())
+                .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(historyBasedStatisticsCacheManager, newObjectMapper, metadata);
         this.config = requireNonNull(config, "config is null");
         this.isNativeExecution = featuresConfig.isNativeExecutionEnabled();

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -74,6 +74,7 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -187,7 +188,7 @@ public final class TaskTestUtils
                 jsonCodec(TableCommitContext.class),
                 new RowExpressionDeterminismEvaluator(metadata),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper(),
+                new ObjectMapper().registerModule(new Jdk8Module()),
                 (session) -> {
                     throw new UnsupportedOperationException();
                 });

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -43,6 +43,7 @@ import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -338,7 +339,7 @@ public class TestSqlTaskManager
                 new BlockEncodingManager(),
                 new OrderingCompiler(),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper(),
+                new ObjectMapper().registerModule(new Jdk8Module()),
                 new SpoolingOutputBufferFactory(new FeaturesConfig()));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -44,6 +44,7 @@ import com.facebook.presto.testing.PageConsumerOperator;
 import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -123,7 +124,7 @@ public class TestDriver
                     Optional.empty()),
             new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
             testSessionBuilder().setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true").build(),
-            new ObjectMapper()).get();
+            new ObjectMapper().registerModule(new Jdk8Module())).get();
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;


### PR DESCRIPTION
Upgrade com.fasterxml.jackson.core:jackson-core from 2.15.4 to 2.18.6 to address GHSA-72hv-8253-57qq

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade Jackson to a newer version and ensure ObjectMapper is configured with JDK8 datatype support where used for planning and task execution.

Enhancements:
- Add jackson-datatype-jdk8 dependency and register Jdk8Module with ObjectMapper instances used by history-based plan statistics and task execution components to handle JDK 8 types consistently.

Build:
- Bump jackson-core and related Jackson BOM version from 2.15.4 to 2.18.6 in the root Maven POM.

Tests:
- Update test utilities and SqlTaskManager/Driver tests to use ObjectMapper instances configured with Jdk8Module.