### PR TITLE
feat(connector): Add support create, drop, list views for sqlserver connector

### DIFF
--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -34,6 +34,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -96,9 +101,41 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mssqlserver</artifactId>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerClient.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.sqlserver;
 
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
 import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
 import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
@@ -20,15 +21,28 @@ import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
 import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcIdentity;
 import com.facebook.presto.plugin.jdbc.JdbcTableHandle;
+import com.facebook.presto.plugin.jdbc.JdbcTypeHandle;
+import com.facebook.presto.plugin.jdbc.mapping.ReadMapping;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.microsoft.sqlserver.jdbc.SQLServerDriver;
 import jakarta.inject.Inject;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static java.lang.String.format;
@@ -89,5 +103,288 @@ public class SqlServerClient
     public String normalizeIdentifier(ConnectorSession session, String identifier)
     {
         return caseSensitiveNameMatchingEnabled ? identifier : identifier.toLowerCase(ENGLISH);
+    }
+
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, List<SchemaTableName> tableNames)
+    {
+        JdbcIdentity identity = new JdbcIdentity(session.getUser(), session.getIdentity().getExtraCredentials());
+        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            for (SchemaTableName schemaTableName : tableNames) {
+                String schemaName = schemaTableName.getSchemaName();
+                String tableName = schemaTableName.getTableName();
+
+                String sql = format(
+                        "SELECT VIEW_DEFINITION FROM INFORMATION_SCHEMA.VIEWS " +
+                                "WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
+                        schemaName, tableName);
+
+                try (Statement statement = connection.createStatement();
+                        ResultSet resultSet = statement.executeQuery(sql)) {
+                    if (resultSet.next()) {
+                        String sqlServerViewSql = resultSet.getString(1);
+
+                        String selectQuery = extractSelectFromCreateView(sqlServerViewSql);
+                        String owner = session.getUser();
+
+                        // Fetch column metadata for the view
+                        List<String> columnJsonList = new ArrayList<>();
+                        try (ResultSet columnsResultSet = connection.getMetaData().getColumns(
+                                null,
+                                schemaName,
+                                tableName,
+                                null)) {
+                            while (columnsResultSet.next()) {
+                                String columnName = columnsResultSet.getString("COLUMN_NAME");
+                                JdbcTypeHandle typeHandle = new JdbcTypeHandle(
+                                        columnsResultSet.getInt("DATA_TYPE"),
+                                        columnsResultSet.getString("TYPE_NAME"),
+                                        columnsResultSet.getInt("COLUMN_SIZE"),
+                                        columnsResultSet.getInt("DECIMAL_DIGITS"));
+
+                                Optional<ReadMapping> readMapping = toPrestoType(session, typeHandle);
+                                if (readMapping.isPresent()) {
+                                    Type prestoType = readMapping.get().getType();
+                                    // Normalize column name
+                                    String normalizedColumnName = normalizeIdentifier(session, columnName);
+                                    // Escape for JSON
+                                    String escapedColumnName = normalizedColumnName
+                                            .replace("\\", "\\\\")
+                                            .replace("\"", "\\\"");
+                                    String escapedTypeName = prestoType.getDisplayName()
+                                            .replace("\\", "\\\\")
+                                            .replace("\"", "\\\"");
+                                    columnJsonList.add(format(
+                                            "{\"name\":\"%s\",\"type\":\"%s\"}",
+                                            escapedColumnName,
+                                            escapedTypeName));
+                                }
+                            }
+                        }
+
+                        // Escape SQL for JSON
+                        String escapedSql = selectQuery
+                                .replace("\\", "\\\\")
+                                .replace("\"", "\\\"")
+                                .replace("\n", "\\n")
+                                .replace("\r", "\\r");
+
+                        String columnsJson = String.join(",", columnJsonList);
+
+                        // Create proper ViewDefinition JSON with all required fields
+                        String prestoViewData = format(
+                                "{\"originalSql\":\"%s\",\"catalog\":\"%s\",\"schema\":\"%s\",\"columns\":[%s],\"owner\":\"%s\",\"runAsInvoker\":false}",
+                                escapedSql,
+                                connectorId,  // Use connector ID as catalog
+                                schemaName,
+                                columnsJson,
+                                owner);
+
+                        views.put(schemaTableName,
+                                new ConnectorViewDefinition(
+                                        schemaTableName,
+                                        Optional.ofNullable(owner),
+                                        prestoViewData));
+                    }
+                }
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+
+        return views.build();
+    }
+
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            try (ResultSet resultSet = getTables(connection, schemaName, Optional.empty(), new String[] {"VIEW"})) {
+                ImmutableList.Builder<SchemaTableName> builder = ImmutableList.builder();
+                while (resultSet.next()) {
+                    String tableName = resultSet.getString("TABLE_NAME");
+                    String schema = schemaName.orElse(resultSet.getString("TABLE_SCHEM"));
+                    builder.add(new SchemaTableName(
+                            normalizeIdentifier(session, schema),
+                            normalizeIdentifier(session, tableName)));
+                }
+                return builder.build();
+            }
+            catch (SQLException e) {
+                throw new PrestoException(JDBC_ERROR, e);
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    public List<SchemaTableName> listSchemasForViews(ConnectorSession session)
+    {
+        List<SchemaTableName> allTableNames = new ArrayList<>();
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            Collection<String> schemaNames = listSchemas(connection);
+            for (String schema : schemaNames) {
+                List<SchemaTableName> tablesNames = listViews(session, Optional.ofNullable(schema));
+                allTableNames.addAll(tablesNames);
+            }
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+        return allTableNames;
+    }
+
+    public void createView(ConnectorSession session, SchemaTableName viewName, String viewData, boolean replace)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            // Extract the original SQL from ViewDefinition JSON
+            String viewSql = extractOriginalSql(viewData);
+
+            // Remove catalog prefix from table references
+            viewSql = removeCatalogPrefix(viewSql);
+            // Remove double quotes around identifiers that Presto adds
+            viewSql = removeQuotes(viewSql);
+
+            String sql;
+            if (replace) {
+                try {
+                    dropView(session, viewName);
+                }
+                catch (Exception e) {
+                    // Ignore if view doesn't exist
+                }
+            }
+            sql = format("CREATE VIEW %s.%s AS %s",
+                    quoted(viewName.getSchemaName()),
+                    quoted(viewName.getTableName()),
+                    viewSql);
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            String sql = format("DROP VIEW %s.%s",
+                    quoted(viewName.getSchemaName()),
+                    quoted(viewName.getTableName()));
+            execute(connection, sql);
+        }
+        catch (SQLException e) {
+            throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    /**
+     * Extract SELECT query from SQL Server's CREATE VIEW statement.
+     * SQL Server returns: "CREATE VIEW schema.name AS SELECT ..."
+     * We need to extract just: "SELECT ..."
+     *
+     * @param createViewSql the CREATE VIEW statement
+     * @return the SELECT query portion
+     */
+    private String extractSelectFromCreateView(
+            final String createViewSql)
+    {
+        int asIndex = createViewSql.toUpperCase(ENGLISH)
+                .indexOf(" AS ");
+        if (asIndex == -1) {
+            return createViewSql.trim();
+        }
+
+        int asLength = 4;
+        String selectPart = createViewSql.substring(
+                asIndex + asLength).trim();
+        return selectPart;
+    }
+
+    /**
+     * Remove catalog prefix from table references in SQL.
+     * @param sql the SQL statement to process
+     * @return SQL with catalog prefixes removed
+     */
+    private String removeCatalogPrefix(final String sql)
+    {
+        String pattern = "\\b([a-zA-Z_][a-zA-Z0-9_]*)"
+                + "\\.([a-zA-Z_][a-zA-Z0-9_]*)"
+                + "\\.([a-zA-Z_][a-zA-Z0-9_]*)\\b";
+        return sql.replaceAll(pattern, "$2.$3");
+    }
+
+    /**
+     * Remove double quotes around identifiers that get added.
+     * @param sql the SQL statement to process
+     * @return SQL with double quotes removed from identifiers
+     */
+    private String removeQuotes(final String sql)
+    {
+        // Remove double quotes around identifiers
+        // This handles cases like "count"(1) -> count(1), "avg"(age) -> avg(age)
+        return sql.replaceAll("\"([a-zA-Z_][a-zA-Z0-9_]*)\"", "$1");
+    }
+
+    private String extractOriginalSql(final String viewData)
+    {
+        int startIndex = viewData.indexOf("\"originalSql\":\"");
+        if (startIndex == -1) {
+            throw new PrestoException(JDBC_ERROR, "Invalid view data: missing originalSql");
+        }
+        startIndex += "\"originalSql\":\"".length();
+
+        StringBuilder sql = new StringBuilder();
+        boolean escaped = false;
+        for (int i = startIndex; i < viewData.length(); i++) {
+            char c = viewData.charAt(i);
+            if (escaped) {
+                if (c == 'n') {
+                    sql.append('\n');
+                }
+                else if (c == 't') {
+                    sql.append('\t');
+                }
+                else if (c == 'r') {
+                    sql.append('\r');
+                }
+                else if (c == '"' || c == '\\') {
+                    sql.append(c);
+                }
+                else {
+                    sql.append('\\').append(c);
+                }
+                escaped = false;
+            }
+            else if (c == '\\') {
+                escaped = true;
+            }
+            else if (c == '"') {
+                break;
+            }
+            else {
+                sql.append(c);
+            }
+        }
+
+        return sql.toString();
+    }
+
+    private ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName, String[] types)
+            throws SQLException
+    {
+        DatabaseMetaData metadata = connection.getMetaData();
+        Optional<String> escape = Optional.ofNullable(metadata.getSearchStringEscape());
+        return metadata.getTables(
+                connection.getCatalog(),
+                schemaName.orElse(null),
+                escapeNamePattern(tableName, escape).orElse(null),
+                types);
     }
 }

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerConnectorFactory.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerConnectorFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.plugin.jdbc.JdbcConnector;
+import com.facebook.presto.plugin.jdbc.JdbcHandleResolver;
+import com.facebook.presto.plugin.jdbc.JdbcModule;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.spi.function.FunctionMetadataManager;
+import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.relation.RowExpressionService;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+
+import java.util.Map;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerConnectorFactory
+        implements ConnectorFactory
+{
+    @Override
+    public String getName()
+    {
+        return "sqlserver";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new JdbcHandleResolver();
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        requireNonNull(requiredConfig, "requiredConfig is null");
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            // Use Modules.override() to replace JdbcMetadataFactory binding
+            // This allows SqlServerMetadataFactory to be used instead of the default
+            Module module = Modules.override(new JdbcModule(catalogName))
+                    .with(new SqlServerMetadataOverrideModule());
+
+            Bootstrap app = new Bootstrap(
+                    binder -> {
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());
+                        binder.bind(StandardFunctionResolution.class).toInstance(context.getStandardFunctionResolution());
+                        binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());
+                    },
+                    module,
+                    new SqlServerClientModule());
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(requiredConfig)
+                    .initialize();
+
+            return injector.getInstance(JdbcConnector.class);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerMetadata.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerMetadata.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.plugin.jdbc.JdbcMetadata;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.TableLocationProvider;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.ConnectorViewDefinition;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class SqlServerMetadata
+        extends JdbcMetadata
+{
+    private final SqlServerClient sqlServerClient;
+
+    public SqlServerMetadata(
+            JdbcMetadataCache jdbcMetadataCache,
+            SqlServerClient sqlServerClient,
+            boolean allowDropTable,
+            TableLocationProvider tableLocationProvider)
+    {
+        super(jdbcMetadataCache, sqlServerClient, allowDropTable, tableLocationProvider);
+        this.sqlServerClient = requireNonNull(sqlServerClient, "sqlServerClient is null");
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        // Determine which views to retrieve based on the prefix
+        List<SchemaTableName> viewNames;
+        if (prefix.getSchemaName() != null && prefix.getTableName() != null) {
+            // Specific view requested
+            viewNames = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
+        }
+        else if (prefix.getSchemaName() != null) {
+            // All views in a specific schema
+            viewNames = sqlServerClient.listViews(session, Optional.of(prefix.getSchemaName()));
+        }
+        else {
+            return ImmutableMap.of();
+        }
+
+        if (viewNames.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        // Retrieve view definitions for the identified views
+        return sqlServerClient.getViews(session, viewNames);
+    }
+
+    @Override
+    public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return sqlServerClient.listViews(session, schemaName);
+    }
+
+    @Override
+    public void createView(ConnectorSession session, ConnectorTableMetadata viewMetadata, String viewData, boolean replace)
+    {
+        sqlServerClient.createView(session, viewMetadata.getTable(), viewData, replace);
+    }
+
+    @Override
+    public void dropView(ConnectorSession session, SchemaTableName viewName)
+    {
+        sqlServerClient.dropView(session, viewName);
+    }
+}

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerMetadataFactory.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerMetadataFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcMetadata;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataCache;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataConfig;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataFactory;
+import com.facebook.presto.plugin.jdbc.TableLocationProvider;
+import jakarta.inject.Inject;
+
+public class SqlServerMetadataFactory
+        extends JdbcMetadataFactory
+{
+    private final JdbcMetadataCache jdbcMetadataCache;
+    private final SqlServerClient sqlServerClient;
+    private final boolean allowDropTable;
+    private final TableLocationProvider tableLocationProvider;
+
+    @Inject
+    public SqlServerMetadataFactory(
+            JdbcMetadataCache jdbcMetadataCache,
+            JdbcClient jdbcClient,
+            JdbcMetadataConfig config,
+            TableLocationProvider tableLocationProvider)
+    {
+        super(jdbcMetadataCache, jdbcClient, config, tableLocationProvider);
+        this.jdbcMetadataCache = jdbcMetadataCache;
+        this.sqlServerClient = (SqlServerClient) jdbcClient;
+        this.allowDropTable = config.isAllowDropTable();
+        this.tableLocationProvider = tableLocationProvider;
+    }
+
+    @Override
+    public JdbcMetadata create()
+    {
+        return new SqlServerMetadata(jdbcMetadataCache, sqlServerClient, allowDropTable, tableLocationProvider);
+    }
+}

--- a/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerMetadataOverrideModule.java
+++ b/presto-sqlserver/src/main/java/com/facebook/presto/plugin/sqlserver/SqlServerMetadataOverrideModule.java
@@ -13,16 +13,18 @@
  */
 package com.facebook.presto.plugin.sqlserver;
 
-import com.facebook.presto.spi.Plugin;
-import com.facebook.presto.spi.connector.ConnectorFactory;
-import com.google.common.collect.ImmutableList;
+import com.facebook.presto.plugin.jdbc.JdbcMetadataFactory;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
 
-public class SqlServerPlugin
-        implements Plugin
+public class SqlServerMetadataOverrideModule
+        implements Module
 {
     @Override
-    public Iterable<ConnectorFactory> getConnectorFactories()
+    public void configure(Binder binder)
     {
-        return ImmutableList.of(new SqlServerConnectorFactory());
+        // Override the JdbcMetadataFactory binding from JdbcModule
+        binder.bind(JdbcMetadataFactory.class).to(SqlServerMetadataFactory.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-sqlserver/src/test/java/com/facebook/presto/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/presto-sqlserver/src/test/java/com/facebook/presto/plugin/sqlserver/SqlServerQueryRunner.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
+import org.testcontainers.containers.MSSQLServerContainer;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+
+/**
+ * Query runner for SQL Server integration tests.
+ */
+public final class SqlServerQueryRunner
+{
+    private SqlServerQueryRunner() {}
+
+    public static QueryRunner createSqlServerQueryRunner(
+            MSSQLServerContainer sqlServerContainer,
+            Map<String, String> extraProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createSqlServerQueryRunner(sqlServerContainer, extraProperties, ImmutableList.copyOf(tables));
+    }
+
+    public static QueryRunner createSqlServerQueryRunner(
+            MSSQLServerContainer sqlServerContainer,
+            Map<String, String> extraProperties,
+            List<TpchTable<?>> tables)
+            throws Exception
+    {
+        QueryRunner queryRunner = null;
+        try {
+            queryRunner = new DistributedQueryRunner(createSession(), 3, extraProperties);
+
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
+
+            // Create test database in SQL Server
+            // Note: 'dbo' is the default schema and is automatically created with the database
+            try (Connection connection = DriverManager.getConnection(
+                    sqlServerContainer.getJdbcUrl(),
+                    sqlServerContainer.getUsername(),
+                    sqlServerContainer.getPassword());
+                    Statement statement = connection.createStatement()) {
+                statement.execute("CREATE DATABASE tpch");
+            }
+
+            Map<String, String> connectorProperties = ImmutableMap.<String, String>builder()
+                    .put("connection-url", sqlServerContainer.getJdbcUrl() + ";databaseName=tpch")
+                    .put("connection-user", sqlServerContainer.getUsername())
+                    .put("connection-password", sqlServerContainer.getPassword())
+                    .build();
+
+            queryRunner.installPlugin(new SqlServerPlugin());
+            queryRunner.createCatalog("sqlserver", "sqlserver", connectorProperties);
+
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    public static Session createSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("sqlserver")
+                .setSchema("dbo")
+                .build();
+    }
+
+    private static void closeAllSuppress(Throwable rootCause, AutoCloseable... closeables)
+    {
+        for (AutoCloseable closeable : closeables) {
+            try {
+                if (closeable != null) {
+                    closeable.close();
+                }
+            }
+            catch (Exception e) {
+                // Self-suppression not permitted
+                if (rootCause != e) {
+                    rootCause.addSuppressed(e);
+                }
+            }
+        }
+    }
+}

--- a/presto-sqlserver/src/test/java/com/facebook/presto/plugin/sqlserver/TestSqlServerViewSupport.java
+++ b/presto-sqlserver/src/test/java/com/facebook/presto/plugin/sqlserver/TestSqlServerViewSupport.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.sqlserver;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.tpch.TpchTable;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Integration tests for SQL Server view support.
+ * Tests basic view operations: CREATE, SHOW, LIST (via SHOW TABLES), and DROP.
+ */
+public class TestSqlServerViewSupport
+        extends AbstractTestIntegrationSmokeTest
+{
+    private final MSSQLServerContainer<?> sqlServerContainer;
+
+    public TestSqlServerViewSupport()
+    {
+        this.sqlServerContainer = new MSSQLServerContainer<>("mcr.microsoft.com/mssql/server:2019-latest")
+                .acceptLicense();
+        this.sqlServerContainer.start();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        sqlServerContainer.stop();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return SqlServerQueryRunner.createSqlServerQueryRunner(
+                sqlServerContainer,
+                ImmutableMap.of(),
+                ImmutableList.of(TpchTable.ORDERS));
+    }
+
+    @Override
+    protected Session getSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("sqlserver")
+                .setSchema("dbo")
+                .build();
+    }
+
+    @Test
+    public void testCreateView()
+    {
+        // Create a simple view
+        assertUpdate("CREATE VIEW test_view AS SELECT orderkey, custkey FROM orders");
+
+        // Query the view
+        MaterializedResult result = computeActual("SELECT orderkey FROM test_view WHERE orderkey = 1");
+        assertEquals(result.getRowCount(), 1);
+
+        // Cleanup
+        assertUpdate("DROP VIEW test_view");
+    }
+
+    @Test
+    public void testShowCreateView()
+    {
+        // Create a view
+        assertUpdate("CREATE VIEW test_show_view AS SELECT orderkey, totalprice FROM orders");
+
+        // Show create view
+        MaterializedResult result = computeActual("SHOW CREATE VIEW test_show_view");
+        assertEquals(result.getRowCount(), 1);
+        String viewDefinition = (String) result.getOnlyValue();
+        assertTrue(viewDefinition.contains("CREATE VIEW"), "View definition should contain CREATE VIEW");
+        assertTrue(viewDefinition.contains("orderkey"), "View definition should contain orderkey column");
+        assertTrue(viewDefinition.contains("totalprice"), "View definition should contain totalprice column");
+
+        // Cleanup
+        assertUpdate("DROP VIEW test_show_view");
+    }
+
+    @Test
+    public void testListViewsWithShowTables()
+    {
+        // Create test views
+        assertUpdate("CREATE VIEW view1 AS SELECT orderkey FROM orders");
+        assertUpdate("CREATE VIEW view2 AS SELECT custkey FROM orders");
+
+        // List views using SHOW TABLES (views should appear as tables)
+        MaterializedResult result = computeActual("SHOW TABLES");
+        List<Object> tableNames = new ArrayList<>(result.getOnlyColumnAsSet());
+
+        boolean foundView1 = false;
+        boolean foundView2 = false;
+        for (Object tableName : tableNames) {
+            String name = (String) tableName;
+            if ("view1".equalsIgnoreCase(name)) {
+                foundView1 = true;
+            }
+            if ("view2".equalsIgnoreCase(name)) {
+                foundView2 = true;
+            }
+        }
+
+        assertTrue(foundView1, "view1 should be listed in SHOW TABLES");
+        assertTrue(foundView2, "view2 should be listed in SHOW TABLES");
+
+        // Cleanup
+        assertUpdate("DROP VIEW view1");
+        assertUpdate("DROP VIEW view2");
+    }
+
+    @Test
+    public void testDropView()
+    {
+        // Create view
+        assertUpdate("CREATE VIEW test_drop_view AS SELECT orderkey FROM orders");
+
+        // Verify view exists
+        MaterializedResult result = computeActual("SHOW TABLES");
+        List<Object> tableNames = new ArrayList<>(result.getOnlyColumnAsSet());
+        boolean viewExists = tableNames.stream()
+                .anyMatch(name -> "test_drop_view".equalsIgnoreCase((String) name));
+        assertTrue(viewExists, "View should exist after creation");
+
+        // Drop view
+        assertUpdate("DROP VIEW test_drop_view");
+
+        // Verify view no longer exists
+        result = computeActual("SHOW TABLES");
+        tableNames = new ArrayList<>(result.getOnlyColumnAsSet());
+        viewExists = tableNames.stream()
+                .anyMatch(name -> "test_drop_view".equalsIgnoreCase((String) name));
+        assertFalse(viewExists, "View should not exist after dropping");
+    }
+
+    private void execute(String sql)
+            throws SQLException
+    {
+        try (Connection connection = DriverManager.getConnection(
+                    sqlServerContainer.getJdbcUrl(),
+                    sqlServerContainer.getUsername(),
+                    sqlServerContainer.getPassword());
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add view support for sql server

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan

```
presto> CREATE VIEW sqlserver.dbo.view_test_1 AS SELECT id, name FROM sqlserver.dbo.test_table WHERE age < 30;
CREATE VIEW

Query 20260323_163112_00003_8bxbu, FINISHED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:17, server-side: 0:17] [0 rows, 0B] [0 rows/s, 0B/s]

presto> CREATE VIEW sqlserver.dbo.view_test_2 AS SELECT id, name, age FROM sqlserver.dbo.test_table WHERE age >= 30;
CREATE VIEW

Query 20260323_163257_00004_8bxbu, FINISHED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:14, server-side: 0:14] [0 rows, 0B] [0 rows/s, 0B/s]

presto> SELECT * FROM sqlserver.dbo.view_test_1;
 id | name 
----+------
  2 | Bob  
(1 row)

Query 20260323_163338_00005_8bxbu, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:26, server-side: 0:26] [1 rows, 0B] [0 rows/s, 0B/s]

presto> SELECT * FROM sqlserver.dbo.view_test_2;
 id |  name   | age 
----+---------+-----
  1 | Alice   |  30 
  3 | Charlie |  35 
(2 rows)

Query 20260323_163412_00006_8bxbu, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:26, server-side: 0:26] [2 rows, 0B] [0 rows/s, 0B/s]

presto> SHOW CREATE VIEW sqlserver.dbo.view_test_1;
                        Create View                        
-----------------------------------------------------------
 CREATE VIEW sqlserver.dbo.view_test_1 SECURITY DEFINER AS 
 SELECT                                                    
   id                                                      
 , name                                                    
 FROM                                                      
   dbo.test_table                                          
 WHERE (age < 30)                                          
(1 row)

Query 20260323_163445_00007_8bxbu, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
[Latency: client-side: 0:07, server-side: 0:07] [0 rows, 0B] [0 rows/s, 0B/s]

presto> DROP VIEW sqlserver.dbo.view_test_1;
DROP VIEW

Query 20260323_163702_00008_8bxbu, FINISHED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 0:06, server-side: 0:06] [0 rows, 0B] [0 rows/s, 0B/s]
```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Sqlserver Connector Changes
* Add view support for the presto sqlserver connector