### PR TITLE
feat: Add split_part_reverse as a global Presto SQL inline function (#27480)

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestSplitPartReverseFunction.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestSplitPartReverseFunction.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.operator.scalar.AbstractTestFunctions;
+import com.facebook.presto.sql.analyzer.SemanticErrorCode;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+
+public class TestSplitPartReverseFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testPositiveIndex()
+    {
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar/baz/qux', '/', 1)",
+                VARCHAR,
+                "foo");
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar/baz/qux', '/', 2)",
+                VARCHAR,
+                "bar");
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar/baz/qux', '/', 4)",
+                VARCHAR,
+                "qux");
+    }
+
+    @Test
+    public void testNegativeIndex()
+    {
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar/baz/qux', '/', -1)",
+                VARCHAR,
+                "qux");
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar/baz/qux', '/', -2)",
+                VARCHAR,
+                "baz");
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar/baz/qux', '/', -4)",
+                VARCHAR,
+                "foo");
+    }
+
+    @Test
+    public void testOutOfBounds()
+    {
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar/baz', '/', 5)",
+                VARCHAR,
+                null);
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar/baz', '/', -5)",
+                VARCHAR,
+                null);
+    }
+
+    @Test
+    public void testCommaDelimiter()
+    {
+        assertFunction(
+                "SPLIT_PART_REVERSE('I,he,she,they', ',', -1)",
+                VARCHAR,
+                "they");
+        assertFunction(
+                "SPLIT_PART_REVERSE('I,he,she,they', ',', 1)",
+                VARCHAR,
+                "I");
+    }
+
+    @Test
+    public void testEmptyParts()
+    {
+        assertFunction(
+                "SPLIT_PART_REVERSE('one,,,four,', ',', -1)",
+                VARCHAR,
+                "");
+        assertFunction(
+                "SPLIT_PART_REVERSE('one,,,four,', ',', -2)",
+                VARCHAR,
+                "four");
+        assertFunction(
+                "SPLIT_PART_REVERSE('one,,,four,', ',', 1)",
+                VARCHAR,
+                "one");
+    }
+
+    @Test
+    public void testNoDelimiter()
+    {
+        assertFunction(
+                "SPLIT_PART_REVERSE('abc', ',', 1)",
+                VARCHAR,
+                "abc");
+        assertFunction(
+                "SPLIT_PART_REVERSE('abc', ',', -1)",
+                VARCHAR,
+                "abc");
+        assertFunction(
+                "SPLIT_PART_REVERSE('abc', ',', 2)",
+                VARCHAR,
+                null);
+    }
+
+    @Test
+    public void testEmptyString()
+    {
+        assertFunction(
+                "SPLIT_PART_REVERSE('', ',', 1)",
+                VARCHAR,
+                "");
+        assertFunction(
+                "SPLIT_PART_REVERSE('', ',', -1)",
+                VARCHAR,
+                "");
+    }
+
+    @Test
+    public void testNull()
+    {
+        assertFunction(
+                "SPLIT_PART_REVERSE(CAST(NULL AS VARCHAR), '/', 1)",
+                VARCHAR,
+                null);
+        assertFunction(
+                "SPLIT_PART_REVERSE('foo/bar', NULL, 1)",
+                VARCHAR,
+                null);
+    }
+
+    @Test
+    public void testError()
+    {
+        assertInvalidFunction(
+                "SPLIT_PART_REVERSE('foo/bar', '/', 'one')",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+        assertInvalidFunction(
+                "SPLIT_PART_REVERSE(123, '/', 1)",
+                SemanticErrorCode.FUNCTION_NOT_FOUND);
+    }
+}

--- a/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/StringSqlFunctions.java
+++ b/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/StringSqlFunctions.java
@@ -41,4 +41,16 @@ public class StringSqlFunctions
     {
         return "RETURN REVERSE(SUBSTR(REVERSE(str), 1, N))";
     }
+
+    @SqlInvokedScalarFunction(value = "split_part_reverse", deterministic = true, calledOnNullInput = false)
+    @Description("Splits string on delimiter and returns the field at the given index. " +
+            "Positive indices count from the start (1-based), matching split_part. " +
+            "Negative indices count from the end (-1 = last, -2 = second-to-last). " +
+            "Returns NULL if the absolute index exceeds the number of parts.")
+    @SqlParameters({@SqlParameter(name = "str", type = "varchar"), @SqlParameter(name = "delimiter", type = "varchar"), @SqlParameter(name = "idx", type = "bigint")})
+    @SqlType("varchar")
+    public static String splitPartReverse()
+    {
+        return "RETURN ELEMENT_AT(SPLIT(str, delimiter), idx)";
+    }
 }


### PR DESCRIPTION
Summary:

Converts the split_part_reverse implementation from a C++ Velox UDF to a Presto SQL-invoked scalar function (`SqlInvokedScalarFunction`), following the pattern in `ArraySqlFunctions.java` per reviewer feedback.

The function body is a single SQL expression:
```sql
RETURN ELEMENT_AT(SPLIT(str, delimiter), idx)
```

This leverages Presto's native `element_at()` negative index support on arrays:
- Positive indices count from start (1-based), matching split_part
- Negative indices count from end (-1 = last, -2 = second-to-last)
- Returns NULL if |index| exceeds the number of parts
- Index 0 throws an error (Presto native behavior)

**Why SQL inline over C++ UDF:**
- No Velox C++ compilation required
- Globally available in all Presto queries (DaiQuery, pipelines, Bento)
- One-liner SQL expression, trivially maintainable
- Follows established pattern (ArraySqlFunctions, StringSqlFunctions)
- Already registered via `SqlInvokedFunctionsPlugin` (StringSqlFunctions.class)

**Usage:**
```sql
SELECT split_part_reverse('foo/bar/baz/qux', '/', -1);  -- 'qux'
SELECT split_part_reverse('foo/bar/baz/qux', '/', -2);  -- 'baz'
SELECT split_part_reverse('foo/bar/baz/qux', '/', 1);   -- 'foo'
```

This addresses T248997604 and incorporates feedback from the presto.dev Workplace thread.

Differential Revision: D89498172
