### PR TITLE
feat(connector): Add support create, drop, list view in postgresql

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadataFactory.java
@@ -19,10 +19,10 @@ import static java.util.Objects.requireNonNull;
 
 public class JdbcMetadataFactory
 {
-    private final JdbcMetadataCache jdbcMetadataCache;
-    private final JdbcClient jdbcClient;
-    private final boolean allowDropTable;
-    private final TableLocationProvider tableLocationProvider;
+    protected final JdbcMetadataCache jdbcMetadataCache;
+    protected final JdbcClient jdbcClient;
+    protected final boolean allowDropTable;
+    protected final TableLocationProvider tableLocationProvider;
 
     @Inject
     public JdbcMetadataFactory(JdbcMetadataCache jdbcMetadataCache, JdbcClient jdbcClient, JdbcMetadataConfig config, TableLocationProvider tableLocationProvider)
@@ -35,6 +35,34 @@ public class JdbcMetadataFactory
     }
 
     public JdbcMetadata create()
+    {
+        // Check if this is a PostgreSQL client and create appropriate metadata
+        String clientClassName = jdbcClient.getClass().getName();
+        if (clientClassName.contains("PostgreSql")) {
+            try {
+                // Use reflection to create PostgreSqlMetadata
+                Class<?> postgreSqlClientClass = Class.forName("com.facebook.presto.plugin.postgresql.PostgreSqlClient");
+                Class<?> postgreSqlMetadataClass = Class.forName("com.facebook.presto.plugin.postgresql.PostgreSqlMetadata");
+
+                if (postgreSqlClientClass.isInstance(jdbcClient)) {
+                    return (JdbcMetadata) postgreSqlMetadataClass
+                            .getConstructor(
+                                    JdbcMetadataCache.class,
+                                    postgreSqlClientClass,
+                                    boolean.class,
+                                    TableLocationProvider.class)
+                            .newInstance(jdbcMetadataCache, jdbcClient, allowDropTable, tableLocationProvider);
+                }
+            }
+            catch (Exception e) {
+                // Fall back to default if reflection fails
+            }
+        }
+
+        return createMetadata();
+    }
+
+    protected JdbcMetadata createMetadata()
     {
         return new JdbcMetadata(jdbcMetadataCache, jdbcClient, allowDropTable, tableLocationProvider);
     }

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlClient.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.postgresql;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
@@ -30,12 +31,16 @@ import com.facebook.presto.plugin.jdbc.QueryBuilder;
 import com.facebook.presto.plugin.jdbc.mapping.ReadMapping;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
@@ -50,6 +55,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,9 +87,11 @@ public class PostgreSqlClient
     protected final Type jsonType;
     private static final String DUPLICATE_TABLE_SQLSTATE = "42P07";
     private final Type uuidType;
+    private final TypeManager typeManager;
 
     private static final JsonFactory JSON_FACTORY = new JsonFactoryBuilder().configure(CANONICALIZE_FIELD_NAMES, false).build();
     private static final ObjectMapper SORTED_MAPPER = new JsonObjectMapperProvider().get().configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
+    private static final JsonCodec<ViewDefinition> VIEW_CODEC = JsonCodec.jsonCodec(ViewDefinition.class);
 
     @Inject
     public PostgreSqlClient(JdbcConnectorId connectorId, BaseJdbcConfig config, TypeManager typeManager)
@@ -91,6 +99,7 @@ public class PostgreSqlClient
         super(connectorId, config, "\"", new DriverConnectionFactory(new Driver(), config));
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
+        this.typeManager = typeManager;
     }
 
     @Override
@@ -246,5 +255,368 @@ public class PostgreSqlClient
     public String normalizeIdentifier(ConnectorSession session, String identifier)
     {
         return caseSensitiveNameMatchingEnabled ? identifier : identifier.toLowerCase(ENGLISH);
+    }
+
+    /**
+     * Get views from PostgreSQL information_schema.
+     * This method retrieves view definitions for the specified schema and table names
+     * and converts them to Presto ViewDefinition JSON format.
+     */
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, JdbcIdentity identity, List<SchemaTableName> tableNames)
+    {
+        if (tableNames.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            Map<SchemaTableName, ConnectorViewDefinition> views = new java.util.HashMap<>();
+
+            // Build the query to fetch view definitions from information_schema
+            StringBuilder sql = new StringBuilder(
+                    "SELECT table_schema, table_name, view_definition " +
+                    "FROM information_schema.views " +
+                    "WHERE (table_schema, table_name) IN (");
+
+            List<String> placeholders = new ArrayList<>();
+            for (int i = 0; i < tableNames.size(); i++) {
+                placeholders.add("(?, ?)");
+            }
+            sql.append(String.join(", ", placeholders));
+            sql.append(")");
+
+            try (PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+                int paramIndex = 1;
+                for (SchemaTableName tableName : tableNames) {
+                    String remoteSchema = toRemoteSchemaName(session, identity, connection, tableName.getSchemaName());
+                    String remoteTable = toRemoteTableName(session, identity, connection, remoteSchema, tableName.getTableName());
+                    statement.setString(paramIndex++, remoteSchema);
+                    statement.setString(paramIndex++, remoteTable);
+                }
+
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    while (resultSet.next()) {
+                        String schemaName = resultSet.getString("table_schema");
+                        String tableName = resultSet.getString("table_name");
+                        String viewSql = resultSet.getString("view_definition");
+
+                        // Normalize identifiers according to PostgreSQL rules
+                        schemaName = normalizeIdentifier(session, schemaName);
+                        tableName = normalizeIdentifier(session, tableName);
+
+                        // Remove trailing semicolon from PostgreSQL view definition
+                        // Presto's SQL parser doesn't accept it
+                        viewSql = viewSql.trim();
+                        if (viewSql.endsWith(";")) {
+                            viewSql = viewSql.substring(0, viewSql.length() - 1).trim();
+                        }
+
+                        SchemaTableName viewName = new SchemaTableName(schemaName, tableName);
+
+                        // Get column information for the view
+                        List<ViewDefinition.ViewColumn> columns = getViewColumns(connection, schemaName, tableName);
+
+                        // Use session user as the view owner
+                        String owner = session.getUser();
+
+                        // Create ViewDefinition and serialize to JSON
+                        // Set catalog to the connector catalog name so Presto can resolve table references
+                        ViewDefinition viewDefinition = new ViewDefinition(
+                                viewSql,
+                                Optional.of(connectorId), // catalog - set to connector catalog
+                                Optional.of(schemaName), // schema - set to view's schema
+                                columns,
+                                Optional.of(owner),
+                                false); // runAsInvoker
+
+                        String viewData = VIEW_CODEC.toJson(viewDefinition);
+
+                        views.put(viewName, new ConnectorViewDefinition(
+                                viewName,
+                                Optional.of(owner),
+                                viewData));
+                    }
+                }
+            }
+
+            return ImmutableMap.copyOf(views);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /**
+     * Get column information for a view from information_schema.columns
+     */
+    private List<ViewDefinition.ViewColumn> getViewColumns(Connection connection, String schemaName, String tableName)
+            throws SQLException
+    {
+        String sql = "SELECT column_name, data_type, udt_name " +
+                     "FROM information_schema.columns " +
+                     "WHERE table_schema = ? AND table_name = ? " +
+                     "ORDER BY ordinal_position";
+
+        List<ViewDefinition.ViewColumn> columns = new ArrayList<>();
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, schemaName);
+            statement.setString(2, tableName);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String columnName = resultSet.getString("column_name");
+                    String dataType = resultSet.getString("data_type");
+                    String udtName = resultSet.getString("udt_name");
+
+                    // Map PostgreSQL type to Presto type
+                    Type prestoType = toPrestoType(dataType, udtName);
+
+                    columns.add(new ViewDefinition.ViewColumn(columnName, prestoType));
+                }
+            }
+        }
+
+        return columns;
+    }
+
+    /**
+     * Map PostgreSQL data type to Presto Type
+     */
+    private Type toPrestoType(String dataType, String udtName)
+    {
+        // Handle common PostgreSQL types
+        switch (dataType.toLowerCase(ENGLISH)) {
+            case "integer":
+            case "int":
+            case "int4":
+                return typeManager.getType(new TypeSignature(StandardTypes.INTEGER));
+            case "bigint":
+            case "int8":
+                return typeManager.getType(new TypeSignature(StandardTypes.BIGINT));
+            case "smallint":
+            case "int2":
+                return typeManager.getType(new TypeSignature(StandardTypes.SMALLINT));
+            case "boolean":
+            case "bool":
+                return typeManager.getType(new TypeSignature(StandardTypes.BOOLEAN));
+            case "real":
+            case "float4":
+                return typeManager.getType(new TypeSignature(StandardTypes.REAL));
+            case "double precision":
+            case "float8":
+                return typeManager.getType(new TypeSignature(StandardTypes.DOUBLE));
+            case "character varying":
+            case "varchar":
+            case "text":
+                return typeManager.getType(new TypeSignature(StandardTypes.VARCHAR));
+            case "character":
+            case "char":
+                return typeManager.getType(new TypeSignature(StandardTypes.CHAR));
+            case "date":
+                return typeManager.getType(new TypeSignature(StandardTypes.DATE));
+            case "timestamp without time zone":
+            case "timestamp":
+                return typeManager.getType(new TypeSignature(StandardTypes.TIMESTAMP));
+            case "bytea":
+                return typeManager.getType(new TypeSignature(StandardTypes.VARBINARY));
+            case "json":
+            case "jsonb":
+                return jsonType;
+            case "uuid":
+                return uuidType;
+            default:
+                // For unknown types, default to VARCHAR
+                return typeManager.getType(new TypeSignature(StandardTypes.VARCHAR));
+        }
+    }
+
+    /**
+     * List all views in the specified schema using JDBC metadata.
+     */
+    public List<SchemaTableName> listViews(ConnectorSession session, JdbcIdentity identity, Optional<String> schema)
+    {
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            Optional<String> remoteSchema = schema.map(s -> toRemoteSchemaName(session, identity, connection, s));
+
+            try (ResultSet resultSet = getTables(connection, remoteSchema, Optional.empty(), new String[] {"VIEW"})) {
+                ImmutableList.Builder<SchemaTableName> list = ImmutableList.builder();
+                while (resultSet.next()) {
+                    String schemaName = getTableSchemaName(resultSet);
+                    String tableName = resultSet.getString("TABLE_NAME");
+
+                    // Normalize identifiers according to PostgreSQL rules
+                    schemaName = normalizeIdentifier(session, schemaName);
+                    tableName = normalizeIdentifier(session, tableName);
+
+                    list.add(new SchemaTableName(schemaName, tableName));
+                }
+                return list.build();
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /**
+     * List all schemas that contain views.
+     */
+    public List<SchemaTableName> listSchemasForViews(ConnectorSession session, JdbcIdentity identity)
+    {
+        ImmutableList.Builder<SchemaTableName> allViews = ImmutableList.builder();
+
+        for (String schema : getSchemaNames(session, identity)) {
+            allViews.addAll(listViews(session, identity, Optional.of(schema)));
+        }
+
+        return allViews.build();
+    }
+
+    /**
+     * Overloaded getTables method that accepts table types as a parameter.
+     * This allows filtering by specific table types like VIEW, TABLE, etc.
+     */
+    protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName, String[] tableTypes)
+            throws SQLException
+    {
+        DatabaseMetaData metadata = connection.getMetaData();
+        Optional<String> escape = Optional.ofNullable(metadata.getSearchStringEscape());
+        return metadata.getTables(
+                connection.getCatalog(),
+                escapeNamePattern(schemaName, escape).orElse(null),
+                escapeNamePattern(tableName, escape).orElse(null),
+                tableTypes);
+    }
+
+    /**
+     * Create a view in PostgreSQL.
+     * Note: viewData contains the Presto ViewDefinition JSON with the original SQL.
+     * We need to extract the SQL and create the PostgreSQL view directly.
+     */
+    public void createView(ConnectorSession session, JdbcIdentity identity, SchemaTableName viewName, String viewData, boolean replace)
+    {
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            // viewData is the JSON string from Presto's CREATE VIEW statement
+            // It contains the original SQL that we need to execute in PostgreSQL
+            // Extract just the SQL portion - viewData format: {"originalSql":"SELECT ...","columns":[...],...}
+
+            // Simple JSON parsing to extract originalSql
+            String viewSql = extractOriginalSql(viewData);
+
+            // Remove catalog prefix from table references (postgresql.schema.table -> schema.table)
+            // PostgreSQL doesn't support cross-database references
+            viewSql = removeCatalogPrefix(viewSql);
+
+            String remoteSchema = toRemoteSchemaName(session, identity, connection, viewName.getSchemaName());
+            String remoteTable = toRemoteTableName(session, identity, connection, remoteSchema, viewName.getTableName());
+
+            String sql;
+            if (replace) {
+                sql = format("CREATE OR REPLACE VIEW %s.%s AS %s",
+                        quote(identifierQuote, remoteSchema),
+                        quote(identifierQuote, remoteTable),
+                        viewSql);
+            }
+            else {
+                sql = format("CREATE VIEW %s.%s AS %s",
+                        quote(identifierQuote, remoteSchema),
+                        quote(identifierQuote, remoteTable),
+                        viewSql);
+            }
+
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /**
+     * Remove catalog prefix from table references in SQL.
+     * Converts "catalog.schema.table" to "schema.table" for PostgreSQL compatibility.
+     */
+    private String removeCatalogPrefix(String sql)
+    {
+        // Pattern to match: word.word.word (catalog.schema.table)
+        // Replace with: word.word (schema.table)
+        // This is a simple regex that handles most cases
+        return sql.replaceAll("\\b\\w+\\.(\\w+\\.\\w+)\\b", "$1");
+    }
+
+    /**
+     * Extract the originalSql from ViewDefinition JSON string.
+     * Simple extraction without full JSON parsing to avoid Type deserialization issues.
+     */
+    private String extractOriginalSql(String viewData)
+    {
+        // viewData format: {"originalSql":"SELECT ...","columns":[...],...}
+        // Find the originalSql value
+        int startIndex = viewData.indexOf("\"originalSql\":\"");
+        if (startIndex == -1) {
+            throw new PrestoException(JDBC_ERROR, "Invalid view data: missing originalSql");
+        }
+
+        startIndex += "\"originalSql\":\"".length();
+
+        // Find the end of the SQL string (look for "," after the closing quote)
+        // Need to handle escaped quotes in the SQL
+        StringBuilder sql = new StringBuilder();
+        boolean escaped = false;
+
+        for (int i = startIndex; i < viewData.length(); i++) {
+            char c = viewData.charAt(i);
+
+            if (escaped) {
+                // Handle escaped characters
+                if (c == 'n') {
+                    sql.append('\n');
+                }
+                else if (c == 't') {
+                    sql.append('\t');
+                }
+                else if (c == 'r') {
+                    sql.append('\r');
+                }
+                else if (c == '"' || c == '\\') {
+                    sql.append(c);
+                }
+                else {
+                    sql.append('\\').append(c);
+                }
+                escaped = false;
+            }
+            else if (c == '\\') {
+                escaped = true;
+            }
+            else if (c == '"') {
+                // End of originalSql value
+                break;
+            }
+            else {
+                sql.append(c);
+            }
+        }
+
+        return sql.toString();
+    }
+
+    /**
+     * Drop a view in PostgreSQL.
+     */
+    public void dropView(ConnectorSession session, JdbcIdentity identity, SchemaTableName viewName)
+    {
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String remoteSchema = toRemoteSchemaName(session, identity, connection, viewName.getSchemaName());
+            String remoteTable = toRemoteTableName(session, identity, connection, remoteSchema, viewName.getTableName());
+
+            String sql = format("DROP VIEW %s.%s",
+                    quote(identifierQuote, remoteSchema),
+                    quote(identifierQuote, remoteTable));
+
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
     }
 }

--- a/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlMetadata.java
+++ b/presto-postgresql/src/main/java/com/facebook/presto/plugin/postgresql/PostgreSqlMetadata.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.postgresql;
+
+import com.facebook.presto.plugin.jdbc.JdbcIdentity;
+import com.facebook.presto.plugin.jdbc.JdbcMetadata;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.TableLocationProvider;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * PostgreSQL-specific metadata implementation that adds view support.
+ * This class extends JdbcMetadata to provide PostgreSQL-specific view operations
+ * including listing views and retrieving view definitions from information_schema.
+ */
+public class PostgreSqlMetadata
+        extends JdbcMetadata
+{
+    private final PostgreSqlClient postgreSqlClient;
+
+    public PostgreSqlMetadata(
+            JdbcMetadataCache jdbcMetadataCache,
+            PostgreSqlClient postgreSqlClient,
+            boolean allowDropTable,
+            TableLocationProvider tableLocationProvider)
+    {
+        super(jdbcMetadataCache, postgreSqlClient, allowDropTable, tableLocationProvider);
+        this.postgreSqlClient = postgreSqlClient;
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+
+        // Determine which views to retrieve based on the prefix
+        List<SchemaTableName> viewNames;
+
+        if (prefix.getSchemaName() != null && prefix.getTableName() != null) {
+            // Specific view requested
+            viewNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        }
+        else if (prefix.getSchemaName() != null) {
+            // All views in a specific schema
+            viewNames = postgreSqlClient.listViews(session, identity, Optional.of(prefix.getSchemaName()));
+        }
+        else {
+            // All views in all schemas
+            viewNames = postgreSqlClient.listSchemasForViews(session, identity);
+        }
+
+        if (viewNames.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        // Retrieve view definitions for the identified views
+        return postgreSqlClient.getViews(session, identity, viewNames);
+    }
+
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        return postgreSqlClient.listViews(session, identity, schemaName);
+    }
+
+    @Override
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        postgreSqlClient.createView(session, identity, viewMetadata.getTable(), viewData, replace);
+    }
+
+    @Override
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        postgreSqlClient.dropView(session, identity, viewName);
+    }
+}

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlViews.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlViews.java
@@ -1,0 +1,491 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.postgresql;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Integration tests for PostgreSQL view operations.
+ * Tests CREATE VIEW, DROP VIEW, and listing views functionality.
+ */
+@Test(singleThreaded = true)
+public class TestPostgreSqlViews
+{
+    private PostgreSQLContainer postgresContainer;
+    private QueryRunner queryRunner;
+    private Session session;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        postgresContainer = new PostgreSQLContainer("postgres:14")
+                .withDatabaseName("tpch")
+                .withUsername("testuser")
+                .withPassword("testpass");
+        postgresContainer.start();
+
+        queryRunner = PostgreSqlQueryRunner.createPostgreSqlQueryRunner(
+                postgresContainer.getJdbcUrl(),
+                ImmutableMap.of(),
+                ImmutableList.of(ORDERS));
+        session = PostgreSqlQueryRunner.createSession();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+            queryRunner = null;
+        }
+        if (postgresContainer != null) {
+            postgresContainer.stop();
+            postgresContainer = null;
+        }
+    }
+
+    @AfterMethod
+    public void cleanupViews()
+            throws SQLException
+    {
+        // Clean up any views created during tests
+        try (Connection connection = DriverManager.getConnection(
+                postgresContainer.getJdbcUrl(),
+                postgresContainer.getUsername(),
+                postgresContainer.getPassword());
+                Statement statement = connection.createStatement()) {
+            // Get all views in tpch schema - collect names first
+            List<String> viewNames = new ArrayList<>();
+            try (ResultSet rs = statement.executeQuery(
+                    "SELECT table_name FROM information_schema.views WHERE table_schema = 'tpch'")) {
+                while (rs.next()) {
+                    viewNames.add(rs.getString(1));
+                }
+            }
+            // Now drop all views
+            for (String viewName : viewNames) {
+                statement.execute(format("DROP VIEW IF EXISTS tpch.%s CASCADE", viewName));
+            }
+        }
+    }
+
+    @Test
+    public void testCreateView()
+            throws Exception
+    {
+        String viewName = "test_create_view";
+
+        // Create view directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderkey, custkey FROM tpch.orders WHERE orderkey < 100", viewName));
+
+        // Verify view exists in Presto
+        assertTrue(queryRunner.tableExists(session, viewName));
+
+        // Verify view can be queried through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT * FROM %s ORDER BY orderkey LIMIT 5", viewName));
+        assertTrue(result.getRowCount() > 0);
+        assertEquals(result.getTypes().size(), 2);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testCreateOrReplaceView()
+            throws Exception
+    {
+        String viewName = "test_replace_view";
+
+        // Create initial view directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderkey FROM tpch.orders", viewName));
+
+        // Verify initial view through Presto
+        MaterializedResult result1 = queryRunner.execute(session, format("SELECT * FROM %s LIMIT 1", viewName));
+        assertEquals(result1.getTypes().size(), 1);
+
+        // Replace view with different definition
+        execute(format("CREATE OR REPLACE VIEW tpch.%s AS SELECT orderkey, custkey, orderstatus FROM tpch.orders", viewName));
+
+        // Verify replaced view has new structure
+        MaterializedResult result2 = queryRunner.execute(session, format("SELECT * FROM %s LIMIT 1", viewName));
+        assertEquals(result2.getTypes().size(), 3);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testDropView()
+            throws Exception
+    {
+        String viewName = "test_drop_view";
+
+        // Create view directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT * FROM tpch.orders", viewName));
+        assertTrue(queryRunner.tableExists(session, viewName));
+
+        // Drop view through PostgreSQL
+        execute(format("DROP VIEW tpch.%s", viewName));
+        assertFalse(queryRunner.tableExists(session, viewName));
+    }
+
+    @Test
+    public void testListViews()
+            throws Exception
+    {
+        String view1 = "test_list_view_1";
+        String view2 = "test_list_view_2";
+
+        // Create multiple views directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderkey FROM tpch.orders", view1));
+        execute(format("CREATE VIEW tpch.%s AS SELECT custkey FROM tpch.orders", view2));
+
+        // List views using SHOW TABLES through Presto
+        MaterializedResult result = queryRunner.execute(session, "SHOW TABLES");
+        assertThat(result.getOnlyColumnAsSet()).contains(view1, view2, "orders");
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", view1));
+        execute(format("DROP VIEW IF EXISTS tpch.%s", view2));
+    }
+
+    @Test
+    public void testViewWithJoin()
+            throws Exception
+    {
+        String viewName = "test_view_join";
+
+        // Create a view with self-join directly in PostgreSQL
+        execute(format(
+                "CREATE VIEW tpch.%s AS " +
+                "SELECT o1.orderkey, o1.custkey, o2.orderstatus " +
+                "FROM tpch.orders o1 JOIN tpch.orders o2 ON o1.orderkey = o2.orderkey " +
+                "WHERE o1.orderkey < 10", viewName));
+
+        // Query the view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT * FROM %s", viewName));
+        assertTrue(result.getRowCount() > 0);
+        assertEquals(result.getTypes().size(), 3);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testViewWithAggregation()
+            throws Exception
+    {
+        String viewName = "test_view_aggregation";
+
+        // Create view with aggregation directly in PostgreSQL
+        execute(format(
+                "CREATE VIEW tpch.%s AS " +
+                "SELECT custkey, COUNT(*) as order_count, SUM(totalprice) as total_spent " +
+                "FROM tpch.orders " +
+                "GROUP BY custkey", viewName));
+
+        // Query the view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT * FROM %s WHERE custkey = 1", viewName));
+        assertEquals(result.getTypes().size(), 3);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testViewWithFilter()
+            throws Exception
+    {
+        String viewName = "test_view_filter";
+
+        // Create view with WHERE clause directly in PostgreSQL
+        // Use column reference instead of string literal to avoid parsing issues
+        execute(format(
+                "CREATE VIEW tpch.%s AS " +
+                "SELECT orderkey, custkey, orderstatus, totalprice, orderdate " +
+                "FROM tpch.orders WHERE orderkey < 100", viewName));
+
+        // Query the view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT orderkey FROM %s ORDER BY orderkey LIMIT 5", viewName));
+
+        // Verify we got results and they are less than 100
+        assertTrue(result.getRowCount() > 0);
+        for (int i = 0; i < result.getRowCount(); i++) {
+            long orderkey = (long) result.getMaterializedRows().get(i).getField(0);
+            assertTrue(orderkey < 100);
+        }
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testViewInInformationSchema()
+            throws Exception
+    {
+        String viewName = "test_info_schema_view";
+
+        // Create view directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderkey, custkey FROM tpch.orders", viewName));
+
+        // Check view appears in information_schema.tables through Presto
+        MaterializedResult result = queryRunner.execute(session,
+                format("SELECT table_name FROM information_schema.tables WHERE table_schema = 'tpch' AND table_name = '%s'", viewName));
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getOnlyValue(), viewName);
+
+        // Check view columns appear in information_schema.columns
+        MaterializedResult columnsResult = queryRunner.execute(session,
+                format("SELECT column_name FROM information_schema.columns WHERE table_schema = 'tpch' AND table_name = '%s' ORDER BY ordinal_position", viewName));
+        assertEquals(columnsResult.getRowCount(), 2);
+        assertThat(columnsResult.getOnlyColumnAsSet()).contains("orderkey", "custkey");
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testViewWithComplexTypes()
+            throws Exception
+    {
+        String viewName = "test_view_complex_types";
+
+        // Create view with various column types directly in PostgreSQL
+        execute(format(
+                "CREATE VIEW tpch.%s AS " +
+                "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority " +
+                "FROM tpch.orders " +
+                "WHERE orderkey < 100", viewName));
+
+        // Query the view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT * FROM %s LIMIT 5", viewName));
+        assertEquals(result.getTypes().size(), 6);
+        assertTrue(result.getRowCount() > 0);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testViewWithSubquery()
+            throws Exception
+    {
+        String viewName = "test_view_subquery";
+
+        // Create view with subquery directly in PostgreSQL
+        execute(format(
+                "CREATE VIEW tpch.%s AS " +
+                "SELECT * FROM tpch.orders WHERE custkey IN (SELECT custkey FROM tpch.orders WHERE orderkey < 10)", viewName));
+
+        // Query the view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT COUNT(*) FROM %s", viewName));
+        assertTrue(result.getRowCount() > 0);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testMultipleViewsInSameSchema()
+            throws Exception
+    {
+        String view1 = "test_multi_view_1";
+        String view2 = "test_multi_view_2";
+        String view3 = "test_multi_view_3";
+
+        // Create multiple views directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderkey FROM tpch.orders WHERE orderkey < 100", view1));
+        execute(format("CREATE VIEW tpch.%s AS SELECT custkey FROM tpch.orders WHERE custkey < 50", view2));
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderstatus FROM tpch.orders", view3));
+
+        // Verify all views exist through Presto
+        assertTrue(queryRunner.tableExists(session, view1));
+        assertTrue(queryRunner.tableExists(session, view2));
+        assertTrue(queryRunner.tableExists(session, view3));
+
+        // Query each view through Presto
+        MaterializedResult result1 = queryRunner.execute(session, format("SELECT COUNT(*) FROM %s", view1));
+        MaterializedResult result2 = queryRunner.execute(session, format("SELECT COUNT(*) FROM %s", view2));
+        MaterializedResult result3 = queryRunner.execute(session, format("SELECT COUNT(*) FROM %s", view3));
+
+        assertTrue(result1.getRowCount() > 0);
+        assertTrue(result2.getRowCount() > 0);
+        assertTrue(result3.getRowCount() > 0);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", view1));
+        execute(format("DROP VIEW IF EXISTS tpch.%s", view2));
+        execute(format("DROP VIEW IF EXISTS tpch.%s", view3));
+    }
+
+    @Test
+    public void testViewNameCaseSensitivity()
+            throws Exception
+    {
+        String viewName = "test_case_view";
+
+        // Create view with lowercase name directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT * FROM tpch.orders", viewName));
+
+        // Query with different case variations through Presto (PostgreSQL is case-insensitive by default)
+        MaterializedResult result1 = queryRunner.execute(session, format("SELECT COUNT(*) FROM %s", viewName));
+        MaterializedResult result2 = queryRunner.execute(session, format("SELECT COUNT(*) FROM %s", viewName.toUpperCase()));
+
+        assertEquals(result1.getOnlyValue(), result2.getOnlyValue());
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testDescribeView()
+            throws Exception
+    {
+        String viewName = "test_describe_view";
+
+        // Create view directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderkey, custkey, orderstatus FROM tpch.orders", viewName));
+
+        // Describe view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("DESCRIBE %s", viewName));
+        assertEquals(result.getRowCount(), 3);
+
+        // Verify column names
+        assertThat(result.getMaterializedRows().get(0).getField(0)).isEqualTo("orderkey");
+        assertThat(result.getMaterializedRows().get(1).getField(0)).isEqualTo("custkey");
+        assertThat(result.getMaterializedRows().get(2).getField(0)).isEqualTo("orderstatus");
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testShowCreateView()
+            throws Exception
+    {
+        String viewName = "test_show_create_view";
+
+        // Create view directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderkey, custkey FROM tpch.orders WHERE orderkey < 100", viewName));
+
+        // Show create view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SHOW CREATE VIEW %s", viewName));
+        assertEquals(result.getRowCount(), 1);
+
+        String createViewSql = (String) result.getOnlyValue();
+        assertThat(createViewSql).contains("CREATE VIEW");
+        assertThat(createViewSql).contains(viewName);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testViewWithOrderBy()
+            throws Exception
+    {
+        String viewName = "test_view_order_by";
+
+        // Create view with ORDER BY directly in PostgreSQL
+        execute(format(
+                "CREATE VIEW tpch.%s AS " +
+                "SELECT orderkey, custkey, totalprice FROM tpch.orders ORDER BY totalprice DESC", viewName));
+
+        // Query the view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT * FROM %s LIMIT 10", viewName));
+        assertEquals(result.getRowCount(), 10);
+        assertEquals(result.getTypes().size(), 3);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testViewWithLimit()
+            throws Exception
+    {
+        String viewName = "test_view_limit";
+
+        // Create view with LIMIT directly in PostgreSQL
+        execute(format(
+                "CREATE VIEW tpch.%s AS " +
+                "SELECT * FROM tpch.orders LIMIT 50", viewName));
+
+        // Query the view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT COUNT(*) FROM %s", viewName));
+        assertEquals(result.getOnlyValue(), 50L);
+
+        // Clean up
+        execute(format("DROP VIEW IF EXISTS tpch.%s", viewName));
+    }
+
+    @Test
+    public void testViewDependingOnAnotherView()
+            throws Exception
+    {
+        String baseView = "test_base_view";
+        String dependentView = "test_dependent_view";
+
+        // Create base view directly in PostgreSQL
+        execute(format("CREATE VIEW tpch.%s AS SELECT orderkey, custkey FROM tpch.orders WHERE orderkey < 100", baseView));
+
+        // Create view depending on base view
+        execute(format("CREATE VIEW tpch.%s AS SELECT * FROM tpch.%s WHERE custkey < 50", dependentView, baseView));
+
+        // Query dependent view through Presto
+        MaterializedResult result = queryRunner.execute(session, format("SELECT COUNT(*) FROM %s", dependentView));
+        assertTrue(result.getRowCount() > 0);
+
+        // Clean up (order matters due to dependency)
+        execute(format("DROP VIEW IF EXISTS tpch.%s", dependentView));
+        execute(format("DROP VIEW IF EXISTS tpch.%s", baseView));
+    }
+
+    private void execute(String sql)
+            throws SQLException
+    {
+        try (Connection connection = DriverManager.getConnection(
+                postgresContainer.getJdbcUrl(),
+                postgresContainer.getUsername(),
+                postgresContainer.getPassword());
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Postgresql Connector Changes
* Add view support for the presto postgresql connector
```

## Summary by Sourcery

Add PostgreSQL-specific JDBC metadata and client support to manage views through the PostgreSQL connector.

New Features:
- Enable creating, replacing, dropping, listing, and reading PostgreSQL views via the Presto PostgreSQL connector.

Enhancements:
- Introduce a PostgreSqlMetadata implementation wired from JdbcMetadataFactory to add PostgreSQL-specific view handling.
- Extend PostgreSqlClient with helpers to discover view schemas, list views, and translate PostgreSQL view definitions into Presto view metadata.

Tests:
- Add PostgreSQL integration tests covering view creation, replacement, deletion, listing, and querying across a variety of SQL patterns and types.