### PR TITLE
Remove function_scheduler shim from xplat/folly/experimental (#27469)

### DIFF
--- a/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicMemoryChecker.h
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 #pragma once
-#include <folly/experimental/FunctionScheduler.h>
+#include <folly/executors/FunctionScheduler.h>
 #include <cstdint>
 #include <queue>
 #include <string>

--- a/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
+++ b/presto-native-execution/presto_cpp/main/PeriodicTaskManager.h
@@ -14,7 +14,7 @@
 #pragma once
 
 #include <folly/executors/ThreadedRepeatingFunctionRunner.h>
-#include <folly/experimental/FunctionScheduler.h>
+#include <folly/executors/FunctionScheduler.h>
 #include "velox/common/memory/Memory.h"
 
 namespace folly {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/fb303/pull/75


X-link: https://github.com/facebookincubator/velox/pull/16969

Folly/experimental is just shims to the real code, rewriting all these references.

#force_dangling_check

Differential Revision: D97588319
