### PR TITLE
test(native): Add E2E tests for DateTime functions

### DIFF
--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeDateTimeScalarFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeDateTimeScalarFunctions.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestDateTimeScalarFunctions;
+import org.testng.annotations.BeforeClass;
+
+import static java.lang.Boolean.parseBoolean;
+
+public class TestPrestoNativeDateTimeScalarFunctions
+        extends AbstractTestDateTimeScalarFunctions
+{
+    private String storageFormat;
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        storageFormat = System.getProperty("storageFormat", "PARQUET");
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "true"));
+        super.init();
+    }
+
+    @Override
+    protected void createTables()
+    {
+        NativeTestsUtils.createTables(storageFormat);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return NativeTestsUtils.createNativeQueryRunner(storageFormat, sidecarEnabled);
+    }
+
+    @Override
+    protected String getWorkerScanTable()
+    {
+        return "hive.tpch.nation";
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDateTimeScalarFunctions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDateTimeScalarFunctions.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.TimeZoneKey;
+import org.testng.annotations.Test;
+
+public abstract class AbstractTestDateTimeScalarFunctions
+        extends AbstractTestQueryFramework
+{
+    protected Session getSessionWithTimeZone(String timeZone)
+    {
+        return Session.builder(getSession())
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(timeZone))
+                .build();
+    }
+
+    /**
+     * Returns the fully-qualified table used to force worker-side execution.
+     * Subclasses backed by a non-TPCH connector (e.g. native Hive) may override.
+     */
+    protected String getWorkerScanTable()
+    {
+        return "tpch.tiny.nation";
+    }
+
+    @Test
+    public void testLocalTime()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuery(session, "SELECT localtime IS NOT NULL", "SELECT true");
+
+        // Test with table scan to exercise execution on workers
+        assertQuery(session, "SELECT bool_and(localtime IS NOT NULL) FROM " + getWorkerScanTable(), "SELECT true");
+    }
+
+    @Test
+    public void testLocalTimestamp()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuery(session, "SELECT localtimestamp IS NOT NULL", "SELECT true");
+
+        assertQuery(session, "SELECT bool_and(localtimestamp IS NOT NULL) FROM " + getWorkerScanTable(), "SELECT true");
+    }
+
+    @Test
+    public void testCurrentTime()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuery(session, "SELECT current_time IS NOT NULL", "SELECT true");
+
+        assertQuery(session, "SELECT bool_and(current_time IS NOT NULL) FROM " + getWorkerScanTable(), "SELECT true");
+    }
+
+    @Test
+    public void testCurrentTimestamp()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuery(session, "SELECT current_timestamp IS NOT NULL", "SELECT true");
+
+        assertQuery(session, "SELECT bool_and(current_timestamp IS NOT NULL) FROM " + getWorkerScanTable(), "SELECT true");
+    }
+
+    @Test
+    public void testCurrentTimezone()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuery(session, "SELECT current_timezone() IS NOT NULL", "SELECT true");
+
+        assertQuery(session, "SELECT bool_and(current_timezone() IS NOT NULL) FROM " + getWorkerScanTable(), "SELECT true");
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDateTimeScalarFunctions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDateTimeScalarFunctions.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.TimeZoneKey;
+import org.testng.annotations.Test;
+
+public abstract class AbstractTestDateTimeScalarFunctions
+        extends AbstractTestQueryFramework
+{
+    protected Session getSessionWithTimeZone(String timeZone)
+    {
+        return Session.builder(getSession())
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(timeZone))
+                .build();
+    }
+
+    /**
+     * Returns the fully-qualified table used to force worker-side execution.
+     * Subclasses backed by a non-TPCH connector (e.g. native Hive) may override.
+     */
+    protected String getWorkerScanTable()
+    {
+        return "tpch.tiny.nation";
+    }
+
+    @Test
+    public void testLocalTime()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuerySucceeds(session, "SELECT localtime IS NOT NULL");
+
+        // Test with table scan to exercise execution on workers
+        assertQuerySucceeds(session, "SELECT localtime IS NOT NULL FROM " + getWorkerScanTable());
+    }
+
+    @Test
+    public void testLocalTimestamp()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuerySucceeds(session, "SELECT localtimestamp IS NOT NULL");
+
+        assertQuerySucceeds(session, "SELECT localtimestamp IS NOT NULL FROM " + getWorkerScanTable());
+    }
+
+    @Test
+    public void testCurrentTime()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuerySucceeds(session, "SELECT current_time IS NOT NULL");
+
+        assertQuerySucceeds(session, "SELECT current_time IS NOT NULL FROM " + getWorkerScanTable());
+    }
+
+    @Test
+    public void testCurrentTimestamp()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuerySucceeds(session, "SELECT current_timestamp IS NOT NULL");
+
+        assertQuerySucceeds(session, "SELECT current_timestamp IS NOT NULL FROM " + getWorkerScanTable());
+    }
+
+    @Test
+    public void testCurrentTimezone()
+    {
+        Session session = getSessionWithTimeZone("America/Chicago");
+        assertQuerySucceeds(session, "SELECT current_timezone() IS NOT NULL");
+
+        assertQuerySucceeds(session, "SELECT current_timezone() IS NOT NULL FROM " + getWorkerScanTable());
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDateTimeScalarFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDateTimeScalarFunctions.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestDateTimeScalarFunctions
+        extends AbstractTestDateTimeScalarFunctions
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        LocalQueryRunner runner = new LocalQueryRunner(testSessionBuilder().build());
+        runner.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.of());
+        return runner;
+    }
+}


### PR DESCRIPTION
## Description
We have recently added some scalar functions such as currentTimestamp, currentTime, localTimestamp, currentTimezone, etc. as part of bringing the parity in velox and presto. This PR adds end-to-end tests to validate the behavior of these functions in Presto Native execution.

## Motivation and Context
These functions are already supported in Presto Java execution, but coverage in Presto Native was missing. Adding end-to-end tests ensures functional parity between the Java and native execution paths and helps detect regressions in time-related functions that depend on session configuration such as timezone.

## Impact
This change only adds test coverage and does not modify existing functionality. It improves validation of date/time scalar functions in Presto Native and helps ensure consistent behavior across execution engines.



## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Add Presto Native E2E tests validating localtime, localtimestamp, current_time, current_timestamp, and current_timezone() execution with a configured session timezone.