### PR TITLE
fix(plugin-native-sidecar): Treat identical lambdas as distinct during expression optimization in NativeExpressionOptimizer

### DIFF
--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
@@ -49,7 +49,6 @@ import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALES
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Collections.newSetFromMap;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toMap;
 
 public class NativeExpressionOptimizer
         implements ExpressionOptimizer
@@ -78,20 +77,18 @@ public class NativeExpressionOptimizer
         List<RowExpression> expressionsToOptimize = collectingVisitor.getExpressionsToOptimize();
 
         // Create a map of original expressions and expressions with variables resolved to constants or row expressions.
-        Map<RowExpression, RowExpression> expressions = expressionsToOptimize.stream()
-                .collect(toMap(
-                        Function.identity(),
-                        rowExpression -> rowExpression.accept(
-                                new ReplacingVisitor(variable -> {
-                                    // Apply resolver
-                                    Object replacement = variableResolver.apply(variable);
-                                    // Preserve original variable if resolver returns null
-                                    return replacement != null
-                                            ? toRowExpression(variable.getSourceLocation(), replacement, variable.getType())
-                                            : variable;
-                                }),
-                                null),
-                        (a, b) -> a));
+        // An IdentityHashMap is needed here to treat identical lambdas as distinct.
+        Map<RowExpression, RowExpression> expressions = new IdentityHashMap<>();
+        for (RowExpression rowExpression : expressionsToOptimize) {
+            expressions.put(rowExpression, rowExpression.accept(
+                    new ReplacingVisitor(variable -> {
+                        Object replacement = variableResolver.apply(variable);
+                        return replacement != null
+                                ? toRowExpression(variable.getSourceLocation(), replacement, variable.getType())
+                                : variable;
+                    }),
+                    null));
+        }
         if (expressions.isEmpty()) {
             return expression;
         }
@@ -108,7 +105,7 @@ public class NativeExpressionOptimizer
         }
 
         // Optimize the expressions using the sidecar interpreter
-        Map<RowExpression, RowExpression> replacements = new HashMap<>();
+        Map<RowExpression, RowExpression> replacements = new IdentityHashMap<>();
         if (!expressions.isEmpty()) {
             // The native endpoint only supports optimizer levels OPTIMIZED or EVALUATED.
             // In the sidecar, SERIALIZABLE is effectively the same as OPTIMIZED,

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeSidecarExpressionInterpreter.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeSidecarExpressionInterpreter.java
@@ -27,10 +27,10 @@ import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
 import java.net.URI;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,6 +46,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.net.HttpHeaders.ACCEPT;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
 public class NativeSidecarExpressionInterpreter
@@ -97,11 +98,11 @@ public class NativeSidecarExpressionInterpreter
                 resolvedExpressions.size(),
                 rowExpressionOptimizationResults.size());
 
-        ImmutableMap.Builder<RowExpression, RowExpression> result = ImmutableMap.builder();
+        Map<RowExpression, RowExpression> result = new IdentityHashMap<>();
         for (int i = 0; i < rowExpressionOptimizationResults.size(); i++) {
             result.put(originalExpressions.get(i), rowExpressionOptimizationResults.get(i).getOptimizedExpression());
         }
-        return result.build();
+        return unmodifiableMap(result);
     }
 
     public List<RowExpressionOptimizationResult> optimize(ConnectorSession session, ExpressionOptimizer.Level level, List<RowExpression> resolvedExpressions)

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -746,6 +746,18 @@ public class TestNativeSidecarPlugin
         assertEquals(
                 computeActual(session, "SELECT JSON_FORMAT(CAST(CAST(ROW(1 + 2, CONCAT('a', 'b')) AS ROW(id BIGINT, name VARCHAR)) AS JSON))"),
                 computeActual("select '{\"id\":3,\"name\":\"ab\"}'"));
+
+        // equal lambda expressions in args
+        assertEquals(
+                computeActual(session, "SELECT REDUCE_AGG((x,y), (0,0), (x, y)->(x[1],y[1]), (x,y)->(x[1],y[1]))[1] FROM (SELECT 1 x, 2 y)"),
+                computeActual(session, "SELECT 0"));
+        assertEquals(
+                computeActual(session, "select reduce_agg(x, array[], (x, y)->array[element_at(x, 2)],  (x, y)->array[element_at(x, 2)]) from (select array[array[1]]) T(x)"),
+                computeActual(session, "select array[null]"));
+        assertQueryFails(session, "select reduce_agg(x, null, (x,y)->try(x+y), (x,y)->try(x+y)) from (select 1 union all select 10) T(x)", "(?s).*Initial value in reduce_agg cannot be null.*");
+        // here some reduce_aggs coalesce overflow/zero-divide errors to null in the input/combine functions
+        assertQueryFails(session, "select reduce_agg(x, 0, (x,y)->try(1/x+1/y), (x,y)->try(1/x+1/y)) from ((select 0) union all select 10.) T(x)", "!states->isNullAt\\(i\\) Lambda expressions in reduce_agg should not return null for non-null inputs", true);
+        assertQueryFails(session, "select reduce_agg(x, 0, (x, y)->try(x+y), (x, y)->try(x+y)) from (values 2817, 9223372036854775807) AS T(x)", "!states->isNullAt\\(i\\) Lambda expressions in reduce_agg should not return null for non-null inputs", true);
     }
 
     @Test


### PR DESCRIPTION
## Description
Fix incorrect deduplication of structurally identical lambda expressions during optimization.

## Motivation and Context
Fixes: https://github.com/prestodb/presto/issues/27314

## Impact
No user impact

## Test Plan
CI, Unit tests
## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Treat logically identical row expressions as distinct when optimizing via the native sidecar to avoid incorrect sharing of results.

Bug Fixes:
- Ensure expression optimization maps in the native sidecar use identity-based keys so identical lambda expressions in aggregates are not conflated.

Tests:
- Add regression queries around REDUCE_AGG with equal lambda arguments to verify correct optimization behavior and expected failure modes.

## Summary by Sourcery

Fix incorrect deduplication of structurally identical row expressions in the native sidecar optimizer by switching to identity-based maps and add regression coverage for lambda-heavy REDUCE_AGG cases.

Bug Fixes:
- Treat structurally identical lambda and row expressions as distinct when building and applying native sidecar optimization maps to avoid conflating separate expressions.

Tests:
- Extend native sidecar plugin tests with queries exercising REDUCE_AGG calls that use equal lambda arguments, including expected success and failure modes.