### PR TITLE
feat(client): Log "Running <query_id>..." in Presto cli in non-interactive mode

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -154,6 +154,7 @@ public class Query
             statusPrinter.printInitialStatusUpdates();
         }
         else {
+            errorChannel.printf("Running %s ...%n", client.currentStatusInfo().getId());
             processInitialStatusUpdates(warningsPrinter);
         }
 


### PR DESCRIPTION
Summary:
It is frustrating not to know the query ID, when yopu running a query
from a file or an SQL statement.
This fixes it.

Differential Revision: D96955453

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enhancements:
- Add a non-interactive mode message that prints the current query ID before processing status updates.