### PR TITLE
feat(planner): Extract remote functions from $internal$try lambda in PlanRemoteProjections

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
@@ -13,10 +13,13 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.common.type.FunctionType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.plan.Assignments;
@@ -30,6 +33,7 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.RowExpressionVisitor;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.VariablesExtractor;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.optimizations.ExternalCallExpressionChecker;
 import com.facebook.presto.sql.planner.optimizations.SymbolMapper;
@@ -40,6 +44,7 @@ import com.google.common.collect.ImmutableMultimap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.isRemoteFunctionsEnabled;
@@ -250,6 +255,15 @@ public class PlanRemoteProjections
             FunctionMetadata functionMetadata = functionAndTypeManager.getFunctionMetadata(call.getFunctionHandle());
             boolean local = !functionMetadata.getImplementationType().isExternalExecution();
 
+            // Special handling for $internal$try: extract remote functions from the lambda body.
+            // The argument is either a LambdaDefinitionExpression directly or a BIND(captured_vars..., lambda)
+            // after lambda capture desugaring.
+            if (local && functionMetadata.getName().getObjectName().equals("$internal$try")
+                    && call.getArguments().size() == 1
+                    && isLambdaOrBindWithLambda(call.getArguments().get(0))) {
+                return processInternalTry(call);
+            }
+
             // Break function arguments into local and remote projections first
             ImmutableList.Builder<RowExpression> newArgumentsBuilder = ImmutableList.builder();
             List<ProjectionContext> processedArguments = processArguments(call.getArguments(), newArgumentsBuilder, local);
@@ -370,6 +384,141 @@ public class PlanRemoteProjections
             }
         }
 
+        private static boolean isLambdaOrBindWithLambda(RowExpression expression)
+        {
+            if (expression instanceof LambdaDefinitionExpression) {
+                return true;
+            }
+            if (expression instanceof SpecialFormExpression
+                    && ((SpecialFormExpression) expression).getForm() == SpecialFormExpression.Form.BIND) {
+                List<RowExpression> bindArgs = ((SpecialFormExpression) expression).getArguments();
+                return bindArgs.get(bindArgs.size() - 1) instanceof LambdaDefinitionExpression;
+            }
+            return false;
+        }
+
+        private List<ProjectionContext> processInternalTry(CallExpression call)
+        {
+            RowExpression tryArgument = call.getArguments().get(0);
+            LambdaDefinitionExpression lambda;
+            List<RowExpression> bindVariables;
+
+            if (tryArgument instanceof LambdaDefinitionExpression) {
+                lambda = (LambdaDefinitionExpression) tryArgument;
+                bindVariables = ImmutableList.of();
+            }
+            else {
+                // BIND(captured_var1, ..., captured_varN, (param1, ..., paramN) -> body)
+                SpecialFormExpression bind = (SpecialFormExpression) tryArgument;
+                List<RowExpression> bindArgs = bind.getArguments();
+                lambda = (LambdaDefinitionExpression) bindArgs.get(bindArgs.size() - 1);
+                bindVariables = bindArgs.subList(0, bindArgs.size() - 1);
+            }
+
+            // Substitute lambda parameters with captured variables in the body so that
+            // the visitor sees plan-level variables instead of lambda-scoped parameters
+            RowExpression body = lambda.getBody();
+            if (!bindVariables.isEmpty()) {
+                List<String> lambdaParams = lambda.getArguments();
+                checkState(bindVariables.size() == lambdaParams.size(),
+                        "BIND variable count doesn't match lambda parameter count");
+                ImmutableMap.Builder<String, RowExpression> substitutions = ImmutableMap.builder();
+                for (int i = 0; i < lambdaParams.size(); i++) {
+                    substitutions.put(lambdaParams.get(i), bindVariables.get(i));
+                }
+                body = VariableSubstitutor.substitute(body, substitutions.build());
+            }
+
+            // Visit the substituted body to extract remote function projections
+            List<ProjectionContext> bodyProjections = body.accept(this, null);
+
+            if (bodyProjections.isEmpty()) {
+                // No remote functions in the lambda body
+                return ImmutableList.of();
+            }
+
+            ProjectionContext lastBodyProjection = bodyProjections.get(bodyProjections.size() - 1);
+            checkState(lastBodyProjection.getProjections().size() == 1,
+                    "Expected single projection in last body projection");
+
+            // Get the result expression for the new lambda body
+            RowExpression newBody;
+            List<ProjectionContext> priorProjections;
+            if (!lastBodyProjection.isRemote()) {
+                // Fold the local expression into the lambda body to avoid consecutive local projections
+                newBody = getOnlyElement(lastBodyProjection.getProjections().values());
+                priorProjections = bodyProjections.subList(0, bodyProjections.size() - 1);
+            }
+            else {
+                // Use the result variable as the lambda body
+                newBody = getOnlyElement(lastBodyProjection.getProjections().keySet());
+                priorProjections = bodyProjections;
+            }
+
+            // Build the new $internal$try argument: wrap the result in a lambda with BIND
+            // to capture any referenced variables from prior projections
+            RowExpression newTryArgument = buildLambdaWithBind(lambda.getSourceLocation(), newBody);
+
+            CallExpression newCall = new CallExpression(
+                    call.getSourceLocation(),
+                    call.getDisplayName(),
+                    call.getFunctionHandle(),
+                    call.getType(),
+                    ImmutableList.of(newTryArgument));
+
+            ImmutableList.Builder<ProjectionContext> projectionContextBuilder = ImmutableList.builder();
+            projectionContextBuilder.addAll(priorProjections);
+            projectionContextBuilder.add(new ProjectionContext(
+                    ImmutableMap.of(variableAllocator.newVariable(newCall), newCall), false));
+            return projectionContextBuilder.build();
+        }
+
+        private RowExpression buildLambdaWithBind(Optional<SourceLocation> sourceLocation, RowExpression body)
+        {
+            List<VariableReferenceExpression> capturedVariables = VariablesExtractor.extractAll(body).stream()
+                    .distinct()
+                    .collect(toImmutableList());
+
+            if (capturedVariables.isEmpty()) {
+                // No captured variables, return a simple lambda
+                return new LambdaDefinitionExpression(
+                        sourceLocation,
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        body);
+            }
+
+            // Create lambda parameters for each captured variable and substitute in the body
+            ImmutableList.Builder<Type> paramTypes = ImmutableList.builder();
+            ImmutableList.Builder<String> paramNames = ImmutableList.builder();
+            ImmutableMap.Builder<String, RowExpression> reverseSubstitutions = ImmutableMap.builder();
+            ImmutableList.Builder<RowExpression> bindArgs = ImmutableList.builder();
+
+            for (VariableReferenceExpression captured : capturedVariables) {
+                VariableReferenceExpression param = variableAllocator.newVariable(captured);
+                paramTypes.add(captured.getType());
+                paramNames.add(param.getName());
+                reverseSubstitutions.put(captured.getName(), param);
+                bindArgs.add(captured);
+            }
+
+            RowExpression lambdaBody = VariableSubstitutor.substitute(body, reverseSubstitutions.build());
+            LambdaDefinitionExpression newLambda = new LambdaDefinitionExpression(
+                    sourceLocation,
+                    paramTypes.build(),
+                    paramNames.build(),
+                    lambdaBody);
+
+            bindArgs.add(newLambda);
+            // BIND's return type is the bound function type: () -> returnType
+            Type bindReturnType = new FunctionType(ImmutableList.of(), body.getType());
+            return new SpecialFormExpression(
+                    sourceLocation,
+                    SpecialFormExpression.Form.BIND,
+                    bindReturnType,
+                    bindArgs.build());
+        }
+
         private List<ProjectionContext> processArguments(List<RowExpression> arguments, ImmutableList.Builder<RowExpression> newArguments, boolean local)
         {
             // Break function arguments into local and remote projections first
@@ -386,6 +535,21 @@ public class PlanRemoteProjections
                             // JsonPath type is not serializable and cannot be an output of a ProjectNode.
                             // Keep it inline when the parent function is local.
                             newArguments.add(argument);
+                            continue;
+                        }
+                        // WHEN clauses are structural parts of SWITCH expressions and cannot be
+                        // standalone variables. Process their sub-arguments to ensure referenced
+                        // variables are tracked through projection layers, then reconstruct the WHEN.
+                        if (local && argument instanceof SpecialFormExpression
+                                && ((SpecialFormExpression) argument).getForm() == SpecialFormExpression.Form.WHEN) {
+                            SpecialFormExpression when = (SpecialFormExpression) argument;
+                            ImmutableList.Builder<RowExpression> whenSubArgs = ImmutableList.builder();
+                            List<ProjectionContext> whenSubProjections = processArguments(when.getArguments(), whenSubArgs, true);
+                            newArguments.add(new SpecialFormExpression(
+                                    when.getForm(), when.getType(), whenSubArgs.build()));
+                            if (!whenSubProjections.isEmpty()) {
+                                argumentProjections.add(whenSubProjections);
+                            }
                             continue;
                         }
                         VariableReferenceExpression variable = variableAllocator.newVariable(argument);
@@ -418,6 +582,92 @@ public class PlanRemoteProjections
         public boolean isRemote()
         {
             return remote;
+        }
+    }
+
+    /**
+     * Substitutes {@link VariableReferenceExpression} instances in a {@link RowExpression} tree
+     * based on a name-to-expression mapping.
+     */
+    private static class VariableSubstitutor
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final Map<String, RowExpression> substitutions;
+
+        VariableSubstitutor(Map<String, RowExpression> substitutions)
+        {
+            this.substitutions = substitutions;
+        }
+
+        static RowExpression substitute(RowExpression expression, Map<String, RowExpression> substitutions)
+        {
+            return expression.accept(new VariableSubstitutor(substitutions), null);
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            List<RowExpression> newArguments = call.getArguments().stream()
+                    .map(arg -> arg.accept(this, null))
+                    .collect(toImmutableList());
+            if (newArguments.equals(call.getArguments())) {
+                return call;
+            }
+            return new CallExpression(
+                    call.getSourceLocation(),
+                    call.getDisplayName(),
+                    call.getFunctionHandle(),
+                    call.getType(),
+                    newArguments);
+        }
+
+        @Override
+        public RowExpression visitInputReference(InputReferenceExpression reference, Void context)
+        {
+            return reference;
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression literal, Void context)
+        {
+            return literal;
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            RowExpression newBody = lambda.getBody().accept(this, null);
+            if (newBody.equals(lambda.getBody())) {
+                return lambda;
+            }
+            return new LambdaDefinitionExpression(
+                    lambda.getSourceLocation(),
+                    lambda.getArgumentTypes(),
+                    lambda.getArguments(),
+                    newBody);
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression reference, Void context)
+        {
+            RowExpression replacement = substitutions.get(reference.getName());
+            return replacement != null ? replacement : reference;
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            List<RowExpression> newArguments = specialForm.getArguments().stream()
+                    .map(arg -> arg.accept(this, null))
+                    .collect(toImmutableList());
+            if (newArguments.equals(specialForm.getArguments())) {
+                return specialForm;
+            }
+            return new SpecialFormExpression(
+                    specialForm.getSourceLocation(),
+                    specialForm.getForm(),
+                    specialForm.getType(),
+                    newArguments);
         }
     }
 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ExternalCallExpressionChecker.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/ExternalCallExpressionChecker.java
@@ -60,8 +60,7 @@ public class ExternalCallExpressionChecker
     @Override
     public Boolean visitLambda(LambdaDefinitionExpression lambda, Void context)
     {
-        // check in lambda is done in ExpressionAnalyzer so we should never reach here if we have external functions
-        return false;
+        return lambda.getBody().accept(this, null);
     }
 
     @Override

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
@@ -24,22 +24,36 @@ import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionImplementationType;
 import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.DesugarTryExpressionRewriter;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.VariablesExtractor;
 import com.facebook.presto.sql.planner.assertions.ExpressionMatcher;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.optimizations.ExternalCallExpressionChecker;
+import com.facebook.presto.sql.relational.SqlToRowExpressionTranslator;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.NodeRef;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -51,6 +65,7 @@ import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Determinism.DETERMINISTIC;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.Language.SQL;
 import static com.facebook.presto.spi.function.RoutineCharacteristics.NullCallClause.RETURNS_NULL_ON_NULL_INPUT;
+import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionTypes;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
@@ -58,6 +73,7 @@ import static com.facebook.presto.sql.planner.iterative.rule.PlanRemoteProjectio
 import static com.facebook.presto.type.JsonPathType.JSON_PATH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestPlanRemoteProjections
 {
@@ -287,6 +303,290 @@ public class TestPlanRemoteProjections
                                                         values(ImmutableMap.of("x", 0, "y", 1)))))));
     }
 
+    @Test
+    void testTryWithRemoteFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(remote_foo(x)) should extract the remote function from the lambda body
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(unittest.memory.remote_foo(x))"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        // Expect: local(args) -> remote(remote_foo) -> local($internal$try)
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithNoRemoteFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(abs(x)) has no remote functions, should be fully local
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(abs(x))"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        assertEquals(rewritten.size(), 1);
+        assertFalse(rewritten.get(0).isRemote());
+    }
+
+    @Test
+    void testTryWithLocalWrappingRemoteFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(abs(remote_foo(x))): local function wrapping remote function inside TRY
+        // The local function should stay inside the lambda, only the remote function is extracted
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(abs(unittest.memory.remote_foo(x)))"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        // Expect: local(args) -> remote(remote_foo) -> local($internal$try(() -> abs(v)))
+        // The local abs() is merged into the lambda, avoiding two consecutive local projections
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithRemoteWrappingLocalFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(remote_foo(abs(x))): remote function wrapping local function inside TRY
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(unittest.memory.remote_foo(abs(x)))"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        // Expect: local(abs(x)) -> remote(remote_foo(v)) -> local($internal$try(() -> v))
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithLocalRemoteLocalNesting()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(abs(remote_foo(abs(x)))): local(remote(local(x))) nesting
+        // local_func2 is extracted as remote arg, local_func stays inside the lambda
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(abs(unittest.memory.remote_foo(abs(x))))"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        // Expect: local(abs(x)) -> remote(remote_foo(v)) -> local($internal$try(() -> abs(v)))
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithRemoteFunctionMixed()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+        planBuilder.variable("y", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // Mix of TRY with remote function and regular remote function
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(unittest.memory.remote_foo(x))"))
+                .put(planBuilder.variable("b"), planBuilder.rowExpression("unittest.memory.remote_foo(y)"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        // Both should produce remote projections
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithRemoteFunctionAndArithmetic()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(remote_foo(x) + 3): remote function with local arithmetic inside TRY
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(unittest.memory.remote_foo(x) + 3)"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        // Expect: local(args) -> remote(remote_foo) -> local($internal$try(() -> add(v, 3)))
+        // The local add is folded into the lambda body
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithNestedTryAndRemoteFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(TRY(remote_foo(x))): nested TRY with remote function
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(TRY(unittest.memory.remote_foo(x)))"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithCaseAndRemoteFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(CASE WHEN x > 0 THEN remote_foo(x) ELSE 0 END)
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(CASE WHEN x > 0 THEN unittest.memory.remote_foo(x) ELSE 0 END)"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithIfAndRemoteFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(IF(x > 0, remote_foo(x), -1))
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(IF(x > 0, unittest.memory.remote_foo(x), -1))"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+    }
+
+    @Test
+    void testTryWithDeeplyNestedRemoteFunctions()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // TRY(abs(remote_foo(abs(remote_foo(x))))): two remote calls nested with local functions
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "TRY(abs(unittest.memory.remote_foo(abs(unittest.memory.remote_foo(x)))))"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        assertEquals(rewritten.size(), 5);
+        assertFalse(rewritten.get(0).isRemote());
+        assertEquals(rewritten.get(1).isRemote(), true);
+        assertFalse(rewritten.get(2).isRemote());
+        assertEquals(rewritten.get(3).isRemote(), true);
+        assertFalse(rewritten.get(4).isRemote());
+    }
+
+    @Test
+    void testExternalCallExpressionCheckerDetectsRemoteInLambda()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        ExternalCallExpressionChecker checker = new ExternalCallExpressionChecker(getFunctionAndTypeManager());
+
+        // TRY(remote_foo(x)) produces $internal$try(BIND(x, (x_bind) -> remote_foo(x_bind)))
+        // The checker should detect the remote function inside the lambda body
+        RowExpression tryWithRemote = desugaredRowExpression(planBuilder, "TRY(unittest.memory.remote_foo(x))");
+        assertTrue(tryWithRemote.accept(checker, null));
+    }
+
+    @Test
+    void testExternalCallExpressionCheckerLocalOnlyLambda()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        ExternalCallExpressionChecker checker = new ExternalCallExpressionChecker(getFunctionAndTypeManager());
+
+        // TRY(abs(x)) produces $internal$try(BIND(x, (x_bind) -> abs(x_bind)))
+        // The checker should not flag a lambda with only local functions
+        RowExpression tryWithLocal = desugaredRowExpression(planBuilder, "TRY(abs(x))");
+        assertFalse(tryWithLocal.accept(checker, null));
+    }
+
+    @Test
+    void testNullIfWithTryAndRemoteFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // NULLIF(TRY(remote_foo(x)), 0) compiles to SWITCH($internal$try(BIND(...)), WHEN(0, NULL), $internal$try(BIND(...)))
+        // The WHEN clause must be kept inline, not extracted as a standalone variable
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "NULLIF(TRY(unittest.memory.remote_foo(x)), 0)"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        // Should not crash and should produce valid projections
+        assertFalse(rewritten.isEmpty());
+        // Verify no WHEN clause was extracted as a standalone projection
+        for (ProjectionContext context : rewritten) {
+            for (RowExpression expr : context.getProjections().values()) {
+                if (expr instanceof SpecialFormExpression) {
+                    SpecialFormExpression sf = (SpecialFormExpression) expr;
+                    assertFalse(sf.getForm() == SpecialFormExpression.Form.WHEN,
+                            "WHEN clause should not be a standalone projection value");
+                }
+            }
+        }
+    }
+
+    @Test
+    void testCaseWhenWithVariableAndTryRemoteFunction()
+    {
+        PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
+        planBuilder.variable("x", INTEGER);
+        planBuilder.variable("y", INTEGER);
+
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
+        // CASE WHEN y > 0 THEN 0 ELSE TRY(remote_foo(x)) END
+        // Compiles to SWITCH(true, WHEN(y > 0, 0), $internal$try(BIND(x, (p) -> remote_foo(p))))
+        // The WHEN clause references 'y', which must be tracked through projection layers
+        List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
+                .put(planBuilder.variable("a"), desugaredRowExpression(planBuilder, "CASE WHEN y > 0 THEN 0 ELSE TRY(unittest.memory.remote_foo(x)) END"))
+                .build(), new VariableAllocator(planBuilder.getTypes().allVariables()));
+        assertEquals(rewritten.size(), 3);
+        assertFalse(rewritten.get(0).isRemote());
+        assertTrue(rewritten.get(1).isRemote());
+        assertFalse(rewritten.get(2).isRemote());
+
+        // Verify 'y' is not directly referenced in the final local projection.
+        // It should be available through an intermediate variable allocated in the first local projection.
+        Set<String> firstLocalOutputNames = rewritten.get(0).getProjections().keySet().stream()
+                .map(VariableReferenceExpression::getName)
+                .collect(java.util.stream.Collectors.toSet());
+        // The first local projection should have extracted 'y > 0' into a variable
+        boolean hasYDerivedVar = rewritten.get(0).getProjections().values().stream()
+                .anyMatch(expr -> !(expr instanceof VariableReferenceExpression) && VariablesExtractor.extractAll(expr).stream()
+                        .anyMatch(v -> v.getName().equals("y")));
+        assertTrue(hasYDerivedVar, "First local projection should contain an expression referencing y");
+    }
+
     @Test(expectedExceptions = PrestoException.class, expectedExceptionsMessageRegExp = ".*Remote functions are not enabled")
     public void testRemoteFunctionDisabled()
     {
@@ -323,5 +623,32 @@ public class TestPlanRemoteProjections
     private FunctionAndTypeManager getFunctionAndTypeManager()
     {
         return getMetadata().getFunctionAndTypeManager();
+    }
+
+    /**
+     * Translates a SQL expression to a RowExpression with TRY desugaring and lambda capture
+     * desugaring applied, matching the real query execution path where $internal$try arguments
+     * are wrapped in BIND rather than being raw LambdaDefinitionExpressions.
+     */
+    private RowExpression desugaredRowExpression(PlanBuilder planBuilder, String sql)
+    {
+        Expression expression = PlanBuilder.expression(sql);
+        expression = DesugarTryExpressionRewriter.rewrite(expression);
+        TypeProvider types = planBuilder.getTypes();
+        expression = LambdaCaptureDesugaringRewriter.rewrite(expression, new VariableAllocator(types.allVariables()));
+        Map<NodeRef<Expression>, com.facebook.presto.common.type.Type> expressionTypes = getExpressionTypes(
+                TEST_SESSION,
+                getMetadata(),
+                new SqlParser(),
+                types,
+                expression,
+                ImmutableMap.of(),
+                WarningCollector.NOOP);
+        return SqlToRowExpressionTranslator.translate(
+                expression,
+                expressionTypes,
+                ImmutableMap.of(),
+                getFunctionAndTypeManager(),
+                TEST_SESSION);
     }
 }


### PR DESCRIPTION
## Description
Extend `PlanRemoteProjections` to extract remote functions from `$internal$try` lambda bodies, and update `ExternalCallExpressionChecker` to detect remote functions inside lambda expressions.

The TRY function is desugared into `$internal$try(() -> expr)` after the query analyzer, wrapping the expression in a lambda. After lambda capture desugaring, the argument becomes `BIND(captured_vars..., lambda)`. Previously, `PlanRemoteProjections` did not process lambda bodies, so remote functions inside TRY were not extracted into separate remote projection nodes.

### Changes
- **PlanRemoteProjections**: Add `processInternalTry` in the `Visitor` to detect `$internal$try` calls with `LambdaDefinitionExpression` or `BIND`-wrapped lambda arguments. Unwraps BIND, substitutes lambda parameters with captured variables, visits the body to extract remote functions, and reconstructs the result with proper BIND wrapping.
- **ExternalCallExpressionChecker**: Recurse into lambda bodies to detect remote functions in all cases, ensuring no remote functions remain undetected in local projection nodes.

### Example
```
TRY(remote_func(x))
  → $internal$try(BIND(x, (x_bind) -> remote_func(x_bind)))
```
is rewritten to:
```
LOCAL:  {v_x = x}
REMOTE: {v = remote_func(v_x)}
LOCAL:  {result = $internal$try(BIND(v, (p) -> p))}
```

## Motivation and Context
The query analyzer does not support remote functions in lambda functions and will fail the query. However, `$internal$try` is an exception — TRY is desugared into a lambda after analysis, so remote functions inside TRY bypass the analyzer check. This change enables `PlanRemoteProjections` to handle this special case while keeping `visitLambda` as a no-op for all other lambda functions.

## Impact
No public API or user-facing changes. Remote functions inside TRY expressions are now correctly extracted into remote projection nodes.

## Test Plan
Added 13 new tests in `TestPlanRemoteProjections`. All TRY tests use `desugaredRowExpression()` which applies `DesugarTryExpressionRewriter` and `LambdaCaptureDesugaringRewriter` before translation, producing `BIND`-wrapped expressions matching the real query execution path.

`PlanRemoteProjections` tests:
- `testTryWithRemoteFunction` — `TRY(remote(x))`
- `testTryWithNoRemoteFunction` — `TRY(local(x))`
- `testTryWithLocalWrappingRemoteFunction` — `TRY(local(remote(x)))`
- `testTryWithRemoteWrappingLocalFunction` — `TRY(remote(local(x)))`
- `testTryWithLocalRemoteLocalNesting` — `TRY(local(remote(local(x))))`
- `testTryWithRemoteFunctionMixed` — `TRY(remote(x))` alongside standalone `remote(y)`
- `testTryWithRemoteFunctionAndArithmetic` — `TRY(remote(x) + 3)`
- `testTryWithNestedTryAndRemoteFunction` — `TRY(TRY(remote(x)))`
- `testTryWithCaseAndRemoteFunction` — `TRY(CASE WHEN ... THEN remote(x) ELSE 0 END)`
- `testTryWithIfAndRemoteFunction` — `TRY(IF(..., remote(x), -1))`
- `testTryWithDeeplyNestedRemoteFunctions` — `TRY(local(remote(local(remote(x)))))` with 5 projection layers

`ExternalCallExpressionChecker` tests:
- `testExternalCallExpressionCheckerDetectsRemoteInLambda` — lambda with remote function body is flagged
- `testExternalCallExpressionCheckerLocalOnlyLambda` — lambda with only local functions is not flagged

All 21 tests pass (8 existing + 13 new).

https://www.internalfb.com/intern/presto/verifier/results/?test_id=309021

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```