### PR TITLE
feat: add encoding_read_factors DDL property for Nimble tables

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
@@ -811,8 +811,10 @@ void extractNimbleSerdeParameters(
     const std::map<std::string, std::string>& tableParameters,
     std::unordered_map<std::string, std::string>& serdeParameters) {
   static constexpr std::string_view kNimblePrefix{"nimble."};
+  static constexpr std::string_view kAlphaPrefix{"alpha."};
   for (const auto& [key, value] : tableParameters) {
-    if (key.compare(0, kNimblePrefix.size(), kNimblePrefix) == 0) {
+    if (key.compare(0, kNimblePrefix.size(), kNimblePrefix) == 0 ||
+        key.starts_with(kAlphaPrefix)) {
       serdeParameters[key] = value;
     }
   }

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h
@@ -64,13 +64,14 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
     const VeloxExprConverter& exprConverter,
     const TypeParser& typeParser);
 
-/// Extracts nimble serde parameters (nimble.*) from table parameters.
+/// Extracts nimble serde parameters (nimble.* and alpha.*) from table
+/// parameters.
 void extractNimbleSerdeParameters(
     const std::map<std::string, std::string>& tableParameters,
     std::unordered_map<std::string, std::string>& serdeParameters);
 
-/// Extracts serde parameters (textfile delimiters and nimble.* config) from
-/// additionalTableParameters during CTAS.
+/// Extracts serde parameters (textfile delimiters, nimble.* and alpha.* config)
+/// from additionalTableParameters during CTAS.
 /// Mirrors Java's HiveMetadata.extractSerdeParameters().
 std::unordered_map<std::string, std::string> extractSerdeParameters(
     const std::map<std::string, std::string>& tableParameters);


### PR DESCRIPTION
Summary:
CONTEXT: Nimble's encoding read factors (e.g., FixedBitWidth=0.9) control the cost-based encoding selection but were only configurable via the legacy alpha.encodingselection.read.factors serde parameter. There was no Presto DDL property to set them at table creation time.

WHAT: Add encoding_read_factors as a Presto DDL table property for ALPHA (Nimble) format tables. The property maps to the existing alpha.encodingselection.read.factors serde key. Also adds alpha.* prefix to extractSerdeParameters filters (Java and C++) so alpha.* serde keys flow correctly through both CREATE TABLE and CTAS paths.

Java:
- Added encoding_read_factors string property to HiveTableProperties
- Added validation (ALPHA-only, must not be empty)
- Wired into getEmptyTableProperties for both CREATE TABLE and CTAS paths
- Added alpha.* prefix to extractSerdeParameters filter

C++:
- Added alpha.* prefix to extractNimbleSerdeParameters in PrestoToVeloxConnectorUtils
- Added Prism CTAS test for alpha.* parameter extraction

Usage:
  CREATE TABLE t (...) WITH (format = 'ALPHA', encoding_read_factors = 'FixedBitWidth=0.9;Dictionary=1.0')
  CREATE TABLE t WITH (format = 'ALPHA', encoding_read_factors = 'FixedBitWidth=0.9') AS SELECT ...

Reviewed By: xiaoxmeng

Differential Revision: D97578162


