### PR TITLE
feat(optimizer): Rewrite map_from_entries(ARRAY[ROW(...)]) to MAP(ARRAY[], ARRAY[])

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
@@ -14,7 +14,11 @@
 package com.facebook.presto.sql.planner.iterative.rule;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.expressions.RowExpressionRewriter;
 import com.facebook.presto.expressions.RowExpressionTreeRewriter;
@@ -28,8 +32,12 @@ import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.SERIALIZABLE;
@@ -37,6 +45,8 @@ import static com.facebook.presto.spi.relation.SpecialFormExpression.Form;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IF;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.ROW_CONSTRUCTOR;
+import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -52,6 +62,7 @@ public class SimplifyRowExpressions
             implements PlanRowExpressionRewriter
     {
         private final NestedIfSimplifier nestedIfSimplifier;
+        private final MapFromEntriesRewriter mapFromEntriesRewriter;
         private final ExpressionOptimizerManager expressionOptimizerManager;
         private final LogicalExpressionRewriter logicalExpressionRewriter;
 
@@ -62,6 +73,7 @@ public class SimplifyRowExpressions
             this.expressionOptimizerManager = requireNonNull(expressionOptimizerManager, "expressionOptimizerManager is null");
             this.logicalExpressionRewriter = new LogicalExpressionRewriter(metadata.getFunctionAndTypeManager());
             this.nestedIfSimplifier = new NestedIfSimplifier(new RowExpressionDeterminismEvaluator(metadata.getFunctionAndTypeManager()));
+            this.mapFromEntriesRewriter = new MapFromEntriesRewriter(metadata.getFunctionAndTypeManager());
         }
 
         @Override
@@ -76,6 +88,7 @@ public class SimplifyRowExpressions
             // It doesn't matter whether we rewrite/optimize first because this will be called by IterativeOptimizer.
             RowExpression rewritten = RowExpressionTreeRewriter.rewriteWith(logicalExpressionRewriter, expression, true);
             rewritten = RowExpressionTreeRewriter.rewriteWith(nestedIfSimplifier, rewritten);
+            rewritten = RowExpressionTreeRewriter.rewriteWith(mapFromEntriesRewriter, rewritten);
             return expressionOptimizerManager.getExpressionOptimizer(session.toConnectorSession()).optimize(rewritten, SERIALIZABLE, session.toConnectorSession());
         }
     }
@@ -140,6 +153,102 @@ public class SimplifyRowExpressions
             }
 
             return rewritten == node ? null : rewritten;
+        }
+    }
+
+    /**
+     * Rewrites {@code map_from_entries(ARRAY[ROW(k1,v1), ROW(k2,v2), ...])}
+     * into {@code MAP(ARRAY[k1,k2,...], ARRAY[v1,v2,...])}, eliminating the
+     * overhead of constructing and then immediately destructuring ROW objects.
+     * <p>
+     * Only fires when the argument is a literal array constructor whose every
+     * element is a two-field {@code ROW_CONSTRUCTOR}.
+     */
+    private static class MapFromEntriesRewriter
+            extends RowExpressionRewriter<Void>
+    {
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final FunctionResolution functionResolution;
+
+        MapFromEntriesRewriter(FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.functionResolution = new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver());
+        }
+
+        @Override
+        public RowExpression rewriteCall(CallExpression node, Void context, RowExpressionTreeRewriter<Void> treeRewriter)
+        {
+            if (node.getArguments().size() != 1 ||
+                    !functionAndTypeManager.getFunctionMetadata(node.getFunctionHandle()).getName().getObjectName().equals("map_from_entries")) {
+                return null;
+            }
+
+            RowExpression argument = node.getArguments().get(0);
+            if (!(argument instanceof CallExpression)) {
+                return null;
+            }
+
+            CallExpression arrayCall = (CallExpression) argument;
+            if (!functionResolution.isArrayConstructor(arrayCall.getFunctionHandle())) {
+                return null;
+            }
+
+            List<RowExpression> entries = arrayCall.getArguments();
+            if (entries.isEmpty()) {
+                return null;
+            }
+
+            List<RowExpression> keys = new ArrayList<>();
+            List<RowExpression> values = new ArrayList<>();
+            Set<RowExpression> seenKeys = new HashSet<>();
+            for (RowExpression entry : entries) {
+                if (!(entry instanceof SpecialFormExpression)
+                        || ((SpecialFormExpression) entry).getForm() != ROW_CONSTRUCTOR) {
+                    return null;
+                }
+                SpecialFormExpression row = (SpecialFormExpression) entry;
+                if (row.getArguments().size() != 2) {
+                    return null;
+                }
+                RowExpression key = row.getArguments().get(0);
+                if (!seenKeys.add(key)) {
+                    // Duplicate key detected; skip rewrite to preserve
+                    // the original map_from_entries error message
+                    return null;
+                }
+                keys.add(key);
+                values.add(row.getArguments().get(1));
+            }
+
+            // Derive key/value types from the map type to handle coerced types correctly
+            MapType mapType = (MapType) node.getType();
+            Type keyType = mapType.getKeyType();
+            Type valueType = mapType.getValueType();
+
+            // Skip rewrite for ROW key types: map_from_entries and MAP() throw
+            // different error codes for null-containing ROW keys, so rewriting
+            // would change observable error semantics
+            if (keyType instanceof RowType) {
+                return null;
+            }
+
+            RowExpression keyArray = buildArrayConstructor(keyType, keys);
+            RowExpression valueArray = buildArrayConstructor(valueType, values);
+
+            return call(functionAndTypeManager, "MAP", node.getType(), keyArray, valueArray);
+        }
+
+        private RowExpression buildArrayConstructor(Type elementType, List<RowExpression> elements)
+        {
+            ImmutableList.Builder<Type> types = ImmutableList.builder();
+            for (RowExpression element : elements) {
+                types.add(element.getType());
+            }
+            return call("ARRAY",
+                    functionResolution.arrayConstructor(types.build()),
+                    new ArrayType(elementType),
+                    elements);
         }
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyMapFromEntries.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyMapFromEntries.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+
+public class TestSimplifyMapFromEntries
+        extends BaseRuleTest
+{
+    private final TestingRowExpressionTranslator translator = new TestingRowExpressionTranslator();
+
+    @Test
+    public void testRewriteSingleEntry()
+    {
+        assertRewritten(
+                "map_from_entries(ARRAY[ROW(K1, V1)])",
+                "MAP(ARRAY[K1], ARRAY[V1])");
+    }
+
+    @Test
+    public void testRewriteMultipleEntries()
+    {
+        assertRewritten(
+                "map_from_entries(ARRAY[ROW(K1, V1), ROW(K2, V2)])",
+                "MAP(ARRAY[K1, K2], ARRAY[V1, V2])");
+    }
+
+    @Test
+    public void testNoRewriteVariableArgument()
+    {
+        Type arrayOfRow = new ArrayType(RowType.anonymous(ImmutableList.of(BIGINT, BIGINT)));
+        Map<String, Type> types = ImmutableMap.of("M", arrayOfRow);
+        RowExpression inputExpression = translator.translate("map_from_entries(M)", types);
+        tester().assertThat(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).projectRowExpressionRewriteRule())
+                .on(p -> p.project(
+                        assignment(p.variable("x"), inputExpression),
+                        p.values(p.variable("M", arrayOfRow))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoRewriteRowKeyType()
+    {
+        // ROW key types have different null-handling error semantics between
+        // map_from_entries and MAP() constructor, so we must skip the rewrite
+        RowType rowKeyType = RowType.anonymous(ImmutableList.of(BIGINT, BIGINT));
+        Map<String, Type> types = ImmutableMap.of("K1", rowKeyType, "V1", VARCHAR);
+        RowExpression inputExpression = translator.translate("map_from_entries(ARRAY[ROW(K1, V1)])", types);
+        tester().assertThat(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).projectRowExpressionRewriteRule())
+                .on(p -> p.project(
+                        assignment(p.variable("x"), inputExpression),
+                        p.values(p.variable("K1", rowKeyType), p.variable("V1", VARCHAR))))
+                .doesNotFire();
+    }
+
+    private void assertRewritten(String inputExpressionStr, String expectedExpressionStr)
+    {
+        Map<String, Type> types = ImmutableMap.of("K1", BIGINT, "K2", BIGINT, "V1", VARCHAR, "V2", VARCHAR);
+        RowExpression inputExpression = translator.translate(inputExpressionStr, types);
+
+        tester().assertThat(new SimplifyRowExpressions(getMetadata(), getExpressionManager()).projectRowExpressionRewriteRule())
+                .on(p -> p.project(
+                        assignment(p.variable("x"), inputExpression),
+                        p.values(p.variable("K1", BIGINT), p.variable("K2", BIGINT), p.variable("V1", VARCHAR), p.variable("V2", VARCHAR))))
+                .matches(project(
+                        ImmutableMap.of("x", expression(expectedExpressionStr)),
+                        values("K1", "K2", "V1", "V2")));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.expressions.RowExpressionRewriter;
@@ -29,6 +31,8 @@ import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.tree.Expression;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import org.testng.annotations.Test;
 
@@ -41,6 +45,7 @@ import java.util.stream.Stream;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -221,7 +226,40 @@ public class TestSimplifyRowExpressions
         }
     }
 
+    @Test
+    public void testMapFromEntriesRewrite()
+    {
+        // Single entry
+        assertMapFromEntries(
+                "map_from_entries(ARRAY[ROW(K1, V1)])",
+                "MAP(ARRAY[K1], ARRAY[V1])");
+
+        // Multiple entries
+        assertMapFromEntries(
+                "map_from_entries(ARRAY[ROW(K1, V1), ROW(K2, V2)])",
+                "MAP(ARRAY[K1, K2], ARRAY[V1, V2])");
+    }
+
+    @Test
+    public void testMapFromEntriesNoRewrite()
+    {
+        // Non-array-constructor argument (variable) — should not rewrite
+        Map<String, Type> types = ImmutableMap.of("M", new ArrayType(RowType.anonymous(ImmutableList.of(BIGINT, BIGINT))));
+        assertSimplifies("map_from_entries(M)", "map_from_entries(M)", types);
+    }
+
+    private static void assertMapFromEntries(String expression, String expected)
+    {
+        Map<String, Type> types = ImmutableMap.of("K1", BIGINT, "K2", BIGINT, "V1", BIGINT, "V2", BIGINT);
+        assertSimplifies(expression, expected, types);
+    }
+
     private static void assertSimplifies(String expression, String rowExpressionExpected)
+    {
+        assertSimplifies(expression, rowExpressionExpected, TYPES);
+    }
+
+    private static void assertSimplifies(String expression, String rowExpressionExpected, Map<String, Type> types)
     {
         Expression actualExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(expression));
 
@@ -229,10 +267,10 @@ public class TestSimplifyRowExpressions
         ExpressionOptimizerManager expressionOptimizerManager = new ExpressionOptimizerManager(new PluginNodeManager(nodeManager), METADATA.getFunctionAndTypeManager(), new JsonCodecRowExpressionSerde(jsonCodec(RowExpression.class)));
 
         TestingRowExpressionTranslator translator = new TestingRowExpressionTranslator(METADATA);
-        RowExpression actualRowExpression = translator.translate(actualExpression, TypeProvider.viewOf(TYPES));
+        RowExpression actualRowExpression = translator.translate(actualExpression, TypeProvider.viewOf(types));
         RowExpression simplifiedRowExpression = SimplifyRowExpressions.rewrite(actualRowExpression, METADATA, TEST_SESSION, expressionOptimizerManager);
         Expression expectedByRowExpression = rewriteIdentifiersToSymbolReferences(SQL_PARSER.createExpression(rowExpressionExpected));
-        RowExpression simplifiedByExpression = translator.translate(expectedByRowExpression, TypeProvider.viewOf(TYPES));
+        RowExpression simplifiedByExpression = translator.translate(expectedByRowExpression, TypeProvider.viewOf(types));
         assertEquals(normalize(simplifiedRowExpression), normalize(simplifiedByExpression));
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -6688,6 +6688,31 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testMapFromEntriesArrayLiteralRewrite()
+    {
+        // All-constant entries: rewrite to MAP(ARRAY[keys], ARRAY[values]), then constant-folded
+        assertQuerySucceeds("SELECT map_from_entries(ARRAY[ROW(1, 'a'), ROW(2, 'b')])");
+
+        // Single entry
+        assertQuerySucceeds("SELECT map_from_entries(ARRAY[ROW(10, 100)])");
+
+        // Used in a filter
+        assertQuery(
+                "SELECT orderkey FROM orders WHERE map_from_entries(ARRAY[ROW(1, true), ROW(2, false)])[1] AND orderkey < 5",
+                "SELECT orderkey FROM orders WHERE orderkey < 5");
+
+        // Mixed with table columns (non-constant values prevent full constant-folding)
+        assertQuery(
+                "SELECT map_from_entries(ARRAY[ROW(1, orderkey), ROW(2, custkey)])[1] FROM orders WHERE orderkey < 5",
+                "SELECT orderkey FROM orders WHERE orderkey < 5");
+
+        // Nested in another expression
+        assertQuery(
+                "SELECT cardinality(map_from_entries(ARRAY[ROW(1, 'x'), ROW(2, 'y'), ROW(3, 'z')]))",
+                "SELECT CAST(3 AS BIGINT)");
+    }
+
+    @Test
     public void testDuplicateUnnestItem()
     {
         // unnest with cross join


### PR DESCRIPTION
## Description
Adds a `MapFromEntriesRewriter` to `SimplifyRowExpressions` that transforms
`map_from_entries(ARRAY[ROW(k1,v1), ROW(k2,v2), ...])` into the more
efficient `MAP(ARRAY[k1,k2,...], ARRAY[v1,v2,...])` form, eliminating the
overhead of constructing and then immediately destructuring ROW objects.

Only fires when the argument is a literal array constructor whose every
element is a two-field `ROW_CONSTRUCTOR`.

## Motivation and Context
When users write `map_from_entries(ARRAY[ROW(1, 'a'), ROW(2, 'b')])`, the planner
creates intermediate ROW objects only to immediately unpack them in the
`MapFromEntriesFunction`. This rewrite skips the ROW construction entirely by
building the MAP directly from separate key and value arrays.

## Impact
Reduces expression evaluation overhead for literal `map_from_entries` calls.

## Test Plan
Unit tests TBD.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Optimize `map_from_entries(ARRAY[ROW(...), ...])` by rewriting to `MAP(ARRAY[keys], ARRAY[values])` at plan time, avoiding intermediate ROW construction.
```

## Summary by Sourcery

Optimize planning of literal map_from_entries calls by rewriting them into direct MAP(key_array, value_array) constructions in the row-expression simplification pipeline.

Enhancements:
- Add a MapFromEntriesRewriter that transforms map_from_entries over literal ARRAY[ROW(key, value), ...] into equivalent MAP(ARRAY[keys], ARRAY[values]) expressions to avoid intermediate row construction.
- Wire the new map-from-entries rewrite into the SimplifyRowExpressions rule so it runs alongside existing logical and nested-if simplifications.