### PR TITLE
[DNR][Test]: Temp test

### DIFF
--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Field.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Field.java
@@ -18,7 +18,9 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.QualifiedName;
 
+import java.util.Locale;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -154,12 +156,22 @@ public class Field
      */
     public boolean canResolve(QualifiedName name)
     {
+        return canResolve(name, s -> s.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Case-sensitivity-aware variant. Uses {@code nameKeyFunction} (the same function that was used
+     * to build the owning {@link RelationType}'s field index) to compare the stored field name
+     * against the queried name suffix, so that case-sensitive catalogs reject wrong-case references.
+     */
+    public boolean canResolve(QualifiedName name, UnaryOperator<String> nameKeyFunction)
+    {
         if (!this.name.isPresent()) {
             return false;
         }
 
-        // TODO: need to know whether the qualified name and the name of this field were quoted
-        return matchesPrefix(name.getPrefix()) && this.name.get().equalsIgnoreCase(name.getSuffix());
+        return matchesPrefix(name.getPrefix()) &&
+                nameKeyFunction.apply(this.name.get()).equals(nameKeyFunction.apply(name.getOriginalSuffix().getValue()));
     }
 
     @Override

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Field.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/Field.java
@@ -18,9 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.QualifiedName;
 
-import java.util.Locale;
 import java.util.Optional;
-import java.util.function.UnaryOperator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -131,47 +129,6 @@ public class Field
     public boolean matchesPrefix(Optional<QualifiedName> prefix)
     {
         return !prefix.isPresent() || relationAlias.isPresent() && relationAlias.get().hasSuffix(prefix.get());
-    }
-
-    /*
-      Namespaces can have names such as "x", "x.y" or "" if there's no name
-      Name to resolve can have names like "a", "x.a", "x.y.a"
-
-      namespace  name     possible match
-       ""         "a"           y
-       "x"        "a"           y
-       "x.y"      "a"           y
-
-       ""         "x.a"         n
-       "x"        "x.a"         y
-       "x.y"      "x.a"         n
-
-       ""         "x.y.a"       n
-       "x"        "x.y.a"       n
-       "x.y"      "x.y.a"       n
-
-       ""         "y.a"         n
-       "x"        "y.a"         n
-       "x.y"      "y.a"         y
-     */
-    public boolean canResolve(QualifiedName name)
-    {
-        return canResolve(name, s -> s.toLowerCase(Locale.ENGLISH));
-    }
-
-    /**
-     * Case-sensitivity-aware variant. Uses {@code nameKeyFunction} (the same function that was used
-     * to build the owning {@link RelationType}'s field index) to compare the stored field name
-     * against the queried name suffix, so that case-sensitive catalogs reject wrong-case references.
-     */
-    public boolean canResolve(QualifiedName name, UnaryOperator<String> nameKeyFunction)
-    {
-        if (!this.name.isPresent()) {
-            return false;
-        }
-
-        return matchesPrefix(name.getPrefix()) &&
-                nameKeyFunction.apply(this.name.get()).equals(nameKeyFunction.apply(name.getOriginalSuffix().getValue()));
     }
 
     @Override

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
@@ -45,11 +45,19 @@ public class RelationType
 
     private final Map<Field, Integer> fieldIndexes;
 
-    // Index for O(1) field resolution by name.
-    // Key is produced by nameKeyFunction (lowercase by default; identity for case-sensitive catalogs).
+    // Primary index: key produced by nameKeyFunction.
+    // In single-catalog relations this is the only index used.
+    // In cross-catalog join results, this holds fields from the left (this) relation.
     private final Map<String, List<Field>> fieldsByName;
 
+    // Secondary index: present only in merged relations produced by joinWith() when the
+    // right side carries a different nameKeyFunction. Key produced by otherNameKeyFunction.
+    private final Map<String, List<Field>> otherFieldsByName;
+
     private final UnaryOperator<String> nameKeyFunction;
+
+    // nameKeyFunction of the right-side relation after joinWith(); null for single-relation types.
+    private final UnaryOperator<String> otherNameKeyFunction;
 
     public RelationType(Field... fields)
     {
@@ -78,6 +86,7 @@ public class RelationType
         requireNonNull(fields, "fields is null");
         requireNonNull(nameKeyFunction, "nameKeyFunction is null");
         this.nameKeyFunction = nameKeyFunction;
+        this.otherNameKeyFunction = null;
         this.allFields = ImmutableList.copyOf(fields);
         this.visibleFields = ImmutableList.copyOf(fields.stream().filter(not(Field::isHidden)).iterator());
 
@@ -98,6 +107,37 @@ public class RelationType
         ImmutableMap.Builder<String, List<Field>> nameIndexBuilder = ImmutableMap.builder();
         nameIndex.forEach((name, fieldList) -> nameIndexBuilder.put(name, ImmutableList.copyOf(fieldList)));
         this.fieldsByName = nameIndexBuilder.build();
+        this.otherFieldsByName = ImmutableMap.of();
+    }
+
+    /**
+     * Private constructor used by {@link #joinWith} to build a merged relation whose field
+     * indices were assembled by the caller — left fields keyed by {@code nameKeyFunction},
+     * right fields keyed by {@code otherNameKeyFunction}.
+     * <p>
+     * When the two functions are identical (same-catalog join) {@code otherFieldsByName} is
+     * empty and lookup falls through to {@code fieldsByName} only. When they differ
+     * (cross-catalog join) {@code resolveFields} consults both indices.
+     */
+    private RelationType(List<Field> allFields,
+            Map<String, List<Field>> fieldsByName,
+            Map<String, List<Field>> otherFieldsByName,
+            UnaryOperator<String> nameKeyFunction,
+            UnaryOperator<String> otherNameKeyFunction)
+    {
+        this.nameKeyFunction = requireNonNull(nameKeyFunction, "nameKeyFunction is null");
+        this.otherNameKeyFunction = otherNameKeyFunction;
+        this.allFields = ImmutableList.copyOf(requireNonNull(allFields, "allFields is null"));
+        this.visibleFields = ImmutableList.copyOf(this.allFields.stream().filter(not(Field::isHidden)).iterator());
+
+        int index = 0;
+        ImmutableMap.Builder<Field, Integer> builder = ImmutableMap.builder();
+        for (Field field : this.allFields) {
+            builder.put(field, index++);
+        }
+        this.fieldIndexes = builder.build();
+        this.fieldsByName = requireNonNull(fieldsByName, "fieldsByName is null");
+        this.otherFieldsByName = requireNonNull(otherFieldsByName, "otherFieldsByName is null");
     }
 
     /**
@@ -177,18 +217,34 @@ public class RelationType
 
     /**
      * Gets the index of all columns matching the specified name.
-     * The lookup key is produced by getNameKeyFunction, matching the same transformation applied at
-     * index-build time — so case-sensitive catalogs require exact-case matches.
+     * <p>
+     * For single-catalog relations the primary index ({@code fieldsByName}) is consulted using
+     * {@code nameKeyFunction}. For merged relations produced by {@link #joinWith} where the two
+     * sides carry different normalization rules, the secondary index ({@code otherFieldsByName})
+     * is also consulted using {@code otherNameKeyFunction}, so that each side's fields are
+     * resolved with their own catalog's rules.
      */
     public List<Field> resolveFields(QualifiedName name)
     {
-        List<Field> candidates = fieldsByName.getOrDefault(nameKeyFunction.apply(name.getOriginalSuffix().getValue()), ImmutableList.of());
-        if (candidates.isEmpty()) {
-            return ImmutableList.of();
-        }
-        return candidates.stream()
+        String suffix = name.getOriginalSuffix().getValue();
+
+        // Always check the primary index (left-side fields, or all fields for single-catalog relations).
+        ImmutableList.Builder<Field> result = ImmutableList.builder();
+        List<Field> primaryCandidates = fieldsByName.getOrDefault(nameKeyFunction.apply(suffix), ImmutableList.of());
+        primaryCandidates.stream()
                 .filter(field -> field.matchesPrefix(name.getPrefix()))
-                .collect(toImmutableList());
+                .forEach(result::add);
+
+        // For cross-catalog joins, also check the secondary index (right-side fields keyed by
+        // the other catalog's normalization function).
+        if (otherNameKeyFunction != null && !otherFieldsByName.isEmpty()) {
+            List<Field> otherCandidates = otherFieldsByName.getOrDefault(otherNameKeyFunction.apply(suffix), ImmutableList.of());
+            otherCandidates.stream()
+                    .filter(field -> field.matchesPrefix(name.getPrefix()))
+                    .forEach(result::add);
+        }
+
+        return result.build();
     }
 
     public boolean canResolve(QualifiedName name)
@@ -200,10 +256,11 @@ public class RelationType
      * Creates a new tuple descriptor containing all fields from this tuple descriptor
      * and all fields from the specified tuple descriptor.
      * <p>
-     * For cross-catalog joins the two relations may carry different nameKeyFunction values.
-     * The merged relation uses this relation's nameKeyFunction for fields coming from {@code this},
-     * and the other relation's nameKeyFunction for fields coming from {@code other}, by delegating
-     * field resolution back to each original relation via their stored functions.
+     * When both sides share the same nameKeyFunction (same-catalog join, the common case),
+     * a single unified index is built and the secondary index is empty. When the two sides
+     * carry different functions (cross-catalog join), left fields are indexed separately
+     * under {@code this.nameKeyFunction} and right fields under {@code other.nameKeyFunction},
+     * so that {@link #resolveFields} can apply the correct normalization rule to each side.
      */
     public RelationType joinWith(RelationType other)
     {
@@ -212,7 +269,39 @@ public class RelationType
                 .addAll(other.allFields)
                 .build();
 
-        return new RelationType(fields, this.nameKeyFunction);
+        // Same function on both sides (same-catalog join, the common case): build one unified index.
+        if (this.nameKeyFunction.equals(other.nameKeyFunction)) {
+            HashMap<String, List<Field>> unified = new HashMap<>();
+            for (Field field : fields) {
+                field.getName().ifPresent(name ->
+                        unified.computeIfAbsent(this.nameKeyFunction.apply(name), k -> new ArrayList<>()).add(field));
+            }
+            ImmutableMap.Builder<String, List<Field>> builder = ImmutableMap.builder();
+            unified.forEach((key, fieldList) -> builder.put(key, ImmutableList.copyOf(fieldList)));
+            return new RelationType(fields, builder.build(), ImmutableMap.of(),
+                    this.nameKeyFunction, null);
+        }
+
+        // Different functions (cross-catalog join): index each side separately so that
+        // resolveFields() can apply each catalog's own normalization when looking up names.
+        HashMap<String, List<Field>> leftIndex = new HashMap<>();
+        for (Field field : this.allFields) {
+            field.getName().ifPresent(name ->
+                    leftIndex.computeIfAbsent(this.nameKeyFunction.apply(name), k -> new ArrayList<>()).add(field));
+        }
+        ImmutableMap.Builder<String, List<Field>> leftBuilder = ImmutableMap.builder();
+        leftIndex.forEach((key, fieldList) -> leftBuilder.put(key, ImmutableList.copyOf(fieldList)));
+
+        HashMap<String, List<Field>> rightIndex = new HashMap<>();
+        for (Field field : other.allFields) {
+            field.getName().ifPresent(name ->
+                    rightIndex.computeIfAbsent(other.nameKeyFunction.apply(name), k -> new ArrayList<>()).add(field));
+        }
+        ImmutableMap.Builder<String, List<Field>> rightBuilder = ImmutableMap.builder();
+        rightIndex.forEach((key, fieldList) -> rightBuilder.put(key, ImmutableList.copyOf(fieldList)));
+
+        return new RelationType(fields, leftBuilder.build(), rightBuilder.build(),
+                this.nameKeyFunction, other.nameKeyFunction);
     }
 
     /**

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/RelationType.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
@@ -44,18 +45,39 @@ public class RelationType
 
     private final Map<Field, Integer> fieldIndexes;
 
-    // Index for O(1) field resolution by name (lowercased).
-    // Maps lowercased field name -> list of fields with that name.
+    // Index for O(1) field resolution by name.
+    // Key is produced by nameKeyFunction (lowercase by default; identity for case-sensitive catalogs).
     private final Map<String, List<Field>> fieldsByName;
+
+    private final UnaryOperator<String> nameKeyFunction;
 
     public RelationType(Field... fields)
     {
         this(ImmutableList.copyOf(fields));
     }
 
+    /**
+     * Backward-compatible constructor. Uses case-insensitive (toLowerCase) field resolution.
+     */
     public RelationType(List<Field> fields)
     {
+        this(fields, s -> s.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Constructor with an explicit name-key function, used when the owning catalog has
+     * specific identifier-normalization rules
+     *
+     * @param fields   the fields of this relation
+     * @param nameKeyFunction function applied to a field name to produce the lookup key;
+     *                  use {@code s -> s.toLowerCase(Locale.ENGLISH)} for case-insensitive
+     *                  and {@code UnaryOperator.identity()} for case-sensitive behaviour
+     */
+    public RelationType(List<Field> fields, UnaryOperator<String> nameKeyFunction)
+    {
         requireNonNull(fields, "fields is null");
+        requireNonNull(nameKeyFunction, "nameKeyFunction is null");
+        this.nameKeyFunction = nameKeyFunction;
         this.allFields = ImmutableList.copyOf(fields);
         this.visibleFields = ImmutableList.copyOf(fields.stream().filter(not(Field::isHidden)).iterator());
 
@@ -66,16 +88,26 @@ public class RelationType
         }
         fieldIndexes = builder.build();
 
-        // Build name index for resolveFields()
+        // Build name index applying nameKeyFunction so lookup keys match what resolveFields() will produce.
         HashMap<String, List<Field>> nameIndex = new HashMap<>();
         for (Field field : fields) {
             field.getName().ifPresent(name ->
-                    nameIndex.computeIfAbsent(name.toLowerCase(Locale.ENGLISH), k -> new ArrayList<>()).add(field));
+                    nameIndex.computeIfAbsent(nameKeyFunction.apply(name), k -> new ArrayList<>()).add(field));
         }
         // Convert to immutable lists
         ImmutableMap.Builder<String, List<Field>> nameIndexBuilder = ImmutableMap.builder();
         nameIndex.forEach((name, fieldList) -> nameIndexBuilder.put(name, ImmutableList.copyOf(fieldList)));
         this.fieldsByName = nameIndexBuilder.build();
+    }
+
+    /**
+     * Returns the name-key function used for field resolution in this relation.
+     * Callers that derive new RelationTypes from this one (e.g. withAlias, joinWith) should
+     * propagate this function so that consistent resolution semantics are maintained.
+     */
+    public UnaryOperator<String> getNameKeyFunction()
+    {
+        return nameKeyFunction;
     }
 
     /**
@@ -144,11 +176,13 @@ public class RelationType
     }
 
     /**
-     * Gets the index of all columns matching the specified name
+     * Gets the index of all columns matching the specified name.
+     * The lookup key is produced by getNameKeyFunction, matching the same transformation applied at
+     * index-build time — so case-sensitive catalogs require exact-case matches.
      */
     public List<Field> resolveFields(QualifiedName name)
     {
-        List<Field> candidates = fieldsByName.getOrDefault(name.getSuffix().toLowerCase(Locale.ENGLISH), ImmutableList.of());
+        List<Field> candidates = fieldsByName.getOrDefault(nameKeyFunction.apply(name.getOriginalSuffix().getValue()), ImmutableList.of());
         if (candidates.isEmpty()) {
             return ImmutableList.of();
         }
@@ -165,6 +199,11 @@ public class RelationType
     /**
      * Creates a new tuple descriptor containing all fields from this tuple descriptor
      * and all fields from the specified tuple descriptor.
+     * <p>
+     * For cross-catalog joins the two relations may carry different nameKeyFunction values.
+     * The merged relation uses this relation's nameKeyFunction for fields coming from {@code this},
+     * and the other relation's nameKeyFunction for fields coming from {@code other}, by delegating
+     * field resolution back to each original relation via their stored functions.
      */
     public RelationType joinWith(RelationType other)
     {
@@ -173,7 +212,7 @@ public class RelationType
                 .addAll(other.allFields)
                 .build();
 
-        return new RelationType(fields);
+        return new RelationType(fields, this.nameKeyFunction);
     }
 
     /**
@@ -219,7 +258,7 @@ public class RelationType
             }
         }
 
-        return new RelationType(fieldsBuilder.build());
+        return new RelationType(fieldsBuilder.build(), this.nameKeyFunction);
     }
 
     /**
@@ -227,7 +266,7 @@ public class RelationType
      */
     public RelationType withOnlyVisibleFields()
     {
-        return new RelationType(visibleFields);
+        return new RelationType(visibleFields, this.nameKeyFunction);
     }
 
     @Override

--- a/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/SemanticExceptions.java
+++ b/presto-analyzer/src/main/java/com/facebook/presto/sql/analyzer/SemanticExceptions.java
@@ -18,6 +18,8 @@ import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.sql.tree.QualifiedName;
 
+import java.util.function.UnaryOperator;
+
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.AMBIGUOUS_ATTRIBUTE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_ATTRIBUTE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
@@ -34,6 +36,15 @@ public final class SemanticExceptions
                 node,
                 name.getPrefix().isPresent() ? "'%s' cannot be resolved" : "Column '%s' cannot be resolved",
                 name);
+    }
+
+    public static SemanticException missingAttributeException(Expression node, QualifiedName name, UnaryOperator<String> nameKeyFunction)
+    {
+        throw new SemanticException(
+                MISSING_ATTRIBUTE,
+                node,
+                name.getPrefix().isPresent() ? "'%s' cannot be resolved" : "Column '%s' cannot be resolved",
+                name.toString(nameKeyFunction));
     }
 
     public static SemanticException ambiguousAttributeException(Expression node, QualifiedName name)

--- a/presto-analyzer/src/test/java/com/facebook/presto/sql/analyzer/TestRelationType.java
+++ b/presto-analyzer/src/test/java/com/facebook/presto/sql/analyzer/TestRelationType.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -309,5 +310,126 @@ public class TestRelationType
         List<Field> result = relationType.resolveFields(QualifiedName.of("anything"));
         assertTrue(result.isEmpty());
         assertFalse(relationType.canResolve(QualifiedName.of("anything")));
+    }
+
+    @Test
+    public void testJoinWithSameCatalogCaseInsensitive()
+    {
+        // Both sides use the default (case-insensitive) function — single unified index.
+        Field left = Field.newQualified(NO_LOCATION, QualifiedName.of("a"), Optional.of("regionid"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field right = Field.newQualified(NO_LOCATION, QualifiedName.of("b"), Optional.of("name"), VARCHAR, false, Optional.empty(), Optional.empty(), false);
+
+        RelationType leftRel = new RelationType(ImmutableList.of(left));
+        RelationType rightRel = new RelationType(ImmutableList.of(right));
+        RelationType joined = leftRel.joinWith(rightRel);
+
+        // Both fields resolvable regardless of case
+        assertEquals(joined.resolveFields(QualifiedName.of("regionid")).size(), 1);
+        assertEquals(joined.resolveFields(QualifiedName.of("REGIONID")).size(), 1);
+        assertEquals(joined.resolveFields(QualifiedName.of("RegionId")).size(), 1);
+        assertEquals(joined.resolveFields(QualifiedName.of("name")).size(), 1);
+        assertEquals(joined.resolveFields(QualifiedName.of("NAME")).size(), 1);
+    }
+
+    @Test
+    public void testJoinWithSameCatalogCaseSensitive()
+    {
+        // Both sides use the identity (case-sensitive) function.
+        UnaryOperator<String> caseSensitive = UnaryOperator.identity();
+
+        Field left = Field.newQualified(NO_LOCATION, QualifiedName.of("a"), Optional.of("RegionId"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field right = Field.newQualified(NO_LOCATION, QualifiedName.of("b"), Optional.of("Name"), VARCHAR, false, Optional.empty(), Optional.empty(), false);
+
+        RelationType leftRel = new RelationType(ImmutableList.of(left), caseSensitive);
+        RelationType rightRel = new RelationType(ImmutableList.of(right), caseSensitive);
+        RelationType joined = leftRel.joinWith(rightRel);
+
+        // Exact case matches
+        assertEquals(joined.resolveFields(QualifiedName.of("RegionId")).size(), 1);
+        assertEquals(joined.resolveFields(QualifiedName.of("Name")).size(), 1);
+
+        // Wrong case — no match in case-sensitive mode
+        assertTrue(joined.resolveFields(QualifiedName.of("regionid")).isEmpty());
+        assertTrue(joined.resolveFields(QualifiedName.of("name")).isEmpty());
+        assertTrue(joined.resolveFields(QualifiedName.of("REGIONID")).isEmpty());
+    }
+
+    @Test
+    public void testJoinWithCrossCatalogCaseSensitiveLeftCaseInsensitiveRight()
+    {
+        // Left catalog: case-sensitive (identity normalizer)
+        // Right catalog: case-insensitive (toLowerCase normalizer)
+        UnaryOperator<String> caseSensitive = UnaryOperator.identity();
+        UnaryOperator<String> caseInsensitive = s -> s.toLowerCase(java.util.Locale.ENGLISH);
+
+        Field leftField = Field.newQualified(NO_LOCATION, QualifiedName.of("cs_tbl"), Optional.of("RegionId"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field rightField = Field.newQualified(NO_LOCATION, QualifiedName.of("ci_tbl"), Optional.of("name"), VARCHAR, false, Optional.empty(), Optional.empty(), false);
+
+        RelationType leftRel = new RelationType(ImmutableList.of(leftField), caseSensitive);
+        RelationType rightRel = new RelationType(ImmutableList.of(rightField), caseInsensitive);
+        RelationType joined = leftRel.joinWith(rightRel);
+
+        // Left field: exact-case "RegionId" → found only in left index (identity key "RegionId").
+        List<Field> exactMatch = joined.resolveFields(QualifiedName.of("RegionId"));
+        assertEquals(exactMatch.size(), 1);
+        assertSame(exactMatch.get(0), leftField);
+
+        assertTrue(joined.resolveFields(QualifiedName.of("regionid")).isEmpty());
+        assertTrue(joined.resolveFields(QualifiedName.of("REGIONID")).isEmpty());
+
+        // Right field: any case of "name" resolves via the right (case-insensitive) index.
+        List<Field> lowerMatch = joined.resolveFields(QualifiedName.of("name"));
+        assertEquals(lowerMatch.size(), 1);
+        assertSame(lowerMatch.get(0), rightField);
+
+        List<Field> upperMatch = joined.resolveFields(QualifiedName.of("NAME"));
+        assertEquals(upperMatch.size(), 1);
+        assertSame(upperMatch.get(0), rightField);
+
+        // "Name" (mixed) — left index (identity) key "Name" → no left field named "Name".
+        // Right index (toLowerCase) key "name" → matches rightField.
+        List<Field> mixedMatch = joined.resolveFields(QualifiedName.of("Name"));
+        assertEquals(mixedMatch.size(), 1);
+        assertSame(mixedMatch.get(0), rightField);
+    }
+
+    @Test
+    public void testJoinWithCrossCatalogAmbiguousResolution()
+    {
+        // When left and right have columns whose normalized forms collide, resolveFields
+        // returns both — the caller (StatementAnalyzer) is responsible for raising AMBIGUOUS_ATTRIBUTE.
+        UnaryOperator<String> caseSensitive = UnaryOperator.identity();
+        UnaryOperator<String> caseInsensitive = s -> s.toLowerCase(java.util.Locale.ENGLISH);
+
+        // Left: "RegionId" stored under key "RegionId" (identity).
+        // Right: "regionid" stored under key "regionid" (toLowerCase).
+        // Query "RegionId": left key = "RegionId" → hits left. Right key = "regionid" → hits right.
+        // Both are returned — this is the correct ambiguous-column behaviour.
+        Field leftField = Field.newQualified(NO_LOCATION, QualifiedName.of("cs_tbl"), Optional.of("RegionId"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field rightField = Field.newQualified(NO_LOCATION, QualifiedName.of("ci_tbl"), Optional.of("regionid"), VARCHAR, false, Optional.empty(), Optional.empty(), false);
+
+        RelationType leftRel = new RelationType(ImmutableList.of(leftField), caseSensitive);
+        RelationType rightRel = new RelationType(ImmutableList.of(rightField), caseInsensitive);
+        RelationType joined = leftRel.joinWith(rightRel);
+
+        // "RegionId": identity → "RegionId" hits left; toLowerCase → "regionid" hits right. Both returned.
+        List<Field> both = joined.resolveFields(QualifiedName.of("RegionId"));
+        assertEquals(both.size(), 2);
+        assertTrue(both.contains(leftField));
+        assertTrue(both.contains(rightField));
+
+        // "regionid": identity → "regionid" misses left (stored as "RegionId"); toLowerCase → "regionid" hits right.
+        List<Field> rightOnly = joined.resolveFields(QualifiedName.of("regionid"));
+        assertEquals(rightOnly.size(), 1);
+        assertSame(rightOnly.get(0), rightField);
+
+        // Table-qualified: exact alias resolves unambiguously.
+        List<Field> qualifiedLeft = joined.resolveFields(QualifiedName.of("cs_tbl", "RegionId"));
+        assertEquals(qualifiedLeft.size(), 1);
+        assertSame(qualifiedLeft.get(0), leftField);
+
+        List<Field> qualifiedRight = joined.resolveFields(QualifiedName.of("ci_tbl", "regionid"));
+        assertEquals(qualifiedRight.size(), 1);
+        assertSame(qualifiedRight.get(0), rightField);
     }
 }

--- a/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightIntegrationMixedCase.java
+++ b/presto-base-arrow-flight/src/test/java/com/facebook/plugin/arrow/TestArrowFlightIntegrationMixedCase.java
@@ -37,6 +37,7 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.createVarcharType;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
 import static com.facebook.presto.tests.QueryAssertions.assertContains;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 @Test
@@ -144,5 +145,35 @@ public class TestArrowFlightIntegrationMixedCase
                 .row(2, "MARY", "test", "kochi")
                 .build();
         assertTrue(actualRow.equals(expectedRow));
+    }
+
+    @Test
+    public void testColumnCaseSensitivityWithDuplicateColumns()
+    {
+        // Test SELECT * works with duplicate columns
+        MaterializedResult result = computeActual("SELECT * FROM arrow_mixed_catalog.tpch_mx.mxtest");
+        assertEquals(result.getRowCount(), 2);
+        // Test selecting specific columns with exact case
+        result = computeActual("SELECT NAME FROM arrow_mixed_catalog.tpch_mx.mxtest");
+        assertEquals(result.getRowCount(), 2);
+        result = computeActual("SELECT name FROM arrow_mixed_catalog.tpch_mx.mxtest");
+        assertEquals(result.getRowCount(), 2);
+        // Test WHERE clause with exact case
+        result = computeActual("SELECT * FROM arrow_mixed_catalog.tpch_mx.mxtest WHERE ID = 1");
+        assertEquals(result.getRowCount(), 1);
+        // Test selecting both NAME and name columns
+        result = computeActual("SELECT NAME, name FROM arrow_mixed_catalog.tpch_mx.mxtest");
+        assertEquals(result.getRowCount(), 2);
+    }
+
+    @Test
+    public void testColumnCaseSensitivityColumnNameError()
+    {
+        // Test WHERE clause with wrong case should fail
+        assertQueryFails("SELECT * FROM arrow_mixed_catalog.tpch_mx.mxtest WHERE address = 'kochi'",
+                ".*Column 'address' cannot be resolved.*");
+        // Test SELECT with wrong case should fail
+        assertQueryFails("SELECT id FROM arrow_mixed_catalog.tpch_mx.mxtest",
+                ".*Column 'id' cannot be resolved.*");
     }
 }

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntergrationMixedCase.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraIntergrationMixedCase.java
@@ -208,4 +208,58 @@ public class TestCassandraIntergrationMixedCase
             session.execute("DROP KEYSPACE keyspace_1");
         }
     }
+
+    @Test
+    public void testColumnCaseSensitivityWithDuplicateColumns()
+    {
+        Session testSession = testSessionBuilder()
+                .setCatalog("cassandra")
+                .setSchema(KEYSPACE)
+                .build();
+        try {
+            session.execute("CREATE TABLE " + KEYSPACE + ".case_sensitive_test (user_id int PRIMARY KEY, \"Age\" int, \"Name\" text, age int, city text)");
+            session.execute("INSERT INTO " + KEYSPACE + ".case_sensitive_test (user_id, \"Age\", \"Name\", age, city) VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertContainsEventually(() -> getQueryRunner().execute("SHOW TABLES FROM cassandra." + KEYSPACE),
+                    resultBuilder(getSession(), createUnboundedVarcharType())
+                            .row("case_sensitive_test")
+                            .build(), new Duration(1, MINUTES));
+            assertQuery(testSession, "SELECT * FROM cassandra." + KEYSPACE + ".case_sensitive_test",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertQuery(testSession, "SELECT \"Age\" FROM cassandra." + KEYSPACE + ".case_sensitive_test", "VALUES 39");
+            assertQuery(testSession, "SELECT age FROM cassandra." + KEYSPACE + ".case_sensitive_test", "VALUES 29");
+            assertQuery(testSession, "SELECT * FROM cassandra." + KEYSPACE + ".case_sensitive_test WHERE \"Age\" > 30",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertQuery(testSession, "SELECT * FROM cassandra." + KEYSPACE + ".case_sensitive_test WHERE age < 30",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertQuery(testSession, "SELECT \"Age\", age FROM cassandra." + KEYSPACE + ".case_sensitive_test",
+                    "VALUES (39, 29)");
+        }
+        finally {
+            session.execute("DROP TABLE IF EXISTS " + KEYSPACE + ".case_sensitive_test");
+        }
+    }
+
+    @Test
+    public void testColumnCaseSensitivityColumnNameError()
+    {
+        Session testSession = testSessionBuilder()
+                .setCatalog("cassandra")
+                .setSchema(KEYSPACE)
+                .build();
+        try {
+            session.execute("CREATE TABLE " + KEYSPACE + ".case_sensitive_error_test (user_id int PRIMARY KEY, \"Age\" int, \"Name\" text, age int, city text)");
+            session.execute("INSERT INTO " + KEYSPACE + ".case_sensitive_error_test (user_id, \"Age\", \"Name\", age, city) VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertContainsEventually(() -> getQueryRunner().execute("SHOW TABLES FROM cassandra." + KEYSPACE),
+                    resultBuilder(getSession(), createUnboundedVarcharType())
+                            .row("case_sensitive_error_test")
+                            .build(), new Duration(1, MINUTES));
+            assertQueryFails(testSession, "SELECT * FROM cassandra." + KEYSPACE + ".case_sensitive_error_test WHERE name = 'Alice'",
+                    ".*Column 'name' cannot be resolved.*");
+            assertQueryFails(testSession, "SELECT \"NAME\" FROM cassandra." + KEYSPACE + ".case_sensitive_error_test",
+                    ".*Column 'NAME' cannot be resolved.*");
+        }
+        finally {
+            session.execute("DROP TABLE IF EXISTS " + KEYSPACE + ".case_sensitive_error_test");
+        }
+    }
 }

--- a/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestClickhouseIntegrationMixedCase.java
+++ b/presto-clickhouse/src/test/java/com/facebook/presto/plugin/clickhouse/TestClickhouseIntegrationMixedCase.java
@@ -205,4 +205,49 @@ public class TestClickhouseIntegrationMixedCase
             getQueryRunner().execute(session, "DROP TABLE IF EXISTS \"Test_ÆØÅ\" ");
         }
     }
+
+    @Test
+    public void testColumnCaseSensitivityWithDuplicateColumns()
+    {
+        try {
+            getQueryRunner().execute(session, "CREATE TABLE case_sensitive_test (user_id int, Age int, Name VARCHAR(50), age int, city VARCHAR(50))");
+            getQueryRunner().execute(session, "INSERT INTO case_sensitive_test VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertTrue(getQueryRunner().tableExists(session, "case_sensitive_test"));
+            // Test SELECT * works with duplicate columns
+            assertQuery(session, "SELECT * FROM case_sensitive_test",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            // Test selecting specific columns with exact case
+            assertQuery(session, "SELECT Age FROM case_sensitive_test", "VALUES 39");
+            assertQuery(session, "SELECT age FROM case_sensitive_test", "VALUES 29");
+            // Test WHERE clause with exact case should work
+            assertQuery(session, "SELECT * FROM case_sensitive_test WHERE Age > 30",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertQuery(session, "SELECT * FROM case_sensitive_test WHERE age < 30",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            // Test selecting both Age and age columns
+            assertQuery(session, "SELECT Age, age FROM case_sensitive_test",
+                    "VALUES (39, 29)");
+        }
+        finally {
+            getQueryRunner().execute(session, "DROP TABLE IF EXISTS case_sensitive_test");
+        }
+    }
+
+    @Test
+    public void testColumnCaseSensitivityColumnNameError()
+    {
+        try {
+            getQueryRunner().execute(session, "CREATE TABLE case_sensitive_error_test (user_id int, Age int, Name VARCHAR(50), city VARCHAR(50))");
+            getQueryRunner().execute(session, "INSERT INTO case_sensitive_error_test VALUES (1, 39, 'Alice', 'Bangalore')");
+            // Test WHERE clause with wrong case should fail
+            assertQueryFails(session, "SELECT * FROM case_sensitive_error_test WHERE name = 'Alice'",
+                    ".*Column 'name' cannot be resolved.*");
+            // Test SELECT with wrong case should fail
+            assertQueryFails(session, "SELECT NAME FROM case_sensitive_error_test",
+                    ".*Column 'NAME' cannot be resolved.*");
+        }
+        finally {
+            getQueryRunner().execute(session, "DROP TABLE IF EXISTS case_sensitive_error_test");
+        }
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RowFieldName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RowFieldName.java
@@ -65,8 +65,7 @@ public class RowFieldName
 
         RowFieldName other = (RowFieldName) o;
 
-        return Objects.equals(this.name, other.name) &&
-                Objects.equals(this.delimited, other.delimited);
+        return Objects.equals(this.name, other.name);
     }
 
     @Override
@@ -81,6 +80,6 @@ public class RowFieldName
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, delimited);
+        return Objects.hash(name);
     }
 }

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchMixedCaseTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchMixedCaseTest.java
@@ -123,4 +123,52 @@ public class TestElasticsearchMixedCaseTest
                 .build();
         assertContains(actualRow, expectedRow);
     }
+
+    @Test
+    public void testColumnCaseSensitivityWithDuplicateColumns()
+            throws IOException
+    {
+        String indexName = "case_sensitive_test";
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("Age", 39)
+                .put("Name", "Alice")
+                .put("age", 29)
+                .put("city", "Bangalore")
+                .put("user_id", 1)
+                .build());
+        MaterializedResult result = computeActual("SELECT * FROM MySchema.case_sensitive_test");
+        assertEquals(result.getRowCount(), 1);
+        result = computeActual("SELECT Age FROM MySchema.case_sensitive_test");
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), 39L);
+        result = computeActual("SELECT age FROM MySchema.case_sensitive_test");
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), 29L);
+        result = computeActual("SELECT * FROM MySchema.case_sensitive_test WHERE Age > 30");
+        assertEquals(result.getRowCount(), 1);
+        result = computeActual("SELECT * FROM MySchema.case_sensitive_test WHERE age < 30");
+        assertEquals(result.getRowCount(), 1);
+        result = computeActual("SELECT Age, age FROM MySchema.case_sensitive_test");
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), 39L);
+        assertEquals(result.getMaterializedRows().get(0).getField(1), 29L);
+    }
+
+    @Test
+    public void testColumnCaseSensitivityColumnNameError()
+            throws IOException
+    {
+        String indexName = "case_sensitive_error_test";
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("Age", 39)
+                .put("Name", "Alice")
+                .put("age", 29)
+                .put("city", "Bangalore")
+                .put("user_id", 1)
+                .build());
+        assertQueryFails("SELECT * FROM MySchema.case_sensitive_error_test WHERE name = 'Alice'",
+                ".*Column 'name' cannot be resolved.*");
+        assertQueryFails("SELECT NAME FROM MySchema.case_sensitive_error_test",
+                ".*Column 'NAME' cannot be resolved.*");
+    }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergCommonModule.java
@@ -337,9 +337,9 @@ public class IcebergCommonModule
 
     @Singleton
     @Provides
-    public ParquetMetadataSource createParquetMetadataSource(ParquetCacheConfig parquetCacheConfig, MBeanExporter exporter)
+    public ParquetMetadataSource createParquetMetadataSource(IcebergConfig icebergConfig, ParquetCacheConfig parquetCacheConfig, MBeanExporter exporter)
     {
-        ParquetMetadataSource parquetMetadataSource = new MetadataReader();
+        ParquetMetadataSource parquetMetadataSource = new MetadataReader(icebergConfig.isCaseSensitiveNameMatching());
         if (parquetCacheConfig.isMetadataCacheEnabled()) {
             Cache<ParquetDataSourceId, ParquetFileMetadata> cache = CacheBuilder.newBuilder()
                     .maximumWeight(parquetCacheConfig.getMetadataCacheSize().toBytes())

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -21,6 +21,9 @@ import com.facebook.presto.hive.HiveCompressionCodec;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.inject.ConfigurationException;
+import com.google.inject.spi.Message;
+import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
@@ -85,6 +88,7 @@ public class IcebergConfig
     private int materializedViewDefaultMaxSnapshotsPerRefresh;
     private boolean aggregatePushDownEnabled = true;
     private DataSize targetMaxFileSize = succinctDataSize(1, GIGABYTE);
+    private boolean caseSensitiveNameMatching;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -593,5 +597,27 @@ public class IcebergConfig
         }
         this.targetMaxFileSize = targetMaxFileSize;
         return this;
+    }
+
+    public boolean isCaseSensitiveNameMatching()
+    {
+        return caseSensitiveNameMatching;
+    }
+
+    @Config("case-sensitive-name-matching")
+    @ConfigDescription("Enable case-sensitive identifier matching for the connector. Default: false (identifiers are lower-cased)")
+    public IcebergConfig setCaseSensitiveNameMatching(boolean caseSensitiveNameMatching)
+    {
+        this.caseSensitiveNameMatching = caseSensitiveNameMatching;
+        return this;
+    }
+
+    @PostConstruct
+    public void validateConfig()
+    {
+        if (caseSensitiveNameMatching && catalogType == HIVE) {
+            throw new ConfigurationException(ImmutableList.of(new Message(
+                    "'case-sensitive-name-matching=true' is not supported for iceberg.catalog.type=HIVE")));
+        }
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -94,6 +94,7 @@ import static com.google.common.base.Throwables.getRootCause;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -108,6 +109,7 @@ public class IcebergNativeMetadata
     private final Optional<String> warehouseDataDir;
     private final IcebergNativeCatalogFactory catalogFactory;
     private final CatalogType catalogType;
+    private final boolean caseSensitiveIdentifierMatching;
     private final ConcurrentMap<SchemaTableName, View> icebergViews = new ConcurrentHashMap<>();
 
     public IcebergNativeMetadata(
@@ -125,13 +127,15 @@ public class IcebergNativeMetadata
             StatisticsFileCache statisticsFileCache,
             IcebergTableProperties tableProperties,
             IsolationLevel isolationLevel,
-            boolean autoCommitContext)
+            boolean autoCommitContext,
+            boolean caseSensitiveNameMatching)
     {
         super(typeManager, procedureRegistry, functionResolution, rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec,
                 nodeVersion, filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext);
         this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
         this.catalogType = requireNonNull(catalogType, "catalogType is null");
         this.warehouseDataDir = Optional.ofNullable(catalogFactory.getCatalogWarehouseDataDir());
+        this.caseSensitiveIdentifierMatching = caseSensitiveNameMatching;
     }
 
     @Override
@@ -428,7 +432,7 @@ public class IcebergNativeMetadata
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
 
-        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()), id -> normalizeIdentifier(session, id));
         FileFormat fileFormat = tableProperties.getFileFormat(session, tableMetadata.getProperties());
 
         try {
@@ -456,7 +460,7 @@ public class IcebergNativeMetadata
 
         Table icebergTable = getIcebergTable(session, schemaTableName);
         ReplaceSortOrder replaceSortOrder = icebergTable.replaceSortOrder();
-        SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
+        SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()), id -> normalizeIdentifier(session, id));
         List<SortField> sortFields = getSupportedSortFields(icebergTable.schema(), sortOrder);
         for (SortField sortField : sortFields) {
             if (sortField.getSortOrder().isAscending()) {
@@ -599,5 +603,11 @@ public class IcebergNativeMetadata
         viewBuilder.createOrReplace();
 
         icebergViews.remove(viewName);
+    }
+
+    @Override
+    public String normalizeIdentifier(ConnectorSession session, String identifier)
+    {
+        return caseSensitiveIdentifierMatching ? identifier : identifier.toLowerCase(ENGLISH);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadataFactory.java
@@ -48,6 +48,7 @@ public class IcebergNativeMetadataFactory
     final FilterStatsCalculatorService filterStatsCalculatorService;
     final StatisticsFileCache statisticsFileCache;
     final IcebergTableProperties tableProperties;
+    final boolean caseSensitiveNameMatching;
 
     @Inject
     public IcebergNativeMetadataFactory(
@@ -78,6 +79,7 @@ public class IcebergNativeMetadataFactory
         this.filterStatsCalculatorService = requireNonNull(filterStatsCalculatorService, "filterStatsCalculatorService is null");
         this.statisticsFileCache = requireNonNull(statisticsFileCache, "statisticsFileCache is null");
         this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
+        this.caseSensitiveNameMatching = config.isCaseSensitiveNameMatching();
     }
 
     public IcebergTransactionMetadata create()
@@ -89,6 +91,7 @@ public class IcebergNativeMetadataFactory
     {
         return new IcebergNativeMetadata(catalogFactory, typeManager, procedureRegistry, functionResolution,
                 rowExpressionService, commitTaskCodec, columnMappingsCodec, schemaTableNamesCodec, catalogType, nodeVersion,
-                filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext);
+                filterStatsCalculatorService, statisticsFileCache, tableProperties, isolationLevel, autoCommitContext,
+                caseSensitiveNameMatching);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -216,6 +216,7 @@ public class IcebergPageSourceProvider
     private final PageIndexerFactory pageIndexerFactory;
     private final int maxOpenPartitions;
     private final SortParameters sortParameters;
+    private final boolean caseSensitiveNameMatching;
 
     @Inject
     public IcebergPageSourceProvider(
@@ -246,6 +247,7 @@ public class IcebergPageSourceProvider
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         requireNonNull(icebergConfig, "icebergConfig is null");
         this.maxOpenPartitions = icebergConfig.getMaxPartitionsPerWriter();
+        this.caseSensitiveNameMatching = icebergConfig.isCaseSensitiveNameMatching();
         this.sortParameters = requireNonNull(sortParameters, "sortParameters is null");
     }
 
@@ -503,7 +505,8 @@ public class IcebergPageSourceProvider
             StripeMetadataSourceFactory stripeMetadataSourceFactory,
             FileFormatDataSourceStats stats,
             Optional<EncryptionInformation> encryptionInformation,
-            DwrfEncryptionProvider dwrfEncryptionProvider)
+            DwrfEncryptionProvider dwrfEncryptionProvider,
+            boolean caseSensitiveNameMatching)
     {
         OrcDataSource orcDataSource = null;
         try {
@@ -560,7 +563,9 @@ public class IcebergPageSourceProvider
                             orcColumn -> Integer.parseInt(orcColumn.getAttributes().get(ORC_ICEBERG_ID_KEY)),
                             orcColumn -> IcebergOrcColumn.copy(orcColumn).setIcebergColumnId(Optional.of(Integer.parseInt(orcColumn.getAttributes().get(ORC_ICEBERG_ID_KEY))))));
 
-            Map<String, IcebergOrcColumn> fileOrcColumnsByName = uniqueIndex(fileOrcColumns, orcColumn -> orcColumn.getColumnName().toLowerCase(ENGLISH));
+            Map<String, IcebergOrcColumn> fileOrcColumnsByName = caseSensitiveNameMatching
+                    ? uniqueIndex(fileOrcColumns, IcebergOrcColumn::getColumnName)
+                    : uniqueIndex(fileOrcColumns, orcColumn -> orcColumn.getColumnName().toLowerCase(ENGLISH));
 
             int nextMissingColumnIndex = fileOrcColumnsByName.size();
             OptionalInt rowPositionColumnIndex = OptionalInt.empty();
@@ -1167,7 +1172,8 @@ public class IcebergPageSourceProvider
                         stripeMetadataSourceFactory,
                         fileFormatDataSourceStats,
                         Optional.empty(),
-                        dwrfEncryptionProvider);
+                        dwrfEncryptionProvider,
+                        caseSensitiveNameMatching);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -1147,6 +1147,7 @@ public class IcebergPageSourceProvider
                         .withTinyStripeThreshold(getOrcTinyStripeThreshold(session))
                         .withMaxBlockSize(getOrcMaxReadBlockSize(session))
                         .withZstdJniDecompressionEnabled(isOrcZstdJniDecompressionEnabled(session))
+                        .withCaseSensitiveNameMatching(caseSensitiveNameMatching)
                         .build();
 
                 // TODO: Implement EncryptionInformation in IcebergSplit instead of Optional.empty()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -138,7 +138,7 @@ public class IcebergTableProperties
                         ImmutableList.of(),
                         false,
                         value -> ((Collection<?>) value).stream()
-                                .map(name -> ((String) name).toLowerCase(ENGLISH))
+                                .map(name -> (String) name)
                                 .collect(toImmutableList()),
                         value -> value))
                 .add(stringProperty(
@@ -260,7 +260,7 @@ public class IcebergTableProperties
                         ImmutableList.of(),
                         false,
                         value -> ((Collection<?>) value).stream()
-                                .map(name -> ((String) name).toLowerCase(ENGLISH))
+                                .map(name -> (String) name)
                                 .collect(toImmutableList()),
                         value -> value)
                         .withAdditionalTypeHandler(VARCHAR, ImmutableList::of));

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionFields.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -42,23 +43,26 @@ import static org.apache.iceberg.expressions.Expressions.year;
 
 public final class PartitionFields
 {
-    private static final String NAME = "[a-z_][a-z0-9_]*";
-    private static final String FUNCTION_NAME = "\\((" + NAME + ")\\)";
-    private static final String FUNCTION_NAME_INT = "\\((" + NAME + "), *(\\d+)\\)";
-
+    // Column identifier: unquoted (any case) or double-quoted (e.g. "MyCol")
     private static final String UNQUOTED_IDENTIFIER = "[a-zA-Z_][a-zA-Z0-9_]*";
     private static final String QUOTED_IDENTIFIER = "\"(?:\"\"|[^\"])*\"";
+    // IDENTIFIER is a single capture group matching either form; used by both partition and sort parsing
     public static final String IDENTIFIER = "(" + UNQUOTED_IDENTIFIER + "|" + QUOTED_IDENTIFIER + ")";
     private static final Pattern UNQUOTED_IDENTIFIER_PATTERN = Pattern.compile(UNQUOTED_IDENTIFIER);
     private static final Pattern QUOTED_IDENTIFIER_PATTERN = Pattern.compile(QUOTED_IDENTIFIER);
 
-    private static final Pattern IDENTITY_PATTERN = Pattern.compile(NAME);
-    private static final Pattern YEAR_PATTERN = Pattern.compile("year" + FUNCTION_NAME);
-    private static final Pattern MONTH_PATTERN = Pattern.compile("month" + FUNCTION_NAME);
-    private static final Pattern DAY_PATTERN = Pattern.compile("day" + FUNCTION_NAME);
-    private static final Pattern HOUR_PATTERN = Pattern.compile("hour" + FUNCTION_NAME);
-    private static final Pattern BUCKET_PATTERN = Pattern.compile("bucket" + FUNCTION_NAME_INT);
-    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate" + FUNCTION_NAME_INT);
+    // Transform function patterns: case-insensitive keyword + IDENTIFIER column argument
+    private static final String FUNCTION_NAME = "\\(" + IDENTIFIER + "\\)";
+    private static final String FUNCTION_NAME_INT = "\\(" + IDENTIFIER + ", *(\\d+)\\)";
+
+    // Identity: bare or double-quoted column name; transforms: case-insensitive keyword + column
+    private static final Pattern IDENTITY_PATTERN = Pattern.compile(IDENTIFIER);
+    private static final Pattern YEAR_PATTERN = Pattern.compile("(?i:year)" + FUNCTION_NAME);
+    private static final Pattern MONTH_PATTERN = Pattern.compile("(?i:month)" + FUNCTION_NAME);
+    private static final Pattern DAY_PATTERN = Pattern.compile("(?i:day)" + FUNCTION_NAME);
+    private static final Pattern HOUR_PATTERN = Pattern.compile("(?i:hour)" + FUNCTION_NAME);
+    private static final Pattern BUCKET_PATTERN = Pattern.compile("(?i:bucket)" + FUNCTION_NAME_INT);
+    private static final Pattern TRUNCATE_PATTERN = Pattern.compile("(?i:truncate)" + FUNCTION_NAME_INT);
 
     private static final Pattern COLUMN_BUCKET_PATTERN = Pattern.compile("bucket\\((\\d+)\\)");
     private static final Pattern COLUMN_TRUNCATE_PATTERN = Pattern.compile("truncate\\((\\d+)\\)");
@@ -69,17 +73,27 @@ public final class PartitionFields
 
     public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields)
     {
-        return parsePartitionFields(schema, fields, null);
+        return parsePartitionFields(schema, fields, null, s -> s.toLowerCase(ENGLISH));
+    }
+
+    public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields, UnaryOperator<String> identifierNormalizer)
+    {
+        return parsePartitionFields(schema, fields, null, identifierNormalizer);
     }
 
     public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields, @Nullable Integer specId)
+    {
+        return parsePartitionFields(schema, fields, specId, s -> s.toLowerCase(ENGLISH));
+    }
+
+    public static PartitionSpec parsePartitionFields(Schema schema, List<String> fields, @Nullable Integer specId, UnaryOperator<String> identifierNormalizer)
     {
         PartitionSpec.Builder builder = Optional.ofNullable(specId)
                 .map(id -> PartitionSpec.builderFor(schema).withSpecId(id))
                 .orElseGet(() -> PartitionSpec.builderFor(schema));
 
         for (String field : fields) {
-            buildPartitionField(builder, field);
+            buildPartitionField(builder, field, identifierNormalizer);
         }
         return builder.build();
     }
@@ -99,15 +113,23 @@ public final class PartitionFields
     @VisibleForTesting
     static void buildPartitionField(PartitionSpec.Builder builder, String field)
     {
+        buildPartitionField(builder, field, s -> s.toLowerCase(ENGLISH));
+    }
+
+    @VisibleForTesting
+    static void buildPartitionField(PartitionSpec.Builder builder, String field, UnaryOperator<String> identifierNormalizer)
+    {
+        // group(1) is the column token which may be a double-quoted identifier like "MyCol";
+        // fromIdentifierToColumn strips the quotes and applies identifierNormalizer to the bare name.
         @SuppressWarnings("PointlessBooleanExpression")
         boolean matched = false ||
-                tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(match.group())) ||
-                tryMatch(field, YEAR_PATTERN, match -> builder.year(match.group(1))) ||
-                tryMatch(field, MONTH_PATTERN, match -> builder.month(match.group(1))) ||
-                tryMatch(field, DAY_PATTERN, match -> builder.day(match.group(1))) ||
-                tryMatch(field, HOUR_PATTERN, match -> builder.hour(match.group(1))) ||
-                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(match.group(1), parseInt(match.group(2)))) ||
-                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(match.group(1), parseInt(match.group(2))));
+                tryMatch(field, IDENTITY_PATTERN, match -> builder.identity(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, YEAR_PATTERN, match -> builder.year(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, MONTH_PATTERN, match -> builder.month(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, DAY_PATTERN, match -> builder.day(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, HOUR_PATTERN, match -> builder.hour(fromIdentifierToColumn(match.group(1), identifierNormalizer))) ||
+                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(fromIdentifierToColumn(match.group(1), identifierNormalizer), parseInt(match.group(2)))) ||
+                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(fromIdentifierToColumn(match.group(1), identifierNormalizer), parseInt(match.group(2))));
         if (!matched) {
             throw new IllegalArgumentException("Invalid partition field declaration: " + field);
         }
@@ -287,9 +309,14 @@ public final class PartitionFields
 
     public static String fromIdentifierToColumn(String identifier)
     {
+        return fromIdentifierToColumn(identifier, s -> s.toLowerCase(ENGLISH));
+    }
+
+    public static String fromIdentifierToColumn(String identifier, UnaryOperator<String> identifierNormalizer)
+    {
         if (QUOTED_IDENTIFIER_PATTERN.matcher(identifier).matches()) {
-            return identifier.substring(1, identifier.length() - 1).replace("\"\"", "\"").toLowerCase(ENGLISH);
+            return identifierNormalizer.apply(identifier.substring(1, identifier.length() - 1).replace("\"\"", "\""));
         }
-        return identifier.toLowerCase(ENGLISH);
+        return identifierNormalizer.apply(identifier);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SortFieldUtils.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/SortFieldUtils.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.types.Types;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,8 +51,13 @@ public class SortFieldUtils
 
     public static SortOrder parseSortFields(Schema schema, List<String> fields)
     {
+        return parseSortFields(schema, fields, s -> s.toLowerCase(Locale.ENGLISH));
+    }
+
+    public static SortOrder parseSortFields(Schema schema, List<String> fields, UnaryOperator<String> identifierNormalizer)
+    {
         SortOrder.Builder builder = SortOrder.builderFor(schema);
-        parseSortFields(builder, fields);
+        parseSortFields(builder, fields, identifierNormalizer);
         SortOrder sortOrder;
         try {
             sortOrder = builder.build();
@@ -74,17 +80,27 @@ public class SortFieldUtils
 
     public static void parseSortFields(SortOrderBuilder<?> sortOrderBuilder, List<String> fields)
     {
-        fields.forEach(field -> parseSortField(sortOrderBuilder, field));
+        parseSortFields(sortOrderBuilder, fields, s -> s.toLowerCase(Locale.ENGLISH));
+    }
+
+    public static void parseSortFields(SortOrderBuilder<?> sortOrderBuilder, List<String> fields, UnaryOperator<String> identifierNormalizer)
+    {
+        fields.forEach(field -> parseSortField(sortOrderBuilder, field, identifierNormalizer));
     }
 
     private static void parseSortField(SortOrderBuilder<?> builder, String field)
+    {
+        parseSortField(builder, field, s -> s.toLowerCase(Locale.ENGLISH));
+    }
+
+    private static void parseSortField(SortOrderBuilder<?> builder, String field, UnaryOperator<String> identifierNormalizer)
     {
         Matcher matcher = PATTERN.matcher(field);
         if (!matcher.matches()) {
             throw new IllegalArgumentException(format("Unable to parse sort field: [%s]", field));
         }
 
-        String columnName = fromIdentifierToColumn(matcher.group("identifier"));
+        String columnName = fromIdentifierToColumn(matcher.group("identifier"), identifierNormalizer);
         boolean ascending;
         String ordering = firstNonNull(matcher.group("ordering"), "ASC").toUpperCase(Locale.ENGLISH);
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -180,7 +180,8 @@ public class RewriteDataFilesProcedure
                             "Use either zorder function alone or regular column names, but not both.");
                 }
 
-                SortOrder specifiedSortOrder = parseSortFields(icebergTable.schema(), nonZOrderFields);
+                SortOrder specifiedSortOrder = parseSortFields(icebergTable.schema(), nonZOrderFields,
+                        id -> procedureContext.getMetadata().normalizeIdentifier(session, id));
                 if (specifiedSortOrder.satisfies(sortOrder)) {
                     // If the specified sort order satisfies the target table's internal sort order, use the specified sort order
                     sortOrder = specifiedSortOrder;

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.ConfigurationException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.testng.annotations.Test;
 
@@ -40,6 +41,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX_DEFAULT;
 import static org.apache.iceberg.TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergConfig
 {
@@ -82,7 +84,8 @@ public class TestIcebergConfig
                 .setMaterializedViewMaxChangedPartitions(100)
                 .setMaterializedViewDefaultMaxSnapshotsPerRefresh(0)
                 .setAggregatePushDownEnabled(true)
-                .setTargetMaxFileSize(succinctDataSize(1, GIGABYTE)));
+                .setTargetMaxFileSize(succinctDataSize(1, GIGABYTE))
+                .setCaseSensitiveNameMatching(false));
     }
 
     @Test
@@ -125,6 +128,7 @@ public class TestIcebergConfig
                 .put("iceberg.materialized-view-default-max-snapshots-per-refresh", "10")
                 .put("iceberg.aggregate-push-down-enabled", "false")
                 .put("iceberg.target-max-file-size", "512MB")
+                .put("case-sensitive-name-matching", "true")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -163,8 +167,23 @@ public class TestIcebergConfig
                 .setMaterializedViewMaxChangedPartitions(2000)
                 .setMaterializedViewDefaultMaxSnapshotsPerRefresh(10)
                 .setAggregatePushDownEnabled(false)
-                .setTargetMaxFileSize(succinctDataSize(512, MEGABYTE));
+                .setTargetMaxFileSize(succinctDataSize(512, MEGABYTE))
+                .setCaseSensitiveNameMatching(true);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testCaseSensitiveNameMatchingNotSupportedForHiveCatalog()
+    {
+        // case-sensitive-name-matching=true must not throw for REST, HADOOP, or NESSIE catalog types.
+        assertThatThrownBy(() ->
+                new IcebergConfig()
+                        .setCatalogType(HIVE)
+                        .setCaseSensitiveNameMatching(true)
+                        .validateConfig())
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("case-sensitive-name-matching=true")
+                .hasMessageContaining("iceberg.catalog.type=HIVE");
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestNameMatchingTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestNameMatchingTestBase.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.presto.Session;
+import com.facebook.presto.hive.NodeVersion;
+import com.facebook.presto.hive.azure.HiveAzureConfig;
+import com.facebook.presto.hive.azure.HiveAzureConfigurationInitializer;
+import com.facebook.presto.hive.gcs.HiveGcsConfig;
+import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
+import com.facebook.presto.hive.s3.HiveS3Config;
+import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
+import com.facebook.presto.iceberg.IcebergCatalogName;
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Table;
+import org.assertj.core.util.Files;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.SESSION;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.getRestServer;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public abstract class IcebergRestNameMatchingTestBase
+        extends AbstractTestQueryFramework
+{
+    protected static final String SCHEMA = "tpch";
+
+    protected TestingHttpServer restServer;
+    protected String serverUri;
+    protected File warehouseLocation;
+
+    @BeforeClass
+    public void init()
+            throws Exception
+    {
+        warehouseLocation = Files.newTemporaryFolder();
+        restServer = getRestServer(warehouseLocation.getAbsolutePath());
+        restServer.start();
+        serverUri = restServer.getBaseUrl().toString();
+        super.init();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        if (restServer != null) {
+            restServer.stop();
+        }
+        if (warehouseLocation != null) {
+            deleteRecursively(warehouseLocation.toPath(), ALLOW_INSECURE);
+        }
+    }
+
+    protected Session testSession()
+    {
+        return testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema(SCHEMA)
+                .build();
+    }
+
+    /**
+     * Builds the {@link IcebergNativeCatalogFactory} for direct Iceberg metadata access.
+     * Subclasses set {@code setCaseSensitiveNameMatching} as appropriate.
+     */
+    protected abstract IcebergNativeCatalogFactory getCatalogFactory();
+
+    /**
+     * Returns the raw Iceberg {@link Table} from the REST catalog, bypassing Presto's
+     * serialisation layer — allows direct inspection of PartitionSpec, Schema, etc.
+     */
+    protected Table getIcebergTable(String schema, String tableName)
+    {
+        return getNativeIcebergTable(getCatalogFactory(), SESSION, SchemaTableName.valueOf(schema + "." + tableName));
+    }
+
+    @Test
+    public void testShowSchemas()
+    {
+        assertQuerySucceeds(testSession(), "SHOW SCHEMAS");
+        assertQuery(testSession(), "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'tpch'", "VALUES 'tpch'");
+    }
+
+    /**
+     * Double-quotes allow special characters (hyphens, spaces) and reserved keywords in identifiers.
+     * These names are stored as-is in case-sensitive mode and lowercased in case-insensitive mode.
+     * Since the names used here are already lowercase, the result is identical in both modes.
+     */
+    @Test
+    public void testSpecialCharacterIdentifiersViaDoubleQuotes()
+    {
+        // Columns with hyphen, space, and reserved keyword — all require double-quotes.
+        assertQuerySucceeds(testSession(), "CREATE TABLE specialcharcols (\"first-name\" varchar, \"last name\" varchar, \"order\" bigint)");
+        assertQuerySucceeds(testSession(), "INSERT INTO specialcharcols VALUES ('Alice', 'Smith', 1)");
+        assertQuery(testSession(), "SELECT \"first-name\", \"last name\", \"order\" FROM specialcharcols", "VALUES ('Alice', 'Smith', 1)");
+
+        String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM specialcharcols").toString();
+        assertTrue(result.contains("first-name"), "Expected 'first-name' in SHOW COLUMNS output");
+        assertTrue(result.contains("last name"), "Expected 'last name' in SHOW COLUMNS output");
+        assertTrue(result.contains("order"), "Expected 'order' in SHOW COLUMNS output");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE specialcharcols");
+
+        // Partition column with hyphen — must embed double-quotes in the raw array string.
+        assertQuerySucceeds(testSession(), "CREATE TABLE specialcharpart (\"region-id\" bigint, name varchar) WITH (partitioning = ARRAY['\"region-id\"'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO specialcharpart VALUES (10, 'north'), (20, 'south')");
+        assertQuery(testSession(), "SELECT \"region-id\", name FROM specialcharpart ORDER BY \"region-id\"", "VALUES (10, 'north'), (20, 'south')");
+        assertQuerySucceeds(testSession(), "DROP TABLE specialcharpart");
+
+        // Reserved keyword 'year' as a partition column — quoting required in the array string
+        // so the parser doesn't confuse it with the year() transform function.
+        assertQuerySucceeds(testSession(), "CREATE TABLE keywordpart (\"year\" bigint, name varchar) WITH (partitioning = ARRAY['\"year\"'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO keywordpart VALUES (2024, 'a'), (2025, 'b')");
+        assertQuery(testSession(), "SELECT \"year\", name FROM keywordpart ORDER BY \"year\"", "VALUES (2024, 'a'), (2025, 'b')");
+        assertQuerySucceeds(testSession(), "DROP TABLE keywordpart");
+    }
+
+    /**
+     * Partition transform keywords (year, month, bucket, truncate …) are accepted in any case
+     * because PartitionFields uses {@code (?i:year)} patterns. The Iceberg library always stores
+     * transforms in lowercase ({@code field.transform().toString()} is hardcoded in the Iceberg
+     * spec), so SHOW CREATE TABLE and the raw metadata both show lowercase regardless of input.
+     */
+    @Test
+    public void testPartitionTransformKeywordCaseInsensitive()
+    {
+        // Uppercase transform keywords accepted
+        assertQuerySucceeds(testSession(), "CREATE TABLE transformcase (ts timestamp, id bigint, val varchar) WITH (partitioning = ARRAY['YEAR(ts)', 'BUCKET(id, 4)'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO transformcase VALUES (TIMESTAMP '2024-03-15 10:00:00', 1, 'a')");
+        assertQuerySucceeds(testSession(), "SELECT val FROM transformcase");
+
+        // 1. SHOW CREATE TABLE serialises transforms in lowercase
+        String showCreate = getQueryRunner().execute(testSession(), "SHOW CREATE TABLE transformcase").toString();
+        assertTrue(showCreate.contains("year(ts)"), "Expected lowercase 'year(ts)' in SHOW CREATE TABLE output, got: " + showCreate);
+        assertTrue(showCreate.contains("bucket(id, 4)"), "Expected lowercase 'bucket(id, 4)' in SHOW CREATE TABLE output, got: " + showCreate);
+
+        // 2. Raw Iceberg catalog metadata also stores transforms in lowercase
+        List<PartitionField> fields = getIcebergTable(SCHEMA, "transformcase").spec().fields();
+        assertEquals(fields.size(), 2);
+        assertEquals(fields.get(0).transform().toString(), "year", "Iceberg must store transform as lowercase 'year'");
+        assertEquals(fields.get(1).transform().toString(), "bucket[4]", "Iceberg must store transform as lowercase 'bucket[4]'");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE transformcase");
+
+        // Mixed-case transform keywords accepted
+        assertQuerySucceeds(testSession(), "CREATE TABLE transformcasemixed (ts timestamp, val varchar) WITH (partitioning = ARRAY['Month(ts)', 'Truncate(val, 8)'])");
+
+        String showCreate2 = getQueryRunner().execute(testSession(), "SHOW CREATE TABLE transformcasemixed").toString();
+        assertTrue(showCreate2.contains("month(ts)"), "Expected lowercase 'month(ts)' in SHOW CREATE TABLE output, got: " + showCreate2);
+        assertTrue(showCreate2.contains("truncate(val, 8)"), "Expected lowercase 'truncate(val, 8)' in SHOW CREATE TABLE output, got: " + showCreate2);
+
+        List<PartitionField> fields2 = getIcebergTable(SCHEMA, "transformcasemixed").spec().fields();
+        assertEquals(fields2.size(), 2);
+        assertEquals(fields2.get(0).transform().toString(), "month", "Iceberg must store transform as lowercase 'month'");
+        assertEquals(fields2.get(1).transform().toString(), "truncate[8]", "Iceberg must store transform as lowercase 'truncate[8]'");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE transformcasemixed");
+    }
+
+    protected IcebergNativeCatalogFactory buildCatalogFactory(IcebergConfig icebergConfig)
+    {
+        return new IcebergRestCatalogFactory(
+                icebergConfig,
+                new IcebergRestConfig().setServerUri(serverUri),
+                new IcebergCatalogName(ICEBERG_CATALOG),
+                new PrestoS3ConfigurationUpdater(new HiveS3Config()),
+                new HiveGcsConfigurationInitializer(new HiveGcsConfig()),
+                new HiveAzureConfigurationInitializer(new HiveAzureConfig()),
+                new NodeVersion("test_version"));
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestNameMatchingTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestNameMatchingTestBase.java
@@ -118,29 +118,40 @@ public abstract class IcebergRestNameMatchingTestBase
     public void testSpecialCharacterIdentifiersViaDoubleQuotes()
     {
         // Columns with hyphen, space, and reserved keyword — all require double-quotes.
-        assertQuerySucceeds(testSession(), "CREATE TABLE specialcharcols (\"first-name\" varchar, \"last name\" varchar, \"order\" bigint)");
-        assertQuerySucceeds(testSession(), "INSERT INTO specialcharcols VALUES ('Alice', 'Smith', 1)");
-        assertQuery(testSession(), "SELECT \"first-name\", \"last name\", \"order\" FROM specialcharcols", "VALUES ('Alice', 'Smith', 1)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE specialcharcols (\"first-name\" varchar, \"last name\" varchar, \"order\" bigint)");
+            assertQuerySucceeds(testSession(), "INSERT INTO specialcharcols VALUES ('Alice', 'Smith', 1)");
+            assertQuery(testSession(), "SELECT \"first-name\", \"last name\", \"order\" FROM specialcharcols", "VALUES ('Alice', 'Smith', 1)");
 
-        String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM specialcharcols").toString();
-        assertTrue(result.contains("first-name"), "Expected 'first-name' in SHOW COLUMNS output");
-        assertTrue(result.contains("last name"), "Expected 'last name' in SHOW COLUMNS output");
-        assertTrue(result.contains("order"), "Expected 'order' in SHOW COLUMNS output");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE specialcharcols");
+            String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM specialcharcols").toString();
+            assertTrue(result.contains("first-name"), "Expected 'first-name' in SHOW COLUMNS output");
+            assertTrue(result.contains("last name"), "Expected 'last name' in SHOW COLUMNS output");
+            assertTrue(result.contains("order"), "Expected 'order' in SHOW COLUMNS output");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS specialcharcols");
+        }
 
         // Partition column with hyphen — must embed double-quotes in the raw array string.
-        assertQuerySucceeds(testSession(), "CREATE TABLE specialcharpart (\"region-id\" bigint, name varchar) WITH (partitioning = ARRAY['\"region-id\"'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO specialcharpart VALUES (10, 'north'), (20, 'south')");
-        assertQuery(testSession(), "SELECT \"region-id\", name FROM specialcharpart ORDER BY \"region-id\"", "VALUES (10, 'north'), (20, 'south')");
-        assertQuerySucceeds(testSession(), "DROP TABLE specialcharpart");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE specialcharpart (\"region-id\" bigint, name varchar) WITH (partitioning = ARRAY['\"region-id\"'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO specialcharpart VALUES (10, 'north'), (20, 'south')");
+            assertQuery(testSession(), "SELECT \"region-id\", name FROM specialcharpart ORDER BY \"region-id\"", "VALUES (10, 'north'), (20, 'south')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS specialcharpart");
+        }
 
         // Reserved keyword 'year' as a partition column — quoting required in the array string
         // so the parser doesn't confuse it with the year() transform function.
-        assertQuerySucceeds(testSession(), "CREATE TABLE keywordpart (\"year\" bigint, name varchar) WITH (partitioning = ARRAY['\"year\"'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO keywordpart VALUES (2024, 'a'), (2025, 'b')");
-        assertQuery(testSession(), "SELECT \"year\", name FROM keywordpart ORDER BY \"year\"", "VALUES (2024, 'a'), (2025, 'b')");
-        assertQuerySucceeds(testSession(), "DROP TABLE keywordpart");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE keywordpart (\"year\" bigint, name varchar) WITH (partitioning = ARRAY['\"year\"'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO keywordpart VALUES (2024, 'a'), (2025, 'b')");
+            assertQuery(testSession(), "SELECT \"year\", name FROM keywordpart ORDER BY \"year\"", "VALUES (2024, 'a'), (2025, 'b')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS keywordpart");
+        }
     }
 
     /**
@@ -153,36 +164,42 @@ public abstract class IcebergRestNameMatchingTestBase
     public void testPartitionTransformKeywordCaseInsensitive()
     {
         // Uppercase transform keywords accepted
-        assertQuerySucceeds(testSession(), "CREATE TABLE transformcase (ts timestamp, id bigint, val varchar) WITH (partitioning = ARRAY['YEAR(ts)', 'BUCKET(id, 4)'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO transformcase VALUES (TIMESTAMP '2024-03-15 10:00:00', 1, 'a')");
-        assertQuerySucceeds(testSession(), "SELECT val FROM transformcase");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE transformcase (ts timestamp, id bigint, val varchar) WITH (partitioning = ARRAY['YEAR(ts)', 'BUCKET(id, 4)'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO transformcase VALUES (TIMESTAMP '2024-03-15 10:00:00', 1, 'a')");
+            assertQuerySucceeds(testSession(), "SELECT val FROM transformcase");
 
-        // 1. SHOW CREATE TABLE serialises transforms in lowercase
-        String showCreate = getQueryRunner().execute(testSession(), "SHOW CREATE TABLE transformcase").toString();
-        assertTrue(showCreate.contains("year(ts)"), "Expected lowercase 'year(ts)' in SHOW CREATE TABLE output, got: " + showCreate);
-        assertTrue(showCreate.contains("bucket(id, 4)"), "Expected lowercase 'bucket(id, 4)' in SHOW CREATE TABLE output, got: " + showCreate);
+            // 1. SHOW CREATE TABLE serialises transforms in lowercase
+            String showCreate = getQueryRunner().execute(testSession(), "SHOW CREATE TABLE transformcase").toString();
+            assertTrue(showCreate.contains("year(ts)"), "Expected lowercase 'year(ts)' in SHOW CREATE TABLE output, got: " + showCreate);
+            assertTrue(showCreate.contains("bucket(id, 4)"), "Expected lowercase 'bucket(id, 4)' in SHOW CREATE TABLE output, got: " + showCreate);
 
-        // 2. Raw Iceberg catalog metadata also stores transforms in lowercase
-        List<PartitionField> fields = getIcebergTable(SCHEMA, "transformcase").spec().fields();
-        assertEquals(fields.size(), 2);
-        assertEquals(fields.get(0).transform().toString(), "year", "Iceberg must store transform as lowercase 'year'");
-        assertEquals(fields.get(1).transform().toString(), "bucket[4]", "Iceberg must store transform as lowercase 'bucket[4]'");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE transformcase");
+            // 2. Raw Iceberg catalog metadata also stores transforms in lowercase
+            List<PartitionField> fields = getIcebergTable(SCHEMA, "transformcase").spec().fields();
+            assertEquals(fields.size(), 2);
+            assertEquals(fields.get(0).transform().toString(), "year", "Iceberg must store transform as lowercase 'year'");
+            assertEquals(fields.get(1).transform().toString(), "bucket[4]", "Iceberg must store transform as lowercase 'bucket[4]'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS transformcase");
+        }
 
         // Mixed-case transform keywords accepted
-        assertQuerySucceeds(testSession(), "CREATE TABLE transformcasemixed (ts timestamp, val varchar) WITH (partitioning = ARRAY['Month(ts)', 'Truncate(val, 8)'])");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE transformcasemixed (ts timestamp, val varchar) WITH (partitioning = ARRAY['Month(ts)', 'Truncate(val, 8)'])");
 
-        String showCreate2 = getQueryRunner().execute(testSession(), "SHOW CREATE TABLE transformcasemixed").toString();
-        assertTrue(showCreate2.contains("month(ts)"), "Expected lowercase 'month(ts)' in SHOW CREATE TABLE output, got: " + showCreate2);
-        assertTrue(showCreate2.contains("truncate(val, 8)"), "Expected lowercase 'truncate(val, 8)' in SHOW CREATE TABLE output, got: " + showCreate2);
+            String showCreate2 = getQueryRunner().execute(testSession(), "SHOW CREATE TABLE transformcasemixed").toString();
+            assertTrue(showCreate2.contains("month(ts)"), "Expected lowercase 'month(ts)' in SHOW CREATE TABLE output, got: " + showCreate2);
+            assertTrue(showCreate2.contains("truncate(val, 8)"), "Expected lowercase 'truncate(val, 8)' in SHOW CREATE TABLE output, got: " + showCreate2);
 
-        List<PartitionField> fields2 = getIcebergTable(SCHEMA, "transformcasemixed").spec().fields();
-        assertEquals(fields2.size(), 2);
-        assertEquals(fields2.get(0).transform().toString(), "month", "Iceberg must store transform as lowercase 'month'");
-        assertEquals(fields2.get(1).transform().toString(), "truncate[8]", "Iceberg must store transform as lowercase 'truncate[8]'");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE transformcasemixed");
+            List<PartitionField> fields2 = getIcebergTable(SCHEMA, "transformcasemixed").spec().fields();
+            assertEquals(fields2.size(), 2);
+            assertEquals(fields2.get(0).transform().toString(), "month", "Iceberg must store transform as lowercase 'month'");
+            assertEquals(fields2.get(1).transform().toString(), "truncate[8]", "Iceberg must store transform as lowercase 'truncate[8]'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS transformcasemixed");
+        }
     }
 
     protected IcebergNativeCatalogFactory buildCatalogFactory(IcebergConfig icebergConfig)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestNameMatchingTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/IcebergRestNameMatchingTestBase.java
@@ -22,6 +22,7 @@ import com.facebook.presto.hive.gcs.HiveGcsConfig;
 import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
 import com.facebook.presto.hive.s3.HiveS3Config;
 import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
+import com.facebook.presto.iceberg.FileFormat;
 import com.facebook.presto.iceberg.IcebergCatalogName;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
@@ -37,6 +38,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.List;
 
+import static com.facebook.presto.iceberg.FileFormat.ORC;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.SESSION;
@@ -55,6 +57,7 @@ public abstract class IcebergRestNameMatchingTestBase
     protected TestingHttpServer restServer;
     protected String serverUri;
     protected File warehouseLocation;
+    protected FileFormat fileFormat = ORC;
 
     @BeforeClass
     public void init()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.FileFormat.ORC;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies the default (case-insensitive) behaviour of the Iceberg REST connector, i.e.
+ * {@code case-sensitive-name-matching} is NOT set (defaults to {@code false}).
+ *
+ * <p>In this mode {@code normalizeIdentifier} lowercases every identifier it receives, so:
+ * <ul>
+ *   <li>Mixed-case table/column names are stored and retrieved in lowercase.</li>
+ *   <li>Double-quoted identifiers with mixed case are also lowercased — quoting only helps
+ *       with special characters or reserved keywords, not with preserving case.</li>
+ * </ul>
+ */
+@Test(singleThreaded = true)
+public class TestIcebergRestCaseInsensitiveNameMatching
+        extends IcebergRestNameMatchingTestBase
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        // No case-sensitive-name-matching property — defaults to false (case-insensitive).
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setFormat(ORC)
+                .setExtraConnectorProperties(ImmutableMap.copyOf(restConnectorProperties(serverUri)))
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .setCreateTpchTables(false)
+                .build()
+                .getQueryRunner();
+    }
+
+    @Override
+    protected IcebergNativeCatalogFactory getCatalogFactory()
+    {
+        IcebergConfig icebergConfig = new IcebergConfig()
+                .setCatalogType(REST)
+                .setCatalogWarehouse(warehouseLocation.getAbsolutePath());
+        return buildCatalogFactory(icebergConfig);
+    }
+
+    @Test
+    public void testCreateTableMixedCase()
+    {
+        // normalizeIdentifier lowercases 'MixedCaseTable' → 'mixedcasetable'.
+        // All case variants resolve to the same stored name.
+        assertQuerySucceeds(testSession(), "CREATE TABLE MixedCaseTable (id bigint, val varchar)");
+
+        assertQuerySucceeds(testSession(), "SELECT * FROM MixedCaseTable");
+        assertQuerySucceeds(testSession(), "SELECT * FROM mixedcasetable");
+        assertQuerySucceeds(testSession(), "SELECT * FROM MIXEDCASETABLE");
+
+        // Creating with a different case input refers to the same table — already exists.
+        assertQueryFails(testSession(), "CREATE TABLE mixedcasetable (id bigint, val varchar)", ".*Table.*already exists.*");
+        assertQuerySucceeds(testSession(), "DROP TABLE MixedCaseTable");
+    }
+
+    @Test
+    public void testCreateTableAsMixedCase()
+    {
+        // 'MyTable' is normalised to 'mytable'; all case variants resolve to the same table.
+        assertQuerySucceeds(testSession(), "CREATE TABLE MyTable AS SELECT 1 AS id, 'hello' AS name");
+
+        assertQuery(testSession(), "SELECT id, name FROM MyTable", "VALUES (1, 'hello')");
+        assertQuery(testSession(), "SELECT id, name FROM mytable", "VALUES (1, 'hello')");
+        assertQuery(testSession(), "SELECT id, name FROM MYTABLE", "VALUES (1, 'hello')");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE MyTable");
+    }
+
+    @Test
+    public void testMixedCaseColumns()
+    {
+        // normalizeIdentifier lowercases every column name regardless of quoting.
+
+        // Quoted: 'FirstName' → 'firstname'. Any case variant retrieves the same column.
+        assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
+        assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
+        assertQuery(testSession(), "SELECT firstname, lastname FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+        assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+        assertQuerySucceeds(testSession(), "DROP TABLE coltestquoted");
+
+        // Unquoted: 'FirstName' → 'firstname'.
+        assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
+        assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
+        assertQuery(testSession(), "SELECT firstname, lastname FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
+        assertQuerySucceeds(testSession(), "DROP TABLE coltestunquoted");
+    }
+
+    @Test
+    public void testMixedCasePartitionColumn()
+    {
+        // normalizeIdentifier lowercases the resolved column name; column definition and
+        // partition array reference both resolve to the same lowercase name.
+
+        // Quoted in array: '"RegionId"' → 'RegionId' → 'regionid'. Column also → 'regionid'. ✓
+        assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
+        assertQuery(testSession(), "SELECT regionid, name FROM partTestQuoted ORDER BY regionid", "VALUES (1, 'north'), (2, 'south')");
+        assertQuerySucceeds(testSession(), "DROP TABLE partTestQuoted");
+
+        // Unquoted in array: 'RegionId' → 'regionid'. ✓
+        assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
+        assertQuery(testSession(), "SELECT regionid, name FROM partTestUnquoted ORDER BY regionid", "VALUES (1, 'north'), (2, 'south')");
+        assertQuerySucceeds(testSession(), "DROP TABLE partTestUnquoted");
+    }
+
+    @Test
+    public void testShowColumnsCaseInsensitive()
+    {
+        // All column names are lowercased regardless of how they were written.
+        assertQuerySucceeds(testSession(), "CREATE TABLE showcols (\"MyCol\" bigint, \"anotherCol\" varchar)");
+        String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcols").toString();
+        assertTrue(result.contains("mycol"), "Expected lowercase 'mycol' in SHOW COLUMNS output");
+        assertTrue(result.contains("anothercol"), "Expected lowercase 'anothercol' in SHOW COLUMNS output");
+        assertQuerySucceeds(testSession(), "DROP TABLE showcols");
+    }
+
+    @Test
+    public void testNormalizeIdentifierLowercases()
+    {
+        String normalized = normalizeIdentifier("MyTable", ICEBERG_CATALOG);
+        assertTrue(normalized.equals("mytable"), "Expected normalizeIdentifier to lowercase 'MyTable', got: " + normalized);
+
+        String normalizedLower = normalizeIdentifier("mytable", ICEBERG_CATALOG);
+        assertTrue(normalizedLower.equals("mytable"), "Expected normalizeIdentifier to return 'mytable' unchanged, got: " + normalizedLower);
+
+        String normalizedUpper = normalizeIdentifier("MYTABLE", ICEBERG_CATALOG);
+        assertTrue(normalizedUpper.equals("mytable"), "Expected normalizeIdentifier to lowercase 'MYTABLE', got: " + normalizedUpper);
+
+        assertFalse(normalized.equals("MyTable"), "normalizeIdentifier must not preserve mixed case in case-insensitive mode");
+        assertFalse(normalizedUpper.equals("MYTABLE"), "normalizeIdentifier must not leave uppercase unchanged in case-insensitive mode");
+    }
+
+    @Test
+    public void testRewriteDataFilesWithSortedByMixedCaseColumn()
+    {
+        assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_ci (Id bigint, Name varchar, VAL integer)");
+        assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_ci VALUES (3, 'c', 30), (1, 'a', 10)");
+        assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_ci VALUES (2, 'b', 20), (4, 'd', 40)");
+
+        // sorted_by 'Id' → normalizeIdentifier → 'id' → matches stored column 'id'
+        assertQuerySucceeds(testSession(), format(
+                "CALL iceberg.system.rewrite_data_files(schema => '%s', table_name => 'rewrite_sorted_ci', " +
+                        "sorted_by => ARRAY['Id'])",
+                SCHEMA));
+
+        // Columns are stored and retrieved as lowercase
+        assertQuery(testSession(), "SELECT id, name, val FROM rewrite_sorted_ci ORDER BY id", "VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)");
+
+        List<Types.NestedField> columns = getIcebergTable(SCHEMA, "rewrite_sorted_ci").schema().columns();
+        assertEquals(columns.get(0).name(), "id", "Column 0 must be stored as lowercase 'id'");
+        assertEquals(columns.get(1).name(), "name", "Column 1 must be stored as lowercase 'name'");
+        assertEquals(columns.get(2).name(), "val", "Column 2 must be stored as lowercase 'val'");
+        assertFalse(columns.get(0).name().equals("Id"), "Column 0 must NOT be stored as mixed-case 'Id'");
+        assertFalse(columns.get(1).name().equals("Name"), "Column 1 must NOT be stored as mixed-case 'Name'");
+        assertFalse(columns.get(2).name().equals("VAL"), "Column 2 must NOT be stored as mixed-case 'VAL'");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE rewrite_sorted_ci");
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
@@ -341,6 +341,156 @@ public class TestIcebergRestCaseInsensitiveNameMatching
         }
     }
 
+    /**
+     * Verifies that nested ROW field names are lowercased by {@code normalizeIdentifier}
+     * in case-insensitive mode — mixed-case names are stored and resolved as lowercase only.
+     */
+    @Test
+    public void testNestedRowFieldsCaseInsensitive()
+    {
+        // Basic nested ROW: mixed-case field names are lowercased on write.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE nested_basic_ci (id bigint, addr ROW(\"Street\" varchar, \"City\" varchar))");
+            assertQuerySucceeds(testSession(), "INSERT INTO nested_basic_ci VALUES (1, ROW('Main St', 'Springfield'))");
+
+            // Stored as 'street' and 'city' — any case variant resolves to the same field.
+            assertQuery(testSession(), "SELECT addr.street, addr.city FROM nested_basic_ci",
+                    "VALUES ('Main St', 'Springfield')");
+            assertQuery(testSession(), "SELECT addr.\"Street\", addr.\"City\" FROM nested_basic_ci",
+                    "VALUES ('Main St', 'Springfield')");
+            assertQuery(testSession(), "SELECT addr.STREET, addr.CITY FROM nested_basic_ci",
+                    "VALUES ('Main St', 'Springfield')");
+
+            // Verify that the raw Iceberg schema stores lowercase field names.
+            Types.NestedField addrField = getIcebergTable(SCHEMA, "nested_basic_ci").schema().findField("addr");
+            List<Types.NestedField> subFields = addrField.type().asStructType().fields();
+            assertEquals(subFields.get(0).name(), "street", "Nested field 0 must be lowercased to 'street'");
+            assertEquals(subFields.get(1).name(), "city", "Nested field 1 must be lowercased to 'city'");
+            assertFalse(subFields.get(0).name().equals("Street"), "Nested field must not preserve 'Street' in case-insensitive mode");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS nested_basic_ci");
+        }
+    }
+
+    /**
+     * Verifies that nested fields whose names differ only in case collapse to the same
+     * lowercase field in case-insensitive mode — duplicates are rejected at CREATE time.
+     */
+    @Test
+    public void testNestedRowFieldsDistinctByCaseInsensitive()
+    {
+        // Attempting to create a ROW with sub-fields that normalise to the same name fails.
+        assertQueryFails(testSession(),
+                "CREATE TABLE nested_case_dup_ci (id bigint, metrics ROW(val bigint, Val bigint, VAL bigint))",
+                ".*Column name 'Val' specified more than once.*");
+
+        // A ROW with already-distinct lowercase sub-field names works, and any-case access resolves correctly.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE nested_case_lower_ci (id bigint, metrics ROW(low bigint, high bigint))");
+            assertQuerySucceeds(testSession(), "INSERT INTO nested_case_lower_ci VALUES (1, ROW(10, 99))");
+
+            assertQuery(testSession(), "SELECT metrics.low, metrics.high FROM nested_case_lower_ci", "VALUES (10, 99)");
+            // Any-case variant resolves to the same stored lowercase field.
+            assertQuery(testSession(), "SELECT metrics.LOW, metrics.HIGH FROM nested_case_lower_ci", "VALUES (10, 99)");
+            assertQuery(testSession(), "SELECT metrics.Low, metrics.High FROM nested_case_lower_ci", "VALUES (10, 99)");
+
+            Types.NestedField metricsField = getIcebergTable(SCHEMA, "nested_case_lower_ci").schema().findField("metrics");
+            List<Types.NestedField> subFields = metricsField.type().asStructType().fields();
+            assertEquals(subFields.size(), 2, "ROW must have exactly 2 sub-fields");
+            assertEquals(subFields.get(0).name(), "low");
+            assertEquals(subFields.get(1).name(), "high");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS nested_case_lower_ci");
+        }
+    }
+
+    /**
+     * Verifies deeply nested ROW (struct inside struct) in case-insensitive mode — both
+     * levels of nesting are lowercased, and any-case access resolves to the stored name.
+     */
+    @Test
+    public void testDeeplyNestedRowFieldsCaseInsensitive()
+    {
+        // Two levels of nesting with mixed-case names.
+        try {
+            assertQuerySucceeds(testSession(),
+                    "CREATE TABLE nested_deep_ci (id bigint, person ROW(\"Name\" varchar, address ROW(\"Street\" varchar, \"Zip\" varchar)))");
+            assertQuerySucceeds(testSession(),
+                    "INSERT INTO nested_deep_ci VALUES (1, ROW('Alice', ROW('Baker St', '90210')))");
+
+            // All field names are lowercased — any-case variant resolves to the stored lowercase name.
+            assertQuery(testSession(), "SELECT person.name FROM nested_deep_ci", "VALUES ('Alice')");
+            assertQuery(testSession(), "SELECT person.\"Name\" FROM nested_deep_ci", "VALUES ('Alice')");
+            assertQuery(testSession(), "SELECT person.address.street, person.address.zip FROM nested_deep_ci",
+                    "VALUES ('Baker St', '90210')");
+            assertQuery(testSession(), "SELECT person.ADDRESS.STREET, person.ADDRESS.ZIP FROM nested_deep_ci",
+                    "VALUES ('Baker St', '90210')");
+
+            // Verify raw Iceberg schema stores lowercase names at both levels.
+            Types.NestedField personField = getIcebergTable(SCHEMA, "nested_deep_ci").schema().findField("person");
+            List<Types.NestedField> personSubFields = personField.type().asStructType().fields();
+            assertEquals(personSubFields.get(0).name(), "name", "Level-1 field 0 must be lowercased to 'name'");
+            assertEquals(personSubFields.get(1).name(), "address", "Level-1 field 1 must stay 'address'");
+            assertFalse(personSubFields.get(0).name().equals("Name"), "Level-1 field must not preserve 'Name' in case-insensitive mode");
+
+            List<Types.NestedField> addrSubFields = personSubFields.get(1).type().asStructType().fields();
+            assertEquals(addrSubFields.get(0).name(), "street", "Level-2 field 0 must be lowercased to 'street'");
+            assertEquals(addrSubFields.get(1).name(), "zip", "Level-2 field 1 must be lowercased to 'zip'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS nested_deep_ci");
+        }
+    }
+
+    /**
+     * Verifies that a nested sub-field can share the same name as its parent column,
+     * and that case-insensitive resolution keeps the two scopes unambiguous.
+     *
+     * <p>Schema: {@code id bigint, addr ROW(addr varchar, id bigint, City varchar)}
+     * <ul>
+     *   <li>{@code addr} — top-level ROW column (stored as {@code addr})</li>
+     *   <li>{@code addr.addr} — sub-field with the same name as the parent; stored as {@code addr}</li>
+     *   <li>{@code addr.id} — sub-field with the same name as the sibling top-level column</li>
+     *   <li>{@code addr.City} — lowercased to {@code city} on write</li>
+     * </ul>
+     */
+    @Test
+    public void testNestedFieldNameSameAsParentColumn()
+    {
+        try {
+            assertQuerySucceeds(testSession(),
+                    "CREATE TABLE nested_shadow_ci (id bigint, addr ROW(addr varchar, id bigint, \"City\" varchar))");
+            assertQuerySucceeds(testSession(),
+                    "INSERT INTO nested_shadow_ci VALUES (1, ROW('Main St', 42, 'Springfield'))");
+
+            // Top-level 'id' and nested 'addr.id' are independent.
+            assertQuery(testSession(), "SELECT id FROM nested_shadow_ci", "VALUES (1)");
+            assertQuery(testSession(), "SELECT addr.id FROM nested_shadow_ci", "VALUES (42)");
+
+            // Top-level 'addr' (the ROW) vs nested 'addr.addr' (the varchar sub-field).
+            assertQuery(testSession(), "SELECT addr.addr FROM nested_shadow_ci", "VALUES ('Main St')");
+
+            // Mixed-case 'City' is lowercased to 'city'; any-case variant resolves to it.
+            assertQuery(testSession(), "SELECT addr.city FROM nested_shadow_ci", "VALUES ('Springfield')");
+            assertQuery(testSession(), "SELECT addr.\"City\" FROM nested_shadow_ci", "VALUES ('Springfield')");
+            assertQuery(testSession(), "SELECT addr.CITY FROM nested_shadow_ci", "VALUES ('Springfield')");
+
+            // Raw schema: sub-fields are lowercased — 'addr', 'id', 'city'.
+            Types.NestedField addrCol = getIcebergTable(SCHEMA, "nested_shadow_ci").schema().findField("addr");
+            List<Types.NestedField> subFields = addrCol.type().asStructType().fields();
+            assertEquals(subFields.size(), 3);
+            assertEquals(subFields.get(0).name(), "addr", "Sub-field 0 must be 'addr' (same as parent)");
+            assertEquals(subFields.get(1).name(), "id", "Sub-field 1 must be 'id' (same as sibling top-level)");
+            assertEquals(subFields.get(2).name(), "city", "Sub-field 2 must be lowercased to 'city'");
+            assertFalse(subFields.get(2).name().equals("City"), "Sub-field 2 must not preserve 'City' in case-insensitive mode");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS nested_shadow_ci");
+        }
+    }
+
     private Set<String> showStatsColumnNames(String tableName)
     {
         MaterializedResult result = computeActual(testSession(), "SHOW STATS FOR " + tableName);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
@@ -23,14 +23,15 @@ import org.apache.iceberg.types.Types;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
 import static com.facebook.presto.iceberg.FileFormat.ORC;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -80,28 +81,35 @@ public class TestIcebergRestCaseInsensitiveNameMatching
     {
         // normalizeIdentifier lowercases 'MixedCaseTable' → 'mixedcasetable'.
         // All case variants resolve to the same stored name.
-        assertQuerySucceeds(testSession(), "CREATE TABLE MixedCaseTable (id bigint, val varchar)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE MixedCaseTable (id bigint, val varchar)");
 
-        assertQuerySucceeds(testSession(), "SELECT * FROM MixedCaseTable");
-        assertQuerySucceeds(testSession(), "SELECT * FROM mixedcasetable");
-        assertQuerySucceeds(testSession(), "SELECT * FROM MIXEDCASETABLE");
+            assertQuerySucceeds(testSession(), "SELECT * FROM MixedCaseTable");
+            assertQuerySucceeds(testSession(), "SELECT * FROM mixedcasetable");
+            assertQuerySucceeds(testSession(), "SELECT * FROM MIXEDCASETABLE");
 
-        // Creating with a different case input refers to the same table — already exists.
-        assertQueryFails(testSession(), "CREATE TABLE mixedcasetable (id bigint, val varchar)", ".*Table.*already exists.*");
-        assertQuerySucceeds(testSession(), "DROP TABLE MixedCaseTable");
+            // Creating with a different case input refers to the same table — already exists.
+            assertQueryFails(testSession(), "CREATE TABLE mixedcasetable (id bigint, val varchar)", ".*Table.*already exists.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS MixedCaseTable");
+        }
     }
 
     @Test
     public void testCreateTableAsMixedCase()
     {
         // 'MyTable' is normalised to 'mytable'; all case variants resolve to the same table.
-        assertQuerySucceeds(testSession(), "CREATE TABLE MyTable AS SELECT 1 AS id, 'hello' AS name");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE MyTable AS SELECT 1 AS id, 'hello' AS name");
 
-        assertQuery(testSession(), "SELECT id, name FROM MyTable", "VALUES (1, 'hello')");
-        assertQuery(testSession(), "SELECT id, name FROM mytable", "VALUES (1, 'hello')");
-        assertQuery(testSession(), "SELECT id, name FROM MYTABLE", "VALUES (1, 'hello')");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE MyTable");
+            assertQuery(testSession(), "SELECT id, name FROM MyTable", "VALUES (1, 'hello')");
+            assertQuery(testSession(), "SELECT id, name FROM mytable", "VALUES (1, 'hello')");
+            assertQuery(testSession(), "SELECT id, name FROM MYTABLE", "VALUES (1, 'hello')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS MyTable");
+        }
     }
 
     @Test
@@ -110,17 +118,25 @@ public class TestIcebergRestCaseInsensitiveNameMatching
         // normalizeIdentifier lowercases every column name regardless of quoting.
 
         // Quoted: 'FirstName' → 'firstname'. Any case variant retrieves the same column.
-        assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
-        assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
-        assertQuery(testSession(), "SELECT firstname, lastname FROM coltestquoted", "VALUES ('Alice', 'Smith')");
-        assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
-        assertQuerySucceeds(testSession(), "DROP TABLE coltestquoted");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
+            assertQuery(testSession(), "SELECT firstname, lastname FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+            assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS coltestquoted");
+        }
 
         // Unquoted: 'FirstName' → 'firstname'.
-        assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
-        assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
-        assertQuery(testSession(), "SELECT firstname, lastname FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
-        assertQuerySucceeds(testSession(), "DROP TABLE coltestunquoted");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
+            assertQuery(testSession(), "SELECT firstname, lastname FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS coltestunquoted");
+        }
     }
 
     @Test
@@ -130,27 +146,39 @@ public class TestIcebergRestCaseInsensitiveNameMatching
         // partition array reference both resolve to the same lowercase name.
 
         // Quoted in array: '"RegionId"' → 'RegionId' → 'regionid'. Column also → 'regionid'. ✓
-        assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
-        assertQuery(testSession(), "SELECT regionid, name FROM partTestQuoted ORDER BY regionid", "VALUES (1, 'north'), (2, 'south')");
-        assertQuerySucceeds(testSession(), "DROP TABLE partTestQuoted");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
+            assertQuery(testSession(), "SELECT regionid, name FROM partTestQuoted ORDER BY regionid", "VALUES (1, 'north'), (2, 'south')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS partTestQuoted");
+        }
 
         // Unquoted in array: 'RegionId' → 'regionid'. ✓
-        assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
-        assertQuery(testSession(), "SELECT regionid, name FROM partTestUnquoted ORDER BY regionid", "VALUES (1, 'north'), (2, 'south')");
-        assertQuerySucceeds(testSession(), "DROP TABLE partTestUnquoted");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
+            assertQuery(testSession(), "SELECT regionid, name FROM partTestUnquoted ORDER BY regionid", "VALUES (1, 'north'), (2, 'south')");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS partTestUnquoted");
+        }
     }
 
     @Test
     public void testShowColumnsCaseInsensitive()
     {
         // All column names are lowercased regardless of how they were written.
-        assertQuerySucceeds(testSession(), "CREATE TABLE showcols (\"MyCol\" bigint, \"anotherCol\" varchar)");
-        String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcols").toString();
-        assertTrue(result.contains("mycol"), "Expected lowercase 'mycol' in SHOW COLUMNS output");
-        assertTrue(result.contains("anothercol"), "Expected lowercase 'anothercol' in SHOW COLUMNS output");
-        assertQuerySucceeds(testSession(), "DROP TABLE showcols");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE showcols (\"MyCol\" bigint, \"anotherCol\" varchar)");
+            String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcols").toString();
+            assertTrue(result.contains("mycol"), "Expected lowercase 'mycol' in SHOW COLUMNS output");
+            assertTrue(result.contains("anothercol"), "Expected lowercase 'anothercol' in SHOW COLUMNS output");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS showcols");
+        }
     }
 
     @Test
@@ -177,21 +205,24 @@ public class TestIcebergRestCaseInsensitiveNameMatching
     @Test
     public void testAnalyzeMixedCaseColumns()
     {
-        assertQuerySucceeds(testSession(), "CREATE TABLE analyze_mixed_ci (Id bigint, Name varchar, VAL integer)");
-        assertQuerySucceeds(testSession(), "INSERT INTO analyze_mixed_ci VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE analyze_mixed_ci (Id bigint, Name varchar, VAL integer)");
+            assertQuerySucceeds(testSession(), "INSERT INTO analyze_mixed_ci VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
 
-        assertQuerySucceeds(testSession(), "ANALYZE analyze_mixed_ci");
+            assertQuerySucceeds(testSession(), "ANALYZE analyze_mixed_ci");
 
-        // All names are lowercased — stored as 'id', 'name', 'val'.
-        Set<String> colNames = showStatsColumnNames("analyze_mixed_ci");
-        assertTrue(colNames.contains("id"), "SHOW STATS must report stored lowercase column 'id', got: " + colNames);
-        assertTrue(colNames.contains("name"), "SHOW STATS must report stored lowercase column 'name', got: " + colNames);
-        assertTrue(colNames.contains("val"), "SHOW STATS must report stored lowercase column 'val', got: " + colNames);
-        assertFalse(colNames.contains("Id"), "SHOW STATS must not preserve mixed-case 'Id' in case-insensitive mode, got: " + colNames);
-        assertFalse(colNames.contains("Name"), "SHOW STATS must not preserve mixed-case 'Name' in case-insensitive mode, got: " + colNames);
-        assertFalse(colNames.contains("VAL"), "SHOW STATS must not preserve mixed-case 'VAL' in case-insensitive mode, got: " + colNames);
-
-        assertQuerySucceeds(testSession(), "DROP TABLE analyze_mixed_ci");
+            // All names are lowercased — stored as 'id', 'name', 'val'.
+            Set<String> colNames = showStatsColumnNames("analyze_mixed_ci");
+            assertTrue(colNames.contains("id"), "SHOW STATS must report stored lowercase column 'id', got: " + colNames);
+            assertTrue(colNames.contains("name"), "SHOW STATS must report stored lowercase column 'name', got: " + colNames);
+            assertTrue(colNames.contains("val"), "SHOW STATS must report stored lowercase column 'val', got: " + colNames);
+            assertFalse(colNames.contains("Id"), "SHOW STATS must not preserve mixed-case 'Id' in case-insensitive mode, got: " + colNames);
+            assertFalse(colNames.contains("Name"), "SHOW STATS must not preserve mixed-case 'Name' in case-insensitive mode, got: " + colNames);
+            assertFalse(colNames.contains("VAL"), "SHOW STATS must not preserve mixed-case 'VAL' in case-insensitive mode, got: " + colNames);
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS analyze_mixed_ci");
+        }
     }
 
     /**
@@ -201,17 +232,20 @@ public class TestIcebergRestCaseInsensitiveNameMatching
     @Test
     public void testAnalyzeLowerCaseColumns()
     {
-        assertQuerySucceeds(testSession(), "CREATE TABLE analyze_lower_ci (id bigint, name varchar, val integer)");
-        assertQuerySucceeds(testSession(), "INSERT INTO analyze_lower_ci VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE analyze_lower_ci (id bigint, name varchar, val integer)");
+            assertQuerySucceeds(testSession(), "INSERT INTO analyze_lower_ci VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
 
-        assertQuerySucceeds(testSession(), "ANALYZE analyze_lower_ci");
+            assertQuerySucceeds(testSession(), "ANALYZE analyze_lower_ci");
 
-        Set<String> colNames = showStatsColumnNames("analyze_lower_ci");
-        assertTrue(colNames.contains("id"), "SHOW STATS must report column 'id', got: " + colNames);
-        assertTrue(colNames.contains("name"), "SHOW STATS must report column 'name', got: " + colNames);
-        assertTrue(colNames.contains("val"), "SHOW STATS must report column 'val', got: " + colNames);
-
-        assertQuerySucceeds(testSession(), "DROP TABLE analyze_lower_ci");
+            Set<String> colNames = showStatsColumnNames("analyze_lower_ci");
+            assertTrue(colNames.contains("id"), "SHOW STATS must report column 'id', got: " + colNames);
+            assertTrue(colNames.contains("name"), "SHOW STATS must report column 'name', got: " + colNames);
+            assertTrue(colNames.contains("val"), "SHOW STATS must report column 'val', got: " + colNames);
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS analyze_lower_ci");
+        }
     }
 
     /**
@@ -224,16 +258,19 @@ public class TestIcebergRestCaseInsensitiveNameMatching
     public void testShowStatsForFilteredMixedCaseColumns()
     {
         // Column and partition stored as 'regionid' (normalizeIdentifier lowercases).
-        assertQuerySucceeds(testSession(), "CREATE TABLE stats_filter_ci (RegionId bigint, Name varchar) WITH (partitioning = ARRAY['RegionId'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO stats_filter_ci VALUES (1, 'north'), (2, 'south'), (1, 'east')");
-        assertQuerySucceeds(testSession(), "ANALYZE stats_filter_ci");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE stats_filter_ci (RegionId bigint, Name varchar) WITH (partitioning = ARRAY['RegionId'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO stats_filter_ci VALUES (1, 'north'), (2, 'south'), (1, 'east')");
+            assertQuerySucceeds(testSession(), "ANALYZE stats_filter_ci");
 
-        // Lowercase filter — matches stored 'regionid' partition column → pushed down → succeeds.
-        assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_ci WHERE regionid = 1)");
-        // Mixed-case filter — also normalised to 'regionid' → same partition column → succeeds.
-        assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_ci WHERE RegionId = 1)");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE stats_filter_ci");
+            // Lowercase filter — matches stored 'regionid' partition column → pushed down → succeeds.
+            assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_ci WHERE regionid = 1)");
+            // Mixed-case filter — also normalised to 'regionid' → same partition column → succeeds.
+            assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_ci WHERE RegionId = 1)");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS stats_filter_ci");
+        }
     }
 
     /**
@@ -247,56 +284,62 @@ public class TestIcebergRestCaseInsensitiveNameMatching
                 ".*Column name 'ID' specified more than once");
 
         // Table with a single 'id' column — all case variants of the name resolve to it.
-        assertQuerySucceeds(testSession(), "CREATE TABLE casecols_ci (id bigint, name varchar)");
-        assertQuerySucceeds(testSession(), "INSERT INTO casecols_ci VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE casecols_ci (id bigint, name varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO casecols_ci VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')");
 
-        // All case variants of 'id' resolve to the same stored lowercase column.
-        assertQuery(testSession(), "SELECT id FROM casecols_ci ORDER BY id", "VALUES (1), (2), (3)");
-        assertQuery(testSession(), "SELECT ID FROM casecols_ci ORDER BY ID", "VALUES (1), (2), (3)");
-        assertQuery(testSession(), "SELECT Id FROM casecols_ci ORDER BY Id", "VALUES (1), (2), (3)");
+            // All case variants of 'id' resolve to the same stored lowercase column.
+            assertQuery(testSession(), "SELECT id FROM casecols_ci ORDER BY id", "VALUES (1), (2), (3)");
+            assertQuery(testSession(), "SELECT ID FROM casecols_ci ORDER BY ID", "VALUES (1), (2), (3)");
+            assertQuery(testSession(), "SELECT Id FROM casecols_ci ORDER BY Id", "VALUES (1), (2), (3)");
 
-        // WHERE and ORDER BY also resolve any case variant to the same column.
-        assertQuery(testSession(), "SELECT id FROM casecols_ci WHERE ID = 2", "VALUES (2)");
-        assertQuery(testSession(), "SELECT id FROM casecols_ci WHERE Id = 3", "VALUES (3)");
-        assertQuery(testSession(), "SELECT id FROM casecols_ci ORDER BY ID", "VALUES (1), (2), (3)");
+            // WHERE and ORDER BY also resolve any case variant to the same column.
+            assertQuery(testSession(), "SELECT id FROM casecols_ci WHERE ID = 2", "VALUES (2)");
+            assertQuery(testSession(), "SELECT id FROM casecols_ci WHERE Id = 3", "VALUES (3)");
+            assertQuery(testSession(), "SELECT id FROM casecols_ci ORDER BY ID", "VALUES (1), (2), (3)");
 
-        // JOIN USING works with any case variant of 'name' — all resolve to the same column.
-        assertQuery(testSession(), "SELECT a.id FROM casecols_ci a JOIN casecols_ci b USING (name) WHERE a.id = 1", "VALUES (1)");
-        assertQuery(testSession(), "SELECT a.id FROM casecols_ci a JOIN casecols_ci b USING (NAME) WHERE a.id = 2", "VALUES (2)");
+            // JOIN USING works with any case variant of 'name' — all resolve to the same column.
+            assertQuery(testSession(), "SELECT a.id FROM casecols_ci a JOIN casecols_ci b USING (name) WHERE a.id = 1", "VALUES (1)");
+            assertQuery(testSession(), "SELECT a.id FROM casecols_ci a JOIN casecols_ci b USING (NAME) WHERE a.id = 2", "VALUES (2)");
 
-        assertQueryFails(testSession(), "SELECT xyz FROM casecols_ci", ".*Column.*xyz.*cannot be resolved.*");
-        assertQueryFails(testSession(), "SELECT XYZ FROM casecols_ci", ".*Column.*xyz.*cannot be resolved.*");
-        assertQueryFails(testSession(), "SELECT id FROM casecols_ci WHERE XYZ = 1", ".*Column.*xyz.*cannot be resolved.*");
-        assertQueryFails(testSession(), "SELECT id FROM casecols_ci ORDER BY XYZ", ".*Column.*xyz.*cannot be resolved.*");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE casecols_ci");
+            assertQueryFails(testSession(), "SELECT xyz FROM casecols_ci", ".*Column.*xyz.*cannot be resolved.*");
+            assertQueryFails(testSession(), "SELECT XYZ FROM casecols_ci", ".*Column.*xyz.*cannot be resolved.*");
+            assertQueryFails(testSession(), "SELECT id FROM casecols_ci WHERE XYZ = 1", ".*Column.*xyz.*cannot be resolved.*");
+            assertQueryFails(testSession(), "SELECT id FROM casecols_ci ORDER BY XYZ", ".*Column.*xyz.*cannot be resolved.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS casecols_ci");
+        }
     }
 
     @Test
     public void testRewriteDataFilesWithSortedByMixedCaseColumn()
     {
-        assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_ci (Id bigint, Name varchar, VAL integer)");
-        assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_ci VALUES (3, 'c', 30), (1, 'a', 10)");
-        assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_ci VALUES (2, 'b', 20), (4, 'd', 40)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_ci (Id bigint, Name varchar, VAL integer)");
+            assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_ci VALUES (3, 'c', 30), (1, 'a', 10)");
+            assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_ci VALUES (2, 'b', 20), (4, 'd', 40)");
 
-        // sorted_by 'Id' → normalizeIdentifier → 'id' → matches stored column 'id'
-        assertQuerySucceeds(testSession(), format(
-                "CALL iceberg.system.rewrite_data_files(schema => '%s', table_name => 'rewrite_sorted_ci', " +
-                        "sorted_by => ARRAY['Id'])",
-                SCHEMA));
+            // sorted_by 'Id' → normalizeIdentifier → 'id' → matches stored column 'id'
+            assertQuerySucceeds(testSession(), format(
+                    "CALL iceberg.system.rewrite_data_files(schema => '%s', table_name => 'rewrite_sorted_ci', " +
+                            "sorted_by => ARRAY['Id'])",
+                    SCHEMA));
 
-        // Columns are stored and retrieved as lowercase
-        assertQuery(testSession(), "SELECT id, name, val FROM rewrite_sorted_ci ORDER BY id", "VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)");
+            // Columns are stored and retrieved as lowercase
+            assertQuery(testSession(), "SELECT id, name, val FROM rewrite_sorted_ci ORDER BY id", "VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)");
 
-        List<Types.NestedField> columns = getIcebergTable(SCHEMA, "rewrite_sorted_ci").schema().columns();
-        assertEquals(columns.get(0).name(), "id", "Column 0 must be stored as lowercase 'id'");
-        assertEquals(columns.get(1).name(), "name", "Column 1 must be stored as lowercase 'name'");
-        assertEquals(columns.get(2).name(), "val", "Column 2 must be stored as lowercase 'val'");
-        assertFalse(columns.get(0).name().equals("Id"), "Column 0 must NOT be stored as mixed-case 'Id'");
-        assertFalse(columns.get(1).name().equals("Name"), "Column 1 must NOT be stored as mixed-case 'Name'");
-        assertFalse(columns.get(2).name().equals("VAL"), "Column 2 must NOT be stored as mixed-case 'VAL'");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE rewrite_sorted_ci");
+            List<Types.NestedField> columns = getIcebergTable(SCHEMA, "rewrite_sorted_ci").schema().columns();
+            assertEquals(columns.get(0).name(), "id", "Column 0 must be stored as lowercase 'id'");
+            assertEquals(columns.get(1).name(), "name", "Column 1 must be stored as lowercase 'name'");
+            assertEquals(columns.get(2).name(), "val", "Column 2 must be stored as lowercase 'val'");
+            assertFalse(columns.get(0).name().equals("Id"), "Column 0 must NOT be stored as mixed-case 'Id'");
+            assertFalse(columns.get(1).name().equals("Name"), "Column 1 must NOT be stored as mixed-case 'Name'");
+            assertFalse(columns.get(2).name().equals("VAL"), "Column 2 must NOT be stored as mixed-case 'VAL'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS rewrite_sorted_ci");
+        }
     }
 
     private Set<String> showStatsColumnNames(String tableName)
@@ -304,7 +347,7 @@ public class TestIcebergRestCaseInsensitiveNameMatching
         MaterializedResult result = computeActual(testSession(), "SHOW STATS FOR " + tableName);
         return result.getMaterializedRows().stream()
                 .map(row -> (String) row.getField(0))
-                .filter(name -> name != null)
-                .collect(Collectors.toSet());
+                .filter(Objects::nonNull)
+                .collect(toImmutableSet());
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
@@ -236,6 +236,42 @@ public class TestIcebergRestCaseInsensitiveNameMatching
         assertQuerySucceeds(testSession(), "DROP TABLE stats_filter_ci");
     }
 
+    /**
+     * Verifies that in case-insensitive mode all case variants of an identifier collapse to the
+     * same lowercase name.
+     */
+    @Test
+    public void testColumnsDistinctByCase()
+    {
+        assertQueryFails(testSession(), "CREATE TABLE casecols_ci (id bigint, ID bigint, Id bigint, name varchar)",
+                ".*Column name 'ID' specified more than once");
+
+        // Table with a single 'id' column — all case variants of the name resolve to it.
+        assertQuerySucceeds(testSession(), "CREATE TABLE casecols_ci (id bigint, name varchar)");
+        assertQuerySucceeds(testSession(), "INSERT INTO casecols_ci VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma')");
+
+        // All case variants of 'id' resolve to the same stored lowercase column.
+        assertQuery(testSession(), "SELECT id FROM casecols_ci ORDER BY id", "VALUES (1), (2), (3)");
+        assertQuery(testSession(), "SELECT ID FROM casecols_ci ORDER BY ID", "VALUES (1), (2), (3)");
+        assertQuery(testSession(), "SELECT Id FROM casecols_ci ORDER BY Id", "VALUES (1), (2), (3)");
+
+        // WHERE and ORDER BY also resolve any case variant to the same column.
+        assertQuery(testSession(), "SELECT id FROM casecols_ci WHERE ID = 2", "VALUES (2)");
+        assertQuery(testSession(), "SELECT id FROM casecols_ci WHERE Id = 3", "VALUES (3)");
+        assertQuery(testSession(), "SELECT id FROM casecols_ci ORDER BY ID", "VALUES (1), (2), (3)");
+
+        // JOIN USING works with any case variant of 'name' — all resolve to the same column.
+        assertQuery(testSession(), "SELECT a.id FROM casecols_ci a JOIN casecols_ci b USING (name) WHERE a.id = 1", "VALUES (1)");
+        assertQuery(testSession(), "SELECT a.id FROM casecols_ci a JOIN casecols_ci b USING (NAME) WHERE a.id = 2", "VALUES (2)");
+
+        assertQueryFails(testSession(), "SELECT xyz FROM casecols_ci", ".*Column.*xyz.*cannot be resolved.*");
+        assertQueryFails(testSession(), "SELECT XYZ FROM casecols_ci", ".*Column.*xyz.*cannot be resolved.*");
+        assertQueryFails(testSession(), "SELECT id FROM casecols_ci WHERE XYZ = 1", ".*Column.*xyz.*cannot be resolved.*");
+        assertQueryFails(testSession(), "SELECT id FROM casecols_ci ORDER BY XYZ", ".*Column.*xyz.*cannot be resolved.*");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE casecols_ci");
+    }
+
     @Test
     public void testRewriteDataFilesWithSortedByMixedCaseColumn()
     {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
-import static com.facebook.presto.iceberg.FileFormat.ORC;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -59,7 +58,7 @@ public class TestIcebergRestCaseInsensitiveNameMatching
         // No case-sensitive-name-matching property — defaults to false (case-insensitive).
         return IcebergQueryRunner.builder()
                 .setCatalogType(REST)
-                .setFormat(ORC)
+                .setFormat(fileFormat)
                 .setExtraConnectorProperties(ImmutableMap.copyOf(restConnectorProperties(serverUri)))
                 .setDataDirectory(Optional.of(warehouseLocation.toPath()))
                 .setCreateTpchTables(false)

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatching.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg.rest;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
@@ -23,6 +24,8 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
 import static com.facebook.presto.iceberg.FileFormat.ORC;
@@ -166,6 +169,73 @@ public class TestIcebergRestCaseInsensitiveNameMatching
         assertFalse(normalizedUpper.equals("MYTABLE"), "normalizeIdentifier must not leave uppercase unchanged in case-insensitive mode");
     }
 
+    /**
+     * Verifies that ANALYZE succeeds when the table has mixed-case column names in case-insensitive mode.
+     * All column names are lowercased by {@code normalizeIdentifier}, so SHOW STATS must report
+     * the stored lowercase names.
+     */
+    @Test
+    public void testAnalyzeMixedCaseColumns()
+    {
+        assertQuerySucceeds(testSession(), "CREATE TABLE analyze_mixed_ci (Id bigint, Name varchar, VAL integer)");
+        assertQuerySucceeds(testSession(), "INSERT INTO analyze_mixed_ci VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
+
+        assertQuerySucceeds(testSession(), "ANALYZE analyze_mixed_ci");
+
+        // All names are lowercased — stored as 'id', 'name', 'val'.
+        Set<String> colNames = showStatsColumnNames("analyze_mixed_ci");
+        assertTrue(colNames.contains("id"), "SHOW STATS must report stored lowercase column 'id', got: " + colNames);
+        assertTrue(colNames.contains("name"), "SHOW STATS must report stored lowercase column 'name', got: " + colNames);
+        assertTrue(colNames.contains("val"), "SHOW STATS must report stored lowercase column 'val', got: " + colNames);
+        assertFalse(colNames.contains("Id"), "SHOW STATS must not preserve mixed-case 'Id' in case-insensitive mode, got: " + colNames);
+        assertFalse(colNames.contains("Name"), "SHOW STATS must not preserve mixed-case 'Name' in case-insensitive mode, got: " + colNames);
+        assertFalse(colNames.contains("VAL"), "SHOW STATS must not preserve mixed-case 'VAL' in case-insensitive mode, got: " + colNames);
+
+        assertQuerySucceeds(testSession(), "DROP TABLE analyze_mixed_ci");
+    }
+
+    /**
+     * Verifies that ANALYZE and SHOW STATS work correctly with all-lowercase column names in
+     * case-insensitive mode — acts as a regression guard that the fix does not break the normal path.
+     */
+    @Test
+    public void testAnalyzeLowerCaseColumns()
+    {
+        assertQuerySucceeds(testSession(), "CREATE TABLE analyze_lower_ci (id bigint, name varchar, val integer)");
+        assertQuerySucceeds(testSession(), "INSERT INTO analyze_lower_ci VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
+
+        assertQuerySucceeds(testSession(), "ANALYZE analyze_lower_ci");
+
+        Set<String> colNames = showStatsColumnNames("analyze_lower_ci");
+        assertTrue(colNames.contains("id"), "SHOW STATS must report column 'id', got: " + colNames);
+        assertTrue(colNames.contains("name"), "SHOW STATS must report column 'name', got: " + colNames);
+        assertTrue(colNames.contains("val"), "SHOW STATS must report column 'val', got: " + colNames);
+
+        assertQuerySucceeds(testSession(), "DROP TABLE analyze_lower_ci");
+    }
+
+    /**
+     * Verifies that SHOW STATS FOR (subquery) with a partition column filter works in
+     * case-insensitive mode. The column is stored as 'regionid' (lowercased), so any
+     * case variant of the identifier resolves to the same partition column, ensuring
+     * the predicate is pushed down and no FilterNode remains.
+     */
+    @Test
+    public void testShowStatsForFilteredMixedCaseColumns()
+    {
+        // Column and partition stored as 'regionid' (normalizeIdentifier lowercases).
+        assertQuerySucceeds(testSession(), "CREATE TABLE stats_filter_ci (RegionId bigint, Name varchar) WITH (partitioning = ARRAY['RegionId'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO stats_filter_ci VALUES (1, 'north'), (2, 'south'), (1, 'east')");
+        assertQuerySucceeds(testSession(), "ANALYZE stats_filter_ci");
+
+        // Lowercase filter — matches stored 'regionid' partition column → pushed down → succeeds.
+        assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_ci WHERE regionid = 1)");
+        // Mixed-case filter — also normalised to 'regionid' → same partition column → succeeds.
+        assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_ci WHERE RegionId = 1)");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE stats_filter_ci");
+    }
+
     @Test
     public void testRewriteDataFilesWithSortedByMixedCaseColumn()
     {
@@ -191,5 +261,14 @@ public class TestIcebergRestCaseInsensitiveNameMatching
         assertFalse(columns.get(2).name().equals("VAL"), "Column 2 must NOT be stored as mixed-case 'VAL'");
 
         assertQuerySucceeds(testSession(), "DROP TABLE rewrite_sorted_ci");
+    }
+
+    private Set<String> showStatsColumnNames(String tableName)
+    {
+        MaterializedResult result = computeActual(testSession(), "SHOW STATS FOR " + tableName);
+        return result.getMaterializedRows().stream()
+                .map(row -> (String) row.getField(0))
+                .filter(name -> name != null)
+                .collect(Collectors.toSet());
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatchingParquet.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseInsensitiveNameMatchingParquet.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.iceberg.FileFormat.PARQUET;
+
+/**
+ * Runs the full {@link TestIcebergRestCaseInsensitiveNameMatching} suite against the
+ * Parquet file format to verify that case-insensitive name matching behaves identically
+ * regardless of the underlying storage format.
+ */
+@Test(singleThreaded = true)
+public class TestIcebergRestCaseInsensitiveNameMatchingParquet
+        extends TestIcebergRestCaseInsensitiveNameMatching
+{
+    public TestIcebergRestCaseInsensitiveNameMatchingParquet()
+    {
+        fileFormat = PARQUET;
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
@@ -23,14 +23,15 @@ import org.apache.iceberg.types.Types;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
 import static com.facebook.presto.iceberg.FileFormat.ORC;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -77,29 +78,35 @@ public class TestIcebergRestCaseSensitiveNameMatching
     {
         // Both lower-case and upper-case variants can coexist as distinct tables in a
         // case-sensitive catalog — normalizeIdentifier preserves each name as written.
-        assertQuerySucceeds(testSession(), "CREATE TABLE MixedCaseTable (id bigint, val varchar)");
-        assertQuerySucceeds(testSession(), "CREATE TABLE mixedcasetable (id bigint, val varchar)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE MixedCaseTable (id bigint, val varchar)");
+            assertQuerySucceeds(testSession(), "CREATE TABLE mixedcasetable (id bigint, val varchar)");
 
-        assertQuerySucceeds(testSession(), "SELECT * FROM MixedCaseTable");
-        assertQuerySucceeds(testSession(), "SELECT * FROM mixedcasetable");
+            assertQuerySucceeds(testSession(), "SELECT * FROM MixedCaseTable");
+            assertQuerySucceeds(testSession(), "SELECT * FROM mixedcasetable");
 
-        // MIXEDCASETABLE is a third distinct name — does not exist
-        assertQueryFails(testSession(), "SELECT * FROM MIXEDCASETABLE", ".*Table.*does not exist.*");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE MixedCaseTable");
-        assertQuerySucceeds(testSession(), "DROP TABLE mixedcasetable");
+            // MIXEDCASETABLE is a third distinct name — does not exist
+            assertQueryFails(testSession(), "SELECT * FROM MIXEDCASETABLE", ".*Table.*does not exist.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS MixedCaseTable");
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS mixedcasetable");
+        }
     }
 
     @Test
     public void testCreateTableAsMixedCase()
     {
         // 'MyTable' is stored as-is; 'mytable' is a different (non-existent) table.
-        assertQuerySucceeds(testSession(), "CREATE TABLE MyTable AS SELECT 1 AS id, 'hello' AS name");
-        assertQuery(testSession(), "SELECT id, name FROM MyTable", "VALUES (1, 'hello')");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE MyTable AS SELECT 1 AS id, 'hello' AS name");
+            assertQuery(testSession(), "SELECT id, name FROM MyTable", "VALUES (1, 'hello')");
 
-        assertQueryFails(testSession(), "SELECT * FROM mytable", ".*Table.*does not exist.*");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE MyTable");
+            assertQueryFails(testSession(), "SELECT * FROM mytable", ".*Table.*does not exist.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS MyTable");
+        }
     }
 
     @Test
@@ -110,54 +117,78 @@ public class TestIcebergRestCaseSensitiveNameMatching
         // it returns identifiers as-is regardless of whether they were quoted or unquoted in SQL.
 
         // Quoted: double-quotes tell the parser to treat the token as an identifier (not a keyword).
-        assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
-        assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
-        assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
-        assertQueryFails(testSession(), "SELECT firstname, lastname FROM coltestquoted", ".*Column.*firstname.*cannot be resolved.*");
-        assertQuerySucceeds(testSession(), "DROP TABLE coltestquoted");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
+            assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+            assertQueryFails(testSession(), "SELECT firstname, lastname FROM coltestquoted", ".*Column.*firstname.*cannot be resolved.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS coltestquoted");
+        }
 
         // Unquoted mixed-case: normalizeIdentifier preserves as-is; analyser resolution is exact-case too.
-        assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
-        assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
-        assertQuery(testSession(), "SELECT FirstName, lastName FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
-        assertQueryFails(testSession(), "SELECT firstname, lastname FROM coltestunquoted", ".*Column.*firstname.*cannot be resolved.*");
-        assertQuerySucceeds(testSession(), "DROP TABLE coltestunquoted");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
+            assertQuery(testSession(), "SELECT FirstName, lastName FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
+            assertQueryFails(testSession(), "SELECT firstname, lastname FROM coltestunquoted", ".*Column.*firstname.*cannot be resolved.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS coltestunquoted");
+        }
     }
 
     @Test
     public void testMixedCasePartitionColumn()
     {
         // Quoted column in partition array: '"RegionId"' → strips quotes → 'RegionId' preserved.
-        assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
-        assertQuery(testSession(), "SELECT \"RegionId\", name FROM partTestQuoted ORDER BY \"RegionId\"", "VALUES (1, 'north'), (2, 'south')");
-        assertQueryFails(testSession(), "SELECT regionid FROM partTestQuoted", ".*Column.*regionid.*cannot be resolved.*");
-        assertQuerySucceeds(testSession(), "DROP TABLE partTestQuoted");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
+            assertQuery(testSession(), "SELECT \"RegionId\", name FROM partTestQuoted ORDER BY \"RegionId\"", "VALUES (1, 'north'), (2, 'south')");
+            assertQueryFails(testSession(), "SELECT regionid FROM partTestQuoted", ".*Column.*regionid.*cannot be resolved.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS partTestQuoted");
+        }
 
         // Unquoted in partition array: 'RegionId' preserved as-is.
-        assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
-        assertQuery(testSession(), "SELECT RegionId, name FROM partTestUnquoted ORDER BY RegionId", "VALUES (1, 'north'), (2, 'south')");
-        assertQueryFails(testSession(), "SELECT regionid FROM partTestUnquoted", ".*Column.*regionid.*cannot be resolved.*");
-        assertQuerySucceeds(testSession(), "DROP TABLE partTestUnquoted");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
+            assertQuery(testSession(), "SELECT RegionId, name FROM partTestUnquoted ORDER BY RegionId", "VALUES (1, 'north'), (2, 'south')");
+            assertQueryFails(testSession(), "SELECT regionid FROM partTestUnquoted", ".*Column.*regionid.*cannot be resolved.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS partTestUnquoted");
+        }
     }
 
     @Test
     public void testShowColumnsCaseSensitive()
     {
         // Quoted: normalizeIdentifier preserves mixed case.
-        assertQuerySucceeds(testSession(), "CREATE TABLE showcols (\"MyCol\" bigint, \"anotherCol\" varchar)");
-        String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcols").toString();
-        assertTrue(result.contains("MyCol"), "Expected 'MyCol' in SHOW COLUMNS output");
-        assertTrue(result.contains("anotherCol"), "Expected 'anotherCol' in SHOW COLUMNS output");
-        assertQuerySucceeds(testSession(), "DROP TABLE showcols");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE showcols (\"MyCol\" bigint, \"anotherCol\" varchar)");
+            String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcols").toString();
+            assertTrue(result.contains("MyCol"), "Expected 'MyCol' in SHOW COLUMNS output");
+            assertTrue(result.contains("anotherCol"), "Expected 'anotherCol' in SHOW COLUMNS output");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS showcols");
+        }
 
         // Unquoted: same result — normalizeIdentifier preserves as-is.
-        assertQuerySucceeds(testSession(), "CREATE TABLE showcolslower (MyCol bigint, anotherCol varchar)");
-        String resultLower = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcolslower").toString();
-        assertTrue(resultLower.contains("MyCol"), "Expected 'MyCol' in SHOW COLUMNS output");
-        assertTrue(resultLower.contains("anotherCol"), "Expected 'anotherCol' in SHOW COLUMNS output");
-        assertQuerySucceeds(testSession(), "DROP TABLE showcolslower");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE showcolslower (MyCol bigint, anotherCol varchar)");
+            String resultLower = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcolslower").toString();
+            assertTrue(resultLower.contains("MyCol"), "Expected 'MyCol' in SHOW COLUMNS output");
+            assertTrue(resultLower.contains("anotherCol"), "Expected 'anotherCol' in SHOW COLUMNS output");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS showcolslower");
+        }
     }
 
     @Test
@@ -174,82 +205,94 @@ public class TestIcebergRestCaseSensitiveNameMatching
     @Test
     public void testAnalyzeMixedCaseColumns()
     {
-        assertQuerySucceeds(testSession(), "CREATE TABLE analyze_mixed (Id bigint, Name varchar, VAL integer)");
-        assertQuerySucceeds(testSession(), "INSERT INTO analyze_mixed VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE analyze_mixed (Id bigint, Name varchar, VAL integer)");
+            assertQuerySucceeds(testSession(), "INSERT INTO analyze_mixed VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
 
-        assertQuerySucceeds(testSession(), "ANALYZE analyze_mixed");
+            assertQuerySucceeds(testSession(), "ANALYZE analyze_mixed");
 
-        Set<String> colNames = showStatsColumnNames("analyze_mixed");
-        assertTrue(colNames.contains("Id"), "SHOW STATS must report stored column name 'Id', got: " + colNames);
-        assertTrue(colNames.contains("Name"), "SHOW STATS must report stored column name 'Name', got: " + colNames);
-        assertTrue(colNames.contains("VAL"), "SHOW STATS must report stored column name 'VAL', got: " + colNames);
-        assertFalse(colNames.contains("id"), "SHOW STATS must not lowercase 'Id' to 'id', got: " + colNames);
-        assertFalse(colNames.contains("name"), "SHOW STATS must not lowercase 'Name' to 'name', got: " + colNames);
-        assertFalse(colNames.contains("val"), "SHOW STATS must not lowercase 'VAL' to 'val', got: " + colNames);
-
-        assertQuerySucceeds(testSession(), "DROP TABLE analyze_mixed");
+            Set<String> colNames = showStatsColumnNames("analyze_mixed");
+            assertTrue(colNames.contains("Id"), "SHOW STATS must report stored column name 'Id', got: " + colNames);
+            assertTrue(colNames.contains("Name"), "SHOW STATS must report stored column name 'Name', got: " + colNames);
+            assertTrue(colNames.contains("VAL"), "SHOW STATS must report stored column name 'VAL', got: " + colNames);
+            assertFalse(colNames.contains("id"), "SHOW STATS must not lowercase 'Id' to 'id', got: " + colNames);
+            assertFalse(colNames.contains("name"), "SHOW STATS must not lowercase 'Name' to 'name', got: " + colNames);
+            assertFalse(colNames.contains("val"), "SHOW STATS must not lowercase 'VAL' to 'val', got: " + colNames);
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS analyze_mixed");
+        }
     }
 
     @Test
     public void testAnalyzeLowerCaseColumns()
     {
-        assertQuerySucceeds(testSession(), "CREATE TABLE analyze_lower (id bigint, name varchar, val integer)");
-        assertQuerySucceeds(testSession(), "INSERT INTO analyze_lower VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE analyze_lower (id bigint, name varchar, val integer)");
+            assertQuerySucceeds(testSession(), "INSERT INTO analyze_lower VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
 
-        assertQuerySucceeds(testSession(), "ANALYZE analyze_lower");
+            assertQuerySucceeds(testSession(), "ANALYZE analyze_lower");
 
-        Set<String> colNames = showStatsColumnNames("analyze_lower");
-        assertTrue(colNames.contains("id"), "SHOW STATS must report column 'id', got: " + colNames);
-        assertTrue(colNames.contains("name"), "SHOW STATS must report column 'name', got: " + colNames);
-        assertTrue(colNames.contains("val"), "SHOW STATS must report column 'val', got: " + colNames);
-
-        assertQuerySucceeds(testSession(), "DROP TABLE analyze_lower");
+            Set<String> colNames = showStatsColumnNames("analyze_lower");
+            assertTrue(colNames.contains("id"), "SHOW STATS must report column 'id', got: " + colNames);
+            assertTrue(colNames.contains("name"), "SHOW STATS must report column 'name', got: " + colNames);
+            assertTrue(colNames.contains("val"), "SHOW STATS must report column 'val', got: " + colNames);
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS analyze_lower");
+        }
     }
 
     @Test
     public void testShowStatsForFilteredMixedCaseColumns()
     {
         // RegionId is both a column and a partition column — predicates on it are pushed down.
-        assertQuerySucceeds(testSession(), "CREATE TABLE stats_filter_cs (RegionId bigint, Name varchar) WITH (partitioning = ARRAY['RegionId'])");
-        assertQuerySucceeds(testSession(), "INSERT INTO stats_filter_cs VALUES (1, 'north'), (2, 'south'), (1, 'east')");
-        assertQuerySucceeds(testSession(), "ANALYZE stats_filter_cs");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE stats_filter_cs (RegionId bigint, Name varchar) WITH (partitioning = ARRAY['RegionId'])");
+            assertQuerySucceeds(testSession(), "INSERT INTO stats_filter_cs VALUES (1, 'north'), (2, 'south'), (1, 'east')");
+            assertQuerySucceeds(testSession(), "ANALYZE stats_filter_cs");
 
-        // Exact-case partition filter — pushed down to scan, no FilterNode remains → succeeds.
-        assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_cs WHERE RegionId = 1)");
-        // Wrong-case partition filter — 'regionid' does not match stored 'RegionId' in case-sensitive mode.
-        assertQueryFails(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_cs WHERE regionid = 1)", ".*Column.*regionid.*cannot be resolved.*");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE stats_filter_cs");
+            // Exact-case partition filter — pushed down to scan, no FilterNode remains → succeeds.
+            assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_cs WHERE RegionId = 1)");
+            // Wrong-case partition filter — 'regionid' does not match stored 'RegionId' in case-sensitive mode.
+            assertQueryFails(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_cs WHERE regionid = 1)", ".*Column.*regionid.*cannot be resolved.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS stats_filter_cs");
+        }
     }
 
     @Test
     public void testRewriteDataFilesWithSortedByMixedCaseColumn()
     {
-        assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_cs (Id bigint, Name varchar, VAL integer)");
-        assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_cs VALUES (3, 'c', 30), (1, 'a', 10)");
-        assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_cs VALUES (2, 'b', 20), (4, 'd', 40)");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_cs (Id bigint, Name varchar, VAL integer)");
+            assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_cs VALUES (3, 'c', 30), (1, 'a', 10)");
+            assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_cs VALUES (2, 'b', 20), (4, 'd', 40)");
 
-        // sorted_by uses the mixed-case column 'Id' exactly as stored — must resolve correctly
-        assertQuerySucceeds(testSession(), format(
-                "CALL iceberg.system.rewrite_data_files(schema => '%s', table_name => 'rewrite_sorted_cs', " +
-                        "sorted_by => ARRAY['Id'])",
-                SCHEMA));
+            // sorted_by uses the mixed-case column 'Id' exactly as stored — must resolve correctly
+            assertQuerySucceeds(testSession(), format(
+                    "CALL iceberg.system.rewrite_data_files(schema => '%s', table_name => 'rewrite_sorted_cs', " +
+                            "sorted_by => ARRAY['Id'])",
+                    SCHEMA));
 
-        assertQuery(testSession(), "SELECT Id, Name, VAL FROM rewrite_sorted_cs ORDER BY Id", "VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)");
+            assertQuery(testSession(), "SELECT Id, Name, VAL FROM rewrite_sorted_cs ORDER BY Id", "VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)");
 
-        List<Types.NestedField> columns = getIcebergTable(SCHEMA, "rewrite_sorted_cs").schema().columns();
-        assertEquals(columns.get(0).name(), "Id", "Column 0 must be stored as 'Id', not lower cased");
-        assertEquals(columns.get(1).name(), "Name", "Column 1 must be stored as 'Name', not lower cased");
-        assertEquals(columns.get(2).name(), "VAL", "Column 2 must be stored as 'VAL', not lower cased");
-        assertFalse(columns.get(0).name().equals("id"), "Column 0 must NOT be stored as lowercase 'id'");
-        assertFalse(columns.get(1).name().equals("name"), "Column 1 must NOT be stored as lowercase 'name'");
-        assertFalse(columns.get(2).name().equals("val"), "Column 2 must NOT be stored as lowercase 'val'");
+            List<Types.NestedField> columns = getIcebergTable(SCHEMA, "rewrite_sorted_cs").schema().columns();
+            assertEquals(columns.get(0).name(), "Id", "Column 0 must be stored as 'Id', not lower cased");
+            assertEquals(columns.get(1).name(), "Name", "Column 1 must be stored as 'Name', not lower cased");
+            assertEquals(columns.get(2).name(), "VAL", "Column 2 must be stored as 'VAL', not lower cased");
+            assertFalse(columns.get(0).name().equals("id"), "Column 0 must NOT be stored as lowercase 'id'");
+            assertFalse(columns.get(1).name().equals("name"), "Column 1 must NOT be stored as lowercase 'name'");
+            assertFalse(columns.get(2).name().equals("val"), "Column 2 must NOT be stored as lowercase 'val'");
 
-        assertQueryFails(testSession(), "SELECT id FROM rewrite_sorted_cs", ".*Column.*id.*cannot be resolved.*");
-        assertQueryFails(testSession(), "SELECT name FROM rewrite_sorted_cs", ".*Column.*name.*cannot be resolved.*");
-        assertQueryFails(testSession(), "SELECT val FROM rewrite_sorted_cs", ".*Column.*val.*cannot be resolved.*");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE rewrite_sorted_cs");
+            assertQueryFails(testSession(), "SELECT id FROM rewrite_sorted_cs", ".*Column.*id.*cannot be resolved.*");
+            assertQueryFails(testSession(), "SELECT name FROM rewrite_sorted_cs", ".*Column.*name.*cannot be resolved.*");
+            assertQueryFails(testSession(), "SELECT val FROM rewrite_sorted_cs", ".*Column.*val.*cannot be resolved.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS rewrite_sorted_cs");
+        }
     }
 
     /**
@@ -260,35 +303,36 @@ public class TestIcebergRestCaseSensitiveNameMatching
     @Test
     public void testColumnsDistinctByCase()
     {
-        assertQuerySucceeds(testSession(), "CREATE TABLE casecols (id bigint, ID bigint, Id bigint, name varchar)");
-        assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (1, 10, 100, 'alpha')");
-        assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (2, 20, 200, 'beta')");
-        assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (3, 30, 300, 'gamma')");
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE casecols (id bigint, ID bigint, Id bigint, name varchar)");
+            assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (1, 10, 100, 'alpha')");
+            assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (2, 20, 200, 'beta')");
+            assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (3, 30, 300, 'gamma')");
 
-        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols ORDER BY id",
-                "VALUES (1, 10, 100, 'alpha'), (2, 20, 200, 'beta'), (3, 30, 300, 'gamma')");
+            assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols ORDER BY id",
+                    "VALUES (1, 10, 100, 'alpha'), (2, 20, 200, 'beta'), (3, 30, 300, 'gamma')");
 
-        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE id = 2", "VALUES (2, 20, 200, 'beta')");
-        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE ID = 20", "VALUES (2, 20, 200, 'beta')");
+            assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE id = 2", "VALUES (2, 20, 200, 'beta')");
+            assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE ID = 20", "VALUES (2, 20, 200, 'beta')");
+            assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE Id = 200", "VALUES (2, 20, 200, 'beta')");
+            assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE name = 'gamma'", "VALUES (3, 30, 300, 'gamma')");
 
-        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE Id = 200", "VALUES (2, 20, 200, 'beta')");
-        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE name = 'gamma'", "VALUES (3, 30, 300, 'gamma')");
+            assertQuery(testSession(), "SELECT count(*) FROM casecols WHERE ID = 3", "VALUES (0)");
+            assertQuery(testSession(), "SELECT count(*) FROM casecols WHERE id = 100", "VALUES (0)");
 
-        assertQuery(testSession(), "SELECT count(*) FROM casecols WHERE ID = 3", "VALUES (0)");
-        assertQuery(testSession(), "SELECT count(*) FROM casecols WHERE id = 100", "VALUES (0)");
+            assertQuery(testSession(), "SELECT a.id, a.ID, a.Id, name FROM casecols a JOIN casecols b USING (name) WHERE a.id = 1",
+                    "VALUES (1, 10, 100, 'alpha')");
+            assertQuery(testSession(), "SELECT id, a.ID, a.Id FROM casecols a JOIN casecols b USING (id) WHERE id = 2",
+                    "VALUES (2, 20, 200)");
+            assertQueryFails(testSession(), "SELECT a.id FROM casecols a JOIN casecols b USING (iD)", ".*Column.*iD.*missing from left side of join.*");
 
-        assertQuery(testSession(), "SELECT a.id, a.ID, a.Id, name FROM casecols a JOIN casecols b USING (name) WHERE a.id = 1",
-                "VALUES (1, 10, 100, 'alpha')");
-
-        assertQuery(testSession(), "SELECT id, a.ID, a.Id FROM casecols a JOIN casecols b USING (id) WHERE id = 2",
-                "VALUES (2, 20, 200)");
-        assertQueryFails(testSession(), "SELECT a.id FROM casecols a JOIN casecols b USING (iD)", ".*Column.*iD.*missing from left side of join.*");
-
-        assertQueryFails(testSession(), "SELECT iD FROM casecols", ".*Column.*iD.*cannot be resolved.*");
-        assertQueryFails(testSession(), "SELECT id FROM casecols WHERE iD = 1", ".*Column.*iD.*cannot be resolved.*");
-        assertQueryFails(testSession(), "SELECT id FROM casecols ORDER BY iD", ".*Column.*iD.*cannot be resolved.*");
-
-        assertQuerySucceeds(testSession(), "DROP TABLE casecols");
+            assertQueryFails(testSession(), "SELECT iD FROM casecols", ".*Column.*iD.*cannot be resolved.*");
+            assertQueryFails(testSession(), "SELECT id FROM casecols WHERE iD = 1", ".*Column.*iD.*cannot be resolved.*");
+            assertQueryFails(testSession(), "SELECT id FROM casecols ORDER BY iD", ".*Column.*iD.*cannot be resolved.*");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS casecols");
+        }
     }
 
     private Set<String> showStatsColumnNames(String tableName)
@@ -296,7 +340,7 @@ public class TestIcebergRestCaseSensitiveNameMatching
         MaterializedResult result = computeActual(testSession(), "SHOW STATS FOR " + tableName);
         return result.getMaterializedRows().stream()
                 .map(row -> (String) row.getField(0))
-                .filter(name -> name != null)
-                .collect(Collectors.toSet());
+                .filter(Objects::nonNull)
+                .collect(toImmutableSet());
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
@@ -16,6 +16,7 @@ package com.facebook.presto.iceberg.rest;
 import com.facebook.presto.iceberg.IcebergConfig;
 import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
 import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
 import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
@@ -23,6 +24,8 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
 import static com.facebook.presto.iceberg.FileFormat.ORC;
@@ -165,6 +168,57 @@ public class TestIcebergRestCaseSensitiveNameMatching
     }
 
     @Test
+    public void testAnalyzeMixedCaseColumns()
+    {
+        assertQuerySucceeds(testSession(), "CREATE TABLE analyze_mixed (Id bigint, Name varchar, VAL integer)");
+        assertQuerySucceeds(testSession(), "INSERT INTO analyze_mixed VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
+
+        assertQuerySucceeds(testSession(), "ANALYZE analyze_mixed");
+
+        Set<String> colNames = showStatsColumnNames("analyze_mixed");
+        assertTrue(colNames.contains("Id"), "SHOW STATS must report stored column name 'Id', got: " + colNames);
+        assertTrue(colNames.contains("Name"), "SHOW STATS must report stored column name 'Name', got: " + colNames);
+        assertTrue(colNames.contains("VAL"), "SHOW STATS must report stored column name 'VAL', got: " + colNames);
+        assertFalse(colNames.contains("id"), "SHOW STATS must not lowercase 'Id' to 'id', got: " + colNames);
+        assertFalse(colNames.contains("name"), "SHOW STATS must not lowercase 'Name' to 'name', got: " + colNames);
+        assertFalse(colNames.contains("val"), "SHOW STATS must not lowercase 'VAL' to 'val', got: " + colNames);
+
+        assertQuerySucceeds(testSession(), "DROP TABLE analyze_mixed");
+    }
+
+    @Test
+    public void testAnalyzeLowerCaseColumns()
+    {
+        assertQuerySucceeds(testSession(), "CREATE TABLE analyze_lower (id bigint, name varchar, val integer)");
+        assertQuerySucceeds(testSession(), "INSERT INTO analyze_lower VALUES (1, 'alice', 10), (2, 'bob', 20), (3, 'alice', 30)");
+
+        assertQuerySucceeds(testSession(), "ANALYZE analyze_lower");
+
+        Set<String> colNames = showStatsColumnNames("analyze_lower");
+        assertTrue(colNames.contains("id"), "SHOW STATS must report column 'id', got: " + colNames);
+        assertTrue(colNames.contains("name"), "SHOW STATS must report column 'name', got: " + colNames);
+        assertTrue(colNames.contains("val"), "SHOW STATS must report column 'val', got: " + colNames);
+
+        assertQuerySucceeds(testSession(), "DROP TABLE analyze_lower");
+    }
+
+    @Test
+    public void testShowStatsForFilteredMixedCaseColumns()
+    {
+        // RegionId is both a column and a partition column — predicates on it are pushed down.
+        assertQuerySucceeds(testSession(), "CREATE TABLE stats_filter_cs (RegionId bigint, Name varchar) WITH (partitioning = ARRAY['RegionId'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO stats_filter_cs VALUES (1, 'north'), (2, 'south'), (1, 'east')");
+        assertQuerySucceeds(testSession(), "ANALYZE stats_filter_cs");
+
+        // Exact-case partition filter — pushed down to scan, no FilterNode remains → succeeds.
+        assertQuerySucceeds(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_cs WHERE RegionId = 1)");
+        // Wrong-case partition filter — 'regionid' does not match stored 'RegionId' in case-sensitive mode.
+        assertQueryFails(testSession(), "SHOW STATS FOR (SELECT * FROM stats_filter_cs WHERE regionid = 1)", ".*Column.*regionid.*cannot be resolved.*");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE stats_filter_cs");
+    }
+
+    @Test
     public void testRewriteDataFilesWithSortedByMixedCaseColumn()
     {
         assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_cs (Id bigint, Name varchar, VAL integer)");
@@ -188,5 +242,53 @@ public class TestIcebergRestCaseSensitiveNameMatching
         assertFalse(columns.get(2).name().equals("val"), "Column 2 must NOT be stored as lowercase 'val'");
 
         assertQuerySucceeds(testSession(), "DROP TABLE rewrite_sorted_cs");
+    }
+
+    /**
+     * Verifies that columns whose names differ only in case — {@code id}, {@code ID}, {@code Id} —
+     * plus {@code name} — are all stored and resolved as <em>distinct</em> columns in case-sensitive
+     * mode, and that SELECT, WHERE, ORDER BY, and JOIN USING all honour exact-case matching.
+     */
+    @Test
+    public void testColumnsDistinctByCase()
+    {
+        assertQuerySucceeds(testSession(), "CREATE TABLE casecols (id bigint, ID bigint, Id bigint, name varchar)");
+        assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (1, 10, 100, 'alpha')");
+        assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (2, 20, 200, 'beta')");
+        assertQuerySucceeds(testSession(), "INSERT INTO casecols VALUES (3, 30, 300, 'gamma')");
+
+        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols ORDER BY id",
+                "VALUES (1, 10, 100, 'alpha'), (2, 20, 200, 'beta'), (3, 30, 300, 'gamma')");
+
+        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE id = 2", "VALUES (2, 20, 200, 'beta')");
+        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE ID = 20", "VALUES (2, 20, 200, 'beta')");
+
+        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE Id = 200", "VALUES (2, 20, 200, 'beta')");
+        assertQuery(testSession(), "SELECT id, ID, Id, name FROM casecols WHERE name = 'gamma'", "VALUES (3, 30, 300, 'gamma')");
+
+        assertQuery(testSession(), "SELECT count(*) FROM casecols WHERE ID = 3", "VALUES (0)");
+        assertQuery(testSession(), "SELECT count(*) FROM casecols WHERE id = 100", "VALUES (0)");
+
+        assertQuery(testSession(), "SELECT a.id, a.ID, a.Id, name FROM casecols a JOIN casecols b USING (name) WHERE a.id = 1",
+                "VALUES (1, 10, 100, 'alpha')");
+
+        assertQuery(testSession(), "SELECT id, a.ID, a.Id FROM casecols a JOIN casecols b USING (id) WHERE id = 2",
+                "VALUES (2, 20, 200)");
+        assertQueryFails(testSession(), "SELECT a.id FROM casecols a JOIN casecols b USING (iD)", ".*Column.*iD.*missing from left side of join.*");
+
+        assertQueryFails(testSession(), "SELECT iD FROM casecols", ".*Column.*iD.*cannot be resolved.*");
+        assertQueryFails(testSession(), "SELECT id FROM casecols WHERE iD = 1", ".*Column.*iD.*cannot be resolved.*");
+        assertQueryFails(testSession(), "SELECT id FROM casecols ORDER BY iD", ".*Column.*iD.*cannot be resolved.*");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE casecols");
+    }
+
+    private Set<String> showStatsColumnNames(String tableName)
+    {
+        MaterializedResult result = computeActual(testSession(), "SHOW STATS FOR " + tableName);
+        return result.getMaterializedRows().stream()
+                .map(row -> (String) row.getField(0))
+                .filter(name -> name != null)
+                .collect(Collectors.toSet());
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.iceberg.CatalogType.REST;
-import static com.facebook.presto.iceberg.FileFormat.ORC;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -52,7 +51,7 @@ public class TestIcebergRestCaseSensitiveNameMatching
     {
         return IcebergQueryRunner.builder()
                 .setCatalogType(REST)
-                .setFormat(ORC)
+                .setFormat(fileFormat)
                 .setExtraConnectorProperties(ImmutableMap.<String, String>builder()
                         .putAll(restConnectorProperties(serverUri))
                         .put("case-sensitive-name-matching", "true")

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
@@ -334,6 +334,158 @@ public class TestIcebergRestCaseSensitiveNameMatching
         }
     }
 
+    /**
+     * Verifies that nested ROW field names are stored and resolved exactly as written
+     * in case-sensitive mode. Nested fields whose names differ only in case are distinct.
+     */
+    @Test
+    public void testNestedRowFieldsCaseSensitive()
+    {
+        // Basic nested ROW: field names preserved as-is; wrong-case access fails.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE nested_basic_cs (id bigint, addr ROW(\"Street\" varchar, \"City\" varchar))");
+            assertQuerySucceeds(testSession(), "INSERT INTO nested_basic_cs VALUES (1, row('Main St', 'Springfield'))");
+
+            // Exact-case field access succeeds.
+            assertQuery(testSession(), "SELECT id, addr.Street, addr.City FROM nested_basic_cs",
+                    "VALUES (1, 'Main St', 'Springfield')");
+
+            // Wrong-case field access fails — 'street' and 'Street' are distinct in case-sensitive mode.
+            assertQueryFails(testSession(), "SELECT addr.street FROM nested_basic_cs",
+                    "line 1:8: 'addr.street' cannot be resolved");
+
+            // Verify stored field names in raw Iceberg schema.
+            Types.NestedField addrField = getIcebergTable(SCHEMA, "nested_basic_cs").schema().findField("addr");
+            List<Types.NestedField> subFields = addrField.type().asStructType().fields();
+            assertEquals(subFields.get(0).name(), "Street", "Nested field 0 must be stored as 'Street'");
+            assertEquals(subFields.get(1).name(), "City", "Nested field 1 must be stored as 'City'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS nested_basic_cs");
+        }
+    }
+
+    /**
+     * Verifies that nested fields whose names differ only in case are treated as distinct
+     * columns in case-sensitive mode — e.g. {@code val}, {@code Val}, and {@code VAL} inside
+     * the same ROW are three separate fields.
+     */
+    @Test
+    public void testNestedRowFieldsDistinctByCase()
+    {
+        // Three sub-fields that differ only in case — all distinct in case-sensitive mode.
+        try {
+            assertQuerySucceeds(testSession(), "CREATE TABLE nested_case_distinct_cs (id bigint, metrics ROW(val bigint, Val bigint, VAL bigint))");
+            assertQuerySucceeds(testSession(), "INSERT INTO nested_case_distinct_cs VALUES (1, row(10, 20, 30))");
+
+            assertQuery(testSession(), "SELECT metrics.val, metrics.Val, metrics.VAL FROM nested_case_distinct_cs", "VALUES (10, 20, 30)");
+
+            // Each variant resolves to a different stored field.
+            assertQuery(testSession(), "SELECT metrics.val FROM nested_case_distinct_cs", "VALUES (10)");
+            assertQuery(testSession(), "SELECT metrics.Val FROM nested_case_distinct_cs", "VALUES (20)");
+            assertQuery(testSession(), "SELECT metrics.VAL FROM nested_case_distinct_cs", "VALUES (30)");
+
+            // A name that matches none of the three fails.
+            assertQueryFails(testSession(), "SELECT metrics.vAl FROM nested_case_distinct_cs", "line 1:8: 'metrics.vAl' cannot be resolved");
+
+            // Raw schema must carry all three names exactly as written.
+            Types.NestedField metricsField = getIcebergTable(SCHEMA, "nested_case_distinct_cs").schema().findField("metrics");
+            List<Types.NestedField> subFields = metricsField.type().asStructType().fields();
+            assertEquals(subFields.size(), 3, "ROW must have exactly 3 distinct sub-fields");
+            assertEquals(subFields.get(0).name(), "val");
+            assertEquals(subFields.get(1).name(), "Val");
+            assertEquals(subFields.get(2).name(), "VAL");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS nested_case_distinct_cs");
+        }
+    }
+
+    /**
+     * Verifies deeply nested ROW (struct inside struct) with mixed-case field names in
+     * case-sensitive mode — both levels of nesting preserve exact case.
+     */
+    @Test
+    public void testDeeplyNestedRowFieldsCaseSensitive()
+    {
+        // Two levels of nesting: person ROW(Name varchar, address ROW(Street varchar, Zip varchar))
+        try {
+            assertQuerySucceeds(testSession(),
+                    "CREATE TABLE nested_deep_cs (id bigint, person ROW(\"Name\" varchar, address ROW(\"Street\" varchar, \"Zip\" varchar)))");
+            assertQuerySucceeds(testSession(),
+                    "INSERT INTO nested_deep_cs VALUES (1, row('Alice', row('Baker St', '90210')))");
+
+            // Top-level nested field access.
+            assertQuery(testSession(), "SELECT person.Name FROM nested_deep_cs", "VALUES ('Alice')");
+
+            // Second-level nested field access.
+            assertQuery(testSession(), "SELECT person.address.Street, person.address.Zip FROM nested_deep_cs",
+                    "VALUES ('Baker St', '90210')");
+
+            // Wrong-case at either level fails.
+            assertQueryFails(testSession(), "SELECT person.name FROM nested_deep_cs", "line 1:8: 'person.name' cannot be resolved");
+            assertQueryFails(testSession(), "SELECT person.address.street FROM nested_deep_cs", "line 1:8: 'person.address.street' cannot be resolved");
+
+            // Verify raw Iceberg schema for both levels.
+            Types.NestedField personField = getIcebergTable(SCHEMA, "nested_deep_cs").schema().findField("person");
+            List<Types.NestedField> personSubFields = personField.type().asStructType().fields();
+            assertEquals(personSubFields.get(0).name(), "Name", "Level-1 field 0 must be 'Name'");
+            assertEquals(personSubFields.get(1).name(), "address", "Level-1 field 1 must be 'address'");
+
+            List<Types.NestedField> addrSubFields = personSubFields.get(1).type().asStructType().fields();
+            assertEquals(addrSubFields.get(0).name(), "Street", "Level-2 field 0 must be 'Street'");
+            assertEquals(addrSubFields.get(1).name(), "Zip", "Level-2 field 1 must be 'Zip'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS nested_deep_cs");
+        }
+    }
+
+    /**
+     * Verifies that a nested sub-field can share the same name as its parent column,
+     * and that case-sensitive resolution keeps the two scopes unambiguous.
+     *
+     * <p>Schema: {@code id bigint, addr ROW(addr varchar, id bigint, City varchar)}
+     * <ul>
+     *   <li>{@code addr} — top-level ROW column</li>
+     *   <li>{@code addr.addr} — sub-field with the same name as the parent column</li>
+     *   <li>{@code addr.id} — sub-field with the same name as the sibling top-level column</li>
+     *   <li>{@code addr.City} — mixed-case sub-field distinct from any lowercase variant</li>
+     * </ul>
+     */
+    @Test
+    public void testNestedFieldNameSameAsParentColumn()
+    {
+        try {
+            assertQuerySucceeds(testSession(),
+                    "CREATE TABLE nested_shadow_cs (id bigint, addr ROW(addr varchar, id bigint, \"City\" varchar))");
+            assertQuerySucceeds(testSession(),
+                    "INSERT INTO nested_shadow_cs VALUES (1, row('Main St', 42, 'Springfield'))");
+
+            // Top-level 'id' and nested 'addr.id' are independent.
+            assertQuery(testSession(), "SELECT id FROM nested_shadow_cs", "VALUES (1)");
+            assertQuery(testSession(), "SELECT addr.id FROM nested_shadow_cs", "VALUES (42)");
+
+            // Top-level 'addr' (the ROW) vs nested 'addr.addr' (the varchar sub-field).
+            assertQuery(testSession(), "SELECT addr.addr FROM nested_shadow_cs", "VALUES ('Main St')");
+
+            // Mixed-case sub-field preserved as-is; wrong-case fails.
+            assertQuery(testSession(), "SELECT addr.City FROM nested_shadow_cs", "VALUES ('Springfield')");
+            assertQueryFails(testSession(), "SELECT addr.city FROM nested_shadow_cs", "line 1:8: 'addr.city' cannot be resolved");
+
+            // Raw schema: top-level column is 'addr' (ROW), its sub-fields are 'addr', 'id', 'City'.
+            Types.NestedField addrCol = getIcebergTable(SCHEMA, "nested_shadow_cs").schema().findField("addr");
+            List<Types.NestedField> subFields = addrCol.type().asStructType().fields();
+            assertEquals(subFields.size(), 3);
+            assertEquals(subFields.get(0).name(), "addr", "Sub-field 0 must be 'addr' (same as parent)");
+            assertEquals(subFields.get(1).name(), "id", "Sub-field 1 must be 'id' (same as sibling top-level)");
+            assertEquals(subFields.get(2).name(), "City", "Sub-field 2 must be preserved as 'City'");
+        }
+        finally {
+            assertQuerySucceeds(testSession(), "DROP TABLE IF EXISTS nested_shadow_cs");
+        }
+    }
+
     private Set<String> showStatsColumnNames(String tableName)
     {
         MaterializedResult result = computeActual(testSession(), "SHOW STATS FOR " + tableName);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
@@ -113,12 +113,14 @@ public class TestIcebergRestCaseSensitiveNameMatching
         assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
         assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
         assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+        assertQueryFails(testSession(), "SELECT firstname, lastname FROM coltestquoted", ".*Column.*firstname.*cannot be resolved.*");
         assertQuerySucceeds(testSession(), "DROP TABLE coltestquoted");
 
-        // Unquoted mixed-case: same result — normalizeIdentifier preserves as-is.
+        // Unquoted mixed-case: normalizeIdentifier preserves as-is; analyser resolution is exact-case too.
         assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
         assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
         assertQuery(testSession(), "SELECT FirstName, lastName FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
+        assertQueryFails(testSession(), "SELECT firstname, lastname FROM coltestunquoted", ".*Column.*firstname.*cannot be resolved.*");
         assertQuerySucceeds(testSession(), "DROP TABLE coltestunquoted");
     }
 
@@ -129,12 +131,14 @@ public class TestIcebergRestCaseSensitiveNameMatching
         assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
         assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
         assertQuery(testSession(), "SELECT \"RegionId\", name FROM partTestQuoted ORDER BY \"RegionId\"", "VALUES (1, 'north'), (2, 'south')");
+        assertQueryFails(testSession(), "SELECT regionid FROM partTestQuoted", ".*Column.*regionid.*cannot be resolved.*");
         assertQuerySucceeds(testSession(), "DROP TABLE partTestQuoted");
 
         // Unquoted in partition array: 'RegionId' preserved as-is.
         assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
         assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
         assertQuery(testSession(), "SELECT RegionId, name FROM partTestUnquoted ORDER BY RegionId", "VALUES (1, 'north'), (2, 'south')");
+        assertQueryFails(testSession(), "SELECT regionid FROM partTestUnquoted", ".*Column.*regionid.*cannot be resolved.*");
         assertQuerySucceeds(testSession(), "DROP TABLE partTestUnquoted");
     }
 
@@ -240,6 +244,10 @@ public class TestIcebergRestCaseSensitiveNameMatching
         assertFalse(columns.get(0).name().equals("id"), "Column 0 must NOT be stored as lowercase 'id'");
         assertFalse(columns.get(1).name().equals("name"), "Column 1 must NOT be stored as lowercase 'name'");
         assertFalse(columns.get(2).name().equals("val"), "Column 2 must NOT be stored as lowercase 'val'");
+
+        assertQueryFails(testSession(), "SELECT id FROM rewrite_sorted_cs", ".*Column.*id.*cannot be resolved.*");
+        assertQueryFails(testSession(), "SELECT name FROM rewrite_sorted_cs", ".*Column.*name.*cannot be resolved.*");
+        assertQueryFails(testSession(), "SELECT val FROM rewrite_sorted_cs", ".*Column.*val.*cannot be resolved.*");
 
         assertQuerySucceeds(testSession(), "DROP TABLE rewrite_sorted_cs");
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatching.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import com.facebook.presto.iceberg.IcebergConfig;
+import com.facebook.presto.iceberg.IcebergNativeCatalogFactory;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.iceberg.CatalogType.REST;
+import static com.facebook.presto.iceberg.FileFormat.ORC;
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.rest.IcebergRestTestUtil.restConnectorProperties;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies that when {@code case-sensitive-name-matching=true} identifiers (schema names,
+ * table names, column names) are preserved as-is by {@code normalizeIdentifier}, enabling
+ * case-sensitive access to REST catalogs that preserve identifier case.
+ */
+@Test(singleThreaded = true)
+public class TestIcebergRestCaseSensitiveNameMatching
+        extends IcebergRestNameMatchingTestBase
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .setCatalogType(REST)
+                .setFormat(ORC)
+                .setExtraConnectorProperties(ImmutableMap.<String, String>builder()
+                        .putAll(restConnectorProperties(serverUri))
+                        .put("case-sensitive-name-matching", "true")
+                        .build())
+                .setDataDirectory(Optional.of(warehouseLocation.toPath()))
+                .setCreateTpchTables(false)
+                .build()
+                .getQueryRunner();
+    }
+
+    @Override
+    protected IcebergNativeCatalogFactory getCatalogFactory()
+    {
+        IcebergConfig icebergConfig = new IcebergConfig()
+                .setCatalogType(REST)
+                .setCaseSensitiveNameMatching(true)
+                .setCatalogWarehouse(warehouseLocation.getAbsolutePath());
+        return buildCatalogFactory(icebergConfig);
+    }
+
+    @Test
+    public void testCreateTableMixedCase()
+    {
+        // Both lower-case and upper-case variants can coexist as distinct tables in a
+        // case-sensitive catalog — normalizeIdentifier preserves each name as written.
+        assertQuerySucceeds(testSession(), "CREATE TABLE MixedCaseTable (id bigint, val varchar)");
+        assertQuerySucceeds(testSession(), "CREATE TABLE mixedcasetable (id bigint, val varchar)");
+
+        assertQuerySucceeds(testSession(), "SELECT * FROM MixedCaseTable");
+        assertQuerySucceeds(testSession(), "SELECT * FROM mixedcasetable");
+
+        // MIXEDCASETABLE is a third distinct name — does not exist
+        assertQueryFails(testSession(), "SELECT * FROM MIXEDCASETABLE", ".*Table.*does not exist.*");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE MixedCaseTable");
+        assertQuerySucceeds(testSession(), "DROP TABLE mixedcasetable");
+    }
+
+    @Test
+    public void testCreateTableAsMixedCase()
+    {
+        // 'MyTable' is stored as-is; 'mytable' is a different (non-existent) table.
+        assertQuerySucceeds(testSession(), "CREATE TABLE MyTable AS SELECT 1 AS id, 'hello' AS name");
+        assertQuery(testSession(), "SELECT id, name FROM MyTable", "VALUES (1, 'hello')");
+
+        assertQueryFails(testSession(), "SELECT * FROM mytable", ".*Table.*does not exist.*");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE MyTable");
+    }
+
+    @Test
+    public void testMixedCaseColumns()
+    {
+        // The Presto parser preserves identifier case exactly as written — it never lowercases.
+        // normalizeIdentifier is the only thing that changes case; with case-sensitive-name-matching=true
+        // it returns identifiers as-is regardless of whether they were quoted or unquoted in SQL.
+
+        // Quoted: double-quotes tell the parser to treat the token as an identifier (not a keyword).
+        assertQuerySucceeds(testSession(), "CREATE TABLE coltestquoted (\"FirstName\" varchar, \"lastName\" varchar)");
+        assertQuerySucceeds(testSession(), "INSERT INTO coltestquoted VALUES ('Alice', 'Smith')");
+        assertQuery(testSession(), "SELECT \"FirstName\", \"lastName\" FROM coltestquoted", "VALUES ('Alice', 'Smith')");
+        assertQuerySucceeds(testSession(), "DROP TABLE coltestquoted");
+
+        // Unquoted mixed-case: same result — normalizeIdentifier preserves as-is.
+        assertQuerySucceeds(testSession(), "CREATE TABLE coltestunquoted (FirstName varchar, lastName varchar)");
+        assertQuerySucceeds(testSession(), "INSERT INTO coltestunquoted VALUES ('Bob', 'Jones')");
+        assertQuery(testSession(), "SELECT FirstName, lastName FROM coltestunquoted", "VALUES ('Bob', 'Jones')");
+        assertQuerySucceeds(testSession(), "DROP TABLE coltestunquoted");
+    }
+
+    @Test
+    public void testMixedCasePartitionColumn()
+    {
+        // Quoted column in partition array: '"RegionId"' → strips quotes → 'RegionId' preserved.
+        assertQuerySucceeds(testSession(), "CREATE TABLE partTestQuoted (\"RegionId\" bigint, name varchar) WITH (partitioning = ARRAY['\"RegionId\"'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO partTestQuoted VALUES (1, 'north'), (2, 'south')");
+        assertQuery(testSession(), "SELECT \"RegionId\", name FROM partTestQuoted ORDER BY \"RegionId\"", "VALUES (1, 'north'), (2, 'south')");
+        assertQuerySucceeds(testSession(), "DROP TABLE partTestQuoted");
+
+        // Unquoted in partition array: 'RegionId' preserved as-is.
+        assertQuerySucceeds(testSession(), "CREATE TABLE partTestUnquoted (RegionId bigint, name varchar) WITH (partitioning = ARRAY['RegionId'])");
+        assertQuerySucceeds(testSession(), "INSERT INTO partTestUnquoted VALUES (1, 'north'), (2, 'south')");
+        assertQuery(testSession(), "SELECT RegionId, name FROM partTestUnquoted ORDER BY RegionId", "VALUES (1, 'north'), (2, 'south')");
+        assertQuerySucceeds(testSession(), "DROP TABLE partTestUnquoted");
+    }
+
+    @Test
+    public void testShowColumnsCaseSensitive()
+    {
+        // Quoted: normalizeIdentifier preserves mixed case.
+        assertQuerySucceeds(testSession(), "CREATE TABLE showcols (\"MyCol\" bigint, \"anotherCol\" varchar)");
+        String result = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcols").toString();
+        assertTrue(result.contains("MyCol"), "Expected 'MyCol' in SHOW COLUMNS output");
+        assertTrue(result.contains("anotherCol"), "Expected 'anotherCol' in SHOW COLUMNS output");
+        assertQuerySucceeds(testSession(), "DROP TABLE showcols");
+
+        // Unquoted: same result — normalizeIdentifier preserves as-is.
+        assertQuerySucceeds(testSession(), "CREATE TABLE showcolslower (MyCol bigint, anotherCol varchar)");
+        String resultLower = getQueryRunner().execute(testSession(), "SHOW COLUMNS FROM showcolslower").toString();
+        assertTrue(resultLower.contains("MyCol"), "Expected 'MyCol' in SHOW COLUMNS output");
+        assertTrue(resultLower.contains("anotherCol"), "Expected 'anotherCol' in SHOW COLUMNS output");
+        assertQuerySucceeds(testSession(), "DROP TABLE showcolslower");
+    }
+
+    @Test
+    public void testNormalizeIdentifierPreservesCase()
+    {
+        String normalized = normalizeIdentifier("MyTable", ICEBERG_CATALOG);
+        assertTrue(normalized.equals("MyTable"), "Expected normalizeIdentifier to preserve case, got: " + normalized);
+        String normalizedLower = normalizeIdentifier("mytable", ICEBERG_CATALOG);
+        assertTrue(normalizedLower.equals("mytable"), "Expected normalizeIdentifier to preserve lowercase, got: " + normalizedLower);
+        assertFalse(normalized.equals("mytable"), "normalizeIdentifier must not lowercase 'MyTable' in case-sensitive mode");
+        assertFalse(normalizedLower.equals("MYTABLE"), "normalizeIdentifier must not uppercase 'mytable' in case-sensitive mode");
+    }
+
+    @Test
+    public void testRewriteDataFilesWithSortedByMixedCaseColumn()
+    {
+        assertQuerySucceeds(testSession(), "CREATE TABLE rewrite_sorted_cs (Id bigint, Name varchar, VAL integer)");
+        assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_cs VALUES (3, 'c', 30), (1, 'a', 10)");
+        assertQuerySucceeds(testSession(), "INSERT INTO rewrite_sorted_cs VALUES (2, 'b', 20), (4, 'd', 40)");
+
+        // sorted_by uses the mixed-case column 'Id' exactly as stored — must resolve correctly
+        assertQuerySucceeds(testSession(), format(
+                "CALL iceberg.system.rewrite_data_files(schema => '%s', table_name => 'rewrite_sorted_cs', " +
+                        "sorted_by => ARRAY['Id'])",
+                SCHEMA));
+
+        assertQuery(testSession(), "SELECT Id, Name, VAL FROM rewrite_sorted_cs ORDER BY Id", "VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30), (4, 'd', 40)");
+
+        List<Types.NestedField> columns = getIcebergTable(SCHEMA, "rewrite_sorted_cs").schema().columns();
+        assertEquals(columns.get(0).name(), "Id", "Column 0 must be stored as 'Id', not lower cased");
+        assertEquals(columns.get(1).name(), "Name", "Column 1 must be stored as 'Name', not lower cased");
+        assertEquals(columns.get(2).name(), "VAL", "Column 2 must be stored as 'VAL', not lower cased");
+        assertFalse(columns.get(0).name().equals("id"), "Column 0 must NOT be stored as lowercase 'id'");
+        assertFalse(columns.get(1).name().equals("name"), "Column 1 must NOT be stored as lowercase 'name'");
+        assertFalse(columns.get(2).name().equals("val"), "Column 2 must NOT be stored as lowercase 'val'");
+
+        assertQuerySucceeds(testSession(), "DROP TABLE rewrite_sorted_cs");
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatchingParquet.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/rest/TestIcebergRestCaseSensitiveNameMatchingParquet.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.rest;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.iceberg.FileFormat.PARQUET;
+
+/**
+ * Runs the full {@link TestIcebergRestCaseSensitiveNameMatching} suite against the
+ * Parquet file format to verify that case-sensitive name matching behaves identically
+ * regardless of the underlying storage format.
+ */
+@Test(singleThreaded = true)
+public class TestIcebergRestCaseSensitiveNameMatchingParquet
+        extends TestIcebergRestCaseSensitiveNameMatching
+{
+    public TestIcebergRestCaseSensitiveNameMatchingParquet()
+    {
+        fileFormat = PARQUET;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -557,7 +557,8 @@ public class ExpressionAnalyzer
                     if (outerScopeSymbolTypes.containsKey(NodeRef.of(node))) {
                         return setExpressionType(node, outerScopeSymbolTypes.get(NodeRef.of(node)));
                     }
-                    throw missingAttributeException(node, qualifiedName);
+                    UnaryOperator<String> nameKeyFunction = scope.getRelationType().getNameKeyFunction();
+                    throw missingAttributeException(node, qualifiedName, nameKeyFunction);
                 }
             }
 
@@ -577,9 +578,12 @@ public class ExpressionAnalyzer
             RowType rowType = (RowType) baseType;
             String fieldName = node.getField().getValue();
 
+            UnaryOperator<String> nameKeyFunction = context.getContext().getScope().getRelationType().getNameKeyFunction();
+
             Type rowFieldType = null;
             for (RowType.Field rowField : rowType.getFields()) {
-                if (fieldName.equalsIgnoreCase(rowField.getName().orElse(null))) {
+                String storedName = rowField.getName().orElse(null);
+                if (storedName != null && nameKeyFunction.apply(fieldName).equals(nameKeyFunction.apply(storedName))) {
                     rowFieldType = rowField.getType();
                     break;
                 }
@@ -594,7 +598,7 @@ public class ExpressionAnalyzer
 
             if (rowFieldType == null) {
                 qualifiedName = qualifiedName == null ? QualifiedName.of(node.toString()) : qualifiedName;
-                throw missingAttributeException(node, qualifiedName);
+                throw missingAttributeException(node, qualifiedName, nameKeyFunction);
             }
 
             return setExpressionType(node, rowFieldType);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -132,6 +132,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static com.facebook.presto.common.function.OperatorType.ADD;
 import static com.facebook.presto.common.function.OperatorType.SUBSCRIPT;
@@ -171,6 +172,7 @@ import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_ORDER_BY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_PARAMETER_USAGE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_PROCEDURE_ARGUMENTS;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_ATTRIBUTE;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MISSING_ORDER_BY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MULTIPLE_FIELDS_FROM_SUBQUERY;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
@@ -483,7 +485,11 @@ public class ExpressionAnalyzer
             if (!resolvedField.isPresent() && outerScopeSymbolTypes.containsKey(NodeRef.of(node))) {
                 return setExpressionType(node, outerScopeSymbolTypes.get(NodeRef.of(node)));
             }
-            return handleResolvedField(node, resolvedField.orElseThrow(() -> missingAttributeException(node, name)), context);
+            if (!resolvedField.isPresent()) {
+                UnaryOperator<String> nameKeyFunction = context.getContext().getScope().getRelationType().getNameKeyFunction();
+                throw new SemanticException(MISSING_ATTRIBUTE, node, "Column '%s' cannot be resolved", nameKeyFunction.apply(node.getValue()));
+            }
+            return handleResolvedField(node, resolvedField.get(), context);
         }
 
         private Type handleResolvedField(Expression node, ResolvedField resolvedField, StackableAstVisitorContext<Context> context)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -95,6 +95,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 
 import static com.facebook.presto.SystemSessionProperties.isMaterializedViewDataConsistencyEnabled;
 import static com.facebook.presto.SystemSessionProperties.isMaterializedViewPartitionFilteringEnabled;
@@ -916,8 +917,9 @@ public class MaterializedViewQueryOptimizer
                 fields.add(Field.newUnqualified(whereClause.getLocation(), columnMetadata.getName(), columnMetadata.getType()));
             }
 
+            UnaryOperator<String> nameKeyFunction = id -> metadata.normalizeIdentifier(session, baseTableName.getCatalogName(), id);
             return Scope.builder()
-                    .withRelationType(RelationId.anonymous(), new RelationType(fields.build()))
+                    .withRelationType(RelationId.anonymous(), new RelationType(fields.build(), nameKeyFunction))
                     .build();
         }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -251,6 +251,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -2459,8 +2460,10 @@ class StatementAnalyzer
 
             List<Field> outputFields = fields.build();
 
+            UnaryOperator<String> nameKeyFunction = id -> metadata.normalizeIdentifier(session, name.getCatalogName(), id);
+
             Scope accessControlScope = Scope.builder()
-                    .withRelationType(RelationId.anonymous(), new RelationType(outputFields))
+                    .withRelationType(RelationId.anonymous(), new RelationType(outputFields, nameKeyFunction))
                     .build();
             analyzeFiltersAndMasks(table, name, accessControlScope, columnsMetadata);
 
@@ -2479,7 +2482,7 @@ class StatementAnalyzer
                 }
             }
 
-            Scope tableScope = createAndAssignScope(table, scope, outputFields);
+            Scope tableScope = createAndAssignScope(table, scope, outputFields, nameKeyFunction);
 
             if (isMergeIntoStatement) {
                 // Set the target table row id field reference used to process the MERGE command.
@@ -2579,7 +2582,8 @@ class StatementAnalyzer
                 fields.add(field);
             }
 
-            return createAndAssignScope(table, scope, fields.build());
+            UnaryOperator<String> nameKeyFunction = id -> metadata.normalizeIdentifier(session, tableName.getCatalogName(), id);
+            return createAndAssignScope(table, scope, fields.build(), nameKeyFunction);
         }
 
         private Scope processView(Table table, Optional<Scope> scope, QualifiedObjectName name, Optional<ViewDefinition> optionalView)
@@ -2647,12 +2651,13 @@ class StatementAnalyzer
 
             analysis.addRelationCoercion(table, outputFields.stream().map(Field::getType).toArray(Type[]::new));
 
+            UnaryOperator<String> viewNameKeyFunction = id -> metadata.normalizeIdentifier(session, name.getCatalogName(), id);
             Scope accessControlScope = Scope.builder()
-                    .withRelationType(RelationId.anonymous(), new RelationType(outputFields))
+                    .withRelationType(RelationId.anonymous(), new RelationType(outputFields, viewNameKeyFunction))
                     .build();
             analyzeFiltersAndMasks(table, name, accessControlScope, outputFields);
 
-            return createAndAssignScope(table, scope, outputFields);
+            return createAndAssignScope(table, scope, outputFields, viewNameKeyFunction);
         }
 
         private Scope processMaterializedView(
@@ -3967,7 +3972,7 @@ class StatementAnalyzer
 
             analysis.setJoinUsing(node, new Analysis.JoinUsingAnalysis(leftJoinFields, rightJoinFields, leftFields.build(), rightFields.build()));
 
-            return createAndAssignScope(node, scope, new RelationType(outputs.build()));
+            return createAndAssignScope(node, scope, new RelationType(outputs.build(), left.getRelationType().getNameKeyFunction()));
         }
 
         private boolean isLateralRelation(Relation node)
@@ -4499,7 +4504,7 @@ class StatementAnalyzer
                 }
             }
 
-            return createAndAssignScope(node, scope, outputFields.build());
+            return createAndAssignScope(node, scope, outputFields.build(), sourceScope.getRelationType().getNameKeyFunction());
         }
 
         private Scope computeAndAssignOrderByScope(OrderBy node, Scope sourceScope, Scope outputScope)
@@ -5491,6 +5496,11 @@ class StatementAnalyzer
         private Scope createAndAssignScope(Node node, Optional<Scope> parentScope, List<Field> fields)
         {
             return createAndAssignScope(node, parentScope, new RelationType(fields));
+        }
+
+        private Scope createAndAssignScope(Node node, Optional<Scope> parentScope, List<Field> fields, UnaryOperator<String> nameKeyFunction)
+        {
+            return createAndAssignScope(node, parentScope, new RelationType(fields, nameKeyFunction));
         }
 
         private Scope createAndAssignScope(Node node, Optional<Scope> parentScope, RelationType relationType)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -113,6 +113,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -171,6 +172,7 @@ public class ExpressionInterpreter
     private final Map<NodeRef<Expression>, Type> expressionTypes;
     private final InterpretedFunctionInvoker functionInvoker;
     private final boolean legacyRowFieldOrdinalAccess;
+    private final UnaryOperator<String> identifierNormalizer;
 
     private final Visitor visitor;
 
@@ -261,6 +263,8 @@ public class ExpressionInterpreter
         this.optimize = optimize;
         this.functionInvoker = new InterpretedFunctionInvoker(metadata.getFunctionAndTypeManager());
         this.legacyRowFieldOrdinalAccess = isLegacyRowFieldOrdinalAccessEnabled(session);
+        String catalogName = session.getCatalog().orElse("");
+        this.identifierNormalizer = id -> metadata.normalizeIdentifier(session, catalogName, id);
 
         this.visitor = new Visitor();
     }
@@ -330,7 +334,7 @@ public class ExpressionInterpreter
             int index = -1;
             for (int i = 0; i < fields.size(); i++) {
                 Field field = fields.get(i);
-                if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(fieldName)) {
+                if (field.getName().isPresent() && identifierNormalizer.apply(field.getName().get()).equals(identifierNormalizer.apply(fieldName))) {
                     checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
                     index = i;
                 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/LogicalPlanner.java
@@ -113,6 +113,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.isLegacyMaterializedViews;
@@ -396,13 +397,15 @@ public class LogicalPlanner
         TableHandle targetTable = analysis.getAnalyzeTarget().get();
 
         // Plan table scan
+        String analyzeCatalogName = targetTable.getConnectorId().getCatalogName();
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, targetTable);
         ImmutableList.Builder<VariableReferenceExpression> tableScanOutputsBuilder = ImmutableList.builder();
         ImmutableMap.Builder<VariableReferenceExpression, ColumnHandle> variableToColumnHandle = ImmutableMap.builder();
         ImmutableMap.Builder<String, VariableReferenceExpression> columnNameToVariable = ImmutableMap.builder();
         TableMetadata tableMetadata = metadata.getTableMetadata(session, targetTable);
         for (ColumnMetadata column : tableMetadata.getColumns()) {
-            VariableReferenceExpression variable = variableAllocator.newVariable(getSourceLocation(analyzeStatement), column.getName(), column.getType());
+            String normalizedColumnName = metadata.normalizeIdentifier(session, analyzeCatalogName, column.getName());
+            VariableReferenceExpression variable = variableAllocator.newVariable(getSourceLocation(analyzeStatement), normalizedColumnName, column.getType());
             tableScanOutputsBuilder.add(variable);
             variableToColumnHandle.put(variable, columnHandles.get(column.getName()));
             columnNameToVariable.put(column.getName(), variable);
@@ -410,10 +413,11 @@ public class LogicalPlanner
 
         TableStatisticsMetadata tableStatisticsMetadata = metadata.getStatisticsCollectionMetadata(
                 session,
-                targetTable.getConnectorId().getCatalogName(),
+                analyzeCatalogName,
                 tableMetadata.getMetadata());
 
-        TableStatisticAggregation tableStatisticAggregation = statisticsAggregationPlanner.createStatisticsAggregation(tableStatisticsMetadata, columnNameToVariable.build());
+        UnaryOperator<String> nameKeyFunction = id -> metadata.normalizeIdentifier(session, analyzeCatalogName, id);
+        TableStatisticAggregation tableStatisticAggregation = statisticsAggregationPlanner.createStatisticsAggregation(tableStatisticsMetadata, columnNameToVariable.build(), nameKeyFunction);
         StatisticAggregations statisticAggregations = tableStatisticAggregation.getAggregations();
         List<VariableReferenceExpression> tableScanOutputs = tableScanOutputsBuilder.build();
         Map<VariableReferenceExpression, RowExpression> assignments = ImmutableMap.<VariableReferenceExpression, RowExpression>builder()
@@ -764,6 +768,7 @@ public class LogicalPlanner
             Query query,
             Analysis analysis)
     {
+        String ctasCatalogName = tableHandle.getConnectorId().getCatalogName();
         TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
 
         List<ColumnMetadata> visibleTableColumns = tableMetadata.getColumns().stream()
@@ -782,7 +787,7 @@ public class LogicalPlanner
             if (column.isHidden()) {
                 continue;
             }
-            VariableReferenceExpression output = variableAllocator.newVariable(getSourceLocation(query), column.getName(), column.getType());
+            VariableReferenceExpression output = variableAllocator.newVariable(getSourceLocation(query), metadata.normalizeIdentifier(session, ctasCatalogName, column.getName()), column.getType());
             int index = columnHandles.indexOf(columns.get(column.getName()));
             if (index < 0) {
                 Expression cast = new Cast(new NullLiteral(), column.getType().getTypeSignature().toString());
@@ -903,7 +908,9 @@ public class LogicalPlanner
                 .collect(toImmutableSet());
 
         if (!statisticsMetadata.isEmpty()) {
-            TableStatisticAggregation result = statisticsAggregationPlanner.createStatisticsAggregation(statisticsMetadata, columnToVariableMap);
+            String writerCatalogName = target.getConnectorId().getCatalogName();
+            UnaryOperator<String> nameKeyFunction = id -> metadata.normalizeIdentifier(session, writerCatalogName, id);
+            TableStatisticAggregation result = statisticsAggregationPlanner.createStatisticsAggregation(statisticsMetadata, columnToVariableMap, nameKeyFunction);
 
             StatisticAggregations.Parts aggregations = splitIntoPartialAndFinal(result.getAggregations(), variableAllocator, metadata.getFunctionAndTypeManager());
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -292,13 +292,15 @@ public class QueryPlanner
     {
         RelationType descriptor = analysis.getOutputDescriptor(node.getTable());
         TableHandle handle = analysis.getTableHandle(node.getTable());
+        String catalogName = handle.getConnectorId().getCatalogName();
 
         // add table columns
         ImmutableList.Builder<VariableReferenceExpression> outputVariablesBuilder = ImmutableList.builder();
         ImmutableMap.Builder<VariableReferenceExpression, ColumnHandle> columns = ImmutableMap.builder();
         ImmutableList.Builder<Field> fields = ImmutableList.builder();
         for (Field field : descriptor.getAllFields()) {
-            VariableReferenceExpression variable = variableAllocator.newVariable(getSourceLocation(field.getNodeLocation()), field.getName().get(), field.getType());
+            String normalizedName = metadata.normalizeIdentifier(session, catalogName, field.getName().get());
+            VariableReferenceExpression variable = variableAllocator.newVariable(getSourceLocation(field.getNodeLocation()), normalizedName, field.getType());
             outputVariablesBuilder.add(variable);
             columns.put(variable, analysis.getColumn(field));
             fields.add(field);
@@ -422,7 +424,7 @@ public class QueryPlanner
         ImmutableList.Builder<Field> fields = ImmutableList.builder();
         ImmutableList.Builder<Expression> orderedColumnValuesBuilder = ImmutableList.builder();
         for (Field field : descriptor.getAllFields()) {
-            String name = field.getName().get();
+            String name = metadata.normalizeIdentifier(session, catalogName, field.getName().get());
             VariableReferenceExpression variable = variableAllocator.newVariable(getSourceLocation(field.getNodeLocation()), name, field.getType());
             outputVariablesBuilder.add(variable);
             columns.put(variable, analysis.getColumn(field));

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -229,11 +229,13 @@ class RelationPlanner
         }
         else {
             TableHandle handle = analysis.getTableHandle(node);
+            String catalogName = handle.getConnectorId().getCatalogName();
 
             ImmutableList.Builder<VariableReferenceExpression> outputVariablesBuilder = ImmutableList.builder();
             ImmutableMap.Builder<VariableReferenceExpression, ColumnHandle> columns = ImmutableMap.builder();
             for (Field field : scope.getRelationType().getAllFields()) {
-                VariableReferenceExpression variable = variableAllocator.newVariable(getSourceLocation(node), field.getName().get(), field.getType());
+                String normalizedName = metadata.normalizeIdentifier(session, catalogName, field.getName().get());
+                VariableReferenceExpression variable = variableAllocator.newVariable(getSourceLocation(node), normalizedName, field.getType());
                 outputVariablesBuilder.add(variable);
                 columns.put(variable, analysis.getColumn(field));
             }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/StatisticsAggregationPlanner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/StatisticsAggregationPlanner.java
@@ -39,8 +39,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
@@ -75,6 +77,18 @@ public class StatisticsAggregationPlanner
     }
 
     public TableStatisticAggregation createStatisticsAggregation(TableStatisticsMetadata statisticsMetadata, Map<String, VariableReferenceExpression> columnToVariableMap)
+    {
+        return createStatisticsAggregation(statisticsMetadata, columnToVariableMap,
+                name -> name.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Creates statistics aggregations, using {@code nameKeyFunction} to normalise column name
+     * identifiers when resolving SQL function body expressions.
+     */
+    public TableStatisticAggregation createStatisticsAggregation(TableStatisticsMetadata statisticsMetadata,
+            Map<String, VariableReferenceExpression> columnToVariableMap,
+            UnaryOperator<String> nameKeyFunction)
     {
         StatisticAggregationsDescriptor.Builder<VariableReferenceExpression> descriptor = StatisticAggregationsDescriptor.builder();
 
@@ -118,7 +132,7 @@ public class StatisticsAggregationPlanner
             VariableReferenceExpression inputVariable = columnToVariableMap.get(columnName);
             verify(inputVariable != null, "inputVariable is null");
             ColumnStatisticsAggregation aggregation = createColumnAggregation(columnStatisticMetadata, inputVariable,
-                    ImmutableMap.of(columnName, inputVariable.getName()));
+                    ImmutableMap.of(columnName, inputVariable.getName()), nameKeyFunction);
             additionalVariables.putAll(aggregation.getInputProjections());
             VariableReferenceExpression variable = variableAllocator.newVariable(statisticType + ":" + columnName, aggregation.getOutputType());
             aggregations.put(variable, aggregation.getAggregation());
@@ -132,14 +146,16 @@ public class StatisticsAggregationPlanner
     private ColumnStatisticsAggregation createColumnAggregationFromSqlFunction(
             String sqlFunction,
             VariableReferenceExpression input,
-            Map<String, String> columnNameToInputVariableNameMap)
+            Map<String, String> columnNameToInputVariableNameMap,
+            UnaryOperator<String> nameKeyFunction)
     {
         RowExpression expression = sqlFunctionToRowExpression(
                 sqlFunction,
                 ImmutableSet.of(input),
                 functionAndTypeManager,
                 session,
-                columnNameToInputVariableNameMap);
+                columnNameToInputVariableNameMap,
+                nameKeyFunction);
         verify(expression instanceof CallExpression, "column statistic SQL expressions must represent a function call");
         CallExpression call = (CallExpression) expression;
         FunctionMetadata functionMeta = functionAndTypeResolver.getFunctionMetadata(call.getFunctionHandle());
@@ -210,10 +226,10 @@ public class StatisticsAggregationPlanner
     }
 
     private ColumnStatisticsAggregation createColumnAggregation(ColumnStatisticMetadata columnStatisticMetadata, VariableReferenceExpression input,
-            Map<String, String> columnNameToInputVariableNameMap)
+            Map<String, String> columnNameToInputVariableNameMap, UnaryOperator<String> nameKeyFunction)
     {
         if (columnStatisticMetadata.isSqlExpression()) {
-            return createColumnAggregationFromSqlFunction(columnStatisticMetadata.getFunction(), input, columnNameToInputVariableNameMap);
+            return createColumnAggregationFromSqlFunction(columnStatisticMetadata.getFunction(), input, columnNameToInputVariableNameMap, nameKeyFunction);
         }
 
         return createColumnAggregationFromFunctionName(columnStatisticMetadata, input);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/TranslateExpressionsUtil.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/TranslateExpressionsUtil.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import static com.facebook.presto.spi.WarningCollector.NOOP;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.analyzeExpression;
@@ -64,17 +65,24 @@ public class TranslateExpressionsUtil
                 expression,
                 WarningCollector.NOOP,
                 analysis.getTypes()).getExpressionTypes();
+        UnaryOperator<String> nameKeyFunction = analysis.getRootScope().getRelationType().getNameKeyFunction();
         return toRowExpression(
                 expression,
                 metadata,
                 session,
                 analysis.getTypes(), // We need to pass all types when translating subqueries. TODO(pranjalssh): Add a proper test for complex queries which need this
+                nameKeyFunction,
                 context);
     }
 
     public static RowExpression toRowExpression(Expression expression, Metadata metadata, Session session, Map<NodeRef<Expression>, Type> types, SqlToRowExpressionTranslator.Context context)
     {
         return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionAndTypeManager(), session, context);
+    }
+
+    public static RowExpression toRowExpression(Expression expression, Metadata metadata, Session session, Map<NodeRef<Expression>, Type> types, UnaryOperator<String> nameKeyFunction, SqlToRowExpressionTranslator.Context context)
+    {
+        return SqlToRowExpressionTranslator.translate(expression, types, ImmutableMap.of(), metadata.getFunctionAndTypeManager(), session, nameKeyFunction, context);
     }
 
     public static Map<NodeRef<Expression>, Type> analyzeCallExpressionTypes(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlFunctionUtils.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 
 import static com.facebook.presto.spi.function.FunctionImplementationType.SQL;
 import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.analyzeSqlFunctionExpression;
@@ -115,11 +116,18 @@ public final class SqlFunctionUtils
                 argumentVariables);
     }
 
+    /**
+     * Translates a SQL function body to a {@link RowExpression}, using {@code nameKeyFunction} to
+     * normalise identifier names when substituting column parameter references.
+     * <p>Callers must derive {@code nameKeyFunction} from the connector's {@code normalizeIdentifier}
+     * so that the identifier lookup is consistent with how column names are stored and indexed.
+     */
     public static RowExpression sqlFunctionToRowExpression(String functionBody,
             Set<VariableReferenceExpression> variables,
             FunctionAndTypeManager functionAndTypeManager,
             Session session,
-            Map<String, String> columnNameToInputVariableNameMap)
+            Map<String, String> columnNameToInputVariableNameMap,
+            UnaryOperator<String> nameKeyFunction)
     {
         Expression expression = parseSqlFunctionExpression(
                 new SqlInvokedScalarFunctionImplementation(functionBody),
@@ -131,7 +139,7 @@ public final class SqlFunctionUtils
             @Override
             public Expression rewriteIdentifier(Identifier node, Map<String, String> context, ExpressionTreeRewriter<Map<String, String>> treeRewriter)
             {
-                String name = node.getValueLowerCase();
+                String name = nameKeyFunction.apply(node.getValue());
                 if (context.containsKey(name)) {
                     return new Identifier(context.get(name));
                 }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -104,6 +104,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 
 import static com.facebook.presto.SystemSessionProperties.isNativeExecutionEnabled;
@@ -169,6 +170,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public final class SqlToRowExpressionTranslator
@@ -213,7 +215,31 @@ public final class SqlToRowExpressionTranslator
                 session.getSqlFunctionProperties(),
                 session.getSessionFunctions(),
                 context,
-                isNativeExecutionEnabled(session));
+                isNativeExecutionEnabled(session),
+                s -> s.toLowerCase(ENGLISH));
+    }
+
+    public static RowExpression translate(
+            Expression expression,
+            Map<NodeRef<Expression>, Type> types,
+            Map<VariableReferenceExpression, Integer> layout,
+            FunctionAndTypeManager functionAndTypeManager,
+            Session session,
+            UnaryOperator<String> identifierNormalizer,
+            Context context)
+    {
+        return translate(
+                expression,
+                types,
+                layout,
+                functionAndTypeManager,
+                Optional.of(session.getUser()),
+                session.getTransactionId(),
+                session.getSqlFunctionProperties(),
+                session.getSessionFunctions(),
+                context,
+                isNativeExecutionEnabled(session),
+                identifierNormalizer);
     }
 
     public static RowExpression translate(
@@ -252,6 +278,24 @@ public final class SqlToRowExpressionTranslator
             Context context,
             boolean nativeExecutionEnabled)
     {
+        return translate(expression, types, layout, functionAndTypeManager, user, transactionId,
+                sqlFunctionProperties, sessionFunctions, context, nativeExecutionEnabled,
+                s -> s.toLowerCase(ENGLISH));
+    }
+
+    private static RowExpression translate(
+            Expression expression,
+            Map<NodeRef<Expression>, Type> types,
+            Map<VariableReferenceExpression, Integer> layout,
+            FunctionAndTypeManager functionAndTypeManager,
+            Optional<String> user,
+            Optional<TransactionId> transactionId,
+            SqlFunctionProperties sqlFunctionProperties,
+            Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
+            Context context,
+            boolean nativeExecutionEnabled,
+            UnaryOperator<String> identifierNormalizer)
+    {
         Visitor visitor = new Visitor(
                 types,
                 layout,
@@ -260,7 +304,8 @@ public final class SqlToRowExpressionTranslator
                 transactionId,
                 sqlFunctionProperties,
                 sessionFunctions,
-                nativeExecutionEnabled);
+                nativeExecutionEnabled,
+                identifierNormalizer);
         RowExpression result = visitor.process(expression, context);
         requireNonNull(result, "translated expression is null");
         return result;
@@ -303,6 +348,7 @@ public final class SqlToRowExpressionTranslator
         private final Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions;
         private final FunctionResolution functionResolution;
         private final boolean nativeExecutionEnabled;
+        private final UnaryOperator<String> identifierNormalizer;
 
         private Visitor(
                 Map<NodeRef<Expression>, Type> types,
@@ -312,7 +358,8 @@ public final class SqlToRowExpressionTranslator
                 Optional<TransactionId> transactionId,
                 SqlFunctionProperties sqlFunctionProperties,
                 Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions,
-                boolean nativeExecutionEnabled)
+                boolean nativeExecutionEnabled,
+                UnaryOperator<String> identifierNormalizer)
         {
             this.types = requireNonNull(types, "types is null");
             this.layout = requireNonNull(layout);
@@ -324,6 +371,7 @@ public final class SqlToRowExpressionTranslator
             this.functionResolution = new FunctionResolution(functionAndTypeResolver);
             this.sessionFunctions = requireNonNull(sessionFunctions);
             this.nativeExecutionEnabled = nativeExecutionEnabled;
+            this.identifierNormalizer = requireNonNull(identifierNormalizer, "identifierNormalizer is null");
         }
 
         private Type getType(Expression node)
@@ -741,7 +789,7 @@ public final class SqlToRowExpressionTranslator
             int index = -1;
             for (int i = 0; i < fields.size(); i++) {
                 Field field = fields.get(i);
-                if (field.getName().isPresent() && field.getName().get().equalsIgnoreCase(fieldName)) {
+                if (field.getName().isPresent() && identifierNormalizer.apply(field.getName().get()).equals(identifierNormalizer.apply(fieldName))) {
                     checkArgument(index < 0, "Ambiguous field %s in type %s", field, rowType.getDisplayName());
                     index = i;
                 }

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoDbIntegrationMixedCaseTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoDbIntegrationMixedCaseTest.java
@@ -220,4 +220,62 @@ public class TestMongoDbIntegrationMixedCaseTest
             mongoClient.getDatabase("testdb1").drop();
         }
     }
+
+    @Test
+    public void testColumnCaseSensitivityWithDuplicateColumns()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("mongodb")
+                .setSchema("Mixed_Test_Database")
+                .build();
+        MongoClient mongoClient = mongoQueryRunner.getMongoClient();
+        try {
+            mongoClient.getDatabase("Mixed_Test_Database").getCollection("case_sensitive_test")
+                    .insertOne(new Document()
+                            .append("user_id", 1)
+                            .append("Age", 39)
+                            .append("Name", "Alice")
+                            .append("age", 29)
+                            .append("city", "Bangalore"));
+            assertQuery(session, "SELECT * FROM Mixed_Test_Database.case_sensitive_test",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertQuery(session, "SELECT Age FROM Mixed_Test_Database.case_sensitive_test", "VALUES 39");
+            assertQuery(session, "SELECT age FROM Mixed_Test_Database.case_sensitive_test", "VALUES 29");
+            assertQuery(session, "SELECT * FROM Mixed_Test_Database.case_sensitive_test WHERE Age > 30",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertQuery(session, "SELECT * FROM Mixed_Test_Database.case_sensitive_test WHERE age < 30",
+                    "VALUES (1, 39, 'Alice', 29, 'Bangalore')");
+            assertQuery(session, "SELECT Age, age FROM Mixed_Test_Database.case_sensitive_test",
+                    "VALUES (39, 29)");
+        }
+        finally {
+            mongoClient.getDatabase("Mixed_Test_Database").getCollection("case_sensitive_test").drop();
+        }
+    }
+
+    @Test
+    public void testColumnCaseSensitivityColumnNameError()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("mongodb")
+                .setSchema("Mixed_Test_Database")
+                .build();
+        MongoClient mongoClient = mongoQueryRunner.getMongoClient();
+        try {
+            mongoClient.getDatabase("Mixed_Test_Database").getCollection("case_sensitive_where_test")
+                    .insertOne(new Document()
+                            .append("user_id", 1)
+                            .append("Age", 39)
+                            .append("Name", "Alice")
+                            .append("age", 29)
+                            .append("city", "Bangalore"));
+            assertQueryFails(session, "SELECT * FROM Mixed_Test_Database.case_sensitive_where_test WHERE name = 'Alice'",
+                    ".*Column 'name' cannot be resolved.*");
+            assertQueryFails(session, "SELECT NAME FROM Mixed_Test_Database.case_sensitive_where_test",
+                    ".*Column 'NAME' cannot be resolved.*");
+        }
+        finally {
+            mongoClient.getDatabase("Mixed_Test_Database").getCollection("case_sensitive_where_test").drop();
+        }
+    }
 }

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationMixedCaseTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationMixedCaseTest.java
@@ -194,6 +194,51 @@ public class TestMySqlIntegrationMixedCaseTest
                 "Duplicate column name 'orderkey'");
     }
 
+    @Test
+    public void testColumnCaseSensitivitySingleColumn()
+            throws SQLException
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("mysql")
+                .setSchema("Mixed_Test_Database")
+                .build();
+        try {
+            execute("CREATE TABLE Mixed_Test_Database.case_sensitive_test (user_id INT PRIMARY KEY, Age INT, Name VARCHAR(255), city VARCHAR(255))");
+            execute("INSERT INTO Mixed_Test_Database.case_sensitive_test (user_id, Age, Name, city) VALUES (1, 39, 'Alice', 'Bangalore')");
+            assertQuery(session, "SELECT * FROM Mixed_Test_Database.case_sensitive_test",
+                    "VALUES (1, 39, 'Alice', 'Bangalore')");
+            assertQuery(session, "SELECT Age FROM Mixed_Test_Database.case_sensitive_test", "VALUES 39");
+            assertQuery(session, "SELECT * FROM Mixed_Test_Database.case_sensitive_test WHERE Age > 30",
+                    "VALUES (1, 39, 'Alice', 'Bangalore')");
+            assertQuery(session, "SELECT Age, Name FROM Mixed_Test_Database.case_sensitive_test",
+                    "VALUES (39, 'Alice')");
+        }
+        finally {
+            execute("DROP TABLE IF EXISTS Mixed_Test_Database.case_sensitive_test");
+        }
+    }
+
+    @Test
+    public void testColumnCaseSensitivityColumnNameError()
+            throws SQLException
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("mysql")
+                .setSchema("Mixed_Test_Database")
+                .build();
+        try {
+            execute("CREATE TABLE Mixed_Test_Database.case_sensitive_error_test (user_id INT PRIMARY KEY, Age INT, Name VARCHAR(255), city VARCHAR(255))");
+            execute("INSERT INTO Mixed_Test_Database.case_sensitive_error_test (user_id, Age, Name, city) VALUES (1, 39, 'Alice', 'Bangalore')");
+            assertQueryFails(session, "SELECT * FROM Mixed_Test_Database.case_sensitive_error_test WHERE name = 'Alice'",
+                    ".*Column 'name' cannot be resolved.*");
+            assertQueryFails(session, "SELECT NAME FROM Mixed_Test_Database.case_sensitive_error_test",
+                    ".*Column 'NAME' cannot be resolved.*");
+        }
+        finally {
+            execute("DROP TABLE IF EXISTS Mixed_Test_Database.case_sensitive_error_test");
+        }
+    }
+
     private void execute(String sql)
             throws SQLException
     {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -156,7 +156,8 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
             boolean cacheable,
             RuntimeStats runtimeStats,
             Optional<OrcFileIntrospector> fileIntrospector,
-            long fileModificationTime)
+            long fileModificationTime,
+            boolean caseSensitiveNameMatching)
     {
         requireNonNull(includedColumns, "includedColumns is null");
         requireNonNull(predicate, "predicate is null");
@@ -243,7 +244,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
 
         this.currentStripeSystemMemoryContext = this.systemMemoryUsage.newOrcAggregatedMemoryContext();
 
-        Set<Integer> includedOrcColumns = getIncludedOrcColumns(types, this.presentColumns, requireNonNull(requiredSubfields, "requiredSubfields is null"));
+        Set<Integer> includedOrcColumns = getIncludedOrcColumns(types, this.presentColumns, requireNonNull(requiredSubfields, "requiredSubfields is null"), caseSensitiveNameMatching);
         this.encryptionLibrary = encryptionLibrary;
         this.dwrfEncryptionGroupMap = ImmutableMap.copyOf(dwrfEncryptionGroupMap);
         this.intermediateKeyMetadata = createIntermediateKeysMap(columnToIntermediateKeyMap, dwrfEncryptionGroupMap, orcDataSource.getId());
@@ -289,45 +290,46 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
         }
     }
 
-    private static Set<Integer> getIncludedOrcColumns(List<OrcType> types, Set<Integer> includedColumns, Map<Integer, List<Subfield>> requiredSubfields)
+    private static Set<Integer> getIncludedOrcColumns(List<OrcType> types, Set<Integer> includedColumns, Map<Integer, List<Subfield>> requiredSubfields, boolean caseSensitiveNameMatching)
     {
         Set<Integer> includes = new LinkedHashSet<>();
 
         OrcType root = types.get(0);
         for (int includedColumn : includedColumns) {
             List<Subfield> subfields = Optional.ofNullable(requiredSubfields.get(includedColumn)).orElse(ImmutableList.of());
-            includeOrcColumnsRecursive(types, includes, root.getFieldTypeIndex(includedColumn), subfields);
+            includeOrcColumnsRecursive(types, includes, root.getFieldTypeIndex(includedColumn), subfields, caseSensitiveNameMatching);
         }
 
         return includes;
     }
 
-    private static void includeOrcColumnsRecursive(List<OrcType> types, Set<Integer> result, int typeId, List<Subfield> requiredSubfields)
+    private static void includeOrcColumnsRecursive(List<OrcType> types, Set<Integer> result, int typeId, List<Subfield> requiredSubfields, boolean caseSensitiveNameMatching)
     {
         result.add(typeId);
         OrcType type = types.get(typeId);
 
         Optional<Map<String, List<Subfield>>> requiredFields = Optional.empty();
         if (type.getOrcTypeKind() == STRUCT) {
-            requiredFields = getRequiredFields(requiredSubfields);
+            requiredFields = getRequiredFields(requiredSubfields, caseSensitiveNameMatching);
         }
 
         int children = type.getFieldCount();
         for (int i = 0; i < children; ++i) {
             List<Subfield> subfields = ImmutableList.of();
             if (requiredFields.isPresent()) {
-                String fieldName = type.getFieldNames().get(i).toLowerCase(Locale.ENGLISH);
+                String fieldName = type.getFieldNames().get(i);
+                fieldName = caseSensitiveNameMatching ? fieldName : fieldName.toLowerCase(Locale.ENGLISH);
                 if (!requiredFields.get().containsKey(fieldName)) {
                     continue;
                 }
                 subfields = requiredFields.get().get(fieldName);
             }
 
-            includeOrcColumnsRecursive(types, result, type.getFieldTypeIndex(i), subfields);
+            includeOrcColumnsRecursive(types, result, type.getFieldTypeIndex(i), subfields, caseSensitiveNameMatching);
         }
     }
 
-    private static Optional<Map<String, List<Subfield>>> getRequiredFields(List<Subfield> requiredSubfields)
+    private static Optional<Map<String, List<Subfield>>> getRequiredFields(List<Subfield> requiredSubfields, boolean caseSensitiveNameMatching)
     {
         if (requiredSubfields.isEmpty()) {
             return Optional.empty();
@@ -339,7 +341,8 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
             if (path.size() == 1 && path.get(0) instanceof Subfield.NoSubfield) {
                 continue;
             }
-            String name = ((Subfield.NestedField) path.get(0)).getName().toLowerCase(Locale.ENGLISH);
+            String name = ((Subfield.NestedField) path.get(0)).getName();
+            name = caseSensitiveNameMatching ? name : name.toLowerCase(Locale.ENGLISH);
             fields.computeIfAbsent(name, k -> new ArrayList<>());
             if (path.size() > 1) {
                 fields.get(name).add(new Subfield("c", path.subList(1, path.size())));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -109,7 +109,8 @@ public class OrcBatchRecordReader
                 cacheable,
                 runtimeStats,
                 Optional.empty(),
-                 fileModificationTime);
+                fileModificationTime,
+                options.isCaseSensitiveNameMatching());
     }
 
     public int nextBatch()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -32,6 +32,7 @@ public class OrcReaderOptions
     // slice reader will throw if the slice size is larger than this value
     private final DataSize maxSliceSize;
     private final boolean resetAllReaders;
+    private final boolean caseSensitiveNameMatching;
 
     /**
      * Read column statistics for flat map columns. Usually there are quite a
@@ -48,7 +49,8 @@ public class OrcReaderOptions
             boolean appendRowNumber,
             boolean readMapStatistics,
             DataSize maxSliceSize,
-            boolean resetAllReaders)
+            boolean resetAllReaders,
+            boolean caseSensitiveNameMatching)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
@@ -59,6 +61,7 @@ public class OrcReaderOptions
         this.readMapStatistics = readMapStatistics;
         this.maxSliceSize = maxSliceSize;
         this.resetAllReaders = resetAllReaders;
+        this.caseSensitiveNameMatching = caseSensitiveNameMatching;
     }
 
     public DataSize getMaxMergeDistance()
@@ -106,6 +109,11 @@ public class OrcReaderOptions
         return resetAllReaders;
     }
 
+    public boolean isCaseSensitiveNameMatching()
+    {
+        return caseSensitiveNameMatching;
+    }
+
     @Override
     public String toString()
     {
@@ -119,6 +127,7 @@ public class OrcReaderOptions
                 .add("readMapStatistics", readMapStatistics)
                 .add("maxSliceSize", maxSliceSize)
                 .add("resetAllReaders", resetAllReaders)
+                .add("caseSensitiveNameMatching", caseSensitiveNameMatching)
                 .toString();
     }
 
@@ -138,6 +147,7 @@ public class OrcReaderOptions
         private boolean readMapStatistics;
         private DataSize maxSliceSize = DEFAULT_MAX_SLICE_SIZE;
         private boolean resetAllReaders;
+        private boolean caseSensitiveNameMatching;
 
         private Builder() {}
 
@@ -195,6 +205,12 @@ public class OrcReaderOptions
             return this;
         }
 
+        public Builder withCaseSensitiveNameMatching(boolean caseSensitiveNameMatching)
+        {
+            this.caseSensitiveNameMatching = caseSensitiveNameMatching;
+            return this;
+        }
+
         public OrcReaderOptions build()
         {
             return new OrcReaderOptions(
@@ -206,7 +222,8 @@ public class OrcReaderOptions
                     appendRowNumber,
                     readMapStatistics,
                     maxSliceSize,
-                    resetAllReaders);
+                    resetAllReaders,
+                    caseSensitiveNameMatching);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
@@ -27,6 +27,7 @@ public class OrcRecordReaderOptions
     private final boolean appendRowNumber;
     private final long maxSliceSize;
     private final boolean resetAllReaders;
+    private final boolean caseSensitiveNameMatching;
 
     public OrcRecordReaderOptions(OrcReaderOptions options)
     {
@@ -36,7 +37,8 @@ public class OrcRecordReaderOptions
                 options.mapNullKeysEnabled(),
                 options.appendRowNumber(),
                 options.getMaxSliceSize(),
-                options.isResetAllReaders());
+                options.isResetAllReaders(),
+                options.isCaseSensitiveNameMatching());
     }
 
     public OrcRecordReaderOptions(
@@ -46,7 +48,8 @@ public class OrcRecordReaderOptions
             boolean mapNullKeysEnabled,
             boolean appendRowNumber,
             DataSize maxSliceSize,
-            boolean resetAllReaders)
+            boolean resetAllReaders,
+            boolean caseSensitiveNameMatching)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
@@ -57,6 +60,7 @@ public class OrcRecordReaderOptions
         checkArgument(maxSliceSize.toBytes() > 0, "maxSliceSize must be positive");
         this.maxSliceSize = maxSliceSize.toBytes();
         this.resetAllReaders = resetAllReaders;
+        this.caseSensitiveNameMatching = caseSensitiveNameMatching;
     }
 
     public DataSize getMaxMergeDistance()
@@ -92,5 +96,10 @@ public class OrcRecordReaderOptions
     public boolean isResetAllReaders()
     {
         return resetAllReaders;
+    }
+
+    public boolean isCaseSensitiveNameMatching()
+    {
+        return caseSensitiveNameMatching;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -232,7 +232,8 @@ public class OrcSelectiveRecordReader
                 cacheable,
                 runtimeStats,
                 fileIntrospector,
-                fileModificationTime);
+                fileModificationTime,
+                options.isCaseSensitiveNameMatching());
 
         // Hive column indices can't be used to index into arrays because they are negative
         // for partition and hidden columns. Hence, we create synthetic zero-based indices.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructBatchStreamReader.java
@@ -79,14 +79,16 @@ public class StructBatchStreamReader
         this.type = (RowType) type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
 
+        boolean caseSensitive = options.isCaseSensitiveNameMatching();
         Map<String, StreamDescriptor> nestedStreams = Maps.uniqueIndex(
-                streamDescriptor.getNestedStreams(), stream -> stream.getFieldName().toLowerCase(Locale.ENGLISH));
+                streamDescriptor.getNestedStreams(),
+                stream -> caseSensitive ? stream.getFieldName() : stream.getFieldName().toLowerCase(Locale.ENGLISH));
         ImmutableList.Builder<String> fieldNames = ImmutableList.builder();
         ImmutableMap.Builder<String, BatchStreamReader> structFields = ImmutableMap.builder();
         for (Field field : this.type.getFields()) {
             String fieldName = field.getName()
-                    .orElseThrow(() -> new IllegalArgumentException("ROW type does not have field names declared: " + type))
-                    .toLowerCase(Locale.ENGLISH);
+                    .orElseThrow(() -> new IllegalArgumentException("ROW type does not have field names declared: " + type));
+            fieldName = caseSensitive ? fieldName : fieldName.toLowerCase(Locale.ENGLISH);
             fieldNames.add(fieldName);
 
             StreamDescriptor fieldStream = nestedStreams.get(fieldName);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/StructSelectiveStreamReader.java
@@ -132,10 +132,12 @@ public class StructSelectiveStreamReader
             }
         }
 
+        boolean caseSensitive = options.isCaseSensitiveNameMatching();
         Map<String, StreamDescriptor> nestedStreams = Maps.uniqueIndex(
-                streamDescriptor.getNestedStreams(), stream -> stream.getFieldName().toLowerCase(Locale.ENGLISH));
+                streamDescriptor.getNestedStreams(),
+                stream -> caseSensitive ? stream.getFieldName() : stream.getFieldName().toLowerCase(Locale.ENGLISH));
 
-        Optional<Map<String, List<Subfield>>> requiredFields = getRequiredFields(requiredSubfields);
+        Optional<Map<String, List<Subfield>>> requiredFields = getRequiredFields(requiredSubfields, caseSensitive);
 
         // TODO streamDescriptor may be missing some fields (due to schema evolution, e.g. add field?)
         // TODO fields in streamDescriptor may be out of order (due to schema evolution, e.g. remove field?)
@@ -149,7 +151,7 @@ public class StructSelectiveStreamReader
                 .map(Subfield.NestedField::getName)
                 .collect(toImmutableSet());
 
-        if (!checkMissingFieldFilters(nestedStreams.values(), filters)) {
+        if (!checkMissingFieldFilters(nestedStreams.values(), filters, caseSensitive)) {
             this.missingFieldFilterIsFalse = true;
             this.nestedReaders = ImmutableMap.of();
             this.orderedNestedReaders = new SelectiveStreamReader[0];
@@ -157,10 +159,11 @@ public class StructSelectiveStreamReader
         else if (outputRequired || !fieldsWithFilters.isEmpty()) {
             ImmutableMap.Builder<String, SelectiveStreamReader> nestedReaders = ImmutableMap.builder();
             Map<String, Field> nestedTypes = outputType.isPresent() ? ((RowType) this.outputType).getFields().stream()
-                    .collect(toImmutableMap(field -> field.getName()
-                            .orElseThrow(() -> new IllegalArgumentException(
-                                    "ROW type does not have field names declared: " + this.outputType))
-                            .toLowerCase(Locale.ENGLISH), Function.identity()))
+                    .collect(toImmutableMap(field -> {
+                        String name = field.getName().orElseThrow(() -> new IllegalArgumentException(
+                                "ROW type does not have field names declared: " + this.outputType));
+                        return caseSensitive ? name : name.toLowerCase(Locale.ENGLISH);
+                    }, Function.identity()))
                     : ImmutableMap.of();
             Set<String> structFields = outputType.isPresent() ? nestedTypes.keySet() : nestedStreams.keySet();
             for (String fieldName : structFields) {
@@ -208,7 +211,7 @@ public class StructSelectiveStreamReader
         }
     }
 
-    private boolean checkMissingFieldFilters(Collection<StreamDescriptor> nestedStreams, Map<Subfield, TupleDomainFilter> filters)
+    private boolean checkMissingFieldFilters(Collection<StreamDescriptor> nestedStreams, Map<Subfield, TupleDomainFilter> filters, boolean caseSensitiveNameMatching)
     {
         if (filters.isEmpty()) {
             return true;
@@ -216,7 +219,7 @@ public class StructSelectiveStreamReader
 
         Set<String> presentFieldNames = nestedStreams.stream()
                 .map(StreamDescriptor::getFieldName)
-                .map(name -> name.toLowerCase(Locale.ENGLISH))
+                .map(name -> caseSensitiveNameMatching ? name : name.toLowerCase(Locale.ENGLISH))
                 .collect(toImmutableSet());
 
         for (Map.Entry<Subfield, TupleDomainFilter> entry : filters.entrySet()) {
@@ -682,7 +685,7 @@ public class StructSelectiveStreamReader
         return Optional.of(filter);
     }
 
-    private static Optional<Map<String, List<Subfield>>> getRequiredFields(List<Subfield> requiredSubfields)
+    private static Optional<Map<String, List<Subfield>>> getRequiredFields(List<Subfield> requiredSubfields, boolean caseSensitiveNameMatching)
     {
         if (requiredSubfields.isEmpty()) {
             return Optional.empty();
@@ -694,7 +697,8 @@ public class StructSelectiveStreamReader
             if (path.size() == 1 && path.get(0) instanceof Subfield.NoSubfield) {
                 continue;
             }
-            String name = ((Subfield.NestedField) path.get(0)).getName().toLowerCase(Locale.ENGLISH);
+            String name = ((Subfield.NestedField) path.get(0)).getName();
+            name = caseSensitiveNameMatching ? name : name.toLowerCase(Locale.ENGLISH);
             fields.computeIfAbsent(name, k -> new ArrayList<>());
             if (path.size() > 1) {
                 fields.get(name).add(new Subfield("c", path.subList(1, path.size())));

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -102,6 +102,24 @@ public final class MetadataReader
     private static final ParquetMetadataConverter PARQUET_METADATA_CONVERTER = new ParquetMetadataConverter();
     private static final long MODIFICATION_TIME_NOT_SET = 0L;
 
+    /**
+     * When {@code true}, field names and column-chunk paths are preserved exactly as written
+     * in the Parquet file footer rather than being lowercased for Hive compatibility.
+     * Set via {@link #MetadataReader(boolean)} by connectors configured with
+     * {@code case-sensitive-name-matching=true} (e.g. the Iceberg connector).
+     */
+    private final boolean caseSensitiveNameMatching;
+
+    public MetadataReader()
+    {
+        this(false);
+    }
+
+    public MetadataReader(boolean caseSensitiveNameMatching)
+    {
+        this.caseSensitiveNameMatching = caseSensitiveNameMatching;
+    }
+
     public static ParquetFileMetadata readFooter(ParquetDataSource parquetDataSource, long fileSize, Optional<InternalFileDecryptor> fileDecryptor, boolean readMaskedValue)
             throws IOException
     {
@@ -109,6 +127,12 @@ public final class MetadataReader
     }
 
     public static ParquetFileMetadata readFooter(ParquetDataSource parquetDataSource, long fileSize, long modificationTime, Optional<InternalFileDecryptor> fileDecryptor, boolean readMaskedValue)
+            throws IOException
+    {
+        return readFooter(parquetDataSource, fileSize, modificationTime, fileDecryptor, readMaskedValue, false);
+    }
+
+    private static ParquetFileMetadata readFooter(ParquetDataSource parquetDataSource, long fileSize, long modificationTime, Optional<InternalFileDecryptor> fileDecryptor, boolean readMaskedValue, boolean caseSensitiveNameMatching)
             throws IOException
     {
         // Parquet File Layout: https://github.com/apache/parquet-format/blob/master/Encryption.md
@@ -139,10 +163,16 @@ public final class MetadataReader
             tailSlice = wrappedBuffer(footerBuffer, 0, footerBuffer.length);
         }
 
-        return readParquetMetadata(tailSlice.slice(tailSlice.length() - completeFooterSize, metadataLength).getInput(), metadataLength, modificationTime, fileDecryptor, encryptedFooterMode, parquetDataSource.getId(), readMaskedValue);
+        return readParquetMetadata(tailSlice.slice(tailSlice.length() - completeFooterSize, metadataLength).getInput(), metadataLength, modificationTime, fileDecryptor, encryptedFooterMode, parquetDataSource.getId(), readMaskedValue, caseSensitiveNameMatching);
     }
 
     private static ParquetFileMetadata readParquetMetadata(BasicSliceInput input, int metadataLength, long modificationTime, Optional<InternalFileDecryptor> fileDecryptor, boolean encryptedFooterMode, ParquetDataSourceId id, boolean readMaskedValue)
+            throws IOException
+    {
+        return readParquetMetadata(input, metadataLength, modificationTime, fileDecryptor, encryptedFooterMode, id, readMaskedValue, false);
+    }
+
+    private static ParquetFileMetadata readParquetMetadata(BasicSliceInput input, int metadataLength, long modificationTime, Optional<InternalFileDecryptor> fileDecryptor, boolean encryptedFooterMode, ParquetDataSourceId id, boolean readMaskedValue, boolean caseSensitiveNameMatching)
             throws IOException
     {
         checkArgument(!encryptedFooterMode || fileDecryptor.isPresent(), "fileDecryptionProperties cannot be null when encryptedFooterMode is true");
@@ -158,10 +188,16 @@ public final class MetadataReader
         }
 
         FileMetaData fileMetaData = readFileMetaData(input, footerDecryptor, additionalAuthenticationData);
-        return convertToParquetMetadata(input, fileMetaData, metadataLength, modificationTime, fileDecryptor, encryptedFooterMode, id, readMaskedValue);
+        return convertToParquetMetadata(input, fileMetaData, metadataLength, modificationTime, fileDecryptor, encryptedFooterMode, id, readMaskedValue, caseSensitiveNameMatching);
     }
 
     private static ParquetFileMetadata convertToParquetMetadata(BasicSliceInput input, FileMetaData fileMetaData, int metadataLength, long modificationTime, Optional<InternalFileDecryptor> fileDecryptor, boolean encryptedFooter, ParquetDataSourceId id, boolean readMaskedValue)
+            throws IOException
+    {
+        return convertToParquetMetadata(input, fileMetaData, metadataLength, modificationTime, fileDecryptor, encryptedFooter, id, readMaskedValue, false);
+    }
+
+    private static ParquetFileMetadata convertToParquetMetadata(BasicSliceInput input, FileMetaData fileMetaData, int metadataLength, long modificationTime, Optional<InternalFileDecryptor> fileDecryptor, boolean encryptedFooter, ParquetDataSourceId id, boolean readMaskedValue, boolean caseSensitiveNameMatching)
             throws IOException
     {
         List<SchemaElement> schema = fileMetaData.getSchema();
@@ -186,7 +222,7 @@ public final class MetadataReader
             }
         }
 
-        MessageType messageType = readParquetSchema(schema);
+        MessageType messageType = readParquetSchema(schema, caseSensitiveNameMatching);
         List<BlockMetaData> blocks = new ArrayList<>();
         List<RowGroup> rowGroups = fileMetaData.getRow_groups();
         Set<ColumnPath> maskedColumns = new HashSet<>();
@@ -212,7 +248,7 @@ public final class MetadataReader
                     boolean encryptedMetadata = false;
 
                     if (null == cryptoMetaData) { // Plaintext column
-                        columnPath = getPath(metaData);
+                        columnPath = getPath(metaData, caseSensitiveNameMatching);
                         if (fileDecryptor.isPresent() && !fileDecryptor.get().plaintextFile()) {
                             // mark this column as plaintext in encrypted file decryptor
                             fileDecryptor.get().setColumnCryptoMetadata(columnPath, false, false, (byte[]) null, columnOrdinal);
@@ -229,7 +265,7 @@ public final class MetadataReader
                             if (!fileDecryptor.isPresent()) {
                                 throw new ParquetCryptoRuntimeException("Column encrypted with footer key: No keys available");
                             }
-                            columnPath = getPath(metaData);
+                            columnPath = getPath(metaData, caseSensitiveNameMatching);
                             fileDecryptor.get().setColumnCryptoMetadata(columnPath, true, true, (byte[]) null, columnOrdinal);
                         }
                         else { // Column encrypted with column key
@@ -314,8 +350,13 @@ public final class MetadataReader
 
     private static ColumnPath getPath(ColumnMetaData metaData)
     {
+        return getPath(metaData, false);
+    }
+
+    private static ColumnPath getPath(ColumnMetaData metaData, boolean caseSensitiveNameMatching)
+    {
         String[] path = metaData.path_in_schema.stream()
-                .map(value -> value.toLowerCase(Locale.ENGLISH))
+                .map(value -> caseSensitiveNameMatching ? value : value.toLowerCase(Locale.ENGLISH))
                 .toArray(String[]::new);
         return ColumnPath.get(path);
     }
@@ -344,21 +385,31 @@ public final class MetadataReader
 
     private static MessageType readParquetSchema(List<SchemaElement> schema)
     {
+        return readParquetSchema(schema, false);
+    }
+
+    private static MessageType readParquetSchema(List<SchemaElement> schema, boolean caseSensitiveNameMatching)
+    {
         Iterator<SchemaElement> schemaIterator = schema.iterator();
         SchemaElement rootSchema = schemaIterator.next();
         Types.MessageTypeBuilder builder = Types.buildMessage();
-        readTypeSchema(builder, schemaIterator, rootSchema.getNum_children());
+        readTypeSchema(builder, schemaIterator, rootSchema.getNum_children(), caseSensitiveNameMatching);
         return builder.named(rootSchema.name);
     }
 
     private static void readTypeSchema(Types.GroupBuilder<?> builder, Iterator<SchemaElement> schemaIterator, int typeCount)
+    {
+        readTypeSchema(builder, schemaIterator, typeCount, false);
+    }
+
+    private static void readTypeSchema(Types.GroupBuilder<?> builder, Iterator<SchemaElement> schemaIterator, int typeCount, boolean caseSensitiveNameMatching)
     {
         for (int i = 0; i < typeCount; i++) {
             SchemaElement element = schemaIterator.next();
             Types.Builder<?, ?> typeBuilder;
             if (element.type == null) {
                 typeBuilder = builder.group(Repetition.valueOf(element.repetition_type.name()));
-                readTypeSchema((Types.GroupBuilder<?>) typeBuilder, schemaIterator, element.num_children);
+                readTypeSchema((Types.GroupBuilder<?>) typeBuilder, schemaIterator, element.num_children, caseSensitiveNameMatching);
             }
             else {
                 Types.PrimitiveBuilder<?> primitiveBuilder = builder.primitive(getTypeName(element.type), Repetition.valueOf(element.repetition_type.name()));
@@ -385,7 +436,7 @@ public final class MetadataReader
             if (element.isSetField_id()) {
                 typeBuilder.id(element.field_id);
             }
-            typeBuilder.named(element.name.toLowerCase(Locale.ENGLISH));
+            typeBuilder.named(caseSensitiveNameMatching ? element.name : element.name.toLowerCase(Locale.ENGLISH));
         }
     }
 
@@ -555,7 +606,7 @@ public final class MetadataReader
             boolean readMaskedValue)
             throws IOException
     {
-        return readFooter(parquetDataSource, fileSize, modificationTime, fileDecryptor, readMaskedValue);
+        return readFooter(parquetDataSource, fileSize, modificationTime, fileDecryptor, readMaskedValue, caseSensitiveNameMatching);
     }
 
     private static IndexReference toColumnIndexReference(ColumnChunk columnChunk)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/QualifiedName.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Streams;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -67,6 +68,11 @@ public class QualifiedName
     public List<Identifier> getOriginalParts()
     {
         return originalParts;
+    }
+
+    public String toString(UnaryOperator<String> nameKeyFunction)
+    {
+        return Joiner.on('.').join(originalParts.stream().map(id -> nameKeyFunction.apply(id.getValue())).collect(toImmutableList()));
     }
 
     @Override

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/mysql/TestMySQLMixedCaseSupportOn.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/mysql/TestMySQLMixedCaseSupportOn.java
@@ -74,7 +74,7 @@ public class TestMySQLMixedCaseSupportOn
         query("CREATE TABLE " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME_JOIN_LOWER + "\" AS " +
                 "SELECT d.* FROM " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME + "\" d " +
                 "INNER JOIN " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME + "\" m " +
-                "ON d.id = m.id WHERE d.id = 1");
+                "ON d.ID = m.ID WHERE d.ID = 1");
 
         assertThat(query("SHOW TABLES FROM " + CATALOG + ".\"" + SCHEMA_NAME + "\""))
                 .containsOnly(row("testtable0"), row("testtable"), row("TestTable1"), row("TESTTABLE2"), row("createdfromlowercase"), row("createdwithjoinlower"));
@@ -112,7 +112,7 @@ public class TestMySQLMixedCaseSupportOn
         query("INSERT INTO " + CATALOG + ".\"" + SCHEMA_NAME_UPPER + "\".\"" + TABLE_NAME_UPPER_SCHEMA_3 + "\" VALUES ('zack', 601, 100.1), ('jane', 602, 200.2)");
         query("INSERT INTO " + CATALOG + ".\"" + SCHEMA_NAME_MIXED + "\".\"" + TABLE_NAME_FROM_MIXED + "\" VALUES ('ruby', 701), ('ted', 702)");
         query("INSERT INTO " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME_MIXED_1 + "\" " +
-                "SELECT name, id FROM " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME + "\"");
+                "SELECT name, ID FROM " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME + "\"");
         query("INSERT INTO " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME + "\" " +
                 "SELECT Name, id FROM " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME_MIXED_1 + "\"");
 
@@ -145,10 +145,10 @@ public class TestMySQLMixedCaseSupportOn
                 .containsOnly(row("eva", 301), row("lisa", 302), row("ivan", 401), row("nora", 402), row("eva", 301), row("lisa", 302));
 
         // Even if we define a column as ID, we can refer to it as id, ID, or anything else in any case — with or without backticks.
-        assertThat(query("SELECT name, id FROM " + CATALOG + "." + SCHEMA_NAME + "." + TABLE_NAME))
+        assertThat(query("SELECT name, ID FROM " + CATALOG + "." + SCHEMA_NAME + "." + TABLE_NAME))
                 .containsOnly(row("eva", 301), row("lisa", 302), row("ivan", 401), row("nora", 402), row("eva", 301), row("lisa", 302));
 
-        assertThat(query("SELECT name FROM " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME_MIXED_1 + "\" WHERE id = 401"))
+        assertThat(query("SELECT Name FROM " + CATALOG + ".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME_MIXED_1 + "\" WHERE id = 401"))
                 .containsOnly(row("ivan"));
 
         assertThat(query("SELECT name FROM " + CATALOG + ".\"" + SCHEMA_NAME_UPPER + "\".\"" + TABLE_NAME_UPPER_SCHEMA_02 + "\" WHERE id = 501"))
@@ -159,8 +159,8 @@ public class TestMySQLMixedCaseSupportOn
 
         assertThat(query("SELECT Name, ID " +
                 "FROM " + CATALOG + ".\"" + SCHEMA_NAME_UPPER + "\".\"" + TABLE_NAME_UPPER_SCHEMA_4 + "\" " +
-                "WHERE name IN (" +
-                "SELECT Name FROM " + CATALOG + ".\"" + SCHEMA_NAME_MIXED + "\".\"" + TABLE_NAME_FROM_MIXED + "\" WHERE id = 501)"))
+                "WHERE Name IN (" +
+                "SELECT name FROM " + CATALOG + ".\"" + SCHEMA_NAME_MIXED + "\".\"" + TABLE_NAME_FROM_MIXED + "\" WHERE ID = 501)"))
                 .containsOnly(row("kate", 501));
     }
 

--- a/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationMixedCase.java
+++ b/presto-redis/src/test/java/com/facebook/presto/redis/TestRedisIntegrationMixedCase.java
@@ -220,4 +220,48 @@ public class TestRedisIntegrationMixedCase
                 .build();
         assertContains(result, expected);
     }
+
+    @Test
+    public void testColumnCaseSensitivityWithDuplicateColumns()
+    {
+        populateTestTable(1);
+        MaterializedResult result = queryRunner.execute("SELECT * FROM " + testTable);
+        assertEquals(result.getRowCount(), 1);
+        result = queryRunner.execute("SELECT name FROM " + testTable);
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), "name_value_0");
+        result = queryRunner.execute("SELECT NAME FROM " + testTable);
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), "NAME_value_0");
+        result = queryRunner.execute("SELECT * FROM " + testTable + " WHERE age = 25");
+        assertEquals(result.getRowCount(), 1);
+        result = queryRunner.execute("SELECT * FROM " + testTable + " WHERE name = 'name_value_0'");
+        assertEquals(result.getRowCount(), 1);
+        result = queryRunner.execute("SELECT name, NAME FROM " + testTable);
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getMaterializedRows().get(0).getField(0), "name_value_0");
+        assertEquals(result.getMaterializedRows().get(0).getField(1), "NAME_value_0");
+    }
+
+    @Test
+    public void testColumnCaseSensitivityColumnNameError()
+    {
+        populateTestTable(1);
+        try {
+            queryRunner.execute("SELECT * FROM " + testTable + " WHERE address = 'Address_value_0'");
+            throw new AssertionError("Expected query to fail");
+        }
+        catch (Exception e) {
+            assertTrue(e.getMessage().contains("Column 'address' cannot be resolved") ||
+                    e.getMessage().contains("line 1:") && e.getMessage().contains("address"));
+        }
+        try {
+            queryRunner.execute("SELECT band FROM " + testTable);
+            throw new AssertionError("Expected query to fail");
+        }
+        catch (Exception e) {
+            assertTrue(e.getMessage().contains("Column 'band' cannot be resolved") ||
+                    e.getMessage().contains("line 1:") && e.getMessage().contains("band"));
+        }
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/VariableAllocator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/VariableAllocator.java
@@ -27,7 +27,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableMap;
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class VariableAllocator
@@ -96,9 +95,6 @@ public class VariableAllocator
     {
         requireNonNull(nameHint, "name is null");
         requireNonNull(type, "type is null");
-
-        // TODO: workaround for the fact that QualifiedName lowercases parts
-        nameHint = nameHint.toLowerCase(ENGLISH);
 
         // don't strip the tail if the only _ is the first character
         int index = nameHint.lastIndexOf("_");


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Clarify column resolution behavior for case-sensitive identifiers and add coverage across multiple connectors.

Bug Fixes:
- Prefer exact-case column name matches when resolving ambiguous fields to avoid incorrect attribute resolution in mixed-case schemas.

Enhancements:
- Propagate session and metadata into nested ExpressionAnalyzer instances to support context-aware expression analysis.

Tests:
- Add mixed-case column resolution tests for MongoDB, Cassandra, MySQL, Elasticsearch, ClickHouse, Redis, and Arrow Flight connectors, including success and error cases for selects, WHERE clauses, and ambiguous columns.