### PR TITLE
feat(connector): Add filter pushdown for Lance connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/lance.rst
+++ b/presto-docs/src/main/sphinx/connector/lance.rst
@@ -190,6 +190,52 @@ of columns only read those columns from disk:
 
     SELECT id, name FROM lance.default.my_table;
 
+Predicate Pushdown
+^^^^^^^^^^^^^^^^^^
+
+The Lance connector supports predicate pushdown for ``WHERE`` clauses.
+Filter predicates are converted to Lance SQL filter strings and evaluated
+natively by Lance during scan, reducing data read from disk.
+
+.. code-block:: sql
+
+    SELECT * FROM lance.default.my_table
+    WHERE age > 30 AND status = 'active';
+
+The following predicate types are pushed down:
+
+- **Equality**: ``col = value``
+- **Comparisons**: ``col > value``, ``col >= value``, ``col < value``, ``col <= value``
+- **IN lists**: ``col IN (v1, v2, v3)``
+- **NULL checks**: ``col IS NULL``
+- **Range**: ``col >= low AND col < high``
+- **Multiple columns**: predicates on different columns are combined with ``AND``
+
+The following data types are supported in pushed-down predicates:
+
+========================= ======================================
+Presto Type               Lance Filter Literal
+========================= ======================================
+``BOOLEAN``               ``true`` / ``false``
+``TINYINT``               Integer literal
+``SMALLINT``              Integer literal
+``INTEGER``               Integer literal
+``BIGINT``                Integer literal
+``REAL``                  Float literal
+``DOUBLE``                Double literal
+``VARCHAR``               ``'string'`` (single quotes escaped)
+``DATE``                  ``date '2024-01-15'``
+``TIMESTAMP``             ``timestamp '2024-01-15 10:30:00.000000'``
+========================= ======================================
+
+.. note::
+
+    Predicates on unsupported types (e.g., ``VARBINARY``, ``ARRAY``) and
+    complex predicates with more than 100 ranges per column are not pushed
+    down. In these cases, Presto evaluates the filter at the executor level.
+    Correctness is always guaranteed because Presto re-evaluates all
+    predicates regardless of pushdown.
+
 DROP TABLE
 ^^^^^^^^^^
 
@@ -228,8 +274,8 @@ Limitations
   * :doc:`/sql/delete`
   * :doc:`/sql/update`
 
-* Predicate pushdown is not supported. Only column projection is pushed down
-  to the Lance reader.
+* Predicate pushdown is not supported for ``VARBINARY`` and ``ARRAY`` types.
+  Only column projection is pushed down for these types.
 * ``ARRAY`` types are supported for reads but cannot be written.
 * Only local filesystem paths are supported in the current ``dir`` implementation.
 * Data written by one Presto cluster is not visible to another cluster until the

--- a/presto-docs/src/main/sphinx/connector/lance.rst
+++ b/presto-docs/src/main/sphinx/connector/lance.rst
@@ -230,7 +230,7 @@ Presto Type               Lance Filter Literal
 
 .. note::
 
-    Predicates on unsupported types (e.g., ``VARBINARY``, ``ARRAY``) and
+    Predicates on unsupported types such as ``VARBINARY``, ``ARRAY``, and
     complex predicates with more than 100 ranges per column are not pushed
     down. In these cases, Presto evaluates the filter at the executor level.
     Correctness is always guaranteed because Presto re-evaluates all

--- a/presto-docs/src/main/sphinx/connector/lance.rst
+++ b/presto-docs/src/main/sphinx/connector/lance.rst
@@ -263,6 +263,22 @@ Show the columns and types of a Lance table:
 
     DESCRIBE lance.default.my_table;
 
+Session Properties
+------------------
+
+The following session properties can be set per-query using ``SET SESSION``:
+
+.. code-block:: sql
+
+    SET SESSION lance.filter_pushdown_enabled = false;
+
+================================================= ================================================================ =========
+Property Name                                     Description                                                      Default
+================================================= ================================================================ =========
+``filter_pushdown_enabled``                        Enable SQL predicate pushdown to the Lance scanner. Disable     ``true``
+                                                   to fall back to executor-level filtering only.
+================================================= ================================================================ =========
+
 Limitations
 -----------
 

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceArrowToPageScanner.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceArrowToPageScanner.java
@@ -34,6 +34,7 @@ import org.lance.ipc.LanceScanner;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -52,7 +53,8 @@ public class LanceArrowToPageScanner
             BufferAllocator allocator,
             List<LanceColumnHandle> columns,
             ScannerFactory scannerFactory,
-            ArrowBlockBuilder arrowBlockBuilder)
+            ArrowBlockBuilder arrowBlockBuilder,
+            Optional<String> filter)
     {
         this.allocator = requireNonNull(allocator, "allocator is null");
         this.columns = requireNonNull(columns, "columns is null");
@@ -61,7 +63,7 @@ public class LanceArrowToPageScanner
         List<String> columnNames = columns.stream()
                 .map(LanceColumnHandle::getColumnName)
                 .collect(toImmutableList());
-        LanceScanner scanner = scannerFactory.open(allocator, columnNames);
+        LanceScanner scanner = scannerFactory.open(allocator, columnNames, filter);
         this.arrowReader = scanner.scanBatches();
     }
 

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceBasePageSource.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceBasePageSource.java
@@ -20,6 +20,7 @@ import org.apache.arrow.memory.BufferAllocator;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -37,7 +38,8 @@ public abstract class LanceBasePageSource
             List<LanceColumnHandle> columns,
             ScannerFactory scannerFactory,
             ArrowBlockBuilder arrowBlockBuilder,
-            BufferAllocator parentAllocator)
+            BufferAllocator parentAllocator,
+            Optional<String> filter)
     {
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
         requireNonNull(columns, "columns is null");
@@ -53,7 +55,8 @@ public abstract class LanceBasePageSource
                     bufferAllocator,
                     columns,
                     scannerFactory,
-                    arrowBlockBuilder);
+                    arrowBlockBuilder,
+                    filter);
         }
         catch (RuntimeException e) {
             bufferAllocator.close();

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnector.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnector.java
@@ -21,9 +21,12 @@ import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
+
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -38,6 +41,7 @@ public class LanceConnector
     private final ConnectorSplitManager splitManager;
     private final ConnectorPageSourceProvider pageSourceProvider;
     private final ConnectorPageSinkProvider pageSinkProvider;
+    private final LanceSessionProperties sessionProperties;
 
     @Inject
     public LanceConnector(
@@ -46,7 +50,8 @@ public class LanceConnector
             LanceNamespaceHolder namespaceHolder,
             ConnectorSplitManager splitManager,
             ConnectorPageSourceProvider pageSourceProvider,
-            ConnectorPageSinkProvider pageSinkProvider)
+            ConnectorPageSinkProvider pageSinkProvider,
+            LanceSessionProperties sessionProperties)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
@@ -54,6 +59,7 @@ public class LanceConnector
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
     }
 
     @Override
@@ -84,6 +90,12 @@ public class LanceConnector
     public ConnectorPageSinkProvider getPageSinkProvider()
     {
         return pageSinkProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties.getSessionProperties();
     }
 
     @Override

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceFragmentPageSource.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceFragmentPageSource.java
@@ -23,6 +23,7 @@ import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 
 import java.util.List;
+import java.util.Optional;
 
 public class LanceFragmentPageSource
         extends LanceBasePageSource
@@ -36,9 +37,11 @@ public class LanceFragmentPageSource
             String tablePath,
             int readBatchSize,
             ArrowBlockBuilder arrowBlockBuilder,
-            BufferAllocator parentAllocator)
+            BufferAllocator parentAllocator,
+            Optional<String> filter,
+            List<String> filterProjectionColumns)
     {
-        super(tableHandle, columns, new FragmentScannerFactory(fragments, tablePath, readBatchSize), arrowBlockBuilder, parentAllocator);
+        super(tableHandle, columns, new FragmentScannerFactory(fragments, tablePath, readBatchSize, filterProjectionColumns), arrowBlockBuilder, parentAllocator, filter);
     }
 
     private static class FragmentScannerFactory
@@ -47,25 +50,35 @@ public class LanceFragmentPageSource
         private final List<Integer> fragmentIds;
         private final String tablePath;
         private final int readBatchSize;
+        private final List<String> filterProjectionColumns;
         private Dataset dataset;
         private LanceScanner scanner;
 
-        FragmentScannerFactory(List<Integer> fragmentIds, String tablePath, int readBatchSize)
+        FragmentScannerFactory(List<Integer> fragmentIds, String tablePath, int readBatchSize, List<String> filterProjectionColumns)
         {
             this.fragmentIds = ImmutableList.copyOf(fragmentIds);
             this.tablePath = tablePath;
             this.readBatchSize = readBatchSize;
+            this.filterProjectionColumns = ImmutableList.copyOf(filterProjectionColumns);
         }
 
         @Override
-        public LanceScanner open(BufferAllocator allocator, List<String> columns)
+        public LanceScanner open(BufferAllocator allocator, List<String> columns, Optional<String> filter)
         {
             ScanOptions.Builder optionsBuilder = new ScanOptions.Builder();
-            if (!columns.isEmpty()) {
-                optionsBuilder.columns(columns);
+
+            // Combine output columns with filter projection columns
+            List<String> allColumns = ImmutableList.<String>builder()
+                    .addAll(columns)
+                    .addAll(filterProjectionColumns)
+                    .build();
+
+            if (!allColumns.isEmpty()) {
+                optionsBuilder.columns(allColumns);
             }
             optionsBuilder.batchSize(readBatchSize);
             optionsBuilder.fragmentIds(fragmentIds);
+            filter.ifPresent(optionsBuilder::filter);
 
             this.dataset = Dataset.open(tablePath, new ReadOptions.Builder().build());
             this.scanner = dataset.newScan(optionsBuilder.build());

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceModule.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceModule.java
@@ -34,6 +34,7 @@ public class LanceModule
         binder.bind(LanceNamespaceHolder.class).in(Scopes.SINGLETON);
         binder.bind(LanceConnector.class).in(Scopes.SINGLETON);
         binder.bind(LanceMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(LanceSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(ArrowBlockBuilder.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorSplitManager.class).to(LanceSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSourceProvider.class).to(LancePageSourceProvider.class).in(Scopes.SINGLETON);

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
@@ -25,6 +25,8 @@ import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 
+import com.google.common.collect.ImmutableList;
+
 import javax.inject.Inject;
 
 import java.util.List;
@@ -72,15 +74,20 @@ public class LancePageSourceProvider
 
         // Build filter from predicate pushdown
         TupleDomain<ColumnHandle> predicate = layoutHandle.getTupleDomain();
-        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(predicate);
+        Optional<String> filter = LanceSessionProperties.isFilterPushdownEnabled(session)
+                ? LanceSqlFilterBuilder.buildFilter(predicate)
+                : Optional.empty();
 
-        // Determine filter projection columns (needed for filter but not in output)
+        // Determine filter projection columns (needed for filter but not in output).
+        // Only add extra columns when a filter was actually pushed down.
         Set<String> outputColumnNames = lanceColumns.stream()
                 .map(LanceColumnHandle::getColumnName)
                 .collect(toImmutableSet());
-        List<String> filterProjectionColumns = LanceSqlFilterBuilder.extractFilterColumnNames(predicate).stream()
-                .filter(name -> !outputColumnNames.contains(name))
-                .collect(toImmutableList());
+        List<String> filterProjectionColumns = filter.isPresent()
+                ? LanceSqlFilterBuilder.extractFilterColumnNames(predicate).stream()
+                        .filter(name -> !outputColumnNames.contains(name))
+                        .collect(toImmutableList())
+                : ImmutableList.of();
 
         return new LanceFragmentPageSource(
                 tableHandle,

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
@@ -31,9 +31,9 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 public class LancePageSourceProvider
@@ -78,14 +78,10 @@ public class LancePageSourceProvider
         // Determine filter projection columns (needed for filter but not in output)
         Set<String> outputColumnNames = lanceColumns.stream()
                 .map(LanceColumnHandle::getColumnName)
-                .collect(Collectors.toSet());
-        List<String> filterProjectionColumns = predicate.getDomains()
-                .map(domains -> domains.keySet().stream()
-                        .map(LanceColumnHandle.class::cast)
-                        .map(LanceColumnHandle::getColumnName)
-                        .filter(name -> !outputColumnNames.contains(name))
-                        .collect(toImmutableList()))
-                .orElse(ImmutableList.of());
+                .collect(toImmutableSet());
+        List<String> filterProjectionColumns = LanceSqlFilterBuilder.extractFilterColumnNames(predicate).stream()
+                .filter(name -> !outputColumnNames.contains(name))
+                .collect(toImmutableList());
 
         return new LanceFragmentPageSource(
                 tableHandle,

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-
 import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
@@ -15,6 +15,7 @@ package com.facebook.presto.lance;
 
 import com.facebook.plugin.arrow.ArrowBlockBuilder;
 import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
@@ -23,10 +24,14 @@ import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -66,6 +71,22 @@ public class LancePageSourceProvider
 
         String tablePath = namespaceHolder.getTablePath(tableHandle.getTableName());
 
+        // Build filter from predicate pushdown
+        TupleDomain<ColumnHandle> predicate = layoutHandle.getTupleDomain();
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(predicate);
+
+        // Determine filter projection columns (needed for filter but not in output)
+        Set<String> outputColumnNames = lanceColumns.stream()
+                .map(LanceColumnHandle::getColumnName)
+                .collect(Collectors.toSet());
+        List<String> filterProjectionColumns = predicate.getDomains()
+                .map(domains -> domains.keySet().stream()
+                        .map(LanceColumnHandle.class::cast)
+                        .map(LanceColumnHandle::getColumnName)
+                        .filter(name -> !outputColumnNames.contains(name))
+                        .collect(toImmutableList()))
+                .orElse(ImmutableList.of());
+
         return new LanceFragmentPageSource(
                 tableHandle,
                 lanceColumns,
@@ -73,6 +94,8 @@ public class LancePageSourceProvider
                 tablePath,
                 config.getReadBatchSize(),
                 arrowBlockBuilder,
-                namespaceHolder.getAllocator());
+                namespaceHolder.getAllocator(),
+                filter,
+                filterProjectionColumns);
     }
 }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
 

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
@@ -80,6 +80,10 @@ public class LancePageSourceProvider
 
         // Determine filter projection columns (needed for filter but not in output).
         // Only add extra columns when a filter was actually pushed down.
+        // TODO: extractFilterColumnNames returns all TupleDomain columns, but buildFilter
+        //   silently skips unsupported types (e.g. VARBINARY). In mixed queries this may
+        //   add skipped columns to filterProjectionColumns, causing unnecessary I/O.
+        //   Fix: have buildFilter also return the set of successfully pushed column names.
         Set<String> outputColumnNames = lanceColumns.stream()
                 .map(LanceColumnHandle::getColumnName)
                 .collect(toImmutableSet());

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceSessionProperties.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceSessionProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.session.PropertyMetadata;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
+
+public final class LanceSessionProperties
+{
+    public static final String FILTER_PUSHDOWN_ENABLED = "filter_pushdown_enabled";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public LanceSessionProperties()
+    {
+        sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(booleanProperty(
+                        FILTER_PUSHDOWN_ENABLED,
+                        "Enable SQL predicate pushdown to Lance DataFusion scanner",
+                        true,
+                        false))
+                .build();
+    }
+
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    public static boolean isFilterPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(FILTER_PUSHDOWN_ENABLED, Boolean.class);
+    }
+}

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceSessionProperties.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceSessionProperties.java
@@ -35,7 +35,7 @@ public final class LanceSessionProperties
         sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
                 .add(booleanProperty(
                         FILTER_PUSHDOWN_ENABLED,
-                        "Enable SQL predicate pushdown to Lance DataFusion scanner",
+                        "Enable SQL predicate pushdown to the Lance scanner",
                         true,
                         false))
                 .build();

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceSqlFilterBuilder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceSqlFilterBuilder.java
@@ -30,18 +30,18 @@ import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ColumnHandle;
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Math.toIntExact;
 
 public final class LanceSqlFilterBuilder
@@ -62,7 +62,7 @@ public final class LanceSqlFilterBuilder
         }
 
         Map<ColumnHandle, Domain> domains = tupleDomain.getDomains().get();
-        List<String> conjuncts = new ArrayList<>();
+        ImmutableList.Builder<String> conjuncts = ImmutableList.builder();
 
         for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
             LanceColumnHandle column = (LanceColumnHandle) entry.getKey();
@@ -71,10 +71,27 @@ public final class LanceSqlFilterBuilder
             predicate.ifPresent(conjuncts::add);
         }
 
-        if (conjuncts.isEmpty()) {
+        List<String> parts = conjuncts.build();
+        if (parts.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(String.join(" AND ", conjuncts));
+        return Optional.of(String.join(" AND ", parts));
+    }
+
+    /**
+     * Extract column names referenced by the filter predicates.
+     * Used to determine filter projection columns (columns needed for
+     * filter evaluation but not in query output).
+     */
+    public static List<String> extractFilterColumnNames(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        if (tupleDomain.isAll() || tupleDomain.isNone()) {
+            return ImmutableList.of();
+        }
+        return tupleDomain.getDomains().get().keySet().stream()
+                .map(LanceColumnHandle.class::cast)
+                .map(LanceColumnHandle::getColumnName)
+                .collect(toImmutableList());
     }
 
     private static Optional<String> buildColumnPredicate(LanceColumnHandle column, Domain domain)
@@ -90,7 +107,8 @@ public final class LanceSqlFilterBuilder
             if (domain.isNullAllowed()) {
                 return Optional.of(quotedName + " IS NULL");
             }
-            return Optional.empty();
+            // Domain matches nothing — return "false" to filter all rows
+            return Optional.of("false");
         }
 
         SortedRangeSet rangeSet = (SortedRangeSet) domain.getValues();
@@ -100,13 +118,13 @@ public final class LanceSqlFilterBuilder
             return Optional.empty();
         }
 
-        List<String> disjuncts = new ArrayList<>();
+        ImmutableList.Builder<String> disjuncts = ImmutableList.builder();
 
         // Check if all ranges are single values for IN optimization
         boolean allSingleValues = ranges.stream().allMatch(Range::isSingleValue);
 
         if (allSingleValues && ranges.size() > 1) {
-            List<String> values = new ArrayList<>();
+            ImmutableList.Builder<String> values = ImmutableList.builder();
             for (Range range : ranges) {
                 Optional<String> literal = toLiteral(type, range.getSingleValue());
                 if (!literal.isPresent()) {
@@ -114,7 +132,7 @@ public final class LanceSqlFilterBuilder
                 }
                 values.add(literal.get());
             }
-            disjuncts.add(quotedName + " IN (" + String.join(", ", values) + ")");
+            disjuncts.add(quotedName + " IN (" + String.join(", ", values.build()) + ")");
         }
         else {
             for (Range range : ranges) {
@@ -126,12 +144,13 @@ public final class LanceSqlFilterBuilder
             }
         }
 
+        List<String> disjunctList = disjuncts.build();
         String valuesPredicate;
-        if (disjuncts.size() == 1) {
-            valuesPredicate = disjuncts.get(0);
+        if (disjunctList.size() == 1) {
+            valuesPredicate = disjunctList.get(0);
         }
         else {
-            valuesPredicate = "(" + String.join(" OR ", disjuncts) + ")";
+            valuesPredicate = "(" + String.join(" OR ", disjunctList) + ")";
         }
 
         if (domain.isNullAllowed()) {
@@ -147,7 +166,7 @@ public final class LanceSqlFilterBuilder
             return literal.map(l -> quotedName + " = " + l);
         }
 
-        List<String> parts = new ArrayList<>();
+        ImmutableList.Builder<String> parts = ImmutableList.builder();
 
         if (!range.getLow().isLowerUnbounded()) {
             Optional<String> literal = toLiteral(type, range.getLow().getValue());
@@ -167,11 +186,16 @@ public final class LanceSqlFilterBuilder
             parts.add(quotedName + op + literal.get());
         }
 
-        if (parts.isEmpty()) {
+        List<String> partList = parts.build();
+        if (partList.isEmpty()) {
             return Optional.of("true");
         }
 
-        return Optional.of(String.join(" AND ", parts));
+        // Parenthesize multi-part range expressions for unambiguous precedence
+        if (partList.size() > 1) {
+            return Optional.of("(" + String.join(" AND ", partList) + ")");
+        }
+        return Optional.of(partList.get(0));
     }
 
     private static Optional<String> toLiteral(Type type, Object value)
@@ -179,8 +203,8 @@ public final class LanceSqlFilterBuilder
         if (type instanceof BooleanType) {
             return Optional.of(((Boolean) value) ? "true" : "false");
         }
-        if (type instanceof TinyintType || type instanceof SmallintType ||
-                type instanceof IntegerType || type instanceof BigintType) {
+        if (type instanceof TinyintType || type instanceof SmallintType
+                || type instanceof IntegerType || type instanceof BigintType) {
             return Optional.of(String.valueOf((long) value));
         }
         if (type instanceof RealType) {
@@ -207,24 +231,12 @@ public final class LanceSqlFilterBuilder
             String formatted = TIMESTAMP_FORMATTER.format(instant.atOffset(ZoneOffset.UTC));
             return Optional.of("timestamp '" + formatted + "'");
         }
-        // Unsupported type
+        // Unsupported type — skip pushdown for this column
         return Optional.empty();
     }
 
     private static String quoteColumnName(String columnName)
     {
         return "`" + columnName + "`";
-    }
-
-    // Visible for testing
-    static List<String> extractFilterColumnNames(TupleDomain<ColumnHandle> tupleDomain)
-    {
-        if (tupleDomain.isAll() || tupleDomain.isNone()) {
-            return new ArrayList<>();
-        }
-        return tupleDomain.getDomains().get().keySet().stream()
-                .map(LanceColumnHandle.class::cast)
-                .map(LanceColumnHandle::getColumnName)
-                .collect(Collectors.toList());
     }
 }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceSqlFilterBuilder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceSqlFilterBuilder.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Marker;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.DateType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TinyintType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.ColumnHandle;
+import io.airlift.slice.Slice;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.lang.Math.toIntExact;
+
+public final class LanceSqlFilterBuilder
+{
+    private static final int MAX_RANGES_PER_COLUMN = 100;
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+
+    private LanceSqlFilterBuilder() {}
+
+    public static Optional<String> buildFilter(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        if (tupleDomain.isAll()) {
+            return Optional.empty();
+        }
+        if (tupleDomain.isNone()) {
+            return Optional.of("false");
+        }
+
+        Map<ColumnHandle, Domain> domains = tupleDomain.getDomains().get();
+        List<String> conjuncts = new ArrayList<>();
+
+        for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+            LanceColumnHandle column = (LanceColumnHandle) entry.getKey();
+            Domain domain = entry.getValue();
+            Optional<String> predicate = buildColumnPredicate(column, domain);
+            predicate.ifPresent(conjuncts::add);
+        }
+
+        if (conjuncts.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(String.join(" AND ", conjuncts));
+    }
+
+    private static Optional<String> buildColumnPredicate(LanceColumnHandle column, Domain domain)
+    {
+        String quotedName = quoteColumnName(column.getColumnName());
+        Type type = column.getColumnType();
+
+        if (domain.isAll()) {
+            return Optional.empty();
+        }
+
+        if (domain.getValues().isNone()) {
+            if (domain.isNullAllowed()) {
+                return Optional.of(quotedName + " IS NULL");
+            }
+            return Optional.empty();
+        }
+
+        SortedRangeSet rangeSet = (SortedRangeSet) domain.getValues();
+        List<Range> ranges = rangeSet.getOrderedRanges();
+
+        if (ranges.size() > MAX_RANGES_PER_COLUMN) {
+            return Optional.empty();
+        }
+
+        List<String> disjuncts = new ArrayList<>();
+
+        // Check if all ranges are single values for IN optimization
+        boolean allSingleValues = ranges.stream().allMatch(Range::isSingleValue);
+
+        if (allSingleValues && ranges.size() > 1) {
+            List<String> values = new ArrayList<>();
+            for (Range range : ranges) {
+                Optional<String> literal = toLiteral(type, range.getSingleValue());
+                if (!literal.isPresent()) {
+                    return Optional.empty();
+                }
+                values.add(literal.get());
+            }
+            disjuncts.add(quotedName + " IN (" + String.join(", ", values) + ")");
+        }
+        else {
+            for (Range range : ranges) {
+                Optional<String> rangeExpr = buildRangeExpression(quotedName, type, range);
+                if (!rangeExpr.isPresent()) {
+                    return Optional.empty();
+                }
+                disjuncts.add(rangeExpr.get());
+            }
+        }
+
+        String valuesPredicate;
+        if (disjuncts.size() == 1) {
+            valuesPredicate = disjuncts.get(0);
+        }
+        else {
+            valuesPredicate = "(" + String.join(" OR ", disjuncts) + ")";
+        }
+
+        if (domain.isNullAllowed()) {
+            return Optional.of("(" + valuesPredicate + " OR " + quotedName + " IS NULL)");
+        }
+        return Optional.of(valuesPredicate);
+    }
+
+    private static Optional<String> buildRangeExpression(String quotedName, Type type, Range range)
+    {
+        if (range.isSingleValue()) {
+            Optional<String> literal = toLiteral(type, range.getSingleValue());
+            return literal.map(l -> quotedName + " = " + l);
+        }
+
+        List<String> parts = new ArrayList<>();
+
+        if (!range.getLow().isLowerUnbounded()) {
+            Optional<String> literal = toLiteral(type, range.getLow().getValue());
+            if (!literal.isPresent()) {
+                return Optional.empty();
+            }
+            String op = (range.getLow().getBound() == Marker.Bound.ABOVE) ? " > " : " >= ";
+            parts.add(quotedName + op + literal.get());
+        }
+
+        if (!range.getHigh().isUpperUnbounded()) {
+            Optional<String> literal = toLiteral(type, range.getHigh().getValue());
+            if (!literal.isPresent()) {
+                return Optional.empty();
+            }
+            String op = (range.getHigh().getBound() == Marker.Bound.BELOW) ? " < " : " <= ";
+            parts.add(quotedName + op + literal.get());
+        }
+
+        if (parts.isEmpty()) {
+            return Optional.of("true");
+        }
+
+        return Optional.of(String.join(" AND ", parts));
+    }
+
+    private static Optional<String> toLiteral(Type type, Object value)
+    {
+        if (type instanceof BooleanType) {
+            return Optional.of(((Boolean) value) ? "true" : "false");
+        }
+        if (type instanceof TinyintType || type instanceof SmallintType ||
+                type instanceof IntegerType || type instanceof BigintType) {
+            return Optional.of(String.valueOf((long) value));
+        }
+        if (type instanceof RealType) {
+            float floatVal = Float.intBitsToFloat(toIntExact((long) value));
+            return Optional.of(String.valueOf(floatVal));
+        }
+        if (type instanceof DoubleType) {
+            return Optional.of(String.valueOf((double) value));
+        }
+        if (type instanceof VarcharType) {
+            String strVal = ((Slice) value).toStringUtf8();
+            return Optional.of("'" + strVal.replace("'", "''") + "'");
+        }
+        if (type instanceof DateType) {
+            long daysSinceEpoch = (long) value;
+            LocalDate date = LocalDate.ofEpochDay(daysSinceEpoch);
+            return Optional.of("date '" + date + "'");
+        }
+        if (type instanceof TimestampType) {
+            long micros = (long) value;
+            Instant instant = Instant.ofEpochSecond(
+                    micros / 1_000_000,
+                    (micros % 1_000_000) * 1000);
+            String formatted = TIMESTAMP_FORMATTER.format(instant.atOffset(ZoneOffset.UTC));
+            return Optional.of("timestamp '" + formatted + "'");
+        }
+        // Unsupported type
+        return Optional.empty();
+    }
+
+    private static String quoteColumnName(String columnName)
+    {
+        return "`" + columnName + "`";
+    }
+
+    // Visible for testing
+    static List<String> extractFilterColumnNames(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        if (tupleDomain.isAll() || tupleDomain.isNone()) {
+            return new ArrayList<>();
+        }
+        return tupleDomain.getDomains().get().keySet().stream()
+                .map(LanceColumnHandle.class::cast)
+                .map(LanceColumnHandle::getColumnName)
+                .collect(Collectors.toList());
+    }
+}

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceSqlFilterBuilder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceSqlFilterBuilder.java
@@ -103,6 +103,12 @@ public final class LanceSqlFilterBuilder
             return Optional.empty();
         }
 
+        if (domain.getValues().isAll()) {
+            // values.isAll() && !isNullAllowed() => IS NOT NULL
+            // (values.isAll() && isNullAllowed() is caught by domain.isAll() above)
+            return Optional.of(quotedName + " IS NOT NULL");
+        }
+
         if (domain.getValues().isNone()) {
             if (domain.isNullAllowed()) {
                 return Optional.of(quotedName + " IS NULL");
@@ -111,6 +117,10 @@ public final class LanceSqlFilterBuilder
             return Optional.of("false");
         }
 
+        if (!(domain.getValues() instanceof SortedRangeSet)) {
+            // Non-orderable types (e.g., ARRAY, JSON) use EquatableValueSet — skip pushdown
+            return Optional.empty();
+        }
         SortedRangeSet rangeSet = (SortedRangeSet) domain.getValues();
         List<Range> ranges = rangeSet.getOrderedRanges();
 
@@ -209,10 +219,17 @@ public final class LanceSqlFilterBuilder
         }
         if (type instanceof RealType) {
             float floatVal = Float.intBitsToFloat(toIntExact((long) value));
+            if (Float.isNaN(floatVal) || Float.isInfinite(floatVal)) {
+                return Optional.empty();
+            }
             return Optional.of(String.valueOf(floatVal));
         }
         if (type instanceof DoubleType) {
-            return Optional.of(String.valueOf((double) value));
+            double doubleVal = (double) value;
+            if (Double.isNaN(doubleVal) || Double.isInfinite(doubleVal)) {
+                return Optional.empty();
+            }
+            return Optional.of(String.valueOf(doubleVal));
         }
         if (type instanceof VarcharType) {
             String strVal = ((Slice) value).toStringUtf8();
@@ -237,6 +254,6 @@ public final class LanceSqlFilterBuilder
 
     private static String quoteColumnName(String columnName)
     {
-        return "`" + columnName + "`";
+        return "`" + columnName.replace("`", "``") + "`";
     }
 }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/ScannerFactory.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/ScannerFactory.java
@@ -17,10 +17,11 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.lance.ipc.LanceScanner;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ScannerFactory
 {
-    LanceScanner open(BufferAllocator allocator, List<String> columns);
+    LanceScanner open(BufferAllocator allocator, List<String> columns, Optional<String> filter);
 
     void close();
 }

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceFragmentPageSource.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceFragmentPageSource.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -76,7 +77,9 @@ public class TestLanceFragmentPageSource
                 tablePath,
                 8192,
                 arrowBlockBuilder,
-                namespaceHolder.getAllocator())) {
+                namespaceHolder.getAllocator(),
+                Optional.empty(),
+                ImmutableList.of())) {
             Page page = pageSource.getNextPage();
             assertNotNull(page);
             assertEquals(page.getChannelCount(), 4);
@@ -108,7 +111,9 @@ public class TestLanceFragmentPageSource
                 tablePath,
                 8192,
                 arrowBlockBuilder,
-                namespaceHolder.getAllocator())) {
+                namespaceHolder.getAllocator(),
+                Optional.empty(),
+                ImmutableList.of())) {
             Page page = pageSource.getNextPage();
             assertNotNull(page);
             assertEquals(page.getChannelCount(), 2);
@@ -140,7 +145,9 @@ public class TestLanceFragmentPageSource
                 tablePath,
                 8192,
                 arrowBlockBuilder,
-                namespaceHolder.getAllocator())) {
+                namespaceHolder.getAllocator(),
+                Optional.empty(),
+                ImmutableList.of())) {
             Page page = pageSource.getNextPage();
             assertNotNull(page);
             assertEquals(page.getChannelCount(), 2);

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
@@ -366,8 +366,12 @@ public class TestLanceSqlFilterBuilder
     @Test
     public void testNonOrderableTypeSkipsPushdown()
     {
-        // Domain.all() returns empty regardless of type; for non-orderable types,
-        // the instanceof SortedRangeSet guard also catches any non-all/none domains.
+        // This test exercises the domain.isAll() early-return path, not the instanceof
+        // SortedRangeSet guard. Domain.all(arrayType) returns empty immediately at line 102.
+        // The instanceof guard protects against hypothetical future comparable-but-not-orderable
+        // types whose non-all/non-none domains would be EquatableValueSet; Presto's current type
+        // system does not produce such domains for ARRAY, so the guard is not directly testable
+        // via public API.
         ArrayType arrayType = new ArrayType(BIGINT);
         LanceColumnHandle column = new LanceColumnHandle("tags", arrayType);
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.ColumnHandle;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestLanceSqlFilterBuilder
+{
+    @Test
+    public void testAllDomain()
+    {
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(TupleDomain.all());
+        assertFalse(filter.isPresent());
+    }
+
+    @Test
+    public void testNoneDomain()
+    {
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(TupleDomain.none());
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "false");
+    }
+
+    @Test
+    public void testBigintEquality()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("id", BIGINT);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(BIGINT, 42L)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`id` = 42");
+    }
+
+    @Test
+    public void testIntegerEquality()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("count", INTEGER);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(INTEGER, 10L)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`count` = 10");
+    }
+
+    @Test
+    public void testInList()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("id", BIGINT);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.multipleValues(BIGINT, com.google.common.collect.ImmutableList.of(1L, 2L, 3L))));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`id` IN (1, 2, 3)");
+    }
+
+    @Test
+    public void testRange()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("value", BIGINT);
+        Domain domain = Domain.create(
+                ValueSet.ofRanges(Range.range(BIGINT, 10L, false, 20L, false)),
+                false);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`value` > 10 AND `value` < 20");
+    }
+
+    @Test
+    public void testRangeInclusive()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("value", BIGINT);
+        Domain domain = Domain.create(
+                ValueSet.ofRanges(Range.range(BIGINT, 10L, true, 20L, true)),
+                false);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`value` >= 10 AND `value` <= 20");
+    }
+
+    @Test
+    public void testVarcharEquality()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("name", VarcharType.VARCHAR);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(VarcharType.VARCHAR, Slices.utf8Slice("hello"))));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`name` = 'hello'");
+    }
+
+    @Test
+    public void testVarcharWithSingleQuote()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("name", VarcharType.VARCHAR);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(VarcharType.VARCHAR, Slices.utf8Slice("it's"))));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`name` = 'it''s'");
+    }
+
+    @Test
+    public void testDateEquality()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("dt", DATE);
+        // 2024-01-15 is day 19737 since epoch
+        long daysSinceEpoch = java.time.LocalDate.of(2024, 1, 15).toEpochDay();
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(DATE, daysSinceEpoch)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`dt` = date '2024-01-15'");
+    }
+
+    @Test
+    public void testIsNull()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("col", BIGINT);
+        Domain domain = Domain.onlyNull(BIGINT);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`col` IS NULL");
+    }
+
+    @Test
+    public void testMultipleColumnsWithAnd()
+    {
+        LanceColumnHandle col1 = new LanceColumnHandle("a", BIGINT);
+        LanceColumnHandle col2 = new LanceColumnHandle("b", BIGINT);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(
+                        col1, Domain.singleValue(BIGINT, 1L),
+                        col2, Domain.singleValue(BIGINT, 2L)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        // Order may vary, so check both parts are present
+        String result = filter.get();
+        assertTrue(result.contains("`a` = 1"));
+        assertTrue(result.contains("`b` = 2"));
+        assertTrue(result.contains(" AND "));
+    }
+
+    @Test
+    public void testBooleanTrue()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("flag", BOOLEAN);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(BOOLEAN, true)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`flag` = true");
+    }
+
+    @Test
+    public void testBooleanFalse()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("flag", BOOLEAN);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(BOOLEAN, false)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`flag` = false");
+    }
+
+    @Test
+    public void testDoubleEquality()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("price", DOUBLE);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(DOUBLE, 3.14)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`price` = 3.14");
+    }
+
+    @Test
+    public void testNullableWithValues()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("id", BIGINT);
+        Domain domain = Domain.create(
+                ValueSet.ofRanges(Range.equal(BIGINT, 42L)),
+                true);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "(`id` = 42 OR `id` IS NULL)");
+    }
+
+    @Test
+    public void testGreaterThan()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("value", BIGINT);
+        Domain domain = Domain.create(
+                ValueSet.ofRanges(Range.greaterThan(BIGINT, 10L)),
+                false);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`value` > 10");
+    }
+
+    @Test
+    public void testLessThanOrEqual()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("value", BIGINT);
+        Domain domain = Domain.create(
+                ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 100L)),
+                false);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`value` <= 100");
+    }
+
+    @Test
+    public void testAllDomainForColumn()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("id", BIGINT);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.all(BIGINT)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertFalse(filter.isPresent());
+    }
+
+    @Test
+    public void testMultipleRangesOrDisjunction()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("value", BIGINT);
+        Domain domain = Domain.create(
+                ValueSet.ofRanges(
+                        Range.range(BIGINT, 1L, true, 5L, true),
+                        Range.range(BIGINT, 10L, true, 20L, true)),
+                false);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "(`value` >= 1 AND `value` <= 5 OR `value` >= 10 AND `value` <= 20)");
+    }
+}

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
@@ -102,7 +102,7 @@ public class TestLanceSqlFilterBuilder
 
         Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
         assertTrue(filter.isPresent());
-        assertEquals(filter.get(), "`value` > 10 AND `value` < 20");
+        assertEquals(filter.get(), "(`value` > 10 AND `value` < 20)");
     }
 
     @Test
@@ -117,7 +117,7 @@ public class TestLanceSqlFilterBuilder
 
         Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
         assertTrue(filter.isPresent());
-        assertEquals(filter.get(), "`value` >= 10 AND `value` <= 20");
+        assertEquals(filter.get(), "(`value` >= 10 AND `value` <= 20)");
     }
 
     @Test

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
@@ -17,6 +17,8 @@ import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ColumnHandle;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +32,7 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static java.lang.Float.floatToIntBits;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -293,6 +296,47 @@ public class TestLanceSqlFilterBuilder
 
         Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
         assertTrue(filter.isPresent());
-        assertEquals(filter.get(), "(`value` >= 1 AND `value` <= 5 OR `value` >= 10 AND `value` <= 20)");
+        assertEquals(filter.get(), "((`value` >= 1 AND `value` <= 5) OR (`value` >= 10 AND `value` <= 20))");
+    }
+
+    @Test
+    public void testValuesNoneNotNullable()
+    {
+        // #2: values.isNone() + !isNullAllowed() should produce "false", not empty
+        LanceColumnHandle column = new LanceColumnHandle("col", BIGINT);
+        Domain domain = Domain.none(BIGINT);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "false");
+    }
+
+    @Test
+    public void testRealEquality()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("score", RealType.REAL);
+        long floatBits = floatToIntBits(3.14f);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(RealType.REAL, floatBits)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`score` = 3.14");
+    }
+
+    @Test
+    public void testTimestampEquality()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("ts", TimestampType.TIMESTAMP);
+        // 2024-01-15 10:30:00 UTC in microseconds since epoch
+        long micros = 1705314600000000L;
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(TimestampType.TIMESTAMP, micros)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`ts` = timestamp '2024-01-15 10:30:00.000000'");
     }
 }

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSqlFilterBuilder.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.VarcharType;
@@ -300,9 +301,9 @@ public class TestLanceSqlFilterBuilder
     }
 
     @Test
-    public void testValuesNoneNotNullable()
+    public void testTupleDomainNone()
     {
-        // #2: values.isNone() + !isNullAllowed() should produce "false", not empty
+        // TupleDomain.withColumnDomains with a Domain.none entry collapses to TupleDomain.none()
         LanceColumnHandle column = new LanceColumnHandle("col", BIGINT);
         Domain domain = Domain.none(BIGINT);
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
@@ -311,6 +312,81 @@ public class TestLanceSqlFilterBuilder
         Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
         assertTrue(filter.isPresent());
         assertEquals(filter.get(), "false");
+    }
+
+    @Test
+    public void testIsNotNull()
+    {
+        // Domain.notNull(type) => values.isAll() && !isNullAllowed() => IS NOT NULL
+        LanceColumnHandle column = new LanceColumnHandle("col", BIGINT);
+        Domain domain = Domain.notNull(BIGINT);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, domain));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`col` IS NOT NULL");
+    }
+
+    @Test
+    public void testFloatNanSkipsPushdown()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("score", RealType.REAL);
+        long nanBits = floatToIntBits(Float.NaN);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(RealType.REAL, nanBits)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertFalse(filter.isPresent());
+    }
+
+    @Test
+    public void testFloatInfinitySkipsPushdown()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("score", RealType.REAL);
+        long infBits = floatToIntBits(Float.POSITIVE_INFINITY);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(RealType.REAL, infBits)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertFalse(filter.isPresent());
+    }
+
+    @Test
+    public void testDoubleNanSkipsPushdown()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("price", DOUBLE);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(DOUBLE, Double.NaN)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertFalse(filter.isPresent());
+    }
+
+    @Test
+    public void testNonOrderableTypeSkipsPushdown()
+    {
+        // Domain.all() returns empty regardless of type; for non-orderable types,
+        // the instanceof SortedRangeSet guard also catches any non-all/none domains.
+        ArrayType arrayType = new ArrayType(BIGINT);
+        LanceColumnHandle column = new LanceColumnHandle("tags", arrayType);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.all(arrayType)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertFalse(filter.isPresent());
+    }
+
+    @Test
+    public void testColumnNameWithBacktick()
+    {
+        LanceColumnHandle column = new LanceColumnHandle("col`name", BIGINT);
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, Domain.singleValue(BIGINT, 1L)));
+
+        Optional<String> filter = LanceSqlFilterBuilder.buildFilter(tupleDomain);
+        assertTrue(filter.isPresent());
+        assertEquals(filter.get(), "`col``name` = 1");
     }
 
     @Test

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestWideTypesTable.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestWideTypesTable.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -260,7 +261,9 @@ public class TestWideTypesTable
                     tablePath,
                     8192,
                     arrowBlockBuilder,
-                    namespaceHolder.getAllocator());
+                    namespaceHolder.getAllocator(),
+                    Optional.empty(),
+                    ImmutableList.of());
             try {
                 Page page = pageSource.getNextPage();
                 assertNotNull(page);


### PR DESCRIPTION
## Description
Add SQL filter pushdown for the Lance connector. Converts Presto's `TupleDomain` predicates to Lance SQL WHERE clause strings and pushes them down to the Lance scanner via `ScanOptions.Builder.filter()`. Lance evaluates filters natively during scan using its DataFusion-based SQL parser, reducing data read from disk.

### Key components
- **`LanceSqlFilterBuilder`**: Converts `TupleDomain<ColumnHandle>` to SQL string. Supports Boolean, Integer, Bigint, Real, Double, Varchar, Date, Timestamp types with equality, IN, range, and IS NULL predicates. Column names are backtick-quoted for safety.
- **Filter projection columns**: Columns needed for filter evaluation but not in query output are added to the Lance scan projection, ensuring Lance can evaluate the filter without scanning all columns.
- **Safety**: The filter is returned as unenforced (following Iceberg's pattern), so Presto re-evaluates at executor level as a correctness guard. Unsupported types and complex filters (>100 ranges) are gracefully skipped — Presto handles them.

### Supported pushed-down predicates

| Predicate | Example |
|---|---|
| Equality | `col = 42` |
| Comparisons | `col > 30`, `col <= 100` |
| IN lists | `col IN (1, 2, 3)` |
| NULL checks | `col IS NULL` |
| Range | `col >= 10 AND col < 20` |
| Multi-column | predicates combined with `AND` |

### Supported types in filter literals

| Presto Type | Lance Filter Literal |
|---|---|
| `BOOLEAN` | `true` / `false` |
| `TINYINT/SMALLINT/INTEGER/BIGINT` | Integer literal |
| `REAL` | Float literal |
| `DOUBLE` | Double literal |
| `VARCHAR` | `'string'` (single quotes escaped) |
| `DATE` | `date '2024-01-15'` |
| `TIMESTAMP` | `timestamp '2024-01-15 10:30:00.000000'` |

No new dependencies — uses Lance's built-in SQL filter parser (DataFusion-based) via `ScanOptions.Builder.filter(String)`.

## Motivation and Context
Without filter pushdown, Lance reads all rows from disk and Presto filters them at the executor level. With filter pushdown, Lance evaluates predicates natively during scan, significantly reducing I/O for selective queries.

## Impact
New class and minor modifications in `presto-lance` connector only. No changes to existing Presto code. Documentation updated in `lance.rst`.

## Test Plan
- All 49 presto-lance unit tests pass: `./mvnw test -pl presto-lance`
- `TestLanceSqlFilterBuilder` — 17 new test cases covering:
  - Equality, IN lists, exclusive/inclusive ranges
  - Varchar with single-quote escaping
  - Date and timestamp literals
  - IS NULL, boolean, double
  - Multiple columns with AND
  - All-domain skip, multi-range OR disjunction
  - Nullable with values (OR IS NULL)
- Existing tests updated for new constructor signature

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

Lance Connector Changes
* Add SQL filter pushdown to reduce data read from disk for selective queries. Supports equality, comparisons, IN lists, IS NULL, and range predicates on Boolean, Integer, Bigint, Real, Double, Varchar, Date, and Timestamp types.
```
