### PR TITLE
fix(native): Handle NULL ROWs when returning from native expression optimizer

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -322,6 +322,15 @@ VeloxToPrestoExprConverter::getRowConstructorExpression(
   result["form"] = kRowConstructor;
   result["returnType"] = getTypeSignature(constantExpr->valueVector()->type());
 
+  // Check if the ROW constant is NULL. If so, it should not be converted to
+  // ROW_CONSTRUCTOR but rather kept as a NULL ConstantExpression.
+  VELOX_CHECK(
+      !constantExpr->isNull(),
+      "getRowConstructorExpression should not be called for NULL ROW constants. "
+      "Expression type: {}, Expression string: {}. ",
+      constantExpr->type()->toString(),
+      constantExpr->toString());
+
   const auto& constVector = constantExpr->toConstantVector(pool_);
   const auto* rowVector = constVector->valueVector()->as<velox::RowVector>();
   VELOX_CHECK_NOT_NULL(
@@ -438,9 +447,9 @@ RowExpressionPtr VeloxToPrestoExprConverter::getRowExpression(
     case velox::core::ExprKind::kConstant: {
       const auto* constantExpr =
           expr->asUnchecked<velox::core::ConstantTypedExpr>();
-      // ConstantTypedExpr of ROW type maps to SpecialFormExpression of type
-      // ROW_CONSTRUCTOR in Presto.
-      if (expr->type()->isRow()) {
+      // Non-NULL ConstantTypedExpr of ROW type maps to SpecialFormExpression of
+      // type ROW_CONSTRUCTOR in Presto.
+      if (expr->type()->isRow() && !constantExpr->isNull()) {
         return getRowConstructorExpression(constantExpr);
       }
       return getConstantExpression(constantExpr);

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -772,6 +772,11 @@ public class TestNativeSidecarPlugin
                         "(4, 4, 'O'), " +
                         "(6, 6, 'F'), " +
                         "(7, 7, 'O')");
+
+        assertQueryWithSameQueryRunner(session, "SELECT CAST(NULL AS ROW(s1 VARCHAR, s2 VARCHAR))", "SELECT NULL");
+        assertQueryWithSameQueryRunner(session,
+                "SELECT IF (0 = 0, NULL, ROW(regionkey, 1)) FROM region",
+                "VALUES (NULL), (NULL), (NULL), (NULL), (NULL)");
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes incorrect conversion of NULL ROW constants to `ROW_CONSTRUCTOR` with garbage data in the native expression optimizer.

In `VeloxToPrestoExpr.cpp`, the `getRowExpression()` method unconditionally calls `getRowConstructorExpression() `for all ROW-typed constant expressions, including NULL ones. The `getRowConstructorExpression()` function then extracts child values from the ROW vector, which contain uninitialized data when the ROW itself is NULL.


## Motivation and Context
Resolves: https://github.com/prestodb/presto/issues/27560

## Impact
No user impact

## Test Plan
Unit tests, CI
## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Handle NULL ROW constants correctly in the native expression conversion to Presto row expressions and extend coverage in the native sidecar plugin tests.

Bug Fixes:
- Ensure ROW-typed ConstantTypedExpr values that are NULL are kept as NULL ConstantExpression instead of being converted to ROW_CONSTRUCTOR forms in native expression conversion.

Tests:
- Add native sidecar plugin tests verifying correct handling and optimization of NULL ROW constants in simple selects and IF expressions.

## Summary by Sourcery

Correct handling of NULL ROW constants in the native expression converter and extend test coverage in the native sidecar plugin.

Bug Fixes:
- Avoid converting NULL ROW-typed constant expressions into ROW_CONSTRUCTOR forms and keep them as NULL ConstantExpression values in the native expression optimizer.

Tests:
- Add native sidecar plugin assertions to verify correct optimization and query results for NULL ROW constants in simple SELECT and IF expressions.