### PR TITLE
misc(native): Clean up SystemConnector: fix fragile statics, macro hygiene, const-correctness, and switch safety

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/SystemConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/SystemConnector.cpp
@@ -29,43 +29,39 @@ static const std::string kTasksTable = "tasks";
 } // namespace
 
 const velox::RowTypePtr SystemTableHandle::taskSchema() const {
-  static std::vector<std::string> kTaskColumnNames = {
-      "node_id",
-      "task_id",
-      "stage_execution_id",
-      "stage_id",
-      "query_id",
-      "state",
-      "splits",
-      "queued_splits",
-      "running_splits",
-      "completed_splits",
-      "split_scheduled_time_ms",
-      "split_cpu_time_ms",
-      "split_blocked_time_ms",
-      "raw_input_bytes",
-      "raw_input_rows",
-      "processed_input_bytes",
-      "processed_input_rows",
-      "output_bytes",
-      "output_rows",
-      "physical_written_bytes",
-      "created",
-      "start",
-      "last_heartbeat",
-      "end"};
-
-  static std::vector<velox::TypePtr> kTaskColumnTypes = {
-      velox::VARCHAR(),   velox::VARCHAR(),   velox::VARCHAR(),
-      velox::VARCHAR(),   velox::VARCHAR(),   velox::VARCHAR(),
-      velox::BIGINT(),    velox::BIGINT(),    velox::BIGINT(),
-      velox::BIGINT(),    velox::BIGINT(),    velox::BIGINT(),
-      velox::BIGINT(),    velox::BIGINT(),    velox::BIGINT(),
-      velox::BIGINT(),    velox::BIGINT(),    velox::BIGINT(),
-      velox::BIGINT(),    velox::BIGINT(),    velox::TIMESTAMP(),
-      velox::TIMESTAMP(), velox::TIMESTAMP(), velox::TIMESTAMP()};
   static const RowTypePtr kTaskSchema =
-      ROW(std::move(kTaskColumnNames), std::move(kTaskColumnTypes));
+      ROW({"node_id",
+           "task_id",
+           "stage_execution_id",
+           "stage_id",
+           "query_id",
+           "state",
+           "splits",
+           "queued_splits",
+           "running_splits",
+           "completed_splits",
+           "split_scheduled_time_ms",
+           "split_cpu_time_ms",
+           "split_blocked_time_ms",
+           "raw_input_bytes",
+           "raw_input_rows",
+           "processed_input_bytes",
+           "processed_input_rows",
+           "output_bytes",
+           "output_rows",
+           "physical_written_bytes",
+           "created",
+           "start",
+           "last_heartbeat",
+           "end"},
+          {velox::VARCHAR(),   velox::VARCHAR(),   velox::VARCHAR(),
+           velox::VARCHAR(),   velox::VARCHAR(),   velox::VARCHAR(),
+           velox::BIGINT(),    velox::BIGINT(),    velox::BIGINT(),
+           velox::BIGINT(),    velox::BIGINT(),    velox::BIGINT(),
+           velox::BIGINT(),    velox::BIGINT(),    velox::BIGINT(),
+           velox::BIGINT(),    velox::BIGINT(),    velox::BIGINT(),
+           velox::BIGINT(),    velox::BIGINT(),    velox::TIMESTAMP(),
+           velox::TIMESTAMP(), velox::TIMESTAMP(), velox::TIMESTAMP()});
   return kTaskSchema;
 }
 
@@ -140,24 +136,24 @@ void SystemDataSource::addSplit(
   VELOX_CHECK(currentSplit_, "Wrong type of split for SystemDataSource.");
 }
 
-#define SET_TASK_COLUMN(value)            \
-  int j = 0;                              \
-  for (const auto& taskEntry : taskMap) { \
-    auto task = taskEntry.second;         \
-    auto taskInfo = taskInfos[j];         \
-    flat->set(j, value);                  \
-    j++;                                  \
+#define SET_TASK_COLUMN(value)                            \
+  int j = 0;                                              \
+  for (const auto& taskEntry : taskMap) {                 \
+    [[maybe_unused]] const auto& task = taskEntry.second; \
+    [[maybe_unused]] const auto& taskInfo = taskInfos[j]; \
+    flat->set(j, value);                                  \
+    j++;                                                  \
   }
 
-#define SET_TASK_FMT_COLUMN(value)        \
-  int j = 0;                              \
-  std::string temp;                       \
-  for (const auto& taskEntry : taskMap) { \
-    auto task = taskEntry.second;         \
-    auto taskInfo = taskInfos[j];         \
-    temp = fmt::format("{}", value);      \
-    flat->set(j, StringView(temp));       \
-    j++;                                  \
+#define SET_TASK_FMT_COLUMN(value)                        \
+  int j = 0;                                              \
+  std::string temp;                                       \
+  for (const auto& taskEntry : taskMap) {                 \
+    [[maybe_unused]] const auto& task = taskEntry.second; \
+    [[maybe_unused]] const auto& taskInfo = taskInfos[j]; \
+    temp = fmt::format("{}", value);                      \
+    flat->set(j, StringView(temp));                       \
+    j++;                                                  \
   }
 
 RowVectorPtr SystemDataSource::getTaskResults() {
@@ -326,10 +322,16 @@ RowVectorPtr SystemDataSource::getTaskResults() {
         SET_TASK_COLUMN(velox::Timestamp::fromMillis(task->lastEndTimeMs));
         break;
       }
+
+      default:
+        VELOX_UNREACHABLE();
     }
   }
   return result;
 }
+
+#undef SET_TASK_COLUMN
+#undef SET_TASK_FMT_COLUMN
 
 std::optional<RowVectorPtr> SystemDataSource::next(
     uint64_t size,

--- a/presto-native-execution/presto_cpp/main/connectors/SystemSplit.h
+++ b/presto-native-execution/presto_cpp/main/connectors/SystemSplit.h
@@ -27,11 +27,11 @@ struct SystemSplit : public velox::connector::ConnectorSplit {
         schemaName_(schemaName),
         tableName_(tableName) {}
 
-  const std::string& schemaName() {
+  const std::string& schemaName() const {
     return schemaName_;
   }
 
-  const std::string& tableName() {
+  const std::string& tableName() const {
     return tableName_;
   }
 


### PR DESCRIPTION
Summary:
Several code quality issues in SystemConnector accumulated over time:

**B1: Fix std::move from static local vectors in taskSchema()**
`kTaskColumnNames` and `kTaskColumnTypes` were mutable `static` vectors that got `std::move`d into the `ROW()` constructor. After the first call, these vectors would be in a moved-from (empty) state. The code worked by accident because `kTaskSchema` is also static and initialized once, but it was fragile and confusing. Replaced with a single `static const RowTypePtr` constructed directly.

**B2: Fix macro copy-by-value and add #undef**
`SET_TASK_COLUMN` and `SET_TASK_FMT_COLUMN` macros copied `task` (shared_ptr) and `taskInfo` (TaskInfo struct) by value on every loop iteration. Changed to `const auto&` references with `[[maybe_unused]]` since each macro expansion may use only one of the two variables. Added `#undef` after use.

**B4: Add const to SystemSplit accessors**
`schemaName()` and `tableName()` returned `const std::string&` but were not `const`-qualified, preventing use on `const SystemSplit&`.

**B5: Add default case to getTaskResults() switch**
The switch over `TaskColumnEnum` had no `default` clause. Adding a new column enum without updating the switch would silently skip population. Added `default: VELOX_UNREACHABLE()`.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Improve SystemConnector code safety and const-correctness for task metadata handling.

Bug Fixes:
- Replace fragile static mutable task schema vectors with a single static const RowType definition.
- Ensure getTaskResults() handles future TaskColumnEnum additions by adding a default switch case that fails fast.

Enhancements:
- Avoid unnecessary copying in task column helper macros by using referenced task/taskInfo variables and cleaning up macro scope with undef directives.
- Make SystemSplit schemaName() and tableName() accessors const-qualified to support use on const instances.