### PR TITLE
refactor: Prepare TableFunction SPI for C++

### DIFF
--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/testingConnector/tvf/QueryFunctionProvider.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/testingConnector/tvf/QueryFunctionProvider.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
-import static com.facebook.presto.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static com.facebook.presto.spi.function.table.GenericTableReturnTypeSpecification.GENERIC_TABLE;
 import static java.util.Objects.requireNonNull;
 
 public class QueryFunctionProvider

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/TableFunctionRegistry.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/TableFunctionRegistry.java
@@ -21,8 +21,9 @@ import com.facebook.presto.spi.function.CatalogSchemaFunctionName;
 import com.facebook.presto.spi.function.SchemaFunctionName;
 import com.facebook.presto.spi.function.table.ArgumentSpecification;
 import com.facebook.presto.spi.function.table.ConnectorTableFunction;
-import com.facebook.presto.spi.function.table.ReturnTypeSpecification.DescribedTable;
+import com.facebook.presto.spi.function.table.DescribedTableReturnTypeSpecification;
 import com.facebook.presto.spi.function.table.TableArgumentSpecification;
+import com.facebook.presto.spi.function.table.TableFunctionMetadata;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
@@ -157,8 +158,8 @@ public class TableFunctionRegistry
         // Such a table argument is implicitly 'prune when empty'. The TableArgumentSpecification.Builder enforces the 'prune when empty' property
         // for a table argument with row semantics.
 
-        if (tableFunction.getReturnTypeSpecification() instanceof DescribedTable) {
-            DescribedTable describedTable = (DescribedTable) tableFunction.getReturnTypeSpecification();
+        if (tableFunction.getReturnTypeSpecification() instanceof DescribedTableReturnTypeSpecification) {
+            DescribedTableReturnTypeSpecification describedTable = (DescribedTableReturnTypeSpecification) tableFunction.getReturnTypeSpecification();
             checkArgument(describedTable.getDescriptor().isTyped(), "field types missing in returned type specification");
         }
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/table/ExcludeColumns.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/table/ExcludeColumns.java
@@ -42,7 +42,7 @@ import java.util.Set;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.function.table.DescriptorArgument.NULL_DESCRIPTOR;
-import static com.facebook.presto.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static com.facebook.presto.spi.function.table.GenericTableReturnTypeSpecification.GENERIC_TABLE;
 import static com.facebook.presto.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
 import static com.facebook.presto.spi.function.table.TableFunctionProcessorState.Processed.usedInputAndProduced;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;

--- a/presto-main-base/src/main/java/com/facebook/presto/operator/table/Sequence.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/table/Sequence.java
@@ -27,7 +27,7 @@ import com.facebook.presto.spi.function.table.AbstractConnectorTableFunction;
 import com.facebook.presto.spi.function.table.Argument;
 import com.facebook.presto.spi.function.table.ConnectorTableFunction;
 import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
-import com.facebook.presto.spi.function.table.ReturnTypeSpecification.DescribedTable;
+import com.facebook.presto.spi.function.table.DescribedTableReturnTypeSpecification;
 import com.facebook.presto.spi.function.table.ScalarArgument;
 import com.facebook.presto.spi.function.table.ScalarArgumentSpecification;
 import com.facebook.presto.spi.function.table.TableFunctionAnalysis;
@@ -96,7 +96,7 @@ public class Sequence
                                     .type(BIGINT)
                                     .defaultValue(1L)
                                     .build()),
-                    new DescribedTable(descriptor(ImmutableList.of("sequential_number"), ImmutableList.of(BIGINT))));
+                    new DescribedTableReturnTypeSpecification(descriptor(ImmutableList.of("sequential_number"), ImmutableList.of(BIGINT))));
         }
 
         @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -36,7 +36,6 @@ import com.facebook.presto.metadata.CatalogMetadata;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.OperatorNotFoundException;
-import com.facebook.presto.metadata.TableFunctionMetadata;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
@@ -62,6 +61,7 @@ import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.spi.function.table.Argument;
 import com.facebook.presto.spi.function.table.ArgumentSpecification;
 import com.facebook.presto.spi.function.table.ConnectorTableFunction;
+import com.facebook.presto.spi.function.table.DescribedTableReturnTypeSpecification;
 import com.facebook.presto.spi.function.table.Descriptor;
 import com.facebook.presto.spi.function.table.DescriptorArgument;
 import com.facebook.presto.spi.function.table.DescriptorArgumentSpecification;
@@ -71,6 +71,7 @@ import com.facebook.presto.spi.function.table.ScalarArgumentSpecification;
 import com.facebook.presto.spi.function.table.TableArgument;
 import com.facebook.presto.spi.function.table.TableArgumentSpecification;
 import com.facebook.presto.spi.function.table.TableFunctionAnalysis;
+import com.facebook.presto.spi.function.table.TableFunctionMetadata;
 import com.facebook.presto.spi.procedure.DistributedProcedure;
 import com.facebook.presto.spi.procedure.TableDataRewriteDistributedProcedure;
 import com.facebook.presto.spi.relation.DomainTranslator;
@@ -268,7 +269,7 @@ import static com.facebook.presto.spi.connector.ConnectorTableVersion.VersionTyp
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
 import static com.facebook.presto.spi.function.FunctionKind.WINDOW;
 import static com.facebook.presto.spi.function.table.DescriptorArgument.NULL_DESCRIPTOR;
-import static com.facebook.presto.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static com.facebook.presto.spi.function.table.GenericTableReturnTypeSpecification.GENERIC_TABLE;
 import static com.facebook.presto.spi.security.ViewSecurity.DEFINER;
 import static com.facebook.presto.spi.security.ViewSecurity.INVOKER;
 import static com.facebook.presto.sql.MaterializedViewUtils.buildOwnerSession;
@@ -1666,7 +1667,7 @@ class StatementAnalyzer
         private Descriptor verifyProperColumnsDescriptor(TableFunctionInvocation node, ConnectorTableFunction function, ReturnTypeSpecification returnTypeSpecification, Optional<Descriptor> analyzedProperColumnsDescriptor)
         {
             switch (returnTypeSpecification.getReturnType()) {
-                case ReturnTypeSpecification.OnlyPassThrough.returnType:
+                case "PASSTHROUGH":
                     if (analysis.isAliased(node)) {
                         // According to SQL standard ISO/IEC 9075-2, 7.6 <table reference>, p. 409,
                         // table alias is prohibited for a table function with ONLY PASS THROUGH returned type.
@@ -1688,7 +1689,7 @@ class StatementAnalyzer
                         throw new SemanticException(TABLE_FUNCTION_IMPLEMENTATION_ERROR, "A table function with ONLY_PASS_THROUGH return type must have a table argument with pass-through columns.");
                     }
                     return null;
-                case ReturnTypeSpecification.GenericTable.returnType:
+                case "GENERIC":
                     // According to SQL standard ISO/IEC 9075-2, 7.6 <table reference>, p. 409,
                     // table alias is mandatory for a polymorphic table function invocation which produces proper columns.
                     // We don't enforce this requirement.
@@ -1704,7 +1705,7 @@ class StatementAnalyzer
                         // so the function's analyze() method should not return the proper columns descriptor.
                         throw new SemanticException(TABLE_FUNCTION_AMBIGUOUS_RETURN_TYPE, node, "Returned relation type for table function %s is ambiguous", node.getName());
                     }
-                    return ((ReturnTypeSpecification.DescribedTable) returnTypeSpecification).getDescriptor();
+                    return ((DescribedTableReturnTypeSpecification) returnTypeSpecification).getDescriptor();
             }
         }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestingTableFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/connector/tvf/TestingTableFunctions.java
@@ -30,9 +30,10 @@ import com.facebook.presto.spi.function.SchemaFunctionName;
 import com.facebook.presto.spi.function.table.AbstractConnectorTableFunction;
 import com.facebook.presto.spi.function.table.Argument;
 import com.facebook.presto.spi.function.table.ConnectorTableFunctionHandle;
+import com.facebook.presto.spi.function.table.DescribedTableReturnTypeSpecification;
 import com.facebook.presto.spi.function.table.Descriptor;
 import com.facebook.presto.spi.function.table.DescriptorArgumentSpecification;
-import com.facebook.presto.spi.function.table.ReturnTypeSpecification;
+import com.facebook.presto.spi.function.table.GenericTableReturnTypeSpecification;
 import com.facebook.presto.spi.function.table.ScalarArgument;
 import com.facebook.presto.spi.function.table.ScalarArgumentSpecification;
 import com.facebook.presto.spi.function.table.TableArgument;
@@ -63,9 +64,8 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
-import static com.facebook.presto.spi.function.table.ReturnTypeSpecification.DescribedTable;
-import static com.facebook.presto.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
-import static com.facebook.presto.spi.function.table.ReturnTypeSpecification.OnlyPassThrough.ONLY_PASS_THROUGH;
+import static com.facebook.presto.spi.function.table.GenericTableReturnTypeSpecification.GENERIC_TABLE;
+import static com.facebook.presto.spi.function.table.OnlyPassThroughReturnTypeSpecification.ONLY_PASS_THROUGH;
 import static com.facebook.presto.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
 import static com.facebook.presto.spi.function.table.TableFunctionProcessorState.Processed.produced;
 import static com.facebook.presto.spi.function.table.TableFunctionProcessorState.Processed.usedInput;
@@ -99,7 +99,7 @@ public class TestingTableFunctions
         private static final String FUNCTION_NAME = "test_function";
         public TestConnectorTableFunction()
         {
-            super(SCHEMA_NAME, FUNCTION_NAME, ImmutableList.of(), ReturnTypeSpecification.GenericTable.GENERIC_TABLE);
+            super(SCHEMA_NAME, FUNCTION_NAME, ImmutableList.of(), GenericTableReturnTypeSpecification.GENERIC_TABLE);
         }
 
         @Override
@@ -473,7 +473,7 @@ public class TestingTableFunctions
                     SCHEMA_NAME,
                     FUNCTION_NAME,
                     ImmutableList.of(),
-                    new DescribedTable(Descriptor.descriptor(
+                    new DescribedTableReturnTypeSpecification(Descriptor.descriptor(
                             ImmutableList.of("a", "b"),
                             ImmutableList.of(BOOLEAN, INTEGER))));
         }
@@ -499,7 +499,7 @@ public class TestingTableFunctions
                     ImmutableList.of(TableArgumentSpecification.builder()
                             .name("INPUT")
                             .build()),
-                    new DescribedTable(Descriptor.descriptor(
+                    new DescribedTableReturnTypeSpecification(Descriptor.descriptor(
                             ImmutableList.of("a", "b"),
                             ImmutableList.of(BOOLEAN, INTEGER))));
         }
@@ -525,7 +525,7 @@ public class TestingTableFunctions
                             .passThroughColumns()
                             .keepWhenEmpty()
                             .build()),
-                    new DescribedTable(Descriptor.descriptor(
+                    new DescribedTableReturnTypeSpecification(Descriptor.descriptor(
                             ImmutableList.of("x"),
                             ImmutableList.of(BOOLEAN))));
         }
@@ -858,7 +858,7 @@ public class TestingTableFunctions
                             .name("INPUT")
                             .keepWhenEmpty()
                             .build()),
-                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN))))));
+                    new DescribedTableReturnTypeSpecification(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN))))));
         }
 
         @Override
@@ -911,7 +911,7 @@ public class TestingTableFunctions
                             .keepWhenEmpty()
                             .passThroughColumns()
                             .build()),
-                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN))))));
+                    new DescribedTableReturnTypeSpecification(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN))))));
         }
 
         @Override
@@ -979,7 +979,7 @@ public class TestingTableFunctions
                                     .name("INPUT_4")
                                     .keepWhenEmpty()
                                     .build()),
-                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("boolean_result", Optional.of(BOOLEAN))))));
+                    new DescribedTableReturnTypeSpecification(new Descriptor(ImmutableList.of(new Descriptor.Field("boolean_result", Optional.of(BOOLEAN))))));
         }
 
         @Override
@@ -1035,7 +1035,7 @@ public class TestingTableFunctions
                                     .passThroughColumns()
                                     .keepWhenEmpty()
                                     .build()),
-                    new DescribedTable(new Descriptor(ImmutableList.of(
+                    new DescribedTableReturnTypeSpecification(new Descriptor(ImmutableList.of(
                             new Descriptor.Field("input_1_present", Optional.of(BOOLEAN)),
                             new Descriptor.Field("input_2_present", Optional.of(BOOLEAN))))));
         }
@@ -1132,7 +1132,7 @@ public class TestingTableFunctions
                             .name("INPUT")
                             .keepWhenEmpty()
                             .build()),
-                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("got_input", Optional.of(BOOLEAN))))));
+                    new DescribedTableReturnTypeSpecification(new Descriptor(ImmutableList.of(new Descriptor.Field("got_input", Optional.of(BOOLEAN))))));
         }
 
         @Override
@@ -1191,7 +1191,7 @@ public class TestingTableFunctions
                             .rowSemantics()
                             .name("INPUT")
                             .build()),
-                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("boolean_result", Optional.of(BOOLEAN))))));
+                    new DescribedTableReturnTypeSpecification(new Descriptor(ImmutableList.of(new Descriptor.Field("boolean_result", Optional.of(BOOLEAN))))));
         }
 
         @Override
@@ -1242,7 +1242,7 @@ public class TestingTableFunctions
                                     .type(INTEGER)
                                     .defaultValue(1L)
                                     .build()),
-                    new DescribedTable(Descriptor.descriptor(
+                    new DescribedTableReturnTypeSpecification(Descriptor.descriptor(
                             ImmutableList.of("constant_column"),
                             ImmutableList.of(INTEGER))));
         }
@@ -1438,7 +1438,7 @@ public class TestingTableFunctions
                     SCHEMA_NAME,
                     FUNCTION_NAME,
                     ImmutableList.of(),
-                    new DescribedTable(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN))))));
+                    new DescribedTableReturnTypeSpecification(new Descriptor(ImmutableList.of(new Descriptor.Field("column", Optional.of(BOOLEAN))))));
         }
 
         @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/metadata/TestTableFunctionRegistry.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/metadata/TestTableFunctionRegistry.java
@@ -15,6 +15,7 @@ package com.facebook.presto.metadata;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.function.table.TableFunctionMetadata;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/AbstractConnectorTableFunction.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/AbstractConnectorTableFunction.java
@@ -15,6 +15,8 @@ package com.facebook.presto.spi.function.table;
 
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +46,12 @@ public abstract class AbstractConnectorTableFunction
     private final List<ArgumentSpecification> arguments;
     private final ReturnTypeSpecification returnTypeSpecification;
 
-    public AbstractConnectorTableFunction(String schema, String name, List<ArgumentSpecification> arguments, ReturnTypeSpecification returnTypeSpecification)
+    @JsonCreator
+    public AbstractConnectorTableFunction(
+            @JsonProperty("schema") String schema,
+            @JsonProperty("name") String name,
+            @JsonProperty("arguments") List<ArgumentSpecification> arguments,
+            @JsonProperty("returnTypeSpecification") ReturnTypeSpecification returnTypeSpecification)
     {
         this.schema = requireNonNull(schema, "schema is null");
         this.name = requireNonNull(name, "name is null");
@@ -52,24 +59,28 @@ public abstract class AbstractConnectorTableFunction
         this.returnTypeSpecification = requireNonNull(returnTypeSpecification, "returnTypeSpecification is null");
     }
 
+    @JsonProperty
     @Override
     public String getSchema()
     {
         return schema;
     }
 
+    @JsonProperty
     @Override
     public String getName()
     {
         return name;
     }
 
+    @JsonProperty
     @Override
     public List<ArgumentSpecification> getArguments()
     {
         return arguments;
     }
 
+    @JsonProperty
     @Override
     public ReturnTypeSpecification getReturnTypeSpecification()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/ArgumentSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/ArgumentSpecification.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi.function.table;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import jakarta.annotation.Nullable;
 
 import static com.facebook.presto.spi.function.table.Preconditions.checkArgument;
@@ -28,6 +31,14 @@ import static com.facebook.presto.spi.function.table.Preconditions.checkNotNullO
  * <p>
  * Default values are allowed for all arguments except Table arguments.
  */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = DescriptorArgumentSpecification.class, name = "descriptor"),
+        @JsonSubTypes.Type(value = TableArgumentSpecification.class, name = "table"),
+        @JsonSubTypes.Type(value = ScalarArgumentSpecification.class, name = "scalar")})
 public abstract class ArgumentSpecification
 {
     public static final String argumentType = "Abstract";
@@ -45,16 +56,19 @@ public abstract class ArgumentSpecification
         this.defaultValue = defaultValue;
     }
 
+    @JsonProperty
     public String getName()
     {
         return name;
     }
 
+    @JsonProperty
     public boolean isRequired()
     {
         return required;
     }
 
+    @JsonProperty
     public Object getDefaultValue()
     {
         return defaultValue;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/ConnectorTableFunctionHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/ConnectorTableFunctionHandle.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.spi.function.table;
 
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.NodeManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -21,4 +25,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.ALWAYS)
 public interface ConnectorTableFunctionHandle
 {
+    default ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction,
+                                           ConnectorSession session,
+                                           NodeManager nodeManager,
+                                           Object functionAndTypeManager)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/DescribedTableReturnTypeSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/DescribedTableReturnTypeSpecification.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function.table;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.facebook.presto.spi.function.table.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The proper columns of the table function are known at function declaration time.
+ * They do not depend on the actual call arguments.
+ */
+public class DescribedTableReturnTypeSpecification
+        extends ReturnTypeSpecification
+{
+    private final Descriptor descriptor;
+    private static final String returnType = "DESCRIBED";
+
+    @JsonCreator
+    public DescribedTableReturnTypeSpecification(@JsonProperty("descriptor") Descriptor descriptor)
+    {
+        requireNonNull(descriptor, "descriptor is null");
+        checkArgument(descriptor.isTyped(), "field types not specified");
+        this.descriptor = descriptor;
+    }
+
+    public Descriptor getDescriptor()
+    {
+        return descriptor;
+    }
+
+    @Override
+    public String getReturnType()
+    {
+        return returnType;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/DescriptorArgument.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/DescriptorArgument.java
@@ -32,7 +32,7 @@ public class DescriptorArgument
     private final Optional<Descriptor> descriptor;
 
     @JsonCreator
-    private DescriptorArgument(@JsonProperty("descriptor") Optional<Descriptor> descriptor)
+    public DescriptorArgument(@JsonProperty("descriptor") Optional<Descriptor> descriptor)
     {
         this.descriptor = requireNonNull(descriptor, "descriptor is null");
         descriptor.ifPresent(descriptorValue -> checkArgument(

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/DescriptorArgumentSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/DescriptorArgumentSpecification.java
@@ -13,11 +13,17 @@
  */
 package com.facebook.presto.spi.function.table;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 public class DescriptorArgumentSpecification
         extends ArgumentSpecification
 {
     public static final String argumentType = "DescriptorArgumentSpecification";
-    private DescriptorArgumentSpecification(String name, boolean required, Descriptor defaultValue)
+    @JsonCreator
+    public DescriptorArgumentSpecification(
+            @JsonProperty("name") String name,
+            @JsonProperty("required") boolean required,
+            @JsonProperty("defaultValue") Descriptor defaultValue)
     {
         super(name, required, defaultValue);
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/GenericTableReturnTypeSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/GenericTableReturnTypeSpecification.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function.table;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Objects;
+
+/**
+ * The proper columns of the table function are not known at function declaration time.
+ * They must be determined at query analysis time based on the actual call arguments.
+ */
+public class GenericTableReturnTypeSpecification
+        extends ReturnTypeSpecification
+{
+    public static final GenericTableReturnTypeSpecification GENERIC_TABLE = new GenericTableReturnTypeSpecification();
+    private static final String returnType = "GENERIC";
+
+    @JsonCreator
+    public GenericTableReturnTypeSpecification()
+    {}
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GenericTableReturnTypeSpecification that = (GenericTableReturnTypeSpecification) o;
+        return Objects.equals(returnType, that.returnType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(returnType);
+    }
+
+    @Override
+    public String getReturnType()
+    {
+        return returnType;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/OnlyPassThroughReturnTypeSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/OnlyPassThroughReturnTypeSpecification.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.function.table;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * The table function has no proper columns.
+ */
+public class OnlyPassThroughReturnTypeSpecification
+        extends ReturnTypeSpecification
+{
+    public static final OnlyPassThroughReturnTypeSpecification ONLY_PASS_THROUGH = new OnlyPassThroughReturnTypeSpecification();
+    private static final String returnType = "PASSTHROUGH";
+
+    @JsonCreator
+    public OnlyPassThroughReturnTypeSpecification()
+    {}
+
+    @Override
+    public String getReturnType()
+    {
+        return returnType;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/ReturnTypeSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/ReturnTypeSpecification.java
@@ -13,8 +13,8 @@
  */
 package com.facebook.presto.spi.function.table;
 
-import static com.facebook.presto.spi.function.table.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * The return type declaration refers to the proper columns of the table function.
@@ -25,77 +25,15 @@ import static java.util.Objects.requireNonNull;
  * dynamically determined at analysis time (GenericTable), or simply passed through
  * from input tables without adding new columns (OnlyPassThrough).
  */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = GenericTableReturnTypeSpecification.class, name = "generic_table"),
+        @JsonSubTypes.Type(value = OnlyPassThroughReturnTypeSpecification.class, name = "only_pass_through_table"),
+        @JsonSubTypes.Type(value = DescribedTableReturnTypeSpecification.class, name = "described_table")})
 public abstract class ReturnTypeSpecification
 {
-    public static final String returnType = "Abstract";
-    /**
-     * The proper columns of the table function are not known at function declaration time.
-     * They must be determined at query analysis time based on the actual call arguments.
-     */
-    public static class GenericTable
-            extends ReturnTypeSpecification
-    {
-        public static final String returnType = "GenericTable";
-        public static final GenericTable GENERIC_TABLE = new GenericTable();
-
-        private GenericTable() {}
-
-        @Override
-        public String getReturnType()
-        {
-            return returnType;
-        }
-    }
-
-    /**
-     * The table function has no proper columns.
-     */
-    public static class OnlyPassThrough
-            extends ReturnTypeSpecification
-    {
-        public static final String returnType = "OnlyPassThrough";
-        public static final OnlyPassThrough ONLY_PASS_THROUGH = new OnlyPassThrough();
-
-        private OnlyPassThrough() {}
-
-        @Override
-        public String getReturnType()
-        {
-            return returnType;
-        }
-    }
-
-    /**
-     * The proper columns of the table function are known at function declaration time.
-     * They do not depend on the actual call arguments.
-     */
-    public static class DescribedTable
-            extends ReturnTypeSpecification
-    {
-        public static final String returnType = "DescribedTable";
-        private final Descriptor descriptor;
-
-        public DescribedTable(Descriptor descriptor)
-        {
-            requireNonNull(descriptor, "descriptor is null");
-            checkArgument(descriptor.isTyped(), "field types not specified");
-            this.descriptor = descriptor;
-        }
-
-        public Descriptor getDescriptor()
-        {
-            return descriptor;
-        }
-
-        @Override
-        public String getReturnType()
-        {
-            return returnType;
-        }
-    }
-
-    public String getReturnType()
-    {
-        return returnType;
-    }
+    public abstract String getReturnType();
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/ScalarArgumentSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/ScalarArgumentSpecification.java
@@ -15,6 +15,9 @@ package com.facebook.presto.spi.function.table;
 
 import com.facebook.presto.common.predicate.Primitives;
 import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
 
 import static com.facebook.presto.spi.function.table.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -26,7 +29,12 @@ public class ScalarArgumentSpecification
     public static final String argumentType = "ScalarArgumentSpecification";
     private final Type type;
 
-    private ScalarArgumentSpecification(String name, Type type, boolean required, Object defaultValue)
+    @JsonCreator
+    public ScalarArgumentSpecification(
+            @JsonProperty("name") String name,
+            @JsonProperty("type") Type type,
+            @JsonProperty("required") boolean required,
+            @Nullable Object defaultValue)
     {
         super(name, required, defaultValue);
         this.type = requireNonNull(type, "type is null");
@@ -35,6 +43,7 @@ public class ScalarArgumentSpecification
         }
     }
 
+    @JsonProperty
     public Type getType()
     {
         return type;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/TableArgument.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/TableArgument.java
@@ -50,6 +50,12 @@ public class TableArgument
     }
 
     @JsonProperty
+    public List<RowType.Field> getFields()
+    {
+        return rowType.getFields();
+    }
+
+    @JsonProperty
     public List<String> getPartitionBy()
     {
         return partitionBy;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/TableArgumentSpecification.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/TableArgumentSpecification.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi.function.table;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import static com.facebook.presto.spi.function.table.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -24,7 +27,12 @@ public class TableArgumentSpecification
     private final boolean pruneWhenEmpty;
     private final boolean passThroughColumns;
 
-    private TableArgumentSpecification(String name, boolean rowSemantics, boolean pruneWhenEmpty, boolean passThroughColumns)
+    @JsonCreator
+    public TableArgumentSpecification(
+            @JsonProperty("name") String name,
+            @JsonProperty("rowSemantics") boolean rowSemantics,
+            @JsonProperty("pruneWhenEmpty") boolean pruneWhenEmpty,
+            @JsonProperty("passThroughColumns") boolean passThroughColumns)
     {
         super(name, true, null);
 
@@ -36,16 +44,19 @@ public class TableArgumentSpecification
         this.passThroughColumns = passThroughColumns;
     }
 
+    @JsonProperty
     public boolean isRowSemantics()
     {
         return rowSemantics;
     }
 
+    @JsonProperty
     public boolean isPruneWhenEmpty()
     {
         return pruneWhenEmpty;
     }
 
+    @JsonProperty
     public boolean isPassThroughColumns()
     {
         return passThroughColumns;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/table/TableFunctionMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/table/TableFunctionMetadata.java
@@ -11,10 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.metadata;
+package com.facebook.presto.spi.function.table;
 
 import com.facebook.presto.spi.ConnectorId;
-import com.facebook.presto.spi.function.table.ConnectorTableFunction;
 
 import static java.util.Objects.requireNonNull;
 


### PR DESCRIPTION
Add the JSON annotations to prepare the TableFunction SPI classes for C++ serialization

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Annotate table function SPI types for JSON serialization and split table return type variants into dedicated classes to support polymorphic handling, updating callers and validation logic accordingly.

Enhancements:
- Introduce dedicated GenericTable, OnlyPassThrough, and DescribedTable return type specification classes and replace legacy nested implementations.
- Add Jackson type and property annotations to table function SPI classes and argument specifications to enable JSON-based transport and C++ interoperability.
- Extend ConnectorTableFunctionHandle with a default getSplits method and expose additional table argument metadata for external consumers.

Tests:
- Update table function tests and Arrow Flight connector tests to use the new return type specification classes.