### PR TITLE
[presto][diff_train] Fix OSS Spark modules to produce Java 8 bytecode after airbase 109 upgrade (#27416)

### DIFF
--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -18,6 +18,20 @@
         <dep.okio-jvm.version>3.9.1</dep.okio-jvm.version>
     </properties>
 
+    <build>
+        <plugins>
+            <!-- Spark executors run on Java 8; override airbase's default Java 17 target -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencyManagement>
         <dependencies>
             <!-- This is to ensure spark gets the right version of the jersey libs -->

--- a/presto-spark-classloader-interface/pom.xml
+++ b/presto-spark-classloader-interface/pom.xml
@@ -79,4 +79,18 @@
         </profile>
     </profiles>
 
+    <build>
+        <plugins>
+            <!-- Spark executors run on Java 8; override airbase's default Java 17 target -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/presto-spark-classloader-spark2/pom.xml
+++ b/presto-spark-classloader-spark2/pom.xml
@@ -29,4 +29,18 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- Spark executors run on Java 8; override airbase's default Java 17 target -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/presto-spark-classloader-spark3/pom.xml
+++ b/presto-spark-classloader-spark3/pom.xml
@@ -36,4 +36,18 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- Spark executors run on Java 8; override airbase's default Java 17 target -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/presto-spark-common/pom.xml
+++ b/presto-spark-common/pom.xml
@@ -48,4 +48,18 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Spark executors run on Java 8; override airbase's default Java 17 target -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -82,6 +82,15 @@
 
     <build>
         <plugins>
+            <!-- Spark executors run on Java 8; override airbase's default Java 17 target -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/presto-spark-package/pom.xml
+++ b/presto-spark-package/pom.xml
@@ -169,6 +169,15 @@
 
     <build>
         <plugins>
+            <!-- Spark executors run on Java 8; override airbase's default Java 17 target -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/presto-spark/pom.xml
+++ b/presto-spark/pom.xml
@@ -59,6 +59,15 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- Spark executors run on Java 8; override airbase's default Java 17 target -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.basepom.maven</groupId>
                 <artifactId>duplicate-finder-maven-plugin</artifactId>


### PR DESCRIPTION
Summary:

[#27130](https://github.com/prestodb/presto/pull/27130) (meta internal revision D96822883) bumped airlift airbase from v108 to v109, which sets
`project.build.targetJdk=17` by default. Airbase configures
`maven-compiler-plugin` with `<source>${project.build.targetJdk}</source>`
and `<target>${project.build.targetJdk}</target>`, so all modules now
produce Java 17 bytecode (class file version 61.0).

The Spark launcher jar runs on Spark executors using Java 8, which only
supports class file versions up to 52.0. This causes
`UnsupportedClassVersionError` at startup, surfacing as
`WRAPPER_ERROR_UNKNOWN` in Sapphire QueryBank runs.

This diff overrides `maven-compiler-plugin` to target Java 8 in the two
OSS modules that end up on the Spark classpath:
- `presto-spark-launcher`
- `presto-spark-classloader-interface`

Differential Revision: D97804331


