### PR TITLE
[Hive] Support partition spec evolution in partition name parsing

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
@@ -612,9 +612,25 @@ public class MetastoreUtil
         if (!partitionColumnNames.isPresent() || partitionColumnNames.get().size() == 1) {
             return values.build();
         }
+        List<String> keyList = keys.build();
+        List<String> valueList = values.build();
+        Map<String, Integer> keyIndexMap = new HashMap<>();
+        for (int i = 0; i < keyList.size(); i++) {
+            keyIndexMap.put(keyList.get(i), i);
+        }
         ImmutableList.Builder<String> orderedValues = ImmutableList.builder();
-        partitionColumnNames.get()
-                .forEach(columnName -> orderedValues.add(values.build().get(keys.build().indexOf(columnName))));
+        for (String columnName : partitionColumnNames.get()) {
+            Integer idx = keyIndexMap.get(columnName);
+            if (idx != null) {
+                orderedValues.add(valueList.get(idx));
+            }
+            else {
+                // Partition key not present in partition name. This happens when
+                // partition keys are added to a table after this partition was created
+                // (partition spec evolution). Pad with Hive default partition value.
+                orderedValues.add(HIVE_DEFAULT_DYNAMIC_PARTITION);
+            }
+        }
         return orderedValues.build();
     }
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionWithStatistics.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionWithStatistics.java
@@ -27,7 +27,16 @@ public class PartitionWithStatistics
     {
         this.partition = requireNonNull(partition, "partition is null");
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
-        checkArgument(toPartitionValues(partitionName).equals(partition.getValues()), "unexpected partition name: %s != %s", partitionName, partition.getValues());
+        List<String> nameValues = toPartitionValues(partitionName);
+        // Allow partition values to be longer than what the name produces.
+        // This happens with partition spec evolution: old partitions have short
+        // names but Metastore pads the values list with __HIVE_DEFAULT_PARTITION__
+        // for keys added after the partition was created.
+        checkArgument(
+                partition.getValues().size() >= nameValues.size()
+                        && partition.getValues().subList(0, nameValues.size()).equals(nameValues),
+                "unexpected partition name %s: name-parsed values %s are not a prefix of partition values %s",
+                partitionName, nameValues, partition.getValues());
         this.statistics = requireNonNull(statistics, "statistics is null");
     }
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -338,15 +339,19 @@ public class BridgingHiveMetastore
         List<String> partitionNames = partitionNamesWithVersion.stream()
                 .map(PartitionNameWithVersion::getPartitionName)
                 .collect(toImmutableList());
-        Map<String, List<String>> partitionNameToPartitionValuesMap = partitionNames.stream()
-                .collect(Collectors.toMap(identity(), MetastoreUtil::toPartitionValues));
-        Map<List<String>, Partition> partitionValuesToPartitionMap = delegate.getPartitionsByNames(metastoreContext, databaseName, tableName, partitionNames).stream()
-                .map(partition -> fromMetastoreApiPartition(partition, partitionMutator, metastoreContext.getColumnConverter()))
-                .collect(Collectors.toMap(Partition::getValues, identity()));
+        // Join by partition name string rather than parsed values. For evolved
+        // tables, Partition.getValues() is padded for new keys but the partition
+        // name retains its original form, so values-based matching would fail.
+        Map<String, Partition> partitionMap = new HashMap<>();
+        for (org.apache.hadoop.hive.metastore.api.Partition raw :
+                delegate.getPartitionsByNames(metastoreContext, databaseName, tableName, partitionNames)) {
+            partitionMap.put(
+                    raw.getPartitionName(),
+                    fromMetastoreApiPartition(raw, partitionMutator, metastoreContext.getColumnConverter()));
+        }
         ImmutableMap.Builder<String, Optional<Partition>> resultBuilder = ImmutableMap.builder();
-        for (Map.Entry<String, List<String>> entry : partitionNameToPartitionValuesMap.entrySet()) {
-            Partition partition = partitionValuesToPartitionMap.get(entry.getValue());
-            resultBuilder.put(entry.getKey(), Optional.ofNullable(partition));
+        for (String name : partitionNames) {
+            resultBuilder.put(name, Optional.ofNullable(partitionMap.get(name)));
         }
         return resultBuilder.build();
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestHiveMetastoreUtil.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestHiveMetastoreUtil.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.hive.ColumnConverter;
 import com.facebook.presto.hive.PartitionMutator;
+import com.facebook.presto.hive.metastore.Storage.StorageFormat;
 import com.facebook.presto.hive.metastore.thrift.ThriftMetastoreUtil;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -36,6 +37,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_DATE;
 import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.extractPartitionValues;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.reconstructPartitionSchema;
@@ -213,5 +215,84 @@ public class TestHiveMetastoreUtil
         assertEquals(extractPartitionValues("countryPartition=united_states/datePartition=20201221", Optional.of(ImmutableList.of("datePartition", "countryPartition"))), ImmutableList.of(datePartition, countryPartition));
         assertEquals(extractPartitionValues("datePartition=20201221/countryPartition=united_states"), ImmutableList.of(datePartition, countryPartition));
         assertEquals(extractPartitionValues("countryPartition=united_states/datePartition=20201221"), ImmutableList.of(countryPartition, datePartition));
+    }
+
+    @Test
+    public void testExtractPartitionValuesWithSpecEvolution()
+    {
+        // When a table evolves from (ds, country) to (ds, country, region),
+        // old partitions keep their original names with only 2 key segments.
+        // extractPartitionValues should pad missing keys with __HIVE_DEFAULT_PARTITION__.
+        assertEquals(
+                extractPartitionValues(
+                        "ds=2024-01-01/country=US",
+                        Optional.of(ImmutableList.of("ds", "country", "region"))),
+                ImmutableList.of("2024-01-01", "US", HIVE_DEFAULT_DYNAMIC_PARTITION));
+
+        // Multiple evolved keys
+        assertEquals(
+                extractPartitionValues(
+                        "ds=2024-01-01",
+                        Optional.of(ImmutableList.of("ds", "country", "region"))),
+                ImmutableList.of("2024-01-01", HIVE_DEFAULT_DYNAMIC_PARTITION, HIVE_DEFAULT_DYNAMIC_PARTITION));
+
+        // No evolution (all keys present) still works
+        assertEquals(
+                extractPartitionValues(
+                        "ds=2024-01-01/country=US/region=eu-west",
+                        Optional.of(ImmutableList.of("ds", "country", "region"))),
+                ImmutableList.of("2024-01-01", "US", "eu-west"));
+    }
+
+    @Test
+    public void testPartitionWithStatisticsAcceptsEvolvedValues()
+    {
+        // Old partition name has 2 keys, but Metastore pads values to 3.
+        // PartitionWithStatistics should accept this prefix-match.
+        Partition partition = createTestPartition(
+                ImmutableList.of("2024-01-01", "US", HIVE_DEFAULT_DYNAMIC_PARTITION));
+
+        PartitionWithStatistics pws = new PartitionWithStatistics(
+                partition,
+                "ds=2024-01-01/country=US",
+                PartitionStatistics.empty());
+
+        assertEquals(pws.getPartition(), partition);
+        assertEquals(pws.getPartitionName(), "ds=2024-01-01/country=US");
+    }
+
+    @Test
+    public void testPartitionWithStatisticsStillRejectsInvalidNames()
+    {
+        // Values that don't match the name should still fail
+        Partition partition = createTestPartition(ImmutableList.of("2024-01-01", "UK"));
+
+        assertThatThrownBy(() -> new PartitionWithStatistics(
+                partition,
+                "ds=2024-01-01/country=US",
+                PartitionStatistics.empty()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Partition createTestPartition(List<String> values)
+    {
+        Storage storage = Storage.builder()
+                .setStorageFormat(StorageFormat.fromHiveStorageFormat(com.facebook.presto.hive.HiveStorageFormat.ORC))
+                .setLocation("file:///test")
+                .build();
+        return new Partition(
+                Optional.empty(),
+                "test_db",
+                "test_table",
+                values,
+                storage,
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                Optional.empty(),
+                false,
+                false,
+                0,
+                0,
+                Optional.empty());
     }
 }


### PR DESCRIPTION
Summary:
Hive Metastore is adding support for partition spec evolution: appending
new partition keys to an existing table without rewriting old partitions
or data. This is analogous to Iceberg's partition spec evolution.

When a table evolves from (ds, country) to (ds, country, region), old
partitions keep their original names (ds=2024-01-01/country=US) and
storage paths. The Metastore pads the Partition.values list with
__HIVE_DEFAULT_PARTITION__ for evolved keys, but the partition name
string retains its original shorter form. This preserves compatibility
with external systems (Compendium, replication, caches) that store
partition names as opaque string references.

This creates a mismatch in Presto where partition name parsing produces
fewer values than the table schema expects. Two fixes:

1. MetastoreUtil.extractPartitionValues: When a table partition column
   is not found in the partition name (because it was added after the
   partition was created), pad with HIVE_DEFAULT_DYNAMIC_PARTITION
   instead of throwing IllegalArgumentException. Uses a HashMap for
   O(1) key lookup.

2. PartitionWithStatistics: Relax the assertion that name-parsed values
   must exactly equal Partition.getValues(). Check prefix-match instead,
   since the values list may have trailing default entries for evolved
   keys that do not appear in the stored partition name.

Differential Revision: D97015202

## Summary by Sourcery

Handle Hive partition spec evolution by tolerating missing evolved keys in partition names and aligning partition lookups with Metastore behavior.

Bug Fixes:
- Ensure extractPartitionValues pads missing evolved partition keys with the Hive default dynamic partition value instead of failing.
- Allow PartitionWithStatistics to accept partitions whose value lists extend the name-parsed values when extra entries are default padding from spec evolution.
- Join partitions returned from the metastore to requested names by partition name string rather than by parsed value lists to avoid mismatches with evolved specs.

Tests:
- Add unit tests covering extractPartitionValues behavior with evolved partition specs and padding of missing keys.
- Add unit tests verifying PartitionWithStatistics accepts prefix-matching values for evolved partitions and still rejects inconsistent partition names.