### PR TITLE
refactor: Migrate to folly::available_concurrency

### DIFF
--- a/presto-native-execution/presto_cpp/main/PrestoServer.cpp
+++ b/presto-native-execution/presto_cpp/main/PrestoServer.cpp
@@ -931,7 +931,7 @@ class BatchThreadFactory : public folly::NamedThreadFactory {
 #endif
 
 void PrestoServer::initializeThreadPools() {
-  const auto hwConcurrency = folly::hardware_concurrency();
+  const auto hwConcurrency = folly::available_concurrency();
   auto* systemConfig = SystemConfig::instance();
 
   const auto numDriverCpuThreads = std::max<size_t>(
@@ -975,7 +975,7 @@ void PrestoServer::initializeThreadPools() {
   }
   const auto numExchangeHttpClientIoThreads = std::max<size_t>(
       systemConfig->exchangeHttpClientNumIoThreadsHwMultiplier() *
-          folly::hardware_concurrency(),
+          folly::available_concurrency(),
       1);
   exchangeHttpIoExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
       numExchangeHttpClientIoThreads,
@@ -995,7 +995,7 @@ void PrestoServer::initializeThreadPools() {
 
   const auto numExchangeHttpClientCpuThreads = std::max<size_t>(
       systemConfig->exchangeHttpClientNumCpuThreadsHwMultiplier() *
-          folly::hardware_concurrency(),
+          folly::available_concurrency(),
       1);
 
   exchangeHttpCpuExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
@@ -1367,7 +1367,7 @@ std::vector<std::string> PrestoServer::registerVeloxConnectors(
 
   const auto numConnectorCpuThreads = std::max<size_t>(
       SystemConfig::instance()->connectorNumCpuThreadsHwMultiplier() *
-          folly::hardware_concurrency(),
+          folly::available_concurrency(),
       0);
   if (numConnectorCpuThreads > 0) {
     connectorCpuExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
@@ -1381,7 +1381,7 @@ std::vector<std::string> PrestoServer::registerVeloxConnectors(
 
   const auto numConnectorIoThreads = std::max<size_t>(
       SystemConfig::instance()->connectorNumIoThreadsHwMultiplier() *
-          folly::hardware_concurrency(),
+          folly::available_concurrency(),
       0);
   if (numConnectorIoThreads > 0) {
     connectorIoExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
@@ -1707,7 +1707,7 @@ void PrestoServer::checkOverload() {
     memOverloaded_ = memOverloaded;
   }
 
-  static const auto hwConcurrency = folly::hardware_concurrency();
+  static const auto hwConcurrency = folly::available_concurrency();
   const auto overloadedThresholdCpuPct =
       systemConfig->workerOverloadedThresholdCpuPct();
   const auto overloadedThresholdQueuedDrivers = hwConcurrency *
@@ -1902,7 +1902,7 @@ protocol::NodeStatus PrestoServer::fetchNodeStatus() {
       address_,
       address_,
       **memoryInfo_.rlock(),
-      (int)folly::hardware_concurrency(),
+      (int)folly::available_concurrency(),
       cpuLoadPct,
       cpuLoadPct,
       pool_ ? pool_->usedBytes() : 0,

--- a/presto-native-execution/presto_cpp/main/common/Configs.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Configs.cpp
@@ -40,9 +40,9 @@ std::string bool2String(bool value) {
 }
 
 uint32_t hardwareConcurrency() {
-  const auto numLogicalCores = folly::hardware_concurrency();
-  // The spec says folly::hardware_concurrency() might return 0.
-  // But we depend on folly::hardware_concurrency() to create executors.
+  const auto numLogicalCores = folly::available_concurrency();
+  // The spec says folly::available_concurrency() might return 0.
+  // But we depend on folly::available_concurrency() to create executors.
   // Check to ensure numThreads is > 0.
   VELOX_CHECK_GT(numLogicalCores, 0);
   return numLogicalCores;

--- a/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
+++ b/presto-native-execution/presto_cpp/main/common/tests/ConfigTest.cpp
@@ -225,7 +225,7 @@ TEST_F(ConfigTest, optionalNodeConfigs) {
 TEST_F(ConfigTest, optionalSystemConfigsWithDefault) {
   SystemConfig config;
   init(config, {});
-  ASSERT_EQ(config.maxDriversPerTask(), folly::hardware_concurrency());
+  ASSERT_EQ(config.maxDriversPerTask(), folly::available_concurrency());
   init(config, {{std::string(SystemConfig::kMaxDriversPerTask), "1024"}});
   ASSERT_EQ(config.maxDriversPerTask(), 1024);
 }

--- a/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tests/ServerOperationTest.cpp
@@ -246,7 +246,7 @@ TEST_F(ServerOperationTest, systemConfigEndpoint) {
       {.target = ServerOperation::Target::kSystemConfig,
        .action = ServerOperation::Action::kGetProperty},
       &httpMessage);
-  EXPECT_EQ(std::stoi(getPropertyResponse), folly::hardware_concurrency());
+  EXPECT_EQ(std::stoi(getPropertyResponse), folly::available_concurrency());
 }
 
 TEST_F(ServerOperationTest, veloxQueryConfigEndpoint) {
@@ -270,7 +270,7 @@ TEST_F(ServerOperationTest, veloxQueryConfigEndpoint) {
       {.target = ServerOperation::Target::kVeloxQueryConfig,
        .action = ServerOperation::Action::kGetProperty},
       &httpMessage);
-  EXPECT_EQ(std::stoi(getPropertyResponse), folly::hardware_concurrency());
+  EXPECT_EQ(std::stoi(getPropertyResponse), folly::available_concurrency());
 
   // Setting a registered property returns a message with "velox query config"
   // wording (verifying the copy-paste bug fix from systemConfigOperation).

--- a/presto-native-execution/presto_cpp/main/tool/trace/tests/BroadcastWriteReplayerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tool/trace/tests/BroadcastWriteReplayerTest.cpp
@@ -308,7 +308,7 @@ class BroadcastWriteReplayerTest : public HiveConnectorTestBase {
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
     executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
-        folly::hardware_concurrency());
+        folly::available_concurrency());
     // Clear mock writers from any previous test
     clearMockWriters();
   }

--- a/presto-native-execution/presto_cpp/main/tool/trace/tests/PartitionAndSerializeReplayerTest.cpp
+++ b/presto-native-execution/presto_cpp/main/tool/trace/tests/PartitionAndSerializeReplayerTest.cpp
@@ -144,7 +144,7 @@ class PartitionAndSerializeReplayerTest : public HiveConnectorTestBase {
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
     executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
-        folly::hardware_concurrency());
+        folly::available_concurrency());
   }
 
   void TearDown() override {


### PR DESCRIPTION
Summary: The name `hardware_concurrency`, while parallel to `std::thread::hardware_concurrency`, may be misleading. Migrate to the name `available_concurrency`.

Differential Revision: D96480646

## Summary by Sourcery

Migrate Presto server concurrency configuration and related tests from folly::hardware_concurrency to folly::available_concurrency for determining core-based thread counts and limits.

Enhancements:
- Use folly::available_concurrency for sizing server thread pools, connector executors, and overload thresholds instead of folly::hardware_concurrency.

Tests:
- Update server and config tests to assert against folly::available_concurrency so they reflect the new concurrency source.

```
== NO RELEASE NOTE ==
```