### PR TITLE
feat(plugin-iceberg): Support creating branches on empty tables

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1127,19 +1127,20 @@ public abstract class IcebergAbstractMetadata
         if (ifNotExists && branchExists) {
             return;
         }
-        long targetSnapshotId = tableVersion.map(version -> getSnapshotIdForTableVersion(icebergTable, version))
-                .orElseGet(() -> {
-                    if (icebergTable.currentSnapshot() == null) {
-                        throw new PrestoException(NOT_FOUND, format("Table %s has no current snapshot", icebergTableHandle.getSchemaTableName().getTableName()));
-                    }
-                    return icebergTable.currentSnapshot().snapshotId();
-                });
+        Optional<Long> targetSnapshotId = tableVersion
+                .map(version -> getSnapshotIdForTableVersion(icebergTable, version))
+                .or(() -> Optional.ofNullable(icebergTable.currentSnapshot()).map(Snapshot::snapshotId));
         ManageSnapshots manageSnapshots = icebergTable.manageSnapshots();
         if (replace && branchExists) {
-            manageSnapshots.replaceBranch(branchName, targetSnapshotId);
+            targetSnapshotId.ifPresent(snapshotId -> manageSnapshots.replaceBranch(branchName, snapshotId));
         }
         else if (!branchExists) {
-            manageSnapshots.createBranch(branchName, targetSnapshotId);
+            if (targetSnapshotId.isPresent()) {
+                manageSnapshots.createBranch(branchName, targetSnapshotId.get());
+            }
+            else {
+                manageSnapshots.createBranch(branchName);
+            }
         }
         else {
             throw new PrestoException(ALREADY_EXISTS, format("Branch %s already exists in table %s", branchName, icebergTableHandle.getSchemaTableName().getTableName()));

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergCreateBranch.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergCreateBranch.java
@@ -74,6 +74,53 @@ public class TestIcebergCreateBranch
     }
 
     @Test
+    public void testCreateBranchOnEmptyTable()
+    {
+        String tableName = "create_branch_on_empty_table_test";
+
+        try {
+            assertUpdate(session, "CREATE TABLE IF NOT EXISTS " + tableName + " (id BIGINT, name VARCHAR) WITH (format = 'PARQUET')");
+            assertUpdate(session, "ALTER TABLE " + tableName + " CREATE BRANCH 'test_branch'");
+            assertQuery(session, "SELECT count(*) FROM \"" + tableName + "$refs\" where name = 'test_branch' and type = 'BRANCH'", "VALUES 1");
+            assertQuery(session, "SELECT count(*) FROM " + tableName + " FOR SYSTEM_VERSION AS OF 'test_branch'", "VALUES 0");
+
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES(1, '1001'), (3, '1003')", 2);
+            assertUpdate(session, "INSERT INTO \"" + tableName + ".branch_test_branch\" VALUES(2, '1002'), (4, '1004')", 2);
+            assertQuery(session, "SELECT * FROM " + tableName, "VALUES(1, '1001'), (3, '1003')");
+            assertQuery(session, "SELECT * FROM " + tableName + " FOR SYSTEM_VERSION AS OF 'test_branch'", "VALUES(2, '1002'), (4, '1004')");
+
+            assertUpdate(session, "ALTER TABLE " + tableName + " DROP BRANCH 'test_branch'");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
+    public void testReplaceBranchOnEmptyTable()
+    {
+        String tableName = "replace_branch_on_empty_table_test";
+
+        try {
+            assertUpdate(session, "CREATE TABLE IF NOT EXISTS " + tableName + " (id BIGINT, name VARCHAR) WITH (format = 'PARQUET')");
+            assertUpdate(session, "ALTER TABLE " + tableName + " CREATE OR REPLACE BRANCH 'test_branch'");
+            assertQuery(session, "SELECT count(*) FROM \"" + tableName + "$refs\" where name = 'test_branch' and type = 'BRANCH'", "VALUES 1");
+            assertQuery(session, "SELECT count(*) FROM " + tableName + " FOR SYSTEM_VERSION AS OF 'test_branch'", "VALUES 0");
+            assertUpdate(session, "ALTER TABLE " + tableName + " CREATE OR REPLACE BRANCH 'test_branch'");
+
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES(1, '1001'), (3, '1003')", 2);
+            assertUpdate(session, "INSERT INTO \"" + tableName + ".branch_test_branch\" VALUES(2, '1002'), (4, '1004')", 2);
+            assertQuery(session, "SELECT * FROM " + tableName, "VALUES(1, '1001'), (3, '1003')");
+            assertQuery(session, "SELECT * FROM " + tableName + " FOR SYSTEM_VERSION AS OF 'test_branch'", "VALUES(2, '1002'), (4, '1004')");
+
+            assertUpdate(session, "ALTER TABLE " + tableName + " DROP BRANCH 'test_branch'");
+        }
+        finally {
+            dropTable(tableName);
+        }
+    }
+
+    @Test
     public void testCreateBranchBasic()
     {
         String tableName = "create_branch_basic_table_test";


### PR DESCRIPTION
## Description

Iceberg itself supports creating branches on empty tables. However, in Presto, this currently throws an exception as follows:

```
Table <table_name> has no current snapshot
```

This PR fixes the issue by allowing branches to be created directly on empty Iceberg tables.

## Motivation and Context

 - Support creating branches on empty Iceberg tables

## Impact

N/A

## Test Plan

 - Newly added test cases in `TestIcebergCreateBranch` to verify branch creation and replacement on empty Iceberg tables

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Allow creating and replacing Iceberg table branches when the table has no current snapshot and cover the behavior with tests.

New Features:
- Support creating branches on empty Iceberg tables without a current snapshot.

Bug Fixes:
- Prevent failures when creating or replacing branches on Iceberg tables that do not yet have a snapshot.

Tests:
- Add tests validating create and create-or-replace branch operations on empty Iceberg tables, including data isolation and branch cleanup behavior.