### PR TITLE
Add working credentials configs for non cluster mode

### DIFF
--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisClusterAsyncCommandsFactory.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisClusterAsyncCommandsFactory.java
@@ -16,8 +16,12 @@ package com.facebook.presto.statistic;
 import com.facebook.presto.spi.statistics.HistoricalPlanStatistics;
 import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
+
+import java.net.URI;
+import java.util.Optional;
 
 public class RedisClusterAsyncCommandsFactory
 {
@@ -30,7 +34,24 @@ public class RedisClusterAsyncCommandsFactory
 
     public static RedisClient getRedisClient(RedisProviderConfig redisProviderConfig)
     {
-        return RedisClient.create(redisProviderConfig.getServerUri());
+        URI serverUri = URI.create(redisProviderConfig.getServerUri());
+        RedisURI.Builder redisUriBuilder = RedisURI.builder()
+                .withHost(serverUri.getHost())
+                .withPort(serverUri.getPort());
+
+        Optional<String> username = Optional.ofNullable(redisProviderConfig.getRedisUsername());
+        Optional<String> password = Optional.ofNullable(redisProviderConfig.getRedisPassword());
+
+        if (password.isPresent()) {
+            if (username.isPresent()) {
+                redisUriBuilder.withAuthentication(username.get(), password.get());
+            }
+            else {
+                redisUriBuilder.withPassword(password.get());
+            }
+        }
+
+        return RedisClient.create(redisUriBuilder.build());
     }
 
     public static RedisClusterAsyncCommands<String, HistoricalPlanStatistics> getRedisClusterAsyncCommands(RedisProviderConfig redisProviderConfig,

--- a/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderConfig.java
+++ b/redis-hbo-provider/src/main/java/com/facebook/presto/statistic/RedisProviderConfig.java
@@ -43,6 +43,8 @@ public class RedisProviderConfig
     private long totalSetTimeoutMs;
     private String credentialsPath;
     private String redisPropertiesPath;
+    private String redisUsername;
+    private String redisPassword;
 
     @Config("hbo.redis-provider.cluster-mode-enabled")
     public RedisProviderConfig setClusterModeEnabled(boolean value)
@@ -163,5 +165,31 @@ public class RedisProviderConfig
     public String getCredentialsPath()
     {
         return credentialsPath;
+    }
+
+    @Config("hbo.redis-provider.redis-username")
+    @ConfigSecuritySensitive
+    public RedisProviderConfig setRedisUsername(String value)
+    {
+        this.redisUsername = value;
+        return this;
+    }
+
+    public String getRedisUsername()
+    {
+        return redisUsername;
+    }
+
+    @Config("hbo.redis-provider.redis-password")
+    @ConfigSecuritySensitive
+    public RedisProviderConfig setRedisPassword(String value)
+    {
+        this.redisPassword = value;
+        return this;
+    }
+
+    public String getRedisPassword()
+    {
+        return redisPassword;
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add configurable Redis username and password support for the Redis HBO provider and wire them into non-cluster Redis client creation.

New Features:
- Introduce configuration properties for Redis username and password in the Redis HBO provider.
- Support authenticated non-cluster Redis connections using optional username/password credentials.