### PR TITLE
feat: Prism <> Iceberg [prism] Support SQL-standard time travel syntax (FOR TIMESTAMP AS OF) (#27421)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1691,6 +1691,20 @@ public abstract class IcebergAbstractMetadata
                 long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).getPrecision().toMillis(timestampValue);
                 return getSnapshotIdTimeOperator(table, millisUtc, tableVersion.getVersionOperator());
             }
+            else if (tableVersion.getVersionExpressionType() instanceof BigintType) {
+                return getSnapshotIdTimeOperator(table, (long) tableVersion.getTableVersion(), tableVersion.getVersionOperator());
+            }
+            else if (tableVersion.getVersionExpressionType() instanceof VarcharType) {
+                try {
+                    long millisUtc = Long.parseLong(((Slice) tableVersion.getTableVersion()).toStringUtf8());
+                    return getSnapshotIdTimeOperator(table, millisUtc, tableVersion.getVersionOperator());
+                }
+                catch (NumberFormatException e) {
+                    throw new PrestoException(NOT_SUPPORTED,
+                            "VARCHAR value for time travel must be a numeric epoch millisecond timestamp, got: " +
+                                    ((Slice) tableVersion.getTableVersion()).toStringUtf8());
+                }
+            }
             throw new PrestoException(NOT_SUPPORTED, "Unsupported table version expression type: " + tableVersion.getVersionExpressionType());
         }
         if (tableVersion.getVersionType() == VersionType.VERSION) {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableVersion.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergTableVersion.java
@@ -325,6 +325,20 @@ public class TestIcebergTableVersion
             assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP BEFORE TIMESTAMP " + "'" + timestampWithoutTZ2 + "'", "VALUES 'aaa', 'bbb'");
             assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP AS OF TIMESTAMP " + "'" + timestampWithoutTZ3 + "'", "VALUES 'aaa', 'bbb', 'ccc'");
             assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP BEFORE TIMESTAMP " + "'" + timestampWithoutTZ3 + "'", "VALUES 'aaa', 'bbb', 'ccc'");
+
+            // BIGINT epoch millis time travel
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP AS OF CAST(" + timestampMillis1 + " AS BIGINT)", "VALUES 'aaa'");
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP AS OF CAST(" + timestampMillis2 + " AS BIGINT)", "VALUES 'aaa', 'bbb'");
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP AS OF CAST(" + timestampMillis3 + " AS BIGINT)", "VALUES 'aaa', 'bbb', 'ccc'");
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP BEFORE CAST(" + timestampMillis2 + " AS BIGINT)", "VALUES 'aaa', 'bbb'");
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP BEFORE CAST(" + timestampMillis3 + " AS BIGINT)", "VALUES 'aaa', 'bbb', 'ccc'");
+
+            // VARCHAR epoch millis time travel
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP AS OF '" + timestampMillis1 + "'", "VALUES 'aaa'");
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP AS OF '" + timestampMillis2 + "'", "VALUES 'aaa', 'bbb'");
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP AS OF '" + timestampMillis3 + "'", "VALUES 'aaa', 'bbb', 'ccc'");
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP BEFORE '" + timestampMillis2 + "'", "VALUES 'aaa', 'bbb'");
+            assertQuery(session, "SELECT desc FROM " + tableName + " FOR TIMESTAMP BEFORE '" + timestampMillis3 + "'", "VALUES 'aaa', 'bbb', 'ccc'");
         }
         finally {
             assertQuerySucceeds("DROP TABLE IF EXISTS " + tableName);
@@ -344,23 +358,23 @@ public class TestIcebergTableVersion
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR VERSION AS OF " + tab2VersionId1 + " - " + tab2VersionId1, "Iceberg snapshot ID does not exists: 0");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR VERSION AS OF CAST (100 AS BIGINT)", "Iceberg snapshot ID does not exists: 100");
 
-        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF 100", ".* Type integer is invalid. Supported table version AS OF/BEFORE expression type is Timestamp or Timestamp with Time Zone.");
-        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF 'bad'", ".* Type varchar\\(3\\) is invalid. Supported table version AS OF/BEFORE expression type is Timestamp or Timestamp with Time Zone.");
+        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF 100", ".* Type integer is invalid. Supported table version AS OF/BEFORE expression type is Timestamp, Timestamp with Time Zone, BIGINT, or VARCHAR.");
+        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF 'bad'", "VARCHAR value for time travel must be a numeric epoch millisecond timestamp, got: bad");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF id", ".* cannot be resolved");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF (SELECT CURRENT_TIMESTAMP)", ".* Constant expression cannot contain a subquery");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF NULL", "Table version AS OF/BEFORE expression cannot be NULL for .*");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF TIMESTAMP " + "'" + tab2Timestamp1 + "' - INTERVAL '1' MONTH", "No history found based on timestamp for table iceberg.test_tt_schema.test_table_version_tab2");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF CAST ('2023-01-01' AS TIMESTAMP WITH TIME ZONE)", "No history found based on timestamp for table iceberg.test_tt_schema.test_table_version_tab2");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF CAST ('2023-01-01' AS TIMESTAMP)", "No history found based on timestamp for table iceberg.test_tt_schema.test_table_version_tab2");
-        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF CAST ('2023-01-01' AS DATE)", ".* Type date is invalid. Supported table version AS OF/BEFORE expression type is Timestamp or Timestamp with Time Zone.");
-        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF CURRENT_DATE", ".* Type date is invalid. Supported table version AS OF/BEFORE expression type is Timestamp or Timestamp with Time Zone.");
+        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF CAST ('2023-01-01' AS DATE)", ".* Type date is invalid. Supported table version AS OF/BEFORE expression type is Timestamp, Timestamp with Time Zone, BIGINT, or VARCHAR.");
+        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF CURRENT_DATE", ".* Type date is invalid. Supported table version AS OF/BEFORE expression type is Timestamp, Timestamp with Time Zone, BIGINT, or VARCHAR.");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP AS OF TIMESTAMP '2023-01-01 00:00:00.000'", "No history found based on timestamp for table iceberg.test_tt_schema.test_table_version_tab2");
 
         assertQueryFails("SELECT desc FROM " + tableName1 + " FOR VERSION BEFORE " + tab1VersionId1 + " ORDER BY 1", "No history found based on timestamp for table iceberg.test_tt_schema.test_table_version_tab1");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP BEFORE TIMESTAMP " + "'" + tab2Timestamp1 + "' - INTERVAL '1' MONTH", "No history found based on timestamp for table iceberg.test_tt_schema.test_table_version_tab2");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR VERSION BEFORE 100", ".* Type integer is invalid. Supported table version AS OF/BEFORE expression type is BIGINT or VARCHAR");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR VERSION BEFORE " + tab2VersionId1 + " - " + tab2VersionId1, "Iceberg snapshot ID does not exists: 0");
-        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP BEFORE 'bad'", ".* Type varchar\\(3\\) is invalid. Supported table version AS OF/BEFORE expression type is Timestamp or Timestamp with Time Zone.");
+        assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP BEFORE 'bad'", "VARCHAR value for time travel must be a numeric epoch millisecond timestamp, got: bad");
         assertQueryFails("SELECT desc FROM " + tableName2 + " FOR TIMESTAMP BEFORE NULL", "Table version AS OF/BEFORE expression cannot be NULL for .*");
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2441,9 +2441,10 @@ class StatementAnalyzer
             }
             Object evalStateExpr = evaluateConstantExpression(stateExpr, stateExprType, metadata, session, analysis.getParameters());
             if (tableVersionType == TIMESTAMP) {
-                if (!(stateExprType instanceof TimestampWithTimeZoneType || stateExprType instanceof TimestampType)) {
+                if (!(stateExprType instanceof TimestampWithTimeZoneType || stateExprType instanceof TimestampType
+                        || stateExprType instanceof BigintType || stateExprType instanceof VarcharType)) {
                     throw new SemanticException(TYPE_MISMATCH, stateExpr,
-                            "Type %s is invalid. Supported table version AS OF/BEFORE expression type is Timestamp or Timestamp with Time Zone.",
+                            "Type %s is invalid. Supported table version AS OF/BEFORE expression type is Timestamp, Timestamp with Time Zone, BIGINT, or VARCHAR.",
                             stateExprType.getDisplayName());
                 }
             }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/presto-facebook/pull/3608


The Presto parser and analyzer already support the SQL-2011 temporal query syntax (`FOR TIMESTAMP AS OF`, `FOR SYSTEM_TIME AS OF`) via the `ConnectorTableVersion` SPI. The Iceberg connector implements it. The Prism connector does not, despite Metastore already supporting snapshot versioning through the `timestamp` table name encoding.

This change:
1. Adds the 3-argument `getTableHandle(session, tableName, tableVersion)` override to `PrismMetadata` that converts the SQL time travel clause into the existing `timestamp` encoding
2. Extends `StatementAnalyzer` to accept `BIGINT` and `VARCHAR` expression types in `FOR TIMESTAMP AS OF` clauses (previously only `TimestampType` and `TimestampWithTimeZoneType` were allowed)

This enables users to write clean time travel queries with multiple syntax options:

```sql
-- Timestamp syntax (existing)
SELECT * FROM dim_users FOR TIMESTAMP AS OF TIMESTAMP '2024-01-15 10:00:00'

-- BIGINT epoch millis (new)
SELECT * FROM dim_users FOR TIMESTAMP AS OF BIGINT '1705312800000'

-- VARCHAR epoch millis string (new)
SELECT * FROM dim_users FOR TIMESTAMP AS OF '1705312800000'
```

instead of the current session-property approach:

```sql
SET SESSION prism.source_table_snapshots_enabled = true;
SET SESSION prism.source_table_snapshots_timestamp_ms = 1705312800000;
SELECT * FROM dim_users;
```

## Benefits
- **Per-table granularity**: Different tables in the same query can time-travel to different timestamps (impossible with session properties)
- **Self-documenting**: Timestamp is in the SQL, not hidden in session state
- **SQL-standard**: Compatible with Athena, Spark 3.3+, SQL-2011
- **Multiple input formats**: Accepts TIMESTAMP, TIMESTAMP WITH TIME ZONE, BIGINT epoch millis, or VARCHAR epoch millis strings
- **No session state management**: Just write the query
- **Backward compatible**: Existing session properties continue to work unchanged

## Supported SQL syntax
- `FOR TIMESTAMP AS OF TIMESTAMP '2023-08-17 13:29:46.822 America/Los_Angeles'` (TimestampWithTimeZoneType)
- `FOR TIMESTAMP AS OF TIMESTAMP '2023-08-17 13:29:46.822'` (TimestampType)
- `FOR TIMESTAMP AS OF CURRENT_TIMESTAMP` (CurrentTime)
- `FOR TIMESTAMP AS OF BIGINT '1624893589000'` (BIGINT epoch millis — NEW)
- `FOR TIMESTAMP AS OF '1624893589000'` (VARCHAR epoch millis string — NEW)

## Implementation

### StatementAnalyzer (presto-trunk)
- Modified type check in `FOR TIMESTAMP AS OF` validation to also accept `BigintType` and `VarcharType` (in addition to `TimestampType` and `TimestampWithTimeZoneType`)
- Updated error message to list all supported types

### PrismMetadata (presto-facebook-trunk)
- `PrismMetadata.getTableHandle(session, tableName, Optional<ConnectorTableVersion>)` — new 3-arg override
- `PrismMetadata.encodeTableNameWithVersion(tableName, timestampMs)` — reuses existing `timestamp` encoding
- `PrismMetadata.extractTimestampMillis(version)` — handles TimestampType, TimestampWithTimeZoneType, BigintType, and VarcharType
- VERSION-based time travel and BEFORE operator are rejected with clear error messages

Reference implementation: `IcebergAbstractMetadata.getSnapshotIdForTableVersion()`

== NO RELEASE NOTE ==

Reviewed By: ghelmling

Differential Revision: D97600298
