### PR TITLE
fix: Remove redundant method calls in MaterializedViewQueryOptimizer

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -347,7 +347,7 @@ public final class ExpressionUtils
         }
         Expression processedExpression = removeExpressionPrefix(singleColumn.getExpression(), removablePrefix);
         if (processedExpression != singleColumn.getExpression()) {
-            return new SingleColumn(removeExpressionPrefix(singleColumn.getExpression(), removablePrefix), singleColumn.getAlias());
+            return new SingleColumn(processedExpression, singleColumn.getAlias());
         }
         return singleColumn;
     }
@@ -386,7 +386,7 @@ public final class ExpressionUtils
             if (processedArgument != argument) {
                 prefixRemoved = true;
             }
-            rewrittenArguments.add(removeExpressionPrefix(argument, removablePrefix));
+            rewrittenArguments.add(processedArgument);
         }
         if (prefixRemoved) {
             return new FunctionCall(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -280,7 +280,7 @@ public class MaterializedViewQueryOptimizer
             return node;
         }
 
-        return new TableSubquery(processSameType(newQuery));
+        return new TableSubquery(newQuery);
     }
 
     @Override
@@ -291,7 +291,7 @@ public class MaterializedViewQueryOptimizer
             return node;
         }
 
-        return new AliasedRelation(processSameType(newRelation), node.getAlias(), node.getColumnNames());
+        return new AliasedRelation(newRelation, node.getAlias(), node.getColumnNames());
     }
 
     @Override
@@ -336,7 +336,7 @@ public class MaterializedViewQueryOptimizer
             return node;
         }
 
-        return new WithQuery(node.getName(), processSameType(node.getQuery()), node.getColumnNames());
+        return new WithQuery(node.getName(), newQuery, node.getColumnNames());
     }
 
     private <T extends Node> List<T> processNodes(List<T> nodes)
@@ -1081,7 +1081,7 @@ public class MaterializedViewQueryOptimizer
 
                 Table table;
                 if (from instanceof Table) {
-                    table = (Table) querySpecification.getFrom().get();
+                    table = (Table) from;
                 }
                 else if (from instanceof AliasedRelation && ((AliasedRelation) from).getRelation() instanceof Table) {
                     table = (Table) ((AliasedRelation) from).getRelation();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -278,7 +278,7 @@ public class MaterializedViewQueryOptimizer
             return node;
         }
 
-        return new TableSubquery(processSameType(newQuery));
+        return new TableSubquery(newQuery);
     }
 
     @Override
@@ -289,7 +289,7 @@ public class MaterializedViewQueryOptimizer
             return node;
         }
 
-        return new AliasedRelation(processSameType(newRelation), node.getAlias(), node.getColumnNames());
+        return new AliasedRelation(newRelation, node.getAlias(), node.getColumnNames());
     }
 
     @Override
@@ -334,7 +334,7 @@ public class MaterializedViewQueryOptimizer
             return node;
         }
 
-        return new WithQuery(node.getName(), processSameType(node.getQuery()), node.getColumnNames());
+        return new WithQuery(node.getName(), newQuery, node.getColumnNames());
     }
 
     private <T extends Node> List<T> processNodes(List<T> nodes)
@@ -932,7 +932,7 @@ public class MaterializedViewQueryOptimizer
 
                 Table table;
                 if (from instanceof Table) {
-                    table = (Table) querySpecification.getFrom().get();
+                    table = (Table) from;
                 }
                 else if (from instanceof AliasedRelation && ((AliasedRelation) from).getRelation() instanceof Table) {
                     table = (Table) ((AliasedRelation) from).getRelation();


### PR DESCRIPTION
## Description

This PR simply removed the redundant method calls in `MaterializedViewQueryOptimizer`.


## Motivation and Context

N/A

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Remove redundant method calls and reuse processed query components in materialized view optimization.

Enhancements:
- Eliminate redundant expression and node processing in materialized view query optimization and related expression utilities.
- Reuse already computed relations and expressions when constructing rewritten query nodes.