### PR TITLE
feat(plugin-lance): Integrate lance-namespace API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2983,6 +2983,17 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>12.1.3</version>
+                <configuration>
+                    <suppressionFiles>
+                        <suppressionFile>${air.main.basedir}/src/dependency-check-suppressions.xml</suppressionFile>
+                    </suppressionFiles>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2751,6 +2751,25 @@
                 <artifactId>scala-library</artifactId>
                 <version>${scala.version}</version>
             </dependency>
+
+            <!-- Lance -->
+            <dependency>
+                <groupId>org.lance</groupId>
+                <artifactId>lance-core</artifactId>
+                <version>2.0.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.lance</groupId>
+                <artifactId>lance-namespace-core</artifactId>
+                <version>0.6.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.lance</groupId>
+                <artifactId>lance-namespace-apache-client</artifactId>
+                <version>0.6.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/presto-docs/src/main/sphinx/connector/lance.rst
+++ b/presto-docs/src/main/sphinx/connector/lance.rst
@@ -23,7 +23,7 @@ replacing the properties as appropriate:
 .. code-block:: none
 
     connector.name=lance
-    lance.root-url=/path/to/lance/data
+    lance.root=/path/to/lance/data
 
 Configuration Properties
 ------------------------
@@ -33,8 +33,11 @@ The following configuration properties are available:
 ===================================== ============================================================= ===============
 Property Name                         Description                                                   Default
 ===================================== ============================================================= ===============
-``lance.impl``                        Namespace implementation: ``dir``                              ``dir``
-``lance.root-url``                    Root storage path for Lance datasets.                          ``""``
+``lance.impl``                        Namespace implementation: ``dir``, ``rest``, or a full class    ``dir``
+                                      name.
+``lance.root``                        Root storage path for Lance datasets.                          ``""``
+``lance.parent``                      Parent namespace prefix for namespaces with three or more      (none)
+                                      levels. Use ``$`` as the delimiter.
 ``lance.single-level-ns``             When ``true``, uses a single-level namespace with a            ``true``
                                       virtual ``default`` schema.
 ``lance.read-batch-size``             Number of rows per Arrow batch during reads.                   ``8192``
@@ -52,14 +55,34 @@ Property Name                         Description                               
 
 Namespace implementation to use. The default ``dir`` uses a directory-based
 table store where each table is a ``<name>.lance`` directory under the root.
+Set this to ``rest`` to use a Lance REST namespace server, or to a fully
+qualified class name to plug in a custom ``LanceNamespace`` implementation.
 
-``lance.root-url``
-^^^^^^^^^^^^^^^^^^
+``lance.root``
+^^^^^^^^^^^^^^
 
 Root storage path for Lance datasets. All tables are stored as subdirectories
-named ``<table_name>.lance`` under this path. For example, if ``lance.root-url``
+named ``<table_name>.lance`` under this path. For example, if ``lance.root``
 is set to ``/data/lance``, a table named ``my_table`` is stored at
 ``/data/lance/my_table.lance``.
+
+This property is required when ``lance.impl`` is ``dir``.
+
+.. note::
+
+    This property was named ``lance.root-url`` in releases 0.297 and 0.298.
+    The old name is no longer accepted. See `Breaking Changes`_.
+
+``lance.parent``
+^^^^^^^^^^^^^^^^
+
+Parent namespace prefix, used when the underlying namespace has three or more
+levels and Presto should be rooted below the top level. Use ``$`` as the
+delimiter, because it does not conflict with the path separators ``/`` and
+``.`` used elsewhere. For example, ``lance.parent=org$warehouse`` makes a
+Presto schema ``sales`` resolve to the namespace ``org$warehouse$sales``.
+
+By default no prefix is applied.
 
 ``lance.single-level-ns``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -134,6 +157,48 @@ cache is automatically invalidated on write operations. The default is ``100``.
 Time-to-live for cached Lance dataset objects. After this duration of
 inactivity, cached datasets are evicted and their resources released. The
 default is ``60m`` (60 minutes).
+
+Namespace Properties
+--------------------
+
+The connector delegates schema and table operations to a
+`Lance namespace <https://lance.org/>`_ implementation selected by
+``lance.impl``. Every catalog property that begins with ``lance.`` is forwarded
+to that implementation with the ``lance.`` prefix removed, so namespace options
+can be set without connector code changes. For example, ``lance.root`` is
+passed through as ``root``.
+
+Properties beginning with ``lance.storage.`` are additionally supplied as
+storage options when opening and creating datasets. For example,
+``lance.storage.aws_access_key_id`` is passed as ``aws_access_key_id``. This is
+how object store credentials are configured:
+
+.. code-block:: none
+
+    connector.name=lance
+    lance.root=s3://my-bucket/lance
+    lance.storage.aws_access_key_id=...
+    lance.storage.aws_secret_access_key=...
+    lance.storage.region=us-east-1
+
+Breaking Changes
+----------------
+
+The ``lance.root-url`` property, available in releases 0.297 and 0.298, is
+replaced by ``lance.root``. The old name is no longer recognized, and a catalog
+that still sets it fails at startup with ``lance.root must be set when using
+lance.impl=dir``. Rename the property in ``etc/catalog/lance.properties``
+before upgrading:
+
+.. code-block:: none
+
+    # Before
+    lance.root-url=/data/lance
+
+    # After
+    lance.root=/data/lance
+
+The value format is unchanged, and no data migration is required.
 
 Data Types
 ----------

--- a/presto-lance/pom.xml
+++ b/presto-lance/pom.xml
@@ -108,7 +108,6 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-core</artifactId>
-            <version>2.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -124,13 +123,11 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.6.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.6.1</version>
         </dependency>
 
         <dependency>

--- a/presto-lance/pom.xml
+++ b/presto-lance/pom.xml
@@ -118,11 +118,19 @@
                     <groupId>com.fasterxml.jackson.datatype</groupId>
                     <artifactId>jackson-datatype-jsr310</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.lance</groupId>
-                    <artifactId>lance-namespace-apache-client</artifactId>
-                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.lance</groupId>
+            <artifactId>lance-namespace-core</artifactId>
+            <version>0.6.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.lance</groupId>
+            <artifactId>lance-namespace-apache-client</artifactId>
+            <version>0.6.1</version>
         </dependency>
 
         <dependency>

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceConfig.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceConfig.java
@@ -24,11 +24,34 @@ import javax.validation.constraints.NotNull;
 import static com.facebook.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+/**
+ * Configuration for Lance connector.
+ * <p>
+ * This class contains only the connector-specific configuration properties.
+ * All other properties (e.g., lance.root, lance.uri, etc.) are passed through
+ * to the LanceNamespace implementation via the catalog properties map.
+ * <p>
+ * Directory namespace example:
+ * <pre>
+ * connector.name=lance
+ * lance.impl=dir
+ * lance.root=/path/to/warehouse
+ * </pre>
+ * <p>
+ * REST namespace example:
+ * <pre>
+ * connector.name=lance
+ * lance.impl=rest
+ * lance.uri=https://api.lancedb.com
+ * </pre>
+ * <p>
+ * All properties prefixed with "lance." are passed to the namespace implementation.
+ */
 public class LanceConfig
 {
     private String impl = "dir";
-    private String rootUrl = "";
     private boolean singleLevelNs = true;
+    private String parent;
     private int readBatchSize = 8192;
     private int maxRowsPerFile = 1_000_000;
     private int maxRowsPerGroup = 100_000;
@@ -45,24 +68,10 @@ public class LanceConfig
     }
 
     @Config("lance.impl")
-    @ConfigDescription("Namespace implementation: 'dir' or full class name")
+    @ConfigDescription("Namespace implementation: 'dir', 'rest', or full class name")
     public LanceConfig setImpl(String impl)
     {
         this.impl = impl;
-        return this;
-    }
-
-    @NotNull
-    public String getRootUrl()
-    {
-        return rootUrl;
-    }
-
-    @Config("lance.root-url")
-    @ConfigDescription("Lance root storage path")
-    public LanceConfig setRootUrl(String rootUrl)
-    {
-        this.rootUrl = rootUrl;
         return this;
     }
 
@@ -72,10 +81,23 @@ public class LanceConfig
     }
 
     @Config("lance.single-level-ns")
-    @ConfigDescription("Access 1st level namespace with virtual 'default' schema")
+    @ConfigDescription("Access 1st level namespace with virtual 'default' schema (no CREATE SCHEMA)")
     public LanceConfig setSingleLevelNs(boolean singleLevelNs)
     {
         this.singleLevelNs = singleLevelNs;
+        return this;
+    }
+
+    public String getParent()
+    {
+        return parent;
+    }
+
+    @Config("lance.parent")
+    @ConfigDescription("Parent namespace prefix for 3+ level namespaces (use $ as delimiter)")
+    public LanceConfig setParent(String parent)
+    {
+        this.parent = parent;
         return this;
     }
 

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnectorFactory.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnectorFactory.java
@@ -21,13 +21,29 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorContext;
 import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class LanceConnectorFactory
         implements ConnectorFactory
 {
+    // Properties that are handled by LanceConfig via @Config annotations.
+    // All other lance.* properties are passed through to the namespace implementation.
+    private static final Set<String> KNOWN_CONFIG_PROPERTIES = ImmutableSet.of(
+            "lance.impl",
+            "lance.single-level-ns",
+            "lance.parent",
+            "lance.read-batch-size",
+            "lance.max-rows-per-file",
+            "lance.max-rows-per-group",
+            "lance.write-batch-size");
+
     @Override
     public String getName()
     {
@@ -45,14 +61,32 @@ public class LanceConnectorFactory
     {
         ClassLoader classLoader = LanceConnectorFactory.class.getClassLoader();
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            // Keep an immutable copy of all config for passing to LanceNamespaceHolder
+            Map<String, String> catalogProperties = ImmutableMap.copyOf(config);
+
+            // Filter to only known properties for the Bootstrap configuration.
+            // This allows free-form lance.* properties to be passed through without error.
+            Map<String, String> knownProperties = new HashMap<>();
+            for (Map.Entry<String, String> entry : config.entrySet()) {
+                if (KNOWN_CONFIG_PROPERTIES.contains(entry.getKey())) {
+                    knownProperties.put(entry.getKey(), entry.getValue());
+                }
+            }
+
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new LanceModule(),
-                    binder -> binder.bind(TypeManager.class).toInstance(context.getTypeManager()));
+                    binder -> {
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                        // Bind the raw namespace properties map for free-form property access
+                        binder.bind(new TypeLiteral<Map<String, String>>() {})
+                                .annotatedWith(LanceNamespaceProperties.class)
+                                .toInstance(catalogProperties);
+                    });
 
             Injector injector = app
                     .doNotInitializeLogging()
-                    .setRequiredConfigurationProperties(config)
+                    .setRequiredConfigurationProperties(knownProperties)
                     .initialize();
 
             return injector.getInstance(LanceConnector.class);

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnectorFactory.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceConnectorFactory.java
@@ -33,8 +33,12 @@ import java.util.Set;
 public class LanceConnectorFactory
         implements ConnectorFactory
 {
-    // Properties that are handled by LanceConfig via @Config annotations.
-    // All other lance.* properties are passed through to the namespace implementation.
+    // Properties handled by LanceConfig via @Config annotations.
+    // All other properties (including free-form lance.* namespace properties like
+    // lance.root, lance.uri, lance.storage.*) are passed through to the namespace
+    // implementation via @LanceNamespaceProperties and must NOT be listed here.
+    // Note: connector.name is stripped by the Presto framework before reaching create().
+    // IMPORTANT: When adding new @Config properties to LanceConfig, update this set.
     private static final Set<String> KNOWN_CONFIG_PROPERTIES = ImmutableSet.of(
             "lance.impl",
             "lance.single-level-ns",

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceMetadata.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceMetadata.java
@@ -52,8 +52,6 @@ import static java.util.Objects.requireNonNull;
 public class LanceMetadata
         implements ConnectorMetadata
 {
-    public static final String LANCE_DEFAULT_SCHEMA = "default";
-
     private final LanceNamespaceHolder namespaceHolder;
     private final JsonCodec<LanceCommitTaskData> commitTaskDataCodec;
 
@@ -69,13 +67,13 @@ public class LanceMetadata
     @Override
     public boolean schemaExists(ConnectorSession session, String schemaName)
     {
-        return LANCE_DEFAULT_SCHEMA.equals(schemaName);
+        return namespaceHolder.schemaExists(schemaName);
     }
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
-        return ImmutableList.of(LANCE_DEFAULT_SCHEMA);
+        return namespaceHolder.listSchemaNames();
     }
 
     @Override
@@ -84,11 +82,13 @@ public class LanceMetadata
         if (!schemaExists(session, tableName.getSchemaName())) {
             return null;
         }
-        if (!namespaceHolder.tableExists(tableName.getTableName())) {
+        String tablePath = namespaceHolder.getTablePath(tableName.getSchemaName(), tableName.getTableName());
+        if (tablePath == null) {
             return null;
         }
-        long datasetVersion = namespaceHolder.getLatestVersion(tableName.getTableName());
-        return new LanceTableHandle(tableName.getSchemaName(), tableName.getTableName(), Optional.of(datasetVersion));
+        List<String> tableId = namespaceHolder.getTableId(tableName.getSchemaName(), tableName.getTableName());
+        long datasetVersion = namespaceHolder.getLatestVersion(tablePath);
+        return new LanceTableHandle(tableName.getSchemaName(), tableName.getTableName(), tablePath, tableId, Optional.of(datasetVersion));
     }
 
     @Override
@@ -101,29 +101,34 @@ public class LanceMetadata
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
         LanceTableHandle lanceTable = (LanceTableHandle) table;
-        if (!namespaceHolder.tableExists(lanceTable.getTableName())) {
+        try {
+            Schema arrowSchema = namespaceHolder.describeTable(lanceTable.getTablePath(), lanceTable.getDatasetVersion());
+            SchemaTableName schemaTableName = new SchemaTableName(lanceTable.getSchemaName(), lanceTable.getTableName());
+
+            ImmutableList.Builder<ColumnMetadata> columnsMetadata = ImmutableList.builder();
+            for (Field field : arrowSchema.getFields()) {
+                columnsMetadata.add(ColumnMetadata.builder()
+                        .setName(field.getName())
+                        .setType(LanceColumnHandle.toPrestoType(field))
+                        .setNullable(field.isNullable())
+                        .build());
+            }
+
+            return new ConnectorTableMetadata(schemaTableName, columnsMetadata.build());
+        }
+        catch (Exception e) {
             return null;
         }
-        Schema arrowSchema = namespaceHolder.describeTable(lanceTable.getTableName(), lanceTable.getDatasetVersion());
-        SchemaTableName schemaTableName = new SchemaTableName(lanceTable.getSchemaName(), lanceTable.getTableName());
-
-        ImmutableList.Builder<ColumnMetadata> columnsMetadata = ImmutableList.builder();
-        for (Field field : arrowSchema.getFields()) {
-            columnsMetadata.add(ColumnMetadata.builder()
-                    .setName(field.getName())
-                    .setType(LanceColumnHandle.toPrestoType(field))
-                    .setNullable(field.isNullable())
-                    .build());
-        }
-
-        return new ConnectorTableMetadata(schemaTableName, columnsMetadata.build());
     }
 
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        String schema = schemaName.orElse(LANCE_DEFAULT_SCHEMA);
-        return namespaceHolder.listTables().stream()
+        String schema = schemaName.orElse(LanceNamespaceHolder.DEFAULT_SCHEMA);
+        if (!namespaceHolder.schemaExists(schema)) {
+            return ImmutableList.of();
+        }
+        return namespaceHolder.listTables(schema).stream()
                 .map(tableName -> new SchemaTableName(schema, tableName))
                 .collect(toImmutableList());
     }
@@ -132,20 +137,22 @@ public class LanceMetadata
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         LanceTableHandle lanceTable = (LanceTableHandle) tableHandle;
-        if (!namespaceHolder.tableExists(lanceTable.getTableName())) {
+        try {
+            Schema arrowSchema = namespaceHolder.describeTable(lanceTable.getTablePath(), lanceTable.getDatasetVersion());
+
+            ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
+            for (Field field : arrowSchema.getFields()) {
+                LanceColumnHandle columnHandle = new LanceColumnHandle(
+                        field.getName(),
+                        LanceColumnHandle.toPrestoType(field),
+                        field.isNullable());
+                columnHandles.put(field.getName(), columnHandle);
+            }
+            return columnHandles.build();
+        }
+        catch (Exception e) {
             return ImmutableMap.of();
         }
-        Schema arrowSchema = namespaceHolder.describeTable(lanceTable.getTableName(), lanceTable.getDatasetVersion());
-
-        ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
-        for (Field field : arrowSchema.getFields()) {
-            LanceColumnHandle columnHandle = new LanceColumnHandle(
-                    field.getName(),
-                    LanceColumnHandle.toPrestoType(field),
-                    field.isNullable());
-            columnHandles.put(field.getName(), columnHandle);
-        }
-        return columnHandles.build();
     }
 
     @Override
@@ -195,17 +202,21 @@ public class LanceMetadata
     {
         Schema arrowSchema = LancePageToArrowConverter.toArrowSchema(tableMetadata.getColumns());
 
-        namespaceHolder.createTable(
-                tableMetadata.getTable().getTableName(),
-                arrowSchema);
+        String schemaName = tableMetadata.getTable().getSchemaName();
+        String tableName = tableMetadata.getTable().getTableName();
+
+        String tablePath = namespaceHolder.createTable(schemaName, tableName, arrowSchema);
+        List<String> tableId = namespaceHolder.getTableId(schemaName, tableName);
 
         List<LanceColumnHandle> columns = tableMetadata.getColumns().stream()
                 .map(col -> new LanceColumnHandle(col.getName(), col.getType(), col.isNullable()))
                 .collect(toImmutableList());
 
         return new LanceWritableTableHandle(
-                tableMetadata.getTable().getSchemaName(),
-                tableMetadata.getTable().getTableName(),
+                schemaName,
+                tableName,
+                tablePath,
+                tableId,
                 arrowSchema.toJson(),
                 columns);
     }
@@ -221,7 +232,7 @@ public class LanceMetadata
 
         if (!fragments.isEmpty()) {
             List<org.lance.FragmentMetadata> allFragments = collectFragments(fragments);
-            namespaceHolder.commitAppend(handle.getTableName(), allFragments);
+            namespaceHolder.commitAppend(handle.getTablePath(), allFragments);
         }
         return Optional.empty();
     }
@@ -230,7 +241,7 @@ public class LanceMetadata
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         LanceTableHandle lanceTable = (LanceTableHandle) tableHandle;
-        Schema arrowSchema = namespaceHolder.describeTable(lanceTable.getTableName(), Optional.empty());
+        Schema arrowSchema = namespaceHolder.describeTable(lanceTable.getTablePath(), lanceTable.getDatasetVersion());
 
         List<LanceColumnHandle> columns = arrowSchema.getFields().stream()
                 .map(field -> new LanceColumnHandle(
@@ -242,6 +253,8 @@ public class LanceMetadata
         return new LanceWritableTableHandle(
                 lanceTable.getSchemaName(),
                 lanceTable.getTableName(),
+                lanceTable.getTablePath(),
+                lanceTable.getTableId(),
                 arrowSchema.toJson(),
                 columns);
     }
@@ -257,7 +270,7 @@ public class LanceMetadata
 
         if (!fragments.isEmpty()) {
             List<org.lance.FragmentMetadata> allFragments = collectFragments(fragments);
-            namespaceHolder.commitAppend(handle.getTableName(), allFragments);
+            namespaceHolder.commitAppend(handle.getTablePath(), allFragments);
         }
         return Optional.empty();
     }
@@ -266,7 +279,7 @@ public class LanceMetadata
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         LanceTableHandle lanceTable = (LanceTableHandle) tableHandle;
-        namespaceHolder.dropTable(lanceTable.getTableName());
+        namespaceHolder.dropTable(lanceTable.getTableId());
     }
 
     private List<org.lance.FragmentMetadata> collectFragments(Collection<Slice> fragments)

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceMetadata.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceMetadata.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.lance;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
@@ -52,6 +53,8 @@ import static java.util.Objects.requireNonNull;
 public class LanceMetadata
         implements ConnectorMetadata
 {
+    private static final Logger log = Logger.get(LanceMetadata.class);
+
     private final LanceNamespaceHolder namespaceHolder;
     private final JsonCodec<LanceCommitTaskData> commitTaskDataCodec;
 
@@ -117,6 +120,7 @@ public class LanceMetadata
             return new ConnectorTableMetadata(schemaTableName, columnsMetadata.build());
         }
         catch (Exception e) {
+            log.warn(e, "Failed to get metadata for %s.%s", lanceTable.getSchemaName(), lanceTable.getTableName());
             return null;
         }
     }
@@ -151,6 +155,7 @@ public class LanceMetadata
             return columnHandles.build();
         }
         catch (Exception e) {
+            log.warn(e, "Failed to get column handles for %s.%s", lanceTable.getSchemaName(), lanceTable.getTableName());
             return ImmutableMap.of();
         }
     }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceMetadata.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceMetadata.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.lance;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
@@ -27,6 +26,7 @@ import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutResult;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
@@ -47,14 +47,13 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 public class LanceMetadata
         implements ConnectorMetadata
 {
-    private static final Logger log = Logger.get(LanceMetadata.class);
-
     private final LanceNamespaceHolder namespaceHolder;
     private final JsonCodec<LanceCommitTaskData> commitTaskDataCodec;
 
@@ -104,24 +103,41 @@ public class LanceMetadata
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
         LanceTableHandle lanceTable = (LanceTableHandle) table;
-        try {
-            Schema arrowSchema = namespaceHolder.describeTable(lanceTable.getTablePath(), lanceTable.getDatasetVersion());
-            SchemaTableName schemaTableName = new SchemaTableName(lanceTable.getSchemaName(), lanceTable.getTableName());
+        Schema arrowSchema = describeTableOrFail(lanceTable);
+        SchemaTableName schemaTableName = new SchemaTableName(lanceTable.getSchemaName(), lanceTable.getTableName());
 
-            ImmutableList.Builder<ColumnMetadata> columnsMetadata = ImmutableList.builder();
-            for (Field field : arrowSchema.getFields()) {
-                columnsMetadata.add(ColumnMetadata.builder()
-                        .setName(field.getName())
-                        .setType(LanceColumnHandle.toPrestoType(field))
-                        .setNullable(field.isNullable())
-                        .build());
-            }
-
-            return new ConnectorTableMetadata(schemaTableName, columnsMetadata.build());
+        ImmutableList.Builder<ColumnMetadata> columnsMetadata = ImmutableList.builder();
+        for (Field field : arrowSchema.getFields()) {
+            columnsMetadata.add(ColumnMetadata.builder()
+                    .setName(field.getName())
+                    .setType(LanceColumnHandle.toPrestoType(field))
+                    .setNullable(field.isNullable())
+                    .build());
         }
-        catch (Exception e) {
-            log.warn(e, "Failed to get metadata for %s.%s", lanceTable.getSchemaName(), lanceTable.getTableName());
-            return null;
+
+        return new ConnectorTableMetadata(schemaTableName, columnsMetadata.build());
+    }
+
+    /**
+     * Reads the Arrow schema for an already-resolved table handle.
+     *
+     * <p>The handle's path came from the namespace, so a failure here means the dataset itself
+     * could not be opened. Returning {@code null}/empty in that case would surface as an NPE or
+     * as a table that appears to have no columns, both of which hide the real cause.
+     */
+    private Schema describeTableOrFail(LanceTableHandle lanceTable)
+    {
+        try {
+            return namespaceHolder.describeTable(lanceTable.getTablePath(), lanceTable.getDatasetVersion());
+        }
+        catch (PrestoException e) {
+            throw e;
+        }
+        catch (RuntimeException e) {
+            throw new PrestoException(LanceErrorCode.LANCE_ERROR,
+                    format("Failed to read schema for table %s.%s at %s",
+                            lanceTable.getSchemaName(), lanceTable.getTableName(), lanceTable.getTablePath()),
+                    e);
         }
     }
 
@@ -141,23 +157,17 @@ public class LanceMetadata
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         LanceTableHandle lanceTable = (LanceTableHandle) tableHandle;
-        try {
-            Schema arrowSchema = namespaceHolder.describeTable(lanceTable.getTablePath(), lanceTable.getDatasetVersion());
+        Schema arrowSchema = describeTableOrFail(lanceTable);
 
-            ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
-            for (Field field : arrowSchema.getFields()) {
-                LanceColumnHandle columnHandle = new LanceColumnHandle(
-                        field.getName(),
-                        LanceColumnHandle.toPrestoType(field),
-                        field.isNullable());
-                columnHandles.put(field.getName(), columnHandle);
-            }
-            return columnHandles.build();
+        ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
+        for (Field field : arrowSchema.getFields()) {
+            LanceColumnHandle columnHandle = new LanceColumnHandle(
+                    field.getName(),
+                    LanceColumnHandle.toPrestoType(field),
+                    field.isNullable());
+            columnHandles.put(field.getName(), columnHandle);
         }
-        catch (Exception e) {
-            log.warn(e, "Failed to get column handles for %s.%s", lanceTable.getSchemaName(), lanceTable.getTableName());
-            return ImmutableMap.of();
-        }
+        return columnHandles.build();
     }
 
     @Override

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -69,6 +70,9 @@ public class LanceNamespaceHolder
     private static final Logger log = Logger.get(LanceNamespaceHolder.class);
     public static final String DEFAULT_SCHEMA = "default";
 
+    // Default max allocation: 8 GB. Can be tuned via lance.allocator-max-bytes if needed.
+    private static final long DEFAULT_ALLOCATOR_MAX_BYTES = 8L * 1024 * 1024 * 1024;
+
     private final BufferAllocator allocator;
     private final LanceNamespace namespace;
     private final boolean singleLevelNs;
@@ -80,7 +84,7 @@ public class LanceNamespaceHolder
     @Inject
     public LanceNamespaceHolder(LanceConfig config, @LanceNamespaceProperties Map<String, String> namespaceProperties)
     {
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
+        this.allocator = new RootAllocator(DEFAULT_ALLOCATOR_MAX_BYTES);
         this.readOptions = new ReadOptions.Builder()
                 .setIndexCacheSizeBytes(config.getIndexCacheSize().toBytes())
                 .setMetadataCacheSizeBytes(config.getMetadataCacheSize().toBytes())
@@ -112,7 +116,13 @@ public class LanceNamespaceHolder
                 }
             }
         }
-        this.namespaceStorageOptions = storageOpts;
+        this.namespaceStorageOptions = ImmutableMap.copyOf(storageOpts);
+
+        // Validate that 'root' is set for directory namespace
+        if ("dir".equals(impl) && !properties.containsKey("root")) {
+            throw new PrestoException(LanceErrorCode.LANCE_ERROR,
+                    "lance.root must be set when using lance.impl=dir");
+        }
 
         // For DirectoryNamespace, ensure default settings are applied
         if ("dir".equals(impl)) {
@@ -127,6 +137,8 @@ public class LanceNamespaceHolder
         this.singleLevelNs = config.isSingleLevelNs();
         String parent = config.getParent();
         if (parent != null && !parent.isEmpty()) {
+            // Parent uses '$' as delimiter to avoid conflicts with common path separators ('/' and '.')
+            // and namespace-level separators. Example: "org$warehouse" -> ["org", "warehouse"]
             this.parentPrefix = Optional.of(Arrays.asList(parent.split("\\$")));
         }
         else {
@@ -216,7 +228,7 @@ public class LanceNamespaceHolder
      * In single-level mode, maps to empty (root).
      * Otherwise, adds parent prefix if configured.
      */
-    public List<String> prestoSchemaToLanceNamespace(String schema)
+    List<String> prestoSchemaToLanceNamespace(String schema)
     {
         if (singleLevelNs) {
             return Collections.emptyList();
@@ -228,7 +240,7 @@ public class LanceNamespaceHolder
     /**
      * Add parent prefix for 3+ level namespaces.
      */
-    public List<String> addParentPrefix(List<String> namespaceId)
+    List<String> addParentPrefix(List<String> namespaceId)
     {
         if (!parentPrefix.isPresent()) {
             return namespaceId;
@@ -341,7 +353,7 @@ public class LanceNamespaceHolder
             DescribeTableResponse response = namespace.describeTable(request);
             Map<String, String> storageOptions = response.getStorageOptions();
             if (storageOptions != null && !storageOptions.isEmpty()) {
-                return storageOptions;
+                return ImmutableMap.copyOf(storageOptions);
             }
         }
         catch (Exception e) {
@@ -349,10 +361,10 @@ public class LanceNamespaceHolder
         }
 
         if (!namespaceStorageOptions.isEmpty()) {
-            return new HashMap<>(namespaceStorageOptions);
+            return namespaceStorageOptions;
         }
 
-        return new HashMap<>();
+        return ImmutableMap.of();
     }
 
     /**
@@ -392,8 +404,21 @@ public class LanceNamespaceHolder
         CreateEmptyTableResponse createResponse = namespace.createEmptyTable(createRequest);
         String tablePath = createResponse.getLocation();
 
-        WriteParams params = new WriteParams.Builder().build();
-        Dataset.create(allocator, tablePath, arrowSchema, params).close();
+        try {
+            WriteParams params = new WriteParams.Builder().build();
+            Dataset.create(allocator, tablePath, arrowSchema, params).close();
+        }
+        catch (Exception e) {
+            // Clean up the namespace entry if physical dataset creation fails
+            try {
+                dropTable(tableId);
+            }
+            catch (Exception dropException) {
+                log.warn(dropException, "Failed to clean up namespace entry for %s after Dataset.create failure", tableId);
+            }
+            throw new PrestoException(LanceErrorCode.LANCE_ERROR,
+                    "Failed to create dataset at " + tablePath + ": " + e.getMessage(), e);
+        }
 
         return tablePath;
     }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
@@ -30,6 +30,10 @@ import org.lance.FragmentOperation;
 import org.lance.ReadOptions;
 import org.lance.WriteParams;
 import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.errors.ErrorCode;
+import org.lance.namespace.errors.LanceNamespaceException;
+import org.lance.namespace.errors.NamespaceNotFoundException;
+import org.lance.namespace.errors.TableNotFoundException;
 import org.lance.namespace.model.CreateEmptyTableRequest;
 import org.lance.namespace.model.CreateEmptyTableResponse;
 import org.lance.namespace.model.DescribeTableRequest;
@@ -57,6 +61,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -70,8 +75,9 @@ public class LanceNamespaceHolder
     private static final Logger log = Logger.get(LanceNamespaceHolder.class);
     public static final String DEFAULT_SCHEMA = "default";
 
-    // Default max allocation: 8 GB. Can be tuned via lance.allocator-max-bytes if needed.
-    private static final long DEFAULT_ALLOCATOR_MAX_BYTES = 8L * 1024 * 1024 * 1024;
+    // Upper bound on off-heap Arrow allocation for this catalog. Fixed at 8 GB;
+    // there is no catalog property to tune it.
+    private static final long ALLOCATOR_MAX_BYTES = 8L * 1024 * 1024 * 1024;
 
     private final BufferAllocator allocator;
     private final LanceNamespace namespace;
@@ -84,7 +90,7 @@ public class LanceNamespaceHolder
     @Inject
     public LanceNamespaceHolder(LanceConfig config, @LanceNamespaceProperties Map<String, String> namespaceProperties)
     {
-        this.allocator = new RootAllocator(DEFAULT_ALLOCATOR_MAX_BYTES);
+        this.allocator = new RootAllocator(ALLOCATOR_MAX_BYTES);
         this.readOptions = new ReadOptions.Builder()
                 .setIndexCacheSizeBytes(config.getIndexCacheSize().toBytes())
                 .setMetadataCacheSizeBytes(config.getMetadataCacheSize().toBytes())
@@ -306,7 +312,25 @@ public class LanceNamespaceHolder
             namespace.namespaceExists(request);
             return true;
         }
-        catch (Exception e) {
+        catch (NamespaceNotFoundException e) {
+            return false;
+        }
+        catch (LanceNamespaceException e) {
+            if (e.getErrorCode() == ErrorCode.NAMESPACE_NOT_FOUND) {
+                return false;
+            }
+            // A namespace that is unreachable, throttled, or rejecting our credentials is not
+            // the same as one that is absent. Surfacing it as "absent" makes CREATE SCHEMA and
+            // SHOW SCHEMAS silently wrong, so fail loudly instead.
+            throw new PrestoException(LanceErrorCode.LANCE_ERROR,
+                    format("Failed to check whether schema %s exists", schema), e);
+        }
+        catch (RuntimeException e) {
+            // The directory namespace calls into native code, which reports every failure --
+            // including a plain "namespace not found" -- as an untyped RuntimeException. With no
+            // error code to inspect, absence is indistinguishable from a transient fault here, so
+            // keep the historical "absent" answer rather than guess from the message text.
+            log.debug(e, "namespaceExists failed for %s; treating as absent", schema);
             return false;
         }
     }
@@ -329,8 +353,22 @@ public class LanceNamespaceHolder
             DescribeTableResponse response = namespace.describeTable(request);
             return response.getLocation();
         }
-        catch (Exception e) {
-            log.debug("Failed to describe table %s.%s: %s", schemaName, tableName, e.getMessage());
+        catch (TableNotFoundException | NamespaceNotFoundException e) {
+            return null;
+        }
+        catch (LanceNamespaceException e) {
+            if (e.getErrorCode() == ErrorCode.TABLE_NOT_FOUND || e.getErrorCode() == ErrorCode.NAMESPACE_NOT_FOUND) {
+                return null;
+            }
+            // Reporting a transient namespace failure as "table absent" turns a retryable error
+            // into a confusing "table does not exist", so only absence maps to null.
+            throw new PrestoException(LanceErrorCode.LANCE_ERROR,
+                    format("Failed to describe table %s.%s", schemaName, tableName), e);
+        }
+        catch (RuntimeException e) {
+            // See schemaExists: the native directory namespace has no typed errors, and callers
+            // such as tableExists and getTableHandle rely on null meaning "not found".
+            log.debug(e, "describeTable failed for %s.%s; treating as not found", schemaName, tableName);
             return null;
         }
     }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceHolder.java
@@ -18,8 +18,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
-import com.google.common.io.MoreFiles;
-import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -30,19 +28,30 @@ import org.lance.FragmentMetadata;
 import org.lance.FragmentOperation;
 import org.lance.ReadOptions;
 import org.lance.WriteParams;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.CreateEmptyTableRequest;
+import org.lance.namespace.model.CreateEmptyTableResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropTableRequest;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
 
 import javax.inject.Inject;
 
-import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -51,27 +60,27 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * Holds the Lance namespace configuration and provides table management operations.
- * For the "dir" implementation, directly manages a directory-based table store.
- * All tables live under a single "default" schema mapped to the root directory.
+ * Holds the Lance namespace and provides table management operations.
+ * Delegates to the LanceNamespace API for table discovery and lifecycle,
+ * supporting pluggable namespace implementations (dir, rest, etc.).
  */
 public class LanceNamespaceHolder
 {
     private static final Logger log = Logger.get(LanceNamespaceHolder.class);
     public static final String DEFAULT_SCHEMA = "default";
-    public static final String TABLE_PATH_SUFFIX = ".lance";
 
     private final BufferAllocator allocator;
-    private final String root;
+    private final LanceNamespace namespace;
     private final boolean singleLevelNs;
+    private final Optional<List<String>> parentPrefix;
+    private final Map<String, String> namespaceStorageOptions;
     private final ReadOptions readOptions;
     private final Cache<DatasetCacheKey, Dataset> datasetCache;
 
     @Inject
-    public LanceNamespaceHolder(LanceConfig config)
+    public LanceNamespaceHolder(LanceConfig config, @LanceNamespaceProperties Map<String, String> namespaceProperties)
     {
-        this.root = requireNonNull(config.getRootUrl(), "root is null");
-        this.singleLevelNs = config.isSingleLevelNs();
+        this.allocator = new RootAllocator(Long.MAX_VALUE);
         this.readOptions = new ReadOptions.Builder()
                 .setIndexCacheSizeBytes(config.getIndexCacheSize().toBytes())
                 .setMetadataCacheSizeBytes(config.getMetadataCacheSize().toBytes())
@@ -88,13 +97,56 @@ public class LanceNamespaceHolder
                     }
                 })
                 .build();
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
-        log.debug("LanceNamespaceHolder initialized: root=%s, singleLevelNs=%s", root, singleLevelNs);
+
+        // Parse namespace properties from catalog config
+        String impl = config.getImpl();
+        Map<String, String> properties = new HashMap<>();
+        Map<String, String> storageOpts = new HashMap<>();
+        for (Map.Entry<String, String> entry : namespaceProperties.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith("lance.")) {
+                String strippedKey = key.substring(6);
+                properties.put(strippedKey, entry.getValue());
+                if (strippedKey.startsWith("storage.")) {
+                    storageOpts.put(strippedKey.substring(8), entry.getValue());
+                }
+            }
+        }
+        this.namespaceStorageOptions = storageOpts;
+
+        // For DirectoryNamespace, ensure default settings are applied
+        if ("dir".equals(impl)) {
+            properties.putIfAbsent("manifest_enabled", "true");
+            properties.putIfAbsent("dir_listing_enabled", "true");
+        }
+
+        // Initialize namespace
+        this.namespace = LanceNamespace.connect(impl, properties, allocator);
+
+        // Initialize namespace level handling
+        this.singleLevelNs = config.isSingleLevelNs();
+        String parent = config.getParent();
+        if (parent != null && !parent.isEmpty()) {
+            this.parentPrefix = Optional.of(Arrays.asList(parent.split("\\$")));
+        }
+        else {
+            this.parentPrefix = Optional.empty();
+        }
+
+        log.debug("LanceNamespaceHolder initialized: impl=%s, singleLevelNs=%s", impl, singleLevelNs);
     }
 
     public void shutdown()
     {
         datasetCache.invalidateAll();
+        if (namespace instanceof Closeable) {
+            try {
+                ((Closeable) namespace).close();
+            }
+            catch (Exception e) {
+                log.warn(e, "Error closing namespace");
+            }
+        }
         try {
             allocator.close();
         }
@@ -108,9 +160,9 @@ public class LanceNamespaceHolder
         return allocator;
     }
 
-    public String getRoot()
+    public LanceNamespace getNamespace()
     {
-        return root;
+        return namespace;
     }
 
     public boolean isSingleLevelNs()
@@ -118,24 +170,11 @@ public class LanceNamespaceHolder
         return singleLevelNs;
     }
 
-    /**
-     * Get ReadOptions with configured cache sizes.
-     */
-    private ReadOptions getReadOptions()
-    {
-        return readOptions;
-    }
+    // ================== Namespace Utilities ==================
 
     /**
      * Get a cached or newly opened Dataset for the given table path with optional version.
      * The returned Dataset is managed by the cache — callers must NOT close it.
-     *
-     * <p>Thread safety: Lance Dataset objects use an internal LockManager for
-     * concurrent access. Multiple threads may safely call getFragments(),
-     * getSchema(), and newScan() on the same cached Dataset instance.
-     *
-     * @param tablePath the full table path (URI)
-     * @param version the dataset version to open (empty for latest)
      */
     Dataset getCachedDataset(String tablePath, Optional<Long> version)
     {
@@ -164,110 +203,220 @@ public class LanceNamespaceHolder
     /**
      * Get the latest version of a dataset. Opens a fresh Dataset each time
      * (bypasses cache) to ensure the returned version is never stale.
-     * The pinned version is then used for all subsequent cached reads.
      */
-    public long getLatestVersion(String tableName)
+    public long getLatestVersion(String tablePath)
     {
-        String tablePath = getTablePath(tableName);
         try (Dataset dataset = Dataset.open(tablePath, readOptions)) {
             return dataset.version();
         }
     }
 
     /**
-     * Get the filesystem path for a table.
+     * Transform Presto schema name to Lance namespace identifier.
+     * In single-level mode, maps to empty (root).
+     * Otherwise, adds parent prefix if configured.
      */
-    public String getTablePath(String tableName)
+    public List<String> prestoSchemaToLanceNamespace(String schema)
     {
-        return Paths.get(root, tableName + TABLE_PATH_SUFFIX).toUri().toString();
+        if (singleLevelNs) {
+            return Collections.emptyList();
+        }
+        List<String> namespaceId = Collections.singletonList(schema);
+        return addParentPrefix(namespaceId);
     }
 
     /**
-     * Check if a table exists on the filesystem.
+     * Add parent prefix for 3+ level namespaces.
      */
-    public boolean tableExists(String tableName)
+    public List<String> addParentPrefix(List<String> namespaceId)
     {
+        if (!parentPrefix.isPresent()) {
+            return namespaceId;
+        }
+        List<String> result = new ArrayList<>(parentPrefix.get());
+        result.addAll(namespaceId);
+        return result;
+    }
+
+    /**
+     * Convert a Presto SchemaTableName to a Lance table identifier.
+     */
+    public List<String> getTableId(String schemaName, String tableName)
+    {
+        List<String> tableId = new ArrayList<>();
+        if (parentPrefix.isPresent()) {
+            tableId.addAll(parentPrefix.get());
+        }
+        if (!singleLevelNs) {
+            tableId.add(schemaName);
+        }
+        tableId.add(tableName);
+        return tableId;
+    }
+
+    // ================== Schema/Namespace Operations ==================
+
+    /**
+     * List schema names (namespaces).
+     */
+    public List<String> listSchemaNames()
+    {
+        if (singleLevelNs) {
+            return Collections.singletonList(DEFAULT_SCHEMA);
+        }
+
+        ListNamespacesRequest request = new ListNamespacesRequest();
+        if (parentPrefix.isPresent()) {
+            request.setId(parentPrefix.get());
+        }
+        ListNamespacesResponse response = namespace.listNamespaces(request);
+        Set<String> namespaces = response.getNamespaces();
+        if (namespaces == null || namespaces.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return namespaces.stream().collect(toImmutableList());
+    }
+
+    /**
+     * Check if a schema (namespace) exists.
+     */
+    public boolean schemaExists(String schema)
+    {
+        if (singleLevelNs && DEFAULT_SCHEMA.equals(schema)) {
+            return true;
+        }
+        if (singleLevelNs) {
+            return false;
+        }
         try {
-            Path path = Paths.get(root, tableName + TABLE_PATH_SUFFIX);
-            return Files.isDirectory(path);
+            NamespaceExistsRequest request = new NamespaceExistsRequest();
+            request.setId(prestoSchemaToLanceNamespace(schema));
+            namespace.namespaceExists(request);
+            return true;
         }
         catch (Exception e) {
             return false;
         }
     }
 
+    // ================== Table Operations ==================
+
+    /**
+     * Get the storage path for a table via namespace API.
+     * Returns null if table does not exist.
+     */
+    public String getTablePath(String schemaName, String tableName)
+    {
+        if (singleLevelNs && !DEFAULT_SCHEMA.equals(schemaName)) {
+            return null;
+        }
+        try {
+            List<String> tableId = getTableId(schemaName, tableName);
+            DescribeTableRequest request = new DescribeTableRequest()
+                    .id(tableId);
+            DescribeTableResponse response = namespace.describeTable(request);
+            return response.getLocation();
+        }
+        catch (Exception e) {
+            log.debug("Failed to describe table %s.%s: %s", schemaName, tableName, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Check if a table exists.
+     */
+    public boolean tableExists(String schemaName, String tableName)
+    {
+        return getTablePath(schemaName, tableName) != null;
+    }
+
+    /**
+     * Get storage options for a table.
+     */
+    public Map<String, String> getStorageOptionsForTable(List<String> tableId)
+    {
+        try {
+            DescribeTableRequest request = new DescribeTableRequest().id(tableId);
+            DescribeTableResponse response = namespace.describeTable(request);
+            Map<String, String> storageOptions = response.getStorageOptions();
+            if (storageOptions != null && !storageOptions.isEmpty()) {
+                return storageOptions;
+            }
+        }
+        catch (Exception e) {
+            log.debug("Failed to get storage options from describeTable for %s: %s", tableId, e.getMessage());
+        }
+
+        if (!namespaceStorageOptions.isEmpty()) {
+            return new HashMap<>(namespaceStorageOptions);
+        }
+
+        return new HashMap<>();
+    }
+
     /**
      * Get the Arrow schema for a table at an optional version.
      */
-    public Schema describeTable(String tableName, Optional<Long> version)
+    public Schema describeTable(String tablePath, Optional<Long> version)
     {
-        String tablePath = getTablePath(tableName);
         return getCachedDataset(tablePath, version).getSchema();
     }
 
     /**
      * List all tables in a schema.
      */
-    public List<String> listTables()
+    public List<String> listTables(String schemaName)
     {
-        Path rootPath = Paths.get(root);
-        if (!Files.isDirectory(rootPath)) {
+        List<String> namespaceId = prestoSchemaToLanceNamespace(schemaName);
+        ListTablesRequest request = new ListTablesRequest();
+        request.setId(namespaceId);
+
+        ListTablesResponse response = namespace.listTables(request);
+        Set<String> tables = response.getTables();
+        if (tables == null || tables.isEmpty()) {
             return Collections.emptyList();
         }
-        List<String> tables = new ArrayList<>();
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(rootPath, "*" + TABLE_PATH_SUFFIX)) {
-            for (Path entry : stream) {
-                if (Files.isDirectory(entry)) {
-                    String fileName = entry.getFileName().toString();
-                    tables.add(fileName.substring(0, fileName.length() - TABLE_PATH_SUFFIX.length()));
-                }
-            }
-        }
-        catch (IOException e) {
-            log.warn(e, "Failed to list tables in %s", root);
-        }
-        return tables;
+        return tables.stream().collect(toImmutableList());
     }
 
     /**
      * Create an empty table with the given schema.
+     * Returns the table path assigned by the namespace.
      */
-    public void createTable(String tableName, Schema arrowSchema)
+    public String createTable(String schemaName, String tableName, Schema arrowSchema)
     {
-        String tablePath = getTablePath(tableName);
+        List<String> tableId = getTableId(schemaName, tableName);
+        CreateEmptyTableRequest createRequest = new CreateEmptyTableRequest()
+                .id(tableId);
+        CreateEmptyTableResponse createResponse = namespace.createEmptyTable(createRequest);
+        String tablePath = createResponse.getLocation();
+
         WriteParams params = new WriteParams.Builder().build();
         Dataset.create(allocator, tablePath, arrowSchema, params).close();
+
+        return tablePath;
     }
 
     /**
      * Drop a table.
      */
-    public void dropTable(String tableName)
+    public void dropTable(List<String> tableId)
     {
-        String tablePath = getTablePath(tableName);
-        invalidateByTablePath(tablePath);
-        Path fsPath = Paths.get(root, tableName + TABLE_PATH_SUFFIX);
-        if (Files.exists(fsPath)) {
-            try {
-                MoreFiles.deleteRecursively(fsPath, RecursiveDeleteOption.ALLOW_INSECURE);
-            }
-            catch (IOException e) {
-                throw new PrestoException(LanceErrorCode.LANCE_ERROR, "Failed to delete table " + tableName, e);
-            }
-        }
+        DropTableRequest dropRequest = new DropTableRequest()
+                .id(tableId);
+        namespace.dropTable(dropRequest);
     }
 
     /**
      * Commit fragments to a table (append operation).
      */
-    public void commitAppend(String tableName, List<FragmentMetadata> fragments)
+    public void commitAppend(String tablePath, List<FragmentMetadata> fragments)
     {
-        String tablePath = getTablePath(tableName);
-        try (Dataset dataset = Dataset.open(tablePath, getReadOptions())) {
+        try (Dataset dataset = Dataset.open(tablePath, readOptions)) {
             FragmentOperation.Append appendOp = new FragmentOperation.Append(fragments);
             Dataset.commit(allocator, tablePath, appendOp, Optional.of(dataset.version()), Collections.emptyMap()).close();
         }
-        // Invalidate all cache entries for this table path
         invalidateByTablePath(tablePath);
     }
 
@@ -282,9 +431,8 @@ public class LanceNamespaceHolder
     /**
      * Get fragments for a table at an optional version.
      */
-    public List<Fragment> getFragments(String tableName, Optional<Long> version)
+    public List<Fragment> getFragments(String tablePath, Optional<Long> version)
     {
-        String tablePath = getTablePath(tableName);
         return getCachedDataset(tablePath, version).getFragments();
     }
 

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceProperties.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceNamespaceProperties.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Binding annotation for the raw namespace properties map.
+ * This allows injection of all lance.* properties from the catalog configuration file,
+ * which are passed through to the LanceNamespace implementation.
+ */
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface LanceNamespaceProperties {}

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSinkProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSinkProvider.java
@@ -78,10 +78,8 @@ public class LancePageSinkProvider
                     "Failed to parse Arrow schema", e);
         }
 
-        String tablePath = namespaceHolder.getTablePath(handle.getTableName());
-
         return new LancePageSink(
-                tablePath,
+                handle.getTablePath(),
                 arrowSchema,
                 handle.getInputColumns(),
                 jsonCodec,

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LancePageSourceProvider.java
@@ -69,8 +69,6 @@ public class LancePageSourceProvider
                 .map(LanceColumnHandle.class::cast)
                 .collect(toImmutableList());
 
-        String tablePath = namespaceHolder.getTablePath(tableHandle.getTableName());
-
         // Build filter from predicate pushdown
         TupleDomain<ColumnHandle> predicate = layoutHandle.getTupleDomain();
         Optional<String> filter = LanceSessionProperties.isFilterPushdownEnabled(session)
@@ -96,7 +94,7 @@ public class LancePageSourceProvider
                 tableHandle,
                 lanceColumns,
                 lanceSplit.getFragments(),
-                tablePath,
+                tableHandle.getTablePath(),
                 config.getReadBatchSize(),
                 namespaceHolder,
                 tableHandle.getDatasetVersion(),

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceSplitManager.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceSplitManager.java
@@ -52,7 +52,7 @@ public class LanceSplitManager
         LanceTableHandle tableHandle = layoutHandle.getTable();
 
         List<Fragment> fragments = namespaceHolder.getFragments(
-                tableHandle.getTableName(),
+                tableHandle.getTablePath(),
                 tableHandle.getDatasetVersion());
 
         // With a pushed-down LIMIT, coalesce just enough leading fragments to cover it into a single

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceTableHandle.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceTableHandle.java
@@ -112,7 +112,7 @@ public class LanceTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, tablePath, datasetVersion, limit);
+        return Objects.hash(schemaName, tableName, tablePath, tableId, datasetVersion, limit);
     }
 
     @Override
@@ -128,6 +128,7 @@ public class LanceTableHandle
         return Objects.equals(this.schemaName, other.schemaName) &&
                 Objects.equals(this.tableName, other.tableName) &&
                 Objects.equals(this.tablePath, other.tablePath) &&
+                Objects.equals(this.tableId, other.tableId) &&
                 Objects.equals(this.datasetVersion, other.datasetVersion) &&
                 Objects.equals(this.limit, other.limit);
     }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceTableHandle.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceTableHandle.java
@@ -16,7 +16,9 @@ package com.facebook.presto.lance;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -29,28 +31,34 @@ public class LanceTableHandle
 {
     private final String schemaName;
     private final String tableName;
+    private final String tablePath;
+    private final List<String> tableId;
     private final Optional<Long> datasetVersion;
     private final OptionalLong limit;
 
-    public LanceTableHandle(String schemaName, String tableName)
+    public LanceTableHandle(String schemaName, String tableName, String tablePath, List<String> tableId)
     {
-        this(schemaName, tableName, Optional.empty(), OptionalLong.empty());
+        this(schemaName, tableName, tablePath, tableId, Optional.empty(), OptionalLong.empty());
     }
 
-    public LanceTableHandle(String schemaName, String tableName, Optional<Long> datasetVersion)
+    public LanceTableHandle(String schemaName, String tableName, String tablePath, List<String> tableId, Optional<Long> datasetVersion)
     {
-        this(schemaName, tableName, datasetVersion, OptionalLong.empty());
+        this(schemaName, tableName, tablePath, tableId, datasetVersion, OptionalLong.empty());
     }
 
     @JsonCreator
     public LanceTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
+            @JsonProperty("tablePath") String tablePath,
+            @JsonProperty("tableId") List<String> tableId,
             @JsonProperty("datasetVersion") Optional<Long> datasetVersion,
             @JsonProperty("limit") OptionalLong limit)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.tablePath = requireNonNull(tablePath, "tablePath is null");
+        this.tableId = ImmutableList.copyOf(requireNonNull(tableId, "tableId is null"));
         this.datasetVersion = requireNonNull(datasetVersion, "datasetVersion is null");
         this.limit = requireNonNull(limit, "limit is null");
     }
@@ -65,6 +73,18 @@ public class LanceTableHandle
     public String getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public String getTablePath()
+    {
+        return tablePath;
+    }
+
+    @JsonProperty
+    public List<String> getTableId()
+    {
+        return tableId;
     }
 
     @JsonProperty
@@ -86,13 +106,13 @@ public class LanceTableHandle
 
     public LanceTableHandle withLimit(long limit)
     {
-        return new LanceTableHandle(schemaName, tableName, datasetVersion, OptionalLong.of(limit));
+        return new LanceTableHandle(schemaName, tableName, tablePath, tableId, datasetVersion, OptionalLong.of(limit));
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, datasetVersion, limit);
+        return Objects.hash(schemaName, tableName, tablePath, datasetVersion, limit);
     }
 
     @Override
@@ -107,6 +127,7 @@ public class LanceTableHandle
         LanceTableHandle other = (LanceTableHandle) obj;
         return Objects.equals(this.schemaName, other.schemaName) &&
                 Objects.equals(this.tableName, other.tableName) &&
+                Objects.equals(this.tablePath, other.tablePath) &&
                 Objects.equals(this.datasetVersion, other.datasetVersion) &&
                 Objects.equals(this.limit, other.limit);
     }
@@ -117,6 +138,7 @@ public class LanceTableHandle
         return toStringHelper(this)
                 .add("schemaName", schemaName)
                 .add("tableName", tableName)
+                .add("tablePath", tablePath)
                 .add("datasetVersion", datasetVersion)
                 .add("limit", limit)
                 .toString();

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceWritableTableHandle.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceWritableTableHandle.java
@@ -91,7 +91,7 @@ public class LanceWritableTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, tablePath, schemaJson, inputColumns);
+        return Objects.hash(schemaName, tableName, tablePath, tableId, schemaJson, inputColumns);
     }
 
     @Override
@@ -107,6 +107,7 @@ public class LanceWritableTableHandle
         return Objects.equals(this.schemaName, other.schemaName) &&
                 Objects.equals(this.tableName, other.tableName) &&
                 Objects.equals(this.tablePath, other.tablePath) &&
+                Objects.equals(this.tableId, other.tableId) &&
                 Objects.equals(this.schemaJson, other.schemaJson) &&
                 Objects.equals(this.inputColumns, other.inputColumns);
     }

--- a/presto-lance/src/main/java/com/facebook/presto/lance/LanceWritableTableHandle.java
+++ b/presto-lance/src/main/java/com/facebook/presto/lance/LanceWritableTableHandle.java
@@ -30,6 +30,8 @@ public class LanceWritableTableHandle
 {
     private final String schemaName;
     private final String tableName;
+    private final String tablePath;
+    private final List<String> tableId;
     private final String schemaJson;
     private final List<LanceColumnHandle> inputColumns;
 
@@ -37,11 +39,15 @@ public class LanceWritableTableHandle
     public LanceWritableTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
+            @JsonProperty("tablePath") String tablePath,
+            @JsonProperty("tableId") List<String> tableId,
             @JsonProperty("schemaJson") String schemaJson,
             @JsonProperty("inputColumns") List<LanceColumnHandle> inputColumns)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.tablePath = requireNonNull(tablePath, "tablePath is null");
+        this.tableId = ImmutableList.copyOf(requireNonNull(tableId, "tableId is null"));
         this.schemaJson = requireNonNull(schemaJson, "schemaJson is null");
         this.inputColumns = ImmutableList.copyOf(requireNonNull(inputColumns, "inputColumns is null"));
     }
@@ -59,6 +65,18 @@ public class LanceWritableTableHandle
     }
 
     @JsonProperty
+    public String getTablePath()
+    {
+        return tablePath;
+    }
+
+    @JsonProperty
+    public List<String> getTableId()
+    {
+        return tableId;
+    }
+
+    @JsonProperty
     public String getSchemaJson()
     {
         return schemaJson;
@@ -73,7 +91,7 @@ public class LanceWritableTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, schemaJson, inputColumns);
+        return Objects.hash(schemaName, tableName, tablePath, schemaJson, inputColumns);
     }
 
     @Override
@@ -88,6 +106,7 @@ public class LanceWritableTableHandle
         LanceWritableTableHandle other = (LanceWritableTableHandle) obj;
         return Objects.equals(this.schemaName, other.schemaName) &&
                 Objects.equals(this.tableName, other.tableName) &&
+                Objects.equals(this.tablePath, other.tablePath) &&
                 Objects.equals(this.schemaJson, other.schemaJson) &&
                 Objects.equals(this.inputColumns, other.inputColumns);
     }
@@ -98,6 +117,7 @@ public class LanceWritableTableHandle
         return toStringHelper(this)
                 .add("schemaName", schemaName)
                 .add("tableName", tableName)
+                .add("tablePath", tablePath)
                 .toString();
     }
 }

--- a/presto-lance/src/test/java/com/facebook/presto/lance/LanceQueryRunner.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/LanceQueryRunner.java
@@ -49,7 +49,7 @@ public class LanceQueryRunner
 
             // Use a temp directory for lance root
             Path tempDir = Files.createTempDirectory("lance-test");
-            connectorProperties.putIfAbsent("lance.root-url", tempDir.toString());
+            connectorProperties.putIfAbsent("lance.root", tempDir.toString());
 
             queryRunner.createCatalog(DEFAULT_CATALOG, "lance", connectorProperties);
             return queryRunner;

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceCachedDataset.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceCachedDataset.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.lance;
 
 import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import org.lance.Dataset;
 import org.testng.annotations.AfterMethod;
@@ -22,11 +23,13 @@ import org.testng.annotations.Test;
 
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
@@ -48,11 +51,11 @@ public class TestLanceCachedDataset
         assertNotNull(dbUrl, "example_db resource not found");
         String rootPath = Paths.get(dbUrl.toURI()).toString();
         LanceConfig config = new LanceConfig()
-                .setRootUrl(rootPath)
                 .setSingleLevelNs(true);
-        namespaceHolder = new LanceNamespaceHolder(config);
-        table1Path = namespaceHolder.getTablePath("test_table1");
-        table2Path = namespaceHolder.getTablePath("test_table2");
+        Map<String, String> namespaceProperties = ImmutableMap.of("lance.root", rootPath);
+        namespaceHolder = new LanceNamespaceHolder(config, namespaceProperties);
+        table1Path = namespaceHolder.getTablePath("default", "test_table1");
+        table2Path = namespaceHolder.getTablePath("default", "test_table2");
     }
 
     @AfterMethod
@@ -119,15 +122,19 @@ public class TestLanceCachedDataset
     @Test
     public void testMissingTablePathThrowsPrestoException()
     {
-        String missingPath = namespaceHolder.getTablePath("does_not_exist");
+        // Namespace API returns null for non-existent tables
+        String missingPath = namespaceHolder.getTablePath("default", "does_not_exist");
+        assertNull(missingPath);
+
+        // getCachedDataset should throw PrestoException for an invalid path
+        String invalidPath = table1Path + "_does_not_exist";
         try {
-            namespaceHolder.getCachedDataset(missingPath, Optional.empty());
+            namespaceHolder.getCachedDataset(invalidPath, Optional.empty());
             fail("Expected PrestoException for missing table path");
         }
         catch (PrestoException expected) {
             assertEquals(expected.getErrorCode(), LanceErrorCode.LANCE_ERROR.toErrorCode());
             assertNotNull(expected.getCause());
-            assertEquals(expected.getCause().getClass(), IllegalArgumentException.class);
         }
     }
 

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceConfig.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceConfig.java
@@ -33,8 +33,8 @@ public class TestLanceConfig
     {
         assertRecordedDefaults(recordDefaults(LanceConfig.class)
                 .setImpl("dir")
-                .setRootUrl("")
                 .setSingleLevelNs(true)
+                .setParent(null)
                 .setReadBatchSize(8192)
                 .setMaxRowsPerFile(1_000_000)
                 .setMaxRowsPerGroup(100_000)
@@ -50,8 +50,8 @@ public class TestLanceConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("lance.impl", "rest")
-                .put("lance.root-url", "/data/lance")
                 .put("lance.single-level-ns", "false")
+                .put("lance.parent", "org$warehouse")
                 .put("lance.read-batch-size", "4096")
                 .put("lance.max-rows-per-file", "500000")
                 .put("lance.max-rows-per-group", "50000")
@@ -64,8 +64,8 @@ public class TestLanceConfig
 
         LanceConfig expected = new LanceConfig()
                 .setImpl("rest")
-                .setRootUrl("/data/lance")
                 .setSingleLevelNs(false)
+                .setParent("org$warehouse")
                 .setReadBatchSize(4096)
                 .setMaxRowsPerFile(500_000)
                 .setMaxRowsPerGroup(50_000)

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceFragmentPageSource.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceFragmentPageSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.spi.ColumnHandle;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import org.lance.Fragment;
 import org.testng.annotations.AfterMethod;
@@ -57,14 +58,19 @@ public class TestLanceFragmentPageSource
         assertNotNull(dbUrl, "example_db resource not found");
         String rootPath = Paths.get(dbUrl.toURI()).toString();
         LanceConfig config = new LanceConfig()
-                .setRootUrl(rootPath)
                 .setSingleLevelNs(true);
-        namespaceHolder = new LanceNamespaceHolder(config);
+
+        Map<String, String> namespaceProperties = ImmutableMap.of("lance.root", rootPath);
+        namespaceHolder = new LanceNamespaceHolder(config, namespaceProperties);
         arrowBlockBuilder = new ArrowBlockBuilder(createTestFunctionAndTypeManager());
-        datasetVersion = namespaceHolder.getLatestVersion("test_table1");
-        tableHandle = new LanceTableHandle("default", "test_table1", Optional.of(datasetVersion));
-        tablePath = namespaceHolder.getTablePath("test_table1");
-        fragments = namespaceHolder.getFragments("test_table1", Optional.of(datasetVersion));
+
+        // Resolve the table handle through the namespace API
+        tablePath = namespaceHolder.getTablePath("default", "test_table1");
+        assertNotNull(tablePath);
+        List<String> tableId = namespaceHolder.getTableId("default", "test_table1");
+        datasetVersion = namespaceHolder.getLatestVersion(tablePath);
+        tableHandle = new LanceTableHandle("default", "test_table1", tablePath, tableId, Optional.of(datasetVersion));
+        fragments = namespaceHolder.getFragments(tablePath, Optional.of(datasetVersion));
     }
 
     @AfterMethod

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceLimitPushdown.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceLimitPushdown.java
@@ -39,7 +39,11 @@ public class TestLanceLimitPushdown
     @Test
     public void testPushesLimitIntoTableScan()
     {
-        LanceTableHandle lanceTable = new LanceTableHandle("default", "t");
+        LanceTableHandle lanceTable = new LanceTableHandle(
+                "default",
+                "t",
+                "file:///tmp/lance/t.lance",
+                ImmutableList.of("t"));
         TableScanNode scan = tableScan(lanceTable);
         LimitNode limit = new LimitNode(Optional.empty(), new PlanNodeId("limit"), scan, 10L, LimitNode.Step.FINAL);
 
@@ -57,7 +61,12 @@ public class TestLanceLimitPushdown
     @Test
     public void testIdempotentWhenAlreadyPushed()
     {
-        LanceTableHandle lanceTable = new LanceTableHandle("default", "t").withLimit(10);
+        LanceTableHandle lanceTable = new LanceTableHandle(
+                "default",
+                "t",
+                "file:///tmp/lance/t.lance",
+                ImmutableList.of("t"))
+                .withLimit(10);
         TableScanNode scan = tableScan(lanceTable);
         LimitNode limit = new LimitNode(Optional.empty(), new PlanNodeId("limit"), scan, 10L, LimitNode.Step.FINAL);
 

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceMetadata.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceMetadata.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import org.testng.annotations.AfterMethod;
@@ -52,9 +53,12 @@ public class TestLanceMetadata
         assertNotNull(dbUrl, "example_db resource not found");
         String rootPath = Paths.get(dbUrl.toURI()).toString();
         LanceConfig config = new LanceConfig()
-                .setRootUrl(rootPath)
                 .setSingleLevelNs(true);
-        LanceNamespaceHolder namespaceHolder = new LanceNamespaceHolder(config);
+
+        // Pass lance.root through namespace properties (as the connector factory would)
+        Map<String, String> namespaceProperties = ImmutableMap.of("lance.root", rootPath);
+
+        LanceNamespaceHolder namespaceHolder = new LanceNamespaceHolder(config, namespaceProperties);
         this.namespaceHolder = namespaceHolder;
         JsonCodec<LanceCommitTaskData> commitTaskDataCodec = jsonCodec(LanceCommitTaskData.class);
         metadata = new LanceMetadata(namespaceHolder, commitTaskDataCodec);
@@ -82,6 +86,8 @@ public class TestLanceMetadata
         LanceTableHandle lanceHandle = (LanceTableHandle) handle;
         assertEquals(lanceHandle.getSchemaName(), "default");
         assertEquals(lanceHandle.getTableName(), "test_table1");
+        assertNotNull(lanceHandle.getTablePath());
+        assertNotNull(lanceHandle.getTableId());
         assertNotNull(lanceHandle.getDatasetVersion());
         assertTrue(lanceHandle.getDatasetVersion().isPresent());
 
@@ -90,6 +96,7 @@ public class TestLanceMetadata
         LanceTableHandle lanceHandle2 = (LanceTableHandle) handle2;
         assertEquals(lanceHandle2.getSchemaName(), "default");
         assertEquals(lanceHandle2.getTableName(), "test_table2");
+        assertNotNull(lanceHandle2.getTablePath());
         assertTrue(lanceHandle2.getDatasetVersion().isPresent());
 
         // non-existent schema

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceNamespaceHolder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceNamespaceHolder.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.lance;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestLanceNamespaceHolder
+{
+    @Test
+    public void testGetTableIdSingleLevel()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig().setSingleLevelNs(true);
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                // In single-level mode, schema is omitted from tableId
+                List<String> tableId = holder.getTableId("default", "my_table");
+                assertEquals(tableId, Collections.singletonList("my_table"));
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testGetTableIdMultiLevel()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig().setSingleLevelNs(false);
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                // In multi-level mode, schema is included in tableId
+                List<String> tableId = holder.getTableId("my_schema", "my_table");
+                assertEquals(tableId.size(), 2);
+                assertEquals(tableId.get(0), "my_schema");
+                assertEquals(tableId.get(1), "my_table");
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testGetTableIdWithParent()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig()
+                    .setSingleLevelNs(false)
+                    .setParent("org$warehouse");
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                List<String> tableId = holder.getTableId("my_schema", "my_table");
+                assertEquals(tableId.size(), 4);
+                assertEquals(tableId.get(0), "org");
+                assertEquals(tableId.get(1), "warehouse");
+                assertEquals(tableId.get(2), "my_schema");
+                assertEquals(tableId.get(3), "my_table");
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testPrestoSchemaToLanceNamespaceSingleLevel()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig().setSingleLevelNs(true);
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                // Single-level mode maps to empty namespace (root)
+                List<String> ns = holder.prestoSchemaToLanceNamespace("default");
+                assertEquals(ns, Collections.emptyList());
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testPrestoSchemaToLanceNamespaceMultiLevel()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig().setSingleLevelNs(false);
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                List<String> ns = holder.prestoSchemaToLanceNamespace("my_schema");
+                assertEquals(ns, Collections.singletonList("my_schema"));
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testPrestoSchemaToLanceNamespaceWithParent()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig()
+                    .setSingleLevelNs(false)
+                    .setParent("p1$p2");
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                List<String> ns = holder.prestoSchemaToLanceNamespace("my_schema");
+                assertEquals(ns.size(), 3);
+                assertEquals(ns.get(0), "p1");
+                assertEquals(ns.get(1), "p2");
+                assertEquals(ns.get(2), "my_schema");
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testSchemaExistsSingleLevel()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig().setSingleLevelNs(true);
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                assertEquals(holder.schemaExists("default"), true);
+                assertEquals(holder.schemaExists("other"), false);
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    private static void deleteRecursively(Path path)
+            throws Exception
+    {
+        if (java.nio.file.Files.isDirectory(path)) {
+            try (java.util.stream.Stream<Path> entries = java.nio.file.Files.list(path)) {
+                for (Path entry : (Iterable<Path>) entries::iterator) {
+                    deleteRecursively(entry);
+                }
+            }
+        }
+        java.nio.file.Files.deleteIfExists(path);
+    }
+}

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceNamespaceHolder.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceNamespaceHolder.java
@@ -23,9 +23,86 @@ import java.util.List;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 
 public class TestLanceNamespaceHolder
 {
+    @Test
+    public void testStoragePropertiesArePassedThrough()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig().setSingleLevelNs(true);
+            // lance.storage.* options are forwarded to the namespace with both the "lance." and
+            // "storage." prefixes stripped, so that new options need no connector code change.
+            Map<String, String> props = ImmutableMap.of(
+                    "lance.root", tempDir.toString(),
+                    "lance.storage.region", "us-east-1",
+                    "lance.storage.aws_access_key_id", "test-key");
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                // No such table, so this falls back to the catalog-level storage options.
+                Map<String, String> storageOptions =
+                        holder.getStorageOptionsForTable(Collections.singletonList("no_such_table"));
+                assertEquals(storageOptions.get("region"), "us-east-1");
+                assertEquals(storageOptions.get("aws_access_key_id"), "test-key");
+                assertEquals(storageOptions.size(), 2);
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testSchemaExistsIsFalseForMissingSchema()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig().setSingleLevelNs(false);
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                // A namespace that is genuinely absent must report false rather than throw.
+                assertFalse(holder.schemaExists("no_such_schema"));
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
+    @Test
+    public void testGetTablePathIsNullForMissingTable()
+            throws Exception
+    {
+        Path tempDir = Files.createTempDirectory("lance-ns-test");
+        try {
+            LanceConfig config = new LanceConfig().setSingleLevelNs(true);
+            Map<String, String> props = ImmutableMap.of("lance.root", tempDir.toString());
+            LanceNamespaceHolder holder = new LanceNamespaceHolder(config, props);
+            try {
+                assertNull(holder.getTablePath("default", "no_such_table"));
+                assertFalse(holder.tableExists("default", "no_such_table"));
+            }
+            finally {
+                holder.shutdown();
+            }
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
     @Test
     public void testGetTableIdSingleLevel()
             throws Exception

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLancePlugin.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLancePlugin.java
@@ -42,7 +42,7 @@ public class TestLancePlugin
         try {
             factory.create(
                     "test",
-                    ImmutableMap.of("lance.root-url", tempDir.toString()),
+                    ImmutableMap.of("lance.root", tempDir.toString()),
                     new TestingConnectorContext())
                     .shutdown();
         }

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLancePlugin.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLancePlugin.java
@@ -51,6 +51,32 @@ public class TestLancePlugin
         }
     }
 
+    @Test
+    public void testCreateConnectorWithUnknownLanceProperties()
+            throws Exception
+    {
+        // Only the properties in LanceConnectorFactory.KNOWN_CONFIG_PROPERTIES are handed to
+        // Bootstrap. Any other lance.* property is a namespace option, and Bootstrap must not
+        // reject it as unrecognized configuration.
+        ConnectorFactory factory = StreamSupport
+                .stream(new LancePlugin().getConnectorFactories().spliterator(), false)
+                .collect(MoreCollectors.onlyElement());
+        Path tempDir = Files.createTempDirectory("lance-test");
+        try {
+            factory.create(
+                    "test",
+                    ImmutableMap.of(
+                            "lance.root", tempDir.toString(),
+                            "lance.storage.region", "us-east-1",
+                            "lance.some-future-namespace-option", "value"),
+                    new TestingConnectorContext())
+                    .shutdown();
+        }
+        finally {
+            deleteRecursively(tempDir);
+        }
+    }
+
     private static void deleteRecursively(Path path)
             throws Exception
     {

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSplitManager.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceSplitManager.java
@@ -17,13 +17,16 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
@@ -45,12 +48,22 @@ public class TestLanceSplitManager
         URL dbUrl = Resources.getResource(TestLanceSplitManager.class, "/example_db");
         String rootPath = Paths.get(dbUrl.toURI()).toString();
         LanceConfig config = new LanceConfig()
-                .setRootUrl(rootPath)
                 .setSingleLevelNs(true);
-        namespaceHolder = new LanceNamespaceHolder(config);
+        Map<String, String> namespaceProperties = ImmutableMap.of("lance.root", rootPath);
+        namespaceHolder = new LanceNamespaceHolder(config, namespaceProperties);
         splitManager = new LanceSplitManager(namespaceHolder);
-        tableHandle = new LanceTableHandle("default", "test_table1");
-        fragmentCount = namespaceHolder.getFragments("test_table1", Optional.empty()).size();
+
+        String tablePath = namespaceHolder.getTablePath("default", "test_table1");
+        List<String> tableId = namespaceHolder.getTableId("default", "test_table1");
+        long datasetVersion = namespaceHolder.getLatestVersion(tablePath);
+        tableHandle = new LanceTableHandle("default", "test_table1", tablePath, tableId, Optional.of(datasetVersion));
+        fragmentCount = namespaceHolder.getFragments(tablePath, Optional.of(datasetVersion)).size();
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        namespaceHolder.shutdown();
     }
 
     @Test

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceTableHandle.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceTableHandle.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.lance;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -26,7 +27,11 @@ import static org.testng.Assert.assertTrue;
 
 public class TestLanceTableHandle
 {
-    private final LanceTableHandle tableHandle = new LanceTableHandle("default", "test_table");
+    private final LanceTableHandle tableHandle = new LanceTableHandle(
+            "default",
+            "test_table",
+            "file:///tmp/lance/test_table.lance",
+            ImmutableList.of("test_table"));
 
     @Test
     public void testJsonRoundTrip()
@@ -43,7 +48,12 @@ public class TestLanceTableHandle
     public void testJsonRoundTripWithVersion()
     {
         JsonCodec<LanceTableHandle> codec = jsonCodec(LanceTableHandle.class);
-        LanceTableHandle handleWithVersion = new LanceTableHandle("default", "test_table", Optional.of(42L));
+        LanceTableHandle handleWithVersion = new LanceTableHandle(
+                "default",
+                "test_table",
+                "file:///tmp/lance/test_table.lance",
+                ImmutableList.of("test_table"),
+                Optional.of(42L));
         String json = codec.toJson(handleWithVersion);
         LanceTableHandle copy = codec.fromJson(json);
         assertEquals(copy, handleWithVersion);

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceWritableTableHandle.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestLanceWritableTableHandle.java
@@ -31,10 +31,16 @@ public class TestLanceWritableTableHandle
                 new LanceColumnHandle("id", INTEGER, false),
                 new LanceColumnHandle("name", VARCHAR, true));
         LanceWritableTableHandle handle = new LanceWritableTableHandle(
-                "default", "test_table", "{}", columns);
+                "default",
+                "test_table",
+                "file:///tmp/lance/test_table.lance",
+                ImmutableList.of("test_table"),
+                "{}",
+                columns);
 
         assertEquals(handle.getSchemaName(), "default");
         assertEquals(handle.getTableName(), "test_table");
+        assertEquals(handle.getTablePath(), "file:///tmp/lance/test_table.lance");
         assertEquals(handle.getSchemaJson(), "{}");
         assertEquals(handle.getInputColumns().size(), 2);
         assertEquals(handle.getInputColumns().get(0).getColumnName(), "id");

--- a/presto-lance/src/test/java/com/facebook/presto/lance/TestWideTypesTable.java
+++ b/presto-lance/src/test/java/com/facebook/presto/lance/TestWideTypesTable.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.spi.ColumnHandle;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import org.lance.Fragment;
 import org.testng.annotations.BeforeMethod;
@@ -86,13 +87,17 @@ public class TestWideTypesTable
         assertNotNull(dbUrl, "example_db resource not found");
         String rootPath = Paths.get(dbUrl.toURI()).toString();
         LanceConfig config = new LanceConfig()
-                .setRootUrl(rootPath)
                 .setSingleLevelNs(true);
-        namespaceHolder = new LanceNamespaceHolder(config);
+        Map<String, String> namespaceProperties = ImmutableMap.of("lance.root", rootPath);
+        namespaceHolder = new LanceNamespaceHolder(config, namespaceProperties);
         arrowBlockBuilder = new ArrowBlockBuilder(createTestFunctionAndTypeManager());
-        tableHandle = new LanceTableHandle("default", "wide_types_table");
-        tablePath = namespaceHolder.getTablePath("wide_types_table");
-        fragments = namespaceHolder.getFragments("wide_types_table", Optional.empty());
+
+        tablePath = namespaceHolder.getTablePath("default", "wide_types_table");
+        assertNotNull(tablePath);
+        List<String> tableId = namespaceHolder.getTableId("default", "wide_types_table");
+        long datasetVersion = namespaceHolder.getLatestVersion(tablePath);
+        tableHandle = new LanceTableHandle("default", "wide_types_table", tablePath, tableId, Optional.of(datasetVersion));
+        fragments = namespaceHolder.getFragments(tablePath, Optional.of(datasetVersion));
         LanceMetadata metadata = new LanceMetadata(namespaceHolder, jsonCodec(LanceCommitTaskData.class));
         columnHandles = metadata.getColumnHandles(null, tableHandle);
     }

--- a/src/dependency-check-suppressions.xml
+++ b/src/dependency-check-suppressions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+The lance-namespace Apache client is generated code. Its published Maven
+metadata points to openapi-generator, which causes Dependency-Check to
+associate vulnerabilities in the generator and its online service with the
+generated runtime client. Presto does not run the generator or the online
+service.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.lance/lance-namespace-apache-client@0\.6\.1$</packageUrl>
+        <cve>CVE-2019-11405</cve>
+        <cve>CVE-2021-21428</cve>
+        <cve>CVE-2021-21429</cve>
+        <cve>CVE-2021-21430</cve>
+        <cve>CVE-2023-27162</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
## Description

Integrate the Presto Lance connector with the `lance-namespace` API.

- Delegate schema and table lifecycle operations to `LanceNamespace`.
- Support pluggable namespace implementations through `lance.impl` and
  pass-through `lance.*` catalog properties.
- Resolve and carry namespace table IDs and table paths in connector handles.
- Support parent namespaces and single-level namespace mapping.

## Motivation and Context

The connector currently implements filesystem namespace operations directly.
Using the shared namespace API enables directory, REST, Glue, and custom
namespace implementations while keeping namespace behavior consistent with
other Lance integrations.

## Impact

This adds pluggable namespace support to the Lance connector.

**This is a breaking change.** The `lance.root-url` catalog property is
replaced by `lance.root`, which is passed to the selected namespace
implementation. `lance.root-url` shipped in 0.297 and is no longer
recognized: a catalog that still sets it fails at startup with
`lance.root must be set when using lance.impl=dir`. Operators must rename the
property in `etc/catalog/lance.properties` before upgrading. The value format
is unchanged and no data migration is required.

## Test Plan

- `./mvnw -s /tmp/maven-central-settings.xml test -pl presto-lance`
  (97 tests passed)
- `./mvnw -s /tmp/maven-central-settings.xml -pl presto-lance -DskipTests verify`
  (checkstyle, SpotBugs, and PMD clean)
- `sphinx-build -b html src/main/sphinx` builds `connector/lance` with no new
  warnings.
- Verified the OWASP suppression targets only the generated
  `lance-namespace-apache-client:0.6.1` artifact and its OpenAPI Generator
  false positives.

New tests cover connector startup with unrecognized `lance.*` properties,
`lance.storage.*` pass-through to namespace storage options, and the
absent-schema / absent-table contracts that `getTableHandle` relies on.

## Contributor checklist

- [x] The submission follows the contributing guide and code style.
- [x] The PR description describes the change and user impact.
- [x] New configuration properties are covered by tests.
- [x] Release notes are included below.
- [x] Adequate tests were added.
- [ ] CI passed.

## Release Notes

```
== RELEASE NOTES ==

Lance Connector Changes
* Add pluggable namespace support to the Lance connector using the
  lance-namespace API, enabling directory, REST, and custom namespace
  implementations.
* Replace the ``lance.root-url`` configuration property with ``lance.root``.
  This is a breaking change: catalogs that set ``lance.root-url`` must be
  updated to ``lance.root`` before upgrading.
* Add the ``lance.parent`` configuration property to select a parent namespace
  prefix for namespaces with three or more levels.
```
