### PR TITLE
fix: libcuda.so.1 missing in ldconfig

### DIFF
--- a/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
+++ b/presto-native-execution/scripts/dockerfiles/prestissimo-runtime.dockerfile
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
     if [[ "${EXTRA_CMAKE_FLAGS}" =~ -DPRESTO_ENABLE_CUDF=ON ]]; then unset CC; unset CXX; source /opt/rh/gcc-toolset-14/enable; fi && \
     COMPILER_LAUNCHER_FLAGS="" && \
     if [ -n "${SCCACHE_BUCKET}" ] && command -v sccache &>/dev/null; then \
-        export SCCACHE_BUCKET="${SCCACHE_BUCKET}" SCCACHE_CACHE_SIZE=2G; \
+        export SCCACHE_BUCKET="${SCCACHE_BUCKET}" SCCACHE_CACHE_SIZE=10G; \
         [ -n "${SCCACHE_REGION}" ] && export SCCACHE_REGION="${SCCACHE_REGION}"; \
         [ -n "${SCCACHE_S3_KEY_PREFIX}" ] && export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX}"; \
         sccache --start-server && \
@@ -88,6 +88,7 @@ COPY --chmod=0775 ./entrypoint.sh /opt/entrypoint.sh
 RUN echo "/usr/lib64/prestissimo-libs" > /etc/ld.so.conf.d/prestissimo.conf && \
     echo "/usr/lib64/prestissimo-libs/ucx" >> /etc/ld.so.conf.d/prestissimo.conf && \
     echo "/usr/local/cuda/lib64" > /etc/ld.so.conf.d/cuda.conf && \
+    echo "/usr/local/cuda/compat" >> /etc/ld.so.conf.d/cuda.conf && \
     ldconfig
 
 RUN rpm --import https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub && \


### PR DESCRIPTION
## Description

```log
presto_server: error while loading shared libraries: libcuda.so.1: cannot open shared object file: No such file or directory
```

```log
find / -name libcuda.so.1
/usr/local/cuda-12.9/compat/libcuda.so.1
bash-5.1# ls -l /usr/local/cuda-12.9/compat/libcuda.so.1
lrwxrwxrwx 1 root root 20 May 24  2025 /usr/local/cuda-12.9/compat/libcuda.so.1 -> libcuda.so.575.57.08
```


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update prestissimo runtime container configuration to fix CUDA library resolution and adjust build cache settings.

Bug Fixes:
- Ensure libcuda.so.1 is discoverable at runtime by adding the CUDA compat directory to ldconfig search paths in the prestissimo runtime image.

Enhancements:
- Increase the sccache maximum cache size from 2G to 10G in the prestissimo runtime image to improve compiler cache effectiveness.