### PR TITLE
misc: Remove dead code in Iceberg connector

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -242,12 +242,6 @@ IcebergPrestoToVeloxConnector::toVeloxColumnHandle(
   //  constructor similar to how Hive Connector is handling for bucketing
   velox::type::fbhive::HiveTypeParser hiveTypeParser;
   auto type = stringToType(icebergColumn->type, typeParser);
-  velox::connector::hive::HiveColumnHandle::ColumnParseParameters
-      columnParseParameters;
-  if (type->isDate()) {
-    columnParseParameters.partitionDateValueFormat = velox::connector::hive::
-        HiveColumnHandle::ColumnParseParameters::kDaysSinceEpoch;
-  }
 
   return std::make_unique<velox::connector::hive::iceberg::IcebergColumnHandle>(
       icebergColumn->columnIdentity.name,


### PR DESCRIPTION
Summary: Remove unused `columnParseParameters` in `IcebergPrestoToVeloxConnector::toVeloxColumnHandle`. The variable was computed for date types but never passed to the `IcebergColumnHandle` constructor, which doesn't accept it — it already hardcodes `kDaysSinceEpoch` internally.

```
== NO RELEASE NOTE ==
```


