### PR TITLE
chore(deps): Bump jjwt from 0.11.5 to 0.12.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1623,18 +1623,18 @@
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-api</artifactId>
-                <version>0.11.5</version>
+                <version>0.12.7</version>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-impl</artifactId>
-                <version>0.11.5</version>
+                <version>0.12.7</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-jackson</artifactId>
-                <version>0.11.5</version>
+                <version>0.12.7</version>
             </dependency>
 
             <dependency>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/rest/IcebergRestCatalogFactory.java
@@ -154,9 +154,9 @@ public class IcebergRestCatalogFactory
                             "version", nodeVersion.toString());
 
                     String jwt = Jwts.builder()
-                            .setSubject(session.getUser())
-                            .setIssuer(nodeVersion.toString())
-                            .setIssuedAt(new Date())
+                            .subject(session.getUser())
+                            .issuer(nodeVersion.toString())
+                            .issuedAt(new Date())
                             .claim("user", session.getUser())
                             .claim("source", session.getSource().orElse(""))
                             .compact();

--- a/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
+++ b/presto-iceberg/src/test/java/org/apache/iceberg/rest/IcebergRestCatalogServlet.java
@@ -187,7 +187,11 @@ public class IcebergRestCatalogServlet
     protected Claims getTokenClaims(String token)
     {
         token = token.replaceAll("Bearer token-exchange-token:sub=", "");
-        return Jwts.parserBuilder().build().parseClaimsJwt(token).getBody();
+        return Jwts.parser()
+                .unsecured()
+                .build()
+                .parseUnsecuredClaims(token)
+                .getPayload();
     }
 
     protected boolean isRestUserSessionToken(String token)

--- a/presto-internal-communication/src/main/java/com/facebook/presto/server/InternalAuthenticationManager.java
+++ b/presto-internal-communication/src/main/java/com/facebook/presto/server/InternalAuthenticationManager.java
@@ -22,6 +22,7 @@ import com.google.common.hash.Hashing;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 
@@ -72,7 +73,7 @@ public class InternalAuthenticationManager
     private String generateJwt()
     {
         return Jwts.builder()
-                .signWith(SignatureAlgorithm.HS256, hmac)
+                .signWith(Keys.hmacShaKeyFor(hmac), SignatureAlgorithm.HS256)
                 .setSubject(nodeId)
                 .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
                 .compact();
@@ -81,9 +82,10 @@ public class InternalAuthenticationManager
     private String parseJwt(String jwt)
     {
         return Jwts.parser()
-                .setSigningKey(hmac)
-                .parseClaimsJws(jwt)
-                .getBody()
+                .verifyWith(Keys.hmacShaKeyFor(hmac))
+                .build()
+                .parseSignedClaims(jwt)
+                .getPayload()
                 .getSubject();
     }
 

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverAuth.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverAuth.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -104,7 +105,7 @@ public class TestPrestoDriverAuth
     {
         String accessToken = Jwts.builder()
                 .setSubject("test")
-                .signWith(SignatureAlgorithm.HS512, defaultKey)
+                .signWith(Keys.hmacShaKeyFor(defaultKey), SignatureAlgorithm.HS512)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -125,7 +126,7 @@ public class TestPrestoDriverAuth
         String accessToken = Jwts.builder()
                 .setSubject("test")
                 .setHeaderParam(KEY_ID, "222")
-                .signWith(SignatureAlgorithm.HS512, hmac222)
+                .signWith(Keys.hmacShaKeyFor(hmac222), SignatureAlgorithm.HS512)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -146,7 +147,7 @@ public class TestPrestoDriverAuth
         String accessToken = Jwts.builder()
                 .setSubject("test")
                 .setHeaderParam(KEY_ID, "33")
-                .signWith(SignatureAlgorithm.RS256, privateKey33)
+                .signWith(privateKey33, SignatureAlgorithm.RS256)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -193,7 +194,7 @@ public class TestPrestoDriverAuth
         String badKey = "iPqFfWmGvClP953xU9110Q48qB4F5dcJ7QQel3O1k0xU52mlR6fT51SMa2f4KzhFRqqpwGUOud8Eo12pK9EW5H4N";
         String accessToken = Jwts.builder()
                 .setSubject("test")
-                .signWith(SignatureAlgorithm.HS512, Base64.getEncoder().encodeToString(badKey.getBytes(US_ASCII)))
+                .signWith(Keys.hmacShaKeyFor(Base64.getDecoder().decode(Base64.getEncoder().encodeToString(badKey.getBytes(US_ASCII)))), SignatureAlgorithm.HS512)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -210,7 +211,7 @@ public class TestPrestoDriverAuth
         String accessToken = Jwts.builder()
                 .setSubject("test")
                 .setHeaderParam(KEY_ID, "42")
-                .signWith(SignatureAlgorithm.RS256, privateKey33)
+                .signWith(privateKey33, SignatureAlgorithm.RS256)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
@@ -227,7 +228,7 @@ public class TestPrestoDriverAuth
         String accessToken = Jwts.builder()
                 .setSubject("test")
                 .setHeaderParam(KEY_ID, "unknown")
-                .signWith(SignatureAlgorithm.RS256, privateKey33)
+                .signWith(privateKey33, SignatureAlgorithm.RS256)
                 .compact();
 
         try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/JsonWebTokenAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/JsonWebTokenAuthenticator.java
@@ -25,10 +25,10 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.JwtParserBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.SigningKeyResolver;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.jackson.io.JacksonDeserializer;
 import jakarta.inject.Inject;
@@ -64,7 +64,7 @@ public class JsonWebTokenAuthenticator
     private static final String KEY_ID_VARIABLE = "${KID}";
 
     private final JwtParser jwtParser;
-    private final Function<JwsHeader<?>, Key> keyLoader;
+    private final Function<JwsHeader, Key> keyLoader;
 
     @Inject
     public JsonWebTokenAuthenticator(JsonWebTokenConfig config)
@@ -78,34 +78,17 @@ public class JsonWebTokenAuthenticator
             keyLoader = new StaticKeyLoader(config.getKeyFile());
         }
 
-        JwtParser jwtParser = Jwts.parserBuilder()
-                .deserializeJsonWith(new JacksonDeserializer<>(ImmutableMap.of(AUTHORIZED_IDENTITY_ATTRIBUTE, AuthorizedIdentity.class)))
-                .setSigningKeyResolver(new SigningKeyResolver()
-                {
-                    // interface uses raw types and this can not be fixed here
-                    @SuppressWarnings("rawtypes")
-                    @Override
-                    public Key resolveSigningKey(JwsHeader header, Claims claims)
-                    {
-                        return keyLoader.apply(header);
-                    }
-
-                    @SuppressWarnings("rawtypes")
-                    @Override
-                    public Key resolveSigningKey(JwsHeader header, String plaintext)
-                    {
-                        return keyLoader.apply(header);
-                    }
-                })
-                .build();
+        JwtParserBuilder parserBuilder = Jwts.parser()
+                .json(new JacksonDeserializer<>(ImmutableMap.of(AUTHORIZED_IDENTITY_ATTRIBUTE, AuthorizedIdentity.class)))
+                .keyLocator(header -> keyLoader.apply((JwsHeader) header));
 
         if (config.getRequiredIssuer() != null) {
-            jwtParser.requireIssuer(config.getRequiredIssuer());
+            parserBuilder.requireIssuer(config.getRequiredIssuer());
         }
         if (config.getRequiredAudience() != null) {
-            jwtParser.requireAudience(config.getRequiredAudience());
+            parserBuilder.requireAudience(config.getRequiredAudience());
         }
-        this.jwtParser = jwtParser;
+        this.jwtParser = parserBuilder.build();
     }
 
     @Override
@@ -124,14 +107,14 @@ public class JsonWebTokenAuthenticator
         }
 
         try {
-            Jws<Claims> claimsJws = jwtParser.parseClaimsJws(token);
+            Jws<Claims> claimsJws = jwtParser.parseSignedClaims(token);
 
-            AuthorizedIdentity authorizedIdentity = claimsJws.getBody().get(AUTHORIZED_IDENTITY_ATTRIBUTE, AuthorizedIdentity.class);
+            AuthorizedIdentity authorizedIdentity = claimsJws.getPayload().get(AUTHORIZED_IDENTITY_ATTRIBUTE, AuthorizedIdentity.class);
             if (authorizedIdentity != null) {
                 setAuthorizedIdentity(request, authorizedIdentity);
             }
 
-            String subject = claimsJws.getBody().getSubject();
+            String subject = claimsJws.getPayload().getSubject();
             return new BasicPrincipal(subject);
         }
         catch (JwtException e) {
@@ -148,7 +131,7 @@ public class JsonWebTokenAuthenticator
     }
 
     private static class StaticKeyLoader
-            implements Function<JwsHeader<?>, Key>
+            implements Function<JwsHeader, Key>
     {
         private final LoadedKey key;
 
@@ -160,7 +143,7 @@ public class JsonWebTokenAuthenticator
         }
 
         @Override
-        public Key apply(JwsHeader<?> header)
+        public Key apply(JwsHeader header)
         {
             SignatureAlgorithm algorithm = SignatureAlgorithm.forName(header.getAlgorithm());
             return key.getKey(algorithm);
@@ -168,7 +151,7 @@ public class JsonWebTokenAuthenticator
     }
 
     private static class DynamicKeyLoader
-            implements Function<JwsHeader<?>, Key>
+            implements Function<JwsHeader, Key>
     {
         private final String keyFile;
         private final ConcurrentMap<String, LoadedKey> keys = new ConcurrentHashMap<>();
@@ -181,14 +164,14 @@ public class JsonWebTokenAuthenticator
         }
 
         @Override
-        public Key apply(JwsHeader<?> header)
+        public Key apply(JwsHeader header)
         {
             String keyId = getKeyId(header);
             SignatureAlgorithm algorithm = SignatureAlgorithm.forName(header.getAlgorithm());
             return keys.computeIfAbsent(keyId, this::loadKey).getKey(algorithm);
         }
 
-        private static String getKeyId(JwsHeader<?> header)
+        private static String getKeyId(JwsHeader header)
         {
             String keyId = header.getKeyId();
             if (keyId == null) {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/JweTokenSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/JweTokenSerializer.java
@@ -93,6 +93,8 @@ public class JweTokenSerializer
                 .requireIssuer(this.issuer)
                 .requireAudience(this.audience)
                 .setCompressionCodecResolver(JweTokenSerializer::resolveCompressionCodec)
+                .unsecured()
+                .unsecuredDecompression()
                 .build();
     }
 
@@ -119,7 +121,7 @@ public class JweTokenSerializer
         try {
             JWEObject jwe = JWEObject.parse(token);
             jwe.decrypt(jweDecrypter);
-            Claims claims = parser.parseClaimsJwt(jwe.getPayload().toString()).getBody();
+            Claims claims = parser.parseUnsecuredClaims(jwe.getPayload().toString()).getPayload();
             return TokenPair.accessAndRefreshTokens(
                     claims.get(ACCESS_TOKEN_KEY, String.class),
                     claims.get(EXPIRATION_TIME_KEY, Date.class),

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/JwtUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/JwtUtil.java
@@ -39,7 +39,7 @@ public final class JwtUtil
 
     public static JwtParserBuilder newJwtParserBuilder()
     {
-        return Jwts.parserBuilder()
-                .deserializeJsonWith(JWT_DESERIALIZER);
+        return Jwts.parser()
+                .json(JWT_DESERIALIZER);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Service.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/OAuth2Service.java
@@ -241,8 +241,8 @@ public class OAuth2Service
     {
         try {
             return jwtParser
-                    .parseClaimsJws(state)
-                    .getBody();
+                    .parseSignedClaims(state)
+                    .getPayload();
         }
         catch (RuntimeException e) {
             throw new ChallengeFailedException("State validation failed", e);

--- a/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/ZstdCodec.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/oauth2/ZstdCodec.java
@@ -18,6 +18,11 @@ import io.airlift.compress.zstd.ZstdDecompressor;
 import io.jsonwebtoken.CompressionCodec;
 import io.jsonwebtoken.CompressionException;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 import static java.lang.Math.toIntExact;
 import static java.util.Arrays.copyOfRange;
 
@@ -25,6 +30,12 @@ public class ZstdCodec
         implements CompressionCodec
 {
     public static final String CODEC_NAME = "ZSTD";
+
+    @Override
+    public String getId()
+    {
+        return CODEC_NAME;
+    }
 
     @Override
     public String getAlgorithmName()
@@ -49,5 +60,39 @@ public class ZstdCodec
         byte[] output = new byte[toIntExact(ZstdDecompressor.getDecompressedSize(bytes, 0, bytes.length))];
         new ZstdDecompressor().decompress(bytes, 0, bytes.length, output, 0, output.length);
         return output;
+    }
+
+    @Override
+    public OutputStream compress(OutputStream out)
+            throws CompressionException
+    {
+        return new ByteArrayOutputStream()
+        {
+            @Override
+            public void close()
+            {
+                try {
+                    byte[] bytes = toByteArray();
+                    out.write(compress(bytes));
+                    out.close();
+                }
+                catch (Exception e) {
+                    throw new CompressionException("Unable to compress", e);
+                }
+            }
+        };
+    }
+
+    @Override
+    public InputStream decompress(InputStream input)
+            throws CompressionException
+    {
+        try {
+            byte[] bytes = input.readAllBytes();
+            return new ByteArrayInputStream(decompress(bytes));
+        }
+        catch (Exception e) {
+            throw new CompressionException("Unable to decompress", e);
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestInternalAuthenticationFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestInternalAuthenticationFilter.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.hash.Hashing;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import jakarta.ws.rs.container.ResourceInfo;
 import org.testng.annotations.Test;
 
@@ -84,7 +85,7 @@ public class TestInternalAuthenticationFilter
         InternalAuthenticationFilter internalAuthenticationFilter =
                 new InternalAuthenticationFilter(internalAuthenticationManager, new ResourceInfoBuilder(TaskResource.class, null, null).build());
         String jwtToken = Jwts.builder()
-                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("secret", UTF_8).asBytes())
+                .signWith(Keys.hmacShaKeyFor(Hashing.sha256().hashString("secret", UTF_8).asBytes()), SignatureAlgorithm.HS256)
                 .setSubject(principalString)
                 .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
                 .compact();
@@ -109,7 +110,7 @@ public class TestInternalAuthenticationFilter
         InternalAuthenticationFilter internalAuthenticationFilter =
                 new InternalAuthenticationFilter(internalAuthenticationManager, new ResourceInfoBuilder(TaskResource.class, null, null).build());
         String jwtToken = Jwts.builder()
-                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("secret", UTF_8).asBytes())
+                .signWith(Keys.hmacShaKeyFor(Hashing.sha256().hashString("secret", UTF_8).asBytes()), SignatureAlgorithm.HS256)
                 .setSubject(principalString)
                 .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
                 .compact();

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestJsonWebTokenAuthenticator.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestJsonWebTokenAuthenticator.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -91,7 +92,7 @@ public class TestJsonWebTokenAuthenticator
     {
         byte[] key = getMimeDecoder().decode(readAllBytes(keyFile.toAbsolutePath()));
         return Jwts.builder()
-                .signWith(HS256, key)
+                .signWith(Keys.hmacShaKeyFor(key), HS256)
                 .setHeaderParam(KEY_ID, KEY_ID_FOO)
                 .setSubject(principal)
                 .claim(AUTHORIZED_IDENTITY_ATTRIBUTE, authorizedIdentity)

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/BaseOAuth2AuthenticationFilterTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/BaseOAuth2AuthenticationFilterTest.java
@@ -200,7 +200,7 @@ public abstract class BaseOAuth2AuthenticationFilterTest
                                         .put("exp", now + 60L)
                                         .put("iat", now)
                                         .put("iss", "https://hydra:4444/")
-                                        .put("jti", UUID.randomUUID())
+                                        .put("jti", UUID.randomUUID().toString())
                                         .put("nbf", now)
                                         .put("scp", ImmutableList.of("openid"))
                                         .put("sub", "foo@bar.com")

--- a/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestJweTokenSerializer.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/oauth2/TestJweTokenSerializer.java
@@ -211,7 +211,8 @@ public class TestJweTokenSerializer
             implements OAuth2Client
     {
         private final Map<String, Object> claims = Jwts.claims()
-                .setSubject("user");
+                .subject("user")
+                .build();
 
         @Override
         public void load()

--- a/presto-proxy/src/main/java/com/facebook/presto/proxy/JsonWebTokenHandler.java
+++ b/presto-proxy/src/main/java/com/facebook/presto/proxy/JsonWebTokenHandler.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.security.pem.PemReader;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import jakarta.inject.Inject;
 
 import java.io.File;
@@ -82,7 +83,7 @@ public class JsonWebTokenHandler
             if (!(key instanceof RSAPrivateKey)) {
                 throw new IOException("Only RSA private keys are supported");
             }
-            return Optional.of(jwt -> jwt.signWith(SignatureAlgorithm.RS256, key));
+            return Optional.of(jwt -> jwt.signWith(key, SignatureAlgorithm.RS256));
         }
         catch (IOException e) {
             throw new RuntimeException("Failed to load key file: " + file, e);
@@ -93,7 +94,7 @@ public class JsonWebTokenHandler
         try {
             byte[] base64Key = readAllBytes(file.toPath());
             byte[] key = Base64.getMimeDecoder().decode(base64Key);
-            return Optional.of(jwt -> jwt.signWith(SignatureAlgorithm.HS256, key));
+            return Optional.of(jwt -> jwt.signWith(Keys.hmacShaKeyFor(key), SignatureAlgorithm.HS256));
         }
         catch (IOException | IllegalArgumentException e) {
             throw new RuntimeException("Failed to load key file: " + file, e);


### PR DESCRIPTION
## Description
chore(deps): Bump jjwt from 0.11.5 to 0.12.7

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update JSON Web Token handling to be compatible with jjwt 0.12.7 and upgrade jjwt dependencies.

Enhancements:
- Adapt JWT parsing, signing, and claims access across server, JDBC, proxy, and OAuth2 components to the jjwt 0.12.7 API, including use of new parser/builder methods and key handling.
- Extend the ZstdCodec implementation with stream-based compress/decompress methods and an explicit codec identifier to satisfy the updated compression interface requirements.

Build:
- Bump jjwt-api, jjwt-impl, and jjwt-jackson dependencies from 0.11.5 to 0.12.7.