### PR TITLE
feat(ci): Add advance velox actions

### DIFF
--- a/.github/workflows/velox-advance-pr-check.yml
+++ b/.github/workflows/velox-advance-pr-check.yml
@@ -1,0 +1,134 @@
+name: Advance velox PR check
+
+on:
+  workflow_run:
+    workflows: [test, prestocpp-linux-build, prestocpp-linux-build-and-unit-test, arrow flight tests, prestocpp-macos-build]
+    types: [completed]
+    branches: [velox-update]
+
+  # Note: workflow_run trigger with dangerous-triggers suppression is safe here because:
+  # 1. Permissions are scoped to pull-requests: write only (no contents: write)
+  # 2. Checkout uses persist-credentials: false
+  # 3. No code execution from untrusted sources
+
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  NOTIFICATION_GROUP: ${{ vars.VELOX_UPDATE_NOTIFICATION_GROUP || '@prestodb/team-velox' }}
+  VELOX_UPDATE_BRANCH: velox-update
+
+jobs:
+  check-pr-status:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.VELOX_UPDATE_BRANCH }}
+          persist-credentials: false
+
+      - name: Get PR info
+        id: pr_info
+        env:
+          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+        run: |
+          # Check if PR exists for velox-update branch
+          PR_JSON=$(gh pr list --head "${{ env.VELOX_UPDATE_BRANCH }}" --state open --json number,url --jq '.[0]' 2>/dev/null)
+
+          if [ -n "$PR_JSON" ] && [ "$PR_JSON" != "null" ]; then
+            echo "pr_number=$(echo "$PR_JSON" | jq -r '.number')" >> $GITHUB_OUTPUT
+            echo "pr_url=$(echo "$PR_JSON" | jq -r '.url')" >> $GITHUB_OUTPUT
+            echo "pr_found=true" >> $GITHUB_OUTPUT
+            echo "Found PR: $(echo "$PR_JSON" | jq -r '.url')"
+          else
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "No PR found for branch ${{ env.VELOX_UPDATE_BRANCH }}"
+          fi
+
+      - name: Check CI status
+        if: steps.pr_info.outputs.pr_found == 'true'
+        id: ci_status
+        env:
+          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+        run: |
+          # Get CI check status for the PR
+          CHECKS_JSON=$(gh pr checks ${{ steps.pr_info.outputs.pr_number }} --json state 2>&1)
+
+          if [ -z "$CHECKS_JSON" ] || [ "$CHECKS_JSON" = "[]" ]; then
+            echo "ci_result=no_checks" >> $GITHUB_OUTPUT
+            echo "No CI checks found"
+            exit 0
+          fi
+
+          STATES=$(echo "$CHECKS_JSON" | jq -r '.[].state' | sort -u)
+
+          # Check if any checks are still running
+          if echo "$STATES" | grep -qE "PENDING|QUEUED|IN_PROGRESS"; then
+            echo "ci_result=still_running" >> $GITHUB_OUTPUT
+            echo "CI checks still running"
+            exit 0
+          fi
+
+          # Check for failures
+          if echo "$STATES" | grep -qE "FAILURE|CANCELLED|TIMED_OUT|ERROR"; then
+            echo "ci_result=failure" >> $GITHUB_OUTPUT
+            echo "CI checks failed"
+          # Verify all checks passed
+          elif [ "$(echo "$CHECKS_JSON" | jq '[.[] | select(.state != "SUCCESS")] | length')" -eq 0 ]; then
+            echo "ci_result=success" >> $GITHUB_OUTPUT
+            echo "All CI checks passed"
+          else
+            echo "ci_result=failure" >> $GITHUB_OUTPUT
+            echo "CI checks completed with non-success states"
+          fi
+
+      - name: Notify CI result
+        if: steps.ci_status.outputs.ci_result == 'success' || steps.ci_status.outputs.ci_result == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+        run: |
+          # Post notification comment based on CI result
+          if [ "${{ steps.ci_status.outputs.ci_result }}" = "success" ]; then
+            gh pr comment ${{ steps.pr_info.outputs.pr_number }} --body "✅ **CI Checks Passed**
+
+          All CI checks have completed successfully for this Velox submodule update.
+
+          ${{ env.NOTIFICATION_GROUP }} This PR is ready for review."
+          else
+            gh pr comment ${{ steps.pr_info.outputs.pr_number }} --body "❌ **CI Checks Failed**
+
+          Some CI checks have failed for this Velox submodule update.
+
+          ${{ env.NOTIFICATION_GROUP }} Please review the failed checks and take appropriate action."
+          fi
+
+      - name: Summary
+        if: always() && steps.pr_info.outputs.pr_found == 'true'
+        run: |
+          # Generate job summary
+          echo "## Check Status Job Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📝 Pull Request: ${{ steps.pr_info.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          case "${{ steps.ci_status.outputs.ci_result }}" in
+            success)
+              echo "✅ CI Status: All checks passed" >> $GITHUB_STEP_SUMMARY
+              ;;
+            failure)
+              echo "❌ CI Status: Some checks failed" >> $GITHUB_STEP_SUMMARY
+              exit 1
+              ;;
+            still_running)
+              echo "⏳ CI Status: Checks still running" >> $GITHUB_STEP_SUMMARY
+              ;;
+            no_checks)
+              echo "⚠️ CI Status: No checks found" >> $GITHUB_STEP_SUMMARY
+              ;;
+          esac

--- a/.github/workflows/velox-advance-pr-create.yml
+++ b/.github/workflows/velox-advance-pr-create.yml
@@ -29,6 +29,7 @@ env:
   RUN_AI_FIX: ${{ github.event.inputs.ai_fix == 'true' }}
   GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
   GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
+  DEPENDENCY_IMAGE_TAG: ${{ vars.DEPENDENCY_IMAGE_TAG || '0.297-202602271419-160459b8' }}
 
 jobs:
   create-pr:
@@ -337,9 +338,9 @@ jobs:
   ai-fix:
     needs: create-pr
     if: needs.create-pr.outputs.pr_created == 'true' || github.event.inputs.ai_fix == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
-      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+      image: prestodb/presto-native-dependency:${{ env.DEPENDENCY_IMAGE_TAG }}
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       CMAKE_BUILD_OPTIONS: |

--- a/.github/workflows/velox-advance-pr-create.yml
+++ b/.github/workflows/velox-advance-pr-create.yml
@@ -1,0 +1,445 @@
+name: Advance velox PR create
+
+on:
+  schedule:
+    # yamllint disable-line rule:quoted-strings
+    - cron: '0 9 * * *' # Daily at 09:00 UTC
+  workflow_dispatch:
+    inputs:
+      close_pr:
+        description: Close existing PR
+        required: false
+        default: false
+        type: boolean
+      ai_fix:
+        description: Force run AI fix
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  NOTIFICATION_GROUP: ${{ vars.VELOX_UPDATE_NOTIFICATION_GROUP || '@prestodb/team-velox' }}
+  BASE_BRANCH: ${{ github.event_name == 'schedule' && 'master' || github.ref_name }}
+  VELOX_UPDATE_BRANCH: velox-update
+  CREATE_NEW_PR: ${{ github.event.inputs.close_pr == 'true' }}
+  RUN_AI_FIX: ${{ github.event.inputs.ai_fix == 'true' }}
+  GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
+  GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_created: ${{ steps.create_pr.outputs.pr_number != '' }}
+      pr_number: ${{ steps.create_pr.outputs.pr_number }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.PRESTODB_CI_TOKEN }}
+          ref: ${{ env.BASE_BRANCH }}
+          persist-credentials: false
+
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check existing PR
+        id: check_pr
+        env:
+          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+        run: |
+          # Check if PR already exists for this branch
+          EXISTING_PR=$(gh pr list --head "${{ env.VELOX_UPDATE_BRANCH }}" --base "${{ env.BASE_BRANCH }}" --state open --json number,url --jq '.[0]')
+
+          if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+            echo "PR_EXISTS=true" >> $GITHUB_ENV
+            echo "pr_number=$(echo "$EXISTING_PR" | jq -r '.number')" >> $GITHUB_OUTPUT
+            echo "pr_url=$(echo "$EXISTING_PR" | jq -r '.url')" >> $GITHUB_OUTPUT
+            echo "Found existing PR: $(echo "$EXISTING_PR" | jq -r '.url')"
+          else
+            echo "PR_EXISTS=false" >> $GITHUB_ENV
+            echo "No existing PR found"
+          fi
+
+      - name: Close existing PR
+        if: env.PR_EXISTS == 'true' && env.CREATE_NEW_PR == 'true'
+        id: close_pr
+        env:
+          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+        run: |
+          # Close existing PR when creating a new one (will add comment with new PR link later)
+          gh pr close ${{ steps.check_pr.outputs.pr_number }}
+          echo "closed_pr_number=${{ steps.check_pr.outputs.pr_number }}" >> $GITHUB_OUTPUT
+          echo "PR_EXISTS=false" >> $GITHUB_ENV
+          echo "Closed existing PR #${{ steps.check_pr.outputs.pr_number }}"
+
+      - name: Check Velox changes
+        id: check_new_changes
+        run: |
+          # Get current and latest velox commits
+          cd presto-native-execution/velox
+
+          # Fetch latest from velox main branch
+          git fetch origin main
+          LATEST_COMMIT=$(git rev-parse origin/main)
+
+          # Get latest commit details
+          echo "latest_commit=$LATEST_COMMIT" >> $GITHUB_OUTPUT
+          echo "latest_commit_short=$(git rev-parse --short $LATEST_COMMIT)" >> $GITHUB_OUTPUT
+          echo "latest_date=$(git show -s --format=%ci $LATEST_COMMIT | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "latest_title=$(git show -s --format=%s $LATEST_COMMIT)" >> $GITHUB_OUTPUT
+
+          # Only check for new changes if PR exists and we're not creating a new one
+          if [ "${{ env.PR_EXISTS }}" = "true" ]; then
+            # Get current commit from PR branch (fetch from main presto repo)
+            cd ../..
+            if git fetch origin "${{ env.VELOX_UPDATE_BRANCH }}" 2>/dev/null; then
+              CURRENT_COMMIT=$(git ls-tree "origin/${{ env.VELOX_UPDATE_BRANCH }}" presto-native-execution/velox | awk '{print $3}')
+              echo "Using velox commit from PR branch"
+            else
+              CURRENT_COMMIT=$(git -C presto-native-execution/velox rev-parse HEAD)
+              echo "PR branch not found, using base branch's velox commit"
+            fi
+            cd presto-native-execution/velox
+
+            # Get current commit details
+            echo "current_commit=$CURRENT_COMMIT" >> $GITHUB_OUTPUT
+            echo "current_commit_short=$(git rev-parse --short $CURRENT_COMMIT)" >> $GITHUB_OUTPUT
+            echo "current_date=$(git show -s --format=%ci $CURRENT_COMMIT | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+            echo "current_title=$(git show -s --format=%s $CURRENT_COMMIT)" >> $GITHUB_OUTPUT
+
+            # Check if new changes are available
+            if [ "$CURRENT_COMMIT" != "$LATEST_COMMIT" ]; then
+              echo "new_changes_available=true" >> $GITHUB_OUTPUT
+              echo "New Velox changes available"
+            else
+              echo "new_changes_available=false" >> $GITHUB_OUTPUT
+              echo "Velox is up to date"
+            fi
+          else
+            # When creating new PR or no PR exists, don't check for changes
+            echo "new_changes_available=false" >> $GITHUB_OUTPUT
+            echo "Will create PR with latest velox commit"
+          fi
+
+      - name: Notify new changes
+        if: steps.check_new_changes.outputs.new_changes_available == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+          CURRENT_COMMIT: ${{ steps.check_new_changes.outputs.current_commit }}
+          CURRENT_COMMIT_SHORT: ${{ steps.check_new_changes.outputs.current_commit_short }}
+          CURRENT_DATE: ${{ steps.check_new_changes.outputs.current_date }}
+          CURRENT_TITLE: ${{ steps.check_new_changes.outputs.current_title }}
+          LATEST_COMMIT: ${{ steps.check_new_changes.outputs.latest_commit }}
+          LATEST_COMMIT_SHORT: ${{ steps.check_new_changes.outputs.latest_commit_short }}
+          LATEST_DATE: ${{ steps.check_new_changes.outputs.latest_date }}
+          LATEST_TITLE: ${{ steps.check_new_changes.outputs.latest_title }}
+        run: |
+          # Notify about new changes without creating a new PR
+          # Note: pr_number is only set when a PR was found and not closed
+          VELOX_REPO="https://github.com/facebookincubator/velox"
+
+          gh pr comment ${{ steps.check_pr.outputs.pr_number }} --body "🔔 **New Velox Changes Available**
+
+          New changes are available in the Velox repository:
+
+          - **Current commit:** \`$CURRENT_COMMIT_SHORT\` $CURRENT_DATE [$CURRENT_TITLE]($VELOX_REPO/commits/$CURRENT_COMMIT)
+          - **Latest commit:** \`$LATEST_COMMIT_SHORT\` $LATEST_DATE [$LATEST_TITLE]($VELOX_REPO/commits/$LATEST_COMMIT)
+
+          ${{ env.NOTIFICATION_GROUP }} To create a new PR with the latest changes, re-run this workflow with \`close_pr: true\`."
+
+      - name: Create PR
+        if: env.PR_EXISTS != 'true'
+        id: create_pr
+        env:
+          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+          LATEST_COMMIT: ${{ steps.check_new_changes.outputs.latest_commit }}
+          LATEST_COMMIT_SHORT: ${{ steps.check_new_changes.outputs.latest_commit_short }}
+          LATEST_DATE: ${{ steps.check_new_changes.outputs.latest_date }}
+          LATEST_TITLE: ${{ steps.check_new_changes.outputs.latest_title }}
+        run: |
+          # Update velox submodule to latest
+          git -C presto-native-execution/velox checkout main
+          git -C presto-native-execution/velox pull
+
+          # Check if there are actual changes
+          if git diff --quiet presto-native-execution/velox; then
+            echo "No changes detected in Velox submodule" >> $GITHUB_STEP_SUMMARY
+            echo "No changes detected in Velox submodule"
+            exit 0
+          fi
+
+          # Push changes to branch
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git switch -C "${{ env.VELOX_UPDATE_BRANCH }}"
+          git add presto-native-execution/velox
+          git commit -m "chore(ci): Advance velox ($(date +'%Y-%m-%d'))"
+          git push -f origin "${{ env.VELOX_UPDATE_BRANCH }}"
+
+          # Create new PR
+          PR_TITLE="chore(ci): Advance velox ($(date +'%Y-%m-%d'))"
+          VELOX_REPO="https://github.com/facebookincubator/velox"
+
+          cat > /tmp/pr_body.txt <<EOF
+          **Velox Update Information:**
+          - **Commit:** \`$LATEST_COMMIT_SHORT\` $LATEST_DATE [$LATEST_TITLE]($VELOX_REPO/commits/$LATEST_COMMIT)
+
+          ---
+
+          \`\`\`
+          == NO RELEASE NOTE ==
+          \`\`\`
+
+          ## Summary by Sourcery
+
+          Chores:
+          - Update the Velox dependency reference under presto-native-execution to the latest desired commit.
+          EOF
+
+          PR_URL=$(gh pr create --title "$PR_TITLE" --body-file /tmp/pr_body.txt --base "${{ env.BASE_BRANCH }}" --head "${{ env.VELOX_UPDATE_BRANCH }}")
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "Created new PR #$PR_NUMBER: $PR_URL"
+
+      - name: Link PRs
+        if: steps.close_pr.outputs.closed_pr_number != '' && steps.create_pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+        run: |
+          # Add comment to closed PR with link to new PR
+          gh pr comment ${{ steps.close_pr.outputs.closed_pr_number }} --body "Closed in favor of new PR #${{ steps.create_pr.outputs.pr_number }}"
+          echo "Added link to new PR #${{ steps.create_pr.outputs.pr_number }} on closed PR #${{ steps.close_pr.outputs.closed_pr_number }}"
+
+      - name: Summary
+        if: always()
+        env:
+          CURRENT_COMMIT: ${{ steps.check_new_changes.outputs.current_commit }}
+          CURRENT_COMMIT_SHORT: ${{ steps.check_new_changes.outputs.current_commit_short }}
+          CURRENT_DATE: ${{ steps.check_new_changes.outputs.current_date }}
+          CURRENT_TITLE: ${{ steps.check_new_changes.outputs.current_title }}
+          LATEST_COMMIT: ${{ steps.check_new_changes.outputs.latest_commit }}
+          LATEST_COMMIT_SHORT: ${{ steps.check_new_changes.outputs.latest_commit_short }}
+          LATEST_DATE: ${{ steps.check_new_changes.outputs.latest_date }}
+          LATEST_TITLE: ${{ steps.check_new_changes.outputs.latest_title }}
+        run: |
+          # Generate job summary
+          VELOX_REPO="https://github.com/facebookincubator/velox"
+          echo "## Create PR Job Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ env.PR_EXISTS }}" = "true" ]; then
+            # Existing PR found, not creating new one
+            echo "ℹ️ Existing PR found" >> $GITHUB_STEP_SUMMARY
+            echo "📝 Pull Request: ${{ steps.check_pr.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            if [ "${{ steps.check_new_changes.outputs.new_changes_available }}" = "true" ]; then
+              echo "🔔 **New Velox changes available:**" >> $GITHUB_STEP_SUMMARY
+              echo "- **Current commit:** \`$CURRENT_COMMIT_SHORT\` $CURRENT_DATE [$CURRENT_TITLE]($VELOX_REPO/commits/$CURRENT_COMMIT)" >> $GITHUB_STEP_SUMMARY
+              echo "- **Latest commit:** \`$LATEST_COMMIT_SHORT\` $LATEST_DATE [$LATEST_TITLE]($VELOX_REPO/commits/$LATEST_COMMIT)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "💡 Re-run with \`close_pr: true\` to create a new PR" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "✅ Velox is up to date at commit: \`$CURRENT_COMMIT_SHORT\` $CURRENT_DATE [$CURRENT_TITLE]($VELOX_REPO/commits/$CURRENT_COMMIT)" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            # PR was closed or no PR existed, new PR created
+            echo "✅ Velox submodule updated to commit: \`$LATEST_COMMIT_SHORT\` $LATEST_DATE [$LATEST_TITLE]($VELOX_REPO/commits/$LATEST_COMMIT)" >> $GITHUB_STEP_SUMMARY
+
+            if [ -n "${{ steps.close_pr.outputs.closed_pr_number }}" ]; then
+              echo "🔄 Closed PR #${{ steps.close_pr.outputs.closed_pr_number }}" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            echo "📝 Pull Request: ${{ steps.create_pr.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  ai-fix:
+    needs: create-pr
+    if: needs.create-pr.outputs.pr_created == 'true' || github.event.inputs.ai_fix == 'true'
+    runs-on: ubuntu-22.04
+    container:
+      image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CMAKE_BUILD_OPTIONS: |
+        -B _build/release
+        -GNinja
+        -DTREAT_WARNINGS_AS_ERRORS=1
+        -DENABLE_ALL_WARNINGS=1
+        -DCMAKE_BUILD_TYPE=Release
+        -DPRESTO_ENABLE_TESTING=ON
+        -DPRESTO_ENABLE_REMOTE_FUNCTIONS=ON
+        -DPRESTO_ENABLE_JWT=ON
+        -DPRESTO_STATS_REPORTER_TYPE=PROMETHEUS
+        -DPRESTO_MEMORY_CHECKER_TYPE=LINUX_MEMORY_CHECKER
+        -DCMAKE_PREFIX_PATH=/usr/local
+        -DThrift_ROOT=/usr/local
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        -DMAX_LINK_JOBS=4
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout velox-update branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.VELOX_UPDATE_BRANCH }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Setup Git
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          git config --global user.email "${{ env.GIT_CI_EMAIL }}"
+          git config --global user.name "${{ env.GIT_CI_USER }}"
+
+      - name: Update velox
+        run: |
+          cd presto-native-execution
+          make velox-submodule
+
+      - name: Install Github CLI
+        run: |
+          curl -L https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.rpm > gh_2.63.2_linux_amd64.rpm
+          rpm -iv gh_2.63.2_linux_amd64.rpm
+          rm -f gh_2.63.2_linux_amd64.rpm
+
+      - name: Restore ccache
+        uses: apache/infrastructure-actions/stash/restore@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-velox-advance-pr-ai-fix
+
+      - name: Zero ccache statistics
+        run: ccache -sz
+
+      - name: Try build engine
+        id: build
+        continue-on-error: true
+        run: |
+          source /opt/rh/gcc-toolset-12/enable
+          cd presto-native-execution
+
+          # Capture both stdout and stderr to build log
+          {
+            cmake $CMAKE_BUILD_OPTIONS 2>&1
+            ninja -C _build/release -j 4 2>&1
+          } | tee ${GITHUB_WORKSPACE}/build_errors.log
+
+          # Return the actual exit code
+          exit ${PIPESTATUS[0]}
+
+      - name: Ccache after build
+        run: ccache -s
+
+      - name: Save ccache
+        uses: apache/infrastructure-actions/stash/save@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-velox-advance-pr-ai-fix
+
+      - name: Install OpenCode and fix build issues
+        if: steps.build.outcome == 'failure'
+        env:
+          OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: 7200000 # 2 hours timeout for build commands
+        run: |
+          # Install OpenCode
+          curl -fsSL https://opencode.ai/install | bash
+
+          # Create OpenCode config directory
+          mkdir -p $HOME/.config/opencode
+
+          # Create OpenCode config file
+          cat > $HOME/.config/opencode/opencode.json <<'EOF'
+          {
+            "$schema": "https://opencode.ai/config.json",
+            "permission": "allow"
+          }
+          EOF
+
+          # Source OpenCode to make it available in PATH
+          export PATH="$HOME/.opencode/bin:$PATH"
+
+          # Enable gcc-toolset-12 for OpenCode to use
+          source /opt/rh/gcc-toolset-12/enable
+
+          # Extract last 200 lines of build errors for context
+          tail -n 200 ${GITHUB_WORKSPACE}/build_errors.log > ${GITHUB_WORKSPACE}/build_errors_summary.log
+
+          # Run OpenCode to fix build issues with error context
+          opencode run "Fix the build issues in presto-native-execution. Build errors are in build_errors_summary.log.
+
+          Requirements:
+          1. Do NOT modify the velox submodule (presto-native-execution/velox directory)
+          2. Only fix issues in presto-native-execution code outside velox
+          3. After fixing, create a git commit with your changes
+          4. Generate a summary file ADVANCE_VELOX_FIX.md in presto-native-execution describing:
+             - What issues were found
+             - What changes were made to fix them
+             - Any important notes about the fixes
+          5. Do NOT commit the ADVANCE_VELOX_FIX.md file
+          6. Before fix, investigate recent velox git history
+
+          Build and verify command(stash the changes in velox and then build):
+          cd presto-native-execution/velox && git stash
+          cd ..
+          cmake $CMAKE_BUILD_OPTIONS
+          ninja -C _build/release -j 4
+          "
+
+      - name: Push fixes to velox-update branch
+        if: steps.build.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin ${{ env.VELOX_UPDATE_BRANCH }} || echo "No changes to push"
+
+      - name: Verify build after fix
+        if: steps.build.outcome == 'failure'
+        run: |
+          source /opt/rh/gcc-toolset-12/enable
+          cd presto-native-execution
+          # make sure all changes only in presto
+          (cd velox && git stash)
+          cmake $CMAKE_BUILD_OPTIONS
+          ninja -C _build/release -j 4
+
+      - name: Post fix summary to PR
+        if: steps.build.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f presto-native-execution/ADVANCE_VELOX_FIX.md ]; then
+            gh pr comment ${{ needs.create-pr.outputs.pr_number }} --body-file presto-native-execution/ADVANCE_VELOX_FIX.md
+          else
+            echo "No fix summary file found"
+          fi
+
+      - name: AI Fix Summary
+        if: always()
+        run: |
+          echo "## AI Fix Job Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            echo "✅ Build succeeded on first attempt - no fixes needed" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.build.outcome }}" = "failure" ]; then
+            echo "🔧 Build failed initially - OpenCode AI attempted to fix the issues" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Check the 'Verify build after fix' step to see if the fixes were successful" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/velox-advance-pr-create.yml
+++ b/.github/workflows/velox-advance-pr-create.yml
@@ -6,8 +6,8 @@ on:
     - cron: '0 9 * * *' # Daily at 09:00 UTC
   workflow_dispatch:
     inputs:
-      close_pr:
-        description: Close existing PR
+      rebase_pr:
+        description: Rebase existing PR on master and update velox
         required: false
         default: false
         type: boolean
@@ -25,7 +25,7 @@ env:
   NOTIFICATION_GROUP: ${{ vars.VELOX_UPDATE_NOTIFICATION_GROUP || '@prestodb/team-velox' }}
   BASE_BRANCH: ${{ github.event_name == 'schedule' && 'master' || github.ref_name }}
   VELOX_UPDATE_BRANCH: velox-update
-  CREATE_NEW_PR: ${{ github.event.inputs.close_pr == 'true' }}
+  REBASE_PR: ${{ github.event.inputs.rebase_pr == 'true' }}
   RUN_AI_FIX: ${{ github.event.inputs.ai_fix == 'true' }}
   GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
   GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
@@ -71,17 +71,85 @@ jobs:
             echo "No existing PR found"
           fi
 
-      - name: Close existing PR
-        if: env.PR_EXISTS == 'true' && env.CREATE_NEW_PR == 'true'
-        id: close_pr
+      - name: Validate PR exists for rebase
+        if: env.REBASE_PR == 'true'
+        run: |
+          if [ "${{ env.PR_EXISTS }}" != "true" ]; then
+            echo "❌ Error: rebase_pr is enabled but no existing PR found"
+            echo "Cannot update PR - no PR exists for branch ${{ env.VELOX_UPDATE_BRANCH }}"
+            exit 1
+          fi
+          echo "✅ Found existing PR #${{ steps.check_pr.outputs.pr_number }} for update"
+
+      - name: Rebase PR on master
+        if: env.PR_EXISTS == 'true' && env.REBASE_PR == 'true'
+        id: rebase_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+        run: |
+          # Fetch the PR branch
+          git fetch origin "${{ env.VELOX_UPDATE_BRANCH }}"
+          git checkout "${{ env.VELOX_UPDATE_BRANCH }}"
+
+          # Fetch latest master
+          git fetch origin master
+
+          # Try to rebase on master
+          echo "Attempting to rebase ${{ env.VELOX_UPDATE_BRANCH }} on master..."
+          if git rebase origin/master; then
+            echo "✅ Rebase successful without conflicts"
+          else
+            echo "❌ Error: Rebase has conflicts"
+            CONFLICT_FILES=$(git diff --name-only --diff-filter=U)
+            echo "Conflicted files:"
+            echo "$CONFLICT_FILES"
+            git rebase --abort
+            echo ""
+            echo "Please resolve conflicts manually."
+            exit 1
+          fi
+
+          echo "rebase_success=true" >> $GITHUB_OUTPUT
+
+      - name: Update velox submodule
+        if: steps.rebase_pr.outputs.rebase_success == 'true'
+        id: update_velox
         env:
           GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
         run: |
-          # Close existing PR when creating a new one (will add comment with new PR link later)
-          gh pr close ${{ steps.check_pr.outputs.pr_number }}
-          echo "closed_pr_number=${{ steps.check_pr.outputs.pr_number }}" >> $GITHUB_OUTPUT
-          echo "PR_EXISTS=false" >> $GITHUB_ENV
-          echo "Closed existing PR #${{ steps.check_pr.outputs.pr_number }}"
+          # Update velox submodule to latest commit
+          echo "Updating velox submodule to latest commit..."
+          cd presto-native-execution/velox
+          git fetch origin main
+          LATEST_VELOX_COMMIT=$(git rev-parse origin/main)
+          git checkout origin/main
+          cd ../..
+
+          # Commit the velox update
+          git add presto-native-execution/velox
+          if git diff --cached --quiet; then
+            echo "Velox already at latest commit"
+            VELOX_UPDATED=false
+          else
+            git commit -m "chore: Update velox submodule to latest"
+            echo "✅ Velox submodule updated to $LATEST_VELOX_COMMIT"
+            VELOX_UPDATED=true
+          fi
+
+          # Push the updated branch
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git push -f origin "${{ env.VELOX_UPDATE_BRANCH }}"
+
+          echo "updated_pr_number=${{ steps.check_pr.outputs.pr_number }}" >> $GITHUB_OUTPUT
+          echo "velox_updated=$VELOX_UPDATED" >> $GITHUB_OUTPUT
+          echo "✅ Successfully updated PR #${{ steps.check_pr.outputs.pr_number }}"
+
+          # Add comment to PR about the update
+          gh pr comment ${{ steps.check_pr.outputs.pr_number }} --body "🔄 **PR Updated**
+
+          - ✅ Rebased on latest \`master\` branch
+          - $(if [ \"$VELOX_UPDATED\" = \"true\" ]; then echo ✅ Velox submodule updated to latest commit; else echo ℹ️ Velox already at latest commit; fi)"
 
       - name: Check Velox changes
         id: check_new_changes
@@ -156,7 +224,7 @@ jobs:
           - **Current commit:** \`$CURRENT_COMMIT_SHORT\` $CURRENT_DATE [$CURRENT_TITLE]($VELOX_REPO/commits/$CURRENT_COMMIT)
           - **Latest commit:** \`$LATEST_COMMIT_SHORT\` $LATEST_DATE [$LATEST_TITLE]($VELOX_REPO/commits/$LATEST_COMMIT)
 
-          ${{ env.NOTIFICATION_GROUP }} To create a new PR with the latest changes, re-run this workflow with \`close_pr: true\`."
+          ${{ env.NOTIFICATION_GROUP }} To update this PR with the latest changes, re-run this workflow with \`rebase_pr: true\`."
 
       - name: Create PR
         if: env.PR_EXISTS != 'true'
@@ -214,15 +282,6 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "Created new PR #$PR_NUMBER: $PR_URL"
 
-      - name: Link PRs
-        if: steps.close_pr.outputs.closed_pr_number != '' && steps.create_pr.outputs.pr_number != ''
-        env:
-          GH_TOKEN: ${{ secrets.PRESTODB_CI_TOKEN }}
-        run: |
-          # Add comment to closed PR with link to new PR
-          gh pr comment ${{ steps.close_pr.outputs.closed_pr_number }} --body "Closed in favor of new PR #${{ steps.create_pr.outputs.pr_number }}"
-          echo "Added link to new PR #${{ steps.create_pr.outputs.pr_number }} on closed PR #${{ steps.close_pr.outputs.closed_pr_number }}"
-
       - name: Summary
         if: always()
         env:
@@ -240,8 +299,22 @@ jobs:
           echo "## Create PR Job Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          if [ "${{ env.PR_EXISTS }}" = "true" ]; then
-            # Existing PR found, not creating new one
+          if [ "${{ env.REBASE_PR }}" = "true" ]; then
+            # PR was updated with rebase
+            if [ -n "${{ steps.update_velox.outputs.updated_pr_number }}" ]; then
+              echo "✅ PR #${{ steps.update_velox.outputs.updated_pr_number }} updated successfully" >> $GITHUB_STEP_SUMMARY
+              echo "- Rebased on latest master" >> $GITHUB_STEP_SUMMARY
+              if [ "${{ steps.update_velox.outputs.velox_updated }}" = "true" ]; then
+                echo "- Velox submodule updated to latest" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "- Velox already at latest" >> $GITHUB_STEP_SUMMARY
+              fi
+              echo "📝 Pull Request: ${{ steps.check_pr.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "❌ Failed to update PR" >> $GITHUB_STEP_SUMMARY
+            fi
+          elif [ "${{ env.PR_EXISTS }}" = "true" ]; then
+            # Existing PR found, not updating
             echo "ℹ️ Existing PR found" >> $GITHUB_STEP_SUMMARY
             echo "📝 Pull Request: ${{ steps.check_pr.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -251,18 +324,13 @@ jobs:
               echo "- **Current commit:** \`$CURRENT_COMMIT_SHORT\` $CURRENT_DATE [$CURRENT_TITLE]($VELOX_REPO/commits/$CURRENT_COMMIT)" >> $GITHUB_STEP_SUMMARY
               echo "- **Latest commit:** \`$LATEST_COMMIT_SHORT\` $LATEST_DATE [$LATEST_TITLE]($VELOX_REPO/commits/$LATEST_COMMIT)" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "💡 Re-run with \`close_pr: true\` to create a new PR" >> $GITHUB_STEP_SUMMARY
+              echo "💡 Re-run with \`rebase_pr: true\` to update the PR" >> $GITHUB_STEP_SUMMARY
             else
               echo "✅ Velox is up to date at commit: \`$CURRENT_COMMIT_SHORT\` $CURRENT_DATE [$CURRENT_TITLE]($VELOX_REPO/commits/$CURRENT_COMMIT)" >> $GITHUB_STEP_SUMMARY
             fi
           else
-            # PR was closed or no PR existed, new PR created
+            # No PR existed, new PR created
             echo "✅ Velox submodule updated to commit: \`$LATEST_COMMIT_SHORT\` $LATEST_DATE [$LATEST_TITLE]($VELOX_REPO/commits/$LATEST_COMMIT)" >> $GITHUB_STEP_SUMMARY
-
-            if [ -n "${{ steps.close_pr.outputs.closed_pr_number }}" ]; then
-              echo "🔄 Closed PR #${{ steps.close_pr.outputs.closed_pr_number }}" >> $GITHUB_STEP_SUMMARY
-            fi
-
             echo "📝 Pull Request: ${{ steps.create_pr.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
           fi
 

--- a/.github/workflows/velox-advance-pr-create.yml
+++ b/.github/workflows/velox-advance-pr-create.yml
@@ -29,7 +29,6 @@ env:
   RUN_AI_FIX: ${{ github.event.inputs.ai_fix == 'true' }}
   GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
   GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
-  DEPENDENCY_IMAGE_TAG: ${{ vars.DEPENDENCY_IMAGE_TAG || '0.297-202602271419-160459b8' }}
 
 jobs:
   create-pr:
@@ -340,7 +339,7 @@ jobs:
     if: needs.create-pr.outputs.pr_created == 'true' || github.event.inputs.ai_fix == 'true'
     runs-on: ubuntu-latest
     container:
-      image: prestodb/presto-native-dependency:${{ env.DEPENDENCY_IMAGE_TAG }}
+      image: prestodb/presto-native-dependency:${{ vars.DEPENDENCY_IMAGE_TAG || '0.297-202602271419-160459b8' }}
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       CMAKE_BUILD_OPTIONS: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,3 +2,8 @@ rules:
   dangerous-triggers:
     ignore:
       - codenotify.yml
+      - velox-advance-pr-check.yml
+  template-injection:
+    ignore:
+      - velox-advance-pr-create.yml
+      - velox-advance-pr-check.yml

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ presto-native-execution/deps-install
 /docker/presto-cli-*-executable.jar
 /docker/presto-server-*.tar.gz
 /docker/presto-function-server-executable.jar
+
+# CI Ignored files
+*.log
+.ccache

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -345,8 +345,8 @@ Presto maintains automated GitHub Actions workflows that run daily to keep Velox
 **How It Works:**
 - **Daily Schedule**: Runs automatically at 09:00 UTC
 - **Auto-creates PR**: Creates a PR on the `velox-update` branch with the latest Velox changes
-- **CI Monitoring**: Automatically monitors CI status and notifies [@prestodb/team-velox](https://github.com/orgs/prestodb/teams/team-velox) when checks pass or fail
-- **Team Notification**: Alerts the team when new Velox changes are available
+- **Change Detection**: If a PR already exists, checks for new Velox changes and notifies the team
+- **AI Auto-fix**: Newly created PRs automatically run AI-powered build fixes (if needed)
 
 **How to Use:**
 
@@ -356,9 +356,9 @@ Presto maintains automated GitHub Actions workflows that run daily to keep Velox
    - Go to [Actions → "Advance velox PR create"](https://github.com/prestodb/presto/actions/workflows/velox-advance-pr-create.yml)
    - Click "Run workflow"
    - Options:
-     - Default: Checks for new changes and notifies if available
-     - `close_pr: true`: Forces creation of a new PR with latest changes
-     - `ai_fix: true`: Forces AI-powered build fix to run after PR creation (automatically runs on scheduled PRs)
+     - Default behavior: Checks for new changes and notifies team if available
+     - `rebase_pr: true`: Rebases existing PR on latest master and updates Velox submodule
+     - `ai_fix: true`: Forces AI-powered build fix to run (automatically runs for scheduled PRs)
 
 3. **Review and merge**: Once CI passes (you'll receive a notification), review and merge the PR
 

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -352,7 +352,7 @@ Presto maintains automated GitHub Actions workflows that run daily to keep Velox
 
 1. **Check for existing PR**: Look for an open PR with title `chore(ci): Advance velox <date>`
 
-2. **Manually trigger workflow** (if needed):
+2. **Manually trigger workflow**
    - Go to [Actions → "Advance velox PR create"](https://github.com/prestodb/presto/actions/workflows/velox-advance-pr-create.yml)
    - Click "Run workflow"
    - Options:

--- a/presto-native-execution/README.md
+++ b/presto-native-execution/README.md
@@ -321,12 +321,48 @@ can be run manually for optional checks using `pre-commit run --hook-stage manua
 * PRs that only change files in `presto-native-execution` should be approved by a Code Owner ([team-velox](https://github.com/orgs/prestodb/teams/team-velox)) to have merging enabled.
 
 ## Advance Velox Version
-For Prestissimo to use a newer Velox version from the Presto repository root:
-* `git -C presto-native-execution/velox checkout main`
-* `git -C presto-native-execution/velox pull`
-* `git add presto-native-execution/velox`
-* Build and run tests (including E2E) to ensure everything works.
-* Submit a PR, get it approved and merged.
+
+Prestissimo uses Velox as a submodule. There are two ways to advance the Velox version:
+
+### 1. Manual Advance (For Immediate Updates)
+
+Use this method when you need to advance Velox immediately or to a specific commit.
+
+**Steps:**
+1. Update the Velox submodule:
+   ```bash
+   git -C presto-native-execution/velox checkout main
+   git -C presto-native-execution/velox pull
+   git add presto-native-execution/velox
+   ```
+2. Build and run tests (including E2E) to ensure everything works
+3. Submit a PR, get it approved and merged
+
+### 2. Automated Advance (Scheduled Workflow)
+
+Presto maintains automated GitHub Actions workflows that run daily to keep Velox up to date.
+
+**How It Works:**
+- **Daily Schedule**: Runs automatically at 09:00 UTC
+- **Auto-creates PR**: Creates a PR on the `velox-update` branch with the latest Velox changes
+- **CI Monitoring**: Automatically monitors CI status and notifies [@prestodb/team-velox](https://github.com/orgs/prestodb/teams/team-velox) when checks pass or fail
+- **Team Notification**: Alerts the team when new Velox changes are available
+
+**How to Use:**
+
+1. **Check for existing PR**: Look for an open PR with title `chore(ci): Advance velox <date>`
+
+2. **Manually trigger workflow** (if needed):
+   - Go to [Actions → "Advance velox PR create"](https://github.com/prestodb/presto/actions/workflows/velox-advance-pr-create.yml)
+   - Click "Run workflow"
+   - Options:
+     - Default: Checks for new changes and notifies if available
+     - `close_pr: true`: Forces creation of a new PR with latest changes
+     - `ai_fix: true`: Forces AI-powered build fix to run after PR creation (automatically runs on scheduled PRs)
+
+3. **Review and merge**: Once CI passes (you'll receive a notification), review and merge the PR
+
+**Notification Group**: By default, [@prestodb/team-velox](https://github.com/orgs/prestodb/teams/team-velox) is notified. This can be customized via the `VELOX_UPDATE_NOTIFICATION_GROUP` repository variable.
 
 ## Functional test using containers
 To build container images and do functional tests, see [Prestissimo: Functional Testing Using Containers](testcontainers/README.md).


### PR DESCRIPTION
## Description

Added 2 github actions to create PR and monitor the CI status. For each iteration, it will run velox-advance-pr-create once(around 4-5 minutes if created, or about 30 seconds if PR exists), and velox-advance-pr-check 5 times(within 30 seconds), It helps prevent the action queue from being blocked.

### 1. velox-advance-pr-create.yml

Creates and manages Velox advance PRs.

#### Triggers

- **Scheduled Run (Daily)**: Runs automatically every day at 09:00 UTC
- **Manual Run**: Triggered via `workflow_dispatch`

#### Manual Run Options

##### `close_pr` Parameter (default: `false`)

- **`false` (Default Mode)**:
  - If PR exists: Checks for new Velox changes and notifies if available
  - If no PR exists: Creates a new PR with latest Velox changes
  
- **`true` (Close & Recreate Mode)**:
  - Closes existing PR (if any)
  - Creates a new PR with latest Velox changes
  - Links the closed PR to the new PR

#### Behavior Details

- **Scheduled Run**:
  - Uses `master` as the base branch
  - Automatically closes existing PR and creates new one
- **Manual Run**:
  - Uses the current branch as base branch
  - Respects the `close_pr` parameter setting
- Updates Velox submodule to latest commit from `main` branch
- Notifies `@prestodb/team-velox` when new changes are available on existing PR
- Uses environment variables (`GITHUB_ENV`) for state management across steps

#### Workflow Steps

1. **Checkout**: Checks out repository with submodules
2. **Setup Git**: Configures git user for commits
3. **Check existing PR**: Looks for open PR on `velox-update` branch
4. **Close existing PR**: Closes PR if `close_pr` is true (scheduled runs always close)
5. **Check Velox changes**: Compares current and latest Velox commits
6. **Notify new changes**: Comments on existing PR if new changes available
7. **Update & create PR**: Updates submodule and creates/updates PR
8. **Link PRs**: Adds comment linking closed PR to new PR
9. **Summary**: Generates job summary with PR status and commit info

---

### 2. velox-advance-pr-check.yml

Checks PR CI status and notifies the team.

#### Triggers

- **Workflow Run**: Triggers when the following workflows complete on `velox-update` branch:
  - `test`
  - `prestocpp-linux-build`
  - `prestocpp-linux-build-and-unit-test`
  - `arrow flight tests`
  - `prestocpp-macos-build`
- **Manual Trigger**: Via `workflow_dispatch`

#### Behavior

- Finds the PR associated with `velox-update` branch
- Monitors CI check status for the PR
- Posts comment to notify `@prestodb/team-velox` when:
  - **CI passes**: "✅ CI Checks Passed - This PR is ready for review"
  - **CI fails**: "❌ CI Checks Failed - Please review the failed checks"
- Handles various CI states:
  - `still_running`: Checks are in progress
  - `no_checks`: No CI checks found
  - `success`: All checks passed
  - `failure`: Some checks failed

#### Workflow Steps

1. **Checkout**: Checks out the `velox-update` branch
2. **Get PR info**: Retrieves PR number and URL
3. **Check CI status**: Monitors CI check states
4. **Notify CI result**: Posts comment based on CI outcome
5. **Summary**: Generates job summary with CI status

---

### Notification Group

Both workflows use the `NOTIFICATION_GROUP` environment variable:
- Default: `@prestodb/team-velox`
- Can be overridden via repository variable `VELOX_UPDATE_NOTIFICATION_GROUP`


## Motivation and Context
https://github.com/prestodb/presto/issues/24976

## Impact
CI

## Test Plan

1. Advance velox PR: https://github.com/unix280/presto/pull/58
2. Check action(result): https://github.com/unix280/presto/actions/runs/24110845597
3. Check action(in progress): https://github.com/unix280/presto/actions/runs/24107802043
4. Create action(PR exists): https://github.com/unix280/presto/actions/runs/24104591282
5. Create action(Close old one): https://github.com/unix280/presto/actions/runs/24104544455

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add a GitHub Actions workflow to automatically advance the Velox submodule and manage its update PR lifecycle.

New Features:
- Introduce a scheduled and manually-triggerable workflow to update the Velox submodule and open or refresh a dedicated update pull request.

Enhancements:
- Automate detection of new Velox commits, PR creation or update, and force-advance behavior via a configurable branch and inputs.
- Add notification comments and job summary output describing Velox changes and CI outcomes for the update PR.
- Integrate CI monitoring for the Velox update PR, reporting pass, failure, or timeout back to the PR and workflow summary.

CI:
- Add a "Advance velox" GitHub Actions workflow that maintains a velox-update branch, manages Velox submodule updates, and tracks CI status for the corresponding PR.

## Summary by Sourcery

Add a GitHub Actions workflow to automatically advance the Velox submodule and manage its update PR lifecycle.

New Features:
- Introduce a scheduled and manually-triggerable GitHub Actions workflow to update the Velox submodule and maintain a dedicated update branch and pull request.

Enhancements:
- Automate detection of new Velox commits and creation or update of the Velox advance pull request, including optional force-advance behavior.
- Add PR commenting and step-summary notifications that describe available Velox changes and the current CI outcome for the advance PR.
- Continuously monitor CI status for the Velox update PR and report success, failure, or timeout back to the PR and workflow summary.

CI:
- Configure an "Advance velox" CI workflow that runs daily and on demand to keep the Velox submodule up to date and its update PR’s CI status tracked.

## Summary by Sourcery

Add GitHub Actions workflows to automatically advance the Velox submodule via a dedicated update branch and manage the lifecycle and CI status of its corresponding pull request.

New Features:
- Introduce a scheduled and manually-triggerable workflow to update the Velox submodule, maintain a velox-update branch, and open or refresh the associated pull request.
- Add a workflow that tracks CI completion for the Velox update pull request and posts status notifications to the team.

CI:
- Configure workflows to run on a daily schedule, workflow_dispatch, and on completion of key CI pipelines for the velox-update branch, including concurrency control.
- Integrate automated PR comments and job summaries reporting Velox commit details and CI outcomes for the Velox advance pull request.

Chores:
- Update zizmor configuration to ignore the new Velox advance workflows for specific rules.