### PR TITLE
docs: Add documentation for type mapping for Oracle connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -120,36 +120,26 @@ The connector maps Oracle types to the corresponding PrestoDB types:
 
   * - Oracle type
     - PrestoDB type
-  * - ``BOOLEAN``, ``BIT``
-    - ``BOOLEAN``
-  * - ``TINYINT``
-    - ``TINYINT``
-  * - ``SMALLINT``
-    - ``SMALLINT``
-  * - ``INTEGER``
-    - ``INTEGER``
-  * - ``BIGINT``
-    - ``BIGINT``
-  * - ``REAL``
-    - ``REAL``
-  * - ``FLOAT``, ``DOUBLE``
+  * - ``NUMBER(p, s)``
+    - ``DECIMAL(p, s)`` (or ``BIGINT`` if ``s = 0`` and within range)
+  * - ``FLOAT``
     - ``DOUBLE``
-  * - ``NUMERIC(p, s)``, ``DECIMAL(p, s)``
-    - ``BIGINT`` (if ``s = 0``), otherwise ``DECIMAL(p, s)``
+  * - ``BINARY_FLOAT``
+    - ``REAL``
+  * - ``BINARY_DOUBLE``
+    - ``DOUBLE``
   * - ``CHAR(n)``, ``NCHAR(n)``
     - ``CHAR(n)``
-  * - ``VARCHAR(n)``, ``NVARCHAR(n)``, ``LONGVARCHAR``
-    - ``VARCHAR``
-  * - ``BINARY``, ``VARBINARY``, ``LONGVARBINARY``
-    - ``VARBINARY``
-  * - ``CLOB``
+  * - ``VARCHAR2(n)``, ``NVARCHAR2(n)``
+    - ``VARCHAR(n)``
+  * - ``CLOB``, ``NCLOB``
     - ``VARCHAR``
   * - ``BLOB``
     - ``VARBINARY``
+  * - ``RAW(n)``, ``LONG RAW``
+    - ``VARBINARY``
   * - ``DATE``
-    - ``DATE``
-  * - ``TIME``
-    - ``TIME``
+    - ``TIMESTAMP``
   * - ``TIMESTAMP``
     - ``TIMESTAMP``
 
@@ -167,29 +157,23 @@ The connector maps PrestoDB types to the corresponding Oracle types:
   * - PrestoDB type
     - Oracle type
   * - ``BOOLEAN``
-    - ``NUMBER``
-  * - ``TINYINT``
-    - ``NUMBER``
-  * - ``SMALLINT``
-    - ``NUMBER``
-  * - ``INTEGER``
-    - ``NUMBER``
-  * - ``BIGINT``
+    - ``NUMBER(1)``
+  * - ``TINYINT``, ``SMALLINT``, ``INTEGER``, ``BIGINT``
     - ``NUMBER``
   * - ``REAL``
-    - ``FLOAT``
+    - ``BINARY_FLOAT``
   * - ``DOUBLE``
-    - ``DOUBLE PRECISION``
+    - ``BINARY_DOUBLE``
   * - ``DECIMAL(p, s)``
     - ``NUMBER(p, s)``
-  * - ``CHAR(n)``, ``VARCHAR(n)``
-    - ``VARCHAR2``
+  * - ``CHAR(n)``
+    - ``CHAR(n)``
+  * - ``VARCHAR(n)``
+    - ``VARCHAR2(n)``
   * - ``VARBINARY``
     - ``BLOB``
   * - ``DATE``
     - ``DATE``
-  * - ``TIME``
-    - ``TIME``
   * - ``TIMESTAMP``
     - ``TIMESTAMP``
 


### PR DESCRIPTION
## Description
Added type mapping tables for the Oracle connector that match the format of the MySQL connector.

## Motivation and Context
The documentation was missing the complete type mapping reference for Presto to Oracle and vice versa. 
Fixes #26314

## Impact
Documentation changes. 

## Test Plan
Local documentation build.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Add type mapping reference tables for the Oracle connector, aligned with the MySQL connector documentation format.