### PR TITLE
Revert D96106074

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2967,10 +2967,7 @@ class StatementAnalyzer
             analysis.setOrderByExpressions(node, orderByExpressions);
 
             List<Expression> sourceExpressions = new ArrayList<>(outputExpressions);
-            // Use the rewritten HAVING expression (to resolve SELECT alias references)
-            if (node.getHaving().isPresent()) {
-                sourceExpressions.add(analysis.getHaving(node));
-            }
+            node.getHaving().ifPresent(sourceExpressions::add);
 
             analyzeGroupingOperations(node, sourceExpressions, orderByExpressions);
             List<FunctionCall> aggregates = analyzeAggregations(node, sourceExpressions, orderByExpressions);
@@ -3823,12 +3820,7 @@ class StatementAnalyzer
             if (node.getHaving().isPresent()) {
                 Expression predicate = node.getHaving().get();
 
-                // Reuse OrderByExpressionRewriter to resolve SELECT aliases in HAVING
-                Multimap<QualifiedName, Expression> namedOutputExpressions = extractNamedOutputExpressions(node.getSelect());
-                Expression rewrittenPredicate = ExpressionTreeRewriter.rewriteWith(new OrderByExpressionRewriter(namedOutputExpressions, "HAVING"), predicate);
-
-                // Analyze the rewritten expression
-                ExpressionAnalysis expressionAnalysis = analyzeExpression(rewrittenPredicate, scope);
+                ExpressionAnalysis expressionAnalysis = analyzeExpression(predicate, scope);
 
                 expressionAnalysis.getWindowFunctions().stream()
                         .findFirst()
@@ -3838,12 +3830,12 @@ class StatementAnalyzer
 
                 analysis.recordSubqueries(node, expressionAnalysis);
 
-                Type predicateType = expressionAnalysis.getType(rewrittenPredicate);
+                Type predicateType = expressionAnalysis.getType(predicate);
                 if (!predicateType.equals(BOOLEAN) && !predicateType.equals(UNKNOWN)) {
-                    throw new SemanticException(TYPE_MISMATCH, rewrittenPredicate, "HAVING clause must evaluate to a boolean: actual type %s", predicateType);
+                    throw new SemanticException(TYPE_MISMATCH, predicate, "HAVING clause must evaluate to a boolean: actual type %s", predicateType);
                 }
 
-                analysis.setHaving(node, rewrittenPredicate);
+                analysis.setHaving(node, predicate);
             }
         }
 
@@ -3894,17 +3886,10 @@ class StatementAnalyzer
                 extends ExpressionRewriter<Void>
         {
             private final Multimap<QualifiedName, Expression> assignments;
-            private final String clauseName;
 
             public OrderByExpressionRewriter(Multimap<QualifiedName, Expression> assignments)
             {
-                this(assignments, "ORDER BY");
-            }
-
-            public OrderByExpressionRewriter(Multimap<QualifiedName, Expression> assignments, String clauseName)
-            {
                 this.assignments = assignments;
-                this.clauseName = clauseName;
             }
 
             @Override
@@ -3917,7 +3902,7 @@ class StatementAnalyzer
                         .collect(Collectors.toSet());
 
                 if (expressions.size() > 1) {
-                    throw new SemanticException(AMBIGUOUS_ATTRIBUTE, reference, "'%s' in '%s' is ambiguous", name, clauseName);
+                    throw new SemanticException(AMBIGUOUS_ATTRIBUTE, reference, "'%s' in ORDER BY is ambiguous", name);
                 }
 
                 if (expressions.size() == 1) {

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -308,32 +308,7 @@ public class TestAnalyzer
     @Test
     public void testHavingReferencesOutputAlias()
     {
-        // HAVING now support referencing SELECT aliases for improved SQL compatibility
-        analyze("SELECT sum(a) x FROM t1 HAVING x > 5");
-        analyze("SELECT sum(a) AS total FROM t1 GROUP BY b HAVING total > 10");
-        analyze("SELECT count(*) AS cnt, sum(a) AS total FROM t1 GROUP BY b HAVING cnt > 5 AND total > 100");
-        analyze("SELECT sum(a) as sum_a FROM t1 GROUP BY b HAVING sum_a > 1");
-    }
-
-    @Test
-    public void testHavingAmbiguousAlias()
-    {
-        // Ambiguous alias referenced in HAVING should throw appropriate error
-        assertFails(AMBIGUOUS_ATTRIBUTE, "SELECT sum(a) AS x, count(b) AS x FROM t1 GROUP BY c HAVING x > 5");
-    }
-
-    @Test
-    public void testHavingNonExistentAlias()
-    {
-        // Non-existent alias in HAVING should fail with MISSING_ATTRIBUTE
-        assertFails(MISSING_ATTRIBUTE, "SELECT sum(a) AS total FROM t1 GROUP BY b HAVING unknown_alias > 5");
-    }
-
-    @Test
-    public void testHavingWindowFunctionViaAlias()
-    {
-        // Window functions are not allowed in HAVING, even when referenced via alias
-        assertFails(NESTED_WINDOW, "SELECT row_number() OVER () AS rn FROM t1 GROUP BY b HAVING rn > 1");
+        assertFails(MISSING_ATTRIBUTE, "SELECT sum(a) x FROM t1 HAVING x > 5");
     }
 
     @Test


### PR DESCRIPTION
Summary:
This reverts the following PR
GitHub Pull Request: #27199

Differential Revision: D97181706

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Revert support for referencing SELECT aliases in HAVING clauses and restore previous semantic analysis behavior.

Enhancements:
- Simplify ORDER BY expression rewriting by removing generic clause handling.

Tests:
- Update analyzer tests to expect failures when HAVING references output aliases and remove now-unsupported HAVING alias test cases.