### PR TITLE
fix(optimizer): Fix infinite loop in UnaliasSymbolReferences due to mapping cycle

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -871,7 +871,7 @@ public class UnaliasSymbolReferences
                         // If we haven't seen the expression before in this projection, record it
                         computedExpressions.put(expression, entry.getKey());
                     }
-                    else {
+                    else if (!wouldCreateCycle(entry.getKey().getName(), computedVariable.getName())) {
                         // If we have seen the expression before and if it is deterministic
                         // then we can rewrite references to the current symbol in terms of the parallel computedVariable in the projection
                         map(entry.getKey(), computedVariable);
@@ -887,10 +887,27 @@ public class UnaliasSymbolReferences
         private VariableReferenceExpression canonicalize(VariableReferenceExpression variable)
         {
             String canonical = variable.getName();
-            while (mapping.containsKey(canonical)) {
+            Set<String> visited = new HashSet<>();
+            while (mapping.containsKey(canonical) && visited.add(canonical)) {
                 canonical = mapping.get(canonical);
             }
             return new VariableReferenceExpression(variable.getSourceLocation(), canonical, types.get(new SymbolReference(getNodeLocation(variable.getSourceLocation()), canonical)));
+        }
+
+        /**
+         * Check if adding a mapping from sourceName to targetName would create a cycle.
+         * A cycle exists if following the mapping chain from targetName leads back to sourceName.
+         */
+        private boolean wouldCreateCycle(String sourceName, String targetName)
+        {
+            String current = targetName;
+            while (mapping.containsKey(current)) {
+                current = mapping.get(current);
+                if (current.equals(sourceName)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private Optional<VariableReferenceExpression> canonicalize(Optional<VariableReferenceExpression> variable)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -47,6 +47,31 @@ public class TestUnaliasSymbolReferences
                                 .withExactOutputs("LEFT_BAR", "RIGHT_BAR")));
     }
 
+    @Test(timeOut = 30_000)
+    public void testDuplicateConstantsAcrossNestedProjectionsDontHang()
+    {
+        // Regression test: when the same constant (e.g., '2026-02-04') is assigned to multiple
+        // variables across nested subquery levels, UnaliasSymbolReferences could create a cycle
+        // in its variable mapping (A -> B -> A) causing an infinite loop. This happens when:
+        //   1. A child ProjectNode deduplicates two constant assignments, mapping $b -> $a
+        //   2. A parent ProjectNode also has both $a and $b assigned to the same constant
+        //   3. The parent stores $b in computedExpressions (original key, not canonical)
+        //   4. Processing $a finds $b and calls map($a, $b), completing the cycle
+        assertPlan(
+                "SELECT metric_ds, ds " +
+                        "FROM (" +
+                        "  SELECT metric_ds, calls, '2026-02-04' AS ds " +
+                        "  FROM (" +
+                        "    SELECT ds, metric_ds, sum(calls) AS calls " +
+                        "    FROM (" +
+                        "      SELECT '2026-02-04' AS metric_ds, '2026-02-04' AS ds, 1 AS calls " +
+                        "      FROM (VALUES 1) t(x)" +
+                        "    ) GROUP BY ds, metric_ds" +
+                        "  )" +
+                        ")",
+                anyTree(values()));
+    }
+
     @Test
     public void testIdenticalValuesCollapseAssignments()
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -8453,4 +8453,54 @@ public abstract class AbstractTestQueries
                 "SELECT regionkey FROM nation LEFT JOIN region USING (regionkey)",
                 disabledSession);
     }
+
+    @Test(timeOut = 60_000)
+    public void testDuplicateConstantsAcrossNestedProjections()
+    {
+        // Regression test: duplicate constant assignments across nested projections
+        // could cause an infinite loop in UnaliasSymbolReferences due to a mapping cycle.
+        assertQuerySucceeds(
+                "SELECT report_date, revenue_a, revenue_b, total_revenue, item_count, " +
+                        "  qualified_count, converted_count, qualified_revenue_a, qualified_revenue, " +
+                        "  '1995-01-01' AS ds " +
+                        "FROM (" +
+                        "  SELECT ds, report_date, " +
+                        "    sum(revenue_a) AS revenue_a, sum(revenue_b) AS revenue_b, " +
+                        "    sum(total_revenue) AS total_revenue, sum(item_count) AS item_count, " +
+                        "    sum(qualified_count) AS qualified_count, sum(converted_count) AS converted_count, " +
+                        "    sum(qualified_revenue_a) AS qualified_revenue_a, " +
+                        "    sum(qualified_revenue) AS qualified_revenue " +
+                        "  FROM (" +
+                        "    SELECT revenue_a, qualified_revenue_a, total_revenue, revenue_b, " +
+                        "      qualified_revenue, ds, report_date, converted_count, " +
+                        "      qualified_count, item_count " +
+                        "    FROM (" +
+                        "      WITH item_rollup AS (" +
+                        "        SELECT '1995-01-01' AS report_date, " +
+                        "          element_at(split(p.name, ' '), 1) AS item_brand, " +
+                        "          max(p.size > 10) AS is_qualified, " +
+                        "          sum(if(p.size > 10, l.extendedprice * (1 - l.discount), 0)) AS qualified_revenue_a, " +
+                        "          sum(if(p.size > 10, l.extendedprice, 0)) AS qualified_revenue, " +
+                        "          sum(l.extendedprice * (1 - l.discount)) AS revenue_a, " +
+                        "          sum(l.extendedprice * l.tax) AS revenue_b, " +
+                        "          sum(l.extendedprice) AS total_revenue, " +
+                        "          sum(l.extendedprice * (1 - l.discount)) * 1.0 / " +
+                        "            sum(l.extendedprice) FILTER (WHERE p.size > 10) > 0.999 AS is_converted " +
+                        "        FROM lineitem l JOIN part p ON l.partkey = p.partkey " +
+                        "        WHERE l.shipdate <= DATE '1995-01-01' " +
+                        "        GROUP BY 1, 2" +
+                        "      )" +
+                        "      SELECT report_date, '1995-01-01' AS ds, " +
+                        "        sum(revenue_a) AS revenue_a, sum(revenue_b) AS revenue_b, " +
+                        "        sum(total_revenue) AS total_revenue, " +
+                        "        count(1) AS item_count, " +
+                        "        count_if(is_qualified) AS qualified_count, " +
+                        "        count_if(is_converted) AS converted_count, " +
+                        "        sum(qualified_revenue_a) AS qualified_revenue_a, " +
+                        "        sum(qualified_revenue) AS qualified_revenue " +
+                        "      FROM item_rollup GROUP BY 1, 2" +
+                        "    )" +
+                        "  ) GROUP BY ds, report_date" +
+                        ")");
+    }
 }


### PR DESCRIPTION
## Description
When the same deterministic expression (e.g., a constant like `'2026-02-04'`) is assigned to multiple variables across nested `ProjectNode`s, `UnaliasSymbolReferences` can create a cycle in its variable mapping (`$a -> $b -> $a`), causing the `canonicalize()` while loop to spin forever.

The cycle forms when:
1. A child `ProjectNode` deduplicates two constant assignments, mapping `$b -> $a`
2. A parent `ProjectNode` also has both `$a` and `$b` assigned to the same constant
3. `computedExpressions` stores the original key `$b` (not the canonical `$a`)
4. Processing `$a` finds `$b` in `computedExpressions` and calls `map($a, $b)`, completing the cycle `$a -> $b -> $a`

The `canonicalize(VariableReferenceExpression)` while loop then follows the cycle forever: `a -> b -> a -> b -> ...`

### Fix
- **Root cause**: Add `wouldCreateCycle()` check before adding a mapping in the deterministic expression deduplication path
- **Defensive**: Add visited-set cycle detection to the `canonicalize` while loop, matching the self-loop guard already present in `SymbolMapper.map`

## Motivation and Context
Production queries with duplicate date constants across nested subquery levels (e.g., `'2026-02-04'` used as both `metric_ds` and `ds`) were causing the optimizer to hang indefinitely during the `UnaliasSymbolReferences` optimization pass.

## Impact
No public API or user-facing feature change. Fixes an optimizer hang for queries with duplicate deterministic expressions across nested projections. The fix may skip a deduplication optimization in rare cycle-forming cases, resulting in a redundant (but semantically correct) computation in the plan.

## Test Plan
- Added `TestUnaliasSymbolReferences#testDuplicateConstantsAcrossNestedProjectionsDontHang` — minimal VALUES-based reproduction with 30s timeout
- Added `AbstractTestQueries#testDuplicateConstantsAcrossNestedProjections` — end-to-end tpch regression test with 60s timeout

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

\`\`\`
== RELEASE NOTES ==
General Changes
* Fix infinite loop in \`\`UnaliasSymbolReferences\`\` optimizer when duplicate deterministic expressions across nested projections create a mapping cycle. (:pr:\`27431\`)
\`\`\`