### PR TITLE
[WIP] index join (#3559)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -679,7 +679,7 @@ public class SqlQueryExecution
                     .withNoMoreBufferIds();
         }
 
-        SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, stateMachine.getWarningCollector());
+        SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, stateMachine.getWarningCollector(), metadata);
         // build the stage execution objects (this doesn't schedule execution)
         SqlQuerySchedulerInterface scheduler = SqlQueryScheduler.createSqlQueryScheduler(
                 locationFactory,

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.PlanFragment;
@@ -659,6 +660,14 @@ public class SqlQueryScheduler
         }
         if (newRoot != fragment.getRoot()) {
             Optional<StatsAndCosts> estimatedStatsAndCosts = fragment.getStatsAndCosts();
+            // Filter the scheduling order to only include sources from the
+            // original fragment. The visitor includes all source nodes (e.g.
+            // IndexSourceNode), but some don't need coordinator-scheduled
+            // splits and were excluded during plan fragmentation.
+            Set<PlanNodeId> originalSources = ImmutableSet.copyOf(fragment.getTableScanSchedulingOrder());
+            List<PlanNodeId> newSchedulingOrder = scheduleOrder(newRoot).stream()
+                    .filter(originalSources::contains)
+                    .collect(toImmutableList());
             return Optional.of(
                     // The partitioningScheme should stay the same
                     // even if the root's outputVariable layout is changed.
@@ -667,7 +676,7 @@ public class SqlQueryScheduler
                             newRoot,
                             fragment.getVariables(),
                             fragment.getPartitioning(),
-                            scheduleOrder(newRoot),
+                            newSchedulingOrder,
                             fragment.getPartitioningScheme(),
                             fragment.getOutputOrderingScheme(),
                             fragment.getStageExecutionDescriptor(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.MetadataDeleteNode;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.OutputNode;
@@ -67,6 +68,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.isForceSingleNodeOutput;
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSingleNodeExecutionEnabled;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.TemporaryTableUtil.assignPartitioningVariables;
@@ -139,12 +141,19 @@ public abstract class BasePlanFragmenter
 
     private SubPlan buildFragment(PlanNode root, FragmentProperties properties, PlanFragmentId fragmentId)
     {
-        List<PlanNodeId> schedulingOrder = scheduleOrder(root);
+        Set<PlanNodeId> partitionedSourcesSet = properties.getPartitionedSources();
+        // Filter the scheduling order to only include partitioned sources.
+        // The visitor always includes all source nodes (e.g. IndexSourceNode),
+        // but not all of them need coordinator-scheduled splits (e.g. non-bucketed
+        // index tables like SequenceStorage, or index sources in Java execution).
+        List<PlanNodeId> schedulingOrder = scheduleOrder(root).stream()
+                .filter(partitionedSourcesSet::contains)
+                .collect(toImmutableList());
         Preconditions.checkArgument(
-                properties.getPartitionedSources().equals(ImmutableSet.copyOf(schedulingOrder)),
+                partitionedSourcesSet.equals(ImmutableSet.copyOf(schedulingOrder)),
                 "Expected scheduling order (%s) to contain an entry for all partitioned sources (%s)",
                 schedulingOrder,
-                properties.getPartitionedSources());
+                partitionedSourcesSet);
 
         Set<VariableReferenceExpression> fragmentVariableTypes = extractOutputVariables(root);
         Set<PlanNodeId> tableWriterNodeIds = PlanFragmenterUtils.getTableWriterNodeIds(root);
@@ -258,6 +267,29 @@ public abstract class BasePlanFragmenter
                 .map(TableLayout.TablePartitioning::getPartitioningHandle)
                 .orElse(SOURCE_DISTRIBUTION);
         context.get().addSourceDistribution(node.getId(), partitioning, metadata, session);
+        return context.defaultRewrite(node, context.get());
+    }
+
+    @Override
+    public PlanNode visitIndexSource(IndexSourceNode node, RewriteContext<FragmentProperties> context)
+    {
+        // Only include the index source in the scheduling path when:
+        // 1. Native execution is enabled (Java execution uses the Index SPI at
+        //    runtime and doesn't need coordinator-scheduled splits), AND
+        // 2. The table layout has partitioning info (i.e., the table is bucketed).
+        //    Bucketed index tables (Hive/Prism) need splits delivered via the
+        //    scheduler. Non-bucketed index tables (e.g., SequenceStorage) handle
+        //    data fetching internally and don't need coordinator-scheduled splits.
+        if (isNativeExecutionEnabled(session)) {
+            boolean hasPartitioning = metadata.getLayout(session, node.getTableHandle())
+                    .getTablePartitioning()
+                    .isPresent();
+            if (hasPartitioning) {
+                // Use addPartitionedSource (not addSourceDistribution) to avoid
+                // overriding the probe's bucketed distribution.
+                context.get().addPartitionedSource(node.getId());
+            }
+        }
         return context.defaultRewrite(node, context.get());
     }
 
@@ -590,6 +622,13 @@ public abstract class BasePlanFragmenter
 
             partitioningHandle = Optional.of(COORDINATOR_DISTRIBUTION);
 
+            return this;
+        }
+
+        public FragmentProperties addPartitionedSource(PlanNodeId source)
+        {
+            requireNonNull(source, "source is null");
+            partitionedSources.add(source);
             return this;
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/GroupedExecutionTagger.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/GroupedExecutionTagger.java
@@ -19,6 +19,8 @@ import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.IndexJoinNode;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
@@ -298,6 +300,67 @@ class GroupedExecutionTagger
                     partitionHandles.size(),
                     metadata.getConnectorCapabilities(session, node.getTable().getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE));
         }
+    }
+
+    @Override
+    public GroupedExecutionTagger.GroupedExecutionProperties visitIndexSource(IndexSourceNode node, Void context)
+    {
+        // IndexSourceNode is similar to TableScanNode - check if the underlying table supports grouped execution
+        Optional<TableLayout.TablePartitioning> tablePartitioning = metadata.getLayout(session, node.getTableHandle()).getTablePartitioning();
+        if (!tablePartitioning.isPresent()) {
+            return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
+        }
+        List<ConnectorPartitionHandle> partitionHandles = nodePartitioningManager.listPartitionHandles(session, tablePartitioning.get().getPartitioningHandle());
+        if (ImmutableList.of(NOT_PARTITIONED).equals(partitionHandles)) {
+            return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
+        }
+        else {
+            return new GroupedExecutionTagger.GroupedExecutionProperties(
+                    true,
+                    false,
+                    ImmutableList.of(node.getId()),
+                    partitionHandles.size(),
+                    metadata.getConnectorCapabilities(session, node.getTableHandle().getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE));
+        }
+    }
+
+    @Override
+    public GroupedExecutionTagger.GroupedExecutionProperties visitIndexJoin(IndexJoinNode node, Void context)
+    {
+        GroupedExecutionTagger.GroupedExecutionProperties probe = node.getProbeSource().accept(this, null);
+        GroupedExecutionTagger.GroupedExecutionProperties index = node.getIndexSource().accept(this, null);
+
+        if (!groupedExecutionEnabled) {
+            return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
+        }
+
+        // For index join with colocated execution, both probe and index sides must be capable
+        // and have the same number of lifespans (buckets)
+        if (probe.currentNodeCapable && index.currentNodeCapable) {
+            if (probe.totalLifespans != index.totalLifespans) {
+                return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
+            }
+            // Include both probe and index side scan nodes for grouped
+            // execution. Each bucket group gets its own index split,
+            // ensuring file alignment for colocated lookup joins.
+            ImmutableList.Builder<PlanNodeId> allScanNodes = ImmutableList.builder();
+            allScanNodes.addAll(probe.capableTableScanNodes);
+            allScanNodes.addAll(index.capableTableScanNodes);
+            return new GroupedExecutionTagger.GroupedExecutionProperties(
+                    true,
+                    true,
+                    allScanNodes.build(),
+                    probe.totalLifespans,
+                    probe.recoveryEligible && index.recoveryEligible);
+        }
+
+        // If only probe side is capable, we can still do grouped execution on the probe side
+        // but the index side will be broadcast/replicated
+        if (probe.currentNodeCapable) {
+            return probe;
+        }
+
+        return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
     }
 
     private GroupedExecutionTagger.GroupedExecutionProperties processChildren(PlanNode node)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SchedulingOrderVisitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SchedulingOrderVisitor.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.spi.plan.IndexJoinNode;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -86,6 +87,13 @@ public class SchedulingOrderVisitor
 
         @Override
         public Void visitTableScan(TableScanNode node, Consumer<PlanNodeId> schedulingOrder)
+        {
+            schedulingOrder.accept(node.getId());
+            return null;
+        }
+
+        @Override
+        public Void visitIndexSource(IndexSourceNode node, Consumer<PlanNodeId> schedulingOrder)
         {
             schedulingOrder.accept(node.getId());
             return null;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
@@ -16,6 +16,10 @@ package com.facebook.presto.sql.planner;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableLayout;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
@@ -24,6 +28,7 @@ import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IndexJoinNode;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
@@ -49,6 +54,7 @@ import com.facebook.presto.spi.plan.WindowNode;
 import com.facebook.presto.split.SampledSplitSource;
 import com.facebook.presto.split.SplitSource;
 import com.facebook.presto.split.SplitSourceProvider;
+import com.facebook.presto.sql.planner.LazySplitSource;
 import com.facebook.presto.sql.planner.plan.AssignUniqueId;
 import com.facebook.presto.sql.planner.plan.CallDistributedProcedureNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
@@ -71,8 +77,10 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.REWINDABLE_GROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
@@ -85,11 +93,13 @@ public class SplitSourceFactory
 
     private final SplitSourceProvider splitSourceProvider;
     private final WarningCollector warningCollector;
+    private final Metadata metadata;
 
-    public SplitSourceFactory(SplitSourceProvider splitSourceProvider, WarningCollector warningCollector)
+    public SplitSourceFactory(SplitSourceProvider splitSourceProvider, WarningCollector warningCollector, Metadata metadata)
     {
         this.splitSourceProvider = requireNonNull(splitSourceProvider, "splitSourceProvider is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
     public Map<PlanNodeId, SplitSource> createSplitSources(PlanFragment fragment, Session session, TableWriteInfo tableWriteInfo)
@@ -210,7 +220,54 @@ public class SplitSourceFactory
         @Override
         public Map<PlanNodeId, SplitSource> visitIndexJoin(IndexJoinNode node, Context context)
         {
-            return node.getProbeSource().accept(this, context);
+            Map<PlanNodeId, SplitSource> probeSplits = node.getProbeSource().accept(this, context);
+            Map<PlanNodeId, SplitSource> indexSplits = node.getIndexSource().accept(this, context);
+            return ImmutableMap.<PlanNodeId, SplitSource>builder()
+                    .putAll(probeSplits)
+                    .putAll(indexSplits)
+                    .build();
+        }
+
+        @Override
+        public Map<PlanNodeId, SplitSource> visitIndexSource(IndexSourceNode node, Context context)
+        {
+            // Only create split sources when native execution is enabled (Java
+            // execution uses the Index SPI at runtime) AND the table is bucketed
+            // (non-bucketed tables like SequenceStorage handle data internally).
+            if (!isNativeExecutionEnabled(session)) {
+                return ImmutableMap.of();
+            }
+
+            boolean hasPartitioning = metadata.getLayout(session, node.getTableHandle())
+                    .getTablePartitioning()
+                    .isPresent();
+            if (!hasPartitioning) {
+                return ImmutableMap.of();
+            }
+
+            TableHandle table = node.getTableHandle();
+            SplitSchedulingStrategy strategy = getSplitSchedulingStrategy(stageExecutionDescriptor, node.getId());
+
+            // If the layout is missing (can happen if PickTableLayout didn't run for the
+            // index side, e.g., LEFT JOIN doesn't push partition predicates), compute it
+            // from the IndexSourceNode's currentConstraint so the split manager can find
+            // the correct partitions.
+            TableHandle finalTable = table;
+            if (!table.getLayout().isPresent()) {
+                Constraint<ColumnHandle> constraint = new Constraint<>(node.getCurrentConstraint());
+                TableLayout tableLayout = metadata.getLayout(session, table, constraint, Optional.empty()).getLayout();
+                finalTable = tableLayout.getNewTableHandle();
+            }
+
+            SplitSource splitSource = splitSourceProvider.getSplits(
+                    session,
+                    finalTable,
+                    strategy,
+                    warningCollector);
+
+            splitSources.add(splitSource);
+
+            return ImmutableMap.of(node.getId(), splitSource);
         }
 
         @Override

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnector.h
@@ -54,11 +54,34 @@ class PrestoToVeloxConnector {
       const protocol::ColumnHandle* column,
       const TypeParser& typeParser) const = 0;
 
+  /// Checks if a ColumnHandle represents a partition key column.
+  /// Default returns false. Connectors should override this to identify
+  /// partition key columns that should be excluded from index source
+  /// conversion.
+  [[nodiscard]] virtual bool isPartitionKeyColumn(
+      const protocol::ColumnHandle* column) const {
+    return false;
+  }
+
   [[nodiscard]] virtual std::unique_ptr<velox::connector::ConnectorTableHandle>
   toVeloxTableHandle(
       const protocol::TableHandle& tableHandle,
       const VeloxExprConverter& exprConverter,
       const TypeParser& typeParser) const = 0;
+
+  /// Creates a Velox ConnectorTableHandle for an IndexSourceNode.
+  /// This method is called when converting IndexSourceNode and passes
+  /// the indexHandle to enable index lookup support.
+  /// Default implementation delegates to toVeloxTableHandle (ignoring
+  /// indexHandle). Connectors supporting index lookup should override this.
+  [[nodiscard]] virtual std::unique_ptr<velox::connector::ConnectorTableHandle>
+  toVeloxTableHandleForIndexSource(
+      const protocol::TableHandle& tableHandle,
+      const protocol::IndexHandle& indexHandle,
+      const VeloxExprConverter& exprConverter,
+      const TypeParser& typeParser) const {
+    return toVeloxTableHandle(tableHandle, exprConverter, typeParser);
+  }
 
   [[nodiscard]] virtual std::unique_ptr<
       velox::connector::ConnectorInsertTableHandle>

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxQueryPlan.cpp
@@ -127,6 +127,18 @@ std::shared_ptr<connector::ConnectorTableHandle> toConnectorTableHandle(
   return connector.toVeloxTableHandle(tableHandle, exprConverter, typeParser);
 }
 
+std::shared_ptr<connector::ConnectorTableHandle>
+toConnectorTableHandleForIndexSource(
+    const protocol::TableHandle& tableHandle,
+    const protocol::IndexHandle& indexHandle,
+    const VeloxExprConverter& exprConverter,
+    const TypeParser& typeParser) {
+  const auto& connector =
+      getPrestoToVeloxConnector(tableHandle.connectorHandle->_type);
+  return connector.toVeloxTableHandleForIndexSource(
+      tableHandle, indexHandle, exprConverter, typeParser);
+}
+
 std::vector<core::TypedExprPtr> getProjections(
     const VeloxExprConverter& exprConverter,
     const protocol::Assignments& assignments) {
@@ -1408,14 +1420,30 @@ VeloxQueryPlanConverterBase::toVeloxQueryPlan(
     const std::shared_ptr<const protocol::IndexSourceNode>& node,
     const std::shared_ptr<protocol::TableWriteInfo>& tableWriteInfo,
     const protocol::TaskId& taskId) {
-  auto rowType = toRowType(node->outputVariables, typeParser_);
   connector::ColumnHandleMap assignments;
+  std::vector<std::string> outputNames;
+  std::vector<TypePtr> outputTypes;
+
+  // Get the connector to check if columns are partition keys.
+  // Partition key columns must be excluded because HiveIndexSource only
+  // handles regular columns.
+  const auto& connector =
+      getPrestoToVeloxConnector(node->tableHandle.connectorHandle->_type);
+
   for (const auto& [variable, columnHandle] : node->assignments) {
+    if (connector.isPartitionKeyColumn(columnHandle.get())) {
+      continue;
+    }
     assignments.emplace(
         variable.name, toColumnHandle(columnHandle.get(), typeParser_));
+    outputNames.push_back(variable.name);
+    outputTypes.push_back(stringToType(variable.type, typeParser_));
   }
-  auto connectorTableHandle =
-      toConnectorTableHandle(node->tableHandle, exprConverter_, typeParser_);
+
+  auto rowType = ROW(std::move(outputNames), std::move(outputTypes));
+  auto connectorTableHandle = toConnectorTableHandleForIndexSource(
+      node->tableHandle, node->indexHandle, exprConverter_, typeParser_);
+
   return std::make_shared<core::TableScanNode>(
       node->id, rowType, connectorTableHandle, assignments);
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -21,6 +21,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.ScheduledSplit;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
@@ -99,6 +100,7 @@ public class PrestoSparkRddFactory
     private static final Logger log = Logger.get(PrestoSparkRddFactory.class);
 
     private final SplitManager splitManager;
+    private final Metadata metadata;
     private final PartitioningProviderManager partitioningProviderManager;
     private final JsonCodec<PrestoSparkTaskDescriptor> taskDescriptorJsonCodec;
     private final Codec<TaskSource> taskSourceCodec;
@@ -107,12 +109,14 @@ public class PrestoSparkRddFactory
     @Inject
     public PrestoSparkRddFactory(
             SplitManager splitManager,
+            Metadata metadata,
             PartitioningProviderManager partitioningProviderManager,
             JsonCodec<PrestoSparkTaskDescriptor> taskDescriptorJsonCodec,
             Codec<TaskSource> taskSourceCodec,
             FeaturesConfig featuresConfig)
     {
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
         this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
         this.taskDescriptorJsonCodec = requireNonNull(taskDescriptorJsonCodec, "taskDescriptorJsonCodec is null");
         this.taskSourceCodec = requireNonNull(taskSourceCodec, "taskSourceCodec is null");
@@ -225,7 +229,7 @@ public class PrestoSparkRddFactory
         List<PrestoSparkSource> sources = findTableScanNodes(fragment.getRoot());
         if (!sources.isEmpty()) {
             try (CloseableSplitSourceProvider splitSourceProvider = new CloseableSplitSourceProvider(splitManager)) {
-                SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, WarningCollector.NOOP);
+                SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, WarningCollector.NOOP, metadata);
                 Map<PlanNodeId, SplitSource> splitSources = splitSourceFactory.createSplitSources(fragment, session, tableWriteInfo);
                 taskSourceRdd = Optional.of(createTaskSourcesRdd(
                         fragment.getId(),


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookexternal/presto-facebook/pull/3559

Differential Revision: D93435409

## Summary by Sourcery

Enable and stabilize index join support across planning, scheduling, and native execution, including proper handling of index sources and grouped execution.

New Features:
- Add index source handling to split creation, grouped execution tagging, fragment partitioning, and scheduling order so index joins can be executed and scheduled like table scans.
- Introduce native execution support for IndexSourceNode in the Presto-to-Velox translation and Hive connector, including index-aware table handles and filtering of partition key columns for Hive index scans.

Bug Fixes:
- Prevent failures when split sources are closed while there are outstanding getNextBatch calls by wrapping them in a close-resilient split source.
- Avoid illegal partition handle errors in FixedSplitSource when grouped execution requests batches for non-NOT_PARTITIONED handles with no splits.
- Fix Hive index scans failing on partition key columns by excluding partition columns from index source column handles and assignments.

Enhancements:
- Extend grouped execution analysis to support index joins with colocated execution when both probe and index sides are compatible, and fall back appropriately when only the probe side is capable.
- Improve layout handling for index sources and split fetching by computing missing table layouts from constraints and logging layout and partitioning decisions.
- Add detailed logging across planning, split management, and scheduling components to aid debugging of index joins and grouped execution behavior.
- Wire Metadata into SplitSourceFactory and PrestoSparkRddFactory to support the new index source and layout resolution logic.