### PR TITLE
fix(ci): Update release-notes-check and presto-release-prepare actions

### DIFF
--- a/.github/workflows/presto-release-prepare.yml
+++ b/.github/workflows/presto-release-prepare.yml
@@ -20,6 +20,7 @@ env:
   MAVEN_OPTS: ${{ vars.MAVEN_OPTS }}
   GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
   GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
+  RELEASE_TOOLS_VERSION: ${{ vars.RELEASE_TOOLS_VERSION || '0.14' }}
 
 jobs:
   prepare-release-branch:
@@ -66,6 +67,71 @@ jobs:
           git config --global user.name "$GIT_CI_USER"
           git config --global alias.ls 'log --pretty=format:"%cd %h %ce: %s" --date=short --no-merges'
           git config pull.rebase false
+
+      - name: Validate Maven publishing requirements
+        run: |
+          echo "=== Validating Maven plugins ==="
+
+          ERROR_FILE=$(mktemp)
+          MISSING_NAME_COUNT=0
+          EMPTY_PLUGIN_COUNT=0
+          TOTAL_POM_COUNT=0
+          TOTAL_PLUGIN_COUNT=0
+
+          echo "Checking all pom.xml files for <name> field..."
+
+          POM_FILES=$(find . -name "pom.xml" -type f \
+              | grep -v "target/" \
+              | grep -v "node_modules" \
+              | grep -v ".vscode" \
+              | sort)
+
+          for POM_FILE in $POM_FILES; do
+              TOTAL_POM_COUNT=$((TOTAL_POM_COUNT + 1))
+              if ! grep -q "<name>[^<]" "$POM_FILE"; then
+                  echo "ERROR: $POM_FILE is missing <name> field or has empty <name>" | tee -a "$ERROR_FILE"
+                  MISSING_NAME_COUNT=$((MISSING_NAME_COUNT + 1))
+              fi
+          done
+
+          echo "Found $TOTAL_POM_COUNT pom.xml files, $MISSING_NAME_COUNT missing <name> field"
+
+          echo "Checking all plugins for Java files..."
+
+          PLUGIN_DIRS=$(find . -name "pom.xml" -type f -exec \
+              grep -l "<packaging>presto-plugin</packaging>" {} \; \
+              | xargs -I{} dirname {})
+
+          for PLUGIN_DIR in $PLUGIN_DIRS; do
+              TOTAL_PLUGIN_COUNT=$((TOTAL_PLUGIN_COUNT + 1))
+
+              JAVA_FILES=$(find "$PLUGIN_DIR/src/main/java" -name "*.java" -type f 2>/dev/null | wc -l)
+
+              if [ "$JAVA_FILES" -eq 0 ]; then
+                  echo "ERROR: Plugin $PLUGIN_DIR has no Java files in src/main/java" | tee -a "$ERROR_FILE"
+                  EMPTY_PLUGIN_COUNT=$((EMPTY_PLUGIN_COUNT + 1))
+              else
+                  echo "Plugin $PLUGIN_DIR has $JAVA_FILES Java files"
+              fi
+          done
+
+          echo "Found $TOTAL_PLUGIN_COUNT Maven plugins, $EMPTY_PLUGIN_COUNT without Java files"
+
+          if [ -s "$ERROR_FILE" ]; then
+              echo "=== Validation failed! ==="
+              echo "Summary:"
+              echo "- $MISSING_NAME_COUNT/$TOTAL_POM_COUNT pom.xml files missing <name> field"
+              echo "- $EMPTY_PLUGIN_COUNT/$TOTAL_PLUGIN_COUNT plugins without Java files"
+              echo ""
+              echo "Errors:"
+              cat "$ERROR_FILE"
+              exit 1
+          else
+              echo "=== All validations passed! ==="
+              echo "Summary:"
+              echo "- All $TOTAL_POM_COUNT pom.xml files have <name>"
+              echo "- All $TOTAL_PLUGIN_COUNT plugins have Java files"
+          fi
 
       - name: Set presto release version
         run: |
@@ -156,6 +222,8 @@ jobs:
       - name: Create release notes pull request
         env:
           JVM_OPTS: ${{ env.MAVEN_OPTS }}
+          RELEASE_TOOLS_VERSION: ${{ env.RELEASE_TOOLS_VERSION }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           echo "In case this job failed, please delete the release notes branch(e.g. release-notes-0.292) in repository ${{ github.repository }}, and re-run the job"
           ./src/release/release-notes.sh ${{ github.repository_owner }} ${{ secrets.PRESTODB_CI_TOKEN }}

--- a/.github/workflows/release-notes-check.yml
+++ b/.github/workflows/release-notes-check.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened]
 
 env:
-  RELEASE_TOOLS_VERSION: "0.11"
+  RELEASE_TOOLS_VERSION: ${{ vars.RELEASE_TOOLS_VERSION || '0.14' }}
 
 jobs:
   check_release_note:
@@ -28,36 +28,32 @@ jobs:
           cache: maven
       - name: Get presto-release-tools
         run: |
-          ./mvnw \
-            -B \
-            -DgroupId=com.facebook.presto \
-            -DartifactId=presto-release-tools -Dversion=${RELEASE_TOOLS_VERSION} \
-            -Dpackaging=jar \
-            -Dclassifier=executable \
-            dependency:get
+          curl -L -o /tmp/presto_release "https://github.com/${{ github.repository_owner }}/presto-release-tools/releases/download/${RELEASE_TOOLS_VERSION}/presto-release-tools-${RELEASE_TOOLS_VERSION}-executable.jar"
+          chmod 755 /tmp/presto_release
       - name: Get PR body from GraphQL API
         id: graphql_query
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "pr_bodytext<<EOF" >> $GITHUB_OUTPUT
           gh api graphql -f query='
-              query {
-                repository(owner: "prestodb", name: "presto") {
-                                      pullRequest(number: ${{ github.event.pull_request.number }}) {
-                                        bodyText
-                                      }
+              query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    bodyText
+                  }
                 }
               }
-            ' --jq '.data.repository.pullRequest.bodyText' >> $GITHUB_OUTPUT
+            ' -f owner="$REPO_OWNER" -f name="$REPO_NAME" -F number="$PR_NUMBER" --jq '.data.repository.pullRequest.bodyText' >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       - name: Echo PR Text
         env:
           PR_BODY: ${{ steps.graphql_query.outputs.pr_bodytext }}
         run: echo "${PR_BODY}"
-      - name: Set presto-release-tools as executable
-        run: chmod +x ~/.m2/repository/com/facebook/presto/presto-release-tools/${RELEASE_TOOLS_VERSION}/presto-release-tools-${RELEASE_TOOLS_VERSION}-executable.jar
       - name: Check release notes
         env:
           PR_BODY: ${{ steps.graphql_query.outputs.pr_bodytext }}
-        run: echo "${PR_BODY}" | ~/.m2/repository/com/facebook/presto/presto-release-tools/${RELEASE_TOOLS_VERSION}/presto-release-tools-${RELEASE_TOOLS_VERSION}-executable.jar check-release-notes
+        run: echo "${PR_BODY}" | /tmp/presto_release check-release-notes

--- a/presto-lance/pom.xml
+++ b/presto-lance/pom.xml
@@ -7,6 +7,7 @@
         <version>0.297-SNAPSHOT</version>
     </parent>
 
+    <name>presto-lance</name>
     <artifactId>presto-lance</artifactId>
     <description>Presto - LanceDB Connector</description>
     <packaging>presto-plugin</packaging>

--- a/src/release/release-notes.sh
+++ b/src/release/release-notes.sh
@@ -5,6 +5,9 @@ if [[ "$#" -ne 2 ]]; then
     exit 1
 fi
 
-curl -L -o /tmp/presto_release "https://oss.sonatype.org/service/local/artifact/maven/redirect?g=com.facebook.presto&a=presto-release-tools&v=RELEASE&r=releases&c=executable&e=jar"
+RELEASE_TOOLS_VERSION=${RELEASE_TOOLS_VERSION:-"0.14"}
+REPO_OWNER=${REPO_OWNER:-"prestodb"}
+
+curl -L -o /tmp/presto_release "https://github.com/${REPO_OWNER}/presto-release-tools/releases/download/${RELEASE_TOOLS_VERSION}/presto-release-tools-${RELEASE_TOOLS_VERSION}-executable.jar"
 chmod 755 /tmp/presto_release
 java ${JVM_OPTS} -jar /tmp/presto_release release-notes --github-user $1 --github-access-token $2


### PR DESCRIPTION
## Description
1. presto-release-tools can not be fetched due to maven central publishing limitation
2. check maven central publishing requirements
3. add required `<name>` field to presto-lance 

## Motivation and Context
Depends on PRs:
- https://github.com/prestodb/presto-release-tools/pull/65
- https://github.com/prestodb/presto-release-tools/pull/64
- https://github.com/prestodb/presto-release-tools/pull/63
- https://github.com/prestodb/presto-release-tools/pull/62

## Impact
CI

## Test Plan
Tested with:
1. release note check action:  https://github.com/prestodb/presto/actions/runs/23815800338/job/69414865062?pr=27466
2. maven central publishing requirements check: https://github.com/unix280/presto/actions/runs/23812452401/job/69402863222#step:8:76
3. Prepare release action in presto => https://github.com/unix280/presto/actions/runs/23812844511
4. Release notes PR => https://github.com/unix280/presto/pull/52
5. Release notes missing list file => https://github.com/unix280/presto/blob/release-notes-0.297/release-notes-missing-0.297.md

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Update CI and release scripts to retrieve presto-release-tools from GitHub releases using a configurable version instead of Maven Central.

CI:
- Change release-notes-check workflow to download the presto-release-tools executable directly from GitHub releases and run it from a temporary path.
- Make the release-notes-check workflow use a configurable RELEASE_TOOLS_VERSION with a default of 0.13.

Deployment:
- Update release preparation workflow and release-notes script to use a configurable RELEASE_TOOLS_VERSION (default 0.13) and fetch presto-release-tools from GitHub releases instead of Maven.

Chores:
- Align release tooling version and retrieval method across CI workflows and release scripts.