### PR TITLE
refactor(plugin-native-sidecar): Replace OkHttpClient with Airlift HttpClient for consistency

### DIFF
--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -61,11 +61,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-function-namespace-managers-common</artifactId>
             <version>${project.version}</version>
@@ -261,19 +256,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <scope>test</scope>
-            <!-- required due to duplicate classes -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-built-in-worker-function-tools</artifactId>
             <version>${project.version}</version>
@@ -343,12 +325,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
-                    <ignoredUnusedDeclaredDependencies>
-                        <!--  OkHttp pulls in kotlin-stdlib in compile scope, but it is only used in tests here.
-                         Changing its scope causes Maven to flag it as unused, leading to build failures.
-                         We add it here to keep it in compile scope while only using it directly in tests.-->
-                        <ignoredUnusedDeclaredDependency>org.jetbrains:annotations</ignoredUnusedDeclaredDependency>
-                    </ignoredUnusedDeclaredDependencies>
                     <ignoredUsedUndeclaredDependencies>
                         <ignoredUsedUndeclaredDependency>com.facebook.airlift.drift:drift-codec:jar</ignoredUsedUndeclaredDependency>
                     </ignoredUsedUndeclaredDependencies>

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
@@ -13,11 +13,17 @@
  */
 package com.facebook.presto.sidecar.nativechecker;
 
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpUriBuilder;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.StringResponseHandler.StringResponse;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.sidecar.ForSidecarInfo;
 import com.facebook.presto.sidecar.NativeSidecarFailureInfo;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
@@ -33,23 +39,25 @@ import com.facebook.presto.spi.plan.TableWriterNode;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
+import com.google.inject.Inject;
 
-import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static com.facebook.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sidecar.nativechecker.NativePlanCheckerErrorCode.NATIVEPLANCHECKER_CONNECTION_ERROR;
 import static com.facebook.presto.sidecar.nativechecker.NativePlanCheckerErrorCode.NATIVEPLANCHECKER_UNKNOWN_CONVERSION_FAILURE;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 
@@ -60,19 +68,19 @@ public final class NativePlanChecker
         implements PlanChecker
 {
     private static final Logger LOG = Logger.get(NativePlanChecker.class);
-    private static final MediaType JSON_CONTENT_TYPE = MediaType.parse("application/json; charset=utf-8");
     private static final JsonCodec<PlanConversionResponse> PLAN_CONVERSION_RESPONSE_JSON_CODEC = JsonCodec.jsonCodec(PlanConversionResponse.class);
     public static final String PLAN_CONVERSION_ENDPOINT = "/v1/velox/plan";
 
     private final NodeManager nodeManager;
     private final JsonCodec<SimplePlanFragment> planFragmentJsonCodec;
-    private final OkHttpClient httpClient;
+    private final HttpClient httpClient;
 
-    public NativePlanChecker(NodeManager nodeManager, JsonCodec<SimplePlanFragment> planFragmentJsonCodec)
+    @Inject
+    public NativePlanChecker(NodeManager nodeManager, JsonCodec<SimplePlanFragment> planFragmentJsonCodec, @ForSidecarInfo HttpClient httpClient)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.planFragmentJsonCodec = requireNonNull(planFragmentJsonCodec, "planFragmentJsonCodec is null");
-        this.httpClient = new OkHttpClient.Builder().build();
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
     }
 
     @Override
@@ -123,45 +131,54 @@ public final class NativePlanChecker
     {
         LOG.debug("Starting native plan validation [fragment: %s, root: %s]", planFragment.getId(), planFragment.getRoot().getId());
         String requestBodyJson = planFragmentJsonCodec.toJson(planFragment);
-        final Request request = buildRequest(requestBodyJson);
 
-        try (Response response = httpClient.newCall(request).execute()) {
-            if (!response.isSuccessful()) {
+        try {
+            StringResponse response = httpClient.execute(getSidecarRequest(requestBodyJson), createStringResponseHandler());
+            if (response.getStatusCode() != 200) {
                 NativeSidecarFailureInfo failure = processResponseFailure(response);
                 String message = String.format("Error from native plan checker: %s", firstNonNull(failure.getMessage(), "Internal error"));
                 throw new PrestoException(failure::getErrorCode, message, failure.toException());
             }
         }
-        catch (final IOException e) {
-            throw new PrestoException(NATIVEPLANCHECKER_CONNECTION_ERROR, "I/O error getting native plan checker response", e);
+        catch (RuntimeException e) {
+            if (e instanceof PrestoException) {
+                throw e;
+            }
+            throw new PrestoException(NATIVEPLANCHECKER_CONNECTION_ERROR, "Error getting native plan checker response", e);
         }
         finally {
             LOG.debug("Native plan validation complete [fragment: %s, root: %s]", planFragment.getId(), planFragment.getRoot().getId());
         }
     }
 
-    private Request buildRequest(String requestBodyJson)
+    private Request getSidecarRequest(String requestBodyJson)
     {
-        // Use native sidecar plan conversion endpoint to validate
-        String planConversionUrl = nodeManager.getSidecarNode().getHttpUri().toString() + PLAN_CONVERSION_ENDPOINT;
-
-        Request.Builder builder = new Request.Builder()
-                .url(planConversionUrl)
-                .addHeader("CONTENT_TYPE", "APPLICATION_JSON")
-                .post(RequestBody.create(JSON_CONTENT_TYPE, requestBodyJson));
-
-        return builder.build();
+        return preparePost()
+                .setUri(getSidecarLocation())
+                .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .setBodyGenerator(createStaticBodyGenerator(requestBodyJson, UTF_8))
+                .build();
     }
 
-    private NativeSidecarFailureInfo processResponseFailure(Response response) throws IOException
+    private URI getSidecarLocation()
     {
-        if (response.body() == null) {
-            throw new PrestoException(NATIVEPLANCHECKER_UNKNOWN_CONVERSION_FAILURE, "Error response without failure from native plan checker with code: " + response.code());
+        Node sidecarNode = nodeManager.getSidecarNode();
+        return HttpUriBuilder
+                .uriBuilderFrom(sidecarNode.getHttpUri())
+                .appendPath(PLAN_CONVERSION_ENDPOINT)
+                .build();
+    }
+
+    private NativeSidecarFailureInfo processResponseFailure(StringResponse response)
+    {
+        String responseBody = response.getBody();
+        if (responseBody == null || responseBody.isEmpty()) {
+            throw new PrestoException(NATIVEPLANCHECKER_UNKNOWN_CONVERSION_FAILURE, "Error response without failure from native plan checker with code: " + response.getStatusCode());
         }
 
-        PlanConversionResponse planConversionResponse = PLAN_CONVERSION_RESPONSE_JSON_CODEC.fromJson(response.body().bytes());
+        PlanConversionResponse planConversionResponse = PLAN_CONVERSION_RESPONSE_JSON_CODEC.fromJson(responseBody);
         if (planConversionResponse.getFailures().isEmpty()) {
-            throw new PrestoException(NATIVEPLANCHECKER_UNKNOWN_CONVERSION_FAILURE, "Error response without failure from native plan checker with code: " + response.code());
+            throw new PrestoException(NATIVEPLANCHECKER_UNKNOWN_CONVERSION_FAILURE, "Error response without failure from native plan checker with code: " + response.getStatusCode());
         }
 
         return planConversionResponse.getFailures().get(0);

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanCheckerModule.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanCheckerModule.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sidecar.nativechecker;
+
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.plan.PlanCheckerProvider;
+import com.facebook.presto.spi.plan.SimplePlanFragment;
+import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static java.util.Objects.requireNonNull;
+
+public class NativePlanCheckerModule
+        implements Module
+{
+    private final NodeManager nodeManager;
+    private final SimplePlanFragmentSerde simplePlanFragmentSerde;
+
+    public NativePlanCheckerModule(NodeManager nodeManager, SimplePlanFragmentSerde simplePlanFragmentSerde)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.simplePlanFragmentSerde = requireNonNull(simplePlanFragmentSerde, "simplePlanFragmentSerde is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(NativePlanCheckerConfig.class, NativePlanCheckerConfig.CONFIG_PREFIX);
+        binder.install(new JsonModule());
+        binder.bind(NodeManager.class).toInstance(nodeManager);
+        binder.bind(SimplePlanFragmentSerde.class).toInstance(simplePlanFragmentSerde);
+        jsonBinder(binder).addSerializerBinding(SimplePlanFragment.class).to(SimplePlanFragmentSerializer.class).in(Scopes.SINGLETON);
+        jsonCodecBinder(binder).bindJsonCodec(SimplePlanFragment.class);
+        binder.bind(NativePlanChecker.class).in(Scopes.SINGLETON);
+        binder.bind(PlanCheckerProvider.class).to(NativePlanCheckerProvider.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanCheckerProvider.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanCheckerProvider.java
@@ -14,11 +14,8 @@
 
 package com.facebook.presto.sidecar.nativechecker;
 
-import com.facebook.airlift.json.JsonCodec;
-import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.plan.PlanChecker;
 import com.facebook.presto.spi.plan.PlanCheckerProvider;
-import com.facebook.presto.spi.plan.SimplePlanFragment;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 
@@ -29,23 +26,20 @@ import static java.util.Objects.requireNonNull;
 public class NativePlanCheckerProvider
         implements PlanCheckerProvider
 {
-    private final NodeManager nodeManager;
-    private final JsonCodec<SimplePlanFragment> planFragmentJsonCodec;
     private final NativePlanCheckerConfig config;
+    private final NativePlanChecker planChecker;
 
     @Inject
-    public NativePlanCheckerProvider(NodeManager nodeManager, JsonCodec<SimplePlanFragment> planFragmentJsonCodec, NativePlanCheckerConfig config)
+    public NativePlanCheckerProvider(NativePlanCheckerConfig config, NativePlanChecker planChecker)
     {
-        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
-        this.planFragmentJsonCodec = requireNonNull(planFragmentJsonCodec, "planFragmentJsonCodec is null");
         this.config = requireNonNull(config, "config is null");
+        this.planChecker = requireNonNull(planChecker, "planChecker is null");
     }
 
     @Override
     public List<PlanChecker> getFragmentPlanCheckers()
     {
         return config.isPlanValidationEnabled() ?
-                ImmutableList.of(new NativePlanChecker(nodeManager, planFragmentJsonCodec)) :
-                ImmutableList.of();
+                ImmutableList.of(planChecker) : ImmutableList.of();
     }
 }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanCheckerProviderFactory.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanCheckerProviderFactory.java
@@ -14,22 +14,15 @@
 package com.facebook.presto.sidecar.nativechecker;
 
 import com.facebook.airlift.bootstrap.Bootstrap;
-import com.facebook.airlift.json.JsonModule;
-import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.sidecar.NativeSidecarCommunicationModule;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.plan.PlanCheckerProvider;
 import com.facebook.presto.spi.plan.PlanCheckerProviderContext;
 import com.facebook.presto.spi.plan.PlanCheckerProviderFactory;
-import com.facebook.presto.spi.plan.SimplePlanFragment;
-import com.facebook.presto.spi.plan.SimplePlanFragmentSerde;
 import com.google.inject.Injector;
-import com.google.inject.Scopes;
 
 import java.util.Map;
 
-import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
-import static com.facebook.airlift.json.JsonBinder.jsonBinder;
-import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static java.util.Objects.requireNonNull;
 
 public class NativePlanCheckerProviderFactory
@@ -49,19 +42,12 @@ public class NativePlanCheckerProviderFactory
     }
 
     @Override
-    public PlanCheckerProvider create(Map<String, String> properties, PlanCheckerProviderContext planCheckerProviderContext)
+    public PlanCheckerProvider create(Map<String, String> properties, PlanCheckerProviderContext context)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
-                    binder -> {
-                        configBinder(binder).bindConfig(NativePlanCheckerConfig.class, NativePlanCheckerConfig.CONFIG_PREFIX);
-                        binder.install(new JsonModule());
-                        binder.bind(NodeManager.class).toInstance(planCheckerProviderContext.getNodeManager());
-                        binder.bind(SimplePlanFragmentSerde.class).toInstance(planCheckerProviderContext.getSimplePlanFragmentSerde());
-                        jsonBinder(binder).addSerializerBinding(SimplePlanFragment.class).to(SimplePlanFragmentSerializer.class).in(Scopes.SINGLETON);
-                        jsonCodecBinder(binder).bindJsonCodec(SimplePlanFragment.class);
-                        binder.bind(PlanCheckerProvider.class).to(NativePlanCheckerProvider.class).in(Scopes.SINGLETON);
-                    });
+                    new NativePlanCheckerModule(context.getNodeManager(), context.getSimplePlanFragmentSerde()),
+                    new NativeSidecarCommunicationModule());
 
             Injector injector = app
                     .noStrictConfig()

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestPlanCheckerProvider.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestPlanCheckerProvider.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.sidecar;
 
+import com.facebook.airlift.http.client.HttpStatus;
+import com.facebook.airlift.http.client.testing.TestingHttpClient;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.ErrorCode;
 import com.facebook.presto.sidecar.nativechecker.NativePlanChecker;
@@ -38,17 +40,17 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import com.google.common.net.MediaType;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.airlift.http.client.testing.TestingResponse.mockResponse;
+import static com.facebook.presto.sidecar.nativechecker.NativePlanChecker.PLAN_CONVERSION_ENDPOINT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -63,7 +65,11 @@ public class TestPlanCheckerProvider
     {
         NativePlanCheckerConfig config = new NativePlanCheckerConfig();
         assertTrue(config.isPlanValidationEnabled());
-        NativePlanCheckerProvider provider = new NativePlanCheckerProvider(new TestingNodeManager(URI.create("localhost")), PLAN_FRAGMENT_JSON_CODEC, config);
+        TestingHttpClient client = new TestingHttpClient(
+                request ->
+                        mockResponse(HttpStatus.OK, MediaType.JSON_UTF_8, ""));
+        NativePlanChecker planChecker = new NativePlanChecker(new TestingNodeManager(URI.create("localhost")), PLAN_FRAGMENT_JSON_CODEC, client);
+        NativePlanCheckerProvider provider = new NativePlanCheckerProvider(config, planChecker);
         assertTrue(provider.getIntermediatePlanCheckers().isEmpty());
         assertTrue(provider.getFinalPlanCheckers().isEmpty());
         assertEquals(provider.getFragmentPlanCheckers().size(), 1);
@@ -71,7 +77,6 @@ public class TestPlanCheckerProvider
 
     @Test
     public void testNativePlanMockValidate()
-            throws IOException
     {
         TestingPlanNode root = new TestingPlanNode();
         ConnectorPartitioningHandle connectorPartitioningHandle = new TestingConnectorPartitioningHandle();
@@ -79,26 +84,34 @@ public class TestPlanCheckerProvider
         PartitioningScheme partitioningScheme = new PartitioningScheme(new Partitioning(handle, ImmutableList.of()), ImmutableList.of());
         SimplePlanFragment fragment = new SimplePlanFragment(new PlanFragmentId(1), root, ImmutableSet.of(), handle, ImmutableList.of(), partitioningScheme, StageExecutionDescriptor.ungroupedExecution(), false);
 
-        try (MockWebServer server = new MockWebServer()) {
-            server.start();
-            TestingNodeManager nodeManager = new TestingNodeManager(server.url(NativePlanChecker.PLAN_CONVERSION_ENDPOINT).uri());
-            NativePlanChecker checker = new NativePlanChecker(nodeManager, PLAN_FRAGMENT_JSON_CODEC);
+        // set ok response
+        PlanConversionResponse responseOk = new PlanConversionResponse(ImmutableList.of());
+        NativePlanChecker okPlanchecker = createChecker(responseOk, HttpStatus.OK);
+        okPlanchecker.validateFragment(fragment, null, null);
 
-            PlanConversionResponse responseOk = new PlanConversionResponse(ImmutableList.of());
-            String responseOkString = PLAN_CONVERSION_RESPONSE_JSON_CODEC.toJson(responseOk);
-            server.enqueue(new MockResponse().setBody(responseOkString));
-            checker.validateFragment(fragment, null, null);
+        // set error response
+        String errorMessage = "native conversion error";
+        ErrorCode errorCode = StandardErrorCode.NOT_SUPPORTED.toErrorCode();
+        PlanConversionResponse responseError = new PlanConversionResponse(ImmutableList.of(new NativeSidecarFailureInfo("MockError", errorMessage, null, ImmutableList.of(), ImmutableList.of(), errorCode)));
+        NativePlanChecker errorPlanChecker = createChecker(responseError, HttpStatus.BAD_REQUEST);
+        PrestoException error = expectThrows(PrestoException.class,
+                () -> errorPlanChecker.validateFragment(fragment, null, null));
+        assertEquals(error.getErrorCode(), errorCode);
+        assertTrue(error.getMessage().contains(errorMessage));
+    }
 
-            String errorMessage = "native conversion error";
-            ErrorCode errorCode = StandardErrorCode.NOT_SUPPORTED.toErrorCode();
-            PlanConversionResponse responseError = new PlanConversionResponse(ImmutableList.of(new NativeSidecarFailureInfo("MockError", errorMessage, null, ImmutableList.of(), ImmutableList.of(), errorCode)));
-            String responseErrorString = PLAN_CONVERSION_RESPONSE_JSON_CODEC.toJson(responseError);
-            server.enqueue(new MockResponse().setResponseCode(500).setBody(responseErrorString));
-            PrestoException error = expectThrows(PrestoException.class,
-                    () -> checker.validateFragment(fragment, null, null));
-            assertEquals(error.getErrorCode(), errorCode);
-            assertTrue(error.getMessage().contains(errorMessage));
-        }
+    private NativePlanChecker createChecker(PlanConversionResponse response, HttpStatus status)
+    {
+        TestingHttpClient client = new TestingHttpClient(
+                request -> mockResponse(
+                        status,
+                        MediaType.JSON_UTF_8,
+                        PLAN_CONVERSION_RESPONSE_JSON_CODEC.toJson(response)));
+
+        return new NativePlanChecker(
+                new TestingNodeManager(URI.create("http://localhost" + PLAN_CONVERSION_ENDPOINT)),
+                PLAN_FRAGMENT_JSON_CODEC,
+                client);
     }
 
     public static class TestingConnectorPartitioningHandle


### PR DESCRIPTION
## Description
Replace `OkHttpClient` with Airlift HttpClient in `NativePlanChecker` to make it consistent with all the other http clients used in `presto-native-sidecar-plugin` module.

## Motivation and Context
This change allows us to inject the internal communication auth layer on all http clients in the sidecar module which would be added in a follow-up PR.

## Impact
No user impact

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refactor the native sidecar plan checker to use the shared Airlift HTTP client and centralized sidecar communication wiring, simplifying configuration and dependency management.

Enhancements:
- Replace the native plan checker’s direct OkHttp usage with the shared Airlift HttpClient obtained via dependency injection.
- Introduce a dedicated Guice module to configure native plan checker bindings, JSON codecs, and use the centralized sidecar communication module.
- Update the native plan checker provider to inject and reuse a singleton NativePlanChecker instead of constructing new instances per request.

Build:
- Remove OkHttp and its test utilities from the native sidecar plugin Maven dependencies and clean up related dependency plugin configuration.

Tests:
- Refactor native plan checker tests to use Airlift TestingHttpClient and helper methods instead of OkHttp MockWebServer.

## Summary by Sourcery

Refactor the native sidecar plan checker to use the shared Airlift HTTP client and centralized sidecar communication wiring, simplifying configuration and dependency management.

Enhancements:
- Replace the native plan checker’s direct OkHttp usage with the shared Airlift HttpClient obtained via dependency injection.
- Introduce a dedicated Guice module to configure native plan checker bindings, JSON codecs, and use the centralized sidecar communication module.
- Update the native plan checker provider to inject and reuse a singleton NativePlanChecker instead of constructing new instances per request.

Build:
- Remove OkHttp and its test utilities from the native sidecar plugin Maven dependencies and clean up related dependency plugin configuration.

Tests:
- Refactor native plan checker tests to use Airlift TestingHttpClient and helper methods instead of OkHttp MockWebServer.