### PR TITLE
Refactor VectorSerde named serde API from Kind to string (#27229)

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -1538,15 +1538,15 @@ void PrestoServer::registerVectorSerdes() {
   if (!velox::isRegisteredVectorSerde()) {
     velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
   }
-  if (!velox::isRegisteredNamedVectorSerde(velox::VectorSerde::Kind::kPresto)) {
+  if (!velox::isRegisteredNamedVectorSerde("Presto")) {
     velox::serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
   if (!velox::isRegisteredNamedVectorSerde(
-          velox::VectorSerde::Kind::kCompactRow)) {
+          "CompactRow")) {
     velox::serializer::CompactRowVectorSerde::registerNamedVectorSerde();
   }
   if (!velox::isRegisteredNamedVectorSerde(
-          velox::VectorSerde::Kind::kUnsafeRow)) {
+          "UnsafeRow")) {
     velox::serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
 }

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastFile.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastFile.cpp
@@ -118,7 +118,7 @@ BroadcastFileWriter::BroadcastFileWriter(
           writeBufferSize,
           "",
           std::move(serdeOptions),
-          getNamedVectorSerde(VectorSerde::Kind::kPresto),
+          getNamedVectorSerde("Presto"),
           pool),
       maxBroadcastBytes_(maxBroadcastBytes) {}
 

--- a/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/BroadcastWrite.cpp
@@ -62,7 +62,7 @@ class BroadcastWriteOperator : public Operator {
         getVectorSerdeOptions(
             common::stringToCompressionKind(
                 ctx->queryConfig().shuffleCompressionKind()),
-            VectorSerde::Kind::kPresto),
+            "Presto"),
         operatorCtx_->pool());
   }
 

--- a/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/ShuffleRead.cpp
@@ -35,7 +35,7 @@ ShuffleRead::ShuffleRead(
           std::make_shared<core::ExchangeNode>(
               shuffleReadNode->id(),
               shuffleReadNode->outputType(),
-              VectorSerde::Kind::kCompactRow),
+              "CompactRow"),
           exchangeClient,
           "ShuffleRead") {
   initStats();

--- a/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
+++ b/presto-native-execution/presto_cpp/main/operators/tests/BroadcastTest.cpp
@@ -118,7 +118,7 @@ class BroadcastTest : public exec::test::OperatorTestBase,
       const std::vector<std::string>& broadcastFilePaths) {
     // Create plan for read node using file path.
     auto readerPlan = exec::test::PlanBuilder()
-                          .exchange(dataType, velox::VectorSerde::Kind::kPresto)
+                          .exchange(dataType, "Presto")
                           .planNode();
     exec::CursorParameters broadcastReadParams;
     broadcastReadParams.planNode = readerPlan;
@@ -349,7 +349,7 @@ TEST_P(BroadcastTest, malformedBroadcastInfoJson) {
   std::string invalidBroadcastFilePath = "/tmp/file.bin";
 
   auto readerPlan = exec::test::PlanBuilder()
-                        .exchange(dataType, velox::VectorSerde::Kind::kPresto)
+                        .exchange(dataType, "Presto")
                         .planNode();
   exec::CursorParameters broadcastReadParams;
   broadcastReadParams.planNode = readerPlan;

--- a/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/TaskManagerTest.cpp
@@ -112,13 +112,13 @@ class Cursor {
       TaskManager* taskManager,
       const protocol::TaskId& taskId,
       const RowTypePtr& rowType,
-      velox::VectorSerde::Kind serdeKind,
+      std::string serdeKind,
       memory::MemoryPool* pool)
       : pool_(pool),
         taskManager_(taskManager),
         taskId_(taskId),
         rowType_(rowType),
-        serdeKind_(serdeKind) {}
+        serdeKind_(std::move(serdeKind)) {}
 
   std::optional<std::vector<RowVectorPtr>> next() {
     if (atEnd_) {
@@ -178,7 +178,7 @@ class Cursor {
   TaskManager* const taskManager_;
   const protocol::TaskId taskId_;
   const RowTypePtr rowType_;
-  const velox::VectorSerde::Kind serdeKind_;
+  const std::string serdeKind_;
   bool atEnd_{false};
   uint64_t sequence_{0};
 };
@@ -190,13 +190,13 @@ void setAggregationSpillConfig(
 }
 
 class TaskManagerTest : public exec::test::OperatorTestBase,
-                        public testing::WithParamInterface<VectorSerde::Kind> {
+                        public testing::WithParamInterface<std::string> {
  public:
-  static std::vector<VectorSerde::Kind> getTestParams() {
-    const std::vector<VectorSerde::Kind> kinds(
-        {VectorSerde::Kind::kPresto,
-         VectorSerde::Kind::kCompactRow,
-         VectorSerde::Kind::kUnsafeRow});
+  static std::vector<std::string> getTestParams() {
+    const std::vector<std::string> kinds(
+        {"Presto",
+         "CompactRow",
+         "UnsafeRow"});
     return kinds;
   }
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -360,12 +360,12 @@ core::LocalPartitionNode::Type toLocalExchangeType(
   }
 }
 
-VectorSerde::Kind toVeloxSerdeKind(protocol::ExchangeEncoding encoding) {
+std::string toVeloxSerdeKind(protocol::ExchangeEncoding encoding) {
   switch (encoding) {
     case protocol::ExchangeEncoding::COLUMNAR:
-      return VectorSerde::Kind::kPresto;
+      return "Presto";
     case protocol::ExchangeEncoding::ROW_WISE:
-      return VectorSerde::Kind::kCompactRow;
+      return "CompactRow";
   }
   VELOX_UNSUPPORTED("Unsupported encoding: {}.", fmt::underlying(encoding));
 }
@@ -2261,7 +2261,7 @@ core::PlanNodePtr VeloxQueryPlanConverterBase::toVeloxQueryPlan(
   return core::PartitionedOutputNode::single(
       node->id,
       toRowType(node->outputVariables, typeParser_),
-      VectorSerde::Kind::kPresto,
+      "Presto",
       toVeloxQueryPlan(node->source, tableWriteInfo, taskId));
 }
 
@@ -2331,7 +2331,7 @@ core::PlanFragment VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
         partitionedOutputNode->id(),
         1,
         broadcastWriteNode->outputType(),
-        VectorSerde::Kind::kPresto,
+        "Presto",
         {broadcastWriteNode});
     return planFragment;
   }
@@ -2403,7 +2403,7 @@ core::PlanNodePtr VeloxBatchQueryPlanConverter::toVeloxQueryPlan(
   // Broadcast exchange source.
   if (node->exchangeType == protocol::ExchangeNodeType::REPLICATE) {
     return std::make_shared<core::ExchangeNode>(
-        node->id, rowType, VectorSerde::Kind::kPresto);
+        node->id, rowType, "Presto");
   }
   // Partitioned shuffle exchange source.
   return std::make_shared<operators::ShuffleReadNode>(node->id, rowType);

--- a/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PlanConverterTest.cpp
@@ -144,7 +144,7 @@ TEST_F(PlanConverterTest, partitionedOutput) {
   ASSERT_EQ(keys.size(), 2);
   ASSERT_EQ(keys[0]->toString(), "{cluster_label_v2}");
   ASSERT_EQ(keys[1]->toString(), "\"expr_181\"");
-  ASSERT_EQ(partitionedOutput->serdeKind(), VectorSerde::Kind::kCompactRow);
+  ASSERT_EQ(partitionedOutput->serdeKind(), "CompactRow");
 }
 
 // Final Agg stage plan for select regionkey, sum(1) from nation group by 1


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/16558


X-link: https://github.com/facebookincubator/axiom/pull/971

Change getNamedVectorSerde, registerNamedVectorSerde, deregisterNamedVectorSerde,
and isRegisteredNamedVectorSerde to accept const std::string& instead of
VectorSerde::Kind. Change VectorSerde::kind_ member from Kind to std::string.
Update all callers, PlanNodes, serializers, and tests. Add legacy inline
overloads accepting VectorSerde::Kind for backward compatibility.

Reviewed By: singcha, xiaoxmeng

Differential Revision: D94569860

## Summary by Sourcery

Refactor Presto native execution code to use string-based vector serde identifiers instead of the VectorSerde::Kind enum across query planning, operators, and tests.

Enhancements:
- Switch query plan construction and exchange/broadcast/shuffle operators to pass vector serde identifiers as strings (e.g., "Presto", "CompactRow", "UnsafeRow") instead of VectorSerde::Kind.
- Update Presto server serde registration logic to use string-based named vector serde lookups.

Tests:
- Adjust TaskManager and broadcast/operator plan converter tests to parameterize and assert vector serde kinds using string identifiers.