### PR TITLE
refactor: Rename targetTableName to indexName

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -1955,20 +1955,20 @@ public class Analysis
     public static final class CreateVectorIndexAnalysis
     {
         private final QualifiedObjectName sourceTableName;
-        private final QualifiedObjectName targetTableName;
+        private final QualifiedObjectName indexName;
         private final List<Identifier> columns;
         private final Map<String, Expression> properties;
         private final Optional<Expression> updatingFor;
 
         public CreateVectorIndexAnalysis(
                 QualifiedObjectName sourceTableName,
-                QualifiedObjectName targetTableName,
+                QualifiedObjectName indexName,
                 List<Identifier> columns,
                 Map<String, Expression> properties,
                 Optional<Expression> updatingFor)
         {
             this.sourceTableName = requireNonNull(sourceTableName, "sourceTableName is null");
-            this.targetTableName = requireNonNull(targetTableName, "targetTableName is null");
+            this.indexName = requireNonNull(indexName, "indexName is null");
             this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
             this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
             this.updatingFor = requireNonNull(updatingFor, "updatingFor is null");
@@ -1979,9 +1979,9 @@ public class Analysis
             return sourceTableName;
         }
 
-        public QualifiedObjectName getTargetTableName()
+        public QualifiedObjectName getIndexName()
         {
-            return targetTableName;
+            return indexName;
         }
 
         public List<Identifier> getColumns()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -420,7 +420,7 @@ public class LogicalPlanner
         Analysis.CreateVectorIndexAnalysis vectorIndexAnalysis = analysis.getCreateVectorIndexAnalysis().get();
 
         QualifiedObjectName sourceTableName = vectorIndexAnalysis.getSourceTableName();
-        QualifiedObjectName targetTableName = vectorIndexAnalysis.getTargetTableName();
+        QualifiedObjectName indexName = vectorIndexAnalysis.getIndexName();
 
         // Resolve source table handle and metadata
         TableHandle sourceTableHandle = metadata.getHandleVersion(session, sourceTableName, Optional.empty())
@@ -536,7 +536,7 @@ public class LogicalPlanner
                 Optional.empty());
 
         // Build target table metadata with properties
-        ConnectorId connectorId = getConnectorIdOrThrow(session, metadata, targetTableName.getCatalogName());
+        ConnectorId connectorId = getConnectorIdOrThrow(session, metadata, indexName.getCatalogName());
 
         // Vector index properties are not registered with TablePropertyManager, so we evaluate
         // them directly. The connector's plan optimizer is responsible for validating these properties
@@ -553,7 +553,7 @@ public class LogicalPlanner
                 ColumnMetadata.builder().setName("result").setType(VARCHAR).build());
 
         ConnectorTableMetadata targetTableMetadata = new ConnectorTableMetadata(
-                toSchemaTableName(targetTableName),
+                toSchemaTableName(indexName),
                 targetColumns,
                 properties,
                 Optional.empty());


### PR DESCRIPTION
Summary: Rename targetTableName to indexName

Differential Revision: D97415619

## Summary by Sourcery

Enhancements:
- Rename CreateVectorIndexAnalysis target table identifier to indexName and propagate the new name through logical planning of vector index creation.


## Release Notes
```
== NO RELEASE NOTE ==
```