### PR TITLE
fix: Use correct isBlocked getters in OperatorStats.merge()

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -827,9 +827,9 @@ public class OperatorStats
 
             totalDrivers += operator.totalDrivers;
 
-            isBlockedCalls += operator.getGetOutputCalls();
-            isBlockedWall += operator.getGetOutputWall().roundTo(NANOSECONDS);
-            isBlockedCpu += operator.getGetOutputCpu().roundTo(NANOSECONDS);
+            isBlockedCalls += operator.getIsBlockedCalls();
+            isBlockedWall += operator.getIsBlockedWall().roundTo(NANOSECONDS);
+            isBlockedCpu += operator.getIsBlockedCpu().roundTo(NANOSECONDS);
             isBlockedAllocation += operator.getIsBlockedAllocationInBytes();
 
             addInputCalls += operator.getAddInputCalls();

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -190,6 +190,10 @@ public class TestOperatorStats
         assertEquals(actual.getOperatorType(), "test");
 
         assertEquals(actual.getTotalDrivers(), 1);
+        assertEquals(actual.getIsBlockedCalls(), 1);
+        assertEquals(actual.getIsBlockedWall(), new Duration(2, NANOSECONDS));
+        assertEquals(actual.getIsBlockedCpu(), new Duration(3, NANOSECONDS));
+        assertEquals(actual.getIsBlockedAllocationInBytes(), 234);
         assertEquals(actual.getAddInputCalls(), 2);
         assertEquals(actual.getAddInputWall(), new Duration(3, NANOSECONDS));
         assertEquals(actual.getAddInputCpu(), new Duration(4, NANOSECONDS));
@@ -239,6 +243,10 @@ public class TestOperatorStats
         assertEquals(actual.getOperatorType(), "test");
 
         assertEquals(actual.getTotalDrivers(), 3 * 1);
+        assertEquals(actual.getIsBlockedCalls(), 3 * 1);
+        assertEquals(actual.getIsBlockedWall(), new Duration(3 * 2, NANOSECONDS));
+        assertEquals(actual.getIsBlockedCpu(), new Duration(3 * 3, NANOSECONDS));
+        assertEquals(actual.getIsBlockedAllocationInBytes(), 3 * 234);
         assertEquals(actual.getAddInputCalls(), 3 * 2);
         assertEquals(actual.getAddInputWall(), new Duration(3 * 3, NANOSECONDS));
         assertEquals(actual.getAddInputCpu(), new Duration(3 * 4, NANOSECONDS));
@@ -293,6 +301,10 @@ public class TestOperatorStats
         assertEquals(actual.getOperatorType(), "test");
 
         assertEquals(actual.getTotalDrivers(), 1 * 1);
+        assertEquals(actual.getIsBlockedCalls(), 1 * 1);
+        assertEquals(actual.getIsBlockedWall(), new Duration(1 * 2, NANOSECONDS));
+        assertEquals(actual.getIsBlockedCpu(), new Duration(1 * 3, NANOSECONDS));
+        assertEquals(actual.getIsBlockedAllocationInBytes(), 1 * 234);
         assertEquals(actual.getAddInputCalls(), 1 * 2);
         assertEquals(actual.getAddInputWall(), new Duration(1 * 3, NANOSECONDS));
         assertEquals(actual.getAddInputCpu(), new Duration(1 * 4, NANOSECONDS));
@@ -345,6 +357,10 @@ public class TestOperatorStats
         assertEquals(actual.getOperatorType(), "test");
 
         assertEquals(actual.getTotalDrivers(), 3 * 1);
+        assertEquals(actual.getIsBlockedCalls(), 3 * 1);
+        assertEquals(actual.getIsBlockedWall(), new Duration(3 * 2, NANOSECONDS));
+        assertEquals(actual.getIsBlockedCpu(), new Duration(3 * 3, NANOSECONDS));
+        assertEquals(actual.getIsBlockedAllocationInBytes(), 3 * 234);
         assertEquals(actual.getAddInputCalls(), 3 * 2);
         assertEquals(actual.getAddInputWall(), new Duration(3 * 3, NANOSECONDS));
         assertEquals(actual.getAddInputCpu(), new Duration(3 * 4, NANOSECONDS));
@@ -399,6 +415,10 @@ public class TestOperatorStats
         assertEquals(actual.getOperatorType(), "test");
 
         assertEquals(actual.getTotalDrivers(), 3);
+        assertEquals(actual.getIsBlockedCalls(), 3 * 1);
+        assertEquals(actual.getIsBlockedWall(), new Duration(3 * 2, NANOSECONDS));
+        assertEquals(actual.getIsBlockedCpu(), new Duration(3 * 3, NANOSECONDS));
+        assertEquals(actual.getIsBlockedAllocationInBytes(), 3 * 234);
         assertEquals(actual.getAddInputCalls(), 3 * 2);
         assertEquals(actual.getAddInputWall(), new Duration(3 * 3, NANOSECONDS));
         assertEquals(actual.getAddInputCpu(), new Duration(3 * 4, NANOSECONDS));
@@ -449,6 +469,10 @@ public class TestOperatorStats
         assertEquals(actual.getOperatorType(), "test");
 
         assertEquals(actual.getTotalDrivers(), 3);
+        assertEquals(actual.getIsBlockedCalls(), 3 * 1);
+        assertEquals(actual.getIsBlockedWall(), new Duration(3 * 2, NANOSECONDS));
+        assertEquals(actual.getIsBlockedCpu(), new Duration(3 * 3, NANOSECONDS));
+        assertEquals(actual.getIsBlockedAllocationInBytes(), 3 * 234);
         assertEquals(actual.getAddInputCalls(), 3 * 2);
         assertEquals(actual.getAddInputWall(), new Duration(3 * 3, NANOSECONDS));
         assertEquals(actual.getAddInputCpu(), new Duration(3 * 4, NANOSECONDS));


### PR DESCRIPTION
## Description
Fix a copy-paste bug in `OperatorStats.merge()`: `isBlockedCalls`, `isBlockedWall`, and `isBlockedCpu` were accumulated using the `getGetOutput*` getters instead of the `getIsBlocked*` ones, so merged stats reported `getOutput` values as `isBlocked` metrics.

## Motivation and Context
Pipeline/stage-level aggregations relying on merged `isBlocked` stats were silently showing `getOutput` costs instead of actual blocking behavior. The bug went unnoticed because no test in `TestOperatorStats` asserted `isBlocked` fields after merging.

## Impact
No public API or JSON schema changes. Downstream consumers of merged `isBlockedCalls`/`isBlockedWall`/`isBlockedCpu` (query stats, UI dashboards, performance analysis) will now see correct values.

## Test Plan
Added `isBlocked` (calls, wall, cpu, allocation) assertions to all six merge-related test methods in `TestOperatorStats`. These assertions fail before the fix and pass after.

## Contributor checklist
- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== RELEASE NOTES ==

General Changes
* Fix incorrect isBlocked metrics in merged OperatorStats.
```

## Summary by Sourcery

Fix incorrect aggregation of isBlocked metrics in OperatorStats.merge() and extend merge-related tests to verify isBlocked statistics.

Bug Fixes:
- Correct merged isBlockedCalls, isBlockedWall, and isBlockedCpu to use the isBlocked getters instead of getOutput getters in OperatorStats.merge().

Tests:
- Add isBlocked (calls, wall, CPU, allocation) assertions to all merge-related OperatorStats tests to validate correct aggregation behavior.