### PR TITLE
docs(plugin-iceberg): Supplement documentation for transaction support

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -1936,11 +1936,37 @@ to a single Iceberg table. To run transaction statements, use
 The Iceberg connector provides snapshot isolation at ``REPEATABLE READ`` level.
 This also satisfies ``READ COMMITTED`` and ``READ UNCOMMITTED``, so these
 isolation levels are supported as well. For snapshot semantics, use
-``REPEATABLE READ``::
+``REPEATABLE READ``.
+
+Within a transaction, reads can access multiple tables, while write operations are
+restricted to a single Iceberg table. All operations execute under snapshot isolation.
+The transaction therefore behaves as a **multi-table read, single-table write** transaction::
 
     START TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+    INSERT INTO iceberg.default.test_table
+        SELECT id, status
+        FROM iceberg.source.source_table1
+        WHERE status = 'pending';
+    INSERT INTO iceberg.default.test_table
+        SELECT * FROM iceberg.source.source_table2;
     INSERT INTO iceberg.default.test_table (id, status) VALUES (1, 'pending');
+    UPDATE iceberg.default.test_table
+        SET status = 'committed'
+        WHERE id < 100 and status = 'pending';
+    COMMIT;
+
+Statements executed within the same transaction follow **read-your-writes**
+semantics. This behavior is important for standard SQL interactive transactions.
+Data modifications performed earlier in the transaction are visible to subsequent
+statements before the transaction is committed::
+
+    START TRANSACTION;
+    INSERT INTO iceberg.default.test_table (id, status) VALUES (1, 'pending'), (2, 'pending');
     UPDATE iceberg.default.test_table SET status = 'committed' WHERE id = 1;
+    SELECT * FROM iceberg.default.test_table;   -- (1, 'committed'), (2, 'pending')
+
+    DELETE FROM iceberg.default.test_table WHERE status = 'pending';
+    SELECT * FROM iceberg.default.test_table;   -- (1, 'committed')
     COMMIT;
 
 Limitations:


### PR DESCRIPTION
## Description

This PR supplements the documentation for Iceberg transaction support, adding descriptions for the following two features:

 - ``multi-table read, single-table write`` capability under snapshot isolation
 - ``read-your-writes`` visibility semantics in uncommitted transactions

## Motivation and Context

Add more details about Iceberg transaction features

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update Iceberg connector documentation to describe additional transaction semantics and capabilities.

Documentation:
- Document snapshot isolation support for multi-table reads with single-table writes in Iceberg transactions.
- Describe read-your-writes visibility semantics for uncommitted Iceberg transactions.