### PR TITLE
chore(deps): Upgrade dep.okhttp.version to 5.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
         <dep.aws-sdk.version>1.12.782</dep.aws-sdk.version>
-        <dep.okhttp.version>4.12.0</dep.okhttp.version>
+        <dep.okhttp.version>5.3.2</dep.okhttp.version>
         <dep.jdbi3.version>3.49.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>${dep.airlift.version}</dep.drift.version>
@@ -271,7 +271,7 @@
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio-jvm</artifactId>
-                <version>3.9.1</version>
+                <version>3.16.4</version>
             </dependency>
 
             <!-- pull up to the version used in okio-jvm to avoid conlict with okhttp-* -->
@@ -1633,7 +1633,7 @@
 
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
+                <artifactId>okhttp-jvm</artifactId>
                 <version>${dep.okhttp.version}</version>
             </dependency>
 
@@ -1645,7 +1645,7 @@
 
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>mockwebserver</artifactId>
+                <artifactId>mockwebserver3</artifactId>
                 <version>${dep.okhttp.version}</version>
             </dependency>
 

--- a/presto-benchmark-driver/pom.xml
+++ b/presto-benchmark-driver/pom.xml
@@ -76,7 +76,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <!-- for testing -->

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -100,7 +100,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>
@@ -123,7 +123,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
+            <artifactId>mockwebserver3</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
@@ -23,9 +23,9 @@ import com.facebook.presto.common.type.BigintType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import okhttp3.Headers;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
@@ -107,9 +107,19 @@ public abstract class AbstractCliTest
 
     protected MockResponse createMockResponse()
     {
-        return new MockResponse()
+        return new MockResponse.Builder()
                 .addHeader(CONTENT_TYPE, "application/json")
-                .setBody(QUERY_RESULTS_JSON_CODEC.toJson(createMockQueryResults()));
+                .body(QUERY_RESULTS_JSON_CODEC.toJson(createMockQueryResults()))
+                .build();
+    }
+
+    protected MockResponse createMockResponseWithHeader(String headerName, String headerValue)
+    {
+        return new MockResponse.Builder()
+                .addHeader(CONTENT_TYPE, "application/json")
+                .addHeader(headerName, headerValue)
+                .body(QUERY_RESULTS_JSON_CODEC.toJson(createMockQueryResults()))
+                .build();
     }
 
     protected void executeQueries(List<String> queries)

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestInsecureQueryRunner.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestInsecureQueryRunner.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.cli;
 
 import com.google.common.collect.ImmutableList;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockWebServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -48,7 +48,7 @@ public class TestInsecureQueryRunner
     {
         server = new MockWebServer();
         SSLContext sslContext = buildTestSslContext();
-        server.useHttps(sslContext.getSocketFactory(), false);
+        server.useHttps(sslContext.getSocketFactory());
         server.start();
     }
 
@@ -68,7 +68,7 @@ public class TestInsecureQueryRunner
         executeQueries(createQueryRunner(createMockClientSession(), true),
                 ImmutableList.of("query with insecure mode;"));
         try {
-            assertEquals(server.takeRequest(1, SECONDS).getPath(), "/v1/statement");
+            assertEquals(server.takeRequest(1, SECONDS).getUrl().encodedPath(), "/v1/statement");
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestQueryRunner.java
@@ -15,7 +15,7 @@ package com.facebook.presto.cli;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import okhttp3.mockwebserver.MockResponse;
+import mockwebserver3.MockResponse;
 import org.testng.annotations.Test;
 
 import static com.google.common.net.HttpHeaders.COOKIE;
@@ -30,10 +30,11 @@ public class TestQueryRunner
     public void testCookie()
             throws InterruptedException
     {
-        server.enqueue(new MockResponse()
-                .setResponseCode(307)
+        server.enqueue(new MockResponse.Builder()
+                .code(307)
                 .addHeader(LOCATION, server.url("/v1/statement"))
-                .addHeader(SET_COOKIE, "a=apple"));
+                .addHeader(SET_COOKIE, "a=apple")
+                .build());
         server.enqueue(createMockResponse());
         server.enqueue(createMockResponse());
 

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestTemporaryFunctions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestTemporaryFunctions.java
@@ -29,12 +29,12 @@ public class TestTemporaryFunctions
     public void testAddAndDropTempFunctions()
             throws InterruptedException
     {
-        server.enqueue(createMockResponse().addHeader(PRESTO_ADDED_SESSION_FUNCTION, "foo=foofunction"));
-        server.enqueue(createMockResponse().addHeader(PRESTO_ADDED_SESSION_FUNCTION, "bar=barfunction"));
+        server.enqueue(createMockResponseWithHeader(PRESTO_ADDED_SESSION_FUNCTION, "foo=foofunction"));
+        server.enqueue(createMockResponseWithHeader(PRESTO_ADDED_SESSION_FUNCTION, "bar=barfunction"));
         server.enqueue(createMockResponse());
-        server.enqueue(createMockResponse().addHeader(PRESTO_REMOVED_SESSION_FUNCTION, "foo"));
+        server.enqueue(createMockResponseWithHeader(PRESTO_REMOVED_SESSION_FUNCTION, "foo"));
         server.enqueue(createMockResponse());
-        server.enqueue(createMockResponse().addHeader(PRESTO_REMOVED_SESSION_FUNCTION, "bar"));
+        server.enqueue(createMockResponseWithHeader(PRESTO_REMOVED_SESSION_FUNCTION, "bar"));
         server.enqueue(createMockResponse());
 
         executeQueries(ImmutableList.of(

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -86,7 +86,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>
@@ -165,7 +165,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
+            <artifactId>mockwebserver3</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-client/src/test/java/com/facebook/presto/client/auth/external/TestHttpTokenPoller.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/auth/external/TestHttpTokenPoller.java
@@ -13,11 +13,11 @@
  */
 package com.facebook.presto.client.auth.external;
 
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -103,7 +103,7 @@ public class TestHttpTokenPoller
     @Test
     public void testBadHttpStatus()
     {
-        server.enqueue(new MockResponse().setResponseCode(HTTP_GONE));
+        server.enqueue(new MockResponse.Builder().code(HTTP_GONE).build());
 
         TokenPollResult result = tokenPoller.pollForToken(tokenUri(), ONE_SECOND);
 
@@ -170,7 +170,7 @@ public class TestHttpTokenPoller
 
         RecordedRequest request = server.takeRequest(1, MILLISECONDS);
         assertThat(request.getMethod()).isEqualTo("DELETE");
-        assertThat(request.getRequestUrl()).isEqualTo(HttpUrl.get(tokenUri()));
+        assertThat(request.getUrl()).isEqualTo(HttpUrl.get(tokenUri()));
     }
 
     @Test
@@ -210,15 +210,17 @@ public class TestHttpTokenPoller
 
     private static MockResponse statusAndBody(int status, String body)
     {
-        return new MockResponse()
-                .setResponseCode(status)
-                .addHeader(CONTENT_TYPE, JSON_UTF_8)
-                .setBody(body);
+        return new MockResponse.Builder()
+                .code(status)
+                .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .body(body)
+                .build();
     }
 
     private static MockResponse status(int status)
     {
-        return new MockResponse()
-                .setResponseCode(status);
+        return new MockResponse.Builder()
+                .code(status)
+                .build();
     }
 }

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -54,7 +54,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>
@@ -245,7 +245,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
+            <artifactId>mockwebserver3</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -19,8 +19,8 @@ import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.client.StatementStats;
 import com.facebook.presto.common.type.BigintType;
 import com.google.common.collect.ImmutableList;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -109,9 +109,10 @@ public class TestProgressMonitor
             throws SQLException
     {
         for (String result : createResults()) {
-            server.enqueue(new MockResponse()
+            server.enqueue(new MockResponse.Builder()
                     .addHeader(CONTENT_TYPE, "application/json")
-                    .setBody(result));
+                    .body(result)
+                    .build());
         }
 
         try (Connection connection = createConnection()) {

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestQueryExecutor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestQueryExecutor.java
@@ -16,9 +16,9 @@ package com.facebook.presto.jdbc;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.units.Duration;
 import com.facebook.presto.client.ServerInfo;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -59,9 +59,10 @@ public class TestQueryExecutor
     {
         ServerInfo expected = new ServerInfo(UNKNOWN, "test", true, false, Optional.of(Duration.valueOf("2m")));
 
-        server.enqueue(new MockResponse()
+        server.enqueue(new MockResponse.Builder()
                 .addHeader(CONTENT_TYPE, "application/json")
-                .setBody(SERVER_INFO_CODEC.toJson(expected)));
+                .body(SERVER_INFO_CODEC.toJson(expected))
+                .build());
 
         QueryExecutor executor = new QueryExecutor(new OkHttpClient());
 
@@ -70,6 +71,6 @@ public class TestQueryExecutor
         assertEquals(actual.getUptime(), Optional.of(Duration.valueOf("2m")));
 
         assertEquals(server.getRequestCount(), 1);
-        assertEquals(server.takeRequest().getPath(), "/v1/info");
+        assertEquals(server.takeRequest().getUrl().encodedPath(), "/v1/info");
     }
 }

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -458,7 +458,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
+            <artifactId>mockwebserver3</artifactId>
             <scope>test</scope>
             <exclusions>
                 <!-- conflicts with org.hamcrest:hamcrest:3.0 from jaxrs-testing -->
@@ -520,11 +520,11 @@
                         <ignoredNonTestScopedDependency>com.facebook.airlift.drift:drift-protocol</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>io.netty:netty-buffer</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>javax.inject:javax.inject</ignoredNonTestScopedDependency>
-                        <ignoredNonTestScopedDependency>com.squareup.okhttp3:okhttp</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>com.squareup.okhttp3:okhttp-jvm</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>com.squareup.okhttp3:okhttp-urlconnection</ignoredNonTestScopedDependency>
                     </ignoredNonTestScopedDependencies>
                     <ignoredUsedUndeclaredDependencies>
-                        <ignoredUsedUndeclaredDependency>com.squareup.okhttp3:okhttp</ignoredUsedUndeclaredDependency>
+                        <ignoredUsedUndeclaredDependency>com.squareup.okhttp3:okhttp-jvm</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>com.squareup.okhttp3:okhttp-urlconnection</ignoredUsedUndeclaredDependency>
                     </ignoredUsedUndeclaredDependencies>
                 </configuration>

--- a/presto-plan-checker-router-plugin/pom.xml
+++ b/presto-plan-checker-router-plugin/pom.xml
@@ -93,7 +93,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-prometheus/pom.xml
+++ b/presto-prometheus/pom.xml
@@ -72,7 +72,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-router/pom.xml
+++ b/presto-router/pom.xml
@@ -218,7 +218,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
+            <artifactId>mockwebserver3</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -234,4 +234,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredUsedUndeclaredDependencies>
+                        <ignoredUsedUndeclaredDependency>com.squareup.okhttp3:okhttp-jvm</ignoredUsedUndeclaredDependency>
+                    </ignoredUsedUndeclaredDependencies>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>com.squareup.okhttp3:okhttp-jvm</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-router/src/test/java/com/facebook/presto/router/TestPredictorManager.java
+++ b/presto-router/src/test/java/com/facebook/presto/router/TestPredictorManager.java
@@ -28,10 +28,10 @@ import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Injector;
-import okhttp3.mockwebserver.Dispatcher;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.Dispatcher;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -147,17 +147,19 @@ public class TestPredictorManager
             @Override
             public MockResponse dispatch(RecordedRequest request)
             {
-                switch (request.getPath()) {
+                switch (request.getUrl().encodedPath()) {
                     case "/v1/cpu":
-                        return new MockResponse()
+                        return new MockResponse.Builder()
                                 .addHeader(CONTENT_TYPE, "application/json")
-                                .setBody("{\"cpu_pred_label\": 2, \"cpu_pred_str\": \"1h - 5h\"}");
+                                .body("{\"cpu_pred_label\": 2, \"cpu_pred_str\": \"1h - 5h\"}")
+                                .build();
                     case "/v1/memory":
-                        return new MockResponse()
+                        return new MockResponse.Builder()
                                 .addHeader(CONTENT_TYPE, "application/json")
-                                .setBody("{\"memory_pred_label\": 2, \"memory_pred_str\": \"> 1TB\"}");
+                                .body("{\"memory_pred_label\": 2, \"memory_pred_str\": \"> 1TB\"}")
+                                .build();
                 }
-                return new MockResponse().setResponseCode(404);
+                return new MockResponse.Builder().code(404).build();
             }
         };
 

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -14,8 +14,8 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <dep.jetty.version>9.4.55.v20240627</dep.jetty.version>
-        <dep.okhttp.version>4.12.0</dep.okhttp.version>
-        <dep.okio-jvm.version>3.9.1</dep.okio-jvm.version>
+        <dep.okhttp.version>5.3.2</dep.okhttp.version>
+        <dep.okio-jvm.version>3.16.4</dep.okio-jvm.version>
     </properties>
 
     <dependencyManagement>
@@ -164,7 +164,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
             <version>${dep.okhttp.version}</version>
         </dependency>
 
@@ -458,11 +458,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
+                    <ignoredUsedUndeclaredDependencies>
+                        <ignoredUsedUndeclaredDependency>org.jetbrains.kotlin:kotlin-stdlib</ignoredUsedUndeclaredDependency>
+                    </ignoredUsedUndeclaredDependencies>
                     <ignoredNonTestScopedDependencies>
                         <ignoredNonTestScopedDependency>com.facebook.presto:presto-expressions</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>it.unimi.dsi:fastutil</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>com.facebook.airlift:log-manager</ignoredNonTestScopedDependency>
                         <ignoredNonTestScopedDependency>com.squareup.okio:okio-jvm</ignoredNonTestScopedDependency>
+                        <ignoredNonTestScopedDependency>org.jetbrains.kotlin:kotlin-stdlib</ignoredNonTestScopedDependency>
                     </ignoredNonTestScopedDependencies>
                     <ignoredUnusedDeclaredDependencies>
                         <ignoredUnusedDeclaredDependency>javax.ws.rs:javax.ws.rs-api</ignoredUnusedDeclaredDependency>

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/http/TestPrestoSparkHttpClient.java
@@ -1119,6 +1119,33 @@ public class TestPrestoSparkHttpClient
         {
             return Timeout.NONE;
         }
+
+        @Override
+        public <T> T tag(Class<? extends T> type)
+        {
+            return request.tag(type);
+        }
+
+        @Override
+        public <T> T tag(Class<T> type, kotlin.jvm.functions.Function0<? extends T> defaultValue)
+        {
+            T tag = request.tag(type);
+            return tag != null ? tag : defaultValue.invoke();
+        }
+
+        @Override
+        public <T> T tag(kotlin.reflect.KClass<T> type)
+        {
+            // Convert KClass to Java Class and delegate to the Class-based method
+            return tag(kotlin.jvm.JvmClassMappingKt.getJavaClass(type));
+        }
+
+        @Override
+        public <T> T tag(kotlin.reflect.KClass<T> type, kotlin.jvm.functions.Function0<? extends T> defaultValue)
+        {
+            // Convert KClass to Java Class and delegate to the Class-based method
+            return tag(kotlin.jvm.JvmClassMappingKt.getJavaClass(type), defaultValue);
+        }
     }
 
     /**

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -174,7 +174,7 @@
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Description
Upgrade dep.okhttp.version to 5.3.2

Upgraded jars:
com.squareup.okhttp3:okhttp-jvm:jar:5.3
com.squareup.okhttp3:okhttp-urlconnection:jar:5.3
com.squareup.okhttp3:mockwebserver3:jar:5.3
com.squareup.okio:okio-jvm:3.16.4jar

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.



```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Upgrade OkHttp and Okio dependencies to the latest 5.3.2/3.16.4 stack and adjust usage across modules and tests to the new APIs.

Enhancements:
- Switch all modules from okhttp to okhttp-jvm and from mockwebserver to mockwebserver3, aligning with the new OkHttp 5 artifact layout.
- Update OkHttp-based tests to use the new MockResponse.Builder API, URL accessors, and HTTPS configuration required by OkHttp 5.
- Add okhttp-jvm to dependency management and update Maven dependency plugin ignore lists for new okhttp and Kotlin stdlib dependencies.

Build:
- Bump global OkHttp version to 5.3.2 and Okio JVM version to 3.16.4 in parent and spark-base POMs.
- Introduce explicit okhttp-jvm dependency and mockwebserver3 test dependency in relevant modules and dependencyManagement sections.

## Summary by Sourcery

Upgrade OkHttp/Okio dependencies to the OkHttp 5.3.2 stack and align affected modules and tests with the new client and mock server APIs.

Enhancements:
- Migrate all modules from the legacy okhttp artifact to okhttp-jvm and from mockwebserver to mockwebserver3, including associated URL and HTTPS usage changes in tests.
- Add helper methods and tag-handling overrides in tests to support the updated OkHttp 5 request tagging behavior and Kotlin interop.
- Adjust HTTP test utilities to use the new MockResponse.Builder API and updated request URL accessors required by OkHttp 5.

Build:
- Bump global OkHttp version to 5.3.2 and Okio JVM version to 3.16.4 in the parent and spark-base POMs.
- Update Maven dependency management and maven-dependency-plugin configuration to reference okhttp-jvm/mockwebserver3 and to ignore new OkHttp/Kotlin stdlib dependencies where appropriate.