### PR TITLE
fix(plugin-iceberg): Reduce max history queries to avoid OOM in CI test

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -106,7 +106,12 @@ public abstract class IcebergDistributedSmokeTestBase
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return IcebergQueryRunner.builder().setCatalogType(catalogType).build().getQueryRunner();
+        return IcebergQueryRunner.builder()
+                .setCatalogType(catalogType)
+                .setExtraProperties(ImmutableMap.of("query.max-age", "10s",
+                        "query.max-history", "10"))
+                .build()
+                .getQueryRunner();
     }
 
     @Test

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedSmokeTestBase.java
@@ -108,6 +108,9 @@ public abstract class IcebergDistributedSmokeTestBase
     {
         return IcebergQueryRunner.builder()
                 .setCatalogType(catalogType)
+                // These tests do not rely on long query history (no assertions on past queries,
+                // retries, or timing behavior). The aggressive limits below are chosen solely to
+                // reduce query history memory usage and are safe for all Iceberg distributed tests.
                 .setExtraProperties(ImmutableMap.of("query.max-age", "10s",
                         "query.max-history", "10"))
                 .build()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -227,6 +227,9 @@ public abstract class IcebergDistributedTestBase
         this.icebergQueryRunner = IcebergQueryRunner.builder()
                 .setCatalogType(catalogType)
                 .setExtraConnectorProperties(extraConnectorProperties)
+                // These tests do not rely on long query history (no assertions on past queries,
+                // retries, or timing behavior). The aggressive limits below are chosen solely to
+                // reduce query history memory usage and are safe for all Iceberg distributed tests.
                 .setExtraProperties(ImmutableMap.of("query.max-age", "10s",
                         "query.max-history", "10"))
                 .build();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/IcebergDistributedTestBase.java
@@ -227,6 +227,8 @@ public abstract class IcebergDistributedTestBase
         this.icebergQueryRunner = IcebergQueryRunner.builder()
                 .setCatalogType(catalogType)
                 .setExtraConnectorProperties(extraConnectorProperties)
+                .setExtraProperties(ImmutableMap.of("query.max-age", "10s",
+                        "query.max-history", "10"))
                 .build();
         return icebergQueryRunner.getQueryRunner();
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
@@ -60,6 +60,9 @@ public abstract class TestIcebergDistributedQueries
         return IcebergQueryRunner.builder()
                 .setCatalogType(catalogType)
                 .setExtraConnectorProperties(extraConnectorProperties)
+                // These tests do not rely on long query history (no assertions on past queries,
+                // retries, or timing behavior). The aggressive limits below are chosen solely to
+                // reduce query history memory usage and are safe for all Iceberg distributed tests.
                 .setExtraProperties(ImmutableMap.of("query.max-age", "10s",
                         "query.max-history", "10"))
                 .build().getQueryRunner();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributedQueries.java
@@ -60,6 +60,8 @@ public abstract class TestIcebergDistributedQueries
         return IcebergQueryRunner.builder()
                 .setCatalogType(catalogType)
                 .setExtraConnectorProperties(extraConnectorProperties)
+                .setExtraProperties(ImmutableMap.of("query.max-age", "10s",
+                        "query.max-history", "10"))
                 .build().getQueryRunner();
     }
 


### PR DESCRIPTION
## Description

Currently, as several major Iceberg test classes (TestIcebergDistributedQueries, IcebergDistributedSmokeTestBase, IcebergDistributedTestBase) continue to grow, the number of history queries tracked within the same `QueryRunner` for each test class has been increasing. This leads to growing memory usage that often causes OOM failures in CI testing. For example, after running all tests in `TestIcebergDistributedQueries`, the total number of history queries tracked in the queryRunner reaches 2900+, occupying approximately 600MB of additional memory.

This PR explicitly sets `query.max-history` and `query.max-age` for the `QueryRunner` built in these test classes to significantly reduce this memory overhead. For example, after this change, after running all tests in `TestIcebergDistributedQueries`, the total number of history queries tracked in the queryRunner is around 200.

## Motivation and Context

Reduce OOM during Iceberg CI tests.

## Impact

N/A

## Test Plan

N/A

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Tests:
- Configure Iceberg distributed test query runners with low query.max-age and query.max-history values to cap in-memory query history during tests.