### PR TITLE
fix: Disallow remote functions in TRY expressions and fix lambda plan validation

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -1458,6 +1458,7 @@ public class ExpressionAnalyzer
         public Type visitTryExpression(TryExpression node, StackableAstVisitorContext<Context> context)
         {
             Type type = process(node.getInnerExpression(), context);
+            verifyNoExternalFunctions(resolvedFunctions, functionAndTypeResolver, node.getInnerExpression(), "TRY expression");
             return setExpressionType(node, type);
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ExternalCallExpressionChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ExternalCallExpressionChecker.java
@@ -60,8 +60,7 @@ public class ExternalCallExpressionChecker
     @Override
     public Boolean visitLambda(LambdaDefinitionExpression lambda, Void context)
     {
-        // check in lambda is done in ExpressionAnalyzer so we should never reach here if we have external functions
-        return false;
+        return lambda.getBody().accept(this, null);
     }
 
     @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
@@ -30,16 +30,20 @@ import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.planner.assertions.ExpressionMatcher;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.optimizations.ExternalCallExpressionChecker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -58,6 +62,7 @@ import static com.facebook.presto.sql.planner.iterative.rule.PlanRemoteProjectio
 import static com.facebook.presto.type.JsonPathType.JSON_PATH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestPlanRemoteProjections
 {
@@ -313,6 +318,46 @@ public class TestPlanRemoteProjections
                             p.values(p.variable("x", INTEGER)));
                 })
                 .matches(anyTree());
+    }
+
+    @Test
+    void testExternalCallExpressionCheckerDetectsRemoteFunctionInLambda()
+    {
+        FunctionAndTypeManager functionAndTypeManager = getFunctionAndTypeManager();
+        ExternalCallExpressionChecker checker = new ExternalCallExpressionChecker(functionAndTypeManager);
+
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        // A remote function call directly should be detected
+        RowExpression remoteCall = planBuilder.rowExpression("unittest.memory.remote_foo(x)");
+        assertTrue(remoteCall.accept(checker, null));
+
+        // A remote function call inside a lambda should be detected
+        LambdaDefinitionExpression lambdaWithRemote = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                remoteCall);
+        assertTrue(lambdaWithRemote.accept(checker, null));
+
+        // A local function call inside a lambda should not be flagged
+        RowExpression localCall = planBuilder.rowExpression("abs(x)");
+        LambdaDefinitionExpression lambdaWithLocal = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                localCall);
+        assertFalse(lambdaWithLocal.accept(checker, null));
+
+        // A remote function nested inside a local function inside a lambda should be detected
+        RowExpression nestedRemoteCall = planBuilder.rowExpression("abs(unittest.memory.remote_foo(x))");
+        LambdaDefinitionExpression lambdaWithNestedRemote = new LambdaDefinitionExpression(
+                Optional.empty(),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                nestedRemoteCall);
+        assertTrue(lambdaWithNestedRemote.accept(checker, null));
     }
 
     private Metadata getMetadata()

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
@@ -536,6 +536,15 @@ public class TestSqlFunctions
     {
         assertQuerySucceeds("CREATE FUNCTION testing.test.foo(x varchar) RETURNS varchar LANGUAGE JAVA EXTERNAL");
         assertQueryFails("SELECT reduce(a, '', (s, x) -> s || testing.test.foo(x), s -> s) from (VALUES (array['a', 'b'])) t(a)", ".*External functions in Lambda expression is not supported:.*");
+
+        // TRY with local functions should still work
+        assertQuerySucceeds("SELECT TRY(upper(a)) from (VALUES 'abc') t(a)");
+
+        // Remote functions in TRY expression should be disallowed
+        assertQueryFails("SELECT TRY(testing.test.foo(a)) from (VALUES 'abc') t(a)", ".*External functions in TRY expression is not supported:.*");
+
+        // Remote functions nested inside local functions within TRY should also be disallowed
+        assertQueryFails("SELECT TRY(upper(testing.test.foo(a))) from (VALUES 'abc') t(a)", ".*External functions in TRY expression is not supported:.*");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Disallow remote functions in TRY expressions at analysis time.** TRY(expr) is desugared into `$internal$try(() -> expr)` after analysis, so remote functions inside TRY were not caught by the existing lambda check. Added `verifyNoExternalFunctions` in `ExpressionAnalyzer.visitTryExpression` to block this early.
- **Fix `ExternalCallExpressionChecker.visitLambda` to recurse into lambda bodies.** Previously it short-circuited with `return false`, trusting the analysis-time check. This left a gap for lambdas created by desugaring (e.g., TRY). Now `VerifyProjectionLocality` correctly detects remote functions inside lambdas at plan validation time.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Fix validation to disallow remote/external functions inside TRY expressions. Previously, remote functions used within TRY (e.g., ``TRY(remote_func(x))``), were not caught during analysis, which could lead to incorrect plan generation. (:pr:`27446`)
```

## Test plan

- Added end-to-end tests in `TestSqlFunctions.testUnsupportedRemoteFunctions`:
  - `TRY(upper(a))` — positive control: TRY with local functions still works
  - `TRY(remote_func(x))` — direct remote function in TRY
  - `TRY(upper(remote_func(x)))` — nested remote function in TRY
- Added unit tests in `TestPlanRemoteProjections.testExternalCallExpressionCheckerDetectsRemoteFunctionInLambda`:
  - Remote function directly → detected
  - Remote function inside lambda → detected
  - Local function inside lambda → not flagged
  - Remote function nested in local function inside lambda → detected