### PR TITLE
fix(native): Caps the count metric at int64_t's max value

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoTask.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoTask.cpp
@@ -998,11 +998,17 @@ folly::dynamic PrestoTask::toJson() const {
 protocol::RuntimeMetric toRuntimeMetric(
     const std::string& name,
     const RuntimeMetric& metric) {
+  // Presto's RuntimeMetric uses int64_t for count, but Velox's RuntimeMetric
+  // uses uint64_t. To avoid overflow, we cap the count at int64_t's max value.
+  static const uint64_t maxCount =
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  const auto count = static_cast<int64_t>(
+      std::min(static_cast<uint64_t>(metric.count), maxCount));
   return protocol::RuntimeMetric{
       name,
       toPrestoRuntimeUnit(metric.unit),
       metric.sum,
-      metric.count,
+      count,
       metric.max,
       metric.min};
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

Presto's RuntimeMetric uses int64_t for count, but Velox's RuntimeMetric
uses uint64_t. To avoid overflow, we cap the count at int64_t's max value.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

A refactor to change the count metric from int64_t to uint64_t is going on in 
Velox. To avoid overflow when converting to Presto metric, this PR updates
Presto count metric to consistent type.
https://github.com/facebookincubator/velox/pull/15536

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

Ensures no overflow when converting the uint64 count metric to int64.

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```