### PR TITLE
fix(planner): Use LinkedHashMap in optimizer rules to fix type mismatch

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/MultipleDistinctAggregationToMarkDistinct.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Iterables;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -114,7 +115,7 @@ public class MultipleDistinctAggregationToMarkDistinct
         // the distinct marker for the given set of input columns
         Map<Set<VariableReferenceExpression>, VariableReferenceExpression> markers = new HashMap<>();
 
-        Map<VariableReferenceExpression, Aggregation> newAggregations = new HashMap<>();
+        Map<VariableReferenceExpression, Aggregation> newAggregations = new LinkedHashMap<>();
         PlanNode subPlan = parent.getSource();
 
         for (Map.Entry<VariableReferenceExpression, Aggregation> entry : parent.getAggregations().entrySet()) {

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateBeforeGroupId.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PreAggregateBeforeGroupId.java
@@ -36,8 +36,8 @@ import com.facebook.presto.sql.planner.plan.GroupIdNode;
 import com.google.common.collect.ImmutableList;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -161,9 +161,13 @@ public class PreAggregateBeforeGroupId
         // 1. PARTIAL: raw values → partialVar (intermediate type)
         // 2. INTERMEDIATE below GroupId: partialVar → preGroupIdVar (intermediate type)
         // 3. INTERMEDIATE above GroupId: preGroupIdVar → originalOutputVar (intermediate type)
-        Map<VariableReferenceExpression, VariableReferenceExpression> outputToPartialVarMap = new HashMap<>();
-        Map<VariableReferenceExpression, VariableReferenceExpression> outputToPreGroupIdVarMap = new HashMap<>();
-        Map<VariableReferenceExpression, Aggregation> newPartialAggregations = new HashMap<>();
+        // Use LinkedHashMap with pre-sizing to preserve deterministic iteration order
+        // matching AggregationNode.getAggregations() and avoid type mismatches at native
+        // execution boundaries (see issue #27492).
+        int aggregationCount = node.getAggregations().size();
+        Map<VariableReferenceExpression, VariableReferenceExpression> outputToPartialVarMap = new LinkedHashMap<>(aggregationCount);
+        Map<VariableReferenceExpression, VariableReferenceExpression> outputToPreGroupIdVarMap = new LinkedHashMap<>(aggregationCount);
+        Map<VariableReferenceExpression, Aggregation> newPartialAggregations = new LinkedHashMap<>(aggregationCount);
 
         for (Map.Entry<VariableReferenceExpression, Aggregation> entry : node.getAggregations().entrySet()) {
             Aggregation originalAggregation = entry.getValue();
@@ -225,7 +229,7 @@ public class PreAggregateBeforeGroupId
                         newPartialAggregation.getOutputVariables()));
 
         // Step 3: Create INTERMEDIATE AggregationNode below GroupId to merge partial states after shuffle
-        Map<VariableReferenceExpression, Aggregation> preGroupIdIntermediateAggregations = new HashMap<>();
+        Map<VariableReferenceExpression, Aggregation> preGroupIdIntermediateAggregations = new LinkedHashMap<>(aggregationCount);
         for (Map.Entry<VariableReferenceExpression, Aggregation> entry : node.getAggregations().entrySet()) {
             Aggregation originalAggregation = entry.getValue();
             FunctionHandle functionHandle = originalAggregation.getFunctionHandle();
@@ -281,7 +285,7 @@ public class PreAggregateBeforeGroupId
         // Step 5: Change the original PARTIAL aggregation above GroupId to INTERMEDIATE.
         // It takes intermediate state (passed through GroupId) and produces intermediate
         // state for the existing FINAL above.
-        Map<VariableReferenceExpression, Aggregation> aboveGroupIdIntermediateAggregations = new HashMap<>();
+        Map<VariableReferenceExpression, Aggregation> aboveGroupIdIntermediateAggregations = new LinkedHashMap<>(aggregationCount);
         for (Map.Entry<VariableReferenceExpression, Aggregation> entry : node.getAggregations().entrySet()) {
             Aggregation originalAggregation = entry.getValue();
             FunctionHandle functionHandle = originalAggregation.getFunctionHandle();

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -41,7 +41,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -257,8 +257,8 @@ public class PushPartialAggregationThroughExchange
     private PlanNode split(AggregationNode node, Context context)
     {
         // otherwise, add a partial and final with an exchange in between
-        Map<VariableReferenceExpression, AggregationNode.Aggregation> intermediateAggregation = new HashMap<>();
-        Map<VariableReferenceExpression, AggregationNode.Aggregation> finalAggregation = new HashMap<>();
+        Map<VariableReferenceExpression, AggregationNode.Aggregation> intermediateAggregation = new LinkedHashMap<>();
+        Map<VariableReferenceExpression, AggregationNode.Aggregation> finalAggregation = new LinkedHashMap<>();
         for (Map.Entry<VariableReferenceExpression, AggregationNode.Aggregation> entry : node.getAggregations().entrySet()) {
             AggregationNode.Aggregation originalAggregation = entry.getValue();
             String functionName = functionAndTypeManager.getFunctionMetadata(originalAggregation.getFunctionHandle()).getName().getObjectName();

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMultipleDistinctAggregationToMarkDistinctOrdering.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestMultipleDistinctAggregationToMarkDistinctOrdering.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertEquals;
+
+public class TestMultipleDistinctAggregationToMarkDistinctOrdering
+        extends BaseRuleTest
+{
+    @Test
+    public void testMixedTypeOutputVariableOrdering()
+    {
+        // Verifies that MultipleDistinctAggregationToMarkDistinct preserves
+        // aggregation output variable ordering. HashMap would scramble "sum_x"
+        // and "min_y" causing BIGINT vs VARCHAR type mismatch in Velox.
+        PlanNode result = tester().assertThat(new MultipleDistinctAggregationToMarkDistinct())
+                .setSystemProperty("use_mark_distinct", "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    VariableReferenceExpression y = p.variable("y", VARCHAR);
+
+                    return p.aggregation(agg -> agg
+                            .addAggregation(
+                                    p.variable("sum_x", BIGINT),
+                                    p.rowExpression("sum(x)"),
+                                    true)
+                            .addAggregation(
+                                    p.variable("min_y", VARCHAR),
+                                    p.rowExpression("min(y)"),
+                                    true)
+                            .singleGroupingSet(a)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.values(a, x, y)));
+                })
+                .get();
+
+        // Output variables must preserve original order:
+        // grouping key [a(BIGINT)] then aggregation outputs [sum_x(BIGINT), min_y(VARCHAR)]
+        List<Type> expectedTypes = ImmutableList.of(BIGINT, BIGINT, VARCHAR);
+        List<Type> actualTypes = result.getOutputVariables().stream()
+                .map(VariableReferenceExpression::getType)
+                .collect(Collectors.toList());
+        assertEquals(actualTypes, expectedTypes,
+                "Output variable types must preserve original aggregation ordering to avoid " +
+                "type mismatch at PartitionedOutput in Velox native execution");
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateBeforeGroupId.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPreAggregateBeforeGroupId.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.sql.planner.iterative.rule;
 
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
@@ -24,12 +26,17 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static com.facebook.presto.SystemSessionProperties.PRE_AGGREGATE_BEFORE_GROUPING_SETS;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static org.testng.Assert.assertEquals;
 
 public class TestPreAggregateBeforeGroupId
         extends BaseRuleTest
@@ -352,5 +359,109 @@ public class TestPreAggregateBeforeGroupId
                                                                 ImmutableMap.of("sum", functionCall("sum", ImmutableList.of("x"))),
                                                                 AggregationNode.Step.PARTIAL,
                                                                 values("y", "z", "x")))))));
+    }
+    @Test
+    public void testPreAggregatesMixedTypes()
+    {
+        tester().assertThat(new PreAggregateBeforeGroupId(getFunctionManager()))
+                .setSystemProperty(PRE_AGGREGATE_BEFORE_GROUPING_SETS, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", VARCHAR);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    VariableReferenceExpression y = p.variable("y", VARCHAR);
+                    VariableReferenceExpression groupId = p.variable("groupId", BIGINT);
+
+                    return p.aggregation(agg -> agg
+                            .addAggregation(
+                                    p.variable("sum_x", BIGINT),
+                                    p.rowExpression("sum(x)"))
+                            .addAggregation(
+                                    p.variable("min_y", VARCHAR),
+                                    p.rowExpression("min(y)"))
+                            .groupingSets(new AggregationNode.GroupingSetDescriptor(
+                                    ImmutableList.of(a, b, groupId),
+                                    3,
+                                    ImmutableSet.of()))
+                            .groupIdVariable(groupId)
+                            .step(AggregationNode.Step.PARTIAL)
+                            .source(p.groupId(
+                                    ImmutableList.of(
+                                            ImmutableList.of(a, b),
+                                            ImmutableList.of(a)),
+                                    ImmutableList.of(x, y),
+                                    groupId,
+                                    p.values(a, b, x, y))));
+                })
+                .matches(
+                        aggregation(
+                                ImmutableMap.of(
+                                        "sum_x", functionCall("sum", ImmutableList.of("sum_0")),
+                                        "min_y", functionCall("min", ImmutableList.of("min_0"))),
+                                AggregationNode.Step.INTERMEDIATE,
+                                node(GroupIdNode.class,
+                                        aggregation(
+                                                ImmutableMap.of(
+                                                        "sum_0", functionCall("sum", ImmutableList.of("sum")),
+                                                        "min_0", functionCall("min", ImmutableList.of("min"))),
+                                                AggregationNode.Step.INTERMEDIATE,
+                                                node(ExchangeNode.class,
+                                                        aggregation(
+                                                                ImmutableMap.of(
+                                                                        "sum", functionCall("sum", ImmutableList.of("x")),
+                                                                        "min", functionCall("min", ImmutableList.of("y"))),
+                                                                AggregationNode.Step.PARTIAL,
+                                                                values("a", "b", "x", "y")))))));
+    }
+
+    @Test
+    public void testMixedTypeOutputVariableOrdering()
+    {
+        // Verifies that aggregation output variables preserve insertion order.
+        // HashMap scrambles "sum_x" and "min_y" (confirmed empirically),
+        // causing BIGINT vs VARCHAR type mismatch at PartitionedOutput in Velox.
+        PlanNode result = tester().assertThat(new PreAggregateBeforeGroupId(getFunctionManager()))
+                .setSystemProperty(PRE_AGGREGATE_BEFORE_GROUPING_SETS, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", VARCHAR);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    VariableReferenceExpression y = p.variable("y", VARCHAR);
+                    VariableReferenceExpression groupId = p.variable("groupId", BIGINT);
+
+                    return p.aggregation(agg -> agg
+                            .addAggregation(
+                                    p.variable("sum_x", BIGINT),
+                                    p.rowExpression("sum(x)"))
+                            .addAggregation(
+                                    p.variable("min_y", VARCHAR),
+                                    p.rowExpression("min(y)"))
+                            .groupingSets(new AggregationNode.GroupingSetDescriptor(
+                                    ImmutableList.of(a, b, groupId),
+                                    3,
+                                    ImmutableSet.of()))
+                            .groupIdVariable(groupId)
+                            .step(AggregationNode.Step.PARTIAL)
+                            .source(p.groupId(
+                                    ImmutableList.of(
+                                            ImmutableList.of(a, b),
+                                            ImmutableList.of(a)),
+                                    ImmutableList.of(x, y),
+                                    groupId,
+                                    p.values(a, b, x, y))));
+                })
+                .get();
+
+        // Output variables must preserve original aggregation order:
+        // grouping keys [a(BIGINT), b(VARCHAR), groupId(BIGINT)] then
+        // aggregation outputs [sum_x(BIGINT), min_y(VARCHAR)]
+        // With HashMap, sum_x and min_y get swapped → [VARCHAR, BIGINT]
+        List<Type> expectedTypes = ImmutableList.of(BIGINT, VARCHAR, BIGINT, BIGINT, VARCHAR);
+        List<Type> actualTypes = result.getOutputVariables().stream()
+                .map(VariableReferenceExpression::getType)
+                .collect(Collectors.toList());
+        assertEquals(actualTypes, expectedTypes,
+                "Output variable types must preserve original aggregation ordering to avoid " +
+                "type mismatch at PartitionedOutput in Velox native execution");
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushPartialAggregationThroughExchangeOrdering.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushPartialAggregationThroughExchangeOrdering.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertEquals;
+
+public class TestPushPartialAggregationThroughExchangeOrdering
+        extends BaseRuleTest
+{
+    @Test
+    public void testMixedTypeOutputVariableOrdering()
+    {
+        // Verifies that the split() method in PushPartialAggregationThroughExchange
+        // preserves aggregation output variable ordering when creating PARTIAL and FINAL
+        // AggregationNodes. HashMap would scramble "sum_x" and "min_y" causing
+        // BIGINT vs VARCHAR type mismatch at PartitionedOutput in Velox.
+        PlanNode result = tester().assertThat(new PushPartialAggregationThroughExchange(getFunctionManager(), false))
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    VariableReferenceExpression y = p.variable("y", VARCHAR);
+
+                    return p.aggregation(agg -> agg
+                            .addAggregation(
+                                    p.variable("sum_x", BIGINT),
+                                    p.rowExpression("sum(x)"))
+                            .addAggregation(
+                                    p.variable("min_y", VARCHAR),
+                                    p.rowExpression("min(y)"))
+                            .singleGroupingSet(a)
+                            .step(AggregationNode.Step.SINGLE)
+                            .source(p.gatheringExchange(
+                                    ExchangeNode.Scope.REMOTE_STREAMING,
+                                    p.values(a, x, y))));
+                })
+                .get();
+
+        // The FINAL AggregationNode's output variables must preserve original order:
+        // grouping key [a(BIGINT)] then aggregation outputs [sum_x(BIGINT), min_y(VARCHAR)]
+        List<Type> expectedTypes = ImmutableList.of(BIGINT, BIGINT, VARCHAR);
+        List<Type> actualTypes = result.getOutputVariables().stream()
+                .map(VariableReferenceExpression::getType)
+                .collect(Collectors.toList());
+        assertEquals(actualTypes, expectedTypes,
+                "Output variable types must preserve original aggregation ordering to avoid " +
+                "type mismatch at PartitionedOutput in Velox native execution");
+    }
+}


### PR DESCRIPTION
## Description
Three optimizer rules use `HashMap` for aggregation maps passed to `AggregationNode` constructors, producing non-deterministic iteration order. When multiple aggregation functions have different intermediate types (e.g. BIGINT and VARCHAR), the shuffled column order at Exchange boundaries causes a type mismatch at `PartitionedOutput` in Velox native execution:

```
type_->kindEquals(vector.type()) Type mismatch: BIGINT vs. VARCHAR
Operator: PartitionedOutput[root.1487]
```

## Motivation and Context
`HashMap` does not guarantee iteration order. `AggregationNode.getOutputVariables()` returns grouping keys followed by aggregation map keys in iteration order. Velox uses channel positions (not variable names) for column layout, so wrong ordering causes type mismatch crashes.

## Impact
Fixes runtime crashes in Velox native execution when queries use mixed-type aggregations with grouping sets, partial aggregation through exchange, or multiple distinct aggregations.

## Affected Rules
- **PreAggregateBeforeGroupId** — 5 HashMaps (confirmed crash in production, query `20260401_195833_40294_y56gj`)
- **PushPartialAggregationThroughExchange** — 2 HashMaps (`intermediateAggregation`, `finalAggregation` in `split()`)
- **MultipleDistinctAggregationToMarkDistinct** — 1 HashMap (`newAggregations`)

## Test Plan
- `TestPreAggregateBeforeGroupId#testMixedTypeOutputVariableOrdering` — uses `.get()` to extract the transformed plan and asserts output variable type LIST ordering
- `TestPushPartialAggregationThroughExchangeOrdering#testMixedTypeOutputVariableOrdering` — same pattern
- `TestMultipleDistinctAggregationToMarkDistinctOrdering#testMixedTypeOutputVariableOrdering` — same pattern

All three tests **fail with HashMap** (`Lists differ at element [N]: bigint != varchar`) and **pass with LinkedHashMap**.

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Fix runtime type mismatch crashes in Velox native execution caused by non-deterministic HashMap iteration order in PreAggregateBeforeGroupId, PushPartialAggregationThroughExchange, and MultipleDistinctAggregationToMarkDistinct optimizer rules. Replace HashMap with LinkedHashMap to preserve aggregation output variable ordering.
```

Fixes #27492