### PR TITLE
[Presto] Add identity check in RowExpressionVariableInliner to preserve reference identity

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionVariableInliner.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/RowExpressionVariableInliner.java
@@ -54,6 +54,11 @@ public final class RowExpressionVariableInliner
         if (!excludedNames.contains(node.getName())) {
             RowExpression result = mapping.apply(node);
             checkState(result != null, "Cannot resolve symbol %s", node.getName());
+            // Return null to signal "no change" to RowExpressionTreeRewriter,
+            // preserving reference identity and avoiding unnecessary parent rebuilds
+            if (result == node) {
+                return null;
+            }
             return result;
         }
         return null;

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RowExpressionRewriteRuleSet.java
@@ -173,8 +173,16 @@ public class RowExpressionRewriteRuleSet
             Assignments.Builder builder = Assignments.builder();
             boolean anyRewritten = false;
             for (Map.Entry<VariableReferenceExpression, RowExpression> entry : projectNode.getAssignments().getMap().entrySet()) {
-                RowExpression rewritten = rewriter.rewrite(entry.getValue(), context);
-                if (!rewritten.equals(entry.getValue())) {
+                RowExpression expression = entry.getValue();
+                // Skip variable references: no rewriter transforms a bare variable.
+                // We do NOT skip ConstantExpression because pluggable ExpressionOptimizers
+                // (used by RewriteRowExpressions) could theoretically transform constants.
+                if (expression instanceof VariableReferenceExpression) {
+                    builder.put(entry.getKey(), expression);
+                    continue;
+                }
+                RowExpression rewritten = rewriter.rewrite(expression, context);
+                if (!rewritten.equals(expression)) {
                     anyRewritten = true;
                 }
                 builder.put(entry.getKey(), rewritten);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/SimplifyRowExpressions.java
@@ -21,8 +21,10 @@ import com.facebook.presto.expressions.RowExpressionTreeRewriter;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.relational.FunctionResolution;
@@ -72,6 +74,10 @@ public class SimplifyRowExpressions
 
         private RowExpression rewrite(RowExpression expression, Session session)
         {
+            // Leaf expressions (variable references and constants) cannot be simplified
+            if (expression instanceof VariableReferenceExpression || expression instanceof ConstantExpression) {
+                return expression;
+            }
             // Rewrite RowExpression first to reduce depth of RowExpression tree by balancing AND/OR predicates.
             // It doesn't matter whether we rewrite/optimize first because this will be called by IterativeOptimizer.
             RowExpression rewritten = RowExpressionTreeRewriter.rewriteWith(logicalExpressionRewriter, expression, true);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -887,7 +887,12 @@ public class UnaliasSymbolReferences
 
         private VariableReferenceExpression canonicalize(VariableReferenceExpression variable)
         {
-            String canonical = variable.getName();
+            String name = variable.getName();
+            if (!mapping.containsKey(name)) {
+                // Fast path: no mapping exists, return original variable to avoid allocation
+                return variable;
+            }
+            String canonical = name;
             Set<String> visited = new HashSet<>();
             visited.add(canonical);
             while (mapping.containsKey(canonical)) {
@@ -898,6 +903,10 @@ public class UnaliasSymbolReferences
                     mapping.remove(canonical);
                     break;
                 }
+            }
+            if (canonical.equals(name)) {
+                // Mapping resolved back to original name (cycle was broken), return original
+                return variable;
             }
             return new VariableReferenceExpression(variable.getSourceLocation(), canonical, types.get(new SymbolReference(getNodeLocation(variable.getSourceLocation()), canonical)));
         }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionVariableInliner.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionVariableInliner.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -32,6 +33,7 @@ import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
 import static java.util.Collections.emptyList;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 
 public class TestRowExpressionVariableInliner
 {
@@ -74,6 +76,41 @@ public class TestRowExpressionVariableInliner
                         variable("b")),
                 variable("a")),
                 variable("b"));
+    }
+
+    @Test
+    public void testIdentityMappingPreservesReference()
+    {
+        // When a variable maps to itself, the inliner should preserve the original expression reference
+        VariableReferenceExpression a = variable("a");
+        RowExpression result = RowExpressionVariableInliner.inlineVariables(v -> v, a);
+        assertSame(result, a, "Identity mapping should return the exact same object");
+    }
+
+    @Test
+    public void testIdentityMappingInComplexExpression()
+    {
+        // In a complex expression where variables map to themselves, the original tree should be preserved
+        VariableReferenceExpression a = variable("a");
+        VariableReferenceExpression b = variable("b");
+        CallExpression expression = new CallExpression("add", TEST_FUNCTION, BIGINT, ImmutableList.of(a, b));
+        RowExpression result = RowExpressionVariableInliner.inlineVariables(v -> v, expression);
+        assertSame(result, expression, "Identity mapping on complex expression should preserve the original tree");
+    }
+
+    @Test
+    public void testPartialIdentityMapping()
+    {
+        // When some variables are mapped and others are identity, the mapped ones should change
+        VariableReferenceExpression a = variable("a");
+        VariableReferenceExpression b = variable("b");
+        VariableReferenceExpression c = variable("c");
+        CallExpression expression = new CallExpression("add", TEST_FUNCTION, BIGINT, ImmutableList.of(a, b));
+        RowExpression result = RowExpressionVariableInliner.inlineVariables(
+                ImmutableMap.of(a, c, b, b),
+                expression);
+        // a -> c, b -> b (identity), so expression should change
+        assertEquals(result, new CallExpression("add", TEST_FUNCTION, BIGINT, ImmutableList.of(c, b)));
     }
 
     @Test

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestSimplifyRowExpressions.java
@@ -21,26 +21,35 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.nodeManager.PluginNodeManager;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.expressions.ExpressionOptimizerManager;
 import com.facebook.presto.sql.expressions.JsonCodecRowExpressionSerde;
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
 import com.facebook.presto.sql.tree.Expression;
 import com.google.common.collect.Streams;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -52,16 +61,77 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
 public class TestSimplifyRowExpressions
 {
     private static final SqlParser SQL_PARSER = new SqlParser();
     private static final MetadataManager METADATA = createTestMetadataManager();
+    private RuleTester ruleTester;
     private static final Map<String, Type> TYPES = Streams.concat(
             Stream.of("A", "B", "C", "D", "E", "F", "I", "V", "X", "Y", "Z"),
             IntStream.range(1, 61).boxed().map(i -> format("A%s", i)))
             .collect(toMap(Function.identity(), string -> BOOLEAN));
+
+    @BeforeClass
+    public void setUp()
+    {
+        ruleTester = new RuleTester();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        closeAllRuntimeException(ruleTester);
+        ruleTester = null;
+    }
+
+    @Test
+    public void testProjectRuleDoesNotFireForVariableReferenceAssignments()
+    {
+        // ProjectRowExpressionRewrite should not fire when all assignments are
+        // VariableReferenceExpression (passthrough variables) since no rewriter
+        // transforms a bare variable reference
+        SimplifyRowExpressions simplifyRowExpressions = new SimplifyRowExpressions(
+                ruleTester.getMetadata(),
+                ruleTester.getExpressionManager());
+        ruleTester.assertThat(simplifyRowExpressions.projectRowExpressionRewriteRule())
+                .on(p -> {
+                    VariableReferenceExpression x = p.variable("x", BIGINT);
+                    VariableReferenceExpression y = p.variable("y", BIGINT);
+                    VariableReferenceExpression passthrough1 = p.variable("passthrough1", BIGINT);
+                    VariableReferenceExpression passthrough2 = p.variable("passthrough2", BIGINT);
+                    return p.project(
+                            Assignments.builder()
+                                    .put(passthrough1, x)
+                                    .put(passthrough2, y)
+                                    .build(),
+                            p.values(x, y));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testLeafExpressionsShortCircuit()
+    {
+        // SimplifyRowExpressions.rewrite() should return the exact same object
+        // for leaf expressions (VariableReferenceExpression and ConstantExpression)
+        // without going through the 3-pass pipeline
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+        ExpressionOptimizerManager expressionOptimizerManager = new ExpressionOptimizerManager(
+                new PluginNodeManager(nodeManager),
+                METADATA.getFunctionAndTypeManager(),
+                new JsonCodecRowExpressionSerde(jsonCodec(RowExpression.class)));
+
+        VariableReferenceExpression variable = new VariableReferenceExpression(Optional.empty(), "x", BIGINT);
+        RowExpression simplifiedVariable = SimplifyRowExpressions.rewrite(variable, METADATA, TEST_SESSION, expressionOptimizerManager);
+        assertSame(simplifiedVariable, variable, "VariableReferenceExpression should be returned as-is");
+
+        ConstantExpression constant = new ConstantExpression(42L, BIGINT);
+        RowExpression simplifiedConstant = SimplifyRowExpressions.rewrite(constant, METADATA, TEST_SESSION, expressionOptimizerManager);
+        assertSame(simplifiedConstant, constant, "ConstantExpression should be returned as-is");
+    }
 
     @Test
     public void testPushesDownNegations()

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -21,6 +21,7 @@ import static com.facebook.presto.spi.plan.JoinType.INNER;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
 
 public class TestUnaliasSymbolReferences
@@ -45,6 +46,25 @@ public class TestUnaliasSymbolReferences
                                 anyTree(values("RIGHT_BAR")))
                                 .withNumberOfOutputColumns(2)
                                 .withExactOutputs("LEFT_BAR", "RIGHT_BAR")));
+    }
+
+    @Test
+    public void testWideProjectionNoAliasPassthrough()
+    {
+        // Verify that wide projections with passthrough columns (no aliasing)
+        // produce valid plans. The fast-path in canonicalize should return original
+        // variables when no mapping exists, avoiding unnecessary allocation.
+        StringBuilder columns = new StringBuilder();
+        for (int i = 1; i <= 50; i++) {
+            if (i > 1) {
+                columns.append(", ");
+            }
+            columns.append(String.format("nationkey + %d AS col_%d", i, i));
+        }
+        assertPlan(
+                String.format("SELECT %s FROM nation", columns),
+                anyTree(
+                        output(anyTree(values()))));
     }
 
     @Test


### PR DESCRIPTION
Summary:
When RowExpressionVariableInliner.rewriteVariableReference() maps a variable
to itself, it currently returns the new-but-equal object. This breaks the
identity-based change detection in RowExpressionTreeRewriter, causing
unnecessary rebuilding of entire parent expression trees.

Return null (the TreeRewriter convention for "no change") when the mapping
returns the same node, preserving reference identity and avoiding cascading
object allocation through expression trees.

For wide ProjectNodes with ~2225 assignments, this prevents thousands of
unnecessary expression tree rebuilds per optimizer pass.

Differential Revision: D99890865

## Summary by Sourcery

Preserve row expression reference identity during variable inlining and simplification to avoid unnecessary expression tree reconstruction and allocations.

Bug Fixes:
- Ensure RowExpressionVariableInliner returns no-op (null) when a variable maps to itself so parent expressions are not rebuilt unnecessarily.
- Skip rewriting bare VariableReferenceExpression assignments in ProjectNode row expression rewrites to avoid redundant work.
- Avoid allocating new VariableReferenceExpression instances in UnaliasSymbolReferences when no mapping or an identity mapping exists.

Enhancements:
- Short-circuit SimplifyRowExpressions for leaf VariableReferenceExpression and ConstantExpression nodes to bypass the full rewrite pipeline for trivially unsimplifiable expressions.

Tests:
- Add tests verifying project rules do not fire for passthrough variable projections and that leaf expressions are returned by SimplifyRowExpressions without modification.
- Add tests ensuring RowExpressionVariableInliner preserves reference identity for identity mappings and behaves correctly with partial mappings and complex expressions.
- Add a wide projection test in UnaliasSymbolReferences to validate the fast-path behavior and plan correctness with many passthrough columns.