### PR TITLE
fix(optimizer): Fix infinite loop in UnaliasSymbolReferences.canonicalize()

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -887,8 +887,16 @@ public class UnaliasSymbolReferences
         private VariableReferenceExpression canonicalize(VariableReferenceExpression variable)
         {
             String canonical = variable.getName();
+            Set<String> visited = new HashSet<>();
+            visited.add(canonical);
             while (mapping.containsKey(canonical)) {
                 canonical = mapping.get(canonical);
+                if (!visited.add(canonical)) {
+                    // Cycle detected in alias mapping; break the cycle by removing the mapping entry
+                    // that would close the loop and stop at the current canonical name.
+                    mapping.remove(canonical);
+                    break;
+                }
             }
             return new VariableReferenceExpression(variable.getSourceLocation(), canonical, types.get(new SymbolReference(getNodeLocation(variable.getSourceLocation()), canonical)));
         }


### PR DESCRIPTION
## Summary
- Fix infinite loop in `UnaliasSymbolReferences.canonicalize()` when the alias mapping contains a cycle
- Queries with redundant `GROUP BY` over constant expressions hang indefinitely during planning because this non-iterative optimizer has no timeout protection
- Add cycle detection using a visited set; when a cycle is found, remove the cyclic mapping entry and break

Fixes #27427

## Root Cause

The `canonicalize()` method follows alias chains via a `while` loop:
```java
while (mapping.containsKey(canonical)) {
    canonical = mapping.get(canonical);
}
```

When multiple variables map to the same constant expression across different ProjectNodes (e.g., `ds = '2026-01-01'` and `report_date = '2026-01-01'`), a cycle can form (`ds → report_date → ds`), causing infinite looping.

## Reproduction (TPC-H)

```sql
SELECT report_date, total_price, order_cnt
FROM (
    SELECT ds, report_date,
        SUM(total_price) AS total_price,
        SUM(order_cnt) AS order_cnt
    FROM (
        SELECT report_date, '2026-01-01' AS ds,
            SUM(totalprice) AS total_price, COUNT(1) AS order_cnt
        FROM (
            SELECT '2026-01-01' AS report_date, orderstatus,
                SUM(totalprice) AS totalprice
            FROM orders GROUP BY 1, 2
        ) GROUP BY 1, 2
    ) GROUP BY ds, report_date  -- redundant GROUP BY over two constants
)
```

## Test plan
- [x] Repro query: infinite hang → completes in 3.3s
- [x] `TestUnaliasSymbolReferences`: 2/2 pass
- [x] `TestLocalQueries`: 523/523 pass, 0 regressions

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Fix infinite loop in ``UnaliasSymbolReferences`` when alias mapping contains a cycle caused by multiple variables mapped to the same constant expression across different ProjectNodes.
```
