### PR TITLE
ci: Use path and paths-ignore to run workflows based on file changes

### DIFF
--- a/.github/workflows/arrow-flight-tests.yml
+++ b/.github/workflows/arrow-flight-tests.yml
@@ -1,6 +1,9 @@
 name: arrow flight tests
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 permissions:
   contents: read
@@ -14,49 +17,26 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
-
   arrowflight-java-tests:
     runs-on: ubuntu-latest
-    needs: changes
     strategy:
       fail-fast: false
       matrix:
         java: ['17']
         modules:
           - :presto-base-arrow-flight # Only run tests for the `presto-base-arrow-flight` module
-
     timeout-minutes: 80
     concurrency:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
-
     steps:
-      # Checkout the code only if there are changes in the relevant files
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
 
       # Set up Java and dependencies for the build environment
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -64,7 +44,6 @@ jobs:
 
       # Cleanup before build
       - name: Clean up before build
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
@@ -72,24 +51,20 @@ jobs:
           docker system prune -af || true
 
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
 
       # Install dependencies for the target module
       - name: Maven Install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -e -am -pl ${{ matrix.modules }}
 
       # Run Maven tests for the target module, excluding native tests
       - name: Maven Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl ${{ matrix.modules }} -Dtest="*,!TestArrowFlightNativeQueries*"
 
   prestocpp-linux-build-for-test:
     runs-on: ubuntu-22.04
-    needs: changes
     container:
       image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
       volumes:
@@ -123,24 +98,20 @@ jobs:
           echo "New available disk space: " $(getAvailableSpace)
 
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
 
       - name: Fix git permissions
-        if: needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Update velox
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           cd presto-native-execution
           make velox-submodule
 
       - name: Install Arrow Flight
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           mkdir -p ${DEPENDENCY_DIR}/adapter-deps/download
           mkdir -p ${INSTALL_PREFIX}/adapter-deps/install
@@ -150,23 +121,19 @@ jobs:
           PROMPT_ALWAYS_RESPOND=n ./scripts/setup-adapters.sh arrow_flight
 
       - name: Install Github CLI for using apache/infrastructure-actions/stash
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           curl -L https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.rpm > gh_2.63.2_linux_amd64.rpm
           rpm -iv gh_2.63.2_linux_amd64.rpm
 
       - uses: apache/infrastructure-actions/stash/restore@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
-        if: needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-linux-build-for-test
 
       - name: Zero ccache statistics
-        if: needs.changes.outputs.codechange == 'true'
         run: ccache -sz
 
       - name: Build engine
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           source /opt/rh/gcc-toolset-12/enable
           cd presto-native-execution
@@ -185,37 +152,32 @@ jobs:
           ninja -C _build/release -j 4
 
       - name: Ccache after
-        if: needs.changes.outputs.codechange == 'true'
         run: ccache -s
 
       - uses: apache/infrastructure-actions/stash/save@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
-        if: needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-linux-build-for-test
 
       - name: Run Unit Tests for the Arrow Flight connector only
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           cd presto-native-execution/_build/release
           ctest -j 4 -VV --output-on-failure --tests-regex ^presto_flight.*
 
       - name: Upload artifacts
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: arrow-flight-presto-native-build
           path: presto-native-execution/_build/release/presto_cpp/main/presto_server
 
       - name: Upload Arrow Flight install artifacts
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: arrow-flight-install
           path: ${{ env.INSTALL_PREFIX }}/lib64/libarrow_flight*
 
   arrowflight-native-e2e-tests:
-    needs: [changes, prestocpp-linux-build-for-test]
+    needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
@@ -229,12 +191,10 @@ jobs:
       matrix:
         modules:
           - :presto-base-arrow-flight # Only run tests for the `presto-base-arrow-flight` module
-
     timeout-minutes: 80
     concurrency:
       group: ${{ github.workflow }}-test-${{ matrix.modules }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-
     steps:
       # We cannot use the github action to free disk space from the runner
       # because we are in the container and not on the runner anymore.
@@ -254,25 +214,21 @@ jobs:
           echo "New available disk space: " $(getAvailableSpace)
 
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
 
       - name: Fix git permissions
-        if: needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Download artifacts
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/download-artifact@v4
         with:
           name: arrow-flight-presto-native-build
           path: presto-native-execution/_build/release/presto_cpp/main
 
       - name: Download Arrow Flight install artifacts
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/download-artifact@v4
         with:
           name: arrow-flight-install
@@ -280,25 +236,21 @@ jobs:
 
       # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
       - name: Restore execute permissions and library path
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server
           # Ensure transitive dependency libboost-iostreams is found.
           ldconfig /usr/local/lib
 
       - name: Install OpenJDK8
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
 
       - name: Maven install
-        if: needs.changes.outputs.codechange == 'true'
         env:
           # Use different Maven options to install.
           MAVEN_OPTS: -Xmx2G -XX:+ExitOnOutOfMemoryError
@@ -307,7 +259,6 @@ jobs:
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl ${{ matrix.modules }}
 
       - name: Run arrowflight native e2e tests
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server"
           mvn test \

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -1,6 +1,9 @@
 name: hive tests
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -12,23 +15,6 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
-
   hive-tests:
     permissions:
       contents: read
@@ -37,36 +23,29 @@ jobs:
       matrix:
         java: ['17']
     runs-on: ubuntu-latest
-    needs: changes
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-hive-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Install Hive Module
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-hive-hadoop2
       - name: Run Hive Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: presto-hive-hadoop2/bin/run_hive_tests.sh
       - name: Run Hive S3 Tests
-        if: needs.changes.outputs.codechange == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.HIVE_AWS_ACCESSKEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.HIVE_AWS_SECRETKEY }}
@@ -77,7 +56,6 @@ jobs:
               presto-hive-hadoop2/bin/run_hive_s3_tests.sh
           fi
       - name: Run Hive Glue Tests
-        if: needs.changes.outputs.codechange == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.HIVE_AWS_ACCESSKEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.HIVE_AWS_SECRETKEY }}
@@ -94,34 +72,27 @@ jobs:
       matrix:
         java: ['17']
     runs-on: ubuntu-latest
-    needs: changes
     timeout-minutes: 20
     concurrency:
       group: ${{ github.workflow }}-hive-dockerized-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Install Hive Module
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-hive
       - name: Run Hive Insert Overwrite Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl :presto-hive -P test-hive-insert-overwrite
       - name: Run Hive SSL Enabled Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl :presto-hive -P test-ssl-enabled-hms

--- a/.github/workflows/jdbc-connector-tests.yml
+++ b/.github/workflows/jdbc-connector-tests.yml
@@ -1,6 +1,9 @@
 name: jdbc connector tests
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -12,23 +15,6 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
-
   jdbc-connector-tests:
     permissions:
       contents: read
@@ -37,31 +23,25 @@ jobs:
       matrix:
         java: ['17']
     runs-on: ubuntu-latest
-    needs: changes
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-jdbc-connector-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Install JDBC Connector Modules
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-mysql,:presto-postgresql
       - name: Run MySQL and PostgreSQL Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -P ci -pl :presto-mysql,:presto-postgresql

--- a/.github/workflows/kudu.yml
+++ b/.github/workflows/kudu.yml
@@ -1,6 +1,9 @@
 name: kudu
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -11,22 +14,6 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
   kudu:
     permissions:
       contents: read
@@ -35,33 +22,27 @@ jobs:
       matrix:
         java: ['17']
     runs-on: ubuntu-latest
-    needs: changes
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-kudu-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven Install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am --no-transfer-progress -pl presto-kudu
       - name: Kudu Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           presto-kudu/bin/run_kudu_tests.sh 3 null
           presto-kudu/bin/run_kudu_tests.sh 1 ""

--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -1,6 +1,9 @@
 name: maven checks
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment

--- a/.github/workflows/owasp-dependency-check.yml
+++ b/.github/workflows/owasp-dependency-check.yml
@@ -2,7 +2,11 @@ name: Maven OWASP Dependency Check
 permissions:
   contents: read
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '**'
+      - '!presto-docs/**'
+      - presto-docs/pom.xml
   workflow_dispatch:
     inputs:
       cvss-threshold:
@@ -12,26 +16,7 @@ on:
         type: string
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
-              - 'presto-docs/pom.xml'
-
   dependency-check:
-    needs: changes
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-owasp-dependency-check-${{ github.event.pull_request.number }}
@@ -42,14 +27,12 @@ jobs:
     steps:
       # Checkout PR branch first to get access to the composite action
       - name: Checkout PR branch
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Find merge base
-        if: needs.changes.outputs.codechange == 'true'
         id: merge-base
         env:
           GH_TOKEN: ${{ github.token }}
@@ -63,7 +46,6 @@ jobs:
           echo "Using merge base: $merge_base"
 
       - name: Checkout base branch
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -71,7 +53,6 @@ jobs:
           path: base
 
       - name: Set up Java
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -79,12 +60,10 @@ jobs:
           cache: maven
 
       - name: Get date for cache key
-        if: needs.changes.outputs.codechange == 'true'
         id: get-date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Restore OWASP database cache
-        if: needs.changes.outputs.codechange == 'true'
         uses: actions/cache/restore@v4
         id: cache-owasp-restore
         with:
@@ -95,7 +74,6 @@ jobs:
             owasp-cache-${{ runner.os }}-
 
       - name: Run OWASP check on base branch
-        if: needs.changes.outputs.codechange == 'true'
         uses: ./.github/actions/maven-owasp-scan
         with:
           working-directory: base
@@ -103,14 +81,13 @@ jobs:
           data-directory: /tmp/.owasp/dependency-check-data
 
       - name: Save OWASP cache after base scan
-        if: needs.changes.outputs.codechange == 'true' && steps.cache-owasp-restore.outputs.cache-hit != 'true'
+        if: steps.cache-owasp-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: /tmp/.owasp/dependency-check-data
           key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}-partial
 
       - name: Run OWASP check on PR branch
-        if: needs.changes.outputs.codechange == 'true'
         uses: ./.github/actions/maven-owasp-scan
         with:
           working-directory: .
@@ -118,7 +95,6 @@ jobs:
           data-directory: /tmp/.owasp/dependency-check-data
 
       - name: Compare and fail on new CVEs above threshold
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           # Extract CVEs above threshold from both branches (CVSS >= $CVSS_THRESHOLD)
           threshold=$CVSS_THRESHOLD
@@ -182,14 +158,14 @@ jobs:
           fi
 
       - name: Save OWASP database cache
-        if: needs.changes.outputs.codechange == 'true' && always()
+        if: always()
         uses: actions/cache/save@v4
         with:
           path: /tmp/.owasp/dependency-check-data
           key: owasp-cache-${{ runner.os }}-v${{ env.OWASP_VERSION }}-${{ steps.get-date.outputs.date }}
 
       - name: Upload reports
-        if: needs.changes.outputs.codechange == 'true' && always()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: owasp-reports

--- a/.github/workflows/prestocpp-linux-build-and-unit-test.yml
+++ b/.github/workflows/prestocpp-linux-build-and-unit-test.yml
@@ -4,31 +4,13 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: 30 0 * * * # Runs at 00:30 UTC daily on master(default) branch
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - name: Run changes check for PRs
-        if: github.event_name != 'schedule'
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
-
   prestocpp-linux-build-for-test:
     runs-on: ubuntu-22.04
-    needs: changes
     container:
       image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
     concurrency:
@@ -40,47 +22,33 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
 
       - name: Fix git permissions
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Update velox
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           cd presto-native-execution
           make velox-submodule
 
       - name: Install Github CLI for using apache/infrastructure-actions/stash
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           curl -L https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.rpm > gh_2.63.2_linux_amd64.rpm
           rpm -iv gh_2.63.2_linux_amd64.rpm
 
       - uses: apache/infrastructure-actions/stash/restore@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-linux-build-for-test
 
       - name: Zero ccache statistics
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: ccache -sz
 
       - name: Build engine
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           source /opt/rh/gcc-toolset-12/enable
           cd presto-native-execution
@@ -101,20 +69,14 @@ jobs:
           ninja -C _build/release -j 4
 
       - name: Ccache after
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: ccache -s
 
       - uses: apache/infrastructure-actions/stash/save@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-linux-build-for-test
 
       - name: Run Unit Tests
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           # Ensure transitive dependency libboost-iostreams is found.
           ldconfig /usr/local/lib
@@ -122,8 +84,6 @@ jobs:
           ctest -j 4 -VV --output-on-failure --exclude-regex ^velox.*
 
       - name: Upload artifacts
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: presto-native-build
@@ -132,7 +92,7 @@ jobs:
             presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
 
   prestocpp-linux-presto-e2e-tests:
-    needs: [changes, prestocpp-linux-build-for-test]
+    needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
@@ -147,14 +107,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
 
       - name: Fix git permissions
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -177,8 +133,6 @@ jobs:
           echo "New available disk space: " $(getAvailableSpace)
 
       - name: Download artifacts
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/download-artifact@v4
         with:
           name: presto-native-build
@@ -186,8 +140,6 @@ jobs:
 
       # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
       - name: Restore execute permissions and library path
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
@@ -195,21 +147,15 @@ jobs:
           ldconfig /usr/local/lib
 
       - name: Install OpenJDK8
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
       - name: Download nodejs to maven cache
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
 
       - name: Maven install
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         env:
           # Use different Maven options to install.
           MAVEN_OPTS: -Xmx2G -XX:+ExitOnOutOfMemoryError
@@ -217,8 +163,6 @@ jobs:
           for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-native-execution' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
 
       - name: Run presto-native e2e tests
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server"
           # Find TestPrestoNative*.java files and iceberg test files
@@ -252,7 +196,7 @@ jobs:
             -T1C
 
   prestocpp-linux-presto-native-tests:
-    needs: [changes, prestocpp-linux-build-for-test]
+    needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -272,14 +216,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
 
       - name: Fix git permissions
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -302,24 +242,18 @@ jobs:
           echo "New available disk space: " $(getAvailableSpace)
 
       - name: Download artifacts
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/download-artifact@v4
         with:
           name: presto-native-build
           path: presto-native-execution/_build/release
 
       - name: Update velox
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           cd presto-native-execution
           make velox-submodule
 
       # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
       - name: Restore execute permissions and library path
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
@@ -327,21 +261,15 @@ jobs:
           ldconfig /usr/local/lib
 
       - name: Install OpenJDK8
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
       - name: Download nodejs to maven cache
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
 
       - name: Maven install
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         env:
           # Use different Maven options to install.
           MAVEN_OPTS: -Xmx2G -XX:+ExitOnOutOfMemoryError
@@ -349,8 +277,6 @@ jobs:
           for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-native-tests' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
 
       - name: Run presto-native tests
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server"
           # Find all Test*.java files and exclude those in the cudf package
@@ -378,7 +304,7 @@ jobs:
             -T1C
 
   prestocpp-linux-presto-on-spark-e2e-tests:
-    needs: [changes, prestocpp-linux-build-for-test]
+    needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -401,14 +327,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
 
       - name: Fix git permissions
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -431,8 +353,6 @@ jobs:
           echo "New available disk space: " $(getAvailableSpace)
 
       - name: Download artifacts
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/download-artifact@v4
         with:
           name: presto-native-build
@@ -440,8 +360,6 @@ jobs:
 
       # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
       - name: Restore execute permissions and library path
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
@@ -449,21 +367,15 @@ jobs:
           ldconfig /usr/local/lib
 
       - name: Install OpenJDK17
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
       - name: Download nodejs to maven cache
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
 
       - name: Maven install
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         env:
           # Use different Maven options to install.
           MAVEN_OPTS: -Xmx2G -XX:+ExitOnOutOfMemoryError
@@ -471,8 +383,6 @@ jobs:
           for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-native-tests' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
 
       - name: Run presto-on-spark native tests
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server"
           export TESTFILES=`find ./presto-native-execution/src/test -type f -name 'TestPrestoSpark*.java'`
@@ -499,7 +409,7 @@ jobs:
             -T1C
 
   prestocpp-linux-presto-sidecar-tests:
-    needs: [changes, prestocpp-linux-build-for-test]
+    needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
@@ -517,13 +427,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
       - name: Fix git permissions
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -546,8 +452,6 @@ jobs:
           echo "New available disk space: " $(getAvailableSpace)
 
       - name: Download artifacts
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/download-artifact@v4
         with:
           name: presto-native-build
@@ -555,8 +459,6 @@ jobs:
 
       # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
       - name: Restore execute permissions and library path
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
@@ -564,21 +466,15 @@ jobs:
           ldconfig /usr/local/lib
 
       - name: Install OpenJDK8
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
       - name: Download nodejs to maven cache
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
 
       - name: Maven install
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         env:
           # Use different Maven options to install.
           MAVEN_OPTS: -Xmx2G -XX:+ExitOnOutOfMemoryError
@@ -586,8 +482,6 @@ jobs:
           for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-native-sidecar-plugin' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
 
       - name: Run presto-native sidecar tests
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server"
           export TESTFILES=`find ./presto-native-sidecar-plugin/src/test -type f -name 'Test*.java'`
@@ -611,7 +505,7 @@ jobs:
             -T1C
 
   prestocpp-linux-presto-plan-checker-router-plugin-tests:
-    needs: [changes, prestocpp-linux-build-for-test]
+    needs: prestocpp-linux-build-for-test
     runs-on: ubuntu-22.04
     container:
       image: prestodb/presto-native-dependency:0.297-202602271419-160459b8
@@ -629,13 +523,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
       - name: Fix git permissions
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -658,8 +548,6 @@ jobs:
           echo "New available disk space: " $(getAvailableSpace)
 
       - name: Download artifacts
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/download-artifact@v4
         with:
           name: presto-native-build
@@ -667,8 +555,6 @@ jobs:
 
       # Permissions are lost when uploading. Details here: https://github.com/actions/upload-artifact/issues/38
       - name: Restore execute permissions and library path
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server
           chmod +x ${GITHUB_WORKSPACE}/presto-native-execution/_build/release/velox/velox/functions/remote/server/velox_functions_remote_server_main
@@ -676,21 +562,15 @@ jobs:
           ldconfig /usr/local/lib
 
       - name: Install OpenJDK8
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
       - name: Download nodejs to maven cache
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
 
       - name: Maven install
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         env:
           # Use different Maven options to install.
           MAVEN_OPTS: -Xmx2G -XX:+ExitOnOutOfMemoryError
@@ -698,8 +578,6 @@ jobs:
           for i in $(seq 1 3); do ./mvnw clean install $MAVEN_FAST_INSTALL -pl 'presto-plan-checker-router-plugin' -am && s=0 && break || s=$? && sleep 10; done; (exit $s)
 
       - name: Run presto-native plan checker router plugin tests
-        if: |
-          github.event_name == 'schedule' || needs.changes.outputs.codechange == 'true'
         run: |
           export PRESTO_SERVER_PATH="${GITHUB_WORKSPACE}/presto-native-execution/_build/release/presto_cpp/main/presto_server"
           mvn test \

--- a/.github/workflows/prestocpp-linux-build.yml
+++ b/.github/workflows/prestocpp-linux-build.yml
@@ -1,30 +1,16 @@
 name: prestocpp-linux-build
 
-on: [workflow_dispatch, pull_request]
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
-
   prestocpp-linux-build-gpu-engine:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-    needs: changes
     container:
       image: prestodb/presto-native-dependency:0.297-202602190453-8d6d9543
       volumes:
@@ -85,40 +71,33 @@ jobs:
           echo "New available disk space: " $(getAvailableSpace)
 
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
 
       - name: Fix git permissions
-        if: needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Update velox
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           cd presto-native-execution
           make velox-submodule
 
       - name: Install Github CLI for using apache/infrastructure-actions/stash
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           curl -L https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.rpm > gh_2.63.2_linux_amd64.rpm
           rpm -iv gh_2.63.2_linux_amd64.rpm
 
       - uses: apache/infrastructure-actions/stash/restore@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
-        if: needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-linux-build-engine
 
       - name: Zero ccache statistics
-        if: needs.changes.outputs.codechange == 'true'
         run: ccache -sz
 
       - name: Remove files not needed for the build
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           find . -name data | xargs rm -r
           find . -name tests | xargs rm -r
@@ -129,40 +108,32 @@ jobs:
           find . -name ".git" -not -path "./.git*" | xargs rm -rf
 
       - name: Disk space consumption before build
-        if: needs.changes.outputs.codechange == 'true'
         run: df
 
       - name: Generate build command script for reuse
-        if: needs.changes.outputs.codechange == 'true'
         run: |
 
       - name: Build engine
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           eval ${{ env.BUILD_SCRIPT }}
 
       - name: Disk space consumption after build
-        if: needs.changes.outputs.codechange == 'true'
         run: df
 
       - name: Ccache after
-        if: needs.changes.outputs.codechange == 'true'
         run: ccache -s
 
       - uses: apache/infrastructure-actions/stash/save@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
-        if: needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-linux-build-engine
 
       - name: Regenerate the protocol files
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export PRESTO_HOME=$(pwd)
           cd presto-native-execution
           make presto_protocol
 
       - name: Incrementally rebuild presto_server with the new protocol
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           eval ${{ env.BUILD_SCRIPT }}

--- a/.github/workflows/prestocpp-macos-build.yml
+++ b/.github/workflows/prestocpp-macos-build.yml
@@ -2,34 +2,17 @@ name: prestocpp-macos-build
 
 on:
   workflow_dispatch: {}
-  pull_request: {}
+  pull_request:
+    paths:
+      - presto-native-execution/**
+      - .github/workflows/prestocpp-macos-build.yml
 
 jobs:
-  changes:
-    runs-on: macos-15
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - name: Run changes check for PRs
-        uses: dorny/paths-filter@7267a8516b6f92bdb098633497bad573efdbf271
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - 'presto-native-execution/**'
-              - '.github/workflows/prestocpp-macos-build.yml'
-
   prestocpp-macos-build-engine:
     strategy:
       matrix:
         os: [macos-15]
     runs-on: ${{ matrix.os }}
-    needs: changes
     permissions:
       contents: read
     env:
@@ -44,28 +27,20 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        if: |
-          needs.changes.outputs.codechange == 'true'
         with:
           persist-credentials: false
 
       - name: Fix git permissions
-        if: |
-          needs.changes.outputs.codechange == 'true'
         # Usually actions/checkout does this but as we run in a container
         # it doesn't work
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
       - name: Update submodules
-        if: |
-          needs.changes.outputs.codechange == 'true'
         run: |
           cd presto-native-execution
           make submodules
 
       - name: Setup MacOS
-        if: |
-          needs.changes.outputs.codechange == 'true'
         run: |
           set -xu
           source presto-native-execution/scripts/setup-macos.sh
@@ -100,26 +75,18 @@ jobs:
           brew link --force protobuf@21
 
       - name: Install Github CLI for using apache/infrastructure-actions/stash
-        if: |
-          needs.changes.outputs.codechange == 'true'
         run: |
           brew install gh
 
       - uses: apache/infrastructure-actions/stash/restore@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
-        if: |
-          needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-macos-build-engine-${{ matrix.os }}
 
       - name: Zero ccache statistics
-        if: |
-          needs.changes.outputs.codechange == 'true'
         run: PATH=${INSTALL_PREFIX}/bin:${PATH} ccache -sz
 
       - name: Build presto_cpp on MacOS
-        if: |
-          needs.changes.outputs.codechange == 'true'
         run: |
           clang --version
           export PATH=$(brew --prefix m4)/bin:$(brew --prefix bison)/bin:${PATH}
@@ -132,13 +99,9 @@ jobs:
           ninja -C _build/${BUILD_TYPE} -j ${NJOBS}
 
       - name: Ccache after
-        if: |
-          needs.changes.outputs.codechange == 'true'
         run: PATH=${INSTALL_PREFIX}/bin:${PATH} ccache -s
 
       - uses: apache/infrastructure-actions/stash/save@4ab8682fbd4623d2b4fc1c98db38aba5091924c3
-        if: |
-          needs.changes.outputs.codechange == 'true'
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-prestocpp-macos-build-engine-${{ matrix.os }}

--- a/.github/workflows/product-tests-basic-environment.yml
+++ b/.github/workflows/product-tests-basic-environment.yml
@@ -1,6 +1,9 @@
 name: product tests (basic)
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -11,22 +14,6 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
   product-tests-basic-environment:
     strategy:
       fail-fast: false
@@ -35,39 +22,32 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: changes
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-basic-environment-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
-        if: needs.changes.outputs.codechange == 'true'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: true
           swap-storage: false
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-test-coverage'
       - name: Run Product Tests Basic Environment
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode -x quarantine,big_query,storage_formats,profile_specific_tests,tpcds,cassandra,mysql_connector,mysql_mixed_case,postgresql_connector,mysql,kafka,avro,mixed_case

--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -11,22 +14,6 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
   product-tests-specific-environment1:
     strategy:
       fail-fast: false
@@ -35,43 +22,35 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: changes
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-specific-environment1-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
-        if: needs.changes.outputs.codechange == 'true'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           docker-images: false
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-test-coverage'
       - name: Product Tests Specific 1.1
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode -g hdfs_no_impersonation,avro,mixed_case
       - name: Product Tests Specific 1.2
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-no-impersonation -g hdfs_no_impersonation
@@ -79,17 +58,14 @@ jobs:
       # - name: Product Tests Specific 1.3
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.4
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
       - name: Product Tests Specific 1.5
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-cross-realm -g storage_formats,cli,hdfs_impersonation
       - name: Product Tests Specific 1.6
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls-kerberos -g cli,group-by,join,tls
@@ -102,58 +78,47 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: changes
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-product-tests-specific-environment2-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
-        if: needs.changes.outputs.codechange == 'true'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           docker-images: false
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing,!presto-test-coverage'
       - name: Product Tests Specific 2.1
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-ldap -g ldap -x simba_jdbc
       - name: Product Tests Specific 2.2
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls -g smoke,cli,group-by,join,tls
       - name: Product Tests Specific 2.3
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-mysql -g mysql_connector,mysql
       - name: Product Tests Specific 2.4
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-postgresql -g postgresql_connector
       - name: Product Tests Specific 2.5
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra
@@ -161,22 +126,18 @@ jobs:
       # - name: Product Tests Specific 2.6
       #  run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption -g storage_formats,cli,hdfs_impersonation,authorization
       - name: Product Tests Specific 2.7
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kafka -g kafka
       - name: Product Tests Specific 2.8
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-sqlserver -g sqlserver
       - name: Product Tests Specific 2.9
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-mysql-mixed-case-on -g mysql_connector,mysql_mixed_case
       - name: Product Tests Specific 2.10
-        if: needs.changes.outputs.codechange == 'true'
         env:
           OVERRIDE_JDK_DIR: ${{ env.JAVA_HOME }}
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption-cipher-suites -g create_table

--- a/.github/workflows/singlestore-tests.yml
+++ b/.github/workflows/singlestore-tests.yml
@@ -1,6 +1,9 @@
 name: singlestore tests
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -12,22 +15,6 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
   singlestore-dockerized-tests:
     strategy:
       fail-fast: false
@@ -36,19 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: changes
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-singlestore-dockerized-tests-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - name: Remove unnecessary pre-installed toolchains for free disk spaces
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           echo "=== BEFORE ==="
           df -h
@@ -60,21 +44,17 @@ jobs:
           echo "=== AFTER ==="
           df -h
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Install SingleStore Module
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am  --no-transfer-progress -pl :presto-singlestore
       - name: Run SingleStore Dockerized Tests
-        if: needs.changes.outputs.codechange == 'true'
         env:
           SINGLESTORE_LICENSE: ${{ secrets.SINGLESTORE_LICENSE }}
         run: ./mvnw test ${MAVEN_TEST} -pl :presto-singlestore

--- a/.github/workflows/spark-integration.yml
+++ b/.github/workflows/spark-integration.yml
@@ -1,6 +1,9 @@
 name: spark integration
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -12,22 +15,6 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
   spark-integration:
     strategy:
       fail-fast: false
@@ -36,37 +23,30 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: changes
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-spark-integration-${{ github.event.pull_request.number }}-${{ matrix.java }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space
-        if: needs.changes.outputs.codechange == 'true'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: true
           swap-storage: false
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven Install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl presto-spark-launcher,presto-spark-package,presto-spark-testing
       - name: Maven Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl :presto-spark-testing -P test-presto-spark-integration-smoke-test

--- a/.github/workflows/test-other-modules.yml
+++ b/.github/workflows/test-other-modules.yml
@@ -1,6 +1,9 @@
 name: test other modules
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -12,22 +15,6 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
   test-other-modules:
     strategy:
       fail-fast: false
@@ -36,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: changes
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-test-other-modules-${{ github.event.pull_request.number }}-${{ matrix.java }}
@@ -48,28 +34,22 @@ jobs:
           tool-cache: true
           swap-storage: false
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       # Workaround for Ubuntu 24 and mysql to find the dependent library (https://github.com/prestodb/presto/issues/24327)
       - name: Create symlink for libaio.so.1
-        if: needs.changes.outputs.codechange == 'true'
         run: sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
       - name: Maven Install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -pl '!:presto-docs,!:presto-server,!presto-test-coverage'
       - name: Maven Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test -T 1 ${MAVEN_TEST} -P skip-native-sidecar-tests -pl '!presto-tests, !presto-native-tests, !presto-accumulo, !presto-cassandra, !presto-hive, !presto-kudu, !presto-docs, !presto-server, !presto-main, !presto-main-base, !presto-mongodb, !presto-spark-package, !presto-spark-launcher, !presto-spark-testing, !presto-spark-base, !presto-redis, !presto-elasticsearch, !presto-orc, !presto-thrift-connector, !presto-native-execution, !presto-test-coverage, !presto-iceberg, !presto-singlestore, !presto-base-arrow-flight, !presto-plan-checker-router-plugin, !presto-mysql, !presto-postgresql'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: test
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - presto-docs/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -12,28 +15,10 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
-
   test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -77,24 +62,19 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           show-progress: false
           persist-credentials: false
       - uses: actions/setup-java@v4
-        if: needs.changes.outputs.codechange == 'true'
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: maven
       - name: Download nodejs to maven cache
-        if: needs.changes.outputs.codechange == 'true'
         run: .github/bin/download_nodejs
       - name: Maven Install
-        if: needs.changes.outputs.codechange == 'true'
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl $(echo '${{ matrix.modules }}' | cut -d' ' -f1)
       - name: Maven Tests
-        if: needs.changes.outputs.codechange == 'true'
         run: ./mvnw test ${MAVEN_TEST} -pl ${{ matrix.modules }}

--- a/.github/workflows/web-ui-checks.yml
+++ b/.github/workflows/web-ui-checks.yml
@@ -1,6 +1,9 @@
 name: web ui checks
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - presto-ui/**
 
 env:
   # An envar that signals to tests we are executing in the CI environment
@@ -8,29 +11,10 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    # Required permissions
-    permissions:
-      pull-requests: read
-    # Set job outputs to values from filter step
-    outputs:
-      codechange: ${{ steps.filter.outputs.codechange }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            codechange:
-              - '!presto-docs/**'
-              - 'presto-ui/**'
   web-ui-checks:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: changes
-    if: needs.changes.outputs.codechange == 'true'
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-web-ui-checks-${{ github.event.pull_request.number }}

--- a/presto-docs/README.md
+++ b/presto-docs/README.md
@@ -4,7 +4,7 @@ Presto documentation is authored in `rst` format and published using [Sphinx](ht
 
 ## Prerequisites
 
-Building the presto-docs module requires Python3 with virtual environment. You can check if you have it installed by running:
+Building the presto-docs module requires Python3 with a virtual environment. You can check if you have it installed by running:
 ```shell
 python3 -m venv --help
 ```


### PR DESCRIPTION
## Description
Use [on.pull_request.<paths|paths-ignore>](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore) to run workflows based on which file paths have changed.

## Motivation and Context

**Motivation**
- Reduce the number of dependencies (`dorny/paths-filter` action) and simplify the code.
- Disable the `.github/workflows/maven-checks.yml` workflow for changes to `presto-docs`.

**Context**
Commit https://github.com/prestodb/presto/commit/0ddccd7ba37c60305f181ff9f084d5cf4079509b introduced the `dorny/paths-filter` action as a replacement for `on.pull_request.<paths|paths-ignore>` with the following desription:
```
Use `jobs.<job_id>.if` condition to control the
job execution instead of `on.pull.paths-ignore`.
In this case, the job status of the skipped jobs
would be `Success` but not `Pending`.
```
However, I don't see the jobs in a `Pending` state. It is possible the behaviour has changed since the commit, or perhaps I am missing some additional context regarding the change.

## Impact
No

## Test Plan
Tested in fork https://github.com/dnskr/presto/pull/1.
Filtered workflows are not executed or even mentioned in the GitHub Web UI:
<img width="973" height="535" alt="image" src="https://github.com/user-attachments/assets/d4eef878-d3b6-4212-accc-80d2fe38679c" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Adjust CI workflows to trigger based on file path changes and simplify conditional execution logic.

CI:
- Update multiple GitHub Actions workflows to use pull_request path and paths-ignore filters instead of a dedicated paths-filter job.
- Remove intermediate change-detection jobs and associated conditional step logic so jobs always run when their workflow is triggered by matching paths.
- Scope specific workflows to relevant directories only, such as presto-native-execution for macOS/native builds and presto-ui for web UI checks, while excluding presto-docs from most non-doc workflows.
- Refine OWASP dependency check triggers to run for all code changes except general docs, while still running when the presto-docs Maven configuration changes.

Documentation:
- Clarify presto-docs README wording around the Python virtual environment prerequisite.

## Summary by Sourcery

Simplify CI workflows by using native GitHub Actions path filters and tightening when specific workflows run.

CI:
- Replace custom dorny/paths-filter jobs and conditional job logic with pull_request paths and paths-ignore filters across multiple workflows, so jobs only run when relevant files change.
- Exclude presto-docs-only changes from most Java, native, and integration test workflows, while still running the OWASP dependency check when overall code or presto-docs/pom.xml change.
- Scope macOS and web UI workflows to run only when presto-native-execution or presto-ui paths (and their own workflow files) are modified, reducing unnecessary CI runs.

Documentation:
- Clarify presto-docs README wording about the Python virtual environment prerequisite.