### PR TITLE
fix(optimizer): Fix PlanRemoteProjections to keep JsonPath arguments inline for local functions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.REMOTE;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.UNKNOWN;
 import static com.facebook.presto.sql.planner.plan.Patterns.project;
+import static com.facebook.presto.type.JsonPathType.JSON_PATH;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -381,6 +382,12 @@ public class PlanRemoteProjections
                 else {
                     List<ProjectionContext> argumentProjection = argument.accept(this, null);
                     if (argumentProjection.isEmpty()) {
+                        if (local && argument.getType().equals(JSON_PATH)) {
+                            // JsonPath type is not serializable and cannot be an output of a ProjectNode.
+                            // Keep it inline when the parent function is local.
+                            newArguments.add(argument);
+                            continue;
+                        }
                         VariableReferenceExpression variable = variableAllocator.newVariable(argument);
                         argumentProjection = ImmutableList.of(new ProjectionContext(ImmutableMap.of(variable, argument), false));
                     }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
@@ -55,7 +55,9 @@ import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTre
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 import static com.facebook.presto.sql.planner.iterative.rule.PlanRemoteProjections.ProjectionContext;
+import static com.facebook.presto.type.JsonPathType.JSON_PATH;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 public class TestPlanRemoteProjections
 {
@@ -186,6 +188,24 @@ public class TestPlanRemoteProjections
                 .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
         assertEquals(rewritten.size(), 4);
         assertEquals(rewritten.get(3).getProjections().size(), 5);
+    }
+
+    @Test
+    void testJsonPathArgumentKeptInline()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), planBuilder.rowExpression("json_extract_scalar(CAST(unittest.memory.remote_foo() AS VARCHAR), '$.key')"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        assertEquals(rewritten.size(), 2);
+        // Verify no projection context extracts a JsonPath-typed variable
+        for (ProjectionContext context : rewritten) {
+            context.getProjections().keySet().forEach(variable ->
+                    assertFalse(variable.getType().equals(JSON_PATH),
+                            "JsonPath type should not be extracted as a ProjectNode output"));
+        }
     }
 
     @Test


### PR DESCRIPTION
  ## Description                                                                                                                                                                                                   
                                                                                                                                                                                                                   
  JsonPath type is not serializable (its `createBlockBuilder` throws). When                                                                                                                                        
  `PlanRemoteProjections` processes a local function that has a JsonPath-typed                                                                                                                                     
  argument (e.g., `json_extract_scalar(remote_func(), '$.key')`), it previously                                                                                                                                    
  extracted the JsonPath argument into a separate ProjectNode output variable.                                                                                                                                     
  This caused a runtime failure when the engine tried to materialize the                                                                                                                                           
  JsonPath-typed block.                                                                                                                                                                                            
                                                                                                                                                                                                                   
  The fix keeps JsonPath-typed arguments inline within the local function call                                                                                                                                     
  when `argumentProjection` is empty (i.e., the argument is a simple leaf                                                                                                                                          
  expression that doesn't need further decomposition). This mirrors the existing                                                                                                                                   
  behavior for ConstantExpression arguments.                                                                                                                                                                       
                                                                                                                                                                                                                   
  ## Motivation and Context                                                                                                                                                                                        

  Remote function calls involving `json_extract_scalar` with JsonPath arguments
  would fail at runtime because JsonPath type cannot be serialized into a block.

  ## Impact

  No public API changes. Fixes runtime failures for queries using
  `json_extract_scalar` (or similar JsonPath-consuming functions) on results of
  remote functions.

  ## Test Plan

  Added `testJsonPathArgumentKeptInline` in `TestPlanRemoteProjections` that
  verifies `json_extract_scalar(CAST(remote_foo() AS VARCHAR), '$.key')` is
  rewritten without extracting any JsonPath-typed variable.

  ## Contributor checklist

  - [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code
  style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
  - [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
  - [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
  - [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
  - [x] Adequate tests were added if applicable.
  - [ ] CI passed.
  - [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

  ## Release Notes

```
== NO RELEASE NOTE == 
```

## Summary by Sourcery

Adjust PlanRemoteProjections handling of JsonPath-typed arguments for local functions to avoid creating non-serializable project outputs and add coverage for this behavior.

Bug Fixes:
- Prevent JsonPath-typed arguments to local functions from being extracted into separate ProjectNode outputs, avoiding runtime failures when materializing JsonPath blocks.

Tests:
- Add a planner rule test ensuring JsonPath-typed arguments to local functions are kept inline and never projected as JsonPath-typed variables.