### PR TITLE
chore(deps): Upgrade netty to 4.2.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>
         <dep.protobuf-java.version>4.30.2</dep.protobuf-java.version>
         <dep.jetty.version>12.0.29</dep.jetty.version>
-        <dep.netty.version>4.1.130.Final</dep.netty.version>
-        <dep.reactor-netty.version>1.2.8</dep.reactor-netty.version>
+        <dep.netty.version>4.2.10.Final</dep.netty.version>
+        <dep.reactor-netty.version>1.3.3</dep.reactor-netty.version>
         <dep.snakeyaml.version>2.5</dep.snakeyaml.version>
         <dep.gson.version>2.12.1</dep.gson.version>
         <dep.commons.lang3.version>3.18.0</dep.commons.lang3.version>
@@ -1647,6 +1647,12 @@
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
                 <version>${dep.reactor-netty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>3.8.3</version>
             </dependency>
 
             <dependency>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -189,6 +189,11 @@
             <artifactId>drift-transport-netty</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerFactory.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlFunctionNamespaceManagerFactory.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.function.FunctionNamespaceManagerContext;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.google.inject.Injector;
+import io.netty.buffer.PooledByteBufAllocator;
 
 import java.util.Map;
 
@@ -51,7 +52,7 @@ public class MySqlFunctionNamespaceManagerFactory
     {
         try {
             Bootstrap app = new Bootstrap(
-                    new DriftNettyClientModule(),
+                    new DriftNettyClientModule(PooledByteBufAllocator.DEFAULT),
                     new MySqlFunctionNamespaceManagerModule(catalogName),
                     new MySqlConnectionModule(),
                     new SimpleAddressSqlFunctionExecutorsModule());

--- a/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/test/java/com/facebook/presto/functionNamespace/mysql/TestMySqlFunctionNamespaceManager.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
+import io.netty.buffer.PooledByteBufAllocator;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.testng.annotations.AfterClass;
@@ -99,7 +100,7 @@ public class TestMySqlFunctionNamespaceManager
         Bootstrap app = new Bootstrap(
                 new MySqlFunctionNamespaceManagerModule(TEST_CATALOG),
                 new SimpleAddressSqlFunctionExecutorsModule(),
-                new DriftNettyClientModule(),
+                new DriftNettyClientModule(PooledByteBufAllocator.DEFAULT),
                 new MySqlConnectionModule());
 
         try {

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -308,6 +308,11 @@
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.facebook.presto:presto-ui</exclude>
+                                    <!-- Netty is not used by the JDBC driver (it uses OkHttp).
+                                         Exclude to avoid: (1) duplicate native .so conflict with
+                                         hadoop-apache shaded jar, (2) Java 11+ bytecode from Netty 4.2
+                                         multi-release classes violating Java 8 bytecode enforcement -->
+                                    <exclude>io.netty:*</exclude>
                                 </excludes>
                             </artifactSet>
                             <createSourcesJar>true</createSourcesJar>

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SafeEventLoopGroup.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SafeEventLoopGroup.java
@@ -52,6 +52,7 @@ public class SafeEventLoopGroup
 
     @Override
     protected EventLoop newChild(Executor executor, Object... args)
+            throws Exception
     {
         return new SafeEventLoop(this, executor);
     }
@@ -71,7 +72,7 @@ public class SafeEventLoopGroup
                 Runnable task = takeTask();
                 if (task != null) {
                     try {
-                        runTask(task);
+                        task.run();
                     }
                     catch (Throwable t) {
                         log.error(t, "Error executing task on event loop");

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -311,7 +311,6 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.8.0-M2</version>
         </dependency>
 
         <dependency>

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -120,6 +120,13 @@ public class PrestoServer
         verifyJvmRequirements();
         verifySystemTimeIsReasonable();
 
+        // Netty 4.2 enables SSL endpoint verification by default. The Drift Netty transport
+        // does not pass hostnames to the SSL engine, causing SSLHandshakeException. Disable
+        // the default endpoint verification until Drift is updated to support it.
+        if (System.getProperty("io.netty.handler.ssl.defaultEndpointVerificationAlgorithm") == null) {
+            System.setProperty("io.netty.handler.ssl.defaultEndpointVerificationAlgorithm", "NONE");
+        }
+
         Logger log = Logger.get(PrestoServer.class);
 
         ImmutableList.Builder<Module> modules = ImmutableList.builder();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -265,6 +265,7 @@ import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import io.airlift.slice.Slice;
+import io.netty.buffer.PooledByteBufAllocator;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 import jakarta.servlet.Filter;
@@ -628,7 +629,7 @@ public class ServerMainModule
                     config.setMaxContentLength(new DataSize(32, MEGABYTE));
                 });
 
-        binder.install(new DriftNettyClientModule());
+        binder.install(new DriftNettyClientModule(PooledByteBufAllocator.DEFAULT));
         driftClientBinder(binder).bindDriftClient(ThriftTaskClient.class, ForExchange.class)
                 .withAddressSelector(((addressSelectorBinder, annotation, prefix) ->
                         addressSelectorBinder.bind(AddressSelector.class).annotatedWith(annotation).to(FixedAddressSelector.class)));

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -50,7 +50,6 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.AbstractEventExecutorGroup;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
@@ -205,14 +204,7 @@ public class HttpRemoteTaskFactory
         this.taskUpdateSizeTrackingEnabled = taskConfig.isTaskUpdateSizeTrackingEnabled();
 
         this.eventLoopGroup = Optional.of(new SafeEventLoopGroup(config.getRemoteTaskMaxCallbackThreads(),
-                new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build(), taskConfig.getSlowMethodThresholdOnEventLoop())
-        {
-            @Override
-            protected EventLoop newChild(Executor executor, Object... args)
-            {
-                return new SafeEventLoop(this, executor);
-            }
-        });
+                new ThreadFactoryBuilder().setNameFormat("task-event-loop-%s").setDaemon(true).build(), taskConfig.getSlowMethodThresholdOnEventLoop()));
     }
 
     @Managed

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -265,6 +265,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceManagerFactory.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2FunctionNamespaceManagerFactory.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.function.FunctionNamespaceManagerContext;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
 import com.facebook.presto.spi.function.SqlFunctionHandle;
 import com.google.inject.Injector;
+import io.netty.buffer.PooledByteBufAllocator;
 
 import java.util.Map;
 
@@ -53,7 +54,7 @@ public class H2FunctionNamespaceManagerFactory
     {
         try {
             Bootstrap app = new Bootstrap(
-                    new DriftNettyClientModule(),
+                    new DriftNettyClientModule(PooledByteBufAllocator.DEFAULT),
                     new MySqlFunctionNamespaceManagerModule(catalogName),
                     new H2ConnectionModule(),
                     new SimpleAddressSqlFunctionExecutorsModule());

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -56,6 +56,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorFactory.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.spi.relation.RowExpressionService;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import io.netty.buffer.PooledByteBufAllocator;
 import org.weakref.jmx.guice.MBeanModule;
 
 import javax.management.MBeanServer;
@@ -65,7 +66,7 @@ public class ThriftConnectorFactory
         try {
             Bootstrap app = new Bootstrap(
                     new MBeanModule(),
-                    new DriftNettyClientModule(),
+                    new DriftNettyClientModule(PooledByteBufAllocator.DEFAULT),
                     binder -> {
                         binder.bind(MBeanServer.class).toInstance(new RebindSafeMBeanServer(getPlatformMBeanServer()));
                         binder.bind(TypeManager.class).toInstance(context.getTypeManager());


### PR DESCRIPTION
## Description
Upgrade Netty to 4.2.10.Final

## Motivation and Context

## Impact

## Test Plan

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Update netty from version 4.1.130.Final to 4.2.10.Final.
```
