### PR TITLE
feat: Add presto-mcp server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,7 @@
         <module>presto-sql-helpers/presto-sql-invoked-functions-plugin</module>
         <module>presto-sql-helpers/presto-native-sql-invoked-functions-plugin</module>
         <module>presto-lance</module>
+        <module>presto-mcp</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-mcp/README.md
+++ b/presto-mcp/README.md
@@ -1,0 +1,249 @@
+# Presto MCP Server
+
+A lightweight server that enables AI applications like Claude Desktop to interact with Presto using the Model Context Protocol (MCP).
+
+## Features
+
+- **5 MCP Tools**: List catalogs, schemas, tables, columns, and execute read-only SQL queries
+- **Read-Only Enforcement**: Blocks INSERT, UPDATE, DELETE, CREATE, DROP operations
+- **Auto Query Limits**: Applies 10-row limit to prevent large result sets by default
+- **Dual Transport**: STDIO and HTTP
+- **Authentication**: Basic Auth or Bearer Token
+
+## Quick Start
+
+### 1. Build
+
+```bash
+cd presto-mcp
+mvn clean package -DskipTests
+```
+
+### 2. Configure
+
+Edit `etc/mcp-server-config.properties`:
+
+```properties
+presto.server.uri=http://localhost:8080
+presto.server.user=your-username
+```
+
+### 3. Setup Claude Desktop
+
+**macOS Config Location:**
+```bash
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+**Edit Config:**
+```json
+{
+  "mcpServers": {
+    "presto": {
+      "command": "java",
+      "args": [
+        "-Dconfig=/absolute/path/to/presto-mcp/etc/mcp-server-config.properties",
+        "-jar",
+        "/absolute/path/to/presto-mcp/target/presto-mcp-0.297-SNAPSHOT-mcp.jar"
+      ]
+    }
+  }
+}
+```
+
+### 4. Restart Claude Desktop
+
+Close and reopen Claude Desktop. Look for 🔌 icon indicating connection.
+
+### 5. Check Logs (if needed)
+
+```bash
+# macOS
+tail -f ~/Library/Logs/Claude/mcp-server-presto.log
+```
+
+## Sample Queries for Claude
+
+### Basic Queries
+
+**List available tools:**
+```
+What tools are available in Presto?
+```
+
+**List catalogs:**
+```
+Which catalogs are available in Presto?
+```
+
+**List schemas:**
+```
+What schemas are in the tpch catalog?
+```
+
+**List tables:**
+```
+Show me all tables in the tpch.sf1 schema
+```
+
+**Get columns:**
+```
+What columns does the customer table have in tpch.sf1?
+```
+
+### Exploration Query
+
+**Multi-step exploration:**
+```
+Can you explore the tpch catalog, find out what tables are in the sf1 schema, 
+and tell me what columns exist in the customer table?
+```
+
+**Expected Response:**
+1. Lists schemas in `tpch` catalog
+2. Lists tables in `tpch.sf1` schema  
+3. Shows columns in `tpch.sf1.customer` table
+
+### Data Queries
+
+**Simple SELECT:**
+```
+Show me the first 10 customers from tpch.sf1.customer
+```
+
+**With filtering:**
+```
+Show me customers from nation 5 in tpch.sf1.customer, limit to 5 results
+```
+
+**Aggregation:**
+```
+How many customers are in each market segment in tpch.sf1.customer?
+```
+
+**Complex analysis:**
+```
+What's the structure of the orders table in tpch.sf1? 
+Then show me the top 5 orders by total price.
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `presto_metadata_list_catalogs` | List all Presto catalogs |
+| `presto_metadata_list_schemas` | List schemas in a catalog |
+| `presto_metadata_list_tables` | List tables in a schema |
+| `presto_metadata_get_columns` | Get column information |
+| `presto_query_run` | Execute read-only SQL queries |
+
+## Security
+
+### Read-Only Operations
+✅ **Allowed:** SELECT, SHOW, DESCRIBE, EXPLAIN, WITH  
+❌ **Blocked:** INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, TRUNCATE, GRANT, REVOKE
+
+### Query Limits
+- Automatic 10-row limit on queries without explicit LIMIT
+- Can be overridden by specifying LIMIT in query
+
+### Authentication
+- Credentials forwarded to Presto
+- All authorization handled by Presto coordinator
+
+## Testing HTTP Mode (Optional)
+
+### Start HTTP Server
+```bash
+java -Dconfig=etc/mcp-server-http-config.properties \
+     -jar target/presto-mcp-0.297-SNAPSHOT-mcp.jar
+```
+
+### Test with MCP Inspector
+```bash
+npx @modelcontextprotocol/inspector http://localhost:18080/mcp
+```
+
+Open browser at `http://localhost:5173`
+
+## Configuration Options
+
+| Property | Required | Default | Description                |
+|----------|----------|---------|----------------------------|
+| `presto.server.uri` | Yes | -       | Presto coordinator URL     |
+| `presto.server.user` | No* | -       | Username (Basic Auth)      |
+| `presto.server.password` | No* | -       | Password (Basic Auth)      |
+| `presto.server.token` | No* | -       | Bearer token (OAuth/JWT)   |
+| `http-server.http.port` | No | 18080   | HTTP port (HTTP mode only) |
+| `mcp.default-limit` | No | 10      | Default result set limit   |
+
+*Either `user` OR `user`+`password` OR `token` required
+
+## Troubleshooting
+
+### Claude Desktop Not Connecting
+
+1. **Check paths are absolute** (no `~` or relative paths)
+2. **View logs:**
+   ```bash
+   tail -f ~/Library/Logs/Claude/mcp*.log
+   ```
+3. **Test manually:**
+   ```bash
+   java -Dconfig=/path/to/config.properties -jar /path/to/presto-mcp.jar
+   ```
+4. **Verify Presto is running:**
+   ```bash
+   curl http://localhost:8080/v1/info
+   ```
+
+### Query Failures
+
+- **Read-only error:** Ensure query is SELECT/SHOW/DESCRIBE/EXPLAIN
+- **Permission error:** Check Presto user permissions
+- **Syntax error:** Verify SQL syntax
+
+## Architecture
+
+```
+Claude Desktop
+    ↓ (JSON-RPC over STDIO)
+MCP Server
+    ↓ (HTTP + Auth)
+Presto Coordinator
+    ↓
+Data Sources
+```
+
+## Example Session
+
+**User:** "List available tools in Presto"
+
+**Claude:** Shows 5 MCP tools with descriptions
+
+---
+
+**User:** "Which catalogs are available in Presto?"
+
+**Claude:** Lists catalogs (e.g., tpch, hive, system)
+
+---
+
+**User:** "Can you explore the tpch catalog, find out what tables are in the sf1 schema, and tell me what columns exist in the customer table?"
+
+**Claude:** 
+1. Lists schemas: sf1, sf100, sf1000, tiny
+2. Lists tables: customer, lineitem, nation, orders, part, partsupp, region, supplier
+3. Shows customer columns: custkey, name, address, nationkey, phone, acctbal, mktsegment, comment
+
+---
+
+**User:** "Show me the first 10 customers from tpch.sf1.customer"
+
+**Claude:** Executes query and displays results in table format
+
+## Related Links
+
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Presto Documentation](https://prestodb.io/docs/current/)
+- [Claude Desktop](https://claude.ai/)

--- a/presto-mcp/etc/mcp-server-config.properties
+++ b/presto-mcp/etc/mcp-server-config.properties
@@ -1,0 +1,7 @@
+#presto.server.uri=http://localhost:8081/
+node.environment=testing
+mcp.default-limit=10
+presto.server.uri=https://localhost:8443
+presto.server.user=presto
+presto.server.password=password
+presto.server.ssl.verification-disabled=true

--- a/presto-mcp/etc/mcp-server-http-config.properties
+++ b/presto-mcp/etc/mcp-server-http-config.properties
@@ -1,0 +1,5 @@
+presto.server.uri=http://localhost:8081/
+node.environment=testing
+mcp.default-limit=10
+http-server.http.port=18080
+presto.server.user=presto

--- a/presto-mcp/pom.xml
+++ b/presto-mcp/pom.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.297-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-mcp</artifactId>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <main-class>com.facebook.presto.mcp.PrestoMcpServer</main-class>
+        <project.build.targetJdk>17</project.build.targetJdk>
+        <air.check.skip-modernizer>true</air.check.skip-modernizer>
+        <air.check.skip-dependency>true</air.check.skip-dependency>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>node</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>event</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <!-- test dependencies-->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.facebook.presto.mcp.PrestoMcpServer</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/JsonRpcServlet.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/JsonRpcServlet.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+
+/**
+ * HTTP servlet for handling JSON-RPC requests to the MCP server.
+ * Accepts POST requests with JSON-RPC payloads and returns JSON-RPC responses.
+ */
+public class JsonRpcServlet
+        extends HttpServlet
+{
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String CONTENT_TYPE_JSON = "application/json";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final McpDispatcher dispatcher;
+
+    @Inject
+    public JsonRpcServlet(McpDispatcher dispatcher)
+    {
+        this.dispatcher = dispatcher;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+            throws IOException
+    {
+        JsonNode rpcRequest = mapper.readTree(req.getInputStream());
+        String authHeader = req.getHeader("Authorization");
+
+        String token = extractBearerToken(authHeader);
+        JsonNode rpcResponse = dispatcher.dispatch(rpcRequest, token);
+
+        resp.setContentType(CONTENT_TYPE_JSON);
+        mapper.writeValue(resp.getOutputStream(), rpcResponse);
+    }
+
+    private String extractBearerToken(String authHeader)
+    {
+        if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+            return authHeader.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/McpDispatcher.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/McpDispatcher.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+
+/**
+ * Dispatcher for MCP (Model Context Protocol) requests.
+ * Handles initialization, tool listing, and tool execution requests.
+ */
+public class McpDispatcher
+{
+    private static final String MCP_PROTOCOL_VERSION = "2024-11-05";
+    private static final String SERVER_NAME = "presto-mcp";
+    private static final String SERVER_VERSION = "1.0.0";
+    private static final String JSONRPC_VERSION = "2.0";
+    private static final int ERROR_CODE_INTERNAL = -32000;
+
+    private final ToolRegistry toolRegistry;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    public McpDispatcher(ToolRegistry toolRegistry)
+    {
+        this.toolRegistry = toolRegistry;
+    }
+
+    /**
+     * Dispatches an MCP request to the appropriate handler.
+     *
+     * @param request the JSON-RPC request
+     * @param token optional authentication token
+     * @return the JSON-RPC response, or null for notifications
+     */
+    public JsonNode dispatch(JsonNode request, String token)
+    {
+        String method = request.get("method").asText();
+        JsonNode params = request.has("params") ? request.get("params") : mapper.createObjectNode();
+        JsonNode idNode = request.get("id");
+        Integer id = (idNode != null && !idNode.isNull()) ? idNode.asInt() : null;
+
+        // Notifications don't need a response
+        if (method.startsWith("notifications/")) {
+            return null;
+        }
+
+        ObjectNode response = mapper.createObjectNode();
+        response.put("jsonrpc", JSONRPC_VERSION);
+        if (id != null) {
+            response.put("id", id);
+        }
+
+        try {
+            switch (method) {
+                case "initialize":
+                    response.set("result", createInitializeResult());
+                    break;
+
+                case "tools/list":
+                    response.set("result", mapper.createObjectNode()
+                            .set("tools", toolRegistry.listTools()));
+                    break;
+
+                case "tools/call":
+                    String toolName = params.get("name").asText();
+                    JsonNode args = params.has("arguments") ? params.get("arguments") : mapper.createObjectNode();
+                    JsonNode toolResult = toolRegistry.callTool(toolName, args, token);
+                    response.set("result", createToolCallResult(toolResult));
+                    break;
+
+                default:
+                    throw new IllegalArgumentException("Unknown method: " + method);
+            }
+        }
+        catch (Exception e) {
+            ObjectNode err = mapper.createObjectNode();
+            err.put("code", ERROR_CODE_INTERNAL);
+            err.put("message", e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+            response.set("error", err);
+        }
+
+        return response;
+    }
+
+    private ObjectNode createInitializeResult()
+    {
+        ObjectNode initResult = mapper.createObjectNode();
+        initResult.put("protocolVersion", MCP_PROTOCOL_VERSION);
+
+        ObjectNode serverInfo = mapper.createObjectNode();
+        serverInfo.put("name", SERVER_NAME);
+        serverInfo.put("version", SERVER_VERSION);
+        initResult.set("serverInfo", serverInfo);
+
+        ObjectNode capabilities = mapper.createObjectNode();
+        ObjectNode toolsCapability = mapper.createObjectNode();
+        toolsCapability.put("listChanged", true);
+        capabilities.set("tools", toolsCapability);
+        initResult.set("capabilities", capabilities);
+
+        return initResult;
+    }
+
+    private ObjectNode createToolCallResult(JsonNode toolResult)
+            throws Exception
+    {
+        ObjectNode callResult = mapper.createObjectNode();
+        callResult.set("content", mapper.createArrayNode()
+                .add(mapper.createObjectNode()
+                        .put("type", "text")
+                        .put("text", mapper.writeValueAsString(toolResult))));
+        return callResult;
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/McpServerConfig.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/McpServerConfig.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp;
+
+import com.facebook.airlift.configuration.Config;
+
+import java.net.URI;
+
+public class McpServerConfig
+{
+    private URI prestoUri;
+    private int defaultLimit = 10;
+    private String prestoUser = "mcp-user";
+    private String prestoPassword;
+    private String prestoToken;
+    private boolean sslVerificationDisabled;
+
+    @Config("presto.server.uri")
+    public McpServerConfig setPrestoUri(URI uri)
+    {
+        this.prestoUri = uri;
+        return this;
+    }
+
+    public URI getPrestoUri()
+    {
+        return prestoUri;
+    }
+
+    @Config("mcp.default-limit")
+    public McpServerConfig setDefaultLimit(int limit)
+    {
+        this.defaultLimit = limit;
+        return this;
+    }
+
+    public int getDefaultLimit()
+    {
+        return defaultLimit;
+    }
+
+    @Config("presto.server.user")
+    public McpServerConfig setPrestoUser(String user)
+    {
+        this.prestoUser = user;
+        return this;
+    }
+
+    public String getPrestoUser()
+    {
+        return prestoUser;
+    }
+
+    @Config("presto.server.password")
+    public McpServerConfig setPrestoPassword(String password)
+    {
+        this.prestoPassword = password;
+        return this;
+    }
+
+    public String getPrestoPassword()
+    {
+        return prestoPassword;
+    }
+
+    @Config("presto.server.token")
+    public McpServerConfig setPrestoToken(String token)
+    {
+        this.prestoToken = token;
+        return this;
+    }
+
+    public String getPrestoToken()
+    {
+        return prestoToken;
+    }
+
+    @Config("presto.server.ssl.verification-disabled")
+    public McpServerConfig setSslVerificationDisabled(boolean disabled)
+    {
+        this.sslVerificationDisabled = disabled;
+        return this;
+    }
+
+    public boolean isSslVerificationDisabled()
+    {
+        return sslVerificationDisabled;
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/McpServerModule.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/McpServerModule.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp;
+
+import com.facebook.airlift.http.server.TheServlet;
+import com.facebook.presto.mcp.mcptools.McpTool;
+import com.facebook.presto.mcp.mcptools.MetadataGetColumnsTool;
+import com.facebook.presto.mcp.mcptools.MetadataListCatalogsTool;
+import com.facebook.presto.mcp.mcptools.MetadataListSchemasTool;
+import com.facebook.presto.mcp.mcptools.MetadataListTablesTool;
+import com.facebook.presto.mcp.mcptools.QueryRunTool;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.multibindings.Multibinder;
+import jakarta.servlet.Servlet;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+
+/**
+ * Guice module for configuring the MCP server components.
+ * Registers all MCP tools and configures HTTP servlet bindings.
+ */
+public class McpServerModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        // Bind configuration
+        configBinder(binder).bindConfig(McpServerConfig.class);
+
+        // Bind core components
+        binder.bind(PrestoQueryClient.class).in(SINGLETON);
+        binder.bind(ToolRegistry.class).in(SINGLETON);
+        binder.bind(McpDispatcher.class).in(SINGLETON);
+        binder.bind(JsonRpcServlet.class).in(SINGLETON);
+        binder.bind(StdioMcpServer.class).in(SINGLETON);
+
+        // Register MCP tools
+        Multibinder<McpTool> toolBinder = Multibinder.newSetBinder(binder, McpTool.class);
+        toolBinder.addBinding().to(QueryRunTool.class);
+        toolBinder.addBinding().to(MetadataListCatalogsTool.class);
+        toolBinder.addBinding().to(MetadataListSchemasTool.class);
+        toolBinder.addBinding().to(MetadataListTablesTool.class);
+        toolBinder.addBinding().to(MetadataGetColumnsTool.class);
+
+        // Configure HTTP servlet mappings
+        // Bind as default servlet (required by HttpServerModule)
+        binder.bind(Servlet.class).annotatedWith(TheServlet.class).to(JsonRpcServlet.class).in(SINGLETON);
+
+        // Also bind to specific path
+        newMapBinder(binder, String.class, Servlet.class, TheServlet.class)
+                .addBinding("/mcp")
+                .to(JsonRpcServlet.class);
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/PrestoMcpServer.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/PrestoMcpServer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.event.client.EventModule;
+import com.facebook.airlift.http.server.HttpServerModule;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.node.NodeModule;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+
+/**
+ * Main entry point for the Presto MCP (Model Context Protocol) server.
+ * Supports two modes:
+ * - STDIO mode: For integration with Claude Desktop and other MCP clients
+ * - HTTP mode: For direct HTTP access to the MCP API
+ */
+public class PrestoMcpServer
+{
+    private static final Logger LOG = Logger.get(PrestoMcpServer.class);
+
+    private PrestoMcpServer() {}
+
+    /**
+     * Starts the MCP server in HTTP mode.
+     * Listens on the configured HTTP port for JSON-RPC requests.
+     */
+    public static void startHttp()
+    {
+        Bootstrap app = new Bootstrap(
+                ImmutableList.<Module>builder()
+                    .add(new NodeModule())
+                    .add(new HttpServerModule())
+                    .add(new JsonModule())
+                    .add(new EventModule())
+                    .add(new McpServerModule())
+                .build());
+
+        try {
+            app.initialize();
+            LOG.info("======== Presto MCP HTTP SERVER STARTED ========");
+        }
+        catch (Throwable t) {
+            LOG.error(t);
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Starts the MCP server in STDIO mode.
+     * Reads JSON-RPC requests from stdin and writes responses to stdout.
+     */
+    public static void startStdio()
+    {
+        try {
+            // Save original streams because Airlift logging initialization intercepts them
+            InputStream originalIn = System.in;
+            PrintStream originalOut = System.out;
+            PrintStream originalErr = System.err;
+
+            // Redirect System.out to System.err so all Airlift standard config/logging goes to stderr.
+            // Claude expects logs on stderr, and STRICTLY only JSON-RPC messages on stdout.
+            System.setOut(originalErr);
+
+            originalErr.println("======== Presto MCP STDIO SERVER STARTING ========");
+            originalErr.flush();
+
+            Bootstrap app = new Bootstrap(
+                    ImmutableList.<Module>builder()
+                        .add(new NodeModule())
+                        .add(new JsonModule())
+                        .add(new McpServerModule())
+                    .build());
+
+            Injector injector = app.initialize();
+            originalErr.println("======== Presto MCP STDIO SERVER INITIALIZED ========");
+            originalErr.flush();
+
+            StdioMcpServer stdioServer = injector.getInstance(StdioMcpServer.class);
+            stdioServer.run(originalIn, originalOut);
+        }
+        catch (Throwable t) {
+            System.err.println("Error starting stdio server: " + t.getMessage());
+            t.printStackTrace(System.err);
+            System.exit(1);
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        // Determine mode: stdio (for Claude Desktop) or HTTP (for direct access)
+        boolean stdioMode = System.console() == null ||
+                           "true".equals(System.getProperty("mcp.stdio")) ||
+                           "stdio".equals(System.getProperty("mcp.mode"));
+
+        if (stdioMode) {
+            System.err.println("Starting in STDIO mode (for Claude Desktop)");
+            startStdio();
+        }
+        else {
+            System.err.println("Starting in HTTP mode");
+            startHttp();
+        }
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/PrestoQueryClient.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/PrestoQueryClient.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp;
+
+import com.facebook.airlift.units.Duration;
+import com.facebook.presto.client.ClientSession;
+import com.facebook.presto.client.StatementClient;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
+import javax.inject.Inject;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static com.facebook.presto.client.StatementClientFactory.newStatementClient;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+/**
+ * Client for executing queries against a Presto server.
+ * Handles authentication (Basic Auth or Bearer Token) and SSL configuration.
+ */
+public class PrestoQueryClient
+{
+    private final McpServerConfig mcpServerConfig;
+    private final OkHttpClient httpClient = new OkHttpClient();
+
+    @Inject
+    public PrestoQueryClient(McpServerConfig mcpServerConfig)
+    {
+        this.mcpServerConfig = mcpServerConfig;
+    }
+
+    /**
+     * Executes a SQL query against the configured Presto server.
+     *
+     * @param sql the SQL query to execute
+     * @param token optional authentication token (overrides config if provided)
+     * @return list of result rows, where each row is a list of column values
+     */
+    public List<List<Object>> runQuery(String sql, String token)
+    {
+        StatementClient client = newStatementClient(buildHttpClientWithAuth(token),
+                createClientSession(mcpServerConfig.getPrestoUri()), sql);
+        try {
+            List<List<Object>> rows = new ArrayList<>();
+
+            while (client.isRunning() && client.advance()) {
+                if (client.currentData() != null && client.currentData().getData() != null) {
+                    for (List<Object> row : client.currentData().getData()) {
+                        rows.add(row);
+                    }
+                }
+            }
+            return rows;
+        }
+        finally {
+            client.close();
+        }
+    }
+
+    private OkHttpClient buildHttpClientWithAuth(String authorizationHeader)
+    {
+        String authHeader = authorizationHeader;
+
+        if (authHeader == null || authHeader.isEmpty()) {
+            if (mcpServerConfig.getPrestoPassword() != null && !mcpServerConfig.getPrestoPassword().isEmpty()) {
+                authHeader = Credentials.basic(mcpServerConfig.getPrestoUser(), mcpServerConfig.getPrestoPassword());
+            }
+            else if (mcpServerConfig.getPrestoToken() != null && !mcpServerConfig.getPrestoToken().isEmpty()) {
+                authHeader = "Bearer " + mcpServerConfig.getPrestoToken();
+            }
+        }
+
+        OkHttpClient.Builder builder = httpClient.newBuilder();
+
+        if (mcpServerConfig.isSslVerificationDisabled()) {
+            builder = configureInsecureSsl(builder);
+        }
+
+        if (authHeader == null || authHeader.isEmpty()) {
+            return builder.build(); // no auth
+        }
+
+        final String finalAuthHeader = authHeader;
+
+        return builder
+                .addInterceptor(chain -> {
+                    Request original = chain.request();
+                    Request.Builder reqBuilder = original.newBuilder()
+                            .header("Authorization", finalAuthHeader)
+                            .method(original.method(), original.body());
+                    return chain.proceed(reqBuilder.build());
+                })
+                .build();
+    }
+
+    /**
+     * Configures the HTTP client to accept all SSL certificates without verification.
+     * WARNING: This should only be used for development/testing with self-signed certificates.
+     * Do not use in production as it disables SSL security.
+     *
+     * @param builder the OkHttpClient builder to configure
+     * @return the configured builder with SSL verification disabled
+     */
+    private OkHttpClient.Builder configureInsecureSsl(OkHttpClient.Builder builder)
+    {
+        try {
+            TrustManager[] trustAllCerts = new TrustManager[] {
+                new X509TrustManager()
+                {
+                    @Override
+                    public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) {}
+
+                    @Override
+                    public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) {}
+
+                    @Override
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers()
+                    {
+                        return new java.security.cert.X509Certificate[]{};
+                    }
+                }
+            };
+
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+            SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+
+            return builder
+                    .sslSocketFactory(sslSocketFactory, (X509TrustManager) trustAllCerts[0])
+                    .hostnameVerifier((hostname, session) -> true);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to configure insecure SSL", e);
+        }
+    }
+
+    private ClientSession createClientSession(URI prestoUri)
+    {
+        return new ClientSession(
+                prestoUri,
+                mcpServerConfig.getPrestoUser(),
+                "source",
+                Optional.empty(),
+                ImmutableSet.of(),
+                null,
+                null,
+                null,
+                "America/Los_Angeles",
+                Locale.ENGLISH,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                null,
+                new Duration(2, MINUTES),
+                true,
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                false);
+    }
+
+    /**
+     * Applies a default LIMIT clause to queries that don't already have one.
+     * This prevents accidentally returning huge result sets.
+     *
+     * @param sql the SQL query
+     * @return the SQL query with LIMIT clause added if not present
+     */
+    public String applyLimit(String sql)
+    {
+        String lower = sql.toLowerCase();
+        if (!lower.contains("limit ")) {
+            return sql + " LIMIT " + mcpServerConfig.getDefaultLimit();
+        }
+        return sql;
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/StdioMcpServer.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/StdioMcpServer.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.inject.Inject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+
+/**
+ * Stdio-based MCP server for Claude Desktop integration.
+ * Reads JSON-RPC requests from stdin and writes responses to stdout.
+ * Supports lazy initialization to respond quickly to the first request.
+ */
+public class StdioMcpServer
+{
+    private static final String MCP_PROTOCOL_VERSION = "2024-11-05";
+    private static final String SERVER_NAME = "presto-mcp";
+    private static final String SERVER_VERSION = "1.0.0";
+    private static final int ERROR_CODE_INTERNAL = -32603;
+
+    private final McpDispatcher dispatcher;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    public StdioMcpServer(McpDispatcher dispatcher)
+    {
+        this.dispatcher = dispatcher;
+    }
+
+    public void run(java.io.InputStream in, java.io.PrintStream out)
+    {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+                PrintWriter writer = new PrintWriter(out, true)) {
+            System.out.flush();
+            System.err.println("Presto MCP Server ready - listening on stdio");
+            System.err.flush();
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                processRequest(line, writer);
+            }
+
+            System.err.println("Stdin closed, shutting down");
+        }
+        catch (Exception e) {
+            System.err.println("Fatal error in stdio server: " + e.getMessage());
+            e.printStackTrace(System.err);
+            System.exit(1);
+        }
+    }
+
+    private void processRequest(String line, PrintWriter writer)
+    {
+        try {
+            if (line.trim().isEmpty()) {
+                return;
+            }
+
+            JsonNode request = mapper.readTree(line);
+            if (!request.has("method") || request.get("method") == null) {
+                System.err.println("Received invalid request (no method): " + line);
+                return;
+            }
+
+            String method = request.get("method").asText();
+            System.err.println("Received request: " + method);
+            System.err.flush();
+
+            // Handle initialize specially - respond immediately even if not fully initialized
+            if ("initialize".equals(method)) {
+                handleInitializeRequest(request, writer);
+                return;
+            }
+
+            // For other requests, use the dispatcher
+            JsonNode response = dispatcher.dispatch(request, null);
+
+            if (response != null) {
+                sendResponse(response, writer);
+                logResponseSent(request);
+            }
+            else {
+                System.err.println("No response needed (notification)");
+                System.err.flush();
+            }
+        }
+        catch (InterruptedException e) {
+            handleInitializationTimeout(line, writer, e);
+        }
+        catch (Exception e) {
+            handleProcessingError(line, writer, e);
+        }
+    }
+
+    private void handleInitializeRequest(JsonNode request, PrintWriter writer)
+    {
+        JsonNode idNode = request.get("id");
+        Integer id = (idNode != null && !idNode.isNull()) ? idNode.asInt() : null;
+
+        String initResponse = String.format(
+                "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"protocolVersion\":\"%s\",\"serverInfo\":{\"name\":\"%s\",\"version\":\"%s\"},\"capabilities\":{\"tools\":{\"listChanged\":true}}}}",
+                id, MCP_PROTOCOL_VERSION, SERVER_NAME, SERVER_VERSION);
+
+        writer.println(initResponse);
+        writer.flush();
+        System.out.flush();
+        System.err.println("Sent initialize response for request id: " + id);
+        System.err.flush();
+    }
+
+    private void sendResponse(JsonNode response, PrintWriter writer)
+            throws Exception
+    {
+        String responseJson = mapper.writeValueAsString(response);
+        writer.println(responseJson);
+        writer.flush();
+        System.out.flush();
+    }
+
+    private void logResponseSent(JsonNode request)
+    {
+        JsonNode idNode = request.get("id");
+        if (idNode != null) {
+            System.err.println("Sent response for request id: " + idNode.asInt());
+            System.err.flush();
+        }
+    }
+
+    private void handleInitializationTimeout(String line, PrintWriter writer, InterruptedException e)
+    {
+        System.err.println("Initialization timeout: " + e.getMessage());
+        e.printStackTrace(System.err);
+        sendErrorResponse(line, writer, "Server still initializing, please retry");
+    }
+
+    private void handleProcessingError(String line, PrintWriter writer, Exception e)
+    {
+        System.err.println("Error processing request: " + e.getMessage());
+        e.printStackTrace(System.err);
+        String message = e.getMessage() != null ? e.getMessage().replace("\"", "\\\"") : "Internal error";
+        sendErrorResponse(line, writer, message);
+    }
+
+    private void sendErrorResponse(String line, PrintWriter writer, String message)
+    {
+        try {
+            JsonNode request = mapper.readTree(line);
+            int id = request.has("id") ? request.get("id").asInt() : -1;
+            String errorResponse = String.format(
+                    "{\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":%d,\"message\":\"%s\"}}",
+                    id, ERROR_CODE_INTERNAL, message);
+            writer.println(errorResponse);
+            writer.flush();
+        }
+        catch (Exception ex) {
+            System.err.println("Failed to send error response: " + ex.getMessage());
+        }
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/ToolRegistry.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/ToolRegistry.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp;
+
+import com.facebook.presto.mcp.mcptools.McpTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Registry for managing MCP tools.
+ * Provides tool discovery and execution capabilities.
+ */
+public class ToolRegistry
+{
+    private final Map<String, McpTool> tools = new HashMap<>();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    public ToolRegistry(Set<McpTool> toolSet)
+    {
+        for (McpTool tool : toolSet) {
+            tools.put(tool.getName(), tool);
+        }
+    }
+
+    /**
+     * Lists all registered tools with their metadata.
+     *
+     * @return JSON array of tool definitions
+     */
+    public JsonNode listTools()
+    {
+        ArrayNode arrayNode = mapper.createArrayNode();
+        for (McpTool tool : tools.values()) {
+            ObjectNode node = mapper.createObjectNode();
+            node.put("name", tool.getName());
+            node.put("description", tool.getDescription());
+            node.set("inputSchema", tool.getInputSchema());
+            arrayNode.add(node);
+        }
+        return arrayNode;
+    }
+
+    /**
+     * Executes a tool by name with the provided arguments.
+     *
+     * @param name the tool name
+     * @param args the tool arguments as JSON
+     * @param token optional authentication token
+     * @return the tool execution result as JSON
+     * @throws Exception if the tool is not found or execution fails
+     */
+    public JsonNode callTool(String name, JsonNode args, String token)
+            throws Exception
+    {
+        McpTool tool = tools.get(name);
+        if (tool == null) {
+            throw new IllegalArgumentException("Tool not found: " + name);
+        }
+        return tool.call(args, token);
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/McpTool.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/McpTool.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp.mcptools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface McpTool
+{
+    String getName();
+    String getDescription();
+    JsonNode getInputSchema();
+    JsonNode call(JsonNode arguments, String token) throws Exception;
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/MetadataGetColumnsTool.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/MetadataGetColumnsTool.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp.mcptools;
+
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class MetadataGetColumnsTool
+        implements McpTool
+{
+    private final PrestoQueryClient prestoClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    public MetadataGetColumnsTool(PrestoQueryClient prestoClient)
+    {
+        this.prestoClient = prestoClient;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "metadata_getColumns";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Return column metadata for a given table.";
+    }
+
+    @Override
+    public JsonNode getInputSchema()
+    {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+
+        ObjectNode props = mapper.createObjectNode();
+        props.putObject("catalog").put("type", "string");
+        props.putObject("schema").put("type", "string");
+        props.putObject("table").put("type", "string");
+
+        schema.set("properties", props);
+        schema.putArray("required").add("catalog").add("schema").add("table");
+
+        return schema;
+    }
+
+    @Override
+    public JsonNode call(JsonNode arguments, String token)
+    {
+        String catalog = arguments.get("catalog").asText();
+        String schema = arguments.get("schema").asText();
+        String table = arguments.get("table").asText();
+
+        String sql = "DESCRIBE " + catalog + "." + schema + "." + table;
+
+        List<List<Object>> rows = prestoClient.runQuery(sql, token);
+
+        List<ObjectNode> cols = rows.stream().map(r -> {
+            ObjectNode col = mapper.createObjectNode();
+            col.put("name", r.get(0).toString());
+            col.put("type", r.get(1).toString());
+            return col;
+        }).collect(toList());
+
+        return mapper.valueToTree(cols);
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/MetadataListCatalogsTool.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/MetadataListCatalogsTool.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp.mcptools;
+
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class MetadataListCatalogsTool
+        implements McpTool
+{
+    private final PrestoQueryClient prestoClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    public MetadataListCatalogsTool(PrestoQueryClient prestoClient)
+    {
+        this.prestoClient = prestoClient;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "metadata_listCatalogs";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Return the list of available catalogs in Presto.";
+    }
+
+    @Override
+    public JsonNode getInputSchema()
+    {
+        return mapper.createObjectNode()
+                .put("type", "object");
+    }
+
+    @Override
+    public JsonNode call(JsonNode arguments, String token)
+    {
+        List<List<Object>> rows = prestoClient.runQuery("SHOW CATALOGS", token);
+
+        List<String> catalogs = rows.stream()
+                .map(r -> r.get(0).toString())
+                .collect(toList());
+
+        return mapper.valueToTree(catalogs);
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/MetadataListSchemasTool.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/MetadataListSchemasTool.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp.mcptools;
+
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class MetadataListSchemasTool
+        implements McpTool
+{
+    private final PrestoQueryClient prestoClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    public MetadataListSchemasTool(PrestoQueryClient prestoClient)
+    {
+        this.prestoClient = prestoClient;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "metadata_listSchemas";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Return the list of schemas for a given catalog.";
+    }
+
+    @Override
+    public JsonNode getInputSchema()
+    {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+
+        ObjectNode props = mapper.createObjectNode();
+        props.putObject("catalog").put("type", "string");
+        schema.set("properties", props);
+        schema.putArray("required").add("catalog");
+
+        return schema;
+    }
+
+    @Override
+    public JsonNode call(JsonNode arguments, String token)
+    {
+        String catalog = arguments.get("catalog").asText();
+
+        List<List<Object>> rows =
+                prestoClient.runQuery("SHOW SCHEMAS FROM " + catalog, token);
+
+        List<String> schemas = rows.stream()
+                .map(r -> r.get(0).toString())
+                .collect(toList());
+
+        return mapper.valueToTree(schemas);
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/MetadataListTablesTool.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/MetadataListTablesTool.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp.mcptools;
+
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class MetadataListTablesTool
+        implements McpTool
+{
+    private final PrestoQueryClient prestoClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    public MetadataListTablesTool(PrestoQueryClient prestoClient)
+    {
+        this.prestoClient = prestoClient;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "metadata_listTables";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Return the list of tables in a given catalog and schema.";
+    }
+
+    @Override
+    public JsonNode getInputSchema()
+    {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+
+        ObjectNode props = mapper.createObjectNode();
+        props.putObject("catalog").put("type", "string");
+        props.putObject("schema").put("type", "string");
+
+        schema.set("properties", props);
+        schema.putArray("required").add("catalog").add("schema");
+
+        return schema;
+    }
+
+    @Override
+    public JsonNode call(JsonNode arguments, String token)
+    {
+        String catalog = arguments.get("catalog").asText();
+        String schema = arguments.get("schema").asText();
+
+        List<List<Object>> rows = prestoClient.runQuery(
+                "SHOW TABLES FROM " + catalog + "." + schema, token);
+
+        List<String> tables = rows.stream()
+                .map(r -> r.get(0).toString())
+                .collect(toList());
+
+        return mapper.valueToTree(tables);
+    }
+}

--- a/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/QueryRunTool.java
+++ b/presto-mcp/src/main/java/com/facebook/presto/mcp/mcptools/QueryRunTool.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcp.mcptools;
+
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+
+import java.util.List;
+
+public class QueryRunTool
+        implements McpTool
+{
+    private final PrestoQueryClient prestoClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    public QueryRunTool(PrestoQueryClient prestoClient)
+    {
+        this.prestoClient = prestoClient;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "query_run";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, EXPLAIN) against Presto and return results. Write operations (INSERT, UPDATE, DELETE, CREATE, DROP, ALTER) are not allowed.";
+    }
+
+    @Override
+    public JsonNode getInputSchema()
+    {
+        ObjectNode schema = mapper.createObjectNode();
+        schema.put("type", "object");
+
+        ObjectNode props = mapper.createObjectNode();
+        props.set("sql", mapper.createObjectNode().put("type", "string"));
+
+        schema.set("properties", props);
+        schema.putArray("required").add("sql");
+
+        return schema;
+    }
+
+    @Override
+    public JsonNode call(JsonNode arguments, String token)
+    {
+        String sql = arguments.get("sql").asText();
+        validateReadOnlyQuery(sql);
+        String limitedSql = prestoClient.applyLimit(sql);
+
+        List<List<Object>> rows = prestoClient.runQuery(limitedSql, token);
+        return mapper.valueToTree(rows);
+    }
+
+    /**
+     * Validates that the SQL query is read-only (SELECT, SHOW, DESCRIBE, EXPLAIN).
+     * Rejects write operations (INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, TRUNCATE, GRANT, REVOKE).
+     *
+     * @param sql the SQL query to validate
+     * @throws IllegalArgumentException if the query contains write operations
+     */
+    private void validateReadOnlyQuery(String sql)
+    {
+        String trimmedSql = sql.trim().toLowerCase();
+
+        while (trimmedSql.startsWith("--") || trimmedSql.startsWith("/*")) {
+            if (trimmedSql.startsWith("--")) {
+                int newlineIndex = trimmedSql.indexOf('\n');
+                if (newlineIndex == -1) {
+                    trimmedSql = "";
+                    break;
+                }
+                trimmedSql = trimmedSql.substring(newlineIndex + 1).trim();
+            }
+            else if (trimmedSql.startsWith("/*")) {
+                int endIndex = trimmedSql.indexOf("*/");
+                if (endIndex == -1) {
+                    throw new IllegalArgumentException("Unclosed comment in SQL query");
+                }
+                trimmedSql = trimmedSql.substring(endIndex + 2).trim();
+            }
+        }
+        // Check for write operations
+        String[] writeOperations = {
+            "insert", "update", "delete", "create", "drop", "alter",
+            "truncate", "grant", "revoke", "merge", "call"
+        };
+        for (String operation : writeOperations) {
+            if (trimmedSql.startsWith(operation + " ") || trimmedSql.equals(operation)) {
+                throw new IllegalArgumentException(
+                        String.format("Write operation '%s' is not allowed. Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are permitted.", operation.toUpperCase()));
+            }
+        }
+        // Allow read-only operations
+        String[] readOnlyOperations = {"select", "show", "describe", "explain", "with"};
+        boolean isReadOnly = false;
+        for (String operation : readOnlyOperations) {
+            if (trimmedSql.startsWith(operation + " ") || trimmedSql.equals(operation)) {
+                isReadOnly = true;
+                break;
+            }
+        }
+        if (!isReadOnly) {
+            throw new IllegalArgumentException("Invalid SQL query. Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed.");
+        }
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/DummyPrestoQueryClient.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/DummyPrestoQueryClient.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Map;
+
+public class DummyPrestoQueryClient
+        extends PrestoQueryClient
+{
+    private final Map<String, List<List<Object>>> responses;
+
+    public DummyPrestoQueryClient(Map<String, List<List<Object>>> responses)
+    {
+        super(null);
+        this.responses = responses;
+    }
+
+    @Override
+    public List<List<Object>> runQuery(String sql, String token)
+    {
+        return responses.getOrDefault(sql, ImmutableList.of());
+    }
+
+    @Override
+    public String applyLimit(String sql)
+    {
+        if (!sql.toLowerCase().contains("limit")) {
+            return sql + " LIMIT 1000";
+        }
+        return sql;
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/TestJsonRpcServlet.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/TestJsonRpcServlet.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.http.server.TheServlet;
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.airlift.http.server.testing.TestingHttpServerModule;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.facebook.presto.mcp.JsonRpcServlet;
+import com.facebook.presto.mcp.McpDispatcher;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.ToolRegistry;
+import com.facebook.presto.mcp.mcptools.McpTool;
+import com.facebook.presto.mcp.mcptools.QueryRunTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import com.google.inject.multibindings.Multibinder;
+import jakarta.servlet.Servlet;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestJsonRpcServlet
+{
+    private TestingHttpServer server;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeMethod
+    public void setup()
+    {
+        Injector injector = new Bootstrap(
+                new JsonModule(),
+                new TestingNodeModule(),
+                new TestingHttpServerModule(),
+                binder -> {
+                    // Dummy Presto client
+                    binder.bind(PrestoQueryClient.class).toInstance(new DummyQueryClient());
+
+                    // Register tools
+                    Multibinder<McpTool> tools = newSetBinder(binder, McpTool.class);
+                    tools.addBinding().to(QueryRunTool.class);
+
+                    // Core components
+                    binder.bind(ToolRegistry.class).in(SINGLETON);
+                    binder.bind(McpDispatcher.class).in(SINGLETON);
+                    binder.bind(JsonRpcServlet.class).in(SINGLETON);
+
+                    // Default servlet required by TestingHttpServer
+                    binder.bind(Servlet.class)
+                            .annotatedWith(TheServlet.class)
+                            .to(JsonRpcServlet.class)
+                            .in(SINGLETON);
+
+                    // Init params binder
+                    newMapBinder(binder, String.class, String.class, TheServlet.class);
+
+                    // Map /mcp to servlet
+                    newMapBinder(binder, String.class, Servlet.class, TheServlet.class)
+                            .addBinding("/mcp")
+                            .to(JsonRpcServlet.class)
+                            .in(SINGLETON);
+                }
+        ).initialize();
+
+        server = injector.getInstance(TestingHttpServer.class);
+    }
+
+    @Test
+    public void testToolsListRequest()
+            throws Exception
+    {
+        OkHttpClient client = new OkHttpClient();
+        String payload =
+                "{" + "\"jsonrpc\":\"2.0\","
+                        + "\"id\":1,"
+                        + "\"method\":\"tools/list\","
+                        + "\"params\":{}"
+                        + "}";
+
+        Request request = new Request.Builder()
+                .url(server.getBaseUrl().resolve("/mcp").toURL())
+                .post(RequestBody.create(payload, MediaType.get("application/json")))
+                .build();
+
+        Response response = client.newCall(request).execute();
+        String body = response.body().string();
+
+        JsonNode json = mapper.readTree(body);
+
+        assertEquals(json.get("id").asInt(), 1);
+        assertTrue(json.has("result"));
+    }
+
+    private static class DummyQueryClient
+            extends PrestoQueryClient
+    {
+        public DummyQueryClient()
+        {
+            super(null);  // no Presto URI for test
+        }
+
+        @Override
+        public List<List<Object>> runQuery(String sql, String token)
+        {
+            // deterministic response without hitting Presto
+            return ImmutableList.of(ImmutableList.of("ok"));
+        }
+
+        @Override
+        public String applyLimit(String sql)
+        {
+            return sql;
+        }
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/TestMcpDispatcher.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/TestMcpDispatcher.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.facebook.presto.mcp.McpDispatcher;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.ToolRegistry;
+import com.facebook.presto.mcp.mcptools.McpTool;
+import com.facebook.presto.mcp.mcptools.QueryRunTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import com.google.inject.multibindings.Multibinder;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestMcpDispatcher
+{
+    @Test
+    public void testToolsList()
+    {
+        Injector injector = new Bootstrap(
+                new JsonModule(),
+                new TestingNodeModule(),
+                binder -> {
+                    Multibinder<McpTool> tools = Multibinder.newSetBinder(binder, McpTool.class);
+                    tools.addBinding().toInstance(new QueryRunTool(new DummyQueryClient()));
+
+                    binder.bind(ToolRegistry.class).in(SINGLETON);
+                    binder.bind(McpDispatcher.class).in(SINGLETON);
+                }
+        ).initialize();
+
+        McpDispatcher dispatcher = injector.getInstance(McpDispatcher.class);
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode request = mapper.createObjectNode();
+        request.put("method", "tools/list");
+        request.put("id", 1);
+        request.put("jsonrpc", "2.0");
+        request.set("params", mapper.createObjectNode());
+
+        JsonNode response = dispatcher.dispatch(request, null);
+
+        assertTrue(response.has("result"));
+        assertEquals(response.get("result").get("tools").get(0).get("name").asText(), "query_run");
+    }
+
+    private static class DummyQueryClient
+            extends PrestoQueryClient
+    {
+        public DummyQueryClient()
+        {
+            super(null);
+        }
+
+        @Override
+        public List<List<Object>> runQuery(String sql, String token)
+        {
+            return ImmutableList.of(ImmutableList.of(42));
+        }
+
+        @Override
+        public String applyLimit(String sql)
+        {
+            return sql;
+        }
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/TestMcpEndToEnd.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/TestMcpEndToEnd.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.http.server.TheServlet;
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.airlift.http.server.testing.TestingHttpServerModule;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.facebook.presto.mcp.JsonRpcServlet;
+import com.facebook.presto.mcp.McpDispatcher;
+import com.facebook.presto.mcp.McpServerConfig;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.ToolRegistry;
+import com.facebook.presto.mcp.mcptools.McpTool;
+import com.facebook.presto.mcp.mcptools.QueryRunTool;
+import com.facebook.presto.plugin.memory.MemoryPlugin;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Injector;
+import com.google.inject.multibindings.Multibinder;
+import jakarta.servlet.Servlet;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestMcpEndToEnd
+{
+    private DistributedQueryRunner presto;
+    private TestingHttpServer mcpServer;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        //
+        // 1. Start Presto (embedded)
+        //
+        Session session = testSessionBuilder()
+                .setCatalog("memory")
+                .setSchema("default")
+                .build();
+
+        presto = DistributedQueryRunner.builder(session)
+                .setNodeCount(1)
+                .build();
+
+        presto.installPlugin(new MemoryPlugin());
+        presto.createCatalog("memory", "memory");
+
+        presto.execute(session, "CREATE SCHEMA IF NOT EXISTS memory.default");
+        presto.execute(session, "CREATE TABLE memory.default.t AS SELECT 123 x");
+
+        URI coordinatorUri = presto.getCoordinator().getBaseUrl();
+
+        //
+        // 2. Start MCP Server (using real Airlift Bootstrap)
+        //
+        Injector injector = new Bootstrap(
+                new JsonModule(),
+                new TestingNodeModule(),
+                new TestingHttpServerModule(),
+                binder -> {
+                    // MCP configuration
+                    McpServerConfig config = new McpServerConfig()
+                            .setPrestoUri(coordinatorUri)
+                            .setDefaultLimit(1000);
+                    binder.bind(McpServerConfig.class).toInstance(config);
+
+                    // PrestoQueryClient → connects to real Presto
+                    binder.bind(PrestoQueryClient.class).in(SINGLETON);
+
+                    // MCP ToolRegistry + Dispatcher
+                    Multibinder<McpTool> tools = newSetBinder(binder, McpTool.class);
+                    tools.addBinding().to(QueryRunTool.class);
+
+                    binder.bind(ToolRegistry.class).in(SINGLETON);
+                    binder.bind(McpDispatcher.class).in(SINGLETON);
+
+                    // Servlet binding
+                    binder.bind(JsonRpcServlet.class).in(SINGLETON);
+                    binder.bind(Servlet.class)
+                            .annotatedWith(TheServlet.class)
+                            .to(JsonRpcServlet.class)
+                            .in(SINGLETON);
+                    newMapBinder(binder, String.class, Servlet.class, TheServlet.class)
+                            .addBinding("/mcp")
+                            .to(JsonRpcServlet.class)
+                            .in(SINGLETON);
+                    newMapBinder(binder, String.class, String.class, TheServlet.class);
+                }
+        ).initialize();
+
+        mcpServer = injector.getInstance(TestingHttpServer.class);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        if (mcpServer != null) {
+            mcpServer.stop();
+        }
+        if (presto != null) {
+            presto.close();
+        }
+    }
+
+    @Test
+    public void testQueryRunEndToEnd()
+            throws Exception
+    {
+        OkHttpClient client = new OkHttpClient();
+        //
+        // Build JSON-RPC query_run payload
+        //
+        String payload =
+                "{" + "\"jsonrpc\":\"2.0\","
+                        + "\"id\":11,"
+                        + "\"method\":\"tools/call\","
+                        + "\"params\":{"
+                        + "\"name\":\"query_run\","
+                        + "\"arguments\":{"
+                        + "\"sql\":\"SELECT * FROM memory.default.t\""
+                        + "}"
+                        + "}"
+                        + "}";
+
+        Request request = new Request.Builder()
+                .url(mcpServer.getBaseUrl().resolve("/mcp").toURL())
+                .post(RequestBody.create(payload, MediaType.get("application/json")))
+                .build();
+
+        Response response = client.newCall(request).execute();
+        String body = response.body().string();
+
+        JsonNode json = mapper.readTree(body);
+
+        assertTrue(json.has("result"));
+        JsonNode contentArray = json.get("result").get("content");
+        String textVal = contentArray.get(0).get("text").asText();
+        JsonNode parsedText = mapper.readTree(textVal);
+        assertEquals(parsedText.get(0).get(0).asInt(), 123);
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/TestToolRegistry.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/TestToolRegistry.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.facebook.presto.mcp.McpDispatcher;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.ToolRegistry;
+import com.facebook.presto.mcp.mcptools.McpTool;
+import com.facebook.presto.mcp.mcptools.QueryRunTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import com.google.inject.multibindings.Multibinder;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static org.testng.Assert.assertEquals;
+
+public class TestToolRegistry
+{
+    @Test
+    public void testToolRegistryLoadsQueryRunTool()
+    {
+        Injector injector = new Bootstrap(
+                new JsonModule(),
+                new TestingNodeModule(),
+                binder -> {
+                    Multibinder<McpTool> tools = Multibinder.newSetBinder(binder, McpTool.class);
+                    tools.addBinding().toInstance(new QueryRunTool(new DummyQueryClient()));
+
+                    binder.bind(ToolRegistry.class).in(SINGLETON);
+                    binder.bind(McpDispatcher.class).in(SINGLETON);
+                }
+        ).initialize();
+
+        ToolRegistry registry = injector.getInstance(ToolRegistry.class);
+
+        JsonNode tools = registry.listTools();
+        assertEquals(tools.get(0).get("name").asText(), "query_run");
+    }
+
+    // Dummy implementation for non-Presto test
+    private static class DummyQueryClient
+            extends PrestoQueryClient
+    {
+        public DummyQueryClient()
+        {
+            super(null);
+        }
+
+        @Override
+        public List<List<Object>> runQuery(String sql, String token)
+        {
+            return ImmutableList.of(ImmutableList.of(1));
+        }
+
+        @Override
+        public String applyLimit(String sql)
+        {
+            return sql;
+        }
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestMetadataGetColumnsTool.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestMetadataGetColumnsTool.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcptools;
+
+import com.facebook.presto.DummyPrestoQueryClient;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.mcptools.MetadataGetColumnsTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+public class TestMetadataGetColumnsTool
+{
+    private MetadataGetColumnsTool tool;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeMethod
+    public void setup()
+    {
+        Map<String, List<List<Object>>> data = ImmutableMap.of(
+                "DESCRIBE hive.default.orders",
+                ImmutableList.of(
+                        ImmutableList.of("orderkey", "bigint"),
+                        ImmutableList.of("custkey", "bigint"),
+                        ImmutableList.of("orderstatus", "varchar")));
+
+        PrestoQueryClient client = new DummyPrestoQueryClient(data);
+        tool = new MetadataGetColumnsTool(client);
+    }
+
+    @Test
+    public void testGetColumns()
+    {
+        ObjectNode args = mapper.createObjectNode();
+        args.put("catalog", "hive");
+        args.put("schema", "default");
+        args.put("table", "orders");
+
+        JsonNode result = tool.call(args, null);
+
+        assertEquals(result.get(0).get("name").asText(), "orderkey");
+        assertEquals(result.get(0).get("type").asText(), "bigint");
+
+        assertEquals(result.get(1).get("name").asText(), "custkey");
+        assertEquals(result.get(1).get("type").asText(), "bigint");
+
+        assertEquals(result.get(2).get("name").asText(), "orderstatus");
+        assertEquals(result.get(2).get("type").asText(), "varchar");
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestMetadataListCatalogsTool.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestMetadataListCatalogsTool.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcptools;
+
+import com.facebook.presto.DummyPrestoQueryClient;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.mcptools.MetadataListCatalogsTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestMetadataListCatalogsTool
+{
+    private MetadataListCatalogsTool tool;
+
+    @BeforeMethod
+    public void setup()
+    {
+        Map<String, List<List<Object>>> data = ImmutableMap.of(
+                "SHOW CATALOGS",
+                ImmutableList.of(
+                        ImmutableList.of("system"),
+                        ImmutableList.of("hive"),
+                        ImmutableList.of("tpch")));
+
+        PrestoQueryClient client = new DummyPrestoQueryClient(data);
+        tool = new MetadataListCatalogsTool(client);
+    }
+
+    @Test
+    public void testListCatalogs()
+    {
+        JsonNode result = tool.call(new ObjectMapper().createObjectNode(), null);
+
+        assertEquals(result.get(0).asText(), "system");
+        assertEquals(result.get(1).asText(), "hive");
+        assertEquals(result.get(2).asText(), "tpch");
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestMetadataListSchemasTool.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestMetadataListSchemasTool.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcptools;
+
+import com.facebook.presto.DummyPrestoQueryClient;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.mcptools.MetadataListSchemasTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+public class TestMetadataListSchemasTool
+{
+    private MetadataListSchemasTool tool;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeMethod
+    public void setup()
+    {
+        Map<String, List<List<Object>>> data = ImmutableMap.of(
+                "SHOW SCHEMAS FROM hive",
+                ImmutableList.of(
+                        ImmutableList.of("default"),
+                        ImmutableList.of("sales")));
+
+        PrestoQueryClient client = new DummyPrestoQueryClient(data);
+        tool = new MetadataListSchemasTool(client);
+    }
+
+    @Test
+    public void testListSchemas()
+    {
+        ObjectNode args = mapper.createObjectNode();
+        args.put("catalog", "hive");
+
+        JsonNode result = tool.call(args, null);
+
+        assertEquals(result.get(0).asText(), "default");
+        assertEquals(result.get(1).asText(), "sales");
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestMetadataListTablesTool.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestMetadataListTablesTool.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcptools;
+
+import com.facebook.presto.DummyPrestoQueryClient;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.mcptools.MetadataListTablesTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+public class TestMetadataListTablesTool
+{
+    private MetadataListTablesTool tool;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeMethod
+    public void setup()
+    {
+        Map<String, List<List<Object>>> data = ImmutableMap.of(
+                "SHOW TABLES FROM hive.default",
+                ImmutableList.of(
+                        ImmutableList.of("orders"),
+                        ImmutableList.of("customers")));
+
+        PrestoQueryClient client = new DummyPrestoQueryClient(data);
+        tool = new MetadataListTablesTool(client);
+    }
+
+    @Test
+    public void testListTables()
+    {
+        ObjectNode args = mapper.createObjectNode();
+        args.put("catalog", "hive");
+        args.put("schema", "default");
+
+        JsonNode result = tool.call(args, null);
+
+        assertEquals(result.get(0).asText(), "orders");
+        assertEquals(result.get(1).asText(), "customers");
+    }
+}

--- a/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestQueryRunTool.java
+++ b/presto-mcp/src/test/java/com/facebook/presto/mcptools/TestQueryRunTool.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.mcptools;
+
+import com.facebook.presto.DummyPrestoQueryClient;
+import com.facebook.presto.mcp.PrestoQueryClient;
+import com.facebook.presto.mcp.mcptools.QueryRunTool;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestQueryRunTool
+{
+    private QueryRunTool tool;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeMethod
+    public void setup()
+    {
+        // Dummy response for the SQL query
+        Map<String, List<List<Object>>> responses = ImmutableMap.of(
+                "SELECT 1 LIMIT 1000",              // because applyLimit() will add LIMIT if missing
+                ImmutableList.of(ImmutableList.of(1)));
+
+        PrestoQueryClient dummyClient = new DummyPrestoQueryClient(responses);
+        tool = new QueryRunTool(dummyClient);
+    }
+
+    @Test
+    public void testQueryRun()
+    {
+        ObjectNode args = mapper.createObjectNode();
+        args.put("sql", "SELECT 1");
+
+        JsonNode result = tool.call(args, null);
+
+        // Should return [[1]]
+        assertEquals(result.get(0).get(0).asInt(), 1);
+    }
+}


### PR DESCRIPTION
## Description
RFC - https://github.com/prestodb/rfcs/pull/53

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Summary by Sourcery

Introduce a new presto-mcp module that exposes a Model Context Protocol server for Presto, with both HTTP and stdio entrypoints, allowing MCP tools to run read-only queries and inspect catalog metadata.

New Features:
- Add a PrestoQueryClient wrapper for executing authenticated, optionally insecure-SSL queries against a configured Presto coordinator with default LIMIT handling.
- Provide an MCP dispatcher, HTTP servlet, and stdio server to handle JSON-RPC requests and route them to registered tools.
- Implement query_run and metadata inspection MCP tools (catalogs, schemas, tables, and columns) backed by Presto.
- Add a McpServerModule and configuration properties for wiring the MCP server into Airlift/Guice and configuring Presto connectivity and limits.

Build:
- Add the presto-mcp Maven module with dependencies, shade configuration, and Java 17 target settings.

Tests:
- Add end-to-end, servlet, dispatcher, tool registry, and individual MCP tool tests, including an embedded Presto-based integration test and a DummyPrestoQueryClient for unit testing.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Add presto-mcp server
```