### PR TITLE
refactor: Replace throw std::invalid_argument with VELOX_USER_FAIL in presto-native-execution

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoExchangeSource.cpp
@@ -38,8 +38,7 @@ std::string extractTaskId(const std::string& path) {
 
   VLOG(1) << "Failed to extract task ID from remote split: " << path;
 
-  throw std::invalid_argument(
-      fmt::format("Cannot extract task ID from remote split URL: {}", path));
+  VELOX_FAIL("Cannot extract task ID from remote split URL: {}", path);
 }
 
 void onFinalFailure(

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -128,8 +128,7 @@ velox::variant VeloxExprConverter::getConstantValue(
           std::string(valueVector->as<velox::SimpleVector<velox::StringView>>()
                           ->valueAt(0)));
     default:
-      throw std::invalid_argument(
-          fmt::format("Unexpected Block type: {}", typeKind));
+      VELOX_UNSUPPORTED("Unexpected Block type: {}", typeKind);
   }
 }
 
@@ -902,8 +901,7 @@ TypedExprPtr VeloxExprConverter::toVeloxExpr(
     return toVeloxExpr(lambda);
   }
 
-  throw std::invalid_argument(
-      "Unsupported RowExpression type: " + pexpr->_type);
+  VELOX_UNSUPPORTED("Unsupported RowExpression type: {}", pexpr->_type);
 }
 
 } // namespace facebook::presto


### PR DESCRIPTION
Summary:
3 production sites throw raw `std::invalid_argument`, which bypasses
`VeloxToPrestoExceptionTranslator` and misclassifies user errors as
`GENERIC_INTERNAL_ERROR`. Replace them with `VELOX_USER_FAIL` so they
are properly translated to user-facing Presto error codes.

Sites fixed:
- `PrestoExchangeSource.cpp` - invalid task ID in remote split URL
- `PrestoToVeloxExpr.cpp:131` - unexpected Block type
- `PrestoToVeloxExpr.cpp:905` - unsupported RowExpression type

Differential Revision: D96025465

## Summary by Sourcery

Normalize error handling in Presto native execution by replacing raw std::invalid_argument throws with Velox error macros for proper Presto error translation.

Bug Fixes:
- Ensure invalid remote split URLs surface as proper Presto user errors by replacing std::invalid_argument with VELOX_FAIL in task ID extraction.
- Classify unexpected Block types and unsupported RowExpression types as Velox user errors by converting std::invalid_argument throws to VELOX_UNSUPPORTED.


```
== NO RELEASE NOTE ==