### PR TITLE
docs(native): Add missing native session properties

### DIFF
--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -45,6 +45,27 @@ that a final aggregation operation can utilize before it starts spilling to disk
 If set to ``0``, there is no limit, allowing the aggregation to consume unlimited memory resources,
 which may impact system performance.
 
+``native_max_partial_aggregation_memory``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``16777216``
+
+Native Execution only. Defines the maximum memory used by partial aggregation when data reduction is not optimal.
+Default is 16MB.
+
+``native_max_extended_partial_aggregation_memory``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``67108864``
+
+Native Execution only. The maximum partial aggregation memory when data reduction is optimal.
+When good data reduction is achieved through partial aggregation, more memory would be given even
+when we reach the limit of ``native_max_partial_aggregation_memory``.
+Default is 64MB.
+
+
 ``native_debug_validate_output_from_operators``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -155,6 +176,15 @@ A value of ``0`` indicates no limit, permitting the join operation to use unlimi
 Native Execution only. Specifies the number of bits (N)
 used to calculate the spilling partition number for hash join and RowNumber operations.
 The partition number is determined as ``2`` raised to the power of N, defining how data is partitioned during the spill process.
+
+``native_max_spill_bytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``107374182400``
+
+Native Execution only. The maximum allowed spill bytes.
+Default is 100GB.
 
 ``native_max_spill_file_size``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR adds missing documentation for three session properties introduced in PR #26389, as requested in Issue #26401.

Properties Added:

native_max_partial_aggregation_memory
native_max_extended_partial_aggregation_memory
native_max_spill_bytes

Resolves #26401 

## Motivation and Context

## Impact
There is no performance impact


## Test Plan


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Documentation:
- Add documentation entries for the native_max_partial_aggregation_memory, native_max_extended_partial_aggregation_memory, and native_max_spill_bytes session properties in the Presto C++ session properties reference.