### PR TITLE
 fix: Change count metric from signed to unsigned (int64_t -> uint64_t)

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -18,6 +18,7 @@
 #include "presto_cpp/main/common/Exception.h"
 #include "presto_cpp/main/common/Utils.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/time/Timer.h"
 
 using namespace facebook::velox;
@@ -974,7 +975,7 @@ protocol::RuntimeMetric toRuntimeMetric(
       name,
       toPrestoRuntimeUnit(metric.unit),
       metric.sum,
-      metric.count,
+      saturateCast(metric.count),
       metric.max,
       metric.min};
 }


### PR DESCRIPTION
Summary:
Use an unsigned type for the count metric while keeping int64_t for value 
metrics. When the unit is kNone, negative values can be valid such as for delta-
type metrics, so int64_t remains appropriate. In contrast, `count` should 
always be non-negative. This PR also addresses potential overflow when 
converting unsigned metrics to `RuntimeMetrics`.

X-link: https://github.com/facebookincubator/velox/pull/15536

Reviewed By: Yuhta

Differential Revision: D95451420

Pulled By: peterenescu

## Summary by Sourcery

Bug Fixes:
- Guard the runtime metric count conversion with saturation to handle unsigned count values safely.