### PR TITLE
fix: Change default config.properties to instantiate a coordinator

### DIFF
--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -6,11 +6,10 @@
 #
 
 # sample nodeId to provide consistency across test runs
-node.id=ffffffff-ffff-ffff-ffff-ffffffffffrm
+node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
 node.environment=test
 http-server.http.port=8080
-coordinator=false
-resource-manager=true
+coordinator=true
 
 discovery-server.enabled=true
 discovery.uri=http://localhost:8080
@@ -53,5 +52,3 @@ plugin.bundles=\
 
 presto.version=testversion
 node-scheduler.include-coordinator=true
-resource-manager-enabled=true
-internal-communication.resource-manager-communication-protocol=HTTP


### PR DESCRIPTION
This PR accidentally changed the default config.properties: https://github.com/prestodb/presto/pull/26635/changes
This changes it back.
```
== NO RELEASE NOTE ==
```