### PR TITLE
refactor(docs): Use f-strings to format text and double quotes for strings

### DIFF
--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -27,7 +27,7 @@ try:
 except:
     pass
 
-sys.path.insert(0, os.path.abspath('ext'))
+sys.path.insert(0, os.path.abspath("ext"))
 
 
 def child_node(node, name):
@@ -45,75 +45,79 @@ def maven_version(pom):
     dom = xml.dom.minidom.parse(pom)
     project = dom.childNodes[0]
 
-    version = child_node(project, 'version')
+    version = child_node(project, "version")
     if version:
         return node_text(version)
 
-    parent = child_node(project, 'parent')
-    version = child_node(parent, 'version')
+    parent = child_node(project, "parent")
+    version = child_node(parent, "version")
     return node_text(version)
 
 
 def get_version():
-    version = os.environ.get('PRESTO_VERSION', '').strip()
-    return version or maven_version('../../../pom.xml')
+    version = os.environ.get("PRESTO_VERSION", "").strip()
+    return version or maven_version("../../../pom.xml")
 
 # -- General configuration -----------------------------------------------------
 
 
-needs_sphinx = '8.2.1'
+needs_sphinx = "8.2.1"
 
 extensions = [
-    'sphinx_immaterial', 'download', 'issue', 'pr', 'sphinx.ext.autosectionlabel'
+    "sphinx_immaterial",
+    "download",
+    "issue",
+    "pr",
+    "sphinx.ext.autosectionlabel"
 ]
 
-copyright = 'The Presto Foundation. All rights reserved. Presto is a registered trademark of LF Projects, LLC'
+copyright = "The Presto Foundation. All rights reserved. Presto is a registered trademark of LF Projects, LLC"
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
-source_suffix = '.rst'
+source_suffix = ".rst"
 
-master_doc = 'index'
+master_doc = "index"
 
-project = u'Presto'
+project = u"Presto"
 
-# Set Author blank to avoid default value of 'unknown'
-author = ''
+# Set Author blank to avoid default value of "unknown"
+author = ""
 
 version = get_version()
 release = version
 
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
-highlight_language = 'sql'
+highlight_language = "sql"
 
-rst_epilog = """
+rst_epilog = f"""
 .. |presto_server_release| replace:: ``presto-server-{release}``
 .. |presto_router_release| replace:: ``presto-router-{release}``
 .. |presto_flight_shim_release| replace:: ``presto-flight-shim-{release}``
-""".replace('{release}', release)
+""".replace("{release}", release)
 
-# 'xelatex' natively supports Unicode
-latex_engine = 'xelatex'
+# "xelatex" natively supports Unicode
+latex_engine = "xelatex"
 
 autosectionlabel_prefix_document = True
 
 # -- Options for HTML output ---------------------------------------------------
 
-html_theme = 'sphinx_immaterial'
+html_theme = "sphinx_immaterial"
 
 # Set link name generated in the top bar.
-html_title = '%s %s Documentation' % (project, release)
-html_logo = 'images/logo.png'
-html_favicon = 'images/favicon.ico'
+html_title = f"{project} {release} Documentation"
+html_logo = "images/logo.png"
+html_favicon = "images/favicon.ico"
 
-html_static_path = ['.']
+html_static_path = ["."]
 
 # Set the primary domain to js because if left as the default python
-# the theme errors when functions aren't available in a python module
-primary_domain = 'js'
+# the theme errors when functions are not available in a python module
+primary_domain = "js"
 
-html_add_permalinks = '#'
+html_add_permalinks = "#"
 html_show_copyright = True
 html_show_sphinx = False
 
@@ -128,12 +132,12 @@ html_theme_options = {
         "provider": "google",
         "property": "G-K7GB6F0LBZ"
     },
-    'features': [
-        'toc.follow',
-        'toc.sticky',
-        'content.code.copy',
+    "features": [
+        "toc.follow",
+        "toc.sticky",
+        "content.code.copy",
     ],
-    'palette': [
+    "palette": [
         {
             "media": "(prefers-color-scheme: light)",
             "scheme": "default",
@@ -155,14 +159,14 @@ html_theme_options = {
             }
         },
     ],
-    'edit_uri': 'blob/master/presto-docs/src/main/sphinx',
+    "edit_uri": "blob/master/presto-docs/src/main/sphinx",
 
-    # 'base_url': '/',
-    'repo_url': 'https://github.com/prestodb/presto',
-    'repo_name': 'Presto',
+    # "base_url": "/",
+    "repo_url": "https://github.com/prestodb/presto",
+    "repo_name": "Presto",
 
     # If true, TOC entries that are not ancestors of the current page are collapsed
-    'globaltoc_collapse': True,
+    "globaltoc_collapse": True,
     "social": [
         {
             "icon": "fontawesome/brands/github",


### PR DESCRIPTION
## Description
Minor code refactoring of Sphinx config `presto-docs/src/main/sphinx/conf.py`:
- The PR replaces all single quotes with double quotes for strings to ensure consistency.
- The PR replaces the modulo operator (%) and replace method call with f-strings for text formatting.

## Motivation and Context
Align Python code with the current standards.

## Impact
No

## Test Plan

Build the documentation and check that the pages are correct:
```shell
presto-docs/build
open target/html/router/deployment.html
```
<img width="1323" height="816" alt="image" src="https://github.com/user-attachments/assets/f274196d-fdd6-4dd7-804f-b6a1449f0783" />



## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refactor the Sphinx documentation configuration for Presto to standardize string formatting and modernize text interpolation.

Enhancements:
- Standardize all string literals in the Sphinx config to use double quotes for consistency with code style guidelines.
- Replace legacy percent and replace-based string formatting with f-strings in the Sphinx configuration to align with modern Python practices.