### PR TITLE
feat(native): Add IndexSourceNode planner support and split scheduling (#27296)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -685,7 +685,7 @@ public class SqlQueryExecution
                     .withNoMoreBufferIds();
         }
 
-        SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, stateMachine.getWarningCollector());
+        SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, stateMachine.getWarningCollector(), metadata);
         // build the stage execution objects (this doesn't schedule execution)
         SqlQuerySchedulerInterface scheduler = SqlQueryScheduler.createSqlQueryScheduler(
                 locationFactory,

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -41,6 +41,7 @@ import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.plan.PlanFragmentId;
 import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.PlanFragment;
@@ -659,6 +660,14 @@ public class SqlQueryScheduler
         }
         if (newRoot != fragment.getRoot()) {
             Optional<StatsAndCosts> estimatedStatsAndCosts = fragment.getStatsAndCosts();
+            // Filter the scheduling order to only include sources from the
+            // original fragment. The visitor includes all source nodes (e.g.
+            // IndexSourceNode), but some don't need coordinator-scheduled
+            // splits and were excluded during plan fragmentation.
+            Set<PlanNodeId> originalSources = ImmutableSet.copyOf(fragment.getTableScanSchedulingOrder());
+            List<PlanNodeId> newSchedulingOrder = scheduleOrder(newRoot).stream()
+                    .filter(originalSources::contains)
+                    .collect(toImmutableList());
             return Optional.of(
                     // The partitioningScheme should stay the same
                     // even if the root's outputVariable layout is changed.
@@ -667,7 +676,7 @@ public class SqlQueryScheduler
                             newRoot,
                             fragment.getVariables(),
                             fragment.getPartitioning(),
-                            scheduleOrder(newRoot),
+                            newSchedulingOrder,
                             fragment.getPartitioningScheme(),
                             fragment.getOutputOrderingScheme(),
                             fragment.getStageExecutionDescriptor(),

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/BasePlanFragmenter.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.MetadataDeleteNode;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.OutputNode;
@@ -69,6 +70,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.isForceSingleNodeOutput;
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSingleNodeExecutionEnabled;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.TemporaryTableUtil.assignPartitioningVariables;
@@ -144,12 +146,19 @@ public abstract class BasePlanFragmenter
 
     private SubPlan buildFragment(PlanNode root, FragmentProperties properties, PlanFragmentId fragmentId)
     {
-        List<PlanNodeId> schedulingOrder = scheduleOrder(root);
+        Set<PlanNodeId> partitionedSourcesSet = properties.getPartitionedSources();
+        // Filter the scheduling order to only include partitioned sources.
+        // The visitor always includes all source nodes (e.g. IndexSourceNode),
+        // but not all of them need coordinator-scheduled splits (e.g. non-bucketed
+        // index tables, or index sources in Java execution).
+        List<PlanNodeId> schedulingOrder = scheduleOrder(root).stream()
+                .filter(partitionedSourcesSet::contains)
+                .collect(toImmutableList());
         Preconditions.checkArgument(
-                properties.getPartitionedSources().equals(ImmutableSet.copyOf(schedulingOrder)),
+                partitionedSourcesSet.equals(ImmutableSet.copyOf(schedulingOrder)),
                 "Expected scheduling order (%s) to contain an entry for all partitioned sources (%s)",
                 schedulingOrder,
-                properties.getPartitionedSources());
+                partitionedSourcesSet);
 
         Set<VariableReferenceExpression> fragmentVariableTypes = extractOutputVariables(root);
         Set<PlanNodeId> tableWriterNodeIds = PlanFragmenterUtils.getTableWriterNodeIds(root);
@@ -264,6 +273,26 @@ public abstract class BasePlanFragmenter
                 .map(TableLayout.TablePartitioning::getPartitioningHandle)
                 .orElse(SOURCE_DISTRIBUTION);
         context.get().addSourceDistribution(node.getId(), partitioning, metadata, session);
+        return context.defaultRewrite(node, context.get());
+    }
+
+    @Override
+    public PlanNode visitIndexSource(IndexSourceNode node, RewriteContext<FragmentProperties> context)
+    {
+        // Only register the index source for coordinator-scheduled splits in
+        // native execution when the underlying table is bucketed (has table
+        // partitioning). Bucketed index tables need coordinator splits for
+        // file-aligned grouped execution. Non-bucketed index tables handle
+        // data fetching internally in the worker via
+        // connector::createIndexSource() and do not need coordinator splits.
+        // Java execution uses the Index SPI at runtime and never needs
+        // coordinator-scheduled splits.
+        if (isNativeExecutionEnabled(session)
+                && metadata.getLayout(session, node.getTableHandle())
+                        .getTablePartitioning()
+                        .isPresent()) {
+            context.get().addPartitionedSource(node.getId());
+        }
         return context.defaultRewrite(node, context.get());
     }
 
@@ -625,6 +654,13 @@ public abstract class BasePlanFragmenter
 
             partitioningHandle = Optional.of(COORDINATOR_DISTRIBUTION);
 
+            return this;
+        }
+
+        public FragmentProperties addPartitionedSource(PlanNodeId source)
+        {
+            requireNonNull(source, "source is null");
+            partitionedSources.add(source);
             return this;
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/GroupedExecutionTagger.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/GroupedExecutionTagger.java
@@ -17,8 +17,11 @@ import com.facebook.presto.Session;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.IndexJoinNode;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
@@ -282,7 +285,18 @@ class GroupedExecutionTagger
     @Override
     public GroupedExecutionTagger.GroupedExecutionProperties visitTableScan(TableScanNode node, Void context)
     {
-        Optional<TableLayout.TablePartitioning> tablePartitioning = metadata.getLayout(session, node.getTable()).getTablePartitioning();
+        return getSourceNodeGroupedExecutionProperties(node.getId(), node.getTable());
+    }
+
+    @Override
+    public GroupedExecutionTagger.GroupedExecutionProperties visitIndexSource(IndexSourceNode node, Void context)
+    {
+        return getSourceNodeGroupedExecutionProperties(node.getId(), node.getTableHandle());
+    }
+
+    private GroupedExecutionTagger.GroupedExecutionProperties getSourceNodeGroupedExecutionProperties(PlanNodeId nodeId, TableHandle tableHandle)
+    {
+        Optional<TableLayout.TablePartitioning> tablePartitioning = metadata.getLayout(session, tableHandle).getTablePartitioning();
         if (!tablePartitioning.isPresent()) {
             return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
         }
@@ -294,10 +308,46 @@ class GroupedExecutionTagger
             return new GroupedExecutionTagger.GroupedExecutionProperties(
                     true,
                     false,
-                    ImmutableList.of(node.getId()),
+                    ImmutableList.of(nodeId),
                     partitionHandles.size(),
-                    metadata.getConnectorCapabilities(session, node.getTable().getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE));
+                    metadata.getConnectorCapabilities(session, tableHandle.getConnectorId()).contains(SUPPORTS_REWINDABLE_SPLIT_SOURCE));
         }
+    }
+
+    @Override
+    public GroupedExecutionTagger.GroupedExecutionProperties visitIndexJoin(IndexJoinNode node, Void context)
+    {
+        GroupedExecutionTagger.GroupedExecutionProperties probe = node.getProbeSource().accept(this, null);
+        GroupedExecutionTagger.GroupedExecutionProperties index = node.getIndexSource().accept(this, null);
+
+        if (!groupedExecutionEnabled) {
+            return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
+        }
+
+        // For index join with colocated execution, both probe and index sides must be capable
+        // and have the same number of lifespans (buckets)
+        if (probe.currentNodeCapable && index.currentNodeCapable) {
+            if (probe.totalLifespans != index.totalLifespans) {
+                return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
+            }
+            // Include both probe and index side scan nodes for grouped
+            // execution. Each bucket group gets its own index split,
+            // ensuring file alignment for colocated lookup joins.
+            ImmutableList.Builder<PlanNodeId> allScanNodes = ImmutableList.builder();
+            allScanNodes.addAll(probe.capableTableScanNodes);
+            allScanNodes.addAll(index.capableTableScanNodes);
+            return new GroupedExecutionTagger.GroupedExecutionProperties(
+                    true,
+                    true,
+                    allScanNodes.build(),
+                    probe.totalLifespans,
+                    probe.recoveryEligible && index.recoveryEligible);
+        }
+
+        // Probe-only grouped execution for index joins is not currently
+        // supported. The index side requires colocated grouped execution
+        // with matching bucket counts for correct split scheduling.
+        return GroupedExecutionTagger.GroupedExecutionProperties.notCapable();
     }
 
     private GroupedExecutionTagger.GroupedExecutionProperties processChildren(PlanNode node)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SchedulingOrderVisitor.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SchedulingOrderVisitor.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.spi.plan.IndexJoinNode;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -86,6 +87,13 @@ public class SchedulingOrderVisitor
 
         @Override
         public Void visitTableScan(TableScanNode node, Consumer<PlanNodeId> schedulingOrder)
+        {
+            schedulingOrder.accept(node.getId());
+            return null;
+        }
+
+        @Override
+        public Void visitIndexSource(IndexSourceNode node, Consumer<PlanNodeId> schedulingOrder)
         {
             schedulingOrder.accept(node.getId());
             return null;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy;
@@ -24,6 +25,7 @@ import com.facebook.presto.spi.plan.DeleteNode;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IndexJoinNode;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.MarkDistinctNode;
@@ -73,6 +75,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.GROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.REWINDABLE_GROUPED_SCHEDULING;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
@@ -85,11 +88,13 @@ public class SplitSourceFactory
 
     private final SplitSourceProvider splitSourceProvider;
     private final WarningCollector warningCollector;
+    private final Metadata metadata;
 
-    public SplitSourceFactory(SplitSourceProvider splitSourceProvider, WarningCollector warningCollector)
+    public SplitSourceFactory(SplitSourceProvider splitSourceProvider, WarningCollector warningCollector, Metadata metadata)
     {
         this.splitSourceProvider = requireNonNull(splitSourceProvider, "splitSourceProvider is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
     public Map<PlanNodeId, SplitSource> createSplitSources(PlanFragment fragment, Session session, TableWriteInfo tableWriteInfo)
@@ -210,7 +215,45 @@ public class SplitSourceFactory
         @Override
         public Map<PlanNodeId, SplitSource> visitIndexJoin(IndexJoinNode node, Context context)
         {
-            return node.getProbeSource().accept(this, context);
+            Map<PlanNodeId, SplitSource> probeSplits = node.getProbeSource().accept(this, context);
+            Map<PlanNodeId, SplitSource> indexSplits = node.getIndexSource().accept(this, context);
+            return ImmutableMap.<PlanNodeId, SplitSource>builder()
+                    .putAll(probeSplits)
+                    .putAll(indexSplits)
+                    .build();
+        }
+
+        @Override
+        public Map<PlanNodeId, SplitSource> visitIndexSource(IndexSourceNode node, Context context)
+        {
+            // Only create split sources for native execution with bucketed
+            // index tables. Non-bucketed index tables handle data fetching
+            // internally in the worker via connector::createIndexSource()
+            // and do not need coordinator splits. Java execution uses the
+            // Index SPI at runtime and never needs coordinator splits.
+            if (!isNativeExecutionEnabled(session)) {
+                return ImmutableMap.of();
+            }
+
+            if (!metadata.getLayout(session, node.getTableHandle())
+                    .getTablePartitioning()
+                    .isPresent()) {
+                return ImmutableMap.of();
+            }
+
+            TableHandle table = node.getTableHandle();
+            SplitSchedulingStrategy strategy = getSplitSchedulingStrategy(stageExecutionDescriptor, node.getId());
+
+            // Use LazySplitSource to defer the potentially expensive MetaStore
+            // call (split enumeration) until splits are actually needed,
+            // consistent with visitTableScan(). The table layout is guaranteed
+            // to be resolved by the connector's plan optimizer
+            // (ApplyConnectorOptimization).
+            SplitSource splitSource = new LazySplitSource(
+                    () -> splitSourceProvider.getSplits(session, table, strategy, warningCollector));
+            splitSources.add(splitSource);
+
+            return ImmutableMap.of(node.getId(), splitSource);
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -618,6 +618,11 @@ public class IndexJoinOptimizer
 
             if (!resultingPredicate.equals(TRUE_CONSTANT)) {
                 // TODO: it is likely we end up with redundant filters here because the predicate push down has already been run... the fix is to run predicate push down again
+                // Note: For native execution, connectors may provide a ConnectorPlanOptimizer
+                // that absorbs this FilterNode into the IndexSourceNode's table handle during
+                // ApplyConnectorOptimization (which runs after this optimizer). If no connector
+                // optimizer absorbs it, the FilterNode is handled in PrestoToVeloxQueryPlan by
+                // unwrapping the filter and merging it into the join's remaining filter.
                 source = new FilterNode(source.getSourceLocation(), idAllocator.getNextId(), source, resultingPredicate);
             }
             context.markSuccess();

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestSchedulingOrderVisitor.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestSchedulingOrderVisitor.java
@@ -14,17 +14,25 @@
 
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.TestingColumnHandle;
+import com.facebook.presto.spi.plan.IndexSourceNode;
 import com.facebook.presto.spi.plan.JoinType;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
+import com.facebook.presto.testing.TestingTransactionHandle;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -58,6 +66,47 @@ public class TestSchedulingOrderVisitor
         TableScanNode b = planBuilder.tableScan(emptyList(), emptyMap());
         List<PlanNodeId> order = scheduleOrder(planBuilder.indexJoin(JoinType.INNER, a, b));
         assertEquals(order, ImmutableList.of(b.getId(), a.getId()));
+    }
+
+    @Test
+    public void testIndexSourceOrder()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), METADATA);
+        TableHandle tableHandle = new TableHandle(
+                new ConnectorId("testConnector"),
+                new TestingTableHandle(),
+                TestingTransactionHandle.create(),
+                Optional.empty());
+        VariableReferenceExpression lookupVar = planBuilder.variable("lookupKey");
+        IndexSourceNode indexSource = planBuilder.indexSource(
+                tableHandle,
+                ImmutableSet.of(lookupVar),
+                ImmutableList.of(lookupVar),
+                ImmutableMap.of(lookupVar, new TestingColumnHandle("lookupKey")),
+                TupleDomain.<ColumnHandle>all());
+        List<PlanNodeId> order = scheduleOrder(indexSource);
+        assertEquals(order, ImmutableList.of(indexSource.getId()));
+    }
+
+    @Test
+    public void testIndexJoinWithIndexSourceOrder()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), METADATA);
+        TableScanNode probe = planBuilder.tableScan(emptyList(), emptyMap());
+        TableHandle tableHandle = new TableHandle(
+                new ConnectorId("testConnector"),
+                new TestingTableHandle(),
+                TestingTransactionHandle.create(),
+                Optional.empty());
+        VariableReferenceExpression lookupVar = planBuilder.variable("lookupKey");
+        IndexSourceNode indexSource = planBuilder.indexSource(
+                tableHandle,
+                ImmutableSet.of(lookupVar),
+                ImmutableList.of(lookupVar),
+                ImmutableMap.of(lookupVar, new TestingColumnHandle("lookupKey")),
+                TupleDomain.<ColumnHandle>all());
+        List<PlanNodeId> order = scheduleOrder(planBuilder.indexJoin(JoinType.INNER, probe, indexSource));
+        assertEquals(order, ImmutableList.of(indexSource.getId(), probe.getId()));
     }
 
     @Test

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -21,6 +21,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.ScheduledSplit;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
@@ -99,6 +100,7 @@ public class PrestoSparkRddFactory
     private static final Logger log = Logger.get(PrestoSparkRddFactory.class);
 
     private final SplitManager splitManager;
+    private final Metadata metadata;
     private final PartitioningProviderManager partitioningProviderManager;
     private final JsonCodec<PrestoSparkTaskDescriptor> taskDescriptorJsonCodec;
     private final Codec<TaskSource> taskSourceCodec;
@@ -107,12 +109,14 @@ public class PrestoSparkRddFactory
     @Inject
     public PrestoSparkRddFactory(
             SplitManager splitManager,
+            Metadata metadata,
             PartitioningProviderManager partitioningProviderManager,
             JsonCodec<PrestoSparkTaskDescriptor> taskDescriptorJsonCodec,
             Codec<TaskSource> taskSourceCodec,
             FeaturesConfig featuresConfig)
     {
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
         this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
         this.taskDescriptorJsonCodec = requireNonNull(taskDescriptorJsonCodec, "taskDescriptorJsonCodec is null");
         this.taskSourceCodec = requireNonNull(taskSourceCodec, "taskSourceCodec is null");
@@ -225,7 +229,7 @@ public class PrestoSparkRddFactory
         List<PrestoSparkSource> sources = findTableScanNodes(fragment.getRoot());
         if (!sources.isEmpty()) {
             try (CloseableSplitSourceProvider splitSourceProvider = new CloseableSplitSourceProvider(splitManager)) {
-                SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, WarningCollector.NOOP);
+                SplitSourceFactory splitSourceFactory = new SplitSourceFactory(splitSourceProvider, WarningCollector.NOOP, metadata);
                 Map<PlanNodeId, SplitSource> splitSources = splitSourceFactory.createSplitSources(fragment, session, tableWriteInfo);
                 taskSourceRdd = Optional.of(createTaskSourcesRdd(
                         fragment.getId(),


### PR DESCRIPTION
Summary:

Enable the coordinator to plan and schedule IndexSourceNode for native
execution (Prestissimo). Previously, IndexSourceNode was invisible to the
planner -- it carried no split sources and was not included in grouped
execution analysis. This meant the native worker received an IndexJoinNode
whose index side had no splits and no bucket alignment, making colocated
index joins impossible.

This diff teaches the planner to treat IndexSourceNode like a table scan
when native execution is enabled and the underlying table is bucketed:
BasePlanFragmenter registers it as a partitioned source, GroupedExecutionTagger
marks it as grouped-execution-capable, and SplitSourceFactory generates
splits for it via LazySplitSource. SectionExecutionFactory handles the
multi-source fallback path for single-node clusters.

All changes are gated behind isNativeExecutionEnabled() and
tablePartitioning.isPresent(), so existing index join connectors
are unaffected.

## Release Notes
```
== NO RELEASE NOTE ==
```