### PR TITLE
docs: Add documentation for Iceberg transaction support

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1927,29 +1927,33 @@ Iceberg tables do not support running multiple :doc:`../sql/merge` statements on
     Found conflicting files that can contain records matching true
 
 Transaction support
--------------------
+^^^^^^^^^^^^^^^^^^^
 
-The Iceberg connector supports explicit multi-statement write transactions on
-a single table. To run transaction statements, use :doc:`/sql/start-transaction`
-with :doc:`/sql/commit` or :doc:`/sql/rollback`.
+The Iceberg connector supports explicit multi-statement transactions with writes
+to a single Iceberg table. To run transaction statements, use
+:doc:`/sql/start-transaction` with :doc:`/sql/commit` or :doc:`/sql/rollback`.
 
-For snapshot semantics, use ``REPEATABLE READ`` isolation::
+The Iceberg connector provides snapshot isolation at ``REPEATABLE READ`` level.
+This also satisfies ``READ COMMITTED`` and ``READ UNCOMMITTED``, so these
+isolation levels are supported as well. For snapshot semantics, use
+``REPEATABLE READ``::
 
     START TRANSACTION ISOLATION LEVEL REPEATABLE READ;
     INSERT INTO iceberg.default.test_table (id, status) VALUES (1, 'pending');
     UPDATE iceberg.default.test_table SET status = 'committed' WHERE id = 1;
     COMMIT;
 
-Current limitations:
+Limitations:
 
 * Writes in the same transaction can target only one Iceberg table. Attempts
   to write to another table fail with ``Not allowed to open write transactions on multiple tables``.
 * ``SERIALIZABLE`` isolation is not supported by the Iceberg connector.
-* ``MERGE INTO`` is only supported in autocommit mode.
-* Some statements are only supported in autocommit mode, including:
-  ``CREATE/DROP/RENAME TABLE``, ``CREATE/DROP/RENAME SCHEMA``,
-  ``CREATE/DROP/RENAME VIEW``, ``CREATE/DROP/REFRESH MATERIALIZED VIEW``,
-  ``TRUNCATE TABLE``, and ``ANALYZE``.
+* The following statements are only supported in autocommit mode:
+  ``MERGE INTO``, ``CREATE/DROP/RENAME TABLE``,
+  ``CREATE/DROP/RENAME SCHEMA``, ``CREATE/DROP/RENAME VIEW``,
+  ``CREATE/DROP/REFRESH MATERIALIZED VIEW``, ``TRUNCATE TABLE``, and
+  ``ANALYZE``.
+* ``CALL`` statements are only supported in autocommit mode.
 * If concurrent transactions change table metadata, commit may fail and require
   retrying the transaction (for example, ``Table metadata refresh is required``).
 


### PR DESCRIPTION
## Summary
- add a new **Transaction support** section to Iceberg connector docs
- document supported multi-statement write transactions on a single table
- document current limitations and autocommit-only operations

## Test plan
- docs-only change; reviewed content against Iceberg transaction behavior in code/tests

Fixes #27243

`== NO RELEASE NOTE ==`

## Summary by Sourcery

Documentation:
- Add a Transaction support section to the Iceberg connector documentation covering multi-statement write transactions and autocommit-only operations.