### PR TITLE
misc: Add alpha prefix for extractNimbleSerdeParameters

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
@@ -811,8 +811,9 @@ void extractNimbleSerdeParameters(
     const std::map<std::string, std::string>& tableParameters,
     std::unordered_map<std::string, std::string>& serdeParameters) {
   static constexpr std::string_view kNimblePrefix{"nimble."};
+  static constexpr std::string_view kAlphaPrefix{"alpha."};
   for (const auto& [key, value] : tableParameters) {
-    if (key.compare(0, kNimblePrefix.size(), kNimblePrefix) == 0) {
+    if (key.starts_with(kNimblePrefix) || key.starts_with(kAlphaPrefix)) {
       serdeParameters[key] = value;
     }
   }

--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h
@@ -64,13 +64,14 @@ std::unique_ptr<velox::connector::ConnectorTableHandle> toHiveTableHandle(
     const VeloxExprConverter& exprConverter,
     const TypeParser& typeParser);
 
-/// Extracts nimble serde parameters (nimble.*) from table parameters.
+/// Extracts nimble serde parameters (nimble.* and alpha.*) from table
+/// parameters.
 void extractNimbleSerdeParameters(
     const std::map<std::string, std::string>& tableParameters,
     std::unordered_map<std::string, std::string>& serdeParameters);
 
-/// Extracts serde parameters (textfile delimiters and nimble.* config) from
-/// additionalTableParameters during CTAS.
+/// Extracts serde parameters (textfile delimiters, nimble.* and alpha.* config)
+/// from additionalTableParameters during CTAS.
 /// Mirrors Java's HiveMetadata.extractSerdeParameters().
 std::unordered_map<std::string, std::string> extractSerdeParameters(
     const std::map<std::string, std::string>& tableParameters);

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -367,6 +367,9 @@ TEST_F(PrestoToVeloxConnectorTest, ctasPassesNimbleSerdeParameters) {
   hiveOutputTableHandle->additionalTableParameters = {
       {"nimble.enable.vectorized.stats", "true"},
       {"nimble.index.columns", "id"},
+      {"alpha.encodingselection.read.factors",
+       "Constant=1.0;Trivial=0.7;FixedBitWidth=0.7;MainlyConstant=1.0;"
+       "SparseBool=1.0;Dictionary=1.0;RLE=1.0;Varint=1.0"},
       {"presto.version", "0.297"}};
 
   protocol::OutputTableHandle outputHandle;
@@ -386,9 +389,13 @@ TEST_F(PrestoToVeloxConnectorTest, ctasPassesNimbleSerdeParameters) {
   ASSERT_NE(hiveInsert, nullptr);
 
   const auto& serdeParams = hiveInsert->serdeParameters();
-  EXPECT_EQ(serdeParams.size(), 2);
+  EXPECT_EQ(serdeParams.size(), 3);
   EXPECT_EQ(serdeParams.at("nimble.enable.vectorized.stats"), "true");
   EXPECT_EQ(serdeParams.at("nimble.index.columns"), "id");
+  EXPECT_EQ(
+      serdeParams.at("alpha.encodingselection.read.factors"),
+      "Constant=1.0;Trivial=0.7;FixedBitWidth=0.7;MainlyConstant=1.0;"
+      "SparseBool=1.0;Dictionary=1.0;RLE=1.0;Varint=1.0");
 }
 
 TEST_F(PrestoToVeloxConnectorTest, ctasEmptySerdeParameters) {


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

New Features:
- Include alpha.*-prefixed table parameters in extracted Nimble serde configuration.