### PR TITLE
fix(native): Allow UTC timezone (key=0) in session config

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoToVeloxQueryConfig.cpp
@@ -99,13 +99,10 @@ void updateFromSessionConfigs(
         folly::join(',', session.clientTags);
   }
 
-  // If there's a timeZoneKey, convert to timezone name and add to the
-  // configs. Throws if timeZoneKey can't be resolved.
-  if (session.timeZoneKey != 0) {
-    queryConfigs.emplace(
-        velox::core::QueryConfig::kSessionTimezone,
-        velox::tz::getTimeZoneName(session.timeZoneKey));
-  }
+  // If there's a timeZoneKey, convert to timezone name and add to the configs.
+  queryConfigs.emplace(
+      velox::core::QueryConfig::kSessionTimezone,
+      velox::tz::getTimeZoneName(session.timeZoneKey));
 }
 
 void updateFromSystemConfigs(

--- a/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/PrestoToVeloxQueryConfigTest.cpp
@@ -316,12 +316,92 @@ TEST_F(PrestoToVeloxQueryConfigTest, sessionPropertiesOverrideSystemConfigs) {
              }
              EXPECT_EQ(expectedBytes, config.maxExchangeBufferSize());
            }},
+
+      {.veloxConfigKey = core::QueryConfig::kMaxLocalExchangeBufferSize,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey =
+           std::string(SystemConfig::kMaxLocalExchangeBufferSize),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 std::stoull(expectedValue),
+                 config.maxLocalExchangeBufferSize());
+           }},
+
+      {.veloxConfigKey = core::QueryConfig::kParallelOutputJoinBuildRowsEnabled,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey =
+           std::string(SystemConfig::kParallelOutputJoinBuildRowsEnabled),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 expectedValue == "true",
+                 config.parallelOutputJoinBuildRowsEnabled());
+           }},
+
+      {.veloxConfigKey =
+           core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey =
+           std::string(SystemConfig::kHashProbeBloomFilterPushdownMaxSize),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 std::stoull(expectedValue),
+                 config.hashProbeBloomFilterPushdownMaxSize());
+           }},
+
+      {.veloxConfigKey = core::QueryConfig::kTaskWriterCount,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey = std::string(SystemConfig::kTaskWriterCount),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(std::stoi(expectedValue), config.taskWriterCount());
+           }},
+
+      {.veloxConfigKey = core::QueryConfig::kTaskPartitionedWriterCount,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey =
+           std::string(SystemConfig::kTaskPartitionedWriterCount),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 std::stoi(expectedValue), config.taskPartitionedWriterCount());
+           }},
+
+      {.veloxConfigKey = core::QueryConfig::kExchangeLazyFetchingEnabled,
+       .sessionPropertyKey = std::nullopt,
+       .systemConfigKey =
+           std::string(SystemConfig::kExchangeLazyFetchingEnabled),
+       .sessionValue = "",
+       .differentSessionValue = "",
+       .validator =
+           [](const core::QueryConfig& config,
+              const std::string& expectedValue) {
+             EXPECT_EQ(
+                 expectedValue == "true", config.exchangeLazyFetchingEnabled());
+           }},
   };
 
   // CRITICAL: This count MUST match the exact number of entries in
   // veloxToPrestoConfigMapping If this assertion fails, it means a new
   // mapping was added and this test needs to be updated
-  const size_t kExpectedMappingCount = 17;
+  const size_t kExpectedMappingCount = 23;
   EXPECT_EQ(kExpectedMappingCount, testCases.size());
 
   // Test each mapping to ensure session properties override system configs
@@ -790,6 +870,7 @@ TEST_F(PrestoToVeloxQueryConfigTest, systemConfigsWithoutSessionOverride) {
   expectedExactConfigs += 2; // kAdjustTimestampToTimezone,
                              // kDriverCpuTimeSliceLimitMs
   expectedExactConfigs += 1; // kSessionStartTime
+  expectedExactConfigs += 1; // kSessionTimezone (always added)
 
   // Use exact matching to catch any config additions/removals
   EXPECT_EQ(veloxConfigs.size(), expectedExactConfigs)

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestDistributedEngineOnlyQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestDistributedEngineOnlyQueries.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.nativetests;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestEngineOnlyQueries;
 import org.testng.annotations.BeforeClass;
@@ -77,5 +79,16 @@ public class TestDistributedEngineOnlyQueries
         //assertQueryFails("SELECT TIME '3:04:05 +06:00'", timeTypeUnsupportedError);
         //assertQueryFails("SELECT TIME '3:04:05 +0507'", timeTypeUnsupportedError);
         //assertQueryFails("SELECT TIME '3:04:05 +03'", timeTypeUnsupportedError);
+    }
+
+    @Test
+    public void testUtcTimezoneConfiguration()
+    {
+        // Test that UTC timezone is correctly propagated to the native execution engine
+        Session utcSession = Session.builder(getSession())
+                .setTimeZoneKey(TimeZoneKey.UTC_KEY)
+                .build();
+
+        assertQueryWithSameQueryRunner(utcSession, "SELECT current_timezone()", "SELECT 'UTC'");
     }
 }


### PR DESCRIPTION
## Description
Allow session timezone with timeZoneKey = 0 (UTC) to be propagated to QueryConfig.

## Motivation and Context
The previous condition session.timeZoneKey != 0 excluded UTC since its key is 0, preventing it from being set in the query configuration.

## Impact
UTC session timezone is now correctly passed to QueryConfig. No impact on other timezones.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Bug Fixes:
- Treat UTC timezone (timeZoneKey 0) as a valid session timezone instead of ignoring it.

## Summary by Sourcery

Bug Fixes:
- Treat UTC (timeZoneKey = 0) as a valid session timezone so it is passed through to QueryConfig instead of being ignored.