### PR TITLE
perf(native): Avoid `LIKE` rewrites for prefix/suffix patterns in native execution

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -105,6 +105,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.regex.Pattern;
 
+import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
 import static com.facebook.presto.common.function.OperatorType.BETWEEN;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.function.OperatorType.NEGATION;
@@ -209,7 +210,8 @@ public final class SqlToRowExpressionTranslator
                 session.getTransactionId(),
                 session.getSqlFunctionProperties(),
                 session.getSessionFunctions(),
-                context);
+                context,
+                isNativeExecutionEnabled(session));
     }
 
     public static RowExpression translate(
@@ -223,6 +225,31 @@ public final class SqlToRowExpressionTranslator
             Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
             Context context)
     {
+        return translate(
+                expression,
+                types,
+                layout,
+                functionAndTypeManager,
+                user,
+                transactionId,
+                sqlFunctionProperties,
+                sessionFunctions,
+                context,
+                false);
+    }
+
+    private static RowExpression translate(
+            Expression expression,
+            Map<NodeRef<Expression>, Type> types,
+            Map<VariableReferenceExpression, Integer> layout,
+            FunctionAndTypeManager functionAndTypeManager,
+            Optional<String> user,
+            Optional<TransactionId> transactionId,
+            SqlFunctionProperties sqlFunctionProperties,
+            Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
+            Context context,
+            boolean nativeExecutionEnabled)
+    {
         Visitor visitor = new Visitor(
                 types,
                 layout,
@@ -230,7 +257,8 @@ public final class SqlToRowExpressionTranslator
                 user,
                 transactionId,
                 sqlFunctionProperties,
-                sessionFunctions);
+                sessionFunctions,
+                nativeExecutionEnabled);
         RowExpression result = visitor.process(expression, context);
         requireNonNull(result, "translated expression is null");
         return result;
@@ -272,6 +300,7 @@ public final class SqlToRowExpressionTranslator
         private final SqlFunctionProperties sqlFunctionProperties;
         private final Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions;
         private final FunctionResolution functionResolution;
+        private final boolean nativeExecutionEnabled;
 
         private Visitor(
                 Map<NodeRef<Expression>, Type> types,
@@ -280,7 +309,8 @@ public final class SqlToRowExpressionTranslator
                 Optional<String> user,
                 Optional<TransactionId> transactionId,
                 SqlFunctionProperties sqlFunctionProperties,
-                Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions)
+                Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
+                boolean nativeExecutionEnabled)
         {
             this.types = requireNonNull(types, "types is null");
             this.layout = requireNonNull(layout);
@@ -291,6 +321,7 @@ public final class SqlToRowExpressionTranslator
             this.sqlFunctionProperties = requireNonNull(sqlFunctionProperties);
             this.functionResolution = new FunctionResolution(functionAndTypeResolver);
             this.sessionFunctions = requireNonNull(sessionFunctions);
+            this.nativeExecutionEnabled = nativeExecutionEnabled;
         }
 
         private Type getType(Expression node)
@@ -927,9 +958,11 @@ public final class SqlToRowExpressionTranslator
                 return likeFunctionCall(value, call(getSourceLocation(node), "LIKE_PATTERN", functionResolution.likePatternFunction(), LIKE_PATTERN, pattern, escape));
             }
 
-            RowExpression prefixOrSuffixMatch = generateLikePrefixOrSuffixMatch(value, pattern);
-            if (prefixOrSuffixMatch != null) {
-                return prefixOrSuffixMatch;
+            if (!nativeExecutionEnabled) {
+                RowExpression prefixOrSuffixMatch = generateLikePrefixOrSuffixMatch(value, pattern);
+                if (prefixOrSuffixMatch != null) {
+                    return prefixOrSuffixMatch;
+                }
             }
 
             if (!functionResolution.supportsLikePatternFunction()) {


### PR DESCRIPTION
## Description

This change conditionally disables Presto's coordinator-side LIKE pattern rewrites when `native-execution-enabled=true`. Velox's `OptimizedLike` implementation provides superior performance for simple LIKE patterns compared to Presto's rewrites that decompose LIKE into SUBSTR/STRPOS calls.

## Motivation and Context

Presto currently optimizes SQL LIKE patterns at the coordinator level:
- `'foo%'` → `SUBSTR(x, 1, len) = 'foo'`
- `'%foo'` → `SUBSTR(x, -len) = 'foo'`
- `'%foo%'` → `STRPOS(x, 'foo') != 0`

When native execution is enabled, Velox's engine natively evaluates LIKE expressions using the `OptimizedLike` template class, which provides fast-path implementations:
- Prefix/suffix matching: Direct `memcmp` on byte ranges (no character indexing overhead)
- Substring matching: `std::string_view::find` for O(n) scanning

In contrast, Presto's SUBSTR/STRPOS rewrites require:
- Character-position counting via UTF-8 codepoint iteration
- Byte-range lookups with explicit index conversion
- Generalized string function evaluation overhead

For constant patterns, Velox's optimized paths are better performant. By letting Velox evaluate LIKE natively, we unlock Velox's optimization by eliminating unnecessary rewriting.

## Impact

- Coordinators without native execution enabled (default): LIKE rewrites continue as before
- No semantic changes: Native LIKE evaluation is equivalent to the coordinator-side rewrites


## Test Plan

- Validated with existing `TestRowExpressionTranslator` test suite

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Guard LIKE prefix/suffix rewrite logic in the SQL-to-row-expression translator with the native execution enablement flag to preserve expected behavior under native execution.

Enhancements:
- Extend SQL-to-row-expression translation APIs and visitor to be aware of native execution enablement.
- Skip LIKE prefix/suffix optimization rewrites when native execution is enabled while preserving existing behavior otherwise.

## Summary by Sourcery

Gate coordinator-side LIKE prefix/suffix pattern rewrites on the native execution flag so that native execution uses Velox’s built-in LIKE evaluation.

Enhancements:
- Extend SQL-to-row-expression translation APIs and visitor to propagate whether native execution is enabled.
- Skip LIKE prefix/suffix optimization rewrites in the LIKE predicate visitor when native execution is enabled, retaining existing behavior otherwise.