### PR TITLE
chore: Enable iceberg tests

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestCreateTable.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestCreateTable.java
@@ -61,7 +61,7 @@ public class TestCreateTable
         }
     }
 
-    @Test(enabled = false) // Investigate
+    @Test
     public void testAllPrimitiveTypes()
     {
         String tableName = "primitive_types";
@@ -115,7 +115,7 @@ public class TestCreateTable
         }
     }
 
-    @Test(enabled = false) // Investigate
+    @Test
     public void testAsSelect()
     {
         String sourceTable = "source";

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestMetadata.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/iceberg/TestMetadata.java
@@ -187,7 +187,7 @@ public class TestMetadata
         }
     }
 
-    @Test(enabled = false) // Investigate
+    @Test
     public void testMetadataWithAllPrimitiveTypes()
     {
         String tableName = "all_types_metadata";


### PR DESCRIPTION
## Description
Enabling recent Iceberg tests to see the CI test failures. The tests are running fine on local Mac setup.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Re-enable Iceberg TestCreateTable coverage for all primitive types and CREATE TABLE AS SELECT.