### PR TITLE
feat(native): Pass storage parameters to HiveInsertTableHandle in write path (#27525)

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/HivePrestoToVeloxConnector.cpp
@@ -447,7 +447,12 @@ HivePrestoToVeloxConnector::toVeloxInsertTableHandle(
           toFileCompressionKind(hiveInsertTableHandle->compressionCodec)),
       std::unordered_map<std::string, std::string>(
           table->storage.serdeParameters.begin(),
-          table->storage.serdeParameters.end()));
+          table->storage.serdeParameters.end()),
+      nullptr, // writerOptions
+      false, // ensureFiles
+      std::make_shared<velox::connector::hive::HiveInsertFileNameGenerator>(),
+      std::unordered_map<std::string, std::string>(
+          table->storage.parameters.begin(), table->storage.parameters.end()));
 }
 
 std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -435,3 +435,43 @@ TEST_F(PrestoToVeloxConnectorTest, ctasEmptySerdeParameters) {
 
   EXPECT_TRUE(hiveInsert->serdeParameters().empty());
 }
+
+TEST_F(PrestoToVeloxConnectorTest, hiveInsertTableHandleTableParameters) {
+  auto protoHandle = std::make_shared<protocol::hive::HiveInsertTableHandle>();
+  protoHandle->_type = "hive";
+
+  protocol::hive::HiveColumnHandle col;
+  col.name = "col1";
+  col.hiveType = "int";
+  col.typeSignature = "integer";
+  col.columnType = protocol::hive::ColumnType::REGULAR;
+  protoHandle->inputColumns = {col};
+
+  protoHandle->locationHandle.targetPath = "/target";
+  protoHandle->locationHandle.writePath = "/write";
+  protoHandle->locationHandle.tableType = protocol::hive::TableType::EXISTING;
+
+  protoHandle->actualStorageFormat = protocol::hive::HiveStorageFormat::DWRF;
+  protoHandle->compressionCodec = protocol::hive::HiveCompressionCodec::NONE;
+
+  auto table = std::make_shared<protocol::hive::Table>();
+  table->storage.parameters = {{"param1", "value1"}, {"param2", "value2"}};
+  protoHandle->pageSinkMetadata.table = table;
+
+  protocol::InsertHandle insertHandle;
+  insertHandle.handle.connectorHandle = protoHandle;
+  insertHandle.handle.connectorId = "hive";
+
+  HivePrestoToVeloxConnector hiveConnector("hive");
+  auto result =
+      hiveConnector.toVeloxInsertTableHandle(&insertHandle, *typeParser_);
+
+  auto* hiveHandle =
+      dynamic_cast<connector::hive::HiveInsertTableHandle*>(result.get());
+  ASSERT_NE(hiveHandle, nullptr);
+
+  const auto& storageParams = hiveHandle->storageParameters();
+  EXPECT_EQ(storageParams.size(), 2);
+  EXPECT_EQ(storageParams.at("param1"), "value1");
+  EXPECT_EQ(storageParams.at("param2"), "value2");
+}


### PR DESCRIPTION
Summary:

Pass `table->storage.parameters` from `HivePageSinkMetadata` to the `HiveInsertTableHandle` constructor in the Presto-to-Velox translation layer. This makes Hive storage-level metadata available to the native write path, enabling file sink factories to use storage properties when performing writes.

Depends on the Velox change that adds the `storageParameters` field to `HiveInsertTableHandle` and `FileSink::Options`. This was added in https://github.com/facebookincubator/velox/pull/16637

Reviewed By: kewang1024

Differential Revision: D94995650


