### PR TITLE
feat: Enable MV data consistency for CTAS and INSERT (#27302)

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -6237,6 +6237,121 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testCtasFromMaterializedViewDataConsistency()
+    {
+        Session stitchingDisabledSession = Session.builder(getSession())
+                .setSystemProperty(MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED, "false")
+                .build();
+        Session stitchingEnabledSession = Session.builder(getSession())
+                .setSystemProperty(MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED, "true")
+                .build();
+
+        assertUpdate("CREATE TABLE mv_ctas_base (id BIGINT, partkey VARCHAR) " +
+                "WITH (partitioned_by=ARRAY['partkey'])");
+        assertUpdate("INSERT INTO mv_ctas_base VALUES (1, 'p1'), (2, 'p2'), (3, 'p1')", 3);
+
+        assertUpdate("CREATE MATERIALIZED VIEW mv_ctas " +
+                "WITH (partitioned_by=ARRAY['partkey']" + retentionDays(30) + ") " +
+                "AS SELECT id, partkey FROM mv_ctas_base");
+
+        try {
+            // CTAS from unrefreshed MV without stitching should produce empty data
+            assertUpdate(stitchingDisabledSession,
+                    "CREATE TABLE mv_ctas_no_stitch AS SELECT * FROM mv_ctas", 0);
+            assertQuery(stitchingDisabledSession,
+                    "SELECT COUNT(*) FROM mv_ctas_no_stitch", "SELECT 0");
+
+            // CTAS from unrefreshed MV with stitching should read from base table
+            assertUpdate(stitchingEnabledSession,
+                    "CREATE TABLE mv_ctas_stitch AS SELECT * FROM mv_ctas", 3);
+            assertQuery(stitchingEnabledSession,
+                    "SELECT * FROM mv_ctas_stitch ORDER BY id",
+                    "VALUES (1, 'p1'), (2, 'p2'), (3, 'p1')");
+
+            // After refreshing, CTAS should return data even without stitching
+            Session fullRefreshSession = Session.builder(getSession())
+                    .setSystemProperty(MATERIALIZED_VIEW_ALLOW_FULL_REFRESH_ENABLED, "true")
+                    .build();
+            assertUpdate(fullRefreshSession, "REFRESH MATERIALIZED VIEW mv_ctas", 3);
+
+            assertUpdate(stitchingDisabledSession,
+                    "CREATE TABLE mv_ctas_refreshed AS SELECT * FROM mv_ctas", 3);
+            assertQuery(stitchingDisabledSession,
+                    "SELECT * FROM mv_ctas_refreshed ORDER BY id",
+                    "VALUES (1, 'p1'), (2, 'p2'), (3, 'p1')");
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS mv_ctas_no_stitch");
+            getQueryRunner().execute("DROP TABLE IF EXISTS mv_ctas_stitch");
+            getQueryRunner().execute("DROP TABLE IF EXISTS mv_ctas_refreshed");
+            getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS mv_ctas");
+            getQueryRunner().execute("DROP TABLE IF EXISTS mv_ctas_base");
+        }
+    }
+
+    @Test
+    public void testInsertFromMaterializedViewDataConsistency()
+    {
+        Session stitchingDisabledSession = Session.builder(getSession())
+                .setSystemProperty(MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED, "false")
+                .build();
+        Session stitchingEnabledSession = Session.builder(getSession())
+                .setSystemProperty(MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED, "true")
+                .build();
+
+        assertUpdate("CREATE TABLE mv_insert_base (id BIGINT, partkey VARCHAR) " +
+                "WITH (partitioned_by=ARRAY['partkey'])");
+        assertUpdate("INSERT INTO mv_insert_base VALUES (1, 'p1'), (2, 'p2'), (3, 'p1')", 3);
+
+        assertUpdate("CREATE MATERIALIZED VIEW mv_insert " +
+                "WITH (partitioned_by=ARRAY['partkey']" + retentionDays(30) + ") " +
+                "AS SELECT id, partkey FROM mv_insert_base");
+
+        try {
+            // INSERT from unrefreshed MV without stitching should produce empty data
+            assertUpdate(stitchingDisabledSession,
+                    "CREATE TABLE mv_insert_no_stitch (id BIGINT, partkey VARCHAR) " +
+                            "WITH (partitioned_by=ARRAY['partkey'])");
+            assertUpdate(stitchingDisabledSession,
+                    "INSERT INTO mv_insert_no_stitch SELECT * FROM mv_insert", 0);
+            assertQuery(stitchingDisabledSession,
+                    "SELECT COUNT(*) FROM mv_insert_no_stitch", "SELECT 0");
+
+            // INSERT from unrefreshed MV with stitching should read from base table
+            assertUpdate(stitchingEnabledSession,
+                    "CREATE TABLE mv_insert_stitch (id BIGINT, partkey VARCHAR) " +
+                            "WITH (partitioned_by=ARRAY['partkey'])");
+            assertUpdate(stitchingEnabledSession,
+                    "INSERT INTO mv_insert_stitch SELECT * FROM mv_insert", 3);
+            assertQuery(stitchingEnabledSession,
+                    "SELECT * FROM mv_insert_stitch ORDER BY id",
+                    "VALUES (1, 'p1'), (2, 'p2'), (3, 'p1')");
+
+            // After refreshing, INSERT should return data even without stitching
+            Session fullRefreshSession = Session.builder(getSession())
+                    .setSystemProperty(MATERIALIZED_VIEW_ALLOW_FULL_REFRESH_ENABLED, "true")
+                    .build();
+            assertUpdate(fullRefreshSession, "REFRESH MATERIALIZED VIEW mv_insert", 3);
+
+            assertUpdate(stitchingDisabledSession,
+                    "CREATE TABLE mv_insert_refreshed (id BIGINT, partkey VARCHAR) " +
+                            "WITH (partitioned_by=ARRAY['partkey'])");
+            assertUpdate(stitchingDisabledSession,
+                    "INSERT INTO mv_insert_refreshed SELECT * FROM mv_insert", 3);
+            assertQuery(stitchingDisabledSession,
+                    "SELECT * FROM mv_insert_refreshed ORDER BY id",
+                    "VALUES (1, 'p1'), (2, 'p2'), (3, 'p1')");
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS mv_insert_no_stitch");
+            getQueryRunner().execute("DROP TABLE IF EXISTS mv_insert_stitch");
+            getQueryRunner().execute("DROP TABLE IF EXISTS mv_insert_refreshed");
+            getQueryRunner().execute("DROP MATERIALIZED VIEW IF EXISTS mv_insert");
+            getQueryRunner().execute("DROP TABLE IF EXISTS mv_insert_base");
+        }
+    }
+
+    @Test
     public void testAlphaFormatDdl()
     {
         assertUpdate("CREATE TABLE test_alpha_ddl_table (col1 bigint) WITH (format = 'ALPHA')");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -2922,6 +2922,7 @@ public class TestHiveMaterializedViewLogicalPlanner
         String table2 = "orders_partitioned_target";
         String table3 = "orders_from_mv";
         String table4 = "orders_from_refreshed_mv";
+        String table5 = "orders_from_mv_no_stitch";
         String view = "test_orders_view";
         try {
             queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS " +
@@ -2936,8 +2937,15 @@ public class TestHiveMaterializedViewLogicalPlanner
             assertUpdate(format("CREATE TABLE %s AS SELECT * FROM %s WHERE 1=0", table2, table1), 0);
             assertTrue(getQueryRunner().tableExists(getSession(), table2));
 
-            // CTAS from a materialized view should succeed (MV is not yet refreshed so storage is empty)
-            assertUpdate(format("CREATE TABLE %s AS SELECT * FROM %s WHERE ds = '2020-01-01'", table3, view), 0);
+            // CTAS from unrefreshed MV without data consistency should read from empty storage
+            Session noStitchSession = Session.builder(getSession())
+                    .setSystemProperty(MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED, "false")
+                    .build();
+            assertUpdate(noStitchSession, format("CREATE TABLE %s AS SELECT * FROM %s WHERE ds = '2020-01-01'", table5, view), 0);
+            assertTrue(getQueryRunner().tableExists(getSession(), table5));
+
+            // CTAS from unrefreshed MV should read from base table via stitching
+            assertUpdate(format("CREATE TABLE %s AS SELECT * FROM %s WHERE ds = '2020-01-01'", table3, view), 255);
             assertTrue(getQueryRunner().tableExists(getSession(), table3));
 
             // Refresh the MV so it has data, then CTAS should read from the refreshed MV
@@ -2961,6 +2969,7 @@ public class TestHiveMaterializedViewLogicalPlanner
             queryRunner.execute("DROP TABLE IF EXISTS " + table2);
             queryRunner.execute("DROP TABLE IF EXISTS " + table3);
             queryRunner.execute("DROP TABLE IF EXISTS " + table4);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table5);
         }
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergMaterializedViewsBase.java
@@ -1762,12 +1762,16 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("CREATE MATERIALIZED VIEW test_mv_insert_mv AS SELECT id, name, value FROM test_mv_insert_base");
 
         try {
-            // CTAS from MV should succeed (no longer blanket-blocked)
-            assertQuerySucceeds("CREATE TABLE test_mv_insert_ctas AS SELECT * FROM test_mv_insert_mv");
+            // CTAS from unrefreshed MV should read from base table via stitching
+            assertUpdate("CREATE TABLE test_mv_insert_ctas AS SELECT * FROM test_mv_insert_mv", 3);
+            assertQuery("SELECT * FROM test_mv_insert_ctas ORDER BY id",
+                    "VALUES (1, 'Alice', 100), (2, 'Bob', 200), (3, 'Charlie', 300)");
 
-            // INSERT from MV into a non-base-table should succeed
+            // INSERT from MV into a non-base-table should succeed with data via stitching
             assertUpdate("CREATE TABLE test_mv_insert_target (id BIGINT, name VARCHAR, value BIGINT)");
-            assertQuerySucceeds("INSERT INTO test_mv_insert_target SELECT * FROM test_mv_insert_mv");
+            assertUpdate("INSERT INTO test_mv_insert_target SELECT * FROM test_mv_insert_mv", 3);
+            assertQuery("SELECT * FROM test_mv_insert_target ORDER BY id",
+                    "VALUES (1, 'Alice', 100), (2, 'Bob', 200), (3, 'Charlie', 300)");
 
             // INSERT from MV into its base table should fail (circular dependency)
             assertQueryFails("INSERT INTO test_mv_insert_base SELECT * FROM test_mv_insert_mv",
@@ -1793,9 +1797,11 @@ public abstract class TestIcebergMaterializedViewsBase
         assertUpdate("CREATE MATERIALIZED VIEW test_mv_transitive_mv AS SELECT id, category, amount FROM test_mv_transitive_view");
 
         try {
-            // INSERT from MV into a non-base-table should succeed
+            // INSERT from MV into a non-base-table should succeed with data via stitching
             assertUpdate("CREATE TABLE test_mv_transitive_target (id BIGINT, category VARCHAR, amount BIGINT)");
-            assertQuerySucceeds("INSERT INTO test_mv_transitive_target SELECT * FROM test_mv_transitive_mv");
+            assertUpdate("INSERT INTO test_mv_transitive_target SELECT * FROM test_mv_transitive_mv", 3);
+            assertQuery("SELECT * FROM test_mv_transitive_target ORDER BY id",
+                    "VALUES (1, 'A', 100), (2, 'B', 200), (3, 'A', 300)");
 
             // INSERT from MV into the transitive base table (underlying table of the view) should fail
             assertQueryFails("INSERT INTO test_mv_transitive_base SELECT * FROM test_mv_transitive_mv",

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2219,7 +2219,7 @@ class StatementAnalyzer
                 }
             }
             Statement statement = analysis.getStatement();
-            if (optionalMaterializedView.isPresent() && statement instanceof Query) {
+            if (optionalMaterializedView.isPresent() && (statement instanceof Query || statement instanceof Insert || statement instanceof CreateTableAsSelect)) {
                 if (isMaterializedViewDataConsistencyEnabled(session) || !isLegacyMaterializedViews(session)) {
                     // When the materialized view has already been expanded, do not process it. Just use it as a table.
                     MaterializedViewAnalysisState materializedViewAnalysisState = analysis.getMaterializedViewAnalysisState(table);


### PR DESCRIPTION
Summary:

Currently materialized view data consistency via stitching only
applies to SELECT queries (`statement instanceof Query`). CTAS
(`CreateTableAsSelect`) and INSERT (`Insert`) bypassed MV processing entirely
and read directly from the MV storage table, returning stale or empty data
if the MV hadn't been fully refreshed.

This PR changes `StatementAnalyzer` to
enable stitching for CTAS and INSERT statements.

```
== RELEASE NOTES ==

General Changes
* Add MV data consistency support for CTAS and INSERT statements
```

Reviewed By: zation99

Differential Revision: D95862080
