### PR TITLE
fix(connector): Skip floating-point MAP key subfield extraction

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -70,6 +70,11 @@ public final class TypeUtils
         return type.equals(DOUBLE) || type.equals(REAL);
     }
 
+    public static boolean hasFloatingPointMapKey(Type type)
+    {
+        return type instanceof MapType && isApproximateNumericType(((MapType) type).getKeyType());
+    }
+
     public static boolean isEnumType(Type type)
     {
         return type instanceof EnumType || type instanceof TypeWithName && ((TypeWithName) type).getType() instanceof EnumType;

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
@@ -39,7 +39,9 @@ import java.util.Optional;
 
 import static com.facebook.presto.common.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isRangeFiltersOnSubscriptsEnabled;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
@@ -96,6 +98,16 @@ public final class SubfieldExtractor
         return subfield.isPresent() && subfield.get().getPath().stream().anyMatch(Subfield.PathElement::isSubscript);
     }
 
+    private static boolean hasFloatingPointMapKey(Type type)
+    {
+        return type instanceof MapType && isFloatingPointType(((MapType) type).getKeyType());
+    }
+
+    private static boolean isFloatingPointType(Type type)
+    {
+        return type.equals(DOUBLE) || type.equals(REAL);
+    }
+
     public Optional<Subfield> extract(RowExpression expression)
     {
         return toSubfield(expression, functionResolution, expressionOptimizer, connectorSession);
@@ -148,6 +160,9 @@ public final class SubfieldExtractor
                 if (indexExpression instanceof ConstantExpression) {
                     Object index = ((ConstantExpression) indexExpression).getValue();
                     if (index instanceof Number) {
+                        if (hasFloatingPointMapKey(arguments.get(0).getType())) {
+                            return Optional.empty();
+                        }
                         elements.add(new Subfield.LongSubscript(((Number) index).longValue()));
                         expression = arguments.get(0);
                         continue;

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
@@ -39,9 +39,8 @@ import java.util.Optional;
 
 import static com.facebook.presto.common.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
-import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
-import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.TypeUtils.hasFloatingPointMapKey;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.hive.HiveCommonSessionProperties.isRangeFiltersOnSubscriptsEnabled;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
@@ -96,16 +95,6 @@ public final class SubfieldExtractor
     private static boolean hasSubscripts(Optional<Subfield> subfield)
     {
         return subfield.isPresent() && subfield.get().getPath().stream().anyMatch(Subfield.PathElement::isSubscript);
-    }
-
-    private static boolean hasFloatingPointMapKey(Type type)
-    {
-        return type instanceof MapType && isFloatingPointType(((MapType) type).getKeyType());
-    }
-
-    private static boolean isFloatingPointType(Type type)
-    {
-        return type.equals(DOUBLE) || type.equals(REAL);
     }
 
     public Optional<Subfield> extract(RowExpression expression)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDomainTranslator.java
@@ -57,7 +57,9 @@ import static com.facebook.presto.common.function.OperatorType.SUBSCRIPT;
 import static com.facebook.presto.common.predicate.TupleDomain.withColumnDomains;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.hive.HiveTestUtils.mapType;
@@ -71,6 +73,7 @@ import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.specialForm;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Float.floatToRawIntBits;
 import static org.testng.Assert.assertEquals;
 
 public class TestDomainTranslator
@@ -78,6 +81,8 @@ public class TestDomainTranslator
     private static final VariableReferenceExpression C_BIGINT = new VariableReferenceExpression(Optional.empty(), "c_bigint", BIGINT);
     private static final VariableReferenceExpression C_BIGINT_ARRAY = new VariableReferenceExpression(Optional.empty(), "c_bigint_array", new ArrayType(BIGINT));
     private static final VariableReferenceExpression C_BIGINT_TO_BIGINT_MAP = new VariableReferenceExpression(Optional.empty(), "c_bigint_to_bigint_map", mapType(BIGINT, BIGINT));
+    private static final VariableReferenceExpression C_DOUBLE_TO_BIGINT_MAP = new VariableReferenceExpression(Optional.empty(), "c_double_to_bigint_map", mapType(DOUBLE, BIGINT));
+    private static final VariableReferenceExpression C_REAL_TO_BIGINT_MAP = new VariableReferenceExpression(Optional.empty(), "c_real_to_bigint_map", mapType(REAL, BIGINT));
     private static final VariableReferenceExpression C_VARCHAR_TO_BIGINT_MAP = new VariableReferenceExpression(Optional.empty(), "c_varchar_to_bigint_map", mapType(VARCHAR, BIGINT));
     private static final VariableReferenceExpression C_STRUCT = new VariableReferenceExpression(Optional.empty(), "c_struct", RowType.from(ImmutableList.of(
             RowType.field("a", BIGINT),
@@ -163,6 +168,13 @@ public class TestDomainTranslator
         assertPredicateTranslates(isNull(C_BIGINT_TO_BIGINT_MAP), C_BIGINT_TO_BIGINT_MAP.getName(), Domain.create(ValueSet.none(mapType), true));
         assertPredicateTranslates(not(isNull(C_BIGINT_TO_BIGINT_MAP)), C_BIGINT_TO_BIGINT_MAP.getName(), Domain.create(ValueSet.all(mapType), false));
         assertPredicateDoesNotTranslate(equal(C_BIGINT_TO_BIGINT_MAP, createConstantExpression(createMapBlock(mapType, ImmutableMap.of(1, 100)), mapType)));
+    }
+
+    @Test
+    public void testFloatingPointMapKeysDoNotTranslate()
+    {
+        assertPredicateDoesNotTranslate(equal(mapSubscript(C_DOUBLE_TO_BIGINT_MAP, constant(0.99, DOUBLE)), bigintLiteral(2L)));
+        assertPredicateDoesNotTranslate(equal(mapSubscript(C_REAL_TO_BIGINT_MAP, constant((long) floatToRawIntBits(0.99f), REAL)), bigintLiteral(2L)));
     }
 
     private RowExpression dereference(RowExpression base, int field)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -152,6 +152,7 @@ import static io.airlift.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 
@@ -998,6 +999,8 @@ public class TestHiveLogicalPlanner
                 "id bigint, " +
                 "a array(bigint), " +
                 "b map(varchar, bigint), " +
+                "f map(double, bigint), " +
+                "g map(real, bigint), " +
                 "c row(" +
                 "a bigint, " +
                 "b row(x bigint), " +
@@ -1034,6 +1037,9 @@ public class TestHiveLogicalPlanner
 
         assertPushdownFilterOnSubfields("SELECT * FROM test_pushdown_filter_on_subfields WHERE c.e['foo'] = 1",
                 ImmutableMap.of(new Subfield("c.e[\"foo\"]"), singleValue(BIGINT, 1L)));
+
+        assertNoPushdownFilterOnSubfields("SELECT * FROM test_pushdown_filter_on_subfields WHERE f[CAST(0.99 AS DOUBLE)] = 1", "f");
+        assertNoPushdownFilterOnSubfields("SELECT * FROM test_pushdown_filter_on_subfields WHERE g[CAST(0.99 AS REAL)] = 1", "g");
 
         assertPushdownFilterOnSubfields("SELECT * FROM test_pushdown_filter_on_subfields WHERE c.a IS NOT NULL AND c.c IS NOT NULL",
                 ImmutableMap.of(new Subfield("c.a"), notNull(BIGINT), new Subfield("c.c"), notNull(new ArrayType(BIGINT))));
@@ -1089,6 +1095,8 @@ public class TestHiveLogicalPlanner
                 "a map(bigint, bigint), " +
                 "b map(bigint, map(bigint, varchar)), " +
                 "c map(varchar, bigint), \n" +
+                "d map(double, bigint), \n" +
+                "e map(real, bigint), \n" +
                 "y map(bigint, row(a bigint, b varchar, c double, d row(d1 bigint, d2 double)))," +
                 "z map(bigint, map(bigint, row(p bigint, e row(e1 bigint, e2 varchar)))))");
 
@@ -1116,6 +1124,12 @@ public class TestHiveLogicalPlanner
 
         assertPushdownSubfields("SELECT mod(c['cat'], 2) FROM test_pushdown_map_subscripts WHERE c['dog'] > 10", "test_pushdown_map_subscripts",
                 ImmutableMap.of("c", toSubfields("c[\"cat\"]", "c[\"dog\"]")));
+
+        assertPushdownSubfields("SELECT d[CAST(0.99 AS DOUBLE)] FROM test_pushdown_map_subscripts", "test_pushdown_map_subscripts",
+                ImmutableMap.of());
+
+        assertPushdownSubfields("SELECT e[CAST(0.99 AS REAL)] FROM test_pushdown_map_subscripts", "test_pushdown_map_subscripts",
+                ImmutableMap.of());
 
         // No subfield pruning
         assertPushdownSubfields("SELECT map_keys(a)[1] FROM test_pushdown_map_subscripts", "test_pushdown_map_subscripts",
@@ -1501,6 +1515,11 @@ public class TestHiveLogicalPlanner
                 ImmutableMap.of("x", toSubfields()));
         assertUpdate("DROP TABLE test_pushdown_map_subfields");
 
+        assertUpdate("CREATE TABLE test_pushdown_map_subfields(id integer, x map(double, double))");
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_subset(x, array[CAST(0.99 AS DOUBLE), CAST(1.01 AS DOUBLE)]) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of());
+        assertUpdate("DROP TABLE test_pushdown_map_subfields");
+
         assertUpdate("CREATE TABLE test_pushdown_map_subfields(id integer, x array(map(integer, double)))");
         assertPushdownSubfields(mapSubset, "SELECT t.id, transform(x, mp -> map_subset(mp, array[1, 2, 3])) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
                 ImmutableMap.of("x", toSubfields("x[*][1]", "x[*][2]", "x[*][3]")));
@@ -1569,6 +1588,11 @@ public class TestHiveLogicalPlanner
                 ImmutableMap.of("x", toSubfields()));
         assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> contains(array[id], k)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
                 ImmutableMap.of("x", toSubfields()));
+        assertUpdate("DROP TABLE test_pushdown_map_subfields");
+
+        assertUpdate("CREATE TABLE test_pushdown_map_subfields(id integer, x map(double, double))");
+        assertPushdownSubfields(mapSubset, "SELECT t.id, map_filter(x, (k, v) -> k = CAST(0.99 AS DOUBLE)) FROM test_pushdown_map_subfields t", "test_pushdown_map_subfields",
+                ImmutableMap.of());
         assertUpdate("DROP TABLE test_pushdown_map_subfields");
 
         assertUpdate("CREATE TABLE test_pushdown_map_subfields(id integer, x array(map(integer, double)))");
@@ -2590,6 +2614,25 @@ public class TestHiveLogicalPlanner
                         withColumnDomains(predicateDomains),
                         TRUE_CONSTANT,
                         predicateDomains.keySet().stream().map(Subfield::getRootName).collect(toImmutableSet())));
+    }
+
+    private void assertNoPushdownFilterOnSubfields(String query, String predicateColumnName)
+    {
+        String tableName = "test_pushdown_filter_on_subfields";
+        assertPlan(pushdownFilterAndNestedColumnFilterEnabled(), query,
+                output(exchange(PlanMatchPattern.tableScan(tableName))),
+                plan -> {
+                    TableScanNode tableScan = searchFrom(plan.getRoot())
+                            .where(node -> isTableScanNode(node, tableName))
+                            .findOnlyElement();
+
+                    assertTrue(tableScan.getTable().getLayout().isPresent());
+                    HiveTableLayoutHandle layoutHandle = (HiveTableLayoutHandle) tableScan.getTable().getLayout().get();
+
+                    assertEquals(layoutHandle.getPredicateColumns().keySet(), ImmutableSet.of(predicateColumnName));
+                    assertEquals(layoutHandle.getDomainPredicate(), TupleDomain.all());
+                    assertNotEquals(layoutHandle.getRemainingPredicate(), TRUE_CONSTANT);
+                });
     }
 
     private void assertParquetDereferencePushDown(String query, String tableName, Map<String, Subfield> expectedDeferencePushDowns)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestSubfieldExtractor.java
@@ -56,6 +56,7 @@ import static com.facebook.presto.sql.relational.Expressions.constant;
 import static com.facebook.presto.sql.relational.Expressions.specialForm;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Float.floatToRawIntBits;
 import static org.testng.Assert.assertTrue;
 
 public class TestSubfieldExtractor
@@ -63,6 +64,8 @@ public class TestSubfieldExtractor
     private static final VariableReferenceExpression C_BIGINT = new VariableReferenceExpression(Optional.empty(), "c_bigint", BIGINT);
     private static final VariableReferenceExpression C_BIGINT_ARRAY = new VariableReferenceExpression(Optional.empty(), "c_bigint_array", new ArrayType(BIGINT));
     private static final VariableReferenceExpression C_BIGINT_TO_BIGINT_MAP = new VariableReferenceExpression(Optional.empty(), "c_bigint_to_bigint_map", mapType(BIGINT, BIGINT));
+    private static final VariableReferenceExpression C_DOUBLE_TO_BIGINT_MAP = new VariableReferenceExpression(Optional.empty(), "c_double_to_bigint_map", mapType(DOUBLE, BIGINT));
+    private static final VariableReferenceExpression C_REAL_TO_BIGINT_MAP = new VariableReferenceExpression(Optional.empty(), "c_real_to_bigint_map", mapType(REAL, BIGINT));
     private static final VariableReferenceExpression C_VARCHAR_TO_BIGINT_MAP = new VariableReferenceExpression(Optional.empty(), "c_varchar_to_bigint_map", mapType(VARCHAR, BIGINT));
     private static final VariableReferenceExpression C_STRUCT = new VariableReferenceExpression(Optional.empty(), "c_struct", RowType.from(ImmutableList.of(
             RowType.field("a", BIGINT),
@@ -113,6 +116,13 @@ public class TestSubfieldExtractor
         assertSubfieldExtract(mapSubscript(dereference(C_STRUCT, 4), constant(Slices.utf8Slice("foo"), VARCHAR)), "c_struct.e[\"foo\"]");
 
         assertEquals(subfieldExtractor.extract(constant(2L, INTEGER)), Optional.empty());
+    }
+
+    @Test
+    public void testFloatingPointMapKeys()
+    {
+        assertEquals(subfieldExtractor.extract(mapSubscript(C_DOUBLE_TO_BIGINT_MAP, constant(0.99, DOUBLE))), Optional.empty());
+        assertEquals(subfieldExtractor.extract(mapSubscript(C_REAL_TO_BIGINT_MAP, constant((long) floatToRawIntBits(0.99f), REAL))), Optional.empty());
     }
 
     @Test

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -79,6 +79,7 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.facebook.presto.sql.planner.plan.UpdateNode;
 import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.tree.QualifiedName;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -102,6 +103,8 @@ import static com.facebook.presto.SystemSessionProperties.isPushdownSubfieldsFro
 import static com.facebook.presto.common.Subfield.allSubscripts;
 import static com.facebook.presto.common.Subfield.noSubfield;
 import static com.facebook.presto.common.Subfield.structureOnly;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
@@ -155,6 +158,24 @@ public class PushdownSubfields
         Rewriter rewriter = new Rewriter(session, metadata, expressionOptimizerProvider);
         PlanNode rewrittenPlan = SimplePlanRewriter.rewriteWith(rewriter, plan, new Rewriter.Context());
         return PlanOptimizerResult.optimizerResult(rewrittenPlan, rewriter.isPlanChanged());
+    }
+
+    @VisibleForTesting
+    static Optional<List<Subfield>> toSubfield(
+            RowExpression expression,
+            FunctionResolution functionResolution,
+            ExpressionOptimizer expressionOptimizer,
+            ConnectorSession connectorSession,
+            FunctionAndTypeManager functionAndTypeManager,
+            boolean isPushdownSubfieldsForMapFunctionsEnabled)
+    {
+        return Rewriter.toSubfield(
+                expression,
+                functionResolution,
+                expressionOptimizer,
+                connectorSession,
+                functionAndTypeManager,
+                isPushdownSubfieldsForMapFunctionsEnabled);
     }
 
     private static class Rewriter
@@ -666,7 +687,8 @@ public class PushdownSubfields
             return metadata.getColumnMetadata(session, tableHandle, columnHandle).getName();
         }
 
-        private static Optional<List<Subfield>> toSubfield(
+        @VisibleForTesting
+        static Optional<List<Subfield>> toSubfield(
                 RowExpression expression,
                 FunctionResolution functionResolution,
                 ExpressionOptimizer expressionOptimizer,
@@ -734,6 +756,9 @@ public class PushdownSubfields
                             if (((Number) index).longValue() < 0 && arguments.get(0).getType() instanceof ArrayType) {
                                 return Optional.empty();
                             }
+                            if (hasFloatingPointMapKey(arguments.get(0).getType())) {
+                                return Optional.empty();
+                            }
 
                             elements.add(new Subfield.LongSubscript(((Number) index).longValue()));
                             expression = arguments.get(0);
@@ -798,6 +823,9 @@ public class PushdownSubfields
         {
             ImmutableList.Builder<Subfield> arguments = ImmutableList.builder();
             checkState(constantArray.getValue() instanceof Block && constantArray.getType() instanceof ArrayType);
+            if (hasFloatingPointMapKey(mapVariable.getType())) {
+                return Optional.empty();
+            }
             Block arrayValue = (Block) constantArray.getValue();
             Type arrayElementType = ((ArrayType) constantArray.getType()).getElementType();
             for (int i = 0; i < arrayValue.getPositionCount(); ++i) {
@@ -817,6 +845,9 @@ public class PushdownSubfields
 
         private static Optional<Subfield> extractSubfieldsFromSingleValue(ConstantExpression mapKey, VariableReferenceExpression mapVariable)
         {
+            if (hasFloatingPointMapKey(mapVariable.getType())) {
+                return Optional.empty();
+            }
             Object value = mapKey.getValue();
             if (value == null) {
                 return Optional.empty();
@@ -828,6 +859,16 @@ public class PushdownSubfields
                 return Optional.of(new Subfield(mapVariable.getName(), ImmutableList.of(new Subfield.StringSubscript(((Slice) value).toStringUtf8()))));
             }
             return Optional.empty();
+        }
+
+        private static boolean hasFloatingPointMapKey(Type type)
+        {
+            return type instanceof MapType && isFloatingPointType(((MapType) type).getKeyType());
+        }
+
+        private static boolean isFloatingPointType(Type type)
+        {
+            return type.equals(DOUBLE) || type.equals(REAL);
         }
 
         private static NestedField nestedField(String name)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -103,8 +103,7 @@ import static com.facebook.presto.SystemSessionProperties.isPushdownSubfieldsFro
 import static com.facebook.presto.common.Subfield.allSubscripts;
 import static com.facebook.presto.common.Subfield.noSubfield;
 import static com.facebook.presto.common.Subfield.structureOnly;
-import static com.facebook.presto.common.type.DoubleType.DOUBLE;
-import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.TypeUtils.hasFloatingPointMapKey;
 import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.JAVA_BUILTIN_NAMESPACE;
@@ -859,16 +858,6 @@ public class PushdownSubfields
                 return Optional.of(new Subfield(mapVariable.getName(), ImmutableList.of(new Subfield.StringSubscript(((Slice) value).toStringUtf8()))));
             }
             return Optional.empty();
-        }
-
-        private static boolean hasFloatingPointMapKey(Type type)
-        {
-            return type instanceof MapType && isFloatingPointType(((MapType) type).getKeyType());
-        }
-
-        private static boolean isFloatingPointType(Type type)
-        {
-            return type.equals(DOUBLE) || type.equals(REAL);
         }
 
         private static NestedField nestedField(String name)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPushdownSubfields.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPushdownSubfields.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.relation.ExpressionOptimizer;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.TestingRowExpressionTranslator;
+import com.facebook.presto.sql.relational.FunctionResolution;
+import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
+
+public class TestPushdownSubfields
+{
+    private static final Metadata METADATA = createTestMetadataManager();
+    private static final TestingRowExpressionTranslator TRANSLATOR = new TestingRowExpressionTranslator(METADATA);
+    private static final ExpressionOptimizer EXPRESSION_OPTIMIZER = new RowExpressionOptimizer(METADATA);
+    private static final FunctionResolution FUNCTION_RESOLUTION = new FunctionResolution(METADATA.getFunctionAndTypeManager().getFunctionAndTypeResolver());
+
+    @Test
+    public void testMapSubscriptExtraction()
+    {
+        assertSubfields(
+                "x[1]",
+                ImmutableMap.of("x", mapType(BIGINT, BIGINT)),
+                false,
+                ImmutableList.of(new Subfield("x[1]")));
+        assertNoSubfields(
+                "x[CAST(0.99E0 AS DOUBLE)]",
+                ImmutableMap.of("x", mapType(DOUBLE, BIGINT)),
+                false);
+        assertNoSubfields(
+                "x[CAST(0.99E0 AS REAL)]",
+                ImmutableMap.of("x", mapType(REAL, BIGINT)),
+                false);
+    }
+
+    @Test
+    public void testMapFunctionExtraction()
+    {
+        assertSubfields(
+                "map_subset(x, array[1, 2])",
+                ImmutableMap.of("x", mapType(BIGINT, BIGINT)),
+                true,
+                ImmutableList.of(new Subfield("x[1]"), new Subfield("x[2]")));
+        assertSubfields(
+                "map_filter(x, (k, v) -> k = 2)",
+                ImmutableMap.of("x", mapType(BIGINT, BIGINT)),
+                true,
+                ImmutableList.of(new Subfield("x[2]")));
+        assertNoSubfields(
+                "map_subset(x, array[CAST(0.99E0 AS DOUBLE), CAST(1.01E0 AS DOUBLE)])",
+                ImmutableMap.of("x", mapType(DOUBLE, BIGINT)),
+                true);
+        assertNoSubfields(
+                "map_filter(x, (k, v) -> k = CAST(0.99E0 AS DOUBLE))",
+                ImmutableMap.of("x", mapType(DOUBLE, BIGINT)),
+                true);
+    }
+
+    private static void assertSubfields(String sql, Map<String, Type> types, boolean pushdownMapFunctionsEnabled, ImmutableList<Subfield> expected)
+    {
+        assertEquals(extractSubfields(sql, types, pushdownMapFunctionsEnabled), Optional.of(expected));
+    }
+
+    private static void assertNoSubfields(String sql, Map<String, Type> types, boolean pushdownMapFunctionsEnabled)
+    {
+        assertEquals(extractSubfields(sql, types, pushdownMapFunctionsEnabled), Optional.empty());
+    }
+
+    private static Optional<ImmutableList<Subfield>> extractSubfields(String sql, Map<String, Type> types, boolean pushdownMapFunctionsEnabled)
+    {
+        RowExpression expression = EXPRESSION_OPTIMIZER.optimize(TRANSLATOR.translate(sql, types), OPTIMIZED, TEST_SESSION.toConnectorSession());
+        return PushdownSubfields.toSubfield(
+                        expression,
+                        FUNCTION_RESOLUTION,
+                        EXPRESSION_OPTIMIZER,
+                        TEST_SESSION.toConnectorSession(),
+                        METADATA.getFunctionAndTypeManager(),
+                        pushdownMapFunctionsEnabled)
+                .map(ImmutableList::copyOf);
+    }
+
+    private static Type mapType(Type keyType, Type valueType)
+    {
+        return METADATA.getFunctionAndTypeManager().getType(parseTypeSignature(format("map(%s,%s)", keyType.getDisplayName(), valueType.getDisplayName())));
+    }
+}


### PR DESCRIPTION
## Description
Skip subfield extraction for MAP subscripts whose key type is DOUBLE or REAL, because those keys cannot be represented losslessly as `Subfield` paths.

Apply the same guard in both Hive's `SubfieldExtractor` and planner-side `PushdownSubfields`, including the `map_subset` and `map_filter` helpers.

## Motivation and Context
Fixes #27507.

`Subfield` can represent integer and string MAP subscripts, but floating-point MAP keys were being coerced through `longValue()`, which could incorrectly turn expressions like `x[0.99]` into `x[0]` during pruning and pushdown. The safe behavior is to leave those expressions unpushed.

## Impact
Correctness fix for Hive and planner subfield pushdown. Queries over MAP columns keyed by DOUBLE or REAL keep working, but those specific key accesses no longer participate in lossy subfield pruning and pushdown.

## Test Plan
- Added `TestPushdownSubfields` coverage for direct MAP subscripts and `map_subset`/`map_filter`.
- Ran `./mvnw -pl presto-main-base -am -Dair.check.skip-all -DskipUI -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TestPushdownSubfields test`.
- Ran `./mvnw -pl presto-hive -am -Dair.check.skip-all -DskipUI -Dsurefire.failIfNoSpecifiedTests=false -Dtest=TestSubfieldExtractor,TestDomainTranslator test`.
- Added `TestHiveLogicalPlanner` coverage for the pushdown and pruning cases; I did not execute that class locally because the available JDK 25 runtime trips a Hadoop `Subject.getSubject` incompatibility during Hive query-runner initialization.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Prevent subfield pushdown and pruning for map accesses with floating-point keys and add regression tests across planner and Hive components.

Bug Fixes:
- Avoid lossy subfield extraction for DOUBLE and REAL map keys in planner-side subfield pushdown logic.
- Skip subfield extraction for DOUBLE and REAL map keys in Hive's SubfieldExtractor and domain translation.

Tests:
- Add planner-level TestPushdownSubfields to cover map subscript and map_* function behavior with numeric and floating-point keys.
- Extend Hive logical planner, subfield extractor, and domain translator tests to verify that floating-point map key predicates are not pushed down or translated.