### PR TITLE
fix: Fix update error with pushdownsubfields optimization

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -2544,4 +2544,27 @@ public abstract class IcebergDistributedSmokeTestBase
             assertUpdate("DROP TABLE test_tstz_io");
         }
     }
+
+    @Test
+    public void testPushdownSubfieldsWithDml()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session session = Session.builder(getSession())
+                .setSystemProperty("pushdown_subfields_enabled", "true")
+                .build();
+        try {
+            queryRunner.execute("CREATE TABLE test_pushdown_subfields_dml(a INTEGER, b VARCHAR, c VARCHAR)");
+            queryRunner.execute("INSERT INTO test_pushdown_subfields_dml VALUES (1, 'x', 'p'), (2, 'y', 'q'), (3, 'z', 'r')");
+
+            assertUpdate(session, "UPDATE test_pushdown_subfields_dml SET a = 10 WHERE c = 'q'", 1);
+            assertQuery("SELECT a, b, c FROM test_pushdown_subfields_dml WHERE c = 'q'", "VALUES (10, 'y', 'q')");
+
+            assertUpdate(session, "UPDATE test_pushdown_subfields_dml SET a = 20 WHERE c = 'nonexistent'", 0);
+            assertUpdate("DELETE FROM test_pushdown_subfields_dml WHERE c = 'r'", 1);
+            assertQuery("SELECT a, b, c FROM test_pushdown_subfields_dml ORDER BY a", "VALUES (1, 'x', 'p'), (10, 'y', 'q')");
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS test_pushdown_subfields_dml");
+        }
+    }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -75,6 +75,7 @@ import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.facebook.presto.sql.planner.plan.RowNumberNode;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.UpdateNode;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
@@ -491,6 +492,13 @@ public class PushdownSubfields
                 context.get().variables.addAll(node.getInputDistribution().get().getInputVariables());
             }
             node.getRowId().ifPresent(r -> context.get().variables.add(r));
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitUpdate(UpdateNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getSource().getOutputVariables());
             return context.defaultRewrite(node, context.get());
         }
 


### PR DESCRIPTION
## Description
- Fix PushdownSubfields optimizer to handle UpdateNode in the plan tree, preventing verify failures when pushdown-subfields-enabled=true is set and UPDATE operations are executed
- Add visitUpdate override that registers all source output variables in the optimizer context, following the same pattern as visitExplainAnalyze

## Motivation and Context
Update with subfields pushdown enabled reports error.

## Test Plan
added test for Iceberg connector for update

== NO RELEASE NOTE ==

## Summary by Sourcery

Handle UPDATE plans in the PushdownSubfields optimizer and add coverage for DML with subfields pushdown enabled for the Iceberg connector.

Bug Fixes:
- Register source output variables for UpdateNode in the PushdownSubfields optimizer to prevent verification failures when subfields pushdown is enabled for UPDATE statements.

Tests:
- Add Iceberg logical planner test covering UPDATE and DELETE operations with subfields pushdown enabled.