### PR TITLE
docs: Add missing doc for ldap.cache-ttl

### DIFF
--- a/presto-docs/src/main/sphinx/security/ldap.rst
+++ b/presto-docs/src/main/sphinx/security/ldap.rst
@@ -117,6 +117,10 @@ Property                                                Description
                                                         must contain the pattern ``${USER}`` which will be
                                                         replaced by the actual username during the password
                                                         authentication. Example: ``${USER}@corp.example.com``.
+``ldap.cache-ttl``                                      The duration for which password authentication results
+                                                        are cached. It reduces the number of subsequent requests
+                                                        to the LDAP server for the same user. Set this property
+                                                        to ``0s`` to disable caching. The default value is ``1h``.
 ======================================================= ======================================================
 
 Based on the LDAP server implementation type, the property


### PR DESCRIPTION
## Description
Add missing documentation for the `ldap.cache-ttl` configuration property in the LDAP authentication section. This property defaults to `1h` and manages the caching duration of authentication results.

Resolves: #12597

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
There is no performance impact

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Add documentation for the ldap.cache-ttl configuration property and its default cache duration in the LDAP authentication section.