### PR TITLE
feat(optimizer): Pull constant projections above remote exchanges

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -1042,8 +1042,8 @@ For example, when enabled, the following query::
 is internally optimized to use a single ``max_by(ROW(v1, v2, v3), k)`` call with field extraction,
 reducing both CPU and memory usage.
 
-``optimizer.pull_constant_projection_above_exchange``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``pull_constant_projection_above_exchange``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``false``
@@ -1054,7 +1054,7 @@ directly below a remote ``ExchangeNode`` are moved to a new ``ProjectNode`` abov
 narrowing the exchange output layout. Constants used in partitioning, hashing, or ordering are not
 pulled up, and for multi-source (``UNION``) exchanges only constants that are identical across all
 sources are pulled up. This is the session-level counterpart of the configuration property
-``optimizer.pull-constant-projection-above-exchange``.
+:ref:`admin/properties:\`\`optimizer.pull-constant-projection-above-exchange\`\``.
 
 ``grouped_execution``
 ^^^^^^^^^^^^^^^^^^^^^

--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -1042,6 +1042,20 @@ For example, when enabled, the following query::
 is internally optimized to use a single ``max_by(ROW(v1, v2, v3), k)`` call with field extraction,
 reducing both CPU and memory usage.
 
+``optimizer.pull_constant_projection_above_exchange``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Pull constant assignments in projections above remote exchanges so that constant values are not
+serialized and shuffled across the network. When enabled, constants produced by a ``ProjectNode``
+directly below a remote ``ExchangeNode`` are moved to a new ``ProjectNode`` above the exchange,
+narrowing the exchange output layout. Constants used in partitioning, hashing, or ordering are not
+pulled up, and for multi-source (``UNION``) exchanges only constants that are identical across all
+sources are pulled up. This is the session-level counterpart of the configuration property
+``optimizer.pull-constant-projection-above-exchange``.
+
 ``grouped_execution``
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -958,6 +958,21 @@ the inner aggregation's parallelism is below what the node can support.
 
 The corresponding session property is :ref:`admin/properties-session:\`\`parallelize_chained_aggregation\`\``.
 
+``optimizer.pull-constant-projection-above-exchange``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Pull constant assignments in projections above remote exchanges so that constant values are
+not serialized and shuffled across the network. When enabled, constants produced by a
+``ProjectNode`` directly below a remote ``ExchangeNode`` are moved to a new ``ProjectNode``
+above the exchange, narrowing the exchange output layout. Constants used in partitioning,
+hashing, or ordering are not pulled up, and for multi-source (``UNION``) exchanges only
+constants that are identical across all sources are pulled up.
+
+The corresponding session property is :ref:`admin/properties-session:\`\`pull_constant_projection_above_exchange\`\``.
+
 ``optimizer.push-aggregation-through-join``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -390,6 +390,7 @@ public final class SystemSessionProperties
     public static final String TABLE_SCAN_SHUFFLE_PARALLELISM_THRESHOLD = "table_scan_shuffle_parallelism_threshold";
     public static final String TABLE_SCAN_SHUFFLE_STRATEGY = "table_scan_shuffle_strategy";
     public static final String SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION = "skip_pushdown_through_exchange_for_remote_projection";
+    public static final String PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE = "pull_constant_projection_above_exchange";
     public static final String REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM = "remote_function_names_for_fixed_parallelism";
     public static final String REMOTE_FUNCTION_FIXED_PARALLELISM_TASK_COUNT = "remote_function_fixed_parallelism_task_count";
     public static final String RPC_FUNCTION_PARALLELISM = "rpc_function_parallelism";
@@ -2278,6 +2279,11 @@ public final class SystemSessionProperties
                         "Skip pushing down remote projection through exchange",
                         featuresConfig.isSkipPushdownThroughExchangeForRemoteProjection(),
                         false),
+                booleanProperty(
+                        PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE,
+                        "Pull constant assignments in projections above remote exchanges to reduce network I/O",
+                        featuresConfig.isPullConstantProjectionAboveExchange(),
+                        false),
                 stringProperty(
                         REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM,
                         "Regex pattern to match remote function names that should use fixed parallelism",
@@ -3957,6 +3963,11 @@ public final class SystemSessionProperties
     public static boolean isSkipPushdownThroughExchangeForRemoteProjection(Session session)
     {
         return session.getSystemProperty(SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION, Boolean.class);
+    }
+
+    public static boolean isPullConstantProjectionAboveExchange(Session session)
+    {
+        return session.getSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, Boolean.class);
     }
 
     public static String getRemoteFunctionNamesForFixedParallelism(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -356,6 +356,7 @@ public class FeaturesConfig
     private double tableScanShuffleParallelismThreshold = 0.1;
     private ShuffleForTableScanStrategy tableScanShuffleStrategy = ShuffleForTableScanStrategy.DISABLED;
     private boolean skipPushdownThroughExchangeForRemoteProjection;
+    private boolean pullConstantProjectionAboveExchange;
     private String remoteFunctionNamesForFixedParallelism = "";
     private int remoteFunctionFixedParallelismTaskCount = 10;
 
@@ -3672,6 +3673,19 @@ public class FeaturesConfig
     public FeaturesConfig setSkipPushdownThroughExchangeForRemoteProjection(boolean skipPushdownThroughExchangeForRemoteProjection)
     {
         this.skipPushdownThroughExchangeForRemoteProjection = skipPushdownThroughExchangeForRemoteProjection;
+        return this;
+    }
+
+    public boolean isPullConstantProjectionAboveExchange()
+    {
+        return pullConstantProjectionAboveExchange;
+    }
+
+    @Config("optimizer.pull-constant-projection-above-exchange")
+    @ConfigDescription("Pull constant assignments in projections above remote exchanges to reduce network I/O")
+    public FeaturesConfig setPullConstantProjectionAboveExchange(boolean pullConstantProjectionAboveExchange)
+    {
+        this.pullConstantProjectionAboveExchange = pullConstantProjectionAboveExchange;
         return this;
     }
 

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -95,6 +95,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PruneTopNColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneUpdateSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneValuesColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneWindowColumns;
+import com.facebook.presto.sql.planner.iterative.rule.PullConstantProjectionAboveExchange;
 import com.facebook.presto.sql.planner.iterative.rule.PullConstantsAboveGroupBy;
 import com.facebook.presto.sql.planner.iterative.rule.PullUpExpressionInLambdaRules;
 import com.facebook.presto.sql.planner.iterative.rule.PushAggregationThroughDisjointUnion;
@@ -1087,6 +1088,14 @@ public class PlanOptimizers
         builder.add(simplifyRowExpressionOptimizer); // Should be always run after PredicatePushDown
         builder.add(projectionPushDown);
         builder.add(inlineProjections);
+        // Pull constant projections above remote exchanges after all other optimizers
+        // have had a chance to generate constants below exchanges
+        builder.add(new IterativeOptimizer(
+                metadata,
+                ruleStats,
+                statsCalculator,
+                costCalculator,
+                ImmutableSet.of(new PullConstantProjectionAboveExchange())));
         builder.add(new UnaliasSymbolReferences(metadata.getFunctionAndTypeManager())); // Run unalias after merging projections to simplify projections more efficiently
         builder.add(new PruneUnreferencedOutputs());
         builder.add(new IterativeOptimizer(

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullConstantProjectionAboveExchange.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PullConstantProjectionAboveExchange.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.PartitioningScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.isPullConstantProjectionAboveExchange;
+import static com.facebook.presto.sql.planner.plan.Patterns.exchange;
+
+/**
+ * Transforms:
+ * <pre>
+ *  Exchange(REMOTE)
+ *    Project(a = col_a, c = CONSTANT)
+ *      Source(col_a)
+ * </pre>
+ * to:
+ * <pre>
+ *  Project(a = a, c = CONSTANT)
+ *    Exchange(REMOTE)
+ *      Project(a = col_a)
+ *        Source(col_a)
+ * </pre>
+ *
+ * This avoids serializing and shuffling constant values across the network.
+ * Constants used in partitioning, ordering, or hash columns are not pulled up.
+ * For multi-source exchanges (UNION), only constants identical across ALL sources are pulled up.
+ */
+public class PullConstantProjectionAboveExchange
+        implements Rule<ExchangeNode>
+{
+    private static final Pattern<ExchangeNode> PATTERN = exchange()
+            .matching(exchange -> exchange.getScope().isRemote());
+
+    @Override
+    public Pattern<ExchangeNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(ExchangeNode exchange, Captures captures, Context context)
+    {
+        if (!isPullConstantProjectionAboveExchange(context.getSession())) {
+            return Result.empty();
+        }
+
+        List<PlanNode> sources = exchange.getSources();
+        List<List<VariableReferenceExpression>> inputs = exchange.getInputs();
+        List<VariableReferenceExpression> outputLayout = exchange.getPartitioningScheme().getOutputLayout();
+
+        // Resolve all sources through the lookup (they may be GroupReferences in the Memo)
+        // and verify all sources are ProjectNodes
+        ProjectNode[] resolvedSources = new ProjectNode[sources.size()];
+        for (int i = 0; i < sources.size(); i++) {
+            PlanNode resolved = context.getLookup().resolve(sources.get(i));
+            if (!(resolved instanceof ProjectNode)) {
+                return Result.empty();
+            }
+            resolvedSources[i] = (ProjectNode) resolved;
+        }
+
+        // Collect variables used in partitioning, hash, and ordering — these cannot be pulled up
+        Set<VariableReferenceExpression> requiredByExchange = new HashSet<>();
+        requiredByExchange.addAll(exchange.getPartitioningScheme().getPartitioning().getVariableReferences());
+        exchange.getPartitioningScheme().getHashColumn().ifPresent(requiredByExchange::add);
+        exchange.getOrderingScheme().ifPresent(ordering ->
+                requiredByExchange.addAll(ordering.getOrderByVariables()));
+
+        // For each output position, check if all sources produce the same constant
+        // Map from output variable index to the constant expression
+        Map<Integer, ConstantExpression> pullableConstants = new HashMap<>();
+
+        for (int outputIdx = 0; outputIdx < outputLayout.size(); outputIdx++) {
+            VariableReferenceExpression outputVar = outputLayout.get(outputIdx);
+
+            // Skip if this variable is required by exchange mechanics
+            if (requiredByExchange.contains(outputVar)) {
+                continue;
+            }
+
+            ConstantExpression commonConstant = null;
+            boolean allSourcesHaveSameConstant = true;
+
+            for (int sourceIdx = 0; sourceIdx < resolvedSources.length; sourceIdx++) {
+                ProjectNode projectNode = resolvedSources[sourceIdx];
+                VariableReferenceExpression inputVar = inputs.get(sourceIdx).get(outputIdx);
+                RowExpression assignment = projectNode.getAssignments().get(inputVar);
+
+                if (assignment instanceof ConstantExpression) {
+                    ConstantExpression constant = (ConstantExpression) assignment;
+                    if (commonConstant == null) {
+                        commonConstant = constant;
+                    }
+                    else if (!constantsAreEqual(commonConstant, constant)) {
+                        allSourcesHaveSameConstant = false;
+                        break;
+                    }
+                }
+                else {
+                    allSourcesHaveSameConstant = false;
+                    break;
+                }
+            }
+
+            if (allSourcesHaveSameConstant && commonConstant != null) {
+                pullableConstants.put(outputIdx, commonConstant);
+            }
+        }
+
+        if (pullableConstants.isEmpty()) {
+            return Result.empty();
+        }
+
+        // Don't pull all columns — exchange must retain at least one output
+        if (pullableConstants.size() >= outputLayout.size()) {
+            return Result.empty();
+        }
+
+        // Build new sources with constant assignments removed
+        ImmutableList.Builder<PlanNode> newSources = ImmutableList.builder();
+        ImmutableList.Builder<List<VariableReferenceExpression>> newInputs = ImmutableList.builder();
+
+        for (int sourceIdx = 0; sourceIdx < resolvedSources.length; sourceIdx++) {
+            ProjectNode projectNode = resolvedSources[sourceIdx];
+            Set<VariableReferenceExpression> constantInputVars = new HashSet<>();
+            for (int outputIdx : pullableConstants.keySet()) {
+                constantInputVars.add(inputs.get(sourceIdx).get(outputIdx));
+            }
+
+            // Build new assignments without the pulled constants
+            Assignments.Builder newAssignments = Assignments.builder();
+            for (Map.Entry<VariableReferenceExpression, RowExpression> entry : projectNode.getAssignments().entrySet()) {
+                if (!constantInputVars.contains(entry.getKey())) {
+                    newAssignments.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            // Build new input list without the pulled constant positions
+            ImmutableList.Builder<VariableReferenceExpression> newInputList = ImmutableList.builder();
+            for (int outputIdx = 0; outputIdx < outputLayout.size(); outputIdx++) {
+                if (!pullableConstants.containsKey(outputIdx)) {
+                    newInputList.add(inputs.get(sourceIdx).get(outputIdx));
+                }
+            }
+
+            Assignments builtAssignments = newAssignments.build();
+            if (builtAssignments.isEmpty()) {
+                return Result.empty();
+            }
+
+            newSources.add(new ProjectNode(
+                    projectNode.getSourceLocation(),
+                    context.getIdAllocator().getNextId(),
+                    projectNode.getSources().get(0),
+                    builtAssignments,
+                    projectNode.getLocality()));
+            newInputs.add(newInputList.build());
+        }
+
+        // Build new output layout without the pulled constants
+        ImmutableList.Builder<VariableReferenceExpression> newOutputLayout = ImmutableList.builder();
+        for (int outputIdx = 0; outputIdx < outputLayout.size(); outputIdx++) {
+            if (!pullableConstants.containsKey(outputIdx)) {
+                newOutputLayout.add(outputLayout.get(outputIdx));
+            }
+        }
+
+        PartitioningScheme newPartitioningScheme = new PartitioningScheme(
+                exchange.getPartitioningScheme().getPartitioning(),
+                newOutputLayout.build(),
+                exchange.getPartitioningScheme().getHashColumn(),
+                exchange.getPartitioningScheme().isReplicateNullsAndAny(),
+                exchange.getPartitioningScheme().isScaleWriters(),
+                exchange.getPartitioningScheme().getEncoding(),
+                exchange.getPartitioningScheme().getBucketToPartition());
+
+        ExchangeNode newExchange = new ExchangeNode(
+                exchange.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                exchange.getType(),
+                exchange.getScope(),
+                newPartitioningScheme,
+                newSources.build(),
+                newInputs.build(),
+                exchange.isEnsureSourceOrdering(),
+                exchange.getOrderingScheme());
+
+        // Build the projection above the exchange: identity for remaining columns + pulled constants
+        Assignments.Builder aboveAssignments = Assignments.builder();
+        for (int outputIdx = 0; outputIdx < outputLayout.size(); outputIdx++) {
+            VariableReferenceExpression outputVar = outputLayout.get(outputIdx);
+            if (pullableConstants.containsKey(outputIdx)) {
+                aboveAssignments.put(outputVar, pullableConstants.get(outputIdx));
+            }
+            else {
+                aboveAssignments.put(outputVar, outputVar);
+            }
+        }
+
+        ProjectNode aboveProject = new ProjectNode(
+                exchange.getSourceLocation(),
+                context.getIdAllocator().getNextId(),
+                newExchange,
+                aboveAssignments.build(),
+                ProjectNode.Locality.LOCAL);
+
+        return Result.ofPlanNode(aboveProject);
+    }
+
+    private static boolean constantsAreEqual(ConstantExpression a, ConstantExpression b)
+    {
+        if (!a.getType().equals(b.getType())) {
+            return false;
+        }
+        if (a.isNull() && b.isNull()) {
+            return true;
+        }
+        if (a.isNull() || b.isNull()) {
+            return false;
+        }
+        return a.getValue().equals(b.getValue());
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughExchange.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughExchange.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.PartitioningScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.RowExpressionVariableInliner;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isPullConstantProjectionAboveExchange;
 import static com.facebook.presto.SystemSessionProperties.isSkipPushdownThroughExchangeForRemoteProjection;
 import static com.facebook.presto.matching.Capture.newCapture;
 import static com.facebook.presto.sql.planner.iterative.rule.Util.restrictOutputs;
@@ -82,6 +84,14 @@ public class PushProjectionThroughExchange
     {
         ExchangeNode exchange = captures.get(CHILD);
         if (isSkipPushdownThroughExchangeForRemoteProjection(context.getSession()) && project.getLocality().equals(ProjectNode.Locality.REMOTE)) {
+            return Result.empty();
+        }
+
+        // When pulling constant projections above exchanges is enabled, do not push a projection
+        // that consists solely of symbol references and constants back below the exchange. This
+        // prevents ping-ponging with PullConstantProjectionAboveExchange. Gated on the session
+        // property so the default plan is unchanged when the feature is disabled.
+        if (isPullConstantProjectionAboveExchange(context.getSession()) && isSymbolOrConstantProjection(project)) {
             return Result.empty();
         }
 
@@ -173,6 +183,12 @@ public class PushProjectionThroughExchange
     private static boolean isSymbolToSymbolProjection(ProjectNode project)
     {
         return project.getAssignments().getExpressions().stream().allMatch(e -> e instanceof VariableReferenceExpression);
+    }
+
+    private static boolean isSymbolOrConstantProjection(ProjectNode project)
+    {
+        return project.getAssignments().getExpressions().stream().allMatch(
+                e -> e instanceof VariableReferenceExpression || e instanceof ConstantExpression);
     }
 
     private static Map<VariableReferenceExpression, VariableReferenceExpression> extractExchangeOutputToInput(ExchangeNode exchange, int sourceIndex)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -310,6 +310,7 @@ public class TestFeaturesConfig
                 .setTableScanShuffleParallelismThreshold(0.1)
                 .setTableScanShuffleStrategy(FeaturesConfig.ShuffleForTableScanStrategy.DISABLED)
                 .setSkipPushdownThroughExchangeForRemoteProjection(false)
+                .setPullConstantProjectionAboveExchange(false)
                 .setUseConnectorProvidedSerializationCodecs(false)
                 .setRemoteFunctionNamesForFixedParallelism("")
                 .setRemoteFunctionFixedParallelismTaskCount(10));
@@ -565,6 +566,7 @@ public class TestFeaturesConfig
                 .put("optimizer.table-scan-shuffle-parallelism-threshold", "0.3")
                 .put("optimizer.table-scan-shuffle-strategy", "ALWAYS_ENABLED")
                 .put("optimizer.skip-pushdown-through-exchange-for-remote-projection", "true")
+                .put("optimizer.pull-constant-projection-above-exchange", "true")
                 .put("use-connector-provided-serialization-codecs", "true")
                 .put("optimizer.remote-function-names-for-fixed-parallelism", "remote_.*")
                 .put("optimizer.remote-function-fixed-parallelism-task-count", "100")
@@ -818,6 +820,7 @@ public class TestFeaturesConfig
                 .setTableScanShuffleParallelismThreshold(0.3)
                 .setTableScanShuffleStrategy(FeaturesConfig.ShuffleForTableScanStrategy.ALWAYS_ENABLED)
                 .setSkipPushdownThroughExchangeForRemoteProjection(true)
+                .setPullConstantProjectionAboveExchange(true)
                 .setUseConnectorProvidedSerializationCodecs(true)
                 .setRemoteFunctionNamesForFixedParallelism("remote_.*")
                 .setPushPartialAggregationThroughJoin(true)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantProjectionAboveExchange.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPullConstantProjectionAboveExchange.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+
+public class TestPullConstantProjectionAboveExchange
+        extends BaseRuleTest
+{
+    @Test
+    public void testSingleSourceSingleConstant()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression constVar = p.variable("const_var", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(constVar, constant(42L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addInputsSet(a, constVar)
+                            .singleDistributionPartitioningScheme(a, constVar));
+                })
+                .matches(
+                        project(
+                                exchange(
+                                        project(
+                                                values(ImmutableList.of("a")))
+                                                .withAlias("a", expression("a"))))
+                                .withAlias("a", expression("a"))
+                                .withAlias("const_var", expression("42")));
+    }
+
+    @Test
+    public void testSingleSourceMultipleConstants()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression c1 = p.variable("c1", BIGINT);
+                    VariableReferenceExpression c2 = p.variable("c2", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(c1, constant(10L, BIGINT))
+                                                    .put(c2, constant(20L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addInputsSet(a, c1, c2)
+                            .singleDistributionPartitioningScheme(a, c1, c2));
+                })
+                .matches(
+                        project(
+                                exchange(
+                                        project(
+                                                values(ImmutableList.of("a")))
+                                                .withAlias("a", expression("a"))))
+                                .withAlias("a", expression("a"))
+                                .withAlias("c1", expression("10"))
+                                .withAlias("c2", expression("20")));
+    }
+
+    @Test
+    public void testConstantInPartitioningKey()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression partKey = p.variable("part_key", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(partKey, constant(42L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addInputsSet(a, partKey)
+                            .fixedHashDistributionPartitioningScheme(
+                                    ImmutableList.of(a, partKey),
+                                    ImmutableList.of(partKey)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testMultiSourceSameConstants()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    VariableReferenceExpression c1 = p.variable("c1", BIGINT);
+                    VariableReferenceExpression c2 = p.variable("c2", BIGINT);
+                    VariableReferenceExpression outData = p.variable("out_data", BIGINT);
+                    VariableReferenceExpression outConst = p.variable("out_const", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(c1, constant(42L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(b, b)
+                                                    .put(c2, constant(42L, BIGINT))
+                                                    .build(),
+                                            p.values(b)))
+                            .addInputsSet(a, c1)
+                            .addInputsSet(b, c2)
+                            .singleDistributionPartitioningScheme(outData, outConst));
+                })
+                .matches(
+                        project(
+                                exchange(
+                                        project(
+                                                values(ImmutableList.of("a"))),
+                                        project(
+                                                values(ImmutableList.of("b")))))
+                                .withAlias("out_const", expression("42")));
+    }
+
+    @Test
+    public void testMultiSourceDifferentConstants()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    VariableReferenceExpression c1 = p.variable("c1", BIGINT);
+                    VariableReferenceExpression c2 = p.variable("c2", BIGINT);
+                    VariableReferenceExpression outData = p.variable("out_data", BIGINT);
+                    VariableReferenceExpression outConst = p.variable("out_const", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(c1, constant(42L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(b, b)
+                                                    .put(c2, constant(99L, BIGINT))
+                                                    .build(),
+                                            p.values(b)))
+                            .addInputsSet(a, c1)
+                            .addInputsSet(b, c2)
+                            .singleDistributionPartitioningScheme(outData, outConst));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testLocalExchangeDoesNotFire()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression constVar = p.variable("const_var", BIGINT);
+                    return p.exchange(e -> e
+                            .scope(LOCAL)
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(constVar, constant(42L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addInputsSet(a, constVar)
+                            .singleDistributionPartitioningScheme(a, constVar));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNoConstantsDoesNotFire()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(b, b)
+                                                    .build(),
+                                            p.values(a, b)))
+                            .addInputsSet(a, b)
+                            .singleDistributionPartitioningScheme(a, b));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSessionPropertyDisabled()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression constVar = p.variable("const_var", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(constVar, constant(42L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addInputsSet(a, constVar)
+                            .singleDistributionPartitioningScheme(a, constVar));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSourceNotProjectDoesNotFire()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(p.values(a))
+                            .addInputsSet(a)
+                            .singleDistributionPartitioningScheme(a));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testAllConstantsDoesNotFire()
+    {
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression c1 = p.variable("c1", BIGINT);
+                    VariableReferenceExpression c2 = p.variable("c2", BIGINT);
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(c1, constant(1L, BIGINT))
+                                                    .put(c2, constant(2L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addInputsSet(c1, c2)
+                            .singleDistributionPartitioningScheme(c1, c2));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testNonDeterministicExpressionNotPulled()
+    {
+        // Only the constant is pulled above the exchange. The non-deterministic
+        // expression (random()) is NOT a ConstantExpression, so it must remain
+        // below the exchange and be evaluated per row.
+        tester().assertThat(new PullConstantProjectionAboveExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression nd = p.variable("nd", DOUBLE);
+                    VariableReferenceExpression constVar = p.variable("const_var", BIGINT);
+                    return p.exchange(e -> e
+                            .addSource(
+                                    p.project(
+                                            Assignments.builder()
+                                                    .put(a, a)
+                                                    .put(nd, p.rowExpression("random()"))
+                                                    .put(constVar, constant(42L, BIGINT))
+                                                    .build(),
+                                            p.values(a)))
+                            .addInputsSet(a, nd, constVar)
+                            .singleDistributionPartitioningScheme(a, nd, constVar));
+                })
+                .matches(
+                        project(
+                                exchange(
+                                        project(
+                                                values(ImmutableList.of("a")))
+                                                .withAlias("a", expression("a"))
+                                                .withAlias("nd", expression("random()"))))
+                                .withAlias("a", expression("a"))
+                                .withAlias("nd", expression("nd"))
+                                .withAlias("const_var", expression("42")));
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughExchangeConstants.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughExchangeConstants.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE;
+import static com.facebook.presto.common.function.OperatorType.MULTIPLY;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.exchange;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+
+/**
+ * Tests for the interaction between PushProjectionThroughExchange and constant projections.
+ * When pull_constant_projection_above_exchange is enabled, identity+constant projections are
+ * NOT pushed through exchanges (to prevent ping-ponging with PullConstantProjectionAboveExchange),
+ * while projections containing non-trivial expressions ARE still pushed. When the feature is
+ * disabled the default behavior is preserved (identity+constant projections are pushed down).
+ */
+public class TestPushProjectionThroughExchangeConstants
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoesNotPushIdentityAndConstantOnly()
+    {
+        tester().assertThat(new PushProjectionThroughExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression constVar = p.variable("const_var", BIGINT);
+                    return p.project(
+                            Assignments.builder()
+                                    .put(a, a)
+                                    .put(constVar, constant(42L, BIGINT))
+                                    .build(),
+                            p.exchange(e -> e
+                                    .addSource(p.values(a))
+                                    .addInputsSet(a)
+                                    .singleDistributionPartitioningScheme(a)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotPushAllConstants()
+    {
+        tester().assertThat(new PushProjectionThroughExchange())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression c1 = p.variable("c1", BIGINT);
+                    VariableReferenceExpression c2 = p.variable("c2", BIGINT);
+                    return p.project(
+                            Assignments.builder()
+                                    .put(c1, constant(10L, BIGINT))
+                                    .put(c2, constant(20L, BIGINT))
+                                    .build(),
+                            p.exchange(e -> e
+                                    .addSource(p.values(a))
+                                    .addInputsSet(a)
+                                    .singleDistributionPartitioningScheme(a)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testStillPushesNonTrivialExpressions()
+    {
+        tester().assertThat(new PushProjectionThroughExchange())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression aTimes5 = p.variable("a_times_5", BIGINT);
+                    VariableReferenceExpression constVar = p.variable("const_var", BIGINT);
+                    return p.project(
+                            Assignments.builder()
+                                    .put(aTimes5, p.binaryOperation(MULTIPLY, a, constant(5L, BIGINT)))
+                                    .put(constVar, constant(42L, BIGINT))
+                                    .build(),
+                            p.exchange(e -> e
+                                    .addSource(p.values(a))
+                                    .addInputsSet(a)
+                                    .singleDistributionPartitioningScheme(a)));
+                })
+                .matches(
+                        exchange(
+                                project(
+                                        values(ImmutableList.of("a")))
+                                        .withAlias("a_times_5", expression("a * 5"))
+                                        .withAlias("const_var", expression("42"))));
+    }
+
+    @Test
+    public void testDoesNotPushIdentityOnly()
+    {
+        tester().assertThat(new PushProjectionThroughExchange())
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    return p.project(
+                            Assignments.builder()
+                                    .put(a, a)
+                                    .put(b, b)
+                                    .build(),
+                            p.exchange(e -> e
+                                    .addSource(p.values(a, b))
+                                    .addInputsSet(a, b)
+                                    .singleDistributionPartitioningScheme(a, b)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID;
 import static com.facebook.presto.SystemSessionProperties.OPTIMIZE_TOP_N_USING_ROW_ID_MIN_COLUMN_SAVINGS;
+import static com.facebook.presto.SystemSessionProperties.PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE;
 import static com.facebook.presto.SystemSessionProperties.PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN;
 import static com.facebook.presto.common.predicate.Marker.Bound.EXACTLY;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -314,5 +315,46 @@ public class TestLocalQueries
                 .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
                 .build();
         assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testPullConstantProjectionAboveExchange()
+    {
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "true")
+                .build();
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty(PULL_CONSTANT_PROJECTION_ABOVE_EXCHANGE, "false")
+                .build();
+
+        // Basic constant projection
+        assertQuery(enabled, "SELECT nationkey, 'constant' AS label FROM nation",
+                disabled, "SELECT nationkey, 'constant' AS label FROM nation");
+
+        // Constant with join (triggers a remote exchange in distributed mode)
+        assertQuery(enabled,
+                "SELECT n.nationkey, 42 AS fixed_val, r.name FROM nation n JOIN region r ON n.regionkey = r.regionkey",
+                disabled,
+                "SELECT n.nationkey, 42 AS fixed_val, r.name FROM nation n JOIN region r ON n.regionkey = r.regionkey");
+
+        // Multiple constants with a filter
+        assertQuery(enabled, "SELECT nationkey, 1 AS one, 'hello' AS greeting FROM nation WHERE regionkey = 1",
+                disabled, "SELECT nationkey, 1 AS one, 'hello' AS greeting FROM nation WHERE regionkey = 1");
+
+        // Constants across a UNION ALL (multi-source exchange): only constants identical
+        // across all sources are pulled above the exchange.
+        assertQuery(enabled,
+                "SELECT nationkey, 7 AS k FROM nation WHERE regionkey = 1 " +
+                        "UNION ALL SELECT nationkey, 7 AS k FROM nation WHERE regionkey = 2",
+                disabled,
+                "SELECT nationkey, 7 AS k FROM nation WHERE regionkey = 1 " +
+                        "UNION ALL SELECT nationkey, 7 AS k FROM nation WHERE regionkey = 2");
+
+        // Non-deterministic expression must NOT be treated as a pullable constant:
+        // results stay correct (per-row evaluation) under both sessions.
+        assertQuery(enabled,
+                "SELECT count(DISTINCT label) >= 1 FROM (SELECT nationkey, CAST(random() < 2 AS VARCHAR) AS label FROM nation)",
+                disabled,
+                "SELECT count(DISTINCT label) >= 1 FROM (SELECT nationkey, CAST(random() < 2 AS VARCHAR) AS label FROM nation)");
     }
 }


### PR DESCRIPTION
## Summary

Add a new optimizer rule `PullConstantProjectionAboveExchange` that moves constant assignments from `ProjectNode`s below remote `ExchangeNode`s to a new `ProjectNode` above the exchange. This avoids serializing and shuffling constant values across the network.

### Before
```
Exchange(REMOTE)
  Project(a = col_a, c = CONSTANT)
    Source(col_a)
```

### After
```
Project(a = a, c = CONSTANT)
  Exchange(REMOTE)
    Project(a = col_a)
      Source(col_a)
```

## Rule behavior

- Matches remote `ExchangeNode`s whose sources are all `ProjectNode`s
- Identifies constant assignments that are identical across all sources (for multi-source/`UNION` exchanges)
- Skips constants used in partitioning, ordering, or hash columns
- Strips pulled constants from source projects and narrows the exchange output layout
- Adds a new project above with identity mappings + pulled constants
- Gated behind the `pull_constant_projection_above_exchange` session property (default: **disabled**)

## Loop prevention (gated)

To prevent oscillation with `PushProjectionThroughExchange` (which would otherwise push the pulled-up constant projection straight back down), that rule skips pushing projections consisting solely of symbol references and constants. This skip is **gated on the same `pull_constant_projection_above_exchange` session property**, so when the feature is disabled the default plan is unchanged.

## Optimizer placement

The rule runs as a standalone `IterativeOptimizer` step **after** the other optimizers, so that any optimizer that may generate constants below exchanges has had a chance to run first.

## Changes

| File | Change |
|------|--------|
| `FeaturesConfig.java` | New `optimizer.pull-constant-projection-above-exchange` config property |
| `SystemSessionProperties.java` | Expose as `pull_constant_projection_above_exchange` session property |
| `PullConstantProjectionAboveExchange.java` | **New** — the optimizer rule |
| `PushProjectionThroughExchange.java` | Gated loop-prevention: skip pushing symbol+constant projections when the feature is enabled |
| `PlanOptimizers.java` | Register the rule as a standalone iterative step |
| `properties-session.rst` | Document the new session property |
| `TestPullConstantProjectionAboveExchange.java` | **New** — 11 unit tests |
| `TestPushProjectionThroughExchangeConstants.java` | **New** — 4 interaction tests |
| `TestFeaturesConfig.java` | Config property test coverage |
| `TestLocalQueries.java` | End-to-end tests (enabled vs disabled) |

## Test Plan

- 11 unit tests: single/multi source, same/different constants, partitioning-key exclusion, local-exchange skip, session-property gating, non-project source, all-constants guard, and a determinism test verifying non-deterministic expressions are **not** pulled.
- 4 interaction tests for the push rule: identity+constant blocked (feature on), all-constants blocked (feature on), non-trivial expressions still pushed, identity-only blocked.
- End-to-end `TestLocalQueries#testPullConstantProjectionAboveExchange` compares results with the optimization enabled vs disabled (basic constants, constant + join, multiple constants + filter, `UNION ALL`, and a non-deterministic expression).
- `TestFeaturesConfig` covers the new property; existing `PushProjectionThroughExchange` behavior is unchanged when the feature is disabled.

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add session property ``pull_constant_projection_above_exchange`` (disabled by default) that pulls constant projection assignments above remote exchanges, avoiding serialization and shuffling of constant values across the network. :pr:`27499`
```

## Summary by Sourcery

Introduce a planner optimization that pulls constant projection assignments above remote exchanges and wires it into the optimizer behind a configurable session property, including safeguards to avoid oscillation with existing projection pushdown.

New Features:
- Add a PullConstantProjectionAboveExchange rule that hoists constant projections above remote exchanges to avoid shuffling constant values.
- Expose a new optimizer session property pull_constant_projection_above_exchange (and corresponding config flag) to toggle the constant-projection pull-up behavior.

Enhancements:
- Adjust PushProjectionThroughExchange to skip pushing projections made only of symbols and constants when constant-pull-up is enabled to prevent optimizer ping-pong.
- Register the new rule as a late-stage iterative optimizer so it runs after other constant-generating optimizations.

Documentation:
- Document the pull_constant_projection_above_exchange session property in the admin session properties reference.

Tests:
- Add rule-level tests for PullConstantProjectionAboveExchange covering single/multi-source exchanges, partitioning key exclusion, locality, non-project sources, all-constant guards, non-deterministic expressions, and session gating.
- Add interaction tests for PushProjectionThroughExchange to verify behavior with constant and non-trivial projections when the feature is enabled or disabled.
- Extend TestLocalQueries to validate end-to-end correctness with the optimization enabled versus disabled.
- Update FeaturesConfig tests to cover the new configuration property.