### PR TITLE
[WIP DNR]fix(connector): Return fresh table metadata when listing tables after collection rename in Mongodb

### DIFF
--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -36,7 +36,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoNamespace;
@@ -143,15 +142,28 @@ public class MongoSession
     public Set<String> getAllTables(String schema)
             throws SchemaNotFoundException
     {
-        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+        MongoDatabase db = client.getDatabase(schema);
 
-        builder.addAll(ImmutableList.copyOf(client.getDatabase(schema).listCollectionNames()).stream()
+        Set<String> actualCollections = ImmutableList.copyOf(db.listCollectionNames()).stream()
                 .filter(name -> !name.equals(schemaCollection))
                 .filter(name -> !SYSTEM_TABLES.contains(name))
-                .collect(toSet()));
-        builder.addAll(getTableMetadataNames(schema));
+                .collect(toSet());
 
-        return builder.build();
+        Set<String> metadataTableNames = getTableMetadataNames(schema);
+
+        // Find stale metadata entries (metadata exists but collection doesn't)
+        Set<String> staleMetadataTableNames = metadataTableNames.stream()
+                .filter(name -> !actualCollections.contains(name))
+                .collect(toSet());
+
+        // Clean up stale metadata entries and invalidate their cache
+        for (String staleTableName : staleMetadataTableNames) {
+            SchemaTableName schemaTableName = new SchemaTableName(schema, staleTableName);
+            log.debug("Removing stale metadata for table: %s", schemaTableName);
+            deleteTableMetadata(schemaTableName);
+            tableCache.invalidate(schemaTableName);
+        }
+        return actualCollections;
     }
 
     public MongoTable getTable(SchemaTableName tableName)
@@ -371,7 +383,7 @@ public class MongoSession
     }
 
     // Internal Schema management
-    private Document getTableMetadata(SchemaTableName schemaTableName)
+    public Document getTableMetadata(SchemaTableName schemaTableName)
             throws TableNotFoundException
     {
         String schemaName = schemaTableName.getSchemaName();

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoSession.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoSession.java
@@ -255,6 +255,43 @@ public class TestMongoSession
     }
 
     @Test
+    public void testGetAllTablesWithCollectionWithoutMetadata()
+    {
+        String schemaName = "test_collection_without_metadata";
+        MongoDatabase database = client.getDatabase(schemaName);
+
+        // Create a collection with data and corresponding _schema metadata
+        MongoCollection<Document> activeTable = database.getCollection("active_table");
+        activeTable.insertOne(new Document("field1", "value1"));
+
+        MongoCollection<Document> schemaCollection = database.getCollection("_schema");
+        schemaCollection.insertOne(new Document("table", "active_table")
+                .append("fields", ImmutableList.of(
+                        new Document("name", "field1").append("type", "varchar").append("hidden", false))));
+
+        // Create a collection that has no _schema metadata at all
+        MongoCollection<Document> collectionOnlyTable = database.getCollection("collection_only_table");
+        collectionOnlyTable.insertOne(new Document("field1", "value1"));
+
+        // Get all tables - should return both tables even though one has no metadata
+        Set<String> tables = session.getAllTables(schemaName);
+
+        // Verify both tables are returned
+        assertEquals(tables.size(), 2, "Should return exactly two tables");
+        assertTrue(tables.contains("active_table"), "Should include active_table with metadata");
+        assertTrue(tables.contains("collection_only_table"), "Should include collection_only_table even without metadata");
+
+        // Verify that only active_table has metadata in _schema
+        Document activeMetadata = schemaCollection.find(new Document("table", "active_table")).first();
+        assertTrue(activeMetadata != null, "Active table should have metadata");
+
+        Document collectionOnlyMetadata = schemaCollection.find(new Document("table", "collection_only_table")).first();
+        assertNull(collectionOnlyMetadata, "Collection-only table should not have metadata");
+
+        database.drop();
+    }
+
+    @Test
     public void testGetAllTablesWithStaleMetadataAfterDirectRename()
     {
         String schemaName = "test_direct_rename_stale_metadata";

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoSession.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoSession.java
@@ -16,11 +16,27 @@ package com.facebook.presto.mongodb;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableNotFoundException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoNamespace;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import de.bwaldvogel.mongo.MongoServer;
 import org.bson.Document;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import static com.facebook.presto.common.predicate.Range.equal;
 import static com.facebook.presto.common.predicate.Range.greaterThan;
@@ -35,12 +51,21 @@ import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 public class TestMongoSession
 {
     private static final MongoColumnHandle COL1 = new MongoColumnHandle("col1", BIGINT, false);
     private static final MongoColumnHandle COL2 = new MongoColumnHandle("col2", createUnboundedVarcharType(), false);
     private static final MongoColumnHandle COL3 = new MongoColumnHandle("col3", VARBINARY, false);
+
+    private MongoServer server;
+    private MongoClient client;
+    private MongoSession session;
+    private TypeManager typeManager;
 
     @Test
     public void testBuildQuery()
@@ -117,5 +142,172 @@ public class TestMongoSession
                 new Document(COL1.getName(), new Document("$gt", 200L)),
                 new Document(COL1.getName(), new Document("$exists", true).append("$eq", null))));
         assertEquals(query, expected);
+    }
+
+    @BeforeClass
+    public void setupMongoServer()
+    {
+        server = new MongoServer(new SyncMemoryBackend());
+        InetSocketAddress address = server.bind();
+        client = new MongoClient(new ServerAddress(address));
+        typeManager = FunctionAndTypeManager.createTestFunctionAndTypeManager();
+
+        MongoClientConfig config = new MongoClientConfig();
+        session = new MongoSession(typeManager, client, config);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDownMongoServer()
+    {
+        if (session != null) {
+            session.shutdown();
+        }
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void testGetAllTablesAfterTableRename()
+    {
+        String schemaName = "test_table_rename";
+        MongoDatabase database = client.getDatabase(schemaName);
+
+        // Create table A with data
+        database.getCollection("table_a").insertOne(new Document("field1", "value1"));
+
+        // Create metadata for table A
+        MongoCollection<Document> schemaCollection = database.getCollection("_schema");
+        schemaCollection.insertOne(new Document("table", "table_a")
+                .append("fields", ImmutableList.of(
+                        new Document("name", "field1").append("type", "varchar").append("hidden", false))));
+
+        // Verify table A exists
+        Set<String> tablesBeforeRename = session.getAllTables(schemaName);
+        assertEquals(tablesBeforeRename.size(), 1);
+        assertTrue(tablesBeforeRename.contains("table_a"));
+        assertFalse(tablesBeforeRename.contains("table_b"));
+
+        // Rename collection from table_a to table_b in MongoDB backend
+        database.getCollection("table_a").renameCollection(new com.mongodb.MongoNamespace(schemaName, "table_b"));
+
+        // Update metadata to reflect the rename
+        schemaCollection.updateOne(
+                new Document("table", "table_a"),
+                new Document("$set", new Document("table", "table_b")));
+
+        // Get all tables after rename - should return table_b only
+        Set<String> tablesAfterRename = session.getAllTables(schemaName);
+
+        // Verify only table_b is returned
+        assertEquals(tablesAfterRename.size(), 1);
+        assertTrue(tablesAfterRename.contains("table_b"));
+        assertFalse(tablesAfterRename.contains("table_a"));
+
+        // Verify metadata reflects the new table name
+        Document metadata = schemaCollection.find(new Document("table", "table_b")).first();
+        assertTrue(metadata != null, "Metadata for table_b should exist");
+        assertEquals(metadata.getString("table"), "table_b");
+
+        // Verify old table name metadata doesn't exist
+        Document oldMetadata = schemaCollection.find(new Document("table", "table_a")).first();
+        assertEquals(oldMetadata, null, "Metadata for table_a should not exist");
+
+        database.drop();
+    }
+
+    @Test
+    public void testGetAllTablesWithStaleMetadata()
+    {
+        String schemaName = "test_stale_metadata";
+        MongoDatabase database = client.getDatabase(schemaName);
+
+        // Create a collection with data
+        MongoCollection<Document> collection = database.getCollection("active_table");
+        collection.insertOne(new Document("field1", "value1"));
+
+        // Create metadata for both active and non-existent tables
+        MongoCollection<Document> schemaCollection = database.getCollection("_schema");
+        schemaCollection.insertOne(new Document("table", "active_table")
+                .append("fields", ImmutableList.of(
+                        new Document("name", "field1").append("type", "varchar").append("hidden", false))));
+        schemaCollection.insertOne(new Document("table", "stale_table")
+                .append("fields", ImmutableList.of(
+                        new Document("name", "field1").append("type", "varchar").append("hidden", false))));
+
+        // Get all tables - should only return active_table and clean up stale_table metadata
+        Set<String> tables = session.getAllTables(schemaName);
+
+        // Verify only active_table is returned
+        assertEquals(tables.size(), 1);
+        assertTrue(tables.contains("active_table"));
+        assertFalse(tables.contains("stale_table"));
+
+        // Verify stale metadata was removed
+        Document staleMetadata = schemaCollection.find(new Document("table", "stale_table")).first();
+        assertEquals(staleMetadata, null, "Stale metadata should have been deleted");
+
+        // Verify active metadata still exists
+        Document activeMetadata = schemaCollection.find(new Document("table", "active_table")).first();
+        assertTrue(activeMetadata != null, "Active metadata should still exist");
+
+        database.drop();
+    }
+
+    @Test
+    public void testGetAllTablesWithStaleMetadataAfterDirectRename()
+    {
+        String schemaName = "test_direct_rename_stale_metadata";
+        MongoDatabase database = client.getDatabase(schemaName);
+
+        //  Create collection table_a with data
+        MongoCollection<Document> tableA = database.getCollection("table_a");
+        tableA.insertOne(new Document("field1", "value1"));
+
+        //  Create _schema metadata for table_a
+        MongoCollection<Document> schemaCollection = database.getCollection("_schema");
+        schemaCollection.insertOne(new Document("table", "table_a")
+                .append("fields", ImmutableList.of(
+                        new Document("name", "field1").append("type", "varchar").append("hidden", false))));
+
+        //  Optionally call getAllTables once to warm any caches
+        Set<String> tablesBeforeRename = session.getAllTables(schemaName);
+        assertEquals(tablesBeforeRename.size(), 1);
+        assertTrue(tablesBeforeRename.contains("table_a"));
+
+        // Rename table_a to table_b in MongoDB WITHOUT updating _schema
+        // This simulates a direct MongoDB operation that leaves stale metadata
+        tableA.renameCollection(new MongoNamespace(schemaName, "table_b"));
+
+        // At this point:
+        // - MongoDB has collection "table_b" (not "table_a")
+        // - _schema still has metadata for "table_a" (stale)
+        // - _schema does NOT have metadata for "table_b"
+
+        // Step 5: Call getAllTables again - this should trigger stale metadata cleanup
+        Set<String> tablesAfterRename = session.getAllTables(schemaName);
+
+        // Step 6: Assert the result includes table_b but not table_a
+        assertEquals(tablesAfterRename.size(), 1, "Should return exactly one table");
+        assertTrue(tablesAfterRename.contains("table_b"), "Should include table_b");
+        assertFalse(tablesAfterRename.contains("table_a"), "Should not include table_a");
+
+        // Step 7: Assert _schema no longer contains a document for table_a
+        Document staleMetadata = schemaCollection.find(new Document("table", "table_a")).first();
+        assertNull(staleMetadata, "Stale metadata for table_a should have been deleted");
+
+        // Verify table_b collection actually exists
+        boolean tableBExists = StreamSupport.stream(database.listCollectionNames().spliterator(), false)
+                .anyMatch("table_b"::equals);
+        assertTrue(tableBExists, "Collection table_b should exist in MongoDB");
+
+        // Step 8: Verify getTable behavior after stale metadata cleanup
+        SchemaTableName oldTable = new SchemaTableName(schemaName, "table_a");
+
+        // Original table_a metadata should be purged and not accessible
+        // This verifies that the cache was properly invalidated and metadata was deleted
+        expectThrows(TableNotFoundException.class, () -> session.getTable(oldTable));
+
+        database.drop();
     }
 }


### PR DESCRIPTION
## Description
This PR fixes a critical issue where stale MongoDB table metadata was being returned when listing tables after a table rename, causing SELECT queries to fail on renamed tables.

## Motivation and Context
This PR fixes issue https://github.com/prestodb/presto/issues/27091

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan


```
presto> show tables in mongodb.TM_LAKEHOUSE_ENGINE_DB_1;
       Table       
-------------------
 test1234          
 test_t1_testtable 
(2 rows)

```

Rename the table test1234 from MongoDB Backend

<img width="759" height="188" alt="image" src="https://github.com/user-attachments/assets/c0cf22b5-6f79-48a9-af08-4c56cebac8d4" />


```
presto> show tables in mongodb.TM_LAKEHOUSE_ENGINE_DB_1 ;
       Table       
-------------------
 test12345         
 test_t1_testtable 
(2 rows)


presto> select * from mongodb.TM_LAKEHOUSE_ENGINE_DB_1.test1234;

Query 20260319_125107_00006_d5g7m, FAILED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:01, server-side: 0:01] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20260319_125107_00006_d5g7m failed: Table mongodb.TM_LAKEHOUSE_ENGINE_DB_1.test1234 does not exist

presto> select * from mongodb.TM_LAKEHOUSE_ENGINE_DB_1.test12345;
 name 
------
 abc  
(1 row)
```



## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* Return fresh table metadata when listing tables after rename
```

## Summary by Sourcery

Clean up stale MongoDB table metadata when listing tables and add coverage for table renames.

Bug Fixes:
- Ensure getAllTables returns only existing MongoDB collections by removing stale metadata entries and invalidating related cache entries.

Build:
- Include the MongoDB plugin module in the default test configuration plugin bundles.

Tests:
- Add an integration-style test using an in-memory MongoDB server to verify table metadata remains consistent after renaming a collection.

## Summary by Sourcery

Ensure MongoDB connector only exposes actual collections and cleans up stale metadata when listing tables.

Bug Fixes:
- Return only existing MongoDB collections from getAllTables and remove stale table metadata entries while invalidating their cache.

Tests:
- Add in-memory MongoDB–backed tests to verify getAllTables correctly reflects renamed collections and removes stale metadata, including cache invalidation behavior.