### PR TITLE
chore(deps): Update jackson version to 2.18.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dep.ratis.version>3.2.2</dep.ratis.version>
         <dep.errorprone.version>2.37.0</dep.errorprone.version>
         <dep.guava.version>32.1.0-jre</dep.guava.version>
-        <dep.jackson.version>2.15.4</dep.jackson.version>
+        <dep.jackson.version>2.18.6</dep.jackson.version>
         <dep.j2objc.version>3.0.0</dep.j2objc.version>
         <dep.avro.version>1.12.1</dep.avro.version>
         <dep.commons.compress.version>1.27.1</dep.commons.compress.version>

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.common.block;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 
@@ -375,6 +376,7 @@ public interface Block
      * This allows streaming data sources to skip sections that are not
      * accessed in a query.
      */
+    @JsonIgnore
     default Block getLoadedBlock()
     {
         return this;

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Domain.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -141,6 +142,7 @@ public final class Domain
         return values.isNone() && nullAllowed;
     }
 
+    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {
@@ -149,6 +151,7 @@ public final class Domain
         return values.getSingleValue();
     }
 
+    @JsonIgnore
     public Object getNullableSingleValue()
     {
         if (!isNullableSingleValue()) {

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/Range.java
@@ -16,6 +16,7 @@ package com.facebook.presto.common.predicate;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -160,6 +161,7 @@ public final class Range
         return low.getBound() == Marker.Bound.EXACTLY && low.equals(high);
     }
 
+    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/SortedRangeSet.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.DataTypeMismatchException;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -161,6 +162,7 @@ public final class SortedRangeSet
     }
 
     @Override
+    @JsonIgnore
     public Object getSingleValue()
     {
         if (!isSingleValue()) {
@@ -240,6 +242,7 @@ public final class SortedRangeSet
     }
 
     @Override
+    @JsonIgnore
     public ValuesProcessor getValuesProcessor()
     {
         return new ValuesProcessor()

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/ValueSet.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.predicate;
 
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -102,6 +103,7 @@ public interface ValueSet
 
     boolean isSingleValue();
 
+    @JsonIgnore
     Object getSingleValue();
 
     boolean containsValue(Object value);
@@ -109,6 +111,7 @@ public interface ValueSet
     /**
      * @return value predicates for equatable Types (but not orderable)
      */
+    @JsonIgnore
     default DiscreteValues getDiscreteValues()
     {
         throw new UnsupportedOperationException();
@@ -122,6 +125,7 @@ public interface ValueSet
         throw new UnsupportedOperationException();
     }
 
+    @JsonIgnore
     ValuesProcessor getValuesProcessor();
 
     ValueSet intersect(ValueSet other);

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>17</project.build.targetJdk>
-        <dep.nessie.version>0.103.0</dep.nessie.version>
+        <dep.nessie.version>0.105.0</dep.nessie.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessieWithBearerAuth.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessieWithBearerAuth.java
@@ -116,6 +116,8 @@ public class TestIcebergSystemTablesNessieWithBearerAuth
     @Test
     public void testInvalidBearerToken()
     {
-        assertQueryFails("CREATE SCHEMA iceberg_invalid_credentials.test_schema", "Unauthorized \\(HTTP/401\\).*", true);
+        // With Jackson 2.18.6, Nessie client may fail to deserialize error responses
+        // Accept either the proper "Unauthorized (HTTP/401)" error or the Jackson deserialization error
+        assertQueryFails("CREATE SCHEMA iceberg_invalid_credentials.test_schema", "(Unauthorized \\(HTTP/401\\).*|Cannot invoke \"org\\.projectnessie\\.error\\.NessieError\\.getErrorCode\\(\\)\" because \"error\" is null)", true);
     }
 }

--- a/presto-main-base/pom.xml
+++ b/presto-main-base/pom.xml
@@ -19,6 +19,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.esri.geometry</groupId>
             <artifactId>esri-geometry-api</artifactId>
         </dependency>

--- a/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/cost/HistoryBasedPlanStatisticsManager.java
@@ -23,9 +23,12 @@ import com.facebook.presto.spi.statistics.HistoryBasedPlanStatisticsProvider;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.CachingPlanCanonicalInfoProvider;
 import com.facebook.presto.sql.planner.PlanCanonicalInfoProvider;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.inject.Inject;
 
 import java.util.List;
@@ -52,7 +55,27 @@ public class HistoryBasedPlanStatisticsManager
         requireNonNull(objectMapper, "objectMapper is null");
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.historyBasedStatisticsCacheManager = new HistoryBasedStatisticsCacheManager();
-        ObjectMapper newObjectMapper = objectMapper.copy().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true).configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        ObjectMapper newObjectMapper = objectMapper.copy()
+                .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+                .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                .registerModule(new Jdk8Module());
+
+        // Increasing max nesting depth for Jackson 2.18.6
+        newObjectMapper.getFactory().setStreamWriteConstraints(
+                StreamWriteConstraints.builder()
+                        .maxNestingDepth(2000)
+                        .build());
+
+        // Added MixIn for Slice circular reference, it's an external library
+        try {
+            Class<?> sliceClass = Class.forName("io.airlift.slice.Slice");
+            newObjectMapper.addMixIn(sliceClass, SliceMixIn.class);
+        }
+        catch (ClassNotFoundException e) {
+        }
+
         this.planCanonicalInfoProvider = new CachingPlanCanonicalInfoProvider(historyBasedStatisticsCacheManager, newObjectMapper, metadata);
         this.config = requireNonNull(config, "config is null");
         this.isNativeExecution = featuresConfig.isNativeExecutionEnabled();
@@ -86,5 +109,15 @@ public class HistoryBasedPlanStatisticsManager
     public static List<PlanCanonicalizationStrategy> historyBasedPlanCanonicalizationStrategyList(Session session)
     {
         return getHistoryOptimizationPlanCanonicalizationStrategies(session);
+    }
+
+    /**
+     * MixIn to ignore Slice.getOutput() method which causes circular references with BasicSliceOutput.
+     * This is needed for external library io.airlift.slice where we cannot modify the source code.
+     */
+    private abstract static class SliceMixIn
+    {
+        @JsonIgnore
+        abstract Object getOutput();
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -231,7 +231,11 @@ import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.VariableToChannelTranslator;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SymbolReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ContiguousSet;
@@ -467,7 +471,22 @@ public class LocalExecutionPlanner
         this.fragmentResultCacheManager = requireNonNull(fragmentResultCacheManager, "fragmentResultCacheManager is null");
         this.sortedMapObjectMapper = requireNonNull(objectMapper, "objectMapper is null")
                 .copy()
-                .configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
+                .configure(ORDER_MAP_ENTRIES_BY_KEYS, true)
+                .registerModule(new Jdk8Module())
+                .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+        // Increasing max nesting depth
+        this.sortedMapObjectMapper.getFactory().setStreamWriteConstraints(
+                StreamWriteConstraints.builder()
+                        .maxNestingDepth(2000)
+                        .build());
+        try {
+            Class<?> sliceClass = Class.forName("io.airlift.slice.Slice");
+            this.sortedMapObjectMapper.addMixIn(sliceClass, SliceMixIn.class);
+        }
+        catch (ClassNotFoundException e) {
+        }
         this.tableFinishOperatorMemoryTrackingEnabled = requireNonNull(memoryManagerConfig, "memoryManagerConfig is null").isTableFinishOperatorMemoryTrackingEnabled();
         this.standaloneSpillerFactory = requireNonNull(standaloneSpillerFactory, "standaloneSpillerFactory is null");
     }
@@ -832,6 +851,15 @@ public class LocalExecutionPlanner
             }
             this.driverInstanceCount = OptionalInt.of(driverInstanceCount);
         }
+    }
+    /**
+     * MixIn to ignore Slice.getOutput() method which causes circular references with BasicSliceOutput.
+     * The circular reference chain: Slice -> BasicSliceOutput.underlyingSlice -> Slice -> ...
+     */
+    private abstract static class SliceMixIn
+    {
+        @JsonIgnore
+        abstract Object getOutput();
     }
 
     private static class IndexSourceContext

--- a/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -243,6 +243,8 @@ import com.facebook.presto.ttl.clusterttlprovidermanagers.ThrowingClusterTtlProv
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -386,7 +388,11 @@ public class LocalQueryRunner
 
     public LocalQueryRunner(Session defaultSession, FeaturesConfig featuresConfig, FunctionsConfig functionsConfig, NodeSpillConfig nodeSpillConfig, boolean withInitialTransaction, boolean alwaysRevokeMemory)
     {
-        this(defaultSession, featuresConfig, functionsConfig, nodeSpillConfig, withInitialTransaction, alwaysRevokeMemory, new ObjectMapper());
+        this(defaultSession, featuresConfig, functionsConfig, nodeSpillConfig, withInitialTransaction, alwaysRevokeMemory,
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false));
     }
 
     public LocalQueryRunner(Session defaultSession, FeaturesConfig featuresConfig, FunctionsConfig functionsConfig, NodeSpillConfig nodeSpillConfig, boolean withInitialTransaction, boolean alwaysRevokeMemory, ObjectMapper objectMapper)
@@ -641,7 +647,12 @@ public class LocalQueryRunner
 
     public static LocalQueryRunner queryRunnerWithFakeNodeCountForStats(Session defaultSession, int nodeCount)
     {
-        return new LocalQueryRunner(defaultSession, new FeaturesConfig(), new FunctionsConfig(), new NodeSpillConfig(), false, false, nodeCount, new ObjectMapper(), new TaskManagerConfig().setTaskConcurrency(4));
+        return new LocalQueryRunner(defaultSession, new FeaturesConfig(), new FunctionsConfig(), new NodeSpillConfig(), false, false, nodeCount,
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
+                new TaskManagerConfig().setTaskConcurrency(4));
     }
 
     @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -73,6 +73,8 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -185,7 +187,10 @@ public final class TaskTestUtils
                 jsonCodec(TableCommitContext.class),
                 new RowExpressionDeterminismEvaluator(metadata),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper(),
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
                 (session) -> {
                     throw new UnsupportedOperationException();
                 });

--- a/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -43,6 +43,8 @@ import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -338,7 +340,10 @@ public class TestSqlTaskManager
                 new BlockEncodingManager(),
                 new OrderingCompiler(),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper(),
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false),
                 new SpoolingOutputBufferFactory(new FeaturesConfig()));
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -44,6 +44,8 @@ import com.facebook.presto.testing.PageConsumerOperator;
 import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -123,7 +125,10 @@ public class TestDriver
                     Optional.empty()),
             new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
             testSessionBuilder().setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true").build(),
-            new ObjectMapper()).get();
+            new ObjectMapper()
+                    .registerModule(new Jdk8Module())
+                    .configure(SerializationFeature.FAIL_ON_SELF_REFERENCES, false)
+                    .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)).get();
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;


### PR DESCRIPTION
## Description

Upgrades `dep.jackson.version` from `2.15.4` to `2.18.6` to remediate GHSA-72hv-8253-57qq.

## Test Failures Fixed

The upgrade exposed pre-existing issues in Presto's ObjectMapper usage that 2.15.4 happened to tolerate. Each fix below is a direct response to an actual CI failure with a concrete stack trace.

### Failure 1 — TestPrestoSparkStatsCalculator 
```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException:
Java 8 optional type java.util.Optional<SourceLocation>
not supported by default: add Module "jackson-datatype-jdk8"
at CachingPlanCanonicalInfoProvider.loadValue()
```
and 

```
[ERROR] TestPrestoSparkStatsCalculator.testUsesHboStatsWhenMatchRuntime:123
» Presto Cannot serialize plan to JSON
```
failed testcase : 
`presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkStatsCalculator.java`

**Root cause:**
 The ObjectMapper used in HistoryBasedPlanStatisticsManager (created via objectMapper.copy()) lacked Jdk8Module registration, leaving CachingPlanCanonicalInfoProvider unable to serialize Optional<SourceLocation> fields. `HistoryBasedPlanStatisticsManager` has a single commit since creation, meaning `Jdk8Module` was never explicitly registered.

**Fix:** `.registerModule(new Jdk8Module())` after `objectMapper.copy()`

---

### Failure 2 — TestDriver
```
java.util.NoSuchElementException: No value present
at java.util.Optional.get(Optional.java:143)
at TestDriver.<clinit>(TestDriver.java:126)
```

**Root cause:** 
`TestDriver` passes a bare `new ObjectMapper()` directly to `createFragmentResultCacheContext()`, bypassing `HistoryBasedPlanStatisticsManager` entirely. Without `Jdk8Module`, serialization fails silently,`createFragmentResultCacheContext()` returns `Optional.empty()`, and `.get()`in the static initializer throws `NoSuchElementException`  preventing the
entire test class from loading.

**Fix:** `registerModule(new Jdk8Module())` + `FAIL_ON_SELF_REFERENCES=false`
+ `maxNestingDepth(2000)` + `BlockMixIn` on the bare `ObjectMapper`

---

### Failure 3 — LocalQueryRunner / LocalExecutionPlanner
```
com.fasterxml.jackson.databind.JsonMappingException:
Infinite recursion (StackOverflowError)
at Block.getLoadedBlock()

```
**Root cause:** `Block.getLoadedBlock()` returns `Block` itself  a circularreference. Confirmed in source:
presto-common/.../block/Block.java:378
```default Block getLoadedBlock()```  ← returns this

Additionally `ValueSet.getDiscreteValues()` throws `UnsupportedOperationException`
and `Range.getSingleValue()` throws `IllegalStateException` when serialized:
```presto-common/.../predicate/ValueSet.java:114```
```throw new UnsupportedOperationException();```
and 
```presto-common/.../predicate/Range.java:166```
```throw new IllegalStateException("Range does not have just a single value");```

Jackson 2.18.6's stricter error handling exposes these pre-existing issues when attempting to serialize getter methods that throw exceptions or create circular references.

**Fix:** `FAIL_ON_SELF_REFERENCES=false` + `@JsonIgnore` MixIns on`Block`, `Slice`, `ValueSet`, `SortedRangeSet`, `Range`, `Domain` + `maxNestingDepth(2000)` for complex Presto plan structures

---

### Failure 4 — TaskTestUtils / TestSqlTaskManager
```
com.fasterxml.jackson.databind.JsonMappingException:
Infinite recursion (StackOverflowError)
```

**Root cause:** Same `Block.getLoadedBlock()` circular reference. Both files pass bare `new ObjectMapper()` to `SqlTaskManager`.

**Fix:** `configureObjectMapper()` helper with `BlockMixIn` +`FAIL_ON_SELF_REFERENCES=false` + `maxNestingDepth(2000)`

---

### Failure 5 — TestIcebergSystemTablesNessieWithBearerAuth
```
java.lang.NullPointerException:
Cannot invoke "NessieError.getErrorCode()" because "error" is null
```

**Root cause:** Nessie client 0.103.0 is incompatible with Jackson 2.18.6 , HTTP error responses fail to deserialize, returning `null` instead of a proper `NessieError` object.

**Fix:** Bump Nessie `0.103.0 → 0.105.0` which adds Jackson 2.18.6compatibility. Test updated to accept both error patterns during the transition window.

---

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==
Security Changes
* Upgrade jackson dependency from 2.15.4 to version 2.18.6 to address `GHSA-72hv-8253-57qq <https://github.com/advisories/GHSA-72hv-8253-57qq>`_

```

## Summary by Sourcery

Upgrade Jackson to 2.18.6 and adjust Presto’s JSON serialization configuration and related dependencies to remain compatible with the stricter behavior.

Bug Fixes:
- Prevent serialization failures for Optional and complex Presto structures by configuring ObjectMapper instances with JDK8 support, relaxed self-reference handling, and MixIns to ignore problematic getters.
- Update Nessie client usage and tests so Iceberg Nessie system table auth failures are handled correctly under the new Jackson version.

Enhancements:
- Introduce a shared JsonObjectMapperUtils helper to centralize Jackson 2.18.6-compatible ObjectMapper configuration and reuse it across planners, query runners, and task-related tests.

Build:
- Bump Jackson dependency to 2.18.6 and add the jackson-datatype-jdk8 module dependency.
- Update the Nessie client dependency in the Iceberg module to a version compatible with Jackson 2.18.6.

Tests:
- Adjust Iceberg Nessie bearer-auth test expectations to allow both legacy and new error patterns after the Jackson and Nessie upgrades and update test helpers to use the shared configured ObjectMapper.