### PR TITLE
feat(): Export partition resitration times as runtime metrics

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -87,4 +87,9 @@ public class RuntimeMetricName
     public static final String DIRECTORY_LISTING_CACHE_MISS = "directoryListingCacheMiss";
     public static final String DIRECTORY_LISTING_TIME_NANOS = "directoryListingTimeNanos";
     public static final String FILES_READ_COUNT = "filesReadCount";
+    public static final String METASTORE_ADD_PARTITIONS_TIME_NANOS = "metastoreAddPartitionsTimeNanos";
+    public static final String METASTORE_ALTER_PARTITION_TIME_NANOS = "metastoreAlterPartitionTimeNanos";
+    public static final String METASTORE_ALTER_PARTITIONS_TIME_NANOS = "metastoreAlterPartitionsTimeNanos";
+    public static final String METASTORE_UPDATE_PARTITION_STATISTICS_TIME_NANOS = "metastoreUpdatePartitionStatisticsTimeNanos";
+    public static final String METASTORE_UPDATE_TABLE_STATISTICS_TIME_NANOS = "metastoreUpdateTableStatisticsTimeNanos";
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -70,6 +70,10 @@ import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.common.ErrorType.USER_ERROR;
 import static com.facebook.presto.common.RuntimeMetricName.GET_PARTITIONS_BY_NAMES_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.GET_TABLE_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.METASTORE_ADD_PARTITIONS_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.METASTORE_ALTER_PARTITION_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.METASTORE_UPDATE_PARTITION_STATISTICS_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.METASTORE_UPDATE_TABLE_STATISTICS_TIME_NANOS;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CORRUPTED_COLUMN_STATISTICS;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
@@ -146,6 +150,11 @@ public class SemiTransactionalHiveMetastore
     private State state = State.EMPTY;
     private boolean throwOnCleanupFailure;
 
+    // RuntimeStats from the original coordinator session, set during beginInsert/beginCreateTable.
+    // Used during commit to record partition registration metrics on the correct instance,
+    // since the session stored in HdfsContext may be a serialized/reconstructed copy with a different RuntimeStats.
+    private volatile RuntimeStats queryRuntimeStats = new RuntimeStats();
+
     public SemiTransactionalHiveMetastore(
             HdfsEnvironment hdfsEnvironment,
             ExtendedHiveMetastore delegate,
@@ -162,6 +171,11 @@ public class SemiTransactionalHiveMetastore
         this.skipDeletionForAlter = skipDeletionForAlter;
         this.skipTargetCleanupOnRollback = skipTargetCleanupOnRollback;
         this.undoMetastoreOperationsEnabled = undoMetastoreOperationsEnabled;
+    }
+
+    public void setQueryRuntimeStats(RuntimeStats runtimeStats)
+    {
+        this.queryRuntimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
     }
 
     public ColumnConverterProvider getColumnConverterProvider()
@@ -1178,7 +1192,7 @@ public class SemiTransactionalHiveMetastore
                         hdfsContext.getSession().map(MetastoreUtil::isUserDefinedTypeEncodingEnabled).orElse(false),
                         columnConverterProvider,
                         hdfsContext.getSession().map(ConnectorSession::getWarningCollector).orElse(NOOP),
-                        hdfsContext.getSession().map(ConnectorSession::getRuntimeStats).orElseGet(RuntimeStats::new));
+                        queryRuntimeStats);
                 switch (action.getType()) {
                     case DROP:
                         committer.prepareDropTable(metastoreContext, schemaTableName);
@@ -1212,7 +1226,7 @@ public class SemiTransactionalHiveMetastore
                             hdfsContext.getSession().map(MetastoreUtil::isUserDefinedTypeEncodingEnabled).orElse(false),
                             columnConverterProvider,
                             hdfsContext.getSession().map(ConnectorSession::getWarningCollector).orElse(NOOP),
-                            hdfsContext.getSession().map(ConnectorSession::getRuntimeStats).orElseGet(RuntimeStats::new));
+                            queryRuntimeStats);
                     switch (action.getType()) {
                         case DROP:
                             committer.prepareDropPartition(metastoreContext, schemaTableName, partitionValues);
@@ -2912,11 +2926,13 @@ public class SemiTransactionalHiveMetastore
         public void run(ExtendedHiveMetastore metastore)
         {
             undo = true;
-            operationResult = Optional.of(metastore.alterPartition(
-                    metastoreContext,
-                    newPartition.getPartition().getDatabaseName(),
-                    newPartition.getPartition().getTableName(),
-                    newPartition));
+            operationResult = Optional.of(metastoreContext.getRuntimeStats().recordWallTime(
+                    METASTORE_ALTER_PARTITION_TIME_NANOS,
+                    () -> metastore.alterPartition(
+                            metastoreContext,
+                            newPartition.getPartition().getDatabaseName(),
+                            newPartition.getPartition().getTableName(),
+                            newPartition)));
         }
 
         public void undo(ExtendedHiveMetastore metastore)
@@ -2951,10 +2967,14 @@ public class SemiTransactionalHiveMetastore
         public void run(ExtendedHiveMetastore metastore)
         {
             if (partitionName.isPresent()) {
-                metastore.updatePartitionStatistics(metastoreContext, tableName.getSchemaName(), tableName.getTableName(), partitionName.get(), this::updateStatistics);
+                metastoreContext.getRuntimeStats().recordWallTime(
+                        METASTORE_UPDATE_PARTITION_STATISTICS_TIME_NANOS,
+                        () -> metastore.updatePartitionStatistics(metastoreContext, tableName.getSchemaName(), tableName.getTableName(), partitionName.get(), this::updateStatistics));
             }
             else {
-                metastore.updateTableStatistics(metastoreContext, tableName.getSchemaName(), tableName.getTableName(), this::updateStatistics);
+                metastoreContext.getRuntimeStats().recordWallTime(
+                        METASTORE_UPDATE_TABLE_STATISTICS_TIME_NANOS,
+                        () -> metastore.updateTableStatistics(metastoreContext, tableName.getSchemaName(), tableName.getTableName(), this::updateStatistics));
             }
             done = true;
         }
@@ -3039,7 +3059,9 @@ public class SemiTransactionalHiveMetastore
             List<List<PartitionWithStatistics>> batchedPartitions = Lists.partition(partitions, batchSize);
             for (List<PartitionWithStatistics> batch : batchedPartitions) {
                 try {
-                    operationResults.add(metastore.addPartitions(metastoreContext, schemaName, tableName, batch));
+                    operationResults.add(metastoreContext.getRuntimeStats().recordWallTime(
+                            METASTORE_ADD_PARTITIONS_TIME_NANOS,
+                            () -> metastore.addPartitions(metastoreContext, schemaName, tableName, batch)));
                     for (PartitionWithStatistics partition : batch) {
                         createdPartitionValues.add(partition.getPartition().getValues());
                     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1739,6 +1739,7 @@ public class HiveMetadata
     public HiveOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
         verifyJvmTimeZone();
+        metastore.setQueryRuntimeStats(session.getRuntimeStats());
 
         if (getExternalLocation(tableMetadata.getProperties()) != null) {
             throw new PrestoException(NOT_SUPPORTED, "External tables cannot be created using CREATE TABLE AS");
@@ -2084,6 +2085,7 @@ public class HiveMetadata
     private HiveInsertTableHandle beginInsertInternal(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         verifyJvmTimeZone();
+        metastore.setQueryRuntimeStats(session.getRuntimeStats());
 
         MetastoreContext metastoreContext = getMetastoreContext(session);
 


### PR DESCRIPTION
Summary:
Export time spent on various partition registration activities as
query runtime metrics.
To expose potential metastore regression and slowness.

Differential Revision: D98159827

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Track and export metastore partition registration and statistics update timings as query runtime metrics.

New Features:
- Record wall-clock time for add partitions, alter partition, and table/partition statistics update operations in the Hive metastore and expose them via query runtime stats.
- Propagate the coordinator session's RuntimeStats into the semi-transactional Hive metastore to ensure partition registration metrics are attributed to the correct query.

Enhancements:
- Wire query RuntimeStats from HiveMetadata into SemiTransactionalHiveMetastore commit paths to centralize metastore timing measurement.