### PR TITLE
docs: Fix doc build errors

### DIFF
--- a/presto-docs/src/main/sphinx/admin/jmx-metrics.rst
+++ b/presto-docs/src/main/sphinx/admin/jmx-metrics.rst
@@ -186,7 +186,9 @@ Hive Connector
 ^^^^^^^^^^^^^^
 
 * ``com.facebook.presto.hive:name=*``: Hive metastore and file system metrics
+
 Example -
+
 * com.facebook.presto.hive:name=hive,type=cachingdirectorylister
 
 Iceberg Connector

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -321,7 +321,6 @@ Property Name                                            Description            
 
 ======================================================== ============================================================================== =============================
 
-.. note::
 These properties are mapped to the corresponding properties in Hive ``LazySerDeParameters`` during serialization and
 follow the same behaviors with ``LazySimpleSerDe``.
 If they are not defined, the Hive defaults are used, which are typically ``\001`` for field delimiter, ``\002`` for

--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -598,7 +598,7 @@ compaction. The value is in the range of [0, 1). Currently only applies to
 approx_most_frequent aggregate with StringView type during global aggregation.
 
 ``native_aggregation_memory_compaction_reclaim_enabled``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``


### PR DESCRIPTION
## Description
Fixing the following five errors in Presto doc builds that have crept in over time. 

```
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst:601: WARNING: Title underline too short.

``native_aggregation_memory_compaction_reclaim_enabled``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst:601: WARNING: Title underline too short.

``native_aggregation_memory_compaction_reclaim_enabled``
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [docutils]


/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/connector/hive.rst:324: ERROR: Content block expected for the "note" directive; none found. [docutils]
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/connector/hive.rst:325: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]

/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/admin/jmx-metrics.rst:189: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
```
## Motivation and Context
Reducing doc build errors when possible improves the doc build time, and improves the ability to debug doc builds by eliminating fixable errors in the doc build. 

## Impact
Documentation. 

## Test Plan
Local doc builds. 

Before: 
**build succeeded, 61 warnings.**

After, the five warnings shown above are gone from the doc build output:
**build succeeded, 56 warnings.**


## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix Sphinx documentation issues to reduce build warnings in the Presto docs.

Documentation:
- Correct heading formatting in the C++ session properties documentation to satisfy Sphinx title rules.
- Fix malformed note markup in the Hive connector documentation so it renders correctly.
- Adjust list formatting in the JMX metrics admin documentation to avoid Sphinx list parsing warnings.