### PR TITLE
feat(scheduler): Add a new scheduler + exchange rules to support multiple table scans in a single stage

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q02.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q02.plan.txt
@@ -9,7 +9,7 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, [d_week_seq_232])
                                     partial aggregation over (d_week_seq_232)
                                         join (INNER, REPLICATED):
-                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 scan web_sales
                                                 scan catalog_sales
                                             local exchange (GATHER, SINGLE, [])
@@ -24,7 +24,7 @@ remote exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [d_week_seq])
                                 partial aggregation over (d_week_seq)
                                     join (INNER, REPLICATED):
-                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                             scan web_sales
                                             scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q05.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q05.plan.txt
@@ -11,7 +11,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (s_store_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         scan store_sales
                                                         scan store_returns
                                                     local exchange (GATHER, SINGLE, [])
@@ -26,7 +26,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (cp_catalog_page_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         scan catalog_sales
                                                         scan catalog_returns
                                                     local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q54.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q54.plan.txt
@@ -30,7 +30,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                                                                             join (INNER, REPLICATED):
                                                                                                                 join (INNER, REPLICATED):
-                                                                                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                                         scan catalog_sales
                                                                                                                         scan web_sales
                                                                                                                     local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q71.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q71.plan.txt
@@ -7,7 +7,7 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             scan web_sales
                                             local exchange (GATHER, SINGLE, [])

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/MultiSourcePartitionedScheduler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/MultiSourcePartitionedScheduler.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.airlift.concurrent.NotThreadSafe;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.SqlStageExecution;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.StageExecutionDescriptor;
+import com.facebook.presto.split.SplitSource;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.ArrayDeque;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+
+import static com.facebook.presto.execution.scheduler.SourcePartitionedScheduler.newSourcePartitionedSchedulerAsSourceScheduler;
+import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Class that implements a scheduler for executing a query stage that reads from multiple table scans within a single stage.
+ * It schedules them sequentially, completing one source before moving to the next.
+ */
+@NotThreadSafe
+public class MultiSourcePartitionedScheduler
+        implements StageScheduler
+{
+    private static final Logger log = Logger.get(MultiSourcePartitionedScheduler.class);
+
+    private final SqlStageExecution stageExecution;
+    private final Queue<SourceScheduler> partitionedSourceSchedulers; // Queue of schedulers, one per split source (table scan nodes).
+
+    public MultiSourcePartitionedScheduler(
+            SqlStageExecution stageExecution,
+            Map<PlanNodeId, SplitSource> splitSources,
+            SplitPlacementPolicy splitPlacementPolicy,
+            int splitBatchSize,
+            StageExecutionDescriptor stageExecutionDescriptor)
+    {
+        requireNonNull(splitSources, "splitSources is null");
+        checkArgument(splitSources.size() > 1, "It is expected that there will be more than one split sources");
+
+        ImmutableList.Builder<SourceScheduler> sourceSchedulers = ImmutableList.builder();
+        for (PlanNodeId planNodeId : splitSources.keySet()) {
+            SplitSource splitSource = splitSources.get(planNodeId);
+            boolean groupedExecutionForScanNode = stageExecutionDescriptor.isScanGroupedExecution(planNodeId);
+
+            // Create a partitioned source scheduler for each split source (typically one per scan node in the stage)
+            SourceScheduler sourceScheduler = newSourcePartitionedSchedulerAsSourceScheduler(
+                    stageExecution,
+                    planNodeId,
+                    splitSource,
+                    splitPlacementPolicy,
+                    splitBatchSize,
+                    groupedExecutionForScanNode);
+            // MultiSourcePartitionedScheduler is used for unpartitioned (task-wide) lifespans.
+            sourceScheduler.startLifespan(Lifespan.taskWide(), NOT_PARTITIONED);
+            sourceSchedulers.add(sourceScheduler);
+        }
+        this.stageExecution = requireNonNull(stageExecution, "stageExecution is null");
+        this.partitionedSourceSchedulers = new ArrayDeque<>(sourceSchedulers.build());
+    }
+
+    @Override
+    public synchronized ScheduleResult schedule()
+    {
+        ImmutableSet.Builder<RemoteTask> newScheduledTasks = ImmutableSet.builder();
+        ListenableFuture<?> blocked = immediateVoidFuture();
+        Optional<ScheduleResult.BlockedReason> blockedReason = Optional.empty();
+        int splitsScheduled = 0;
+
+        while (!partitionedSourceSchedulers.isEmpty()) {
+            SourceScheduler scheduler = partitionedSourceSchedulers.peek();
+            ScheduleResult scheduleResult = scheduler.schedule();
+            scheduler.drainCompletelyScheduledLifespans();
+
+            splitsScheduled += scheduleResult.getSplitsScheduled();
+            newScheduledTasks.addAll(scheduleResult.getNewTasks());
+            blocked = scheduleResult.getBlocked();
+            blockedReason = scheduleResult.getBlockedReason();
+
+            // If the current source is not done scheduling, stop scheduling for now.
+            if (!blocked.isDone() || !scheduleResult.isFinished()) {
+                break;
+            }
+
+            stageExecution.schedulingComplete(scheduler.getPlanNodeId());
+            partitionedSourceSchedulers.remove().close();
+        }
+
+        if (blockedReason.isPresent()) {
+            return ScheduleResult.blocked(partitionedSourceSchedulers.isEmpty(), newScheduledTasks.build(), blocked, blockedReason.get(), splitsScheduled);
+        }
+        return ScheduleResult.nonBlocked(partitionedSourceSchedulers.isEmpty(), newScheduledTasks.build(), splitsScheduled);
+    }
+
+    @Override
+    public void close()
+    {
+        for (SourceScheduler sourceScheduler : partitionedSourceSchedulers) {
+            try {
+                sourceScheduler.close();
+            }
+            catch (Throwable t) {
+                log.warn(t, "Error closing split source");
+            }
+        }
+        partitionedSourceSchedulers.clear();
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/MultiSourcePartitionedScheduler.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/MultiSourcePartitionedScheduler.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution.scheduler;
 
+import com.facebook.airlift.concurrent.MoreFutures;
 import com.facebook.airlift.concurrent.NotThreadSafe;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.execution.Lifespan;
@@ -26,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -48,13 +50,15 @@ public class MultiSourcePartitionedScheduler
 
     private final SqlStageExecution stageExecution;
     private final Queue<SourceScheduler> partitionedSourceSchedulers; // Queue of schedulers, one per split source (table scan nodes).
+    private final CTEMaterializationTracker cteMaterializationTracker;
 
     public MultiSourcePartitionedScheduler(
             SqlStageExecution stageExecution,
             Map<PlanNodeId, SplitSource> splitSources,
             SplitPlacementPolicy splitPlacementPolicy,
             int splitBatchSize,
-            StageExecutionDescriptor stageExecutionDescriptor)
+            StageExecutionDescriptor stageExecutionDescriptor,
+            CTEMaterializationTracker cteMaterializationTracker)
     {
         requireNonNull(splitSources, "splitSources is null");
         checkArgument(splitSources.size() > 1, "It is expected that there will be more than one split sources");
@@ -78,11 +82,22 @@ public class MultiSourcePartitionedScheduler
         }
         this.stageExecution = requireNonNull(stageExecution, "stageExecution is null");
         this.partitionedSourceSchedulers = new ArrayDeque<>(sourceSchedulers.build());
+        this.cteMaterializationTracker = requireNonNull(cteMaterializationTracker, "cteMaterializationTracker is null");
     }
 
     @Override
     public synchronized ScheduleResult schedule()
     {
+        List<ListenableFuture<?>> cteMaterializationFutures = cteMaterializationTracker.waitForCteMaterialization(stageExecution);
+        if (!cteMaterializationFutures.isEmpty()) {
+            return ScheduleResult.blocked(
+                    false,
+                    ImmutableList.of(),
+                    MoreFutures.whenAnyComplete(cteMaterializationFutures),
+                    ScheduleResult.BlockedReason.WAITING_FOR_CTE_MATERIALIZATION,
+                    0);
+        }
+
         ImmutableSet.Builder<RemoteTask> newScheduledTasks = ImmutableSet.builder();
         ListenableFuture<?> blocked = immediateVoidFuture();
         Optional<ScheduleResult.BlockedReason> blockedReason = Optional.empty();

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
@@ -87,6 +87,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -291,19 +292,48 @@ public class SectionExecutionFactory
         int maxTasksPerStage = getMaxTasksPerStage(session);
         Optional<Predicate<Node>> nodePredicate = getNodePoolSelectionPredicate(plan);
         if (partitioningHandle.equals(SOURCE_DISTRIBUTION)) {
-            // nodes are selected dynamically based on the constraints of the splits and the system load
-            Map.Entry<PlanNodeId, SplitSource> entry = splitSources.entrySet().stream().collect(onlyElement());
-            PlanNodeId planNodeId = entry.getKey();
-            SplitSource splitSource = entry.getValue();
-            ConnectorId connectorId = splitSource.getConnectorId();
-            if (isInternalSystemConnector(connectorId)) {
-                connectorId = null;
-            }
-            NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, connectorId, maxTasksPerStage, nodePredicate);
-            SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeSelector, stageExecution::getAllTasks);
+            // Single split source case: Use a single source-partitioned scheduler (SourcePartitionedScheduler).
+            if (splitSources.size() == 1) {
+                // Nodes are selected dynamically based on the constraints of the splits and the system load
+                Map.Entry<PlanNodeId, SplitSource> entry = splitSources.entrySet().stream().collect(onlyElement());
+                PlanNodeId planNodeId = entry.getKey();
+                SplitSource splitSource = entry.getValue();
+                ConnectorId connectorId = splitSource.getConnectorId();
+                if (isInternalSystemConnector(connectorId)) {
+                    connectorId = null;
+                }
+                NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, connectorId, maxTasksPerStage, nodePredicate);
+                SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeSelector, stageExecution::getAllTasks);
 
-            checkArgument(!plan.getFragment().getStageExecutionDescriptor().isStageGroupedExecution());
-            return newSourcePartitionedSchedulerAsStageScheduler(stageExecution, planNodeId, splitSource, placementPolicy, splitBatchSize, cteMaterializationTracker);
+                checkArgument(!plan.getFragment().getStageExecutionDescriptor().isStageGroupedExecution());
+
+                // Return a SourcePartitionedScheduler for the single source.
+                return newSourcePartitionedSchedulerAsStageScheduler(stageExecution, planNodeId, splitSource, placementPolicy, splitBatchSize, cteMaterializationTracker);
+            }
+
+            // Multiple split sources case: Use MultiSourcePartitionedScheduler to coordinate across sources.
+            // Extract all non-internal ConnectorIds from the split sources.
+            Set<ConnectorId> connectorIds = splitSources.values()
+                    .stream()
+                    .map(SplitSource::getConnectorId)
+                    .filter(x -> !isInternalSystemConnector(x))
+                    .collect(toImmutableSet());
+
+            // Validate that all table scans use the same catalog.
+            checkState(connectorIds.size() <= 1, "table scans that are within one stage should read from same catalog");
+
+            // If all connectors are internal system connectors, connectorIds will be empty after filtering.
+            ConnectorId connectorId = connectorIds.isEmpty() ? null : connectorIds.iterator().next();
+
+            NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, connectorId, maxTasksPerStage, nodePredicate);
+
+            // Return MultiSourcePartitionedScheduler to coordinate multiple split sources while ensuring they are from the same catalog.
+            return new MultiSourcePartitionedScheduler(
+                    stageExecution,
+                    splitSources,
+                    new DynamicSplitPlacementPolicy(nodeSelector, stageExecution::getAllTasks),
+                    splitBatchSize,
+                    plan.getFragment().getStageExecutionDescriptor());
         }
         else if (partitioningHandle.equals(SCALED_WRITER_DISTRIBUTION)) {
             Supplier<Collection<TaskStatus>> sourceTasksProvider = () -> childStageExecutions.stream()

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
@@ -292,6 +292,8 @@ public class SectionExecutionFactory
         int maxTasksPerStage = getMaxTasksPerStage(session);
         Optional<Predicate<Node>> nodePredicate = getNodePoolSelectionPredicate(plan);
         if (partitioningHandle.equals(SOURCE_DISTRIBUTION)) {
+            checkArgument(!plan.getFragment().getStageExecutionDescriptor().isStageGroupedExecution());
+
             // Single split source case: Use a single source-partitioned scheduler (SourcePartitionedScheduler).
             if (splitSources.size() == 1) {
                 // Nodes are selected dynamically based on the constraints of the splits and the system load
@@ -304,8 +306,6 @@ public class SectionExecutionFactory
                 }
                 NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, connectorId, maxTasksPerStage, nodePredicate);
                 SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeSelector, stageExecution::getAllTasks);
-
-                checkArgument(!plan.getFragment().getStageExecutionDescriptor().isStageGroupedExecution());
 
                 // Return a SourcePartitionedScheduler for the single source.
                 return newSourcePartitionedSchedulerAsStageScheduler(stageExecution, planNodeId, splitSource, placementPolicy, splitBatchSize, cteMaterializationTracker);

--- a/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
@@ -333,7 +333,8 @@ public class SectionExecutionFactory
                     splitSources,
                     new DynamicSplitPlacementPolicy(nodeSelector, stageExecution::getAllTasks),
                     splitBatchSize,
-                    plan.getFragment().getStageExecutionDescriptor());
+                    plan.getFragment().getStageExecutionDescriptor(),
+                    cteMaterializationTracker);
         }
         else if (partitioningHandle.equals(SCALED_WRITER_DISTRIBUTION)) {
             Supplier<Collection<TaskStatus>> sourceTasksProvider = () -> childStageExecutions.stream()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.connector.system.GlobalSystemConnector;
 import com.facebook.presto.execution.QueryManagerConfig.ExchangeMaterializationStrategy;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.TableLayout;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.Constraint;
@@ -138,6 +139,7 @@ import static com.facebook.presto.SystemSessionProperties.isRedistributeWrites;
 import static com.facebook.presto.SystemSessionProperties.isScaleWriters;
 import static com.facebook.presto.SystemSessionProperties.isSingleNodeExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.isUseStreamingExchangeForMarkDistinctEnabled;
+import static com.facebook.presto.SystemSessionProperties.planWithTableNodePartitioning;
 import static com.facebook.presto.SystemSessionProperties.preferStreamingOperators;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.operator.aggregation.AggregationUtils.hasSingleNodeExecutionPreference;
@@ -1584,8 +1586,25 @@ public class AddExchanges
                         return new PlanWithProperties(node.replaceChildren(distributedChildren));
                     }
                     else if (preferDistributedUnion) {
-                        // Presto currently can not execute stage that has multiple table scans, so in that case
-                        // we have to insert REMOTE exchange with FIXED_ARBITRARY_DISTRIBUTION instead of local exchange
+                        int repartitionedRemoteExchangeNodesCount = distributedChildren.stream().mapToInt(AddExchanges::countRepartitionedRemoteExchangeNodes).sum();
+                        int partitionedConnectorSourceCount = distributedChildren.stream().mapToInt(
+                                children -> AddExchanges.countPartitionedConnectorSource(children, session, metadata)).sum();
+                        long uniqueSourceCatalogCount = distributedChildren.stream().flatMap(AddExchanges::collectSourceCatalogs).distinct().count();
+
+                        // MultiSourcePartitionedScheduler does not support node partitioning.
+                        // Both partitioned remote exchanges and partitioned connector sources require node partitioning.
+                        if (repartitionedRemoteExchangeNodesCount == 0
+                                && partitionedConnectorSourceCount == 0
+                                && uniqueSourceCatalogCount == 1) {
+                            // When all conditions are met to execute multiple table scans in the same stage, then we can use a LOCAL exchange.
+                            return new PlanWithProperties(node.replaceChildren(distributedChildren));
+                        }
+                        // If there is:
+                        //   - at least one non-source distributed source (data is already partitioned/distributed across workers from upstream query processing: joins, aggregations, etc.)
+                        //   OR
+                        //   - one source uses connector-based partitioning (data is already partitioned by the underlying storage system/connector)
+                        // then, a REMOTE exchange with FIXED_ARBITRARY_DISTRIBUTION is necessary instead of a local exchange when merging multiple data sources in a UNION operation.
+                        // Local exchange can only merge data within a single worker. REMOTE exchange enables cross-worker data movement.
                         return new PlanWithProperties(
                                 new ExchangeNode(
                                         node.getSourceLocation(),
@@ -1971,6 +1990,109 @@ public class AddExchanges
         ImmutableList.Builder<PartitioningHandle> handles = ImmutableList.builder();
         nodes.forEach(node -> node.accept(new ExchangePartitioningHandleExtractor(), handles));
         return handles.build();
+    }
+
+    /**
+     * Determines if a given {@code PlanNode} is not a remote {@code ExchangeNode}.
+     *
+     * This method checks whether the provided {@code PlanNode} is an {@code ExchangeNode} and,
+     * if so, verifies that its scope is not remote. If the node is not an {@code ExchangeNode},
+     * it is considered not remote by default.
+     *
+     * @param node the {@code PlanNode} to evaluate
+     * @return {@code true} if the {@code PlanNode} is not a remote {@code ExchangeNode}, or if it
+     *         is not an {@code ExchangeNode}; {@code false} otherwise
+     */
+    private static boolean isNotRemoteExchange(PlanNode node)
+    {
+        if (node instanceof ExchangeNode) {
+            return !((ExchangeNode) node).getScope().isRemote();
+        }
+
+        return true;
+    }
+
+    /**
+     * Counts the number of remote ExchangeNodes in the query plan that are of type REPARTITION.
+     *
+     * This method traverses the query plan starting from the provided root node, identifying instances
+     * of {@code ExchangeNode} that meet the following criteria:
+     * - The exchange has a REMOTE scope.
+     * - The exchange type is REPARTITION.
+     *
+     * The traversal skips subtrees connected via non-remote exchanges.
+     *
+     * @param root the root PlanNode of the query plan tree to search
+     * @return the count of remote ExchangeNodes of type REPARTITION in the query plan
+     */
+    private static int countRepartitionedRemoteExchangeNodes(PlanNode root)
+    {
+        return PlanNodeSearcher
+                .searchFrom(root)
+                .where(node -> {
+                    if (node instanceof ExchangeNode) {
+                        ExchangeNode exchangeNode = (ExchangeNode) node;
+                        return exchangeNode.getScope().isRemote() && exchangeNode.getType() == REPARTITION;
+                    }
+                    return false;
+                })
+                .recurseOnlyWhen(AddExchanges::isNotRemoteExchange)
+                .findAll()
+                .size();
+    }
+
+    /**
+     * Counts the number of TableScanNodes in the given query plan that are associated with partitioned connector sources.
+     *
+     * This method traverses the query plan starting from the provided root node, identifying {@code TableScanNode}
+     * instances that meet specific criteria:
+     * - The table node supports partitioning, as determined by the session configuration.
+     * - The metadata for the table includes a defined table partitioning.
+     *
+     * The method recursively processes PlanNodes, skipping any subtrees connected via remote exchanges.
+     *
+     * @param root the root PlanNode of the query plan tree
+     * @param session the session object containing configuration and metadata context
+     * @param metadata the metadata object for accessing table properties and layouts
+     * @return the count of TableScanNodes associated with partitioned connector sources
+     */
+    private static int countPartitionedConnectorSource(PlanNode root, Session session, Metadata metadata)
+    {
+        return PlanNodeSearcher
+                .searchFrom(root)
+                .where(node -> {
+                    if (node instanceof TableScanNode) {
+                        TableScanNode tableScanNode = (TableScanNode) node;
+                        TableLayout layout = metadata.getLayout(session, tableScanNode.getTable());
+                        return planWithTableNodePartitioning(session) && layout.getTablePartitioning().isPresent();
+                    }
+                    return false;
+                })
+                .recurseOnlyWhen(AddExchanges::isNotRemoteExchange)
+                .findAll()
+                .size();
+    }
+
+    /**
+     * Collects the set of unique ConnectorIds corresponding to table scans present in the given query plan.
+     *
+     * This method traverses the provided query plan tree starting from the given root node, searching for
+     * instances of {@code TableScanNode}. For each TableScanNode found, its associated ConnectorId is extracted
+     * and included in the resulting stream.
+     *
+     * @param root the root PlanNode of the query plan tree to search
+     * @return a Stream of ConnectorIds representing the catalogs used in the plan
+     */
+    private static Stream<ConnectorId> collectSourceCatalogs(PlanNode root)
+    {
+        return PlanNodeSearcher
+                .searchFrom(root)
+                .where(node -> node instanceof TableScanNode)
+                .recurseOnlyWhen(AddExchanges::isNotRemoteExchange)
+                .findAll()
+                .stream()
+                .map(TableScanNode.class::cast)
+                .map(node -> node.getTable().getConnectorId());
     }
 
     private static class ExchangePartitioningHandleExtractor

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5053,6 +5053,21 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testUnionAllAboveBroadcastJoin()
+    {
+        assertQuery(
+                "SELECT COUNT(*) " +
+                "FROM region r " +
+                "JOIN (SELECT nationkey " +
+                "      FROM nation " +
+                "      UNION ALL " +
+                "      SELECT nationkey as key " +
+                "      FROM nation) n " +
+                "ON r.regionkey = n.nationkey",
+                "VALUES 10");
+    }
+
+    @Test
     public void testTableSampleBernoulliBoundaryValues()
     {
         MaterializedResult fullSample = computeActual("SELECT orderkey FROM orders TABLESAMPLE BERNOULLI (100)");


### PR DESCRIPTION
## Description
Add a new scheduler + exchange rules to support multiple table scans in a single stage (#23476)

Scheduler support to run multiple source partitioned table scans in a single stage, and a new algorithm to decide how to add exchanges.

## Impact
Significantly improves the performance of some TPCDS queries. Attached are two examples:
Using Hive connector: 
- Query 2: 31.8% faster
- Query 5: 61.0% faster 

Using Iceberg connector: 
- Query 2: 19.5% faster 
- Query 5: 38.2% faster


## Test Plan
Automated tests to verify Presto uses this optimization an the query results do not change:
- `com.facebook.presto.sql.planner.TestTpcdsCostBasedPlan`: 5 tests in this class verify that "remote exchanges" were replaced with "local exchanges" in the query execution trace.
- `com.facebook.presto.tests.AbstractTestQueries#testUnionAllAboveBroadcastJoin()`: The remote exchanges in the original execution plan of this query were replaced with a local exchange. The test checks that the query result didn't change.

## Query execution plan before and after this enhancement
**TPCDS Query 2:**
[TPCDS Q2 original.json](https://github.com/user-attachments/files/31460323/TPCDS.Q2.original.json)
[TPCDS Q2 with feature changes.json](https://github.com/user-attachments/files/31460326/TPCDS.Q2.with.feature.changes.json)

<img width="658" height="1184" alt="image" src="https://github.com/user-attachments/assets/4b771326-247d-4da5-8541-cf32bbe17ed7" />
<img width="615" height="1193" alt="image" src="https://github.com/user-attachments/assets/0da746dc-e421-4e83-8c6b-edf70208eddd" />

**Zoom in on the execution trace**
<img width="1429" height="1189" alt="image" src="https://github.com/user-attachments/assets/a18f03d2-b635-42d4-a6d0-90f12267b8a8" />
<img width="1342" height="1197" alt="image" src="https://github.com/user-attachments/assets/8d4ffb85-b774-4c7a-b91f-cb40d344c423" />

**TPCDS Query 5:**
[TPCDS Q5 original.json](https://github.com/user-attachments/files/31460324/TPCDS.Q5.original.json)
[TPCDS Q5 with feature changes.json](https://github.com/user-attachments/files/31460325/TPCDS.Q5.with.feature.changes.json)

<img width="1398" height="1176" alt="image" src="https://github.com/user-attachments/assets/41d77b97-c4b5-434a-9d4e-5413f430d9f7" />
<img width="1381" height="1189" alt="image" src="https://github.com/user-attachments/assets/d426535c-8119-456f-beaa-c9bda8ec3ce0" />

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add a new scheduler + exchange rules to support multiple table scans in a single stage #23476
```

## Summary by Sourcery

Introduce support for scheduling stages with multiple table scans by coordinating split scheduling across sources and adjusting exchange planning accordingly.

New Features:
- Add MultiSourcePartitionedScheduler to handle multiple split sources within a single stage using a coordinated scheduling strategy.
- Enable SOURCE_DISTRIBUTION stages to use either a single-source or multi-source scheduler depending on the number of split sources.
- Allow UNION planning to keep multiple distributed children without inserting a remote exchange when they are compatible for multi-source scheduling.

Enhancements:
- Refine AddExchanges logic to detect repartitioned remote exchanges, partitioned connector sources, and source catalogs to decide when a FIXED_ARBITRARY_DISTRIBUTION remote exchange is required.

## Summary by Sourcery

Enable multi-source stage scheduling and optimize exchange placement for compatible table scans.

New Features:
- Support scheduling multiple source-partitioned table scans within a single query stage.

Enhancements:
- Improve exchange planning for UNION operations by allowing compatible scans to use local exchanges while retaining remote exchanges when repartitioning or connector partitioning requires cross-worker data movement.
- Select scheduling strategies and node placement based on the number and catalog compatibility of stage data sources.

Tests:
- Add coverage for UNION ALL plans above broadcast joins and update TPCDS plan expectations for the revised exchange behavior.