### PR TITLE
misc: Add thrift package, allow non-sealed key types

### DIFF
--- a/presto-native-execution/presto_cpp/main/thrift/presto_native.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_native.thrift
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 
+package "facebook.com/presto/thrift"
+
 namespace cpp2 facebook.presto.thrift
 
 struct BroadcastFileFooter {

--- a/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift
@@ -15,6 +15,8 @@
 include "thrift/annotation/cpp.thrift"
 include "thrift/annotation/thrift.thrift"
 
+package "facebook.com/presto/thrift"
+
 namespace cpp2 facebook.presto.thrift
 
 enum TaskState {
@@ -235,6 +237,7 @@ struct TableWriterMergeInfo {
   2: double statisticsCpuTime;
 }
 struct DynamicFilterStats {
+  @thrift.AllowUnsafeNonSealedKeyType
   1: set<PlanNodeId> producerNodeIds;
 }
 struct DriverStats {
@@ -306,7 +309,9 @@ struct LongVariableConstraint {
 }
 struct TaskSource {
   1: PlanNodeId planNodeId;
+  @thrift.AllowUnsafeNonSealedKeyType
   2: set<ScheduledSplit> splits;
+  @thrift.AllowUnsafeNonSealedKeyType
   3: set<Lifespan> noMoreSplitsForLifespan;
   4: bool noMoreSplits;
 }
@@ -356,6 +361,7 @@ struct TaskStatus {
   3: i64 version;
   4: TaskState state;
   5: string selfUri;
+  @thrift.AllowUnsafeNonSealedKeyType
   6: set<Lifespan> completedDriverGroups;
   7: list<ExecutionFailureInfo> failures;
   8: i32 queuedPartitionedDrivers;
@@ -522,10 +528,12 @@ struct SessionRepresentation {
   16: ResourceEstimates resourceEstimates;
   17: i64 startTime;
   18: map<string, string> systemProperties;
+  @thrift.AllowUnsafeNonSealedKeyType
   19: map<ConnectorId, map<string, string>> catalogProperties;
   20: map<string, map<string, string>> unprocessedCatalogProperties;
   21: map<string, SelectedRole> roles;
   22: map<string, string> preparedStatements;
+  @thrift.AllowUnsafeNonSealedKeyType
   23: map<SqlFunctionId, SqlInvokedFunction> sessionFunctions;
 }
 struct SelectedRole {
@@ -561,6 +569,7 @@ struct OutputBuffers {
   1: BufferType type;
   2: i64 version;
   3: bool noMoreBufferIds;
+  @thrift.AllowUnsafeNonSealedKeyType
   4: map<OutputBufferId, i32> buffers;
 }
 struct CreateHandle {
@@ -583,7 +592,9 @@ struct ExecutionFailureInfo {
   1: string type;
   2: string message;
   @cpp.Ref{type = cpp.RefType.SharedMutable}
-  @thrift.DeprecatedUnvalidatedAnnotations{items = {"drift.recursive_reference": "true"}}
+  @thrift.DeprecatedUnvalidatedAnnotations{
+    items = {"drift.recursive_reference": "true"},
+  }
   3: optional ExecutionFailureInfo cause;
   4: list<ExecutionFailureInfo> suppressed;
   5: list<string> stack;
@@ -635,6 +646,7 @@ struct TaskInfo {
   2: TaskStatus taskStatus;
   3: i64 lastHeartbeatInMillis;
   4: OutputBufferInfo outputBuffers;
+  @thrift.AllowUnsafeNonSealedKeyType
   5: set<PlanNodeId> noMoreSplits;
   6: TaskStats stats;
   7: bool needsPlan;

--- a/presto-native-execution/presto_cpp/main/thrift/temp_presto_thrift.thrift
+++ b/presto-native-execution/presto_cpp/main/thrift/temp_presto_thrift.thrift
@@ -15,6 +15,8 @@
 include "thrift/annotation/cpp.thrift"
 include "thrift/annotation/thrift.thrift"
 
+package "facebook.com/presto/thrift"
+
 namespace cpp2 facebook.presto.thrift
 
 enum TaskState {
@@ -235,6 +237,7 @@ struct TableWriterMergeInfo {
   2: double statisticsCpuTime;
 }
 struct DynamicFilterStats {
+  @thrift.AllowUnsafeNonSealedKeyType
   1: set<PlanNodeId> producerNodeIds;
 }
 struct DriverStats {
@@ -306,7 +309,9 @@ struct LongVariableConstraint {
 }
 struct TaskSource {
   1: PlanNodeId planNodeId;
+  @thrift.AllowUnsafeNonSealedKeyType
   2: set<ScheduledSplit> splits;
+  @thrift.AllowUnsafeNonSealedKeyType
   3: set<Lifespan> noMoreSplitsForLifespan;
   4: bool noMoreSplits;
 }
@@ -356,6 +361,7 @@ struct TaskStatus {
   3: i64 version;
   4: TaskState state;
   5: string selfUri;
+  @thrift.AllowUnsafeNonSealedKeyType
   6: set<Lifespan> completedDriverGroups;
   7: list<ExecutionFailureInfo> failures;
   8: i32 queuedPartitionedDrivers;
@@ -522,10 +528,12 @@ struct SessionRepresentation {
   16: ResourceEstimates resourceEstimates;
   17: i64 startTime;
   18: map<string, string> systemProperties;
+  @thrift.AllowUnsafeNonSealedKeyType
   19: map<ConnectorId, map<string, string>> catalogProperties;
   20: map<string, map<string, string>> unprocessedCatalogProperties;
   21: map<string, SelectedRole> roles;
   22: map<string, string> preparedStatements;
+  @thrift.AllowUnsafeNonSealedKeyType
   23: map<SqlFunctionId, SqlInvokedFunction> sessionFunctions;
 }
 struct SelectedRole {
@@ -561,6 +569,7 @@ struct OutputBuffers {
   1: BufferType type;
   2: i64 version;
   3: bool noMoreBufferIds;
+  @thrift.AllowUnsafeNonSealedKeyType
   4: map<OutputBufferId, i32> buffers;
 }
 struct CreateHandle {
@@ -583,7 +592,9 @@ struct ExecutionFailureInfo {
   1: string type;
   2: string message;
   @cpp.Ref{type = cpp.RefType.SharedMutable}
-  @thrift.DeprecatedUnvalidatedAnnotations{items = {"drift.recursive_reference": "true"}}
+  @thrift.DeprecatedUnvalidatedAnnotations{
+    items = {"drift.recursive_reference": "true"},
+  }
   3: optional ExecutionFailureInfo cause;
   4: list<ExecutionFailureInfo> suppressed;
   5: list<string> stack;
@@ -635,6 +646,7 @@ struct TaskInfo {
   2: TaskStatus taskStatus;
   3: i64 lastHeartbeatInMillis;
   4: OutputBufferInfo outputBuffers;
+  @thrift.AllowUnsafeNonSealedKeyType
   5: set<PlanNodeId> noMoreSplits;
   6: TaskStats stats;
   7: bool needsPlan;


### PR DESCRIPTION
Summary:
Apply Thrift package to Thrift files:
- `fbcode/github/presto-trunk/presto-native-execution/presto_cpp/main/thrift/presto_native.thrift`
- `fbcode/github/presto-trunk/presto-native-execution/presto_cpp/main/thrift/presto_thrift.thrift`
- `fbcode/github/presto-trunk/presto-native-execution/presto_cpp/main/thrift/temp_presto_thrift.thrift`

This change was generated using the `thrift-package` tool. Any namespace changes are generated by the tool to ensure there are no changes in the namespaces for code-gen output, as the `package` is used to generate default namespaces.

Differential Revision: D96495136

## Summary by Sourcery

Add a Thrift package declaration to Presto native Thrift IDL files and update annotations to support unsafe non-sealed container key types without changing generated namespaces.

Enhancements:
- Declare the "facebook.com/presto/thrift" package in the Presto native Thrift schemas to standardize package-based namespace generation.
- Mark selected set and map fields with AllowUnsafeNonSealedKeyType to permit their existing container key types under stricter Thrift validation rules.
- Tidy DeprecatedUnvalidatedAnnotations formatting on ExecutionFailureInfo to comply with current Thrift annotation style expectations.