### PR TITLE
fix(build): Use explicit optional constructor

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/ArrowFlightConnectorDataTypeTest.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/arrow_flight/tests/ArrowFlightConnectorDataTypeTest.cpp
@@ -367,7 +367,8 @@ TEST_F(ArrowFlightConnectorDataTypeTest, mapType) {
          std::numeric_limits<int64_t>::max()},
         {std::numeric_limits<int32_t>::min(),
          std::numeric_limits<int64_t>::min()}}},
-      {{}},
+      std::make_optional<
+          std::vector<std::pair<int32_t, std::optional<int64_t>>>>(),
       {{{42, std::nullopt}}},
       std::nullopt,
       {{{3, -300},


### PR DESCRIPTION
Without this change GCC14 won't compile for the Arrow test.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Fix native Arrow Flight connector datatype test initialization to compile with newer GCC.

Bug Fixes:
- Resolve GCC14 compilation failure by using an explicit optional constructor in Arrow Flight connector map type test initialization.

Tests:
- Adjust Arrow Flight connector map type test data initialization to use an explicit optional value instead of brace initialization.

## Summary by Sourcery

Fix Arrow Flight connector map type test initialization to be compatible with newer GCC compilers.

Bug Fixes:
- Resolve GCC14 compilation failure by replacing problematic brace-initialized optional map value with an explicit std::optional construction in the Arrow Flight connector map type test.

Tests:
- Adjust Arrow Flight connector map type test data setup to use an explicitly constructed optional vector value.