### PR TITLE
refactor: HivePartitionManager.parsePartition to instance method and remove timeZone argument

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -207,7 +207,7 @@ public class HivePartitionManager
     {
         if (isOptimizeParsingOfPartitionValues(session) && partitionNames.size() >= getOptimizeParsingOfPartitionValuesThreshold(session)) {
             List<HivePartition> partitionList = partitionNames.stream()
-                    .map(partitionNameWithVersion -> parsePartition(tableName, partitionNameWithVersion, partitionColumns, partitionTypes, timeZone))
+                    .map(partitionNameWithVersion -> parsePartition(tableName, partitionNameWithVersion, partitionColumns, partitionTypes))
                     .collect(toImmutableList());
 
             Map<ColumnHandle, Domain> domains = constraint.getSummary().getDomains().get();
@@ -425,6 +425,7 @@ public class HivePartitionManager
         Table table = getTable(session, metastore, hiveTableHandle, isOfflineDataDebugModeEnabled(session));
 
         List<HiveColumnHandle> partitionColumns = getPartitionKeyColumnHandles(table);
+
         List<Type> partitionColumnTypes = partitionColumns.stream()
                 .map(column -> typeManager.getType(column.getTypeSignature()))
                 .collect(toImmutableList());
@@ -455,7 +456,7 @@ public class HivePartitionManager
             List<Type> partitionColumnTypes,
             Constraint<ColumnHandle> constraint)
     {
-        HivePartition partition = parsePartition(tableName, partitionNameWithVersion, partitionColumns, partitionColumnTypes, timeZone);
+        HivePartition partition = parsePartition(tableName, partitionNameWithVersion, partitionColumns, partitionColumnTypes);
 
         Map<ColumnHandle, Domain> domains = constraint.getSummary().getDomains().get();
         for (HiveColumnHandle column : partitionColumns) {
@@ -512,12 +513,11 @@ public class HivePartitionManager
                 .orElseThrow(() -> new TableNotFoundException(hiveTableHandle.getSchemaTableName()));
     }
 
-    public static HivePartition parsePartition(
+    public HivePartition parsePartition(
             SchemaTableName tableName,
             PartitionNameWithVersion partitionNameWithVersion,
             List<HiveColumnHandle> partitionColumns,
-            List<Type> partitionColumnTypes,
-            DateTimeZone timeZone)
+            List<Type> partitionColumnTypes)
     {
         List<String> partitionColumnNames = partitionColumns.stream()
                 .map(HiveColumnHandle::getName)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -16,11 +16,13 @@ package com.facebook.presto.hive.statistics;
 import com.facebook.presto.cache.CacheConfig;
 import com.facebook.presto.common.predicate.NullableValue;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.TestingTypeManager;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.HiveBasicStatistics;
 import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveColumnHandle;
 import com.facebook.presto.hive.HivePartition;
+import com.facebook.presto.hive.HivePartitionManager;
 import com.facebook.presto.hive.HiveSessionProperties;
 import com.facebook.presto.hive.NamenodeStats;
 import com.facebook.presto.hive.OrcFileWriterConfig;
@@ -65,7 +67,6 @@ import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.PARTITION
 import static com.facebook.presto.hive.BaseHiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CORRUPTED_COLUMN_STATISTICS;
 import static com.facebook.presto.hive.HivePartition.UNPARTITIONED_ID;
-import static com.facebook.presto.hive.HivePartitionManager.parsePartition;
 import static com.facebook.presto.hive.HiveTestUtils.DO_NOTHING_DIRECTORY_LISTER;
 import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
@@ -109,6 +110,8 @@ public class TestMetastoreHiveStatisticsProvider
     private static final HiveColumnHandle PARTITION_COLUMN_2 = new HiveColumnHandle("p2", HIVE_LONG, BIGINT.getTypeSignature(), 1, PARTITION_KEY, Optional.empty(), Optional.empty());
 
     private static final QuickStatsProvider quickStatsProvider = new QuickStatsProvider(new TestingExtendedHiveMetastore(), HDFS_ENVIRONMENT, DO_NOTHING_DIRECTORY_LISTER, new HiveClientConfig(), new NamenodeStats(), ImmutableList.of());
+
+    private final HivePartitionManager hivePartitionManager = new HivePartitionManager(new TestingTypeManager(), new HiveClientConfig());
 
     @Test
     public void testGetPartitionsSample()
@@ -825,9 +828,9 @@ public class TestMetastoreHiveStatisticsProvider
         return format("Corrupted partition statistics (Table: %s Partition: [%s] Column: %s): %s", TABLE, PARTITION, COLUMN, message);
     }
 
-    private static HivePartition partition(String name)
+    private HivePartition partition(String name)
     {
-        return parsePartition(TABLE, new PartitionNameWithVersion(name, Optional.empty()), ImmutableList.of(PARTITION_COLUMN_1, PARTITION_COLUMN_2), ImmutableList.of(VARCHAR, BIGINT), DateTimeZone.getDefault());
+        return hivePartitionManager.parsePartition(TABLE, new PartitionNameWithVersion(name, Optional.empty()), ImmutableList.of(PARTITION_COLUMN_1, PARTITION_COLUMN_2), ImmutableList.of(VARCHAR, BIGINT));
     }
 
     private static PartitionStatistics rowsCount(long rowsCount)


### PR DESCRIPTION
Summary:
Convert parsePartition from a static method to an instance method in
HivePartitionManager (presto-facebook-trunk), removing the DateTimeZone
timeZone parameter. Then parsePartition could use the timeZone member
field of the HivePartitionManager instance instead of requiring callers to pass.
Update call sites within HivePartitionManager,
TestMetastoreHiveStatisticsProvider, and VectorSearchOptimizerUtils.

== NO RELEASE NOTE ==

Differential Revision: D95603597

## Summary by Sourcery

Refactor Hive partition parsing to use an instance-level HivePartitionManager method without an explicit time zone parameter and update call sites and tests accordingly.

Enhancements:
- Convert HivePartitionManager.parsePartition from a static method with a time zone argument to an instance method that relies on manager configuration instead.
- Adjust internal HivePartitionManager callers to use the new instance parsePartition signature when building partitions and applying constraints.

Tests:
- Update TestMetastoreHiveStatisticsProvider to construct a HivePartitionManager instance and use it for partition parsing in test helpers.