### PR TITLE
[presto][iceberg] Add POSITION_UPDATES support to Iceberg split interface

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
@@ -25,7 +25,8 @@ public enum FileContent
 {
     DATA(0),
     POSITION_DELETES(1),
-    EQUALITY_DELETES(2);
+    EQUALITY_DELETES(2),
+    POSITION_UPDATES(3);
 
     private final int id;
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
@@ -49,6 +49,7 @@ public class IcebergSplit
     private final NodeSelectionStrategy nodeSelectionStrategy;
     private final SplitWeight splitWeight;
     private final List<DeleteFile> deletes;
+    private final List<DeleteFile> updates;
     private final Optional<ChangelogSplitInfo> changelogSplitInfo;
     private final long dataSequenceNumber;
     private final long affinitySchedulingFileSectionSize;
@@ -67,6 +68,7 @@ public class IcebergSplit
             @JsonProperty("nodeSelectionStrategy") NodeSelectionStrategy nodeSelectionStrategy,
             @JsonProperty("splitWeight") SplitWeight splitWeight,
             @JsonProperty("deletes") List<DeleteFile> deletes,
+            @JsonProperty("updates") List<DeleteFile> updates,
             @JsonProperty("changelogSplitInfo") Optional<ChangelogSplitInfo> changelogSplitInfo,
             @JsonProperty("dataSequenceNumber") long dataSequenceNumber,
             @JsonProperty("affinitySchedulingSectionSize") long affinitySchedulingFileSectionSize)
@@ -83,6 +85,7 @@ public class IcebergSplit
         this.nodeSelectionStrategy = nodeSelectionStrategy;
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
         this.deletes = ImmutableList.copyOf(requireNonNull(deletes, "deletes is null"));
+        this.updates = updates == null ? ImmutableList.of() : ImmutableList.copyOf(updates);
         this.changelogSplitInfo = requireNonNull(changelogSplitInfo, "changelogSplitInfo is null");
         this.dataSequenceNumber = dataSequenceNumber;
         this.affinitySchedulingFileSectionSize = affinitySchedulingFileSectionSize;
@@ -164,6 +167,12 @@ public class IcebergSplit
     public List<DeleteFile> getDeletes()
     {
         return deletes;
+    }
+
+    @JsonProperty
+    public List<DeleteFile> getUpdates()
+    {
+        return updates;
     }
 
     @JsonProperty

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitSource.java
@@ -150,6 +150,7 @@ public class IcebergSplitSource
                 nodeSelectionStrategy,
                 SplitWeight.fromProportion(Math.min(Math.max((double) task.length() / targetSplitSize, minimumAssignedSplitWeight), 1.0)),
                 task.deletes().stream().map(DeleteFile::fromIceberg).collect(toImmutableList()),
+                ImmutableList.of(),
                 Optional.empty(),
                 getDataSequenceNumber(task.file()),
                 affinitySchedulingFileSectionSize);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/changelog/ChangelogSplitSource.java
@@ -152,6 +152,7 @@ public class ChangelogSplitSource
                 nodeSelectionStrategy,
                 SplitWeight.fromProportion(Math.min(Math.max((double) task.length() / targetSplitSize, minimumAssignedSplitWeight), 1.0)),
                 ImmutableList.of(),
+                ImmutableList.of(),
                 Optional.of(new ChangelogSplitInfo(fromIcebergChangelogOperation(changeTask.operation()),
                         changeTask.changeOrdinal(),
                         changeTask.commitSnapshotId(),

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/equalitydeletes/EqualityDeletesSplitSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/equalitydeletes/EqualityDeletesSplitSource.java
@@ -123,6 +123,7 @@ public class EqualityDeletesSplitSource
                 getNodeSelectionStrategy(session),
                 SplitWeight.standard(),
                 ImmutableList.of(),
+                ImmutableList.of(),
                 Optional.empty(),
                 IcebergUtil.getDataSequenceNumber(deleteFile),
                 affinitySchedulingSectionSize);


### PR DESCRIPTION
Summary:
Extends the Presto Java Iceberg connector interface to support positional
update files. This is the coordinator-side companion to D95595341, which
added the Velox C++ reader for positional updates.

Changes:
- FileContent.java: Added POSITION_UPDATES(3) enum value alongside the
  existing DATA(0), POSITION_DELETES(1), and EQUALITY_DELETES(2) values.
- IcebergSplit.java: Added List<DeleteFile> updates field with JsonProperty
  annotation, constructor parameter, and getter. Reuses the existing
  DeleteFile structure since update files share the same metadata schema
  (content, path, format, recordCount, bounds).
- IcebergSplitSource.java: Passes empty updates list (ImmutableList.of())
  to the new IcebergSplit constructor. Populating actual update files from
  Iceberg metadata will be added when the table spec defines update
  semantics.
- ChangelogSplitSource.java, EqualityDeletesSplitSource.java: Updated
  constructor calls to include the new updates parameter (empty list).

The updates field is serialized via Jackson `JsonProperty` and will be
deserialized on the Prestissimo C++ worker side through the protocol layer
(separate diff).

Reviewed By: xiaoxmeng

Differential Revision: D95596606


