### PR TITLE
perf: Optimize LIKE '%substring%' rewrite to use STRPOS instead of SPLIT

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -17,7 +17,6 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.transaction.TransactionId;
-import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalParseResult;
 import com.facebook.presto.common.type.Decimals;
@@ -109,6 +108,7 @@ import java.util.regex.Pattern;
 import static com.facebook.presto.common.function.OperatorType.BETWEEN;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.function.OperatorType.NEGATION;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -769,6 +769,16 @@ public final class SqlToRowExpressionTranslator
                     rhs);
         }
 
+        private RowExpression buildNotEquals(RowExpression lhs, RowExpression rhs)
+        {
+            return call(
+                    NOT_EQUAL.getOperator(),
+                    functionResolution.comparisonFunction(ComparisonExpression.Operator.NOT_EQUAL, lhs.getType(), rhs.getType()),
+                    BOOLEAN,
+                    lhs,
+                    rhs);
+        }
+
         @Override
         protected RowExpression visitExists(ExistsPredicate existsPredicate, Context context)
         {
@@ -955,11 +965,10 @@ public final class SqlToRowExpressionTranslator
                         }
                         else if (LIKE_SIMPLE_EXISTS_PATTERN.matcher(patternString).matches()) {
                             // pattern should just exist in the string ignoring leading and trailing stuff
-                            // x LIKE '%some string%' is same as CARDINALITY(SPLIT(x, 'some string', 2)) = 2
-                            // Split is most efficient as it uses string.indexOf java builtin so little memory/cpu overhead
-                            return buildEquals(
-                                    call(functionAndTypeManager, "CARDINALITY", BIGINT, call(functionAndTypeManager, "SPLIT", new ArrayType(VARCHAR), value, constant(slice.slice(1, matchBytesLength - 2), VARCHAR), constant(2L, BIGINT))),
-                                    constant(2L, BIGINT));
+                            // x LIKE '%some string%' is same as STRPOS(x, 'some string') != 0
+                            return buildNotEquals(
+                                    call(functionAndTypeManager, "STRPOS", BIGINT, value, constant(slice.slice(1, matchBytesLength - 2), VARCHAR)),
+                                    constant(0L, BIGINT));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Switch the SQL rewriting layer from `CARDINALITY(SPLIT(x, 'pattern', 2)) = 2` to `STRPOS(x, 'pattern') != 0` for `LIKE '%substring%'` patterns
- STRPOS uses Java's `String.indexOf()` internally which is highly optimized
- Performance testing on a big table (1.78T rows) shows significant CPU and memory savings

| Approach | CPU Time | Peak Memory |
|---|---|---|
| `LIKE '%12345%'` | 6d 3h 43m | 8.01 GB |
| `CARDINALITY(SPLIT(..., 2)) = 2` | 6d 0h 1m | 7.72 GB |
| `STRPOS(x, '12345') != 0` | 3d 3h 40m | 4.76 GB |

## Test plan
This is a functionally equivalent rewrite — the following test suites were run to verify neutral behavior:

- **`TestExpressionInterpreter`** (56 tests, all passed) — includes `testLike`, `testLikeOptimization`, and `testLikeNullOptimization` which directly exercise the `LIKE '%substring%'` pattern rewrite path in `SqlToRowExpressionTranslator`
- **`TestLikeFunctions`** (18 tests, all passed) — verifies core LIKE pattern matching behavior including substring patterns

Additionally, all three query approaches (LIKE, SPLIT, STRPOS) were validated on a big table (1.78T rows) and returned identical results.

## Release Notes
```
== RELEASE NOTES ==
General Changes
* Improve ``LIKE '%substring%'`` pattern matching by rewriting to ``STRPOS`` instead of ``CARDINALITY(SPLIT(...))``, improving CPU and memory efficiency. :pr:`27311`
```