### PR TITLE
fix(ci): Skip OWASP dep check for doc-only changes

### DIFF
--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -12,7 +12,26 @@ on:
         type: string
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      codechange: ${{ steps.filter.outputs.codechange }}
+    steps:
+      # For pull requests it's not necessary to checkout the code
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            codechange:
+              - '!presto-docs/**'
+              - 'presto-docs/pom.xml'
+
   dependency-check:
+    needs: changes
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-owasp-dependency-check-${{ github.event.pull_request.number }}
@@ -23,12 +42,14 @@ jobs:
     steps:
       # Checkout PR branch first to get access to the composite action
       - name: Checkout PR branch
+        if: needs.changes.outputs.codechange == 'true'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Find merge base
+        if: needs.changes.outputs.codechange == 'true'
         id: merge-base
         env:
           GH_TOKEN: ${{ github.token }}
@@ -42,6 +63,7 @@ jobs:
           echo "Using merge base: $merge_base"
 
       - name: Checkout base branch
+        if: needs.changes.outputs.codechange == 'true'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -49,6 +71,7 @@ jobs:
           path: base
 
       - name: Set up Java
+        if: needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -56,10 +79,12 @@ jobs:
           cache: maven
 
       - name: Get date for cache key
+        if: needs.changes.outputs.codechange == 'true'
         id: get-date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Restore OWASP database cache
+        if: needs.changes.outputs.codechange == 'true'
         uses: actions/cache/restore@v4
         id: cache-owasp-restore
         with:
@@ -70,6 +95,7 @@ jobs:
             owasp-cache-${{ runner.os }}-
 
       - name: Run OWASP check on base branch
+        if: needs.changes.outputs.codechange == 'true'
         uses: ./.github/actions/maven-owasp-scan
         with:
           working-directory: base
@@ -77,13 +103,14 @@ jobs:
           data-directory: /tmp/.owasp/dependency-check-data
 
       - name: Save OWASP cache after base scan
-        if: steps.cache-owasp-restore.outputs.cache-hit != 'true'
+        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: /tmp/.owasp/dependency-check-data
           key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}-partial
 
       - name: Run OWASP check on PR branch
+        if: needs.changes.outputs.codechange == 'true'
         uses: ./.github/actions/maven-owasp-scan
         with:
           working-directory: .
@@ -91,6 +118,7 @@ jobs:
           data-directory: /tmp/.owasp/dependency-check-data
 
       - name: Compare and fail on new CVEs above threshold
+        if: needs.changes.outputs.codechange == 'true'
         run: |
           # Extract CVEs above threshold from both branches (CVSS >= $CVSS_THRESHOLD)
           threshold=$CVSS_THRESHOLD
@@ -154,14 +182,14 @@ jobs:
           fi
 
       - name: Save OWASP database cache
-        if: always()
+        if: needs.changes.outputs.codechange == 'true' && always()
         uses: actions/cache/save@v4
         with:
           path: /tmp/.owasp/dependency-check-data
           key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}
 
       - name: Upload reports
-        if: always()
+        if: needs.changes.outputs.codechange == 'true' && always()
         uses: actions/upload-artifact@v4
         with:
           name: owasp-reports


### PR DESCRIPTION
## Description
Skip OWASP dep check for doc-only changes; exclude the change in presto-docs/pom.xml. We still want to run OWASP dep check if the pom.xml of the presto-docs project changes.

## Motivation and Context
Doc-only PRs shall skip the OWASP dep check, which reduces the time and resources for the CI jobs.

## Impact
Doc-only PRs skip the OWASP check.

## Test Plan
Use the same mechanism to skip the CI job, and I will also check some doc-only PRs after the change is merged.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Skip the OWASP dependency check workflow for documentation-only pull requests while still running it when presto-docs/pom.xml changes.

CI:
- Introduce a paths-filter job to detect non-doc or presto-docs/pom.xml changes and expose the result as a job output.
- Gate all OWASP dependency-check workflow steps on the presence of relevant code changes so the job is effectively skipped for doc-only PRs.