### PR TITLE
fix: extract 4 unsafe expressions to env vars

### DIFF
--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -156,6 +156,7 @@ jobs:
       - name: Create release notes pull request
         env:
           JVM_OPTS: ${{ env.MAVEN_OPTS }}
+          PRESTODB_CI_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
         run: |
           echo "In case this job failed, please delete the release notes branch(e.g. release-notes-0.292) in repository ${{ github.repository }}, and re-run the job"
-          ./src/release/release-notes.sh ${{ github.repository_owner }} ${{ secrets.PRESTODB_CI_TOKEN }}
+          ./src/release/release-notes.sh ${{ github.repository_owner }} ${PRESTODB_CI_TOKEN}

--- a/.github/workflows/presto-release-publish.yml
+++ b/.github/workflows/presto-release-publish.yml
@@ -212,11 +212,13 @@ jobs:
           GPG_TTY: $(tty)
           GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
           GPG_KEY_FILE: /tmp/gpg-key.txt
+          GPG_SECRET: ${{ secrets.GPG_SECRET }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          echo "${{ secrets.GPG_SECRET }}" > ${{ env.GPG_KEY_FILE }}
+          echo "${GPG_SECRET}" > ${{ env.GPG_KEY_FILE }}
           chmod 600 ${{ env.GPG_KEY_FILE }}
           gpg --import --batch ${{ env.GPG_KEY_FILE }}
-          gpg --batch --yes --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" --sign ${{ env.GPG_KEY_FILE }}
+          gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" --sign ${{ env.GPG_KEY_FILE }}
           df -h
 
       - name: Release Maven Artifacts
@@ -226,13 +228,14 @@ jobs:
           GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
           MAVEN_AUTO_PUBLISH: "${{ env.MAVEN_AUTO_PUBLISH }}"
           RELEASE_TAG: "${{ env.RELEASE_TAG }}"
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
         run: |
           unset MAVEN_CONFIG
           ./mvnw -s ${{ github.workspace }}/settings.xml -V -B -U -e -T1C deploy \
             -Dgpg.passphrase="$GPG_PASSPHRASE" \
             -Dmaven.wagon.http.retryHandler.count=8 \
             -DskipTests \
-            -DstagingProfileId="${{ secrets.MAVEN_STAGING_PROFILE_ID }}" \
+            -DstagingProfileId="${MAVEN_STAGING_PROFILE_ID}" \
             -DkeepStagingRepositoryOnFailure=true \
             -DkeepStagingRepositoryOnCloseRuleFailure=true \
             -DautoReleaseAfterClose=true \


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/presto-release-prepare.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/presto-release-publish.yml` | Extracted 3 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-001 | critical | `.github/workflows/codenotify.yml` | pull_request_target with Fork Code Checkout |
| RGS-006 | high | `.github/workflows/prestocpp-linux-build.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-006 | high | `.github/workflows/prestocpp-linux-build.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-005 | medium | `.github/workflows/codenotify.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) and
[LiteLLM supply chain attacks](https://www.vigilantdefense.com/resources/runner-guard),
which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.