### PR TITLE
feat(plugin-iceberg): Add min max stats for varchar/char column and display as low and high values

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -847,7 +847,6 @@
                         </rules>
                     </configuration>
                 </plugin>
-
             </plugins>
         </pluginManagement>
     </build>

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.facebook.presto.spi.statistics.DisjointRangeDomainHistogram;
 import com.facebook.presto.spi.statistics.DoubleRange;
 import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.StringRange;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -74,6 +75,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.CharBuffer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -269,6 +271,10 @@ public class TableStatisticsMaker
                     columnBuilder.setHistogram(columnBuilder.getHistogram()
                             .map(histogram -> DisjointRangeDomainHistogram
                                     .addConjunction(histogram, Range.range(DOUBLE, histRange.getMin(), true, histRange.getMax(), true))));
+                }
+                else if (min instanceof CharBuffer && max instanceof CharBuffer) {
+                    final StringRange stringRange = new StringRange(String.valueOf(min), String.valueOf(max));
+                    columnBuilder.setStringRange(stringRange);
                 }
             }
             result.setColumnStatistics(columnHandle, columnBuilder.build());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/StatisticsUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/StatisticsUtil.java
@@ -104,7 +104,7 @@ public final class StatisticsUtil
                     .setNullsFraction(icebergColumnStats.getNullsFraction())
                     .setDistinctValuesCount(icebergColumnStats.getDistinctValuesCount())
                     .setHistogram(icebergColumnStats.getHistogram())
-                    .setRange(icebergColumnStats.getRange());
+                    .setStringRange(icebergColumnStats.getStringRange());
             if (hiveColumnStats != null) {
                 // NDVs
                 if (mergeFlags.contains(NUMBER_OF_DISTINCT_VALUES)) {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergHiveStatistics.java
@@ -193,6 +193,68 @@ public class TestIcebergHiveStatistics
     }
 
     @Test
+    public void testStatsWithVarcharColumns()
+    {
+        // Un-partitioned tables
+        assertQuerySucceeds("CREATE TABLE statsBeforeAnalyzeVarChar as SELECT * FROM orders LIMIT 100");
+        MaterializedResult stats = getQueryRunner().execute("SHOW STATS FOR statsBeforeAnalyzeVarChar");
+        assertStatValuePresent(StatsSchema.LOW_VALUE, stats, NON_NUMERIC_ORDERS_COLUMNS);
+        assertStatValuePresent(StatsSchema.HIGH_VALUE, stats, NON_NUMERIC_ORDERS_COLUMNS);
+        // Partitioned table
+        assertQuerySucceeds("CREATE TABLE statsWithPartitionAnalyzeVarChar WITH (partitioning = ARRAY['orderdate']) as SELECT * FROM orders LIMIT 100");
+        MaterializedResult stats2 = getQueryRunner().execute("SHOW STATS FOR statsWithPartitionAnalyzeVarChar");
+        assertStatValuePresent(StatsSchema.LOW_VALUE, stats2, NON_NUMERIC_ORDERS_COLUMNS);
+        assertStatValuePresent(StatsSchema.HIGH_VALUE, stats2, NON_NUMERIC_ORDERS_COLUMNS);
+    }
+
+    @Test
+    public void testStatsWithVarcharColumnIsNull()
+    {
+        // Scenario 1. stats for Empty table
+        assertQuerySucceeds("CREATE TABLE emptyTable (name varchar(10), id varchar(10))");
+        MaterializedResult stats = getQueryRunner().execute("SHOW STATS FOR emptyTable");
+        assertStatValueAbsent(StatsSchema.LOW_VALUE, stats, ImmutableSet.of("id"));
+        assertStatValueAbsent(StatsSchema.HIGH_VALUE, stats, ImmutableSet.of("id"));
+        assertStatValueAbsent(StatsSchema.LOW_VALUE, stats, ImmutableSet.of("name"));
+        assertStatValueAbsent(StatsSchema.HIGH_VALUE, stats, ImmutableSet.of("name"));
+        // Scenario 2. stats for column with null values and non-null values..
+        assertQuerySucceeds("INSERT INTO emptyTable values ( 'n', NULL )");
+        assertQuerySucceeds("INSERT INTO emptyTable values ( 'b', NULL )");
+        MaterializedResult statsWithNull = getQueryRunner().execute("SHOW STATS FOR emptyTable");
+        assertStatValuePresent(StatsSchema.LOW_VALUE, statsWithNull, ImmutableSet.of("name"));
+        assertStatValuePresent(StatsSchema.HIGH_VALUE, statsWithNull, ImmutableSet.of("name"));
+        assertStatValueAbsent(StatsSchema.LOW_VALUE, statsWithNull, ImmutableSet.of("id"));
+        assertStatValueAbsent(StatsSchema.HIGH_VALUE, statsWithNull, ImmutableSet.of("id"));
+        // Scenario 3. inserting non-null values in the column with all nulls should update min/max correctly.
+        // If Nulls were being evaluated as string then we should see min and max NULL and not testString1.
+        String testString1 = "a string1";
+        String testString2 = "z string2";
+        assertQuerySucceeds("INSERT INTO emptyTable values ('c', '" + testString1 + "')");
+        MaterializedResult stats1 = getQueryRunner().execute("SHOW STATS FOR emptyTable");
+        assertStatValue(StatsSchema.LOW_VALUE, stats1, ImmutableSet.of("id"), testString1, false);
+        assertStatValue(StatsSchema.HIGH_VALUE, stats1, ImmutableSet.of("id"), testString1, false);
+        assertQuerySucceeds("INSERT INTO emptyTable values ('d', '" + testString2 + "')");
+        MaterializedResult stats2 = getQueryRunner().execute("SHOW STATS FOR emptyTable");
+        assertStatValue(StatsSchema.LOW_VALUE, stats2, ImmutableSet.of("id"), testString1, false);
+        assertStatValue(StatsSchema.HIGH_VALUE, stats2, ImmutableSet.of("id"), testString2, false);
+
+        // Scenario 4. what if the value itself is string null i.e. 'null'
+        assertQuerySucceeds("CREATE TABLE tableWithNullAsString (name varchar, id varchar(10))");
+        String stringNull = "NULL";
+        assertQuerySucceeds("INSERT INTO tableWithNullAsString values ('d', '" + stringNull + "')");
+        assertQuerySucceeds("INSERT INTO tableWithNullAsString values ('e', NULL)");
+        MaterializedResult statsWithNullAsString = getQueryRunner().execute("SHOW STATS FOR tableWithNullAsString");
+        assertStatValue(StatsSchema.LOW_VALUE, statsWithNullAsString, ImmutableSet.of("id"), stringNull, false);
+        assertStatValue(StatsSchema.HIGH_VALUE, statsWithNullAsString, ImmutableSet.of("id"), stringNull, false);
+        // Scenario 5. Inserting actual values should not remove null inserted as string.
+        String minString = "A";
+        assertQuerySucceeds("INSERT INTO tableWithNullAsString values ('e', '" + minString + "')");
+        statsWithNullAsString = getQueryRunner().execute("SHOW STATS FOR tableWithNullAsString");
+        assertStatValue(StatsSchema.LOW_VALUE, statsWithNullAsString, ImmutableSet.of("id"), minString, false);
+        assertStatValue(StatsSchema.HIGH_VALUE, statsWithNullAsString, ImmutableSet.of("id"), stringNull, false);
+    }
+
+    @Test
     public void testStatsWithPartitionedTableAnalyzed()
     {
         assertQuerySucceeds("CREATE TABLE statsNoPartitionAnalyze as SELECT * FROM orders LIMIT 100");

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/rewrite/ShowStatsRewrite.java
@@ -26,6 +26,7 @@ import com.facebook.presto.common.type.SqlTimestamp;
 import com.facebook.presto.common.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VariableWidthType;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -40,6 +41,7 @@ import com.facebook.presto.spi.security.AccessControl;
 import com.facebook.presto.spi.statistics.ColumnStatistics;
 import com.facebook.presto.spi.statistics.DoubleRange;
 import com.facebook.presto.spi.statistics.Estimate;
+import com.facebook.presto.spi.statistics.StringRange;
 import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.sql.QueryUtil;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
@@ -321,8 +323,15 @@ public class ShowStatsRewrite
             rowValues.add(createEstimateRepresentation(columnStatistics.getDistinctValuesCount()));
             rowValues.add(createEstimateRepresentation(columnStatistics.getNullsFraction()));
             rowValues.add(NULL_DOUBLE);
-            rowValues.add(toStringLiteral(type, columnStatistics.getRange().map(DoubleRange::getMin)));
-            rowValues.add(toStringLiteral(type, columnStatistics.getRange().map(DoubleRange::getMax)));
+            if (columnStatistics.getStringRange().isPresent()) {
+                checkState(type instanceof VariableWidthType, "String range was specified for a non variable width-type %s", type);
+                rowValues.add(columnStatistics.getStringRange().map(StringRange::getMin).<Expression>map(StringLiteral::new).orElse(NULL_VARCHAR));
+                rowValues.add(columnStatistics.getStringRange().map(StringRange::getMax).<Expression>map(StringLiteral::new).orElse(NULL_VARCHAR));
+            }
+            else {
+                rowValues.add(toStringLiteral(type, columnStatistics.getRange().map(DoubleRange::getMin)));
+                rowValues.add(toStringLiteral(type, columnStatistics.getRange().map(DoubleRange::getMax)));
+            }
             rowValues.add(columnStatistics.getHistogram().map(Objects::toString).<Expression>map(StringLiteral::new).orElse(NULL_VARCHAR));
             return new Row(rowValues.build());
         }

--- a/presto-main-base/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/cost/TestConnectorFilterStatsCalculatorService.java
@@ -104,20 +104,20 @@ public class TestConnectorFilterStatsCalculatorService
         TableStatistics filteredToZeroStatistics = TableStatistics.builder()
                 .setRowCount(Estimate.zero())
                 .setTotalSize(Estimate.zero())
-                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.of(1.0), Estimate.zero(), Estimate.zero(), Optional.empty(), Optional.empty()))
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.of(1.0), Estimate.zero(), Estimate.zero(), Optional.empty(), Optional.empty(), Optional.empty()))
                 .build();
         assertPredicate("false", originalTableStatistics, filteredToZeroStatistics);
 
         TableStatistics filteredStatistics = TableStatistics.builder()
                 .setRowCount(Estimate.of(37.5))
                 .setTotalSize(Estimate.of(300))
-                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0)), Optional.empty()))
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0)), Optional.empty(), Optional.empty()))
                 .build();
         assertPredicate("x < 0", originalTableStatistics, filteredStatistics);
 
         TableStatistics filteredStatisticsWithoutTotalSize = TableStatistics.builder()
                 .setRowCount(Estimate.of(37.5))
-                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0)), Optional.empty()))
+                .setColumnStatistics(xColumn, new ColumnStatistics(Estimate.zero(), Estimate.of(20), Estimate.unknown(), Optional.of(new DoubleRange(-10, 0)), Optional.empty(), Optional.empty()))
                 .build();
         assertPredicate("x < 0", originalTableStatisticsWithoutTotalSize, filteredStatisticsWithoutTotalSize);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/ColumnStatistics.java
@@ -21,7 +21,9 @@ import java.util.Optional;
 
 import static com.facebook.presto.spi.statistics.DoubleRange.RANGE_SIZE;
 import static com.facebook.presto.spi.statistics.Estimate.ESTIMATE_SIZE;
+import static com.facebook.presto.spi.statistics.StringRange.STRING_RANGE_SIZE;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public final class ColumnStatistics
@@ -31,13 +33,14 @@ public final class ColumnStatistics
 
     public static final double INFINITE_TO_FINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR = 0.25;
     public static final double INFINITE_TO_INFINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR = 0.5;
-    private static final ColumnStatistics EMPTY = new ColumnStatistics(Estimate.unknown(), Estimate.unknown(), Estimate.unknown(), Optional.empty(), Optional.empty());
+    private static final ColumnStatistics EMPTY = new ColumnStatistics(Estimate.unknown(), Estimate.unknown(), Estimate.unknown(), Optional.empty(), Optional.empty(), Optional.empty());
+    private static final long STRING_CLASS_SIZE = ClassLayout.parseClass(String.class).instanceSize();
 
     private final Estimate nullsFraction;
     private final Estimate distinctValuesCount;
     private final Estimate dataSize;
     private final Optional<DoubleRange> range;
-
+    private final Optional<StringRange> stringRange;
     private final Optional<ConnectorHistogram> histogram;
 
     public static ColumnStatistics empty()
@@ -45,11 +48,23 @@ public final class ColumnStatistics
         return EMPTY;
     }
 
+    @Deprecated
     public ColumnStatistics(
             Estimate nullsFraction,
             Estimate distinctValuesCount,
             Estimate dataSize,
             Optional<DoubleRange> range,
+            Optional<ConnectorHistogram> histogram)
+    {
+        this(nullsFraction, distinctValuesCount, dataSize, range, Optional.empty(), histogram);
+    }
+
+    public ColumnStatistics(
+            Estimate nullsFraction,
+            Estimate distinctValuesCount,
+            Estimate dataSize,
+            Optional<DoubleRange> range,
+            Optional<StringRange> stringRange,
             Optional<ConnectorHistogram> histogram)
     {
         this.nullsFraction = requireNonNull(nullsFraction, "nullsFraction is null");
@@ -67,6 +82,7 @@ public final class ColumnStatistics
             throw new IllegalArgumentException(format("dataSize must be greater than or equal to 0: %s", dataSize.getValue()));
         }
         this.range = requireNonNull(range, "range is null");
+        this.stringRange = requireNonNull(stringRange, "string range is null");
         this.histogram = requireNonNull(histogram, "histogram is null");
     }
 
@@ -95,6 +111,12 @@ public final class ColumnStatistics
     }
 
     @JsonProperty
+    public Optional<StringRange> getStringRange()
+    {
+        return stringRange;
+    }
+
+    @JsonProperty
     public Optional<ConnectorHistogram> getHistogram()
     {
         return histogram;
@@ -114,13 +136,14 @@ public final class ColumnStatistics
                 Objects.equals(distinctValuesCount, that.distinctValuesCount) &&
                 Objects.equals(dataSize, that.dataSize) &&
                 Objects.equals(range, that.range) &&
+                Objects.equals(stringRange, that.stringRange) &&
                 Objects.equals(histogram, that.histogram);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(nullsFraction, distinctValuesCount, dataSize, range, histogram);
+        return Objects.hash(nullsFraction, distinctValuesCount, dataSize, range, stringRange, histogram);
     }
 
     @Override
@@ -131,6 +154,7 @@ public final class ColumnStatistics
                 ", distinctValuesCount=" + distinctValuesCount +
                 ", dataSize=" + dataSize +
                 ", range=" + range +
+                ", stringRange=" + stringRange +
                 ", histogram=" + histogram +
                 '}';
     }
@@ -147,16 +171,36 @@ public final class ColumnStatistics
                 .setDataSize(statistics.getDataSize())
                 .setNullsFraction(statistics.getNullsFraction())
                 .setDistinctValuesCount(statistics.getDistinctValuesCount())
-                .setHistogram(statistics.getHistogram());
+                .setHistogram(statistics.getHistogram())
+                .setStringRange(statistics.getStringRange());
     }
 
     public long getEstimatedSize()
     {
         return COLUMN_STATISTICS_SIZE +
                 3 * ESTIMATE_SIZE +
-                2 * OPTION_SIZE +
-                histogram.map(ConnectorHistogram::getEstimatedSize).orElse(0L) +
-                range.map(unused -> RANGE_SIZE).orElse(0L);
+                estimateHistogram(histogram) +
+                estimateRange(range) +
+                estimateStringRange(stringRange);
+    }
+
+    private long estimateRange(Optional<DoubleRange> range)
+    {
+        return OPTION_SIZE + range.map(unused -> RANGE_SIZE).orElse(0L);
+    }
+
+    private long estimateHistogram(Optional<ConnectorHistogram> histogram)
+    {
+        return OPTION_SIZE + histogram.map(ConnectorHistogram::getEstimatedSize).orElse(0L);
+    }
+
+    private long estimateStringRange(Optional<StringRange> stringRange)
+    {
+        return stringRange.map(value -> {
+            // An empty string occupies 16 bytes in JVM, adding 16 * 2 to account for min and max.
+            long estimate = OPTION_SIZE + STRING_RANGE_SIZE + 32 + value.getMin().getBytes(UTF_8).length + value.getMax().getBytes(UTF_8).length;
+            return (long) (1.1 * estimate); // Overestimate by 10% since in-memory size is not the same as UTF-8 serialized size
+        }).orElse(OPTION_SIZE);
     }
 
     /**
@@ -172,7 +216,7 @@ public final class ColumnStatistics
         private Estimate distinctValuesCount = Estimate.unknown();
         private Estimate dataSize = Estimate.unknown();
         private Optional<DoubleRange> range = Optional.empty();
-
+        private Optional<StringRange> stringRange = Optional.empty();
         private Optional<ConnectorHistogram> histogram = Optional.empty();
 
         public Builder setNullsFraction(Estimate nullsFraction)
@@ -214,6 +258,18 @@ public final class ColumnStatistics
             return this;
         }
 
+        public Builder setStringRange(StringRange stringRange)
+        {
+            this.stringRange = Optional.of(requireNonNull(stringRange, "stringRange is null"));
+            return this;
+        }
+
+        public Builder setStringRange(Optional<StringRange> stringRange)
+        {
+            this.stringRange = requireNonNull(stringRange, "stringRange is null");
+            return this;
+        }
+
         public Builder setRange(Optional<DoubleRange> range)
         {
             this.range = requireNonNull(range, "range is null");
@@ -249,6 +305,10 @@ public final class ColumnStatistics
                 this.range = other.range;
             }
 
+            if (!stringRange.isPresent()) {
+                this.stringRange = other.stringRange;
+            }
+
             if (!histogram.isPresent()) {
                 this.histogram = other.histogram;
             }
@@ -256,9 +316,17 @@ public final class ColumnStatistics
             return this;
         }
 
+        private void validate()
+        {
+            if (stringRange.isPresent() && range.isPresent()) {
+                throw new IllegalArgumentException("Both StringRange and Range cannot be defined simultaneously on a column.");
+            }
+        }
+
         public ColumnStatistics build()
         {
-            return new ColumnStatistics(nullsFraction, distinctValuesCount, dataSize, range, histogram);
+            validate();
+            return new ColumnStatistics(nullsFraction, distinctValuesCount, dataSize, range, stringRange, histogram);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/statistics/StringRange.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/statistics/StringRange.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class StringRange
+{
+    static final long STRING_RANGE_SIZE = ClassLayout.parseClass(StringRange.class).instanceSize();
+
+    private final String min;
+    private final String max;
+
+    public StringRange(String min, String max)
+    {
+        this.min = requireNonNull(min, "min must not be null");
+        this.max = requireNonNull(max, "max must not be null");
+        if (min.compareTo(max) > 0) {
+            throw new IllegalArgumentException(format("max must be greater than or equal to min. min: %s. max: %s", min, max));
+        }
+    }
+
+    @JsonProperty
+    public String getMin()
+    {
+        return min;
+    }
+
+    @JsonProperty
+    public String getMax()
+    {
+        return max;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StringRange range = (StringRange) o;
+        return range.min.compareTo(min) == 0 &&
+                range.max.compareTo(max) == 0;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(min, max);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "StringRange{" +
+                "min=" + min +
+                ", max=" + max +
+                '}';
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/statistics/TestColumnStatistics.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/statistics/TestColumnStatistics.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.statistics;
 
 import org.openjdk.jol.info.ClassLayout;
 import org.openjdk.jol.info.GraphLayout;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -36,10 +37,8 @@ public class TestColumnStatistics
                 .setRange(new DoubleRange(100, 100))
                 .setNullsFraction(Estimate.of(0.1))
                 .build();
-
-        // test without histogram
         long actualSize = GraphLayout.parseInstance(stats).totalSize();
-        assertEquals(actualSize, stats.getEstimatedSize());
+        assertEquals(actualSize, stats.getEstimatedSize(), 16);
     }
 
     /**
@@ -76,6 +75,39 @@ public class TestColumnStatistics
                 .build();
         long actualSize = GraphLayout.parseInstance(stats).totalSize();
         assertEquals(actualSize, stats.getEstimatedSize());
+    }
+
+    @DataProvider(name = "testColumnStatisticsEstimatedSizeAccuracyWithStringRange")
+    public static String[][] minMaxValues()
+    {
+        return new String[][] {{"", ""}, {"", "zzzasA"}, {"aBCd", "z a very long string for"}, {"a medium string", "z"},
+                {"यह एक लंबी स्ट्रिंग है।", "यह स्ट्रिंग लंबी है।"}};
+    }
+
+    @Test(dataProvider = "testColumnStatisticsEstimatedSizeAccuracyWithStringRange")
+    public void testColumnStatisticsEstimatedSizeAccuracyWithStringRange(String min, String max)
+    {
+        ColumnStatistics stats = ColumnStatistics.builder()
+                .setDataSize(Estimate.of(100))
+                .setDistinctValuesCount(Estimate.of(1))
+                .setStringRange(new StringRange(min, max))
+                .setNullsFraction(Estimate.of(0.1))
+                .build();
+        long actualSize = GraphLayout.parseInstance(stats).totalSize();
+        int error = 32; // allow for slight overestimate.
+        assertEquals(actualSize, stats.getEstimatedSize(), error);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeScenarioColumnStatisticsWithBothStringAndDoubleRange()
+    {
+        ColumnStatistics.builder()
+                .setDataSize(Estimate.of(100))
+                .setDistinctValuesCount(Estimate.of(1))
+                .setStringRange(new StringRange("", "zZxZ"))
+                .setRange(new DoubleRange(0, 1))
+                .setNullsFraction(Estimate.of(0.1))
+                .build();
     }
 
     /**

--- a/presto-spi/src/test/java/com/facebook/presto/spi/statistics/TestStringRange.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/statistics/TestStringRange.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.statistics;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestStringRange
+{
+    @Test
+    public void testRange()
+    {
+        assertRange("", "zZxX");
+        assertRange("", "");
+        assertThatThrownBy(() -> new StringRange("Z", "")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("max must be greater than or equal to min. min: Z. max: ");
+    }
+
+    private static void assertRange(String min, String max)
+    {
+        StringRange range = new StringRange(min, max);
+        assertEquals(range.getMin(), min);
+        assertEquals(range.getMax(), max);
+    }
+}


### PR DESCRIPTION

```

presto:test> show stats for taxis;
    column_name     | data_size | distinct_values_count | nulls_fraction | row_count | low_value | high_value | histogram 
--------------------+-----------+-----------------------+----------------+-----------+-----------+------------+-----------
 vendor_id          | NULL      |                   2.0 |            0.0 | NULL      | 1         | 2          | NULL      
 trip_id            | NULL      |                   4.0 |            0.0 | NULL      | 1000371   | 1000377    | NULL      
 trip_distance      | NULL      |                   4.0 |            0.0 | NULL      | 0.9       | 9.4        | NULL      
 fare_amount        | NULL      |                   4.0 |            0.0 | NULL      | 9.01      | 42.13      | NULL      
 store_and_fwd_flag |       4.0 |                   2.0 |            0.0 | NULL      | N         | zex        | NULL      
 NULL               | NULL      | NULL                  | NULL           |       6.0 | NULL      | NULL       | NULL      
(6 rows)

```
## Description
The information around min and max on char/varchar column of iceberg table is already available, the PR surfaces that information in show stats query.

## Motivation and Context
These stats help optimizer perform better when there are range queries on columns with char/varchar type.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Iceberg Connector Changes
* Add low and high values for varchar/char columns of Iceberg tables.
```