### PR TITLE
chore(deps): Upgrade zookeeper version from 3.9.4 to 3.9.5 address the CVE-2026-24281 and CVE-2026-24308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2360,7 +2360,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.9.4</version>
+                <version>3.9.5</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>jline</artifactId>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -91,8 +91,6 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <scope>runtime</scope>
-            <!-- This is the version used by kafka tranitively -->
-            <version>3.8.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
## Description
Upgraded zookeeper version to 3.9.5 to resolve the CVE-2026-24281 and CVE-2026-24308

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
Regression test suite report for Kafka connector

<img width="3456" height="1396" alt="image" src="https://github.com/user-attachments/assets/7f0c3a91-d44e-42ed-9c36-b08385659e6b" />

pinot connector

<img width="3456" height="1186" alt="image" src="https://github.com/user-attachments/assets/120492ba-b6f4-4a11-9d16-370add742845" />


WhitesSource Security check report

<img width="530" height="313" alt="Screenshot 2026-03-13 at 1 10 27 PM" src="https://github.com/user-attachments/assets/16983e5b-e4f0-4997-9bfa-1b7e6e1c4c88" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade zookeeper to version 3.9.5 in response to `CVE-2026-24281 <https://github.com/advisories/GHSA-7xrh-hqfc-g7qr>`,`CVE-2026-24308 <https://github.com/advisories/GHSA-crhr-qqj8-rpxc>`
```

