### PR TITLE
test: Add test for querying iceberg branch

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -2224,11 +2224,26 @@ Querying branches and tags
 
 Iceberg supports branches and tags which are named references to snapshots.
 
-Query Iceberg table by specifying the branch name:
+Query Iceberg table by specifying the branch name using ``FOR SYSTEM_VERSION AS OF``:
 
 .. code-block:: sql
 
     SELECT * FROM nation FOR SYSTEM_VERSION AS OF 'testBranch';
+
+.. code-block:: text
+
+     nationkey |      name     | regionkey | comment
+    -----------+---------------+-----------+---------
+            10 | united states |         1 | comment
+            20 | canada        |         2 | comment
+            30 | mexico        |         3 | comment
+    (3 rows)
+
+Alternatively, you can query a branch using the dot notation syntax with quoted identifiers:
+
+.. code-block:: sql
+
+    SELECT * FROM "nation.branch_testBranch";
 
 .. code-block:: text
 
@@ -2252,6 +2267,8 @@ Query Iceberg table by specifying the tag name:
             10 | united states |         1 | comment
             20 | canada        |         2 | comment
     (3 rows)
+
+**Note:** The dot notation syntax ``"<table>.branch_<branch_name>"`` requires double quotes to prevent the SQL parser from interpreting the dot as a schema.table separator. This syntax works for both querying (SELECT) and mutating (INSERT, UPDATE, DELETE, MERGE) branch data.
 
 Mutating Iceberg Branches
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -2433,6 +2433,30 @@ public abstract class IcebergDistributedTestBase
     }
 
     @Test
+    public void testQueryBranch()
+    {
+        assertUpdate("CREATE TABLE test_branch_dot_notation (id BIGINT, name VARCHAR, value BIGINT)");
+        assertUpdate("INSERT INTO test_branch_dot_notation VALUES (1, 'Alice', 100), (2, 'Bob', 200)", 2);
+        Table icebergTable = loadTable("test_branch_dot_notation");
+        icebergTable.manageSnapshots().createBranch("audit_branch").commit();
+        assertUpdate("INSERT INTO test_branch_dot_notation VALUES (3, 'Charlie', 300), (4, 'David', 400)", 2);
+        // Test querying branch using FOR SYSTEM_VERSION AS OF syntax
+        assertQuery("SELECT count(*) FROM test_branch_dot_notation FOR SYSTEM_VERSION AS OF 'audit_branch'", "VALUES 2");
+        assertQuery("SELECT count(*) FROM test_branch_dot_notation FOR SYSTEM_VERSION AS OF 'main'", "VALUES 4");
+        // Test querying branch using dot notation syntax
+        assertQuery("SELECT count(*) FROM \"test_branch_dot_notation.branch_audit_branch\"", "VALUES 2");
+        assertQuery("SELECT id, name, value FROM \"test_branch_dot_notation.branch_audit_branch\" ORDER BY id",
+                "VALUES (1, 'Alice', 100), (2, 'Bob', 200)");
+        // Verify both syntaxes return the same results by comparing actual results
+        MaterializedResult resultWithForSyntax = computeActual("SELECT id FROM test_branch_dot_notation FOR SYSTEM_VERSION AS OF 'audit_branch' ORDER BY id");
+        MaterializedResult resultWithDotNotation = computeActual("SELECT id FROM \"test_branch_dot_notation.branch_audit_branch\" ORDER BY id");
+        assertEquals(resultWithForSyntax, resultWithDotNotation);
+        // Test that main table has all records
+        assertQuery("SELECT count(*) FROM test_branch_dot_notation", "VALUES 4");
+        assertQuerySucceeds("DROP TABLE test_branch_dot_notation");
+    }
+
+    @Test
     public void testMetadataLogTable()
     {
         try {


### PR DESCRIPTION
## Description
Add test for querying the iceberg branch

## Motivation and Context
Add test for querying the iceberg branch

## Impact
Add test for querying the iceberg branch

## Test Plan
Test Added

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Add an Iceberg integration test that verifies querying a branch via FOR SYSTEM_VERSION AS OF and dot-notation syntaxes and compares results with the main table.