### PR TITLE
chore(deps): Revert Updated airlift base and checkstyle to work with Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>109</version>
+        <version>108</version>
     </parent>
 
     <groupId>com.facebook.presto</groupId>

--- a/presto-client/src/main/java/okhttp/internal/tls/DistinguishedNameParser.java
+++ b/presto-client/src/main/java/okhttp/internal/tls/DistinguishedNameParser.java
@@ -415,8 +415,7 @@ final class DistinguishedNameParser
             }
             if (chars[pos] == ',' || chars[pos] == ';') {
                 //Do nothing
-            }
-            else if (chars[pos] != '+') {
+            } else if (chars[pos] != '+') {
                 throw new IllegalStateException("Malformed DN: " + dn);
             }
             pos++;

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -159,8 +159,8 @@ public final class InternalResourceGroupManager<C>
         this.maxQueryAdmissionsPerSecond = queryManagerConfig.getMaxQueryAdmissionsPerSecond();
         this.minRunningQueriesForPacing = queryManagerConfig.getMinRunningQueriesForPacing();
         this.queryAdmissionIntervalNanos = (maxQueryAdmissionsPerSecond == Integer.MAX_VALUE)
-                ? 0L
-                : 1_000_000_000L / maxQueryAdmissionsPerSecond;
+            ? 0L
+            : 1_000_000_000L / maxQueryAdmissionsPerSecond;
         this.queryPacingContext = new QueryPacingContext()
         {
             @Override

--- a/presto-main-base/src/main/java/com/facebook/presto/resourcemanager/RatisServer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/resourcemanager/RatisServer.java
@@ -61,7 +61,7 @@ public class RatisServer
                 .map(resourceManager -> {
                     RaftPeer.Builder builder = RaftPeer.newBuilder();
                     builder.setId(RaftPeerId.valueOf(resourceManager.getNodeIdentifier()))
-                            .setAddress(resourceManager.getHost() + ":" + resourceManager.getRaftPort().getAsInt());
+                        .setAddress(resourceManager.getHost() + ":" + resourceManager.getRaftPort().getAsInt());
                     return builder.build();
                 }).toArray(RaftPeer[]::new);
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/tdigest/TDigestUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/tdigest/TDigestUtils.java
@@ -424,7 +424,7 @@ public final class TDigestUtils
         order[j] = t;
     }
 
-    private static void swap(int i, int j, double[] key, double[]... values)
+    private static void swap(int i, int j, double[] key, double[]...values)
     {
         double t = key[i];
         key[i] = key[j];

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformValue.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/BenchmarkTransformValue.java
@@ -150,8 +150,8 @@ public class BenchmarkTransformValue
                             call(
                                     GREATER_THAN.name(),
                                     greaterThan, BOOLEAN, ImmutableList.of(
-                                        new VariableReferenceExpression(Optional.empty(), "y", elementType),
-                                        constant(compareValue, elementType)))))));
+                                    new VariableReferenceExpression(Optional.empty(), "y", elementType),
+                                    constant(compareValue, elementType)))))));
             Block block = createChannel(POSITIONS, mapType, elementType);
 
             ImmutableList<RowExpression> projections = projectionsBuilder.build();

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantsAboveGroupBy.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantsAboveGroupBy.java
@@ -89,7 +89,7 @@ public class TestPullConstantsAboveGroupBy
                                     p.values(p.variable("COL"))))
                     .addAggregation(p.variable("AVG", DOUBLE), p.rowExpression("avg(COL)"))
                     .singleGroupingSet(p.variable("CONST_COL"), p.variable("COL"))))
-                .doesNotFire();
+            .doesNotFire();
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRedundantLimitRemoval.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRedundantLimitRemoval.java
@@ -129,6 +129,6 @@ public class TestRedundantLimitRemoval
 
         newTester.assertThat(ImmutableSet.of(new RemoveRedundantLimit()), logicalPropertiesProvider)
             .on("select totalprice from orders o inner join customer c on o.custkey = c.custkey where o.orderkey=10 limit 2")
-                .validates(plan -> assertNodePresentInPlan(plan, LimitNode.class));
+            .validates(plan -> assertNodePresentInPlan(plan, LimitNode.class));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestInternalAuthenticationFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestInternalAuthenticationFilter.java
@@ -151,8 +151,7 @@ public class TestInternalAuthenticationFilter
                     try {
                         method = clazz.getMethod(methodName, parameterTypes);
                     }
-                    catch (NoSuchMethodException e) {
-                    }
+                    catch (NoSuchMethodException e) { }
                     return method;
                 }
 

--- a/presto-native-execution/src/checkstyle/presto-checks.xml
+++ b/presto-native-execution/src/checkstyle/presto-checks.xml
@@ -169,8 +169,6 @@
 
         <module name="AnnotationUseStyle">
             <property name="trailingArrayComma" value="ignore" />
-            <!-- see https://checkstyle.sourceforge.io/checks/annotation/annotationusestyle.html#Properties -->
-            <property name="elementStyle" value="ignore"/>
         </module>
 
         <module name="AvoidStarImport" />

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeGeneralQueries.java
@@ -1788,10 +1788,10 @@ public abstract class AbstractTestNativeGeneralQueries
                     ColumnMetadata.builder()
                             .setName("col")
                             .setType(RowType.from(ImmutableList.of(
-                                new RowType.Field(Optional.of("NationKey"), BIGINT),
-                                new RowType.Field(Optional.of("NAME"), VARCHAR),
-                                new RowType.Field(Optional.of("ReGiOnKeY"), BIGINT),
-                                new RowType.Field(Optional.of("commenT"), VARCHAR))))
+                            new RowType.Field(Optional.of("NationKey"), BIGINT),
+                            new RowType.Field(Optional.of("NAME"), VARCHAR),
+                            new RowType.Field(Optional.of("ReGiOnKeY"), BIGINT),
+                            new RowType.Field(Optional.of("commenT"), VARCHAR))))
                             .build()),
                     tableProperties);
             transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/PrestoSparkNativeQueryRunnerUtils.java
@@ -125,7 +125,7 @@ public class PrestoSparkNativeQueryRunnerUtils
         // Add connectors on the native side to make them available during execution.
         ImmutableMap.Builder<String, Map<String, String>> catalogBuilder = ImmutableMap.builder();
         catalogBuilder.put("hive", ImmutableMap.of("connector.name", "hive"))
-                .putAll(additionalCatalogs);
+            .putAll(additionalCatalogs);
         PrestoSparkQueryRunner queryRunner = createRunner(
                 "hive",
                 new NativeExecutionModule(),

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSource.java
@@ -263,9 +263,9 @@ public class PinotBrokerPageSource
             JsonNode result = rows.get(rowNumber);
             if (result == null || result.size() < blockBuilders.size()) {
                 throw new PinotException(
-                        PINOT_UNEXPECTED_RESPONSE,
-                        Optional.of(query),
-                        String.format("Expected row of %d columns", blockBuilders.size()));
+                    PINOT_UNEXPECTED_RESPONSE,
+                    Optional.of(query),
+                    String.format("Expected row of %d columns", blockBuilders.size()));
             }
             for (int columnNumber = 0; columnNumber < blockBuilders.size(); columnNumber++) {
                 setValue(types.get(columnNumber), blockBuilders.get(columnNumber), result.get(columnNumber));
@@ -280,25 +280,25 @@ public class PinotBrokerPageSource
 
         if (numServersQueried == null || numServersResponded == null || numServersQueried.asInt() > numServersResponded.asInt()) {
             throw new PinotException(
-                    PINOT_INSUFFICIENT_SERVER_RESPONSE,
-                    Optional.of(pinotQuery),
-                    String.format("Only %s out of %s servers responded for query %s", numServersResponded.asInt(), numServersQueried.asInt(), pinotQuery));
+                PINOT_INSUFFICIENT_SERVER_RESPONSE,
+                Optional.of(pinotQuery),
+                String.format("Only %s out of %s servers responded for query %s", numServersResponded.asInt(), numServersQueried.asInt(), pinotQuery));
         }
 
         JsonNode exceptions = jsonBody.get("exceptions");
         if (exceptions != null && exceptions.isArray() && exceptions.size() > 0) {
             if (exceptions.get(0).get("errorCode").asInt() == 180) {
                 throw new PinotException(
-                        PINOT_UNAUTHENTICATED_EXCEPTION,
-                        Optional.empty(),
-                        "Query authentication failed.");
+                    PINOT_UNAUTHENTICATED_EXCEPTION,
+                    Optional.empty(),
+                    "Query authentication failed.");
             }
             // Pinot is known to return exceptions with benign errorcodes like 200
             // so we treat any exception as an error
             throw new PinotException(
-                    PINOT_EXCEPTION,
-                    Optional.of(pinotQuery),
-                    String.format("Query %s encountered exception %s", pinotQuery, exceptions.get(0)));
+                PINOT_EXCEPTION,
+                Optional.of(pinotQuery),
+                String.format("Query %s encountered exception %s", pinotQuery, exceptions.get(0)));
         }
     }
 
@@ -389,9 +389,9 @@ public class PinotBrokerPageSource
             JsonNode dataSchema = resultTable.get("dataSchema");
             if (dataSchema == null) {
                 throw new PinotException(
-                        PINOT_UNEXPECTED_RESPONSE,
-                        Optional.of(sql),
-                        "Expected data schema in the response");
+                    PINOT_UNEXPECTED_RESPONSE,
+                    Optional.of(sql),
+                    "Expected data schema in the response");
             }
             JsonNode columnDataTypes = dataSchema.get("columnDataTypes");
             JsonNode columnNames = dataSchema.get("columnNames");
@@ -400,17 +400,17 @@ public class PinotBrokerPageSource
                     || !columnDataTypes.isArray()
                     || columnDataTypes.size() < blockBuilders.size()) {
                 throw new PinotException(
-                        PINOT_UNEXPECTED_RESPONSE,
-                        Optional.of(sql),
-                        String.format("ColumnDataTypes and results expected for %s, expected %d columnDataTypes but got %d", sql, blockBuilders.size(), columnDataTypes == null ? 0 : columnDataTypes.size()));
+                    PINOT_UNEXPECTED_RESPONSE,
+                    Optional.of(sql),
+                    String.format("ColumnDataTypes and results expected for %s, expected %d columnDataTypes but got %d", sql, blockBuilders.size(), columnDataTypes == null ? 0 : columnDataTypes.size()));
             }
             if (columnNames == null
                     || !columnNames.isArray()
                     || columnNames.size() < blockBuilders.size()) {
                 throw new PinotException(
-                        PINOT_UNEXPECTED_RESPONSE,
-                        Optional.of(sql),
-                        String.format("ColumnNames and results expected for %s, expected %d columnNames but got %d", sql, blockBuilders.size(), columnNames == null ? 0 : columnNames.size()));
+                    PINOT_UNEXPECTED_RESPONSE,
+                    Optional.of(sql),
+                    String.format("ColumnNames and results expected for %s, expected %d columnNames but got %d", sql, blockBuilders.size(), columnNames == null ? 0 : columnNames.size()));
             }
 
             JsonNode rows = resultTable.get("rows");

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
@@ -88,21 +88,21 @@ public class PinotPageSourceProvider
         switch (pinotSplit.getSplitType()) {
             case SEGMENT:
                 return new PinotSegmentPageSource(
-                        session,
-                        pinotConfig,
-                        pinotStreamingQueryClient,
-                        pinotSplit,
-                        handles);
+                    session,
+                    pinotConfig,
+                    pinotStreamingQueryClient,
+                    pinotSplit,
+                    handles);
             case BROKER:
                 return new PinotBrokerPageSource(
-                        pinotConfig,
-                        session,
-                        pinotSplit.getBrokerPinotQuery().get(),
-                        handles,
-                        pinotSplit.getExpectedColumnHandles(),
-                        clusterInfoFetcher,
-                        objectMapper,
-                        brokerAuthenticationProvider);
+                    pinotConfig,
+                    session,
+                    pinotSplit.getBrokerPinotQuery().get(),
+                    handles,
+                    pinotSplit.getExpectedColumnHandles(),
+                    clusterInfoFetcher,
+                    objectMapper,
+                    brokerAuthenticationProvider);
             default:
                 throw new UnsupportedOperationException("Unknown Pinot split type: " + pinotSplit.getSplitType());
         }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
@@ -210,9 +210,10 @@ public class PinotSegmentPageSource
                         }
                         catch (IOException e) {
                             throw new PinotException(
-                                    PINOT_DATA_FETCH_EXCEPTION,
-                                    split.getSegmentPinotQuery(),
-                                    String.format("Encountered Pinot exceptions when fetching data table from Split: < %s >", split), e);
+                                PINOT_DATA_FETCH_EXCEPTION,
+                                split.getSegmentPinotQuery(),
+                                String.format("Encountered Pinot exceptions when fetching data table from Split: < %s >", split),
+                                e);
                         }
                         break;
                     case CommonConstants.Query.Response.ResponseType.METADATA:
@@ -223,9 +224,9 @@ public class PinotSegmentPageSource
                         return null;
                     default:
                         throw new PinotException(
-                                PINOT_UNEXPECTED_RESPONSE,
-                                split.getSegmentPinotQuery(),
-                                String.format("Encountered Pinot exceptions, unknown response type - %s", responseType));
+                            PINOT_UNEXPECTED_RESPONSE,
+                            split.getSegmentPinotQuery(),
+                            String.format("Encountered Pinot exceptions, unknown response type - %s", responseType));
                 }
             }
             Page page = fillNextPage();
@@ -246,9 +247,9 @@ public class PinotSegmentPageSource
         int grpcPort = split.getGrpcPort().orElseThrow(() -> new PinotException(PINOT_INVALID_SEGMENT_QUERY_GENERATED, Optional.empty(), "Expected the segment split to contain the grpc port"));
         if (grpcPort <= 0) {
             throw new PinotException(
-                    PINOT_INVALID_SEGMENT_QUERY_GENERATED,
-                    Optional.empty(),
-                    "Expected the grpc port > 0 always");
+                PINOT_INVALID_SEGMENT_QUERY_GENERATED,
+                Optional.empty(),
+                "Expected the grpc port > 0 always");
         }
         PinotProxyGrpcRequestBuilder grpcRequestBuilder = new PinotProxyGrpcRequestBuilder()
                 .setSegments(split.getSegments())

--- a/presto-product-tests/conf/docker/files/presto-cli.sh
+++ b/presto-product-tests/conf/docker/files/presto-cli.sh
@@ -2,9 +2,4 @@
 
 set -euxo pipefail
 
-echo "java --version"
-echo $(java --version)
-export JAVA_HOME=/docker/volumes/overridejdk
-echo "/docker/volumes/overridejdk/bin/java --version"
-echo $(/docker/volumes/overridejdk/bin/java --version)
-/docker/volumes/overridejdk/bin/java -jar /docker/volumes/presto-cli/presto-cli-executable.jar ${CLI_ARGUMENTS} "$@"
+java -jar /docker/volumes/presto-cli/presto-cli-executable.jar ${CLI_ARGUMENTS} "$@"

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConfigModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/property/NativeExecutionConfigModule.java
@@ -52,7 +52,7 @@ public class NativeExecutionConfigModule
         bind(new TypeLiteral<Map<String, Map<String, String>>>() {})
             .annotatedWith(
                 Names.named(NativeExecutionCatalogConfig.NATIVE_EXECUTION_CATALOG_CONFIG))
-                .toInstance(catalogConfigs);
+            .toInstance(catalogConfigs);
 
         bind(NativeExecutionSystemConfig.class).in(Scopes.SINGLETON);
         bind(NativeExecutionCatalogConfig.class).in(Scopes.SINGLETON);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -340,16 +340,16 @@ public class PrestoSparkQueryRunner
                 // Sql-Standard Access Control Checker
                 // needs us to specify our role
                 .setIdentity(
-                    new Identity(
-                            "hive",
-                            Optional.empty(),
-                            ImmutableMap.of(defaultCatalog,
-                                new SelectedRole(Type.ROLE, Optional.of("admin"))),
-                            ImmutableMap.of(),
-                            ImmutableMap.of(),
-                            Optional.empty(),
-                            Optional.empty()))
-                    .build();
+                        new Identity(
+                                "hive",
+                                Optional.empty(),
+                                ImmutableMap.of(defaultCatalog,
+                                        new SelectedRole(Type.ROLE, Optional.of("admin"))),
+                                ImmutableMap.of(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .build();
 
         transactionManager = injector.getInstance(TransactionManager.class);
         metadata = injector.getInstance(Metadata.class);

--- a/src/checkstyle/presto-checks.xml
+++ b/src/checkstyle/presto-checks.xml
@@ -169,8 +169,6 @@
 
         <module name="AnnotationUseStyle">
             <property name="trailingArrayComma" value="ignore" />
-            <!-- see https://checkstyle.sourceforge.io/checks/annotation/annotationusestyle.html#Properties -->
-            <property name="elementStyle" value="ignore"/>
         </module>
 
         <module name="AvoidStarImport" />


### PR DESCRIPTION
This reverts commit 1ddef8b8f728cd65b71db7cd0bfb1100b4c70bdc due to breaking JDK compatibility: https://github.com/prestodb/presto/issues/27382

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```