### PR TITLE
fix(connector): Delta Lake checkpoint file reading by upgrading Delta Kernel API and updating Snapshot method calls

### DIFF
--- a/presto-delta/pom.xml
+++ b/presto-delta/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <enforcer.skip>true</enforcer.skip>
-        <io.delta.delta-kernel-api.version>3.3.2</io.delta.delta-kernel-api.version>
+        <io.delta.delta-kernel-api.version>4.0.0</io.delta.delta-kernel-api.version>
         <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>

--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaClient.java
@@ -94,7 +94,7 @@ public class DeltaClient
                 schemaTableName.getSchemaName(),
                 schemaTableName.getTableName(),
                 tableLocation,
-                Optional.of(snapshot.getVersion(deltaEngine.get())), // lock the snapshot version
+                Optional.of(snapshot.getVersion()), // lock the snapshot version
                 getSchema(config, schemaTableName, deltaEngine.get(), snapshot)));
     }
 
@@ -162,7 +162,7 @@ public class DeltaClient
 
         try {
             return sourceTable.getSnapshotAsOfVersion(deltaEngine.get(),
-                            deltaTable.getSnapshotId().get()).getScanBuilder(deltaEngine.get()).build()
+                            deltaTable.getSnapshotId().get()).getScanBuilder().build()
                     .getScanFiles(deltaEngine.get());
         }
         catch (TableNotFoundException e) {
@@ -245,7 +245,7 @@ public class DeltaClient
     private static List<DeltaColumn> getSchema(DeltaConfig config, SchemaTableName tableName, Engine deltaEngine,
                                                Snapshot snapshot)
     {
-        try (CloseableIterator<FilteredColumnarBatch> columnBatches = snapshot.getScanBuilder(deltaEngine).build()
+        try (CloseableIterator<FilteredColumnarBatch> columnBatches = snapshot.getScanBuilder().build()
                     .getScanFiles(deltaEngine)) {
             Row row = null;
             while (columnBatches.hasNext()) {
@@ -257,7 +257,7 @@ public class DeltaClient
             }
             Map<String, String> partitionValues = row != null ?
                     InternalScanFileUtils.getPartitionValues(row) : new HashMap<>(0);
-            return snapshot.getSchema(deltaEngine).fields().stream()
+            return snapshot.getSchema().fields().stream()
                     .map(field -> {
                         String columnName = config.isCaseSensitivePartitionsEnabled() ? field.getName() :
                                 field.getName().toLowerCase(US);

--- a/presto-delta/src/test/resources/delta_v1/checkpointed-delta-table/_delta_log/00000000000000000010.json
+++ b/presto-delta/src/test/resources/delta_v1/checkpointed-delta-table/_delta_log/00000000000000000010.json
@@ -1,0 +1,2 @@
+{"commitInfo":{"timestamp":1636316599000,"operation":"WRITE","operationParameters":{"mode":"Append","partitionBy":"[]"},"readVersion":9,"isBlindAppend":true,"operationMetrics":{"numFiles":"1","numOutputBytes":"687","numOutputRows":"1"}}}
+{"add":{"path":"part-00000-checkpoint-c000.snappy.parquet","partitionValues":{},"size":687,"modificationTime":1636316599000,"dataChange":true}}


### PR DESCRIPTION
## Description

A bug was identified in the Delta Lake connector's snapshot handling when a checkpoint file is present in the `_delta_log `directory.
When Delta Lake performs checkpointing (periodically compacting the transaction log into a .checkpoint.parquet file), the Presto Delta connector was failing to correctly read the snapshot state from the checkpoint. This caused the scan to return no files/data, even though the table metadata was resolved successfully.

## Motivation and Context

Resolved the below error:
```
java.lang.RuntimeException: java.lang.ClassNotFoundException: Class org.apache.hadoop.fs.s3a.S3AFileSystem not found
	at org.apache.hadoop.conf.Configuration.getClass(Configuration.java:2737)
	at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:3888)
	at org.apache.hadoop.fs.PrestoFileSystemCache.createFileSystem(PrestoFileSystemCache.java:149)
	at org.apache.hadoop.fs.PrestoFileSystemCache.getInternal(PrestoFileSystemCache.java:108)
	at org.apache.hadoop.fs.PrestoFileSystemCache.get(PrestoFileSystemCache.java:62)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:612)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:366)
	at org.apache.parquet.hadoop.ParquetReader$Builder.build(ParquetReader.java:346)
	at io.delta.kernel.defaults.internal.parquet.ParquetFileReader$1.initParquetReaderIfRequired(ParquetFileReader.java:143)
	at io.delta.kernel.defaults.internal.parquet.ParquetFileReader$1.hasNext(ParquetFileReader.java:73)
	at io.delta.kernel.defaults.engine.DefaultParquetHandler$1.hasNext(DefaultParquetHandler.java:71)
	at io.delta.kernel.defaults.engine.DefaultParquetHandler$1.hasNext(DefaultParquetHandler.java:82)
	at io.delta.kernel.internal.replay.ActionsIterator$1.hasNext(ActionsIterator.java:238)
	at io.delta.kernel.internal.replay.ActionsIterator$2.hasNext(ActionsIterator.java:373)
	at io.delta.kernel.internal.replay.ActionsIterator.tryEnsureNextActionsIterIsReady(ActionsIterator.java:154)
	at io.delta.kernel.internal.replay.ActionsIterator.hasNext(ActionsIterator.java:98)
	at io.delta.kernel.internal.replay.LogReplay.loadTableProtocolAndMetadata(LogReplay.java:212)
	at io.delta.kernel.internal.replay.LogReplay.<init>(LogReplay.java:134)
	at io.delta.kernel.internal.snapshot.SnapshotManager.createSnapshot(SnapshotManager.java:535)
	at io.delta.kernel.internal.snapshot.SnapshotManager.getCoordinatedCommitsAwareSnapshot(SnapshotManager.java:496)
	at io.delta.kernel.internal.snapshot.SnapshotManager.lambda$getSnapshotAtInit$14(SnapshotManager.java:485)
	at java.base/java.util.Optional.map(Optional.java:260)
	at io.delta.kernel.internal.snapshot.SnapshotManager.getSnapshotAtInit(SnapshotManager.java:485)
	at io.delta.kernel.internal.snapshot.SnapshotManager.buildLatestSnapshot(SnapshotManager.java:126)
	at io.delta.kernel.internal.TableImpl.getLatestSnapshot(TableImpl.java:93)
	at com.facebook.presto.delta.DeltaClient.getSnapshot(DeltaClient.java:122)
	at com.facebook.presto.delta.DeltaClient.getTable(DeltaClient.java:91)
	at com.facebook.presto.delta.DeltaMetadata.getTableHandle(DeltaMetadata.java:221)
	at com.facebook.presto.delta.DeltaMetadata.getTableHandle(DeltaMetadata.java:73)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.getTableHandle(ClassLoaderSafeConnectorMetadata.java:234)
	at com.facebook.presto.metadata.MetadataUtil.lambda$getOptionalTableHandle$4(MetadataUtil.java:178)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at com.facebook.presto.metadata.MetadataUtil.getOptionalTableHandle(MetadataUtil.java:178)
	at com.facebook.presto.metadata.MetadataManager$1.getTableHandle(MetadataManager.java:1666)
	at com.facebook.presto.util.MetadataUtils.lambda$getTableColumnMetadata$2(MetadataUtils.java:83)
	at com.facebook.presto.common.RuntimeStats.recordWallTime(RuntimeStats.java:140)
	at com.facebook.presto.util.MetadataUtils.getTableColumnMetadata(MetadataUtils.java:81)
	at com.facebook.presto.util.MetadataUtils.getTableColumnsMetadata(MetadataUtils.java:54)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:2275)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:455)
	at com.facebook.presto.sql.tree.Table.accept(Table.java:60)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:477)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:4277)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:2955)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:455)
	at com.facebook.presto.sql.tree.QuerySpecification.accept(QuerySpecification.java:138)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:477)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:485)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:1509)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:455)
	at com.facebook.presto.sql.tree.Query.accept(Query.java:105)
	at com.facebook.presto.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:477)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:427)
	at com.facebook.presto.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:447)
	at com.facebook.presto.sql.analyzer.Analyzer.analyzeSemantic(Analyzer.java:141)
	at com.facebook.presto.sql.analyzer.BuiltInQueryAnalyzer.analyze(BuiltInQueryAnalyzer.java:134)
	at com.facebook.presto.execution.SqlQueryExecution.lambda$new$0(SqlQueryExecution.java:220)
	at com.facebook.presto.common.RuntimeStats.recordWallAndCpuTime(RuntimeStats.java:158)
	at com.facebook.presto.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:220)
	at com.facebook.presto.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:112)
	at com.facebook.presto.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:1022)
	at com.facebook.presto.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:171)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.ClassNotFoundException: Class org.apache.hadoop.fs.s3a.S3AFileSystem not found
	at org.apache.hadoop.conf.Configuration.getClassByName(Configuration.java:2641)
	at org.apache.hadoop.conf.Configuration.getClass(Configuration.java:2735)
	... 70 more

```

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```