### PR TITLE
fix: Allow avro_schema_url property alongside partitioning

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -1234,7 +1234,7 @@ Limitations
 The following operations are not supported when ``avro_schema_url`` is set:
 
 * ``CREATE TABLE AS`` is not supported.
-* Using partitioning(``partitioned_by``) or bucketing(``bucketed_by``) columns are not supported in ``CREATE TABLE``.
+* Bucketing(``bucketed_by``) columns are not supported in ``CREATE TABLE``.
 * ``ALTER TABLE`` commands modifying columns are not supported.
 
 Parquet Writer Version

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -1070,8 +1070,8 @@ public class HiveMetadata
         List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
         Optional<HiveBucketProperty> bucketProperty = getBucketProperty(tableMetadata.getProperties());
 
-        if ((bucketProperty.isPresent() || !partitionedBy.isEmpty()) && getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
-            throw new PrestoException(NOT_SUPPORTED, "Bucketing/Partitioning columns not supported when Avro schema url is set");
+        if (bucketProperty.isPresent() && getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
+            throw new PrestoException(NOT_SUPPORTED, "Bucketing columns not supported when Avro schema url is set");
         }
 
         List<HiveColumnHandle> columnHandles = getColumnHandles(tableMetadata, ImmutableSet.copyOf(partitionedBy), typeTranslator);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -5150,18 +5150,7 @@ public class TestHiveIntegrationSmokeTest
                 "WITH (avro_schema_url = 'dummy_schema',\n" +
                 "      bucket_count = 2, bucketed_by=ARRAY['dummy'])";
 
-        assertQueryFails(createSql, "Bucketing/Partitioning columns not supported when Avro schema url is set");
-    }
-
-    @Test
-    public void testPartitionedTablesFailWithAvroSchemaUrl()
-            throws Exception
-    {
-        @Language("SQL") String createSql = "CREATE TABLE create_avro (dummy VARCHAR)\n" +
-                "WITH (avro_schema_url = 'dummy_schema',\n" +
-                "      partitioned_by=ARRAY['dummy'])";
-
-        assertQueryFails(createSql, "Bucketing/Partitioning columns not supported when Avro schema url is set");
+        assertQueryFails(createSql, "Bucketing columns not supported when Avro schema url is set");
     }
 
     @Test

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAvroPartitioned.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestAvroPartitioned.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.hive;
+
+import io.prestodb.tempto.AfterTestWithContext;
+import io.prestodb.tempto.BeforeTestWithContext;
+import io.prestodb.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.tests.TestGroups.AVRO;
+import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
+import static io.prestodb.tempto.assertions.QueryAssert.assertThat;
+import static io.prestodb.tempto.query.QueryExecutor.query;
+import static java.lang.String.format;
+
+public class TestAvroPartitioned
+        extends ProductTest
+{
+    private static final String PARTITIONED_TABLE_NAME = "product_tests_avro_partitioned";
+    private static final String ORIGINAL_SCHEMA = "file:///docker/volumes/presto-product-tests/avro/original_schema.avsc";
+
+    private static final String CREATE_TABLE_PARTITIONED = format("" +
+                    "CREATE TABLE %s (string_col VARCHAR, int_col INTEGER, p_col VARCHAR) " +
+                    "WITH (" +
+                    "format='AVRO', " +
+                    "partitioned_by=ARRAY['p_col'], " +
+                    "avro_schema_url='%s'" +
+                    ")",
+            PARTITIONED_TABLE_NAME,
+            ORIGINAL_SCHEMA);
+
+    @BeforeTestWithContext
+    public void createAndLoadTable()
+    {
+        query(format("DROP TABLE IF EXISTS %s", PARTITIONED_TABLE_NAME));
+        query(CREATE_TABLE_PARTITIONED);
+        query(format("INSERT INTO %s (string_col, int_col, p_col) VALUES ('string0', 0, 'p0')", PARTITIONED_TABLE_NAME));
+    }
+
+    @AfterTestWithContext
+    public void dropTestTable()
+    {
+        query(format("DROP TABLE IF EXISTS %s", PARTITIONED_TABLE_NAME));
+    }
+
+    @Test(groups = {AVRO})
+    public void testSelectFromPartitionedAvroTable()
+    {
+        assertThat(query(format("SELECT string_col, p_col FROM %s WHERE p_col = 'p0'", PARTITIONED_TABLE_NAME)))
+                .containsExactly(row("string0", "p0"));
+    }
+
+    @Test(groups = {AVRO})
+    public void testShowColumnsOnPartitionedAvroTable()
+    {
+        // We query information_schema to control exactly which columns are returned
+        String sql = String.format(
+                "SELECT column_name, data_type, extra_info, comment " +
+                        "FROM information_schema.columns " +
+                        "WHERE table_name = '%s' " +
+                        "ORDER BY ordinal_position",
+                PARTITIONED_TABLE_NAME);
+
+        assertThat(query(sql))
+                .containsExactly(
+                        row("string_col", "varchar", null, null),
+                        row("int_col", "integer", null, null),
+                        row("p_col", "varchar", "partition key", null));
+    }
+
+    @Test(groups = {AVRO})
+    public void testInsertAdditionalPartition()
+    {
+        query(format("INSERT INTO %s (string_col, int_col, p_col) VALUES ('string1', 1, 'p1')", PARTITIONED_TABLE_NAME));
+
+        assertThat(query(format("SELECT count(DISTINCT p_col) FROM %s", PARTITIONED_TABLE_NAME)))
+                .containsExactly(row(2));
+    }
+}


### PR DESCRIPTION
## Description
This PR enables the creation of Hive tables in AVRO format using the `avro_schema_url` property in conjunction with partitioning.

This fix is necessary for supporting Avro schemas with non-lowercase column definitions. In such cases, the `avro_schema_url` property must be explicitly set during `CREATE TABLE`. Without this property, queries will not return data.

When creating an external table via Hive, it supports both avro.schema.url and partitioned_by, and Presto can query this table without any problem.

Example:
```sql
CREATE TABLE test_avro_partitioned (
  dummy_col VARCHAR,
  p_col VARCHAR
) WITH (
  format='AVRO',
  partitioned_by=ARRAY['p_col'],
  avro_schema_url='url'
)
```

## Motivation and Context
The `prepareTable` method in `HiveMetadata` threw a `NOT_SUPPORTED` error when attempting to use the `avro_schema_url` property in combination with `partitioned_by`. This blocked the use of the `avro_schema_url` property for tables where it is mandatory, resulting in no data being returned for these tables.
 
## Impact
When working with non-lowercase schema definitions, using an external `avro_schema_url` is mandatory to ensure queries return data. However, if a user attempts to create a partitioned Hive table using this property, the operation currently fails with a `PrestoException`. 

This PR fixes the validation logic in `HiveMetadata` to allow the use of `avro_schema_url` in conjunction with partitioning, ensuring these tables can be created and queried successfully.

**Before:**
```java
if ((bucketProperty.isPresent() || !partitionedBy.isEmpty()) && getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
    throw new PrestoException(NOT_SUPPORTED, "Bucketing/Partitioning columns not supported when Avro schema url is set");
}
```

**After:**

```java
if (bucketProperty.isPresent() && getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
    throw new PrestoException(NOT_SUPPORTED, "Bucketing columns not supported when Avro schema url is set");
}
```


## Test Plan
Verified the fix by:
* Creating a partitioned Avro table with `avro_schema_url` and confirming it no longer throws `NOT_SUPPORTED`.
* Confirming that attempting to create a bucketed table with `avro_schema_url` still correctly throws the expected `PrestoException`.
 
## Contributor checklist
 
- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).
 
## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Hive Connector Changes
* Fix to allow creating partitioned tables using AVRO format and avro_schema_url property.