### PR TITLE
[Hive] Support partition spec evolution in partition name parsing

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
@@ -612,9 +612,25 @@ public class MetastoreUtil
         if (!partitionColumnNames.isPresent() || partitionColumnNames.get().size() == 1) {
             return values.build();
         }
+        List<String> keyList = keys.build();
+        List<String> valueList = values.build();
+        Map<String, Integer> keyIndexMap = new HashMap<>();
+        for (int i = 0; i < keyList.size(); i++) {
+            keyIndexMap.put(keyList.get(i), i);
+        }
         ImmutableList.Builder<String> orderedValues = ImmutableList.builder();
-        partitionColumnNames.get()
-                .forEach(columnName -> orderedValues.add(values.build().get(keys.build().indexOf(columnName))));
+        for (String columnName : partitionColumnNames.get()) {
+            Integer idx = keyIndexMap.get(columnName);
+            if (idx != null) {
+                orderedValues.add(valueList.get(idx));
+            }
+            else {
+                // Partition key not present in partition name. This happens when
+                // partition keys are added to a table after this partition was created
+                // (partition spec evolution). Pad with Hive default partition value.
+                orderedValues.add(HIVE_DEFAULT_DYNAMIC_PARTITION);
+            }
+        }
         return orderedValues.build();
     }
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionWithStatistics.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionWithStatistics.java
@@ -27,7 +27,16 @@ public class PartitionWithStatistics
     {
         this.partition = requireNonNull(partition, "partition is null");
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
-        checkArgument(toPartitionValues(partitionName).equals(partition.getValues()), "unexpected partition name: %s != %s", partitionName, partition.getValues());
+        List<String> nameValues = toPartitionValues(partitionName);
+        // Allow partition values to be longer than what the name produces.
+        // This happens with partition spec evolution: old partitions have short
+        // names but Metastore pads the values list with __HIVE_DEFAULT_PARTITION__
+        // for keys added after the partition was created.
+        checkArgument(
+                partition.getValues().size() >= nameValues.size()
+                        && partition.getValues().subList(0, nameValues.size()).equals(nameValues),
+                "unexpected partition name %s: name-parsed values %s are not a prefix of partition values %s",
+                partitionName, nameValues, partition.getValues());
         this.statistics = requireNonNull(statistics, "statistics is null");
     }
 

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestHiveMetastoreUtil.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestHiveMetastoreUtil.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_DATE;
 import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.extractPartitionValues;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.reconstructPartitionSchema;
@@ -213,5 +214,31 @@ public class TestHiveMetastoreUtil
         assertEquals(extractPartitionValues("countryPartition=united_states/datePartition=20201221", Optional.of(ImmutableList.of("datePartition", "countryPartition"))), ImmutableList.of(datePartition, countryPartition));
         assertEquals(extractPartitionValues("datePartition=20201221/countryPartition=united_states"), ImmutableList.of(datePartition, countryPartition));
         assertEquals(extractPartitionValues("countryPartition=united_states/datePartition=20201221"), ImmutableList.of(countryPartition, datePartition));
+    }
+    @Test
+    public void testExtractPartitionValuesWithSpecEvolution()
+    {
+        // When a table evolves from (ds, country) to (ds, country, region),
+        // old partitions keep their original names with only 2 key segments.
+        // extractPartitionValues should pad missing keys with __HIVE_DEFAULT_PARTITION__.
+        assertEquals(
+                extractPartitionValues(
+                        "ds=2024-01-01/country=US",
+                        Optional.of(ImmutableList.of("ds", "country", "region"))),
+                ImmutableList.of("2024-01-01", "US", HIVE_DEFAULT_DYNAMIC_PARTITION));
+
+        // Multiple evolved keys
+        assertEquals(
+                extractPartitionValues(
+                        "ds=2024-01-01",
+                        Optional.of(ImmutableList.of("ds", "country", "region"))),
+                ImmutableList.of("2024-01-01", HIVE_DEFAULT_DYNAMIC_PARTITION, HIVE_DEFAULT_DYNAMIC_PARTITION));
+
+        // No evolution (all keys present) still works
+        assertEquals(
+                extractPartitionValues(
+                        "ds=2024-01-01/country=US/region=eu-west",
+                        Optional.of(ImmutableList.of("ds", "country", "region"))),
+                ImmutableList.of("2024-01-01", "US", "eu-west"));
     }
 }


### PR DESCRIPTION
Hive Metastore is adding support for partition spec evolution: appending new partition keys to an existing table without rewriting old partitions or data. This is analogous to Iceberg's partition spec evolution.

When a table evolves from (ds, country) to (ds, country, region), old partitions keep their original names (ds=2024-01-01/country=US) and storage paths. The Metastore pads the Partition.values list with __HIVE_DEFAULT_PARTITION__ for evolved keys, but the partition name string retains its original shorter form. This preserves compatibility with external systems (Compendium, replication, caches) that store partition names as opaque string references.

This creates a mismatch in Presto where partition name parsing produces fewer values than the table schema expects. Two fixes:

1. MetastoreUtil.extractPartitionValues: When a table partition column is not found in the partition name (because it was added after the partition was created), pad with HIVE_DEFAULT_DYNAMIC_PARTITION instead of throwing IllegalArgumentException.

2. PartitionWithStatistics: Relax the assertion that name-parsed values must exactly equal Partition.getValues(). Check prefix-match instead, since the values list may have trailing default entries for evolved keys that do not appear in the stored partition name.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [yes ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [yes] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [yes] Adequate tests were added if applicable.
- [ ] CI passed.
- [yes ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Handle Hive partition spec evolution when parsing partition names and validating partition metadata.

Bug Fixes:
- Allow extractPartitionValues to pad missing evolved partition keys with the Hive default dynamic partition value instead of failing when the partition name omits newer keys.
- Relax PartitionWithStatistics validation to accept partition value lists that extend the name-parsed values, treating the parsed values as a required prefix.

Tests:
- Add unit tests covering extractPartitionValues behavior with evolved partition specs and varying partition key presence.