### PR TITLE
fix: Extract serde params from additionalTableParameters in CTAS

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
@@ -14,6 +14,9 @@
 
 #include "presto_cpp/main/connectors/HivePrestoToVeloxConnector.h"
 
+#include <string_view>
+#include <unordered_set>
+
 #include "presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h"
 #include "presto_cpp/main/types/PrestoToVeloxExpr.h"
 #include "presto_cpp/main/types/TypeParser.h"
@@ -30,6 +33,33 @@ namespace facebook::presto {
 using namespace velox;
 
 namespace {
+
+/// Extracts serde parameters from additionalTableParameters.
+/// Mirrors Java's HiveMetadata.extractSerdeParameters():
+/// fbcode/github/presto-facebook-trunk/presto-facebook-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+// TODO: Split additionalTableParameters into table vs serde params on
+// HiveOutputTableHandle to eliminate this. See matching TODO in
+// HiveMetadata.java.
+std::unordered_map<std::string, std::string> extractSerdeParameters(
+    const std::map<std::string, std::string>& tableParameters) {
+  static const std::unordered_set<std::string> kSerdeKeys = {
+      "field.delim",
+      "escape.delim",
+      "collection.delim",
+      "mapkey.delim",
+      "serialization.format",
+  };
+
+  std::unordered_map<std::string, std::string> serdeParameters;
+  for (const auto& [key, value] : tableParameters) {
+    static constexpr std::string_view kNimblePrefix{"nimble."};
+    if (kSerdeKeys.count(key) > 0 ||
+        key.compare(0, kNimblePrefix.size(), kNimblePrefix) == 0) {
+      serdeParameters[key] = value;
+    }
+  }
+  return serdeParameters;
+}
 
 connector::hive::LocationHandle::TableType toTableType(
     protocol::hive::TableType tableType) {
@@ -403,6 +433,9 @@ HivePrestoToVeloxConnector::toVeloxInsertTableHandle(
   bool isPartitioned{false};
   const auto inputColumns = toHiveColumns(
       hiveOutputTableHandle->inputColumns, typeParser, isPartitioned);
+  auto serdeParameters =
+      extractSerdeParameters(hiveOutputTableHandle->additionalTableParameters);
+
   return std::make_unique<velox::connector::hive::HiveInsertTableHandle>(
       inputColumns,
       toLocationHandle(hiveOutputTableHandle->locationHandle),
@@ -410,7 +443,8 @@ HivePrestoToVeloxConnector::toVeloxInsertTableHandle(
       toHiveBucketProperty(
           inputColumns, hiveOutputTableHandle->bucketProperty, typeParser),
       std::optional(
-          toFileCompressionKind(hiveOutputTableHandle->compressionCodec)));
+          toFileCompressionKind(hiveOutputTableHandle->compressionCodec)),
+      std::move(serdeParameters));
 }
 
 std::unique_ptr<velox::connector::ConnectorInsertTableHandle>

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -20,6 +20,7 @@
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 
@@ -292,4 +293,138 @@ TEST_F(PrestoToVeloxConnectorTest, icebergColumnHandleDeeplyNested) {
   EXPECT_EQ(icebergHandle->field().children[0].fieldId, 2);
   ASSERT_EQ(icebergHandle->field().children[0].children.size(), 1);
   EXPECT_EQ(icebergHandle->field().children[0].children[0].fieldId, 3);
+}
+
+TEST_F(PrestoToVeloxConnectorTest, ctasPassesTextfileSerdeParameters) {
+  auto hiveOutputTableHandle =
+      std::make_shared<protocol::hive::HiveOutputTableHandle>();
+  hiveOutputTableHandle->schemaName = "test_schema";
+  hiveOutputTableHandle->tableName = "test_table";
+  hiveOutputTableHandle->tableOwner = "owner";
+  hiveOutputTableHandle->actualStorageFormat =
+      protocol::hive::HiveStorageFormat::TEXTFILE;
+  hiveOutputTableHandle->tableStorageFormat =
+      protocol::hive::HiveStorageFormat::TEXTFILE;
+  hiveOutputTableHandle->partitionStorageFormat =
+      protocol::hive::HiveStorageFormat::TEXTFILE;
+  hiveOutputTableHandle->compressionCodec =
+      protocol::hive::HiveCompressionCodec::NONE;
+  hiveOutputTableHandle->locationHandle.targetPath = "/path/to/target";
+  hiveOutputTableHandle->locationHandle.writePath = "/path/to/write";
+  hiveOutputTableHandle->locationHandle.tableType =
+      protocol::hive::TableType::NEW;
+  hiveOutputTableHandle->additionalTableParameters = {
+      {"field.delim", "|"},
+      {"escape.delim", "\\"},
+      {"collection.delim", "$"},
+      {"mapkey.delim", "#"},
+      {"presto.version", "0.297"}};
+
+  protocol::OutputTableHandle outputHandle;
+  outputHandle.connectorId = "hive";
+  outputHandle.connectorHandle = hiveOutputTableHandle;
+
+  protocol::CreateHandle createHandle;
+  createHandle.handle = outputHandle;
+
+  HivePrestoToVeloxConnector hiveConnector("hive");
+  auto result =
+      hiveConnector.toVeloxInsertTableHandle(&createHandle, *typeParser_);
+  ASSERT_NE(result, nullptr);
+
+  auto* hiveInsert =
+      dynamic_cast<connector::hive::HiveInsertTableHandle*>(result.get());
+  ASSERT_NE(hiveInsert, nullptr);
+
+  const auto& serdeParams = hiveInsert->serdeParameters();
+  // Only serde keys should be extracted, not table-level keys like
+  // presto.version.
+  EXPECT_EQ(serdeParams.size(), 4);
+  EXPECT_EQ(serdeParams.at("field.delim"), "|");
+  EXPECT_EQ(serdeParams.at("escape.delim"), "\\");
+  EXPECT_EQ(serdeParams.at("collection.delim"), "$");
+  EXPECT_EQ(serdeParams.at("mapkey.delim"), "#");
+}
+
+TEST_F(PrestoToVeloxConnectorTest, ctasPassesNimbleSerdeParameters) {
+  auto hiveOutputTableHandle =
+      std::make_shared<protocol::hive::HiveOutputTableHandle>();
+  hiveOutputTableHandle->schemaName = "test_schema";
+  hiveOutputTableHandle->tableName = "test_table";
+  hiveOutputTableHandle->tableOwner = "owner";
+  hiveOutputTableHandle->actualStorageFormat =
+      protocol::hive::HiveStorageFormat::ALPHA;
+  hiveOutputTableHandle->tableStorageFormat =
+      protocol::hive::HiveStorageFormat::ALPHA;
+  hiveOutputTableHandle->partitionStorageFormat =
+      protocol::hive::HiveStorageFormat::ALPHA;
+  hiveOutputTableHandle->compressionCodec =
+      protocol::hive::HiveCompressionCodec::NONE;
+  hiveOutputTableHandle->locationHandle.targetPath = "/path/to/target";
+  hiveOutputTableHandle->locationHandle.writePath = "/path/to/write";
+  hiveOutputTableHandle->locationHandle.tableType =
+      protocol::hive::TableType::NEW;
+  hiveOutputTableHandle->additionalTableParameters = {
+      {"nimble.enable.vectorized.stats", "true"},
+      {"nimble.index.columns", "id"},
+      {"presto.version", "0.297"}};
+
+  protocol::OutputTableHandle outputHandle;
+  outputHandle.connectorId = "hive";
+  outputHandle.connectorHandle = hiveOutputTableHandle;
+
+  protocol::CreateHandle createHandle;
+  createHandle.handle = outputHandle;
+
+  HivePrestoToVeloxConnector hiveConnector("hive");
+  auto result =
+      hiveConnector.toVeloxInsertTableHandle(&createHandle, *typeParser_);
+  ASSERT_NE(result, nullptr);
+
+  auto* hiveInsert =
+      dynamic_cast<connector::hive::HiveInsertTableHandle*>(result.get());
+  ASSERT_NE(hiveInsert, nullptr);
+
+  const auto& serdeParams = hiveInsert->serdeParameters();
+  EXPECT_EQ(serdeParams.size(), 2);
+  EXPECT_EQ(serdeParams.at("nimble.enable.vectorized.stats"), "true");
+  EXPECT_EQ(serdeParams.at("nimble.index.columns"), "id");
+}
+
+TEST_F(PrestoToVeloxConnectorTest, ctasEmptySerdeParameters) {
+  auto hiveOutputTableHandle =
+      std::make_shared<protocol::hive::HiveOutputTableHandle>();
+  hiveOutputTableHandle->schemaName = "test_schema";
+  hiveOutputTableHandle->tableName = "test_table";
+  hiveOutputTableHandle->tableOwner = "owner";
+  hiveOutputTableHandle->actualStorageFormat =
+      protocol::hive::HiveStorageFormat::DWRF;
+  hiveOutputTableHandle->tableStorageFormat =
+      protocol::hive::HiveStorageFormat::DWRF;
+  hiveOutputTableHandle->partitionStorageFormat =
+      protocol::hive::HiveStorageFormat::DWRF;
+  hiveOutputTableHandle->compressionCodec =
+      protocol::hive::HiveCompressionCodec::NONE;
+  hiveOutputTableHandle->locationHandle.targetPath = "/path/to/target";
+  hiveOutputTableHandle->locationHandle.writePath = "/path/to/write";
+  hiveOutputTableHandle->locationHandle.tableType =
+      protocol::hive::TableType::NEW;
+
+  protocol::OutputTableHandle outputHandle;
+  outputHandle.connectorId = "hive";
+  outputHandle.connectorHandle = hiveOutputTableHandle;
+
+  protocol::CreateHandle createHandle;
+  createHandle.handle = outputHandle;
+
+  HivePrestoToVeloxConnector hiveConnector("hive");
+  auto result =
+      hiveConnector.toVeloxInsertTableHandle(&createHandle, *typeParser_);
+  ASSERT_NE(result, nullptr);
+
+  auto* hiveInsert =
+      dynamic_cast<connector::hive::HiveInsertTableHandle*>(result.get());
+  ASSERT_NE(hiveInsert, nullptr);
+
+  EXPECT_TRUE(hiveInsert->serdeParameters().empty());
 }


### PR DESCRIPTION
Summary:
CTAS on Prestissimo silently drops textfile delimiters and nimble config
because the C++ CreateHandle path never reads additionalTableParameters.

Fix: Add extractSerdeParameters() that extracts serde keys (field.delim,
escape.delim, etc. and nimble.*) from additionalTableParameters and
passes them to HiveInsertTableHandle. No protocol changes needed.

Differential Revision: D96672056

## Summary by Sourcery

Ensure Hive CTAS insert handles receive the correct serde parameters from Presto output table handles.

Bug Fixes:
- Preserve textfile delimiter and Nimble serde configuration when creating tables via CTAS by propagating relevant serde parameters into HiveInsertTableHandle.

Enhancements:
- Add extraction of serde-related parameters from additional table properties, including Nimble-prefixed keys, when building Hive insert table handles.

Tests:
- Add connector tests covering serde parameter extraction for textfile CTAS, Nimble serde parameters, and the case with no serde parameters.