### PR TITLE
docs(optimizer): Add more details to the materialized view documentation

### DIFF
--- a/presto-docs/src/main/sphinx/admin/materialized-views.rst
+++ b/presto-docs/src/main/sphinx/admin/materialized-views.rst
@@ -97,19 +97,38 @@ Data Consistency Modes
 Materialized views support three data consistency modes that control how queries are optimized
 when the view's data may be stale:
 
+.. important::
+
+    Materialized views do NOT automatically refresh when base tables change. The storage table
+    remains unchanged until you explicitly run ``REFRESH MATERIALIZED VIEW``. The
+    ``stale_read_behavior`` setting controls how queries are handled when the storage
+    is stale.
+
 **USE_STITCHING** (default)
   Reads fresh data from storage, recomputes stale data from base tables,
   and combines results via UNION.
 
+  - Provides up-to-date results without refreshing the storage
+  - The materialized view itself is not updated
+
 **FAIL**
   Fails the query if the materialized view is stale.
 
+  - Requires the materialized view to be refreshed before querying
+  - Useful when you want to ensure queries only use pre-computed results
+
 **USE_VIEW_QUERY**
   Executes the view query against base tables. Always fresh but highest cost.
+  
+  - The materialized view storage is ignored
+  - The materialized view remains stale internally
 
-Set via session property::
+To update the storage table with fresh data, you must explicitly run ``REFRESH MATERIALIZED VIEW``.
+
+Set with session property::
 
     SET SESSION materialized_view_skip_storage = 'USE_STITCHING';
+
 
 Predicate Stitching (USE_STITCHING Mode)
 ----------------------------------------

--- a/presto-docs/src/main/sphinx/sql/create-materialized-view.rst
+++ b/presto-docs/src/main/sphinx/sql/create-materialized-view.rst
@@ -78,6 +78,21 @@ Create a materialized view with INVOKER security mode::
     FROM orders
     GROUP BY date_trunc('day', order_date)
 
+Create a materialized view with staleness configuration::
+
+    CREATE MATERIALIZED VIEW daily_sales
+    WITH (stale_read_behavior = 'FAIL',
+    staleness_window = '1h')
+    AS
+    SELECT date_trunc('day', order_date) AS day,
+           region,
+           SUM(amount) AS total_sales
+    FROM orders
+    GROUP BY date_trunc('day', order_date), region
+
+
+The optional ``staleness_window`` parameter defines how long stale data is acceptable and allows duration values in hours, minutes, or seconds (for example: 1hr, 30m).
+
 Create a materialized view with connector properties::
 
     CREATE MATERIALIZED VIEW partitioned_sales

--- a/presto-docs/src/main/sphinx/sql/refresh-materialized-view.rst
+++ b/presto-docs/src/main/sphinx/sql/refresh-materialized-view.rst
@@ -29,6 +29,12 @@ Refresh a materialized view::
 
     REFRESH MATERIALIZED VIEW daily_sales
 
+.. important::
+
+    - A newly created materialized view has an **empty storage table**.
+    - Therefore, it is considered **stale immediately after creation**.
+    - You must run a refresh before querying when using strict modes like ``FAIL``.
+
 See Also
 --------
 


### PR DESCRIPTION
## Description
Updated the materialized view documentation to incorporate supporting configurations and relevant examples.

## Motivation and Context
To ensure consistent understanding and usage of materialized views

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Expand and clarify documentation around materialized views, including their creation and refresh behavior.

Documentation:
- Enhance admin documentation for materialized views with additional guidance and context.
- Update SQL reference pages for CREATE MATERIALIZED VIEW and REFRESH MATERIALIZED VIEW to include more details and examples.