### PR TITLE
misc: Migrate cpp.ref_type and drift.recursive_reference in presto thrift

### DIFF
--- a/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
+++ b/presto-native-execution/presto_cpp/main/thrift/CMakeLists.txt
@@ -50,6 +50,8 @@ thrift_library(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/presto_cpp/main/thrift
   ".."
+  THRIFT_INCLUDE_DIRECTORIES
+  ${THRIFT_INCLUDES}
 )
 target_link_libraries(presto_thrift-cpp2 ${presto_thrift_library_dependencies})
 set(presto_thrift_INCLUDES ${CMAKE_CURRENT_BINARY_DIR})

--- a/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
@@ -12,6 +12,9 @@
  * limitations under the License.
  */
 
+include "thrift/annotation/cpp.thrift"
+include "thrift/annotation/thrift.thrift"
+
 namespace cpp2 facebook.presto.thrift
 
 enum TaskState {
@@ -579,10 +582,9 @@ struct UpdateHandle {
 struct ExecutionFailureInfo {
   1: string type;
   2: string message;
-  3: optional ExecutionFailureInfo cause (
-    cpp.ref_type = "shared",
-    drift.recursive_reference = true,
-  );
+  @cpp.Ref{type = cpp.RefType.SharedMutable}
+  @thrift.DeprecatedUnvalidatedAnnotations{items = {"drift.recursive_reference": "true"}}
+  3: optional ExecutionFailureInfo cause;
   4: list<ExecutionFailureInfo> suppressed;
   5: list<string> stack;
   6: ErrorLocation errorLocation;

--- a/presto-native-execution/presto_cpp/main/thrift/temp_presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/temp_presto_thrift.thrift
@@ -12,6 +12,9 @@
  * limitations under the License.
  */
 
+include "thrift/annotation/cpp.thrift"
+include "thrift/annotation/thrift.thrift"
+
 namespace cpp2 facebook.presto.thrift
 
 enum TaskState {
@@ -579,10 +582,9 @@ struct UpdateHandle {
 struct ExecutionFailureInfo {
   1: string type;
   2: string message;
-  3: optional ExecutionFailureInfo cause (
-    cpp.ref_type = "shared",
-    drift.recursive_reference = true,
-  );
+  @cpp.Ref{type = cpp.RefType.SharedMutable}
+  @thrift.DeprecatedUnvalidatedAnnotations{items = {"drift.recursive_reference": "true"}}
+  3: optional ExecutionFailureInfo cause;
   4: list<ExecutionFailureInfo> suppressed;
   5: list<string> stack;
   6: ErrorLocation errorLocation;


### PR DESCRIPTION
Summary:
Migrate cpp.ref_type and drift.recursive_reference unstructured annotations
to their structured equivalents in presto thrift files:
- presto_thrift.thrift
- temp_presto_thrift.thrift

Reviewed By: Mizuchi

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Migrate presto thrift definitions to use structured annotations for ExecutionFailureInfo references.

Enhancements:
- Replace legacy cpp.ref_type and drift.recursive_reference annotations with structured cpp and thrift annotation usage in presto_thrift.thrift and temp_presto_thrift.thrift.
- Add cpp and thrift annotation include files to the presto thrift IDL files to support structured annotations.