### PR TITLE
docs: Fix formatting of code blocks in develop/table-functions.rst

### DIFF
--- a/presto-docs/src/main/sphinx/develop/table-functions.rst
+++ b/presto-docs/src/main/sphinx/develop/table-functions.rst
@@ -20,7 +20,7 @@ To declare a table function, you must implement ``ConnectorTableFunction``. Subc
 The constructor
 ---------------
 
-::
+.. code-block:: java
 
     public class MyFunction
             extends AbstractConnectorTableFunction
@@ -195,7 +195,7 @@ the ``analyze()`` method. This method is called by the engine during the analysi
 of query processing. The ``analyze()`` method is also the place to perform custom checks 
 on the arguments:
 
-::
+.. code-block:: java
   
   @Override
   public TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)


### PR DESCRIPTION
## Description
Edited the formatting of code blocks in [develop/table-functions.rst](https://github.com/prestodb/presto/blob/master/presto-docs/src/main/sphinx/develop/table-functions.rst) to fix warnings during doc builds. 

## Motivation and Context
Reducing the warnings displayed in a doc build allows doc builds to run faster, and simplifies the work to debug future problems. 

## Impact
Doc builds. 

## Test Plan
Local doc builds. 

Before: 
The following displayed in the output of a local doc build: 

```
[...]

/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/develop/table-functions.rst:25: WARNING: Lexing literal_block 'public class MyFunction\n        extends AbstractConnectorTableFunction\n{\n    public MyFunction()\n    {\n        super(\n                "system",\n                "my_function",\n                List.of(\n                        ScalarArgumentSpecification.builder()\n                                .name("COLUMN_COUNT")\n                                .type(INTEGER)\n                                .defaultValue(2)\n                                .build(),\n                        ScalarArgumentSpecification.builder()\n                                .name("ROW_COUNT")\n                                .type(INTEGER)\n                                .build()),\n                  GENERIC_TABLE);\n    }\n}' as "sql" resulted in an error at token: '{'. Retrying in relaxed mode. [misc.highlighting_failure]
/Users/steveburnett/Documents/GitHub/presto/presto-docs/src/main/sphinx/develop/table-functions.rst:200: WARNING: Lexing literal_block '@Override\npublic TableFunctionAnalysis analyze(ConnectorSession session, ConnectorTransactionHandle transaction, Map<String, Argument> arguments)\n{\n    long columnCount = (long) ((ScalarArgument) arguments.get("COLUMN_COUNT")).getValue();\n    long rowCount = (long) ((ScalarArgument) arguments.get("ROW_COUNT")).getValue();\n\n    // custom validation of arguments\n    if (columnCount < 1 || columnCount > 3) {\n        throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "column_count must be in range [1, 3]");\n    }\n\n    if (rowCount < 1) {\n        throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "row_count must be positive");\n    }\n\n    // determine the returned row type\n    List<Descriptor.Field> fields = List.of("col_a", "col_b", "col_c").subList(0, (int) columnCount).stream()\n            .map(name -> new Descriptor.Field(name, Optional.of(BIGINT)))\n            .collect(toList());\n\n    Descriptor returnedType = new Descriptor(fields);\n\n    return TableFunctionAnalysis.builder()\n            .returnedType(returnedType)\n            .handle(new MyHandle(columnCount, rowCount))\n            .build();\n}' as "sql" resulted in an error at token: '{'. Retrying in relaxed mode. [misc.highlighting_failure]


build succeeded, 55 warnings.
```

After:

```
(the two warnings shown here are not displayed)

build succeeded, 53 warnings.

```

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Adjust code block language markers in develop/table-functions.rst so Java examples are highlighted correctly and no longer trigger doc build warnings.