### PR TITLE
feat: Port parametric TIMESTAMP(p) type infrastructure from Trino

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockEncodingManager.java
@@ -40,6 +40,7 @@ public final class BlockEncodingManager
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
+        addBlockEncoding(new Fixed12BlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
         addBlockEncoding(new MapBlockEncoding());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12Block.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.String.format;
+
+/**
+ * A fixed-width block that stores 12 bytes per position using an int[] array
+ * with 3 ints per position. The layout stores a long (as two ints in little-endian
+ * order) followed by an int, for a total of 12 bytes per entry.
+ * <p>
+ * This block type is designed for types that require more than 8 bytes but less than
+ * 16 bytes per value, such as LongTimestamp (epoch micros + picos of micro).
+ */
+public class Fixed12Block
+        implements Block
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12Block.class).instanceSize();
+    public static final int FIXED12_BYTES = Long.BYTES + Integer.BYTES;
+    public static final int SIZE_IN_BYTES_PER_POSITION = FIXED12_BYTES + Byte.BYTES;
+    private static final int INT_LONGS_PER_ENTRY = 3; // 3 ints = 12 bytes = 1 long + 1 int
+
+    private final int positionOffset;
+    private final int positionCount;
+    @Nullable
+    private final boolean[] valueIsNull;
+    private final int[] values;
+
+    private final long retainedSizeInBytes;
+
+    public Fixed12Block(int positionCount, Optional<boolean[]> valueIsNull, int[] values)
+    {
+        this(0, positionCount, valueIsNull.orElse(null), values);
+    }
+
+    Fixed12Block(int positionOffset, int positionCount, boolean[] valueIsNull, int[] values)
+    {
+        if (positionOffset < 0) {
+            throw new IllegalArgumentException("positionOffset is negative");
+        }
+        this.positionOffset = positionOffset;
+        if (positionCount < 0) {
+            throw new IllegalArgumentException("positionCount is negative");
+        }
+        this.positionCount = positionCount;
+
+        if (values.length - (positionOffset * INT_LONGS_PER_ENTRY) < positionCount * INT_LONGS_PER_ENTRY) {
+            throw new IllegalArgumentException("values length is less than positionCount");
+        }
+        this.values = values;
+
+        if (valueIsNull != null && valueIsNull.length - positionOffset < positionCount) {
+            throw new IllegalArgumentException("isNull length is less than positionCount");
+        }
+        this.valueIsNull = valueIsNull;
+
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+    }
+
+    /**
+     * Gets the first component (long) stored at the given position.
+     * The long is reconstructed from two ints stored in little-endian order.
+     */
+    public long getFixed12First(int position)
+    {
+        checkReadablePosition(position);
+        return getFixed12FirstUnchecked(position + positionOffset);
+    }
+
+    /**
+     * Gets the second component (int) stored at the given position.
+     */
+    public int getFixed12Second(int position)
+    {
+        checkReadablePosition(position);
+        return getFixed12SecondUnchecked(position + positionOffset);
+    }
+
+    long getFixed12FirstUnchecked(int internalPosition)
+    {
+        int baseIndex = internalPosition * INT_LONGS_PER_ENTRY;
+        // Reconstruct long from two ints (little-endian: low 32 bits first, high 32 bits second)
+        return (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
+    }
+
+    int getFixed12SecondUnchecked(int internalPosition)
+    {
+        int baseIndex = internalPosition * INT_LONGS_PER_ENTRY;
+        return values[baseIndex + 2];
+    }
+
+    /**
+     * Encodes a long and int into the int[] array at the specified position.
+     */
+    public static void encodeFixed12(long first, int second, int[] target, int position)
+    {
+        int baseIndex = position * INT_LONGS_PER_ENTRY;
+        target[baseIndex] = (int) first; // low 32 bits
+        target[baseIndex + 1] = (int) (first >> 32); // high 32 bits
+        target[baseIndex + 2] = second;
+    }
+
+    /**
+     * Helper to reconstruct the first long from the int[] array at the given position.
+     */
+    static long encodeFirstAsLong(int[] values, int position)
+    {
+        int baseIndex = position * INT_LONGS_PER_ENTRY;
+        return (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        if (valueIsNull != null) {
+            consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        }
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset == 0) {
+            return getFixed12FirstUnchecked(position + positionOffset);
+        }
+        throw new IllegalArgumentException("offset must be 0");
+    }
+
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return getFixed12SecondUnchecked(position + positionOffset);
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return valueIsNull != null;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull != null && isNullUnchecked(position + positionOffset);
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        int internalPos = position + positionOffset;
+        int baseIndex = internalPos * INT_LONGS_PER_ENTRY;
+        if (blockBuilder instanceof Fixed12BlockBuilder) {
+            long first = (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
+            ((Fixed12BlockBuilder) blockBuilder).writeFixed12(first, values[baseIndex + 2]);
+        }
+        else {
+            // Fallback: write as two longs for compatibility
+            long first = (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
+            blockBuilder.writeLong(first);
+            blockBuilder.writeInt(values[baseIndex + 2]);
+            blockBuilder.closeEntry();
+        }
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            output.writeByte(1);
+            int internalPos = position + positionOffset;
+            int baseIndex = internalPos * INT_LONGS_PER_ENTRY;
+            output.writeInt(values[baseIndex]);
+            output.writeInt(values[baseIndex + 1]);
+            output.writeInt(values[baseIndex + 2]);
+        }
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        int internalPos = position + positionOffset;
+        int baseIndex = internalPos * INT_LONGS_PER_ENTRY;
+        return new Fixed12Block(
+                0,
+                1,
+                isNull(position) ? new boolean[] {true} : null,
+                new int[] {values[baseIndex], values[baseIndex + 1], values[baseIndex + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        boolean[] newValueIsNull = null;
+        if (valueIsNull != null) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INT_LONGS_PER_ENTRY];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            if (valueIsNull != null) {
+                newValueIsNull[i] = valueIsNull[position + positionOffset];
+            }
+            int srcBase = (position + positionOffset) * INT_LONGS_PER_ENTRY;
+            int dstBase = i * INT_LONGS_PER_ENTRY;
+            newValues[dstBase] = values[srcBase];
+            newValues[dstBase + 1] = values[srcBase + 1];
+            newValues[dstBase + 2] = values[srcBase + 2];
+        }
+        return new Fixed12Block(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+        return new Fixed12Block(positionOffset + this.positionOffset, length, valueIsNull, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        int absoluteOffset = positionOffset + this.positionOffset;
+        boolean[] newValueIsNull = valueIsNull == null ? null : compactArray(valueIsNull, absoluteOffset, length);
+        int[] newValues = compactIntArray(values, absoluteOffset * INT_LONGS_PER_ENTRY, length * INT_LONGS_PER_ENTRY);
+
+        if (newValueIsNull == valueIsNull && newValues == values) {
+            return this;
+        }
+        return new Fixed12Block(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12BlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12Block(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public Block appendNull()
+    {
+        boolean[] newValueIsNull = appendNullToIsNullArray(valueIsNull, positionOffset, positionCount);
+        int[] newValues = Arrays.copyOf(values, Math.max(values.length, (positionOffset + positionCount + 1) * INT_LONGS_PER_ENTRY));
+        return new Fixed12Block(positionOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        return getFixed12FirstUnchecked(internalPosition);
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return positionOffset;
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Fixed12Block other = (Fixed12Block) obj;
+        return this.positionOffset == other.positionOffset &&
+                this.positionCount == other.positionCount &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values) &&
+                this.retainedSizeInBytes == other.retainedSizeInBytes;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(positionOffset,
+                positionCount,
+                Arrays.hashCode(valueIsNull),
+                Arrays.hashCode(values),
+                retainedSizeInBytes);
+    }
+
+    private static int[] compactIntArray(int[] array, int index, int length)
+    {
+        if (index == 0 && length == array.length) {
+            return array;
+        }
+        return Arrays.copyOfRange(array, index, index + length);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12Block.java
@@ -45,7 +45,7 @@ public class Fixed12Block
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12Block.class).instanceSize();
     public static final int FIXED12_BYTES = Long.BYTES + Integer.BYTES;
     public static final int SIZE_IN_BYTES_PER_POSITION = FIXED12_BYTES + Byte.BYTES;
-    private static final int INT_LONGS_PER_ENTRY = 3; // 3 ints = 12 bytes = 1 long + 1 int
+    static final int INT_LONGS_PER_ENTRY = 3; // 3 ints = 12 bytes = 1 long + 1 int
 
     private final int positionOffset;
     private final int positionCount;
@@ -91,7 +91,7 @@ public class Fixed12Block
     public long getFixed12First(int position)
     {
         checkReadablePosition(position);
-        return getFixed12FirstUnchecked(position + positionOffset);
+        return getFixed12FirstUnchecked(values, position + positionOffset);
     }
 
     /**
@@ -100,17 +100,26 @@ public class Fixed12Block
     public int getFixed12Second(int position)
     {
         checkReadablePosition(position);
-        return getFixed12SecondUnchecked(position + positionOffset);
+        return getFixed12SecondUnchecked(values, position + positionOffset);
     }
 
-    long getFixed12FirstUnchecked(int internalPosition)
+    /**
+     * Gets the first component (long) at the given internal position without bounds checking.
+     * The long is reconstructed from two ints stored in little-endian order.
+     * Package-private for use by Fixed12BlockBuilder and Fixed12BlockEncoding.
+     */
+    static long getFixed12FirstUnchecked(int[] values, int internalPosition)
     {
         int baseIndex = internalPosition * INT_LONGS_PER_ENTRY;
         // Reconstruct long from two ints (little-endian: low 32 bits first, high 32 bits second)
         return (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
     }
 
-    int getFixed12SecondUnchecked(int internalPosition)
+    /**
+     * Gets the second component (int) at the given internal position without bounds checking.
+     * Package-private for use by Fixed12BlockBuilder.
+     */
+    static int getFixed12SecondUnchecked(int[] values, int internalPosition)
     {
         int baseIndex = internalPosition * INT_LONGS_PER_ENTRY;
         return values[baseIndex + 2];
@@ -125,15 +134,6 @@ public class Fixed12Block
         target[baseIndex] = (int) first; // low 32 bits
         target[baseIndex + 1] = (int) (first >> 32); // high 32 bits
         target[baseIndex + 2] = second;
-    }
-
-    /**
-     * Helper to reconstruct the first long from the int[] array at the given position.
-     */
-    static long encodeFirstAsLong(int[] values, int position)
-    {
-        int baseIndex = position * INT_LONGS_PER_ENTRY;
-        return (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
     }
 
     @Override
@@ -193,7 +193,7 @@ public class Fixed12Block
     {
         checkReadablePosition(position);
         if (offset == 0) {
-            return getFixed12FirstUnchecked(position + positionOffset);
+            return getFixed12FirstUnchecked(values, position + positionOffset);
         }
         throw new IllegalArgumentException("offset must be 0");
     }
@@ -202,7 +202,7 @@ public class Fixed12Block
     public int getInt(int position)
     {
         checkReadablePosition(position);
-        return getFixed12SecondUnchecked(position + positionOffset);
+        return getFixed12SecondUnchecked(values, position + positionOffset);
     }
 
     @Override
@@ -223,16 +223,14 @@ public class Fixed12Block
     {
         checkReadablePosition(position);
         int internalPos = position + positionOffset;
-        int baseIndex = internalPos * INT_LONGS_PER_ENTRY;
+        long first = getFixed12FirstUnchecked(values, internalPos);
+        int second = getFixed12SecondUnchecked(values, internalPos);
         if (blockBuilder instanceof Fixed12BlockBuilder) {
-            long first = (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
-            ((Fixed12BlockBuilder) blockBuilder).writeFixed12(first, values[baseIndex + 2]);
+            ((Fixed12BlockBuilder) blockBuilder).writeFixed12(first, second);
         }
         else {
-            // Fallback: write as two longs for compatibility
-            long first = (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
             blockBuilder.writeLong(first);
-            blockBuilder.writeInt(values[baseIndex + 2]);
+            blockBuilder.writeInt(second);
             blockBuilder.closeEntry();
         }
     }
@@ -338,7 +336,7 @@ public class Fixed12Block
     {
         assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
         assert offset == 0 : "offset must be 0";
-        return getFixed12FirstUnchecked(internalPosition);
+        return getFixed12FirstUnchecked(values, internalPosition);
     }
 
     @Override
@@ -371,22 +369,62 @@ public class Fixed12Block
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
+
         Fixed12Block other = (Fixed12Block) obj;
-        return this.positionOffset == other.positionOffset &&
-                this.positionCount == other.positionCount &&
-                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
-                Arrays.equals(this.values, other.values) &&
-                this.retainedSizeInBytes == other.retainedSizeInBytes;
+        if (this.positionCount != other.positionCount) {
+            return false;
+        }
+
+        int thisStart = this.positionOffset;
+        int thisEnd = thisStart + this.positionCount;
+        int otherStart = other.positionOffset;
+        int otherEnd = otherStart + other.positionCount;
+
+        // Compare nulls over the visible range only
+        if (this.valueIsNull != null && other.valueIsNull != null) {
+            if (!Arrays.equals(this.valueIsNull, thisStart, thisEnd,
+                    other.valueIsNull, otherStart, otherEnd)) {
+                return false;
+            }
+        }
+        else if (this.valueIsNull != null || other.valueIsNull != null) {
+            // One has null tracking and the other doesn't; check if the one with tracking has any nulls
+            boolean[] nonNullArray = (this.valueIsNull != null) ? this.valueIsNull : other.valueIsNull;
+            int start = (this.valueIsNull != null) ? thisStart : otherStart;
+            int end = (this.valueIsNull != null) ? thisEnd : otherEnd;
+            for (int i = start; i < end; i++) {
+                if (nonNullArray[i]) {
+                    return false;
+                }
+            }
+        }
+
+        int thisValuesStart = this.positionOffset * INT_LONGS_PER_ENTRY;
+        int thisValuesEnd = thisValuesStart + this.positionCount * INT_LONGS_PER_ENTRY;
+        int otherValuesStart = other.positionOffset * INT_LONGS_PER_ENTRY;
+        int otherValuesEnd = otherValuesStart + other.positionCount * INT_LONGS_PER_ENTRY;
+
+        return Arrays.equals(this.values, thisValuesStart, thisValuesEnd,
+                other.values, otherValuesStart, otherValuesEnd);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(positionOffset,
-                positionCount,
-                Arrays.hashCode(valueIsNull),
-                Arrays.hashCode(values),
-                retainedSizeInBytes);
+        int thisStart = this.positionOffset;
+        int thisEnd = thisStart + this.positionCount;
+        int thisValuesStart = this.positionOffset * INT_LONGS_PER_ENTRY;
+        int thisValuesEnd = thisValuesStart + this.positionCount * INT_LONGS_PER_ENTRY;
+
+        int result = Objects.hash(positionCount);
+        // Hash only the visible range of the arrays
+        for (int i = thisStart; valueIsNull != null && i < thisEnd; i++) {
+            result = 31 * result + Boolean.hashCode(valueIsNull[i]);
+        }
+        for (int i = thisValuesStart; i < thisValuesEnd; i++) {
+            result = 31 * result + Integer.hashCode(values[i]);
+        }
+        return result;
     }
 
     private static int[] compactIntArray(int[] array, int index, int length)

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12BlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12BlockBuilder.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import jakarta.annotation.Nullable;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+import java.util.function.ObjLongConsumer;
+
+import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
+import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
+import static com.facebook.presto.common.block.BlockUtil.compactArray;
+import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static com.facebook.presto.common.block.Fixed12Block.FIXED12_BYTES;
+import static com.facebook.presto.common.block.Fixed12Block.encodeFixed12;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+
+/**
+ * Builder for {@link Fixed12Block}. Each entry stores 12 bytes: a long (8 bytes)
+ * followed by an int (4 bytes).
+ */
+public class Fixed12BlockBuilder
+        implements BlockBuilder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12BlockBuilder.class).instanceSize();
+    private static final Block NULL_VALUE_BLOCK = new Fixed12Block(0, 1, new boolean[] {true}, new int[3]);
+    private static final int INT_LONGS_PER_ENTRY = 3; // 3 ints = 12 bytes
+
+    @Nullable
+    private final BlockBuilderStatus blockBuilderStatus;
+    private boolean initialized;
+    private final int initialEntryCount;
+
+    private int positionCount;
+    private boolean hasNullValue;
+    private boolean hasNonNullValue;
+
+    // it is assumed that these arrays are the same length proportionally
+    private boolean[] valueIsNull = new boolean[0];
+    private int[] values = new int[0];
+
+    private long retainedSizeInBytes;
+
+    public Fixed12BlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        this.blockBuilderStatus = blockBuilderStatus;
+        this.initialEntryCount = max(expectedEntries, 1);
+        updateDataSize();
+    }
+
+    /**
+     * Write a 12-byte fixed entry (long + int).
+     */
+    public Fixed12BlockBuilder writeFixed12(long first, int second)
+    {
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+
+        encodeFixed12(first, second, values, positionCount);
+        hasNonNullValue = true;
+        positionCount++;
+
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public BlockBuilder writeLong(long value)
+    {
+        throw new UnsupportedOperationException("Fixed12BlockBuilder does not support writeLong directly. Use writeFixed12(long, int) instead.");
+    }
+
+    @Override
+    public BlockBuilder writeInt(int value)
+    {
+        throw new UnsupportedOperationException("Fixed12BlockBuilder does not support writeInt directly. Use writeFixed12(long, int) instead.");
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        // No-op: writeFixed12 handles position advancement
+        return this;
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+
+        valueIsNull[positionCount] = true;
+        hasNullValue = true;
+        positionCount++;
+
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + FIXED12_BYTES);
+        }
+        return this;
+    }
+
+    @Override
+    public Block build()
+    {
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, positionCount);
+        }
+        return new Fixed12Block(0, positionCount, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new Fixed12BlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new Fixed12BlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
+    private void growCapacity()
+    {
+        int newSize;
+        if (initialized) {
+            newSize = BlockUtil.calculateNewArraySize(valueIsNull.length);
+        }
+        else {
+            newSize = initialEntryCount;
+            initialized = true;
+        }
+
+        valueIsNull = Arrays.copyOf(valueIsNull, newSize);
+        values = Arrays.copyOf(values, newSize * INT_LONGS_PER_ENTRY);
+        updateDataSize();
+    }
+
+    private void updateDataSize()
+    {
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
+        if (blockBuilderStatus != null) {
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return Fixed12Block.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(Fixed12Block.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return Fixed12Block.SIZE_IN_BYTES_PER_POSITION * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return Fixed12Block.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : FIXED12_BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(this, INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset == 0) {
+            return Fixed12Block.encodeFirstAsLong(values, position);
+        }
+        throw new IllegalArgumentException("offset must be 0");
+    }
+
+    @Override
+    public int getInt(int position)
+    {
+        checkReadablePosition(position);
+        return values[position * INT_LONGS_PER_ENTRY + 2];
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return hasNullValue;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull[position];
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        if (blockBuilder instanceof Fixed12BlockBuilder) {
+            int baseIndex = position * INT_LONGS_PER_ENTRY;
+            long first = (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
+            ((Fixed12BlockBuilder) blockBuilder).writeFixed12(first, values[baseIndex + 2]);
+        }
+        else {
+            int baseIndex = position * INT_LONGS_PER_ENTRY;
+            long first = (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
+            blockBuilder.writeLong(first);
+            blockBuilder.writeInt(values[baseIndex + 2]);
+            blockBuilder.closeEntry();
+        }
+    }
+
+    @Override
+    public void writePositionTo(int position, SliceOutput output)
+    {
+        if (isNull(position)) {
+            output.writeByte(0);
+        }
+        else {
+            output.writeByte(1);
+            int baseIndex = position * INT_LONGS_PER_ENTRY;
+            output.writeInt(values[baseIndex]);
+            output.writeInt(values[baseIndex + 1]);
+            output.writeInt(values[baseIndex + 2]);
+        }
+    }
+
+    @Override
+    public BlockBuilder readPositionFrom(SliceInput input)
+    {
+        boolean isNull = input.readByte() == 0;
+        if (isNull) {
+            appendNull();
+        }
+        else {
+            int low = input.readInt();
+            int high = input.readInt();
+            int second = input.readInt();
+            long first = (low & 0xFFFFFFFFL) | ((long) high << 32);
+            writeFixed12(first, second);
+        }
+        return this;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        int baseIndex = position * INT_LONGS_PER_ENTRY;
+        return new Fixed12Block(
+                0,
+                1,
+                valueIsNull[position] ? new boolean[] {true} : null,
+                new int[] {values[baseIndex], values[baseIndex + 1], values[baseIndex + 2]});
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = new boolean[length];
+        }
+        int[] newValues = new int[length * INT_LONGS_PER_ENTRY];
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            if (hasNullValue) {
+                newValueIsNull[i] = valueIsNull[position];
+            }
+            int srcBase = position * INT_LONGS_PER_ENTRY;
+            int dstBase = i * INT_LONGS_PER_ENTRY;
+            newValues[dstBase] = values[srcBase];
+            newValues[dstBase + 1] = values[srcBase + 1];
+            newValues[dstBase + 2] = values[srcBase + 2];
+        }
+        return new Fixed12Block(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        return new Fixed12Block(positionOffset, length, hasNullValue ? valueIsNull : null, values);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(NULL_VALUE_BLOCK, length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        }
+        int[] newValues = compactIntArray(values, positionOffset * INT_LONGS_PER_ENTRY, length * INT_LONGS_PER_ENTRY);
+        return new Fixed12Block(0, length, newValueIsNull, newValues);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return Fixed12BlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("Fixed12BlockBuilder(%d){positionCount=%d}", hashCode(), getPositionCount());
+    }
+
+    @Override
+    public long getLongUnchecked(int internalPosition, int offset)
+    {
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        assert offset == 0 : "offset must be 0";
+        int baseIndex = internalPosition * INT_LONGS_PER_ENTRY;
+        return (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
+    }
+
+    @Override
+    public boolean isNullUnchecked(int internalPosition)
+    {
+        assert mayHaveNull() : "no nulls present";
+        assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
+        return valueIsNull[internalPosition];
+    }
+
+    @Override
+    public int getOffsetBase()
+    {
+        return 0;
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+
+    private static int[] compactIntArray(int[] array, int index, int length)
+    {
+        if (index == 0 && length == array.length) {
+            return array;
+        }
+        return Arrays.copyOfRange(array, index, index + length);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12BlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12BlockBuilder.java
@@ -28,7 +28,10 @@ import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static com.facebook.presto.common.block.Fixed12Block.FIXED12_BYTES;
+import static com.facebook.presto.common.block.Fixed12Block.INT_LONGS_PER_ENTRY;
 import static com.facebook.presto.common.block.Fixed12Block.encodeFixed12;
+import static com.facebook.presto.common.block.Fixed12Block.getFixed12FirstUnchecked;
+import static com.facebook.presto.common.block.Fixed12Block.getFixed12SecondUnchecked;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 import static java.lang.String.format;
@@ -42,7 +45,6 @@ public class Fixed12BlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(Fixed12BlockBuilder.class).instanceSize();
     private static final Block NULL_VALUE_BLOCK = new Fixed12Block(0, 1, new boolean[] {true}, new int[3]);
-    private static final int INT_LONGS_PER_ENTRY = 3; // 3 ints = 12 bytes
 
     @Nullable
     private final BlockBuilderStatus blockBuilderStatus;
@@ -221,7 +223,7 @@ public class Fixed12BlockBuilder
     {
         checkReadablePosition(position);
         if (offset == 0) {
-            return Fixed12Block.encodeFirstAsLong(values, position);
+            return getFixed12FirstUnchecked(values, position);
         }
         throw new IllegalArgumentException("offset must be 0");
     }
@@ -230,7 +232,7 @@ public class Fixed12BlockBuilder
     public int getInt(int position)
     {
         checkReadablePosition(position);
-        return values[position * INT_LONGS_PER_ENTRY + 2];
+        return getFixed12SecondUnchecked(values, position);
     }
 
     @Override
@@ -250,16 +252,14 @@ public class Fixed12BlockBuilder
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         checkReadablePosition(position);
+        long first = getFixed12FirstUnchecked(values, position);
+        int second = getFixed12SecondUnchecked(values, position);
         if (blockBuilder instanceof Fixed12BlockBuilder) {
-            int baseIndex = position * INT_LONGS_PER_ENTRY;
-            long first = (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
-            ((Fixed12BlockBuilder) blockBuilder).writeFixed12(first, values[baseIndex + 2]);
+            ((Fixed12BlockBuilder) blockBuilder).writeFixed12(first, second);
         }
         else {
-            int baseIndex = position * INT_LONGS_PER_ENTRY;
-            long first = (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
             blockBuilder.writeLong(first);
-            blockBuilder.writeInt(values[baseIndex + 2]);
+            blockBuilder.writeInt(second);
             blockBuilder.closeEntry();
         }
     }
@@ -380,8 +380,7 @@ public class Fixed12BlockBuilder
     {
         assert internalPositionInRange(internalPosition, getOffsetBase(), getPositionCount());
         assert offset == 0 : "offset must be 0";
-        int baseIndex = internalPosition * INT_LONGS_PER_ENTRY;
-        return (values[baseIndex] & 0xFFFFFFFFL) | ((long) values[baseIndex + 1] << 32);
+        return getFixed12FirstUnchecked(values, internalPosition);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12BlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Fixed12BlockEncoding.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+
+import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
+import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
+import static com.facebook.presto.common.block.Fixed12Block.encodeFixed12;
+
+public class Fixed12BlockEncoding
+        implements BlockEncoding
+{
+    public static final String NAME = "FIXED12_ARRAY";
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        sliceOutput.appendInt(positionCount);
+
+        encodeNullsAsBits(sliceOutput, block);
+
+        boolean mayHaveNull = block.mayHaveNull();
+        if (block instanceof Fixed12Block) {
+            Fixed12Block fixed12Block = (Fixed12Block) block;
+            for (int position = 0; position < positionCount; position++) {
+                if (!mayHaveNull || !block.isNull(position)) {
+                    sliceOutput.writeLong(fixed12Block.getFixed12First(position));
+                    sliceOutput.writeInt(fixed12Block.getFixed12Second(position));
+                }
+            }
+        }
+        else {
+            for (int position = 0; position < positionCount; position++) {
+                if (!mayHaveNull || !block.isNull(position)) {
+                    sliceOutput.writeLong(block.getLong(position, 0));
+                    sliceOutput.writeInt(block.getInt(position));
+                }
+            }
+        }
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput sliceInput)
+    {
+        int positionCount = sliceInput.readInt();
+
+        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
+
+        int[] values = new int[positionCount * 3];
+        for (int position = 0; position < positionCount; position++) {
+            if (valueIsNull == null || !valueIsNull[position]) {
+                long first = sliceInput.readLong();
+                int second = sliceInput.readInt();
+                encodeFixed12(first, second, values, position);
+            }
+        }
+
+        return new Fixed12Block(0, positionCount, valueIsNull, values);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestamp.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+/**
+ * Represents a timestamp value with precision greater than microseconds (precision 7-12).
+ * Stores the epoch microseconds and an additional fractional component in picoseconds
+ * of the microsecond (0 to 999999 inclusive).
+ * <p>
+ * This class is the value type used by {@link LongTimestampType} for precisions 7 through 12.
+ */
+public final class LongTimestamp
+        implements Comparable<LongTimestamp>
+{
+    private static final int PICOSECONDS_PER_MICROSECOND = 1_000_000;
+
+    private final long epochMicros;
+    private final int picosOfMicro;
+
+    public LongTimestamp(long epochMicros, int picosOfMicro)
+    {
+        if (picosOfMicro < 0 || picosOfMicro >= PICOSECONDS_PER_MICROSECOND) {
+            throw new IllegalArgumentException(format("picosOfMicro is out of range: %s", picosOfMicro));
+        }
+        this.epochMicros = epochMicros;
+        this.picosOfMicro = picosOfMicro;
+    }
+
+    public long getEpochMicros()
+    {
+        return epochMicros;
+    }
+
+    public int getPicosOfMicro()
+    {
+        return picosOfMicro;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LongTimestamp that = (LongTimestamp) o;
+        return epochMicros == that.epochMicros && picosOfMicro == that.picosOfMicro;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(epochMicros, picosOfMicro);
+    }
+
+    @Override
+    public int compareTo(LongTimestamp other)
+    {
+        int result = Long.compare(epochMicros, other.epochMicros);
+        if (result != 0) {
+            return result;
+        }
+        return Integer.compare(picosOfMicro, other.picosOfMicro);
+    }
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return Timestamps.formatTimestamp(12, epochMicros, picosOfMicro);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongTimestampType.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.BlockBuilderStatus;
+import com.facebook.presto.common.block.Fixed12Block;
+import com.facebook.presto.common.block.Fixed12BlockBuilder;
+import com.facebook.presto.common.block.PageBuilderStatus;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+
+import static com.facebook.presto.common.block.Fixed12Block.FIXED12_BYTES;
+
+/**
+ * Long timestamp type (precision 7-12). Values are stored as 12 bytes
+ * using {@link Fixed12Block}: the first 8 bytes store epoch microseconds
+ * and the last 4 bytes store picoseconds within the microsecond (0-999999).
+ */
+public final class LongTimestampType
+        extends TimestampType
+{
+    LongTimestampType(int precision)
+    {
+        super(precision, LongTimestamp.class);
+        if (precision <= Timestamps.MAX_SHORT_PRECISION) {
+            throw new IllegalArgumentException("Long timestamp precision must be > " + Timestamps.MAX_SHORT_PRECISION + ": " + precision);
+        }
+    }
+
+    @Override
+    public int getFixedSize()
+    {
+        return FIXED12_BYTES;
+    }
+
+    @Override
+    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+
+        if (block instanceof Fixed12Block) {
+            Fixed12Block fixed12Block = (Fixed12Block) block;
+            long epochMicros = fixed12Block.getFixed12First(position);
+            int picosOfMicro = fixed12Block.getFixed12Second(position);
+            return new LongTimestamp(epochMicros, picosOfMicro);
+        }
+
+        // Fallback: read as long + int from generic block
+        long epochMicros = block.getLong(position, 0);
+        int picosOfMicro = block.getInt(position);
+        return new LongTimestamp(epochMicros, picosOfMicro);
+    }
+
+    /**
+     * Gets the LongTimestamp object from a block at the given position.
+     */
+    public LongTimestamp getObject(Block block, int position)
+    {
+        if (block instanceof Fixed12Block) {
+            Fixed12Block fixed12Block = (Fixed12Block) block;
+            return new LongTimestamp(
+                    fixed12Block.getFixed12First(position),
+                    fixed12Block.getFixed12Second(position));
+        }
+        return new LongTimestamp(
+                block.getLong(position, 0),
+                block.getInt(position));
+    }
+
+    /**
+     * Writes a LongTimestamp value to a block builder.
+     */
+    public void writeObject(BlockBuilder blockBuilder, Object value)
+    {
+        LongTimestamp timestamp = (LongTimestamp) value;
+        if (blockBuilder instanceof Fixed12BlockBuilder) {
+            ((Fixed12BlockBuilder) blockBuilder).writeFixed12(timestamp.getEpochMicros(), timestamp.getPicosOfMicro());
+        }
+        else {
+            blockBuilder.writeLong(timestamp.getEpochMicros());
+            blockBuilder.writeInt(timestamp.getPicosOfMicro());
+            blockBuilder.closeEntry();
+        }
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            LongTimestamp value = getObject(block, position);
+            writeObject(blockBuilder, value);
+        }
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        LongTimestamp left = getObject(leftBlock, leftPosition);
+        LongTimestamp right = getObject(rightBlock, rightPosition);
+        return left.equals(right);
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        LongTimestamp value = getObject(block, position);
+        return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        LongTimestamp left = getObject(leftBlock, leftPosition);
+        LongTimestamp right = getObject(rightBlock, rightPosition);
+        return left.compareTo(right);
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
+        }
+        return new Fixed12BlockBuilder(
+                blockBuilderStatus,
+                Math.min(expectedEntries, maxBlockSizeInBytes / FIXED12_BYTES));
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, FIXED12_BYTES);
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new Fixed12BlockBuilder(null, positionCount);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/ShortTimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ShortTimestampType.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.BlockBuilderStatus;
+import com.facebook.presto.common.block.LongArrayBlockBuilder;
+import com.facebook.presto.common.block.PageBuilderStatus;
+import com.facebook.presto.common.block.UncheckedBlock;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import io.airlift.slice.Slice;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.Long.rotateLeft;
+
+/**
+ * Short timestamp type (precision 0-6). Values are stored as a single long:
+ * - Precision 0-3: epoch milliseconds
+ * - Precision 4-6: epoch microseconds
+ * <p>
+ * This class replicates the block-interaction behavior of {@link AbstractLongType}
+ * so that existing code working with timestamp values stored in LongArrayBlock
+ * continues to work transparently.
+ */
+public final class ShortTimestampType
+        extends TimestampType
+{
+    ShortTimestampType(int precision)
+    {
+        super(precision, long.class);
+        if (precision > Timestamps.MAX_SHORT_PRECISION) {
+            throw new IllegalArgumentException("Short timestamp precision must be <= " + Timestamps.MAX_SHORT_PRECISION + ": " + precision);
+        }
+    }
+
+    @Override
+    public int getFixedSize()
+    {
+        return Long.BYTES;
+    }
+
+    @Override
+    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+
+        TimeUnit unit = getStorageUnit();
+        if (properties.isLegacyTimestamp()) {
+            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), unit);
+        }
+        else {
+            return new SqlTimestamp(block.getLong(position), unit);
+        }
+    }
+
+    @Override
+    public long getLong(Block block, int position)
+    {
+        return block.getLong(position);
+    }
+
+    @Override
+    public long getLongUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return block.getLongUnchecked(internalPosition);
+    }
+
+    @Override
+    public Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, getFixedSize());
+    }
+
+    @Override
+    public void writeLong(BlockBuilder blockBuilder, long value)
+    {
+        blockBuilder.writeLong(value).closeEntry();
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            blockBuilder.writeLong(block.getLong(position)).closeEntry();
+        }
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
+        return leftValue == rightValue;
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        return hash(block.getLong(position));
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        long leftValue = leftBlock.getLong(leftPosition);
+        long rightValue = rightBlock.getLong(rightPosition);
+        return Long.compare(leftValue, rightValue);
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
+        }
+        return new LongArrayBlockBuilder(
+                blockBuilderStatus,
+                Math.min(expectedEntries, maxBlockSizeInBytes / Long.BYTES));
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, Long.BYTES);
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new LongArrayBlockBuilder(null, positionCount);
+    }
+
+    public static long hash(long value)
+    {
+        // xxhash64 mix
+        return rotateLeft(value * 0xC2B2AE3D27D4EB4FL, 31) * 0x9E3779B185EBCA87L;
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -69,6 +69,7 @@ public final class StandardTypes
             VARCHAR,
             CHAR,
             DECIMAL,
+            TIMESTAMP,
             ROW,
             ARRAY,
             MAP,

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -16,104 +16,170 @@ package com.facebook.presto.common.type;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static com.facebook.presto.common.type.Timestamps.MAX_PRECISION;
+import static com.facebook.presto.common.type.Timestamps.MAX_SHORT_PRECISION;
+import static java.lang.String.format;
 
-//
-// TIMESTAMP is stored as milliseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-// TIMESTAMP_MICROSECONDS is stored as microseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
-// on a timestamp the client's time zone must be taken into account.
-//
-public final class TimestampType
-        extends AbstractLongType
+/**
+ * TIMESTAMP type with precision 0..12.
+ * <p>
+ * Precision 0-6 (short timestamps) are stored as a single long value:
+ * - Precision 0-3: epoch milliseconds
+ * - Precision 4-6: epoch microseconds
+ * <p>
+ * Precision 7-12 (long timestamps) are stored as 12 bytes (epoch microseconds + picoseconds of microsecond)
+ * using {@link com.facebook.presto.common.block.Fixed12Block}.
+ * <p>
+ * Backward compatibility:
+ * - {@link #TIMESTAMP} is an alias for TIMESTAMP(3) (millisecond precision)
+ * - {@link #TIMESTAMP_MICROSECONDS} is an alias for TIMESTAMP(6) (microsecond precision)
+ */
+public abstract class TimestampType
+        extends AbstractType
+        implements FixedWidthType
 {
-    public static final TimestampType TIMESTAMP = new TimestampType(MILLISECONDS);
-    public static final TimestampType TIMESTAMP_MICROSECONDS = new TimestampType(MICROSECONDS);
+    // Pre-defined instances for common precisions
+    public static final TimestampType TIMESTAMP_SECONDS = createTimestampType(0);
+    public static final TimestampType TIMESTAMP_MILLIS = createTimestampType(3);
+    public static final TimestampType TIMESTAMP_MICROS = createTimestampType(6);
+    public static final TimestampType TIMESTAMP_NANOS = createTimestampType(9);
+    public static final TimestampType TIMESTAMP_PICOS = createTimestampType(12);
 
-    private final TimeUnit precision;
+    // Backward-compatible aliases
+    public static final TimestampType TIMESTAMP = TIMESTAMP_MILLIS;
+    public static final TimestampType TIMESTAMP_MICROSECONDS = TIMESTAMP_MICROS;
 
-    private TimestampType(TimeUnit precision)
+    private final int precision;
+
+    TimestampType(int precision, Class<?> javaType)
     {
-        super(parseTypeSignature(getType(precision)));
+        super(javaType);
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format("TIMESTAMP precision must be in range [0, %d]: %s", MAX_PRECISION, precision));
+        }
         this.precision = precision;
     }
 
-    @Override
-    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    /**
+     * Creates a TimestampType with the given precision (0..12).
+     */
+    public static TimestampType createTimestampType(int precision)
     {
-        if (block.isNull(position)) {
-            return null;
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format("TIMESTAMP precision must be in range [0, %d]: %s", MAX_PRECISION, precision));
         }
-
-        if (properties.isLegacyTimestamp()) {
-            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), precision);
+        if (precision <= MAX_SHORT_PRECISION) {
+            return new ShortTimestampType(precision);
         }
-        else {
-            return new SqlTimestamp(block.getLong(position), precision);
-        }
+        return new LongTimestampType(precision);
     }
 
-    public TimeUnit getPrecision()
+    /**
+     * Returns the precision (0..12) of this timestamp type.
+     */
+    public int getPrecision()
     {
-        return this.precision;
+        return precision;
+    }
+
+    /**
+     * Returns true if this is a short timestamp (precision 0..6), which fits in a single long.
+     */
+    public boolean isShort()
+    {
+        return precision <= MAX_SHORT_PRECISION;
+    }
+
+    /**
+     * Returns true if this is a long timestamp (precision 7..12).
+     */
+    public boolean isLong()
+    {
+        return precision > MAX_SHORT_PRECISION;
+    }
+
+    /**
+     * Returns the storage unit for short timestamps.
+     * For precision 0-3, returns MILLISECONDS.
+     * For precision 4-6, returns MICROSECONDS.
+     */
+    public TimeUnit getStorageUnit()
+    {
+        if (precision <= 3) {
+            return TimeUnit.MILLISECONDS;
+        }
+        if (precision <= MAX_SHORT_PRECISION) {
+            return TimeUnit.MICROSECONDS;
+        }
+        throw new UnsupportedOperationException("Long timestamps do not have a simple TimeUnit storage");
     }
 
     @Override
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    public boolean isComparable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return true;
+    }
+
+    @Override
+    public abstract Object getObjectValue(SqlFunctionProperties properties, Block block, int position);
+
+    @Override
+    public TypeSignature getTypeSignature()
+    {
+        if (precision == 3) {
+            return TypeSignature.parseTypeSignature(StandardTypes.TIMESTAMP);
+        }
+        if (precision == 6) {
+            return TypeSignature.parseTypeSignature(StandardTypes.TIMESTAMP_MICROSECONDS);
+        }
+        return new TypeSignature(StandardTypes.TIMESTAMP, TypeSignatureParameter.of(precision));
+    }
+
+    @Override
     public boolean equals(Object other)
     {
-        if (precision == MICROSECONDS) {
-            return other == TIMESTAMP_MICROSECONDS;
+        if (this == other) {
+            return true;
         }
-        if (precision == MILLISECONDS) {
-            return other == TIMESTAMP;
+        if (!(other instanceof TimestampType)) {
+            return false;
         }
-        throw new UnsupportedOperationException("Unsupported precision " + precision);
+        return this.precision == ((TimestampType) other).precision;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(getClass(), precision);
+        return precision;
     }
 
+    // Legacy compatibility methods
+
     /**
-     * Gets the timestamp's number of total seconds.
-     * The epoch second count is a simple incrementing count of seconds where second 0 is 1970-01-01T00:00:00Z.
-     *
-     * Returns:
-     * the total seconds in timestamp
+     * Gets the timestamp's total seconds from epoch.
+     * Only valid for short timestamps (precision 0-6).
      */
     public long getEpochSecond(long timestamp)
     {
-        return this.precision.toSeconds(timestamp);
+        return getStorageUnit().toSeconds(timestamp);
     }
 
     /**
-     * Gets the timestamp's nanosecond portion.
-     *
-     * Returns:
-     * this timestamp's fractional seconds component
+     * Gets the timestamp's nanosecond portion within the current second.
+     * Only valid for short timestamps (precision 0-6).
      */
     public int getNanos(long timestamp)
     {
-        long unitsPerSecond = precision.convert(1, TimeUnit.SECONDS);
-        return (int) precision.toNanos(timestamp % unitsPerSecond);
-    }
-
-    private static String getType(TimeUnit precision)
-    {
-        if (precision == MICROSECONDS) {
-            return StandardTypes.TIMESTAMP_MICROSECONDS;
-        }
-        if (precision == MILLISECONDS) {
-            return StandardTypes.TIMESTAMP;
-        }
-        throw new IllegalArgumentException("Unsupported precision " + precision);
+        TimeUnit unit = getStorageUnit();
+        long unitsPerSecond = unit.convert(1, TimeUnit.SECONDS);
+        return (int) unit.toNanos(timestamp % unitsPerSecond);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/Timestamps.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/Timestamps.java
@@ -72,7 +72,10 @@ public final class Timestamps
      * Rescales a timestamp value from one precision to another.
      * <p>
      * For example, rescaling 123456 from precision 6 (microseconds) to precision 3 (milliseconds)
-     * produces 123 (truncation). Rescaling 123 from precision 3 to precision 6 produces 123000.
+     * produces 123. Rescaling 123 from precision 3 to precision 6 produces 123000.
+     * <p>
+     * When downscaling, uses floor-based division (rounds toward negative infinity) to maintain
+     * monotonic, consistent behavior for negative timestamps (pre-epoch values).
      */
     public static long rescale(long value, int fromPrecision, int toPrecision)
     {
@@ -85,14 +88,17 @@ public final class Timestamps
             return value * POWERS_OF_TEN[scaleFactor];
         }
         else {
-            // Scale down (truncation)
+            // Scale down using floorDiv for consistent behavior with negative values
             int scaleFactor = fromPrecision - toPrecision;
-            return roundDiv(value, POWERS_OF_TEN[scaleFactor]);
+            return floorDiv(value, POWERS_OF_TEN[scaleFactor]);
         }
     }
 
     /**
-     * Rounds toward zero when dividing.
+     * Divides and truncates toward zero (Java's default integer division behavior).
+     * Note: this is NOT floor division — for negative values, the result is
+     * truncated toward zero rather than toward negative infinity. For floor
+     * division, use {@link Math#floorDiv(long, long)}.
      */
     public static long roundDiv(long value, long divisor)
     {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/Timestamps.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/Timestamps.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+
+/**
+ * Utility class for timestamp precision handling, rescaling, and formatting.
+ */
+public final class Timestamps
+{
+    private Timestamps() {}
+
+    public static final int MAX_PRECISION = 12;
+    public static final int MAX_SHORT_PRECISION = 6;
+    public static final int DEFAULT_PRECISION = 3;
+
+    public static final long MILLISECONDS_PER_SECOND = 1_000L;
+    public static final long MICROSECONDS_PER_SECOND = 1_000_000L;
+    public static final long NANOSECONDS_PER_SECOND = 1_000_000_000L;
+    public static final long PICOSECONDS_PER_SECOND = 1_000_000_000_000L;
+
+    public static final long MICROSECONDS_PER_MILLISECOND = 1_000L;
+    public static final long NANOSECONDS_PER_MILLISECOND = 1_000_000L;
+    public static final long PICOSECONDS_PER_MILLISECOND = 1_000_000_000L;
+
+    public static final long NANOSECONDS_PER_MICROSECOND = 1_000L;
+    public static final long PICOSECONDS_PER_MICROSECOND = 1_000_000L;
+
+    public static final long PICOSECONDS_PER_NANOSECOND = 1_000L;
+
+    public static final long MILLISECONDS_PER_DAY = 86_400_000L;
+
+    public static final long[] POWERS_OF_TEN = {
+            1L,
+            10L,
+            100L,
+            1_000L,
+            10_000L,
+            100_000L,
+            1_000_000L,
+            10_000_000L,
+            100_000_000L,
+            1_000_000_000L,
+            10_000_000_000L,
+            100_000_000_000L,
+            1_000_000_000_000L,
+    };
+
+    /**
+     * Rescales a timestamp value from one precision to another.
+     * <p>
+     * For example, rescaling 123456 from precision 6 (microseconds) to precision 3 (milliseconds)
+     * produces 123 (truncation). Rescaling 123 from precision 3 to precision 6 produces 123000.
+     */
+    public static long rescale(long value, int fromPrecision, int toPrecision)
+    {
+        if (fromPrecision == toPrecision) {
+            return value;
+        }
+        if (fromPrecision < toPrecision) {
+            // Scale up
+            int scaleFactor = toPrecision - fromPrecision;
+            return value * POWERS_OF_TEN[scaleFactor];
+        }
+        else {
+            // Scale down (truncation)
+            int scaleFactor = fromPrecision - toPrecision;
+            return roundDiv(value, POWERS_OF_TEN[scaleFactor]);
+        }
+    }
+
+    /**
+     * Rounds toward zero when dividing.
+     */
+    public static long roundDiv(long value, long divisor)
+    {
+        return value / divisor;
+    }
+
+    /**
+     * Round a value by truncating toward zero.
+     */
+    public static long round(long value, int precision)
+    {
+        if (precision >= MAX_PRECISION) {
+            return value;
+        }
+        long factor = POWERS_OF_TEN[MAX_PRECISION - precision];
+        return (value / factor) * factor;
+    }
+
+    /**
+     * Truncate a long timestamp (epoch micros + picos) to just epoch micros.
+     */
+    public static long truncateToMicros(long epochMicros, int picosOfMicro)
+    {
+        return epochMicros;
+    }
+
+    /**
+     * Returns true if the given precision is a short timestamp (fits in a long).
+     */
+    public static boolean isShortTimestamp(int precision)
+    {
+        return precision <= MAX_SHORT_PRECISION;
+    }
+
+    /**
+     * Formats a timestamp value at the given precision.
+     * <p>
+     * For precision 0-6, epochMicros contains the full value and picosOfMicro should be 0.
+     * For precision 7-12, epochMicros and picosOfMicro together represent the full value.
+     */
+    public static String formatTimestamp(int precision, long epochMicros, int picosOfMicro)
+    {
+        long epochSecond = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+        int microsFraction = toIntExact(floorMod(epochMicros, MICROSECONDS_PER_SECOND));
+
+        // Calculate total picoseconds in the fractional second
+        long totalPicosInSecond = microsFraction * PICOSECONDS_PER_MICROSECOND + picosOfMicro;
+
+        Instant instant = Instant.ofEpochSecond(epochSecond);
+        LocalDateTime dateTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+
+        // Calculate nanoseconds for Java's formatter
+        int nanos = toIntExact(totalPicosInSecond / PICOSECONDS_PER_NANOSECOND);
+        dateTime = dateTime.withNano(nanos);
+
+        // Format up to nanosecond precision using Java's built-in formatting
+        DateTimeFormatterBuilder formatterBuilder = new DateTimeFormatterBuilder()
+                .appendPattern("uuuu-MM-dd HH:mm:ss");
+        if (precision > 0) {
+            int minWidth = Math.min(precision, 9);
+            int maxWidth = Math.min(precision, 9);
+            formatterBuilder.appendFraction(NANO_OF_SECOND, minWidth, maxWidth, true);
+        }
+        DateTimeFormatter formatter = formatterBuilder.toFormatter();
+
+        String result = dateTime.format(formatter);
+
+        // For precision > 9 (sub-nanosecond), append additional digits
+        if (precision > 9) {
+            long subNanoPicos = totalPicosInSecond % PICOSECONDS_PER_NANOSECOND;
+            String subNanoStr = format("%03d", subNanoPicos);
+            int extraDigits = precision - 9;
+            result = result + subNanoStr.substring(0, extraDigits);
+        }
+
+        return result;
+    }
+
+    /**
+     * Converts milliseconds to microseconds.
+     */
+    public static long millisToMicros(long millis)
+    {
+        return millis * MICROSECONDS_PER_MILLISECOND;
+    }
+
+    /**
+     * Converts microseconds to milliseconds (truncation).
+     */
+    public static long microsToMillis(long micros)
+    {
+        return floorDiv(micros, MICROSECONDS_PER_MILLISECOND);
+    }
+
+    /**
+     * Converts microseconds to nanoseconds.
+     */
+    public static long microsToNanos(long micros)
+    {
+        return micros * NANOSECONDS_PER_MICROSECOND;
+    }
+
+    /**
+     * Converts nanoseconds to microseconds (truncation).
+     */
+    public static long nanosToMicros(long nanos)
+    {
+        return floorDiv(nanos, NANOSECONDS_PER_MICROSECOND);
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
@@ -71,6 +71,7 @@ public class TypeSignature
 
         SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIME_WITH_TIME_ZONE);
         SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
+        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIMESTAMP_MICROSECONDS);
         SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.INTERVAL_DAY_TO_SECOND);
         SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.INTERVAL_YEAR_TO_MONTH);
         SIMPLE_TYPE_WITH_SPACES.add("double precision");

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12Block.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12Block.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestFixed12Block
+{
+    @Test
+    public void testWriteAndRead()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 10);
+        builder.writeFixed12(100L, 42);
+        builder.writeFixed12(200L, 84);
+        builder.writeFixed12(-1L, 999999);
+        builder.writeFixed12(Long.MAX_VALUE, 0);
+        builder.writeFixed12(Long.MIN_VALUE, 500000);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+
+        assertEquals(block.getPositionCount(), 5);
+        assertEquals(block.getFixed12First(0), 100L);
+        assertEquals(block.getFixed12Second(0), 42);
+        assertEquals(block.getFixed12First(1), 200L);
+        assertEquals(block.getFixed12Second(1), 84);
+        assertEquals(block.getFixed12First(2), -1L);
+        assertEquals(block.getFixed12Second(2), 999999);
+        assertEquals(block.getFixed12First(3), Long.MAX_VALUE);
+        assertEquals(block.getFixed12Second(3), 0);
+        assertEquals(block.getFixed12First(4), Long.MIN_VALUE);
+        assertEquals(block.getFixed12Second(4), 500000);
+    }
+
+    @Test
+    public void testNullHandling()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(100L, 1);
+        builder.appendNull();
+        builder.writeFixed12(300L, 3);
+
+        Block block = builder.build();
+
+        assertEquals(block.getPositionCount(), 3);
+        assertFalse(block.isNull(0));
+        assertTrue(block.isNull(1));
+        assertFalse(block.isNull(2));
+    }
+
+    @Test
+    public void testGetRegion()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(10L, 1);
+        builder.writeFixed12(20L, 2);
+        builder.writeFixed12(30L, 3);
+        builder.writeFixed12(40L, 4);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+        Block region = block.getRegion(1, 2);
+
+        assertEquals(region.getPositionCount(), 2);
+        assertEquals(((Fixed12Block) region).getFixed12First(0), 20L);
+        assertEquals(((Fixed12Block) region).getFixed12Second(0), 2);
+        assertEquals(((Fixed12Block) region).getFixed12First(1), 30L);
+        assertEquals(((Fixed12Block) region).getFixed12Second(1), 3);
+    }
+
+    @Test
+    public void testCopyPositions()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(10L, 1);
+        builder.writeFixed12(20L, 2);
+        builder.writeFixed12(30L, 3);
+        builder.writeFixed12(40L, 4);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+        Block copied = block.copyPositions(new int[] {0, 2, 3}, 0, 3);
+
+        assertEquals(copied.getPositionCount(), 3);
+        assertEquals(((Fixed12Block) copied).getFixed12First(0), 10L);
+        assertEquals(((Fixed12Block) copied).getFixed12Second(0), 1);
+        assertEquals(((Fixed12Block) copied).getFixed12First(1), 30L);
+        assertEquals(((Fixed12Block) copied).getFixed12Second(1), 3);
+        assertEquals(((Fixed12Block) copied).getFixed12First(2), 40L);
+        assertEquals(((Fixed12Block) copied).getFixed12Second(2), 4);
+    }
+
+    @Test
+    public void testGetSingleValueBlock()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(100L, 42);
+        builder.writeFixed12(200L, 84);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+        Block singleValueBlock = block.getSingleValueBlock(1);
+
+        assertEquals(singleValueBlock.getPositionCount(), 1);
+        assertEquals(((Fixed12Block) singleValueBlock).getFixed12First(0), 200L);
+        assertEquals(((Fixed12Block) singleValueBlock).getFixed12Second(0), 84);
+    }
+
+    @Test
+    public void testCopyRegion()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(10L, 1);
+        builder.writeFixed12(20L, 2);
+        builder.writeFixed12(30L, 3);
+        builder.writeFixed12(40L, 4);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+        Block copy = block.copyRegion(1, 2);
+
+        assertEquals(copy.getPositionCount(), 2);
+        assertEquals(((Fixed12Block) copy).getFixed12First(0), 20L);
+        assertEquals(((Fixed12Block) copy).getFixed12Second(0), 2);
+        assertEquals(((Fixed12Block) copy).getFixed12First(1), 30L);
+        assertEquals(((Fixed12Block) copy).getFixed12Second(1), 3);
+    }
+
+    @Test
+    public void testSizeInBytes()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(10L, 1);
+        builder.writeFixed12(20L, 2);
+        builder.writeFixed12(30L, 3);
+
+        Block block = builder.build();
+        assertEquals(block.getSizeInBytes(), Fixed12Block.SIZE_IN_BYTES_PER_POSITION * 3L);
+    }
+
+    @Test
+    public void testEncodeFixed12()
+    {
+        int[] target = new int[3];
+        Fixed12Block.encodeFixed12(0x0000000100000002L, 42, target, 0);
+        // Verify the encoding: low 32 bits, high 32 bits, int value
+        assertEquals(target[0], 0x00000002); // low 32 bits
+        assertEquals(target[1], 0x00000001); // high 32 bits
+        assertEquals(target[2], 42);
+    }
+
+    @Test
+    public void testEncodeFixed12Roundtrip()
+    {
+        long[] testFirstValues = {0L, 1L, -1L, Long.MAX_VALUE, Long.MIN_VALUE, 1234567890123456L};
+        int[] testSecondValues = {0, 1, 999999, 500000, Integer.MAX_VALUE};
+
+        for (long first : testFirstValues) {
+            for (int second : testSecondValues) {
+                int[] target = new int[3];
+                Fixed12Block.encodeFixed12(first, second, target, 0);
+
+                // Read back using the same logic as Fixed12Block
+                long readFirst = (target[0] & 0xFFFFFFFFL) | ((long) target[1] << 32);
+                int readSecond = target[2];
+
+                assertEquals(readFirst, first, "Roundtrip failed for first=" + first);
+                assertEquals(readSecond, second, "Roundtrip failed for second=" + second);
+            }
+        }
+    }
+
+    @Test
+    public void testWritePositionTo()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(100L, 42);
+        builder.writeFixed12(200L, 84);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+
+        Fixed12BlockBuilder targetBuilder = new Fixed12BlockBuilder(null, 5);
+        block.writePositionTo(0, targetBuilder);
+        block.writePositionTo(1, targetBuilder);
+
+        Fixed12Block targetBlock = (Fixed12Block) targetBuilder.build();
+        assertEquals(targetBlock.getPositionCount(), 2);
+        assertEquals(targetBlock.getFixed12First(0), 100L);
+        assertEquals(targetBlock.getFixed12Second(0), 42);
+        assertEquals(targetBlock.getFixed12First(1), 200L);
+        assertEquals(targetBlock.getFixed12Second(1), 84);
+    }
+
+    @Test
+    public void testAppendNull()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(100L, 42);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+        Block withNull = block.appendNull();
+
+        assertEquals(withNull.getPositionCount(), 2);
+        assertFalse(withNull.isNull(0));
+        assertTrue(withNull.isNull(1));
+    }
+
+    @Test
+    public void testEmptyBlock()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 0);
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 0);
+    }
+
+    @Test
+    public void testAllNulls()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 3);
+        builder.appendNull();
+        builder.appendNull();
+        builder.appendNull();
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 3);
+        assertTrue(block.isNull(0));
+        assertTrue(block.isNull(1));
+        assertTrue(block.isNull(2));
+    }
+
+    @Test
+    public void testBuilderNewBlockBuilderLike()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 10);
+        builder.writeFixed12(100L, 42);
+        builder.writeFixed12(200L, 84);
+
+        BlockBuilder newBuilder = builder.newBlockBuilderLike(null);
+        assertTrue(newBuilder instanceof Fixed12BlockBuilder);
+    }
+
+    @Test
+    public void testConstructorWithOptionalNull()
+    {
+        int[] values = new int[6]; // 2 entries * 3 ints per entry
+        Fixed12Block.encodeFixed12(100L, 42, values, 0);
+        Fixed12Block.encodeFixed12(200L, 84, values, 1);
+
+        Fixed12Block block = new Fixed12Block(2, Optional.empty(), values);
+        assertEquals(block.getPositionCount(), 2);
+        assertFalse(block.mayHaveNull());
+        assertEquals(block.getFixed12First(0), 100L);
+        assertEquals(block.getFixed12Second(0), 42);
+        assertEquals(block.getFixed12First(1), 200L);
+        assertEquals(block.getFixed12Second(1), 84);
+    }
+
+    @Test
+    public void testConstructorWithNulls()
+    {
+        int[] values = new int[6]; // 2 entries
+        Fixed12Block.encodeFixed12(100L, 42, values, 0);
+        boolean[] nulls = new boolean[] {false, true};
+
+        Fixed12Block block = new Fixed12Block(2, Optional.of(nulls), values);
+        assertEquals(block.getPositionCount(), 2);
+        assertTrue(block.mayHaveNull());
+        assertFalse(block.isNull(0));
+        assertTrue(block.isNull(1));
+    }
+
+    @Test
+    public void testLargeValues()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 3);
+        builder.writeFixed12(Long.MAX_VALUE, 999999);
+        builder.writeFixed12(Long.MIN_VALUE, 0);
+        builder.writeFixed12(0L, 500000);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+        assertEquals(block.getFixed12First(0), Long.MAX_VALUE);
+        assertEquals(block.getFixed12Second(0), 999999);
+        assertEquals(block.getFixed12First(1), Long.MIN_VALUE);
+        assertEquals(block.getFixed12Second(1), 0);
+        assertEquals(block.getFixed12First(2), 0L);
+        assertEquals(block.getFixed12Second(2), 500000);
+    }
+
+    @Test
+    public void testGetLong()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 2);
+        builder.writeFixed12(12345L, 42);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+        // getLong(position, 0) should return the first long value
+        assertEquals(block.getLong(0, 0), 12345L);
+    }
+
+    @Test
+    public void testGetInt()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 2);
+        builder.writeFixed12(12345L, 42);
+
+        Fixed12Block block = (Fixed12Block) builder.build();
+        // getInt(position) should return the second int value
+        assertEquals(block.getInt(0), 42);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testGetLongInvalidOffset()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 2);
+        builder.writeFixed12(12345L, 42);
+        Fixed12Block block = (Fixed12Block) builder.build();
+        block.getLong(0, 1); // Should throw since only offset 0 is valid
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testReadOutOfBounds()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 2);
+        builder.writeFixed12(12345L, 42);
+        Fixed12Block block = (Fixed12Block) builder.build();
+        block.getFixed12First(1); // Only position 0 exists
+    }
+
+    @Test
+    public void testEncodingName()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 1);
+        builder.writeFixed12(100L, 42);
+        Block block = builder.build();
+        assertEquals(block.getEncodingName(), Fixed12BlockEncoding.NAME);
+    }
+
+    @Test
+    public void testFixedSizeInBytesPerPosition()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 1);
+        builder.writeFixed12(100L, 42);
+        Block block = builder.build();
+        assertTrue(block.fixedSizeInBytesPerPosition().isPresent());
+        assertEquals(block.fixedSizeInBytesPerPosition().getAsInt(), Fixed12Block.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Test
+    public void testEstimatedDataSizeForStats()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 3);
+        builder.writeFixed12(100L, 42);
+        builder.appendNull();
+
+        Block block = builder.build();
+        assertEquals(block.getEstimatedDataSizeForStats(0), Fixed12Block.FIXED12_BYTES);
+        assertEquals(block.getEstimatedDataSizeForStats(1), 0);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12Block.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestFixed12Block.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.common.block;
 
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -367,5 +371,79 @@ public class TestFixed12Block
         Block block = builder.build();
         assertEquals(block.getEstimatedDataSizeForStats(0), Fixed12Block.FIXED12_BYTES);
         assertEquals(block.getEstimatedDataSizeForStats(1), 0);
+    }
+
+    @Test
+    public void testSliceRoundTripWithWritePositionTo()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 5);
+        builder.writeFixed12(10L, 1);
+        builder.appendNull();
+        builder.writeFixed12(Long.MAX_VALUE, Integer.MAX_VALUE);
+        builder.writeFixed12(0L, 0);
+        builder.appendNull();
+
+        Block original = builder.build();
+
+        // Serialize positions individually using writePositionTo/readPositionFrom
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
+        for (int position = 0; position < original.getPositionCount(); position++) {
+            original.writePositionTo(position, (SliceOutput) sliceOutput);
+        }
+
+        Slice slice = sliceOutput.slice();
+        SliceInput sliceInput = slice.getInput();
+
+        Fixed12BlockBuilder roundTripBuilder = new Fixed12BlockBuilder(null, original.getPositionCount());
+        for (int i = 0; i < original.getPositionCount(); i++) {
+            roundTripBuilder.readPositionFrom(sliceInput);
+        }
+
+        Block roundTripped = roundTripBuilder.build();
+        assertBlockEquals(roundTripped, original);
+    }
+
+    @Test
+    public void testSliceRoundTripNegativeValues()
+    {
+        Fixed12BlockBuilder builder = new Fixed12BlockBuilder(null, 3);
+        builder.writeFixed12(-1L, 999999);
+        builder.writeFixed12(Long.MIN_VALUE, 0);
+        builder.writeFixed12(-123456789L, 500000);
+
+        Block original = builder.build();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
+        for (int position = 0; position < original.getPositionCount(); position++) {
+            original.writePositionTo(position, (SliceOutput) sliceOutput);
+        }
+
+        SliceInput sliceInput = sliceOutput.slice().getInput();
+
+        Fixed12BlockBuilder roundTripBuilder = new Fixed12BlockBuilder(null, original.getPositionCount());
+        for (int i = 0; i < original.getPositionCount(); i++) {
+            roundTripBuilder.readPositionFrom(sliceInput);
+        }
+
+        Block roundTripped = roundTripBuilder.build();
+        assertBlockEquals(roundTripped, original);
+    }
+
+    private void assertBlockEquals(Block actual, Block expected)
+    {
+        assertEquals(actual.getPositionCount(), expected.getPositionCount());
+        for (int i = 0; i < expected.getPositionCount(); i++) {
+            assertEquals(actual.isNull(i), expected.isNull(i), "Null mismatch at position " + i);
+            if (!expected.isNull(i)) {
+                assertEquals(
+                        ((Fixed12Block) actual).getFixed12First(i),
+                        ((Fixed12Block) expected).getFixed12First(i),
+                        "First value mismatch at position " + i);
+                assertEquals(
+                        ((Fixed12Block) actual).getFixed12Second(i),
+                        ((Fixed12Block) expected).getFixed12Second(i),
+                        "Second value mismatch at position " + i);
+            }
+        }
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
@@ -126,20 +126,29 @@ public class TestLongTimestamp
     public void testToString()
     {
         // LongTimestamp.toString() uses Timestamps.formatTimestamp(12, epochMicros, picosOfMicro)
-        LongTimestamp ts = new LongTimestamp(0L, 0);
-        String str = ts.toString();
-        // Should format as a timestamp string with 12 digits of fractional precision
-        assertTrue(str.contains("1970-01-01"), "Expected epoch date in toString: " + str);
+
+        // Epoch timestamp: 1970-01-01 00:00:00.000000000000
+        LongTimestamp epoch = new LongTimestamp(0L, 0);
+        String epochStr = epoch.toString();
+        assertEquals(epochStr, "1970-01-01 00:00:00.000000000000");
+        assertEquals(epochStr.substring(epochStr.indexOf('.') + 1).length(), 12, "Expected 12 fractional digits for epoch timestamp");
+
+        // Negative timestamp just before the epoch:
+        // -1 micro = 1969-12-31 23:59:59.999999000000
+        LongTimestamp negative = new LongTimestamp(-1L, 0);
+        String negativeStr = negative.toString();
+        assertEquals(negativeStr, "1969-12-31 23:59:59.999999000000");
+        assertEquals(negativeStr.substring(negativeStr.indexOf('.') + 1).length(), 12, "Expected 12 fractional digits for negative timestamp");
     }
 
     @Test
     public void testToStringWithPositiveTimestamp()
     {
-        // 2020-01-01 00:00:00.000000 = 1577836800 seconds = 1577836800000000 micros
+        // 2020-01-01 00:00:00.000000123456 = 1577836800 seconds = 1577836800000000 micros, picosOfMicro = 123456
         LongTimestamp ts = new LongTimestamp(1577836800000000L, 123456);
         String str = ts.toString();
-        assertTrue(str.contains("2020-01-01"), "Expected 2020-01-01 in toString: " + str);
-        assertTrue(str.contains("00:00:00"), "Expected 00:00:00 in toString: " + str);
+        assertEquals(str, "2020-01-01 00:00:00.000000123456");
+        assertEquals(str.substring(str.indexOf('.') + 1).length(), 12, "Expected 12 fractional digits for positive timestamp");
     }
 
     @Test

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestLongTimestamp.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestLongTimestamp
+{
+    @Test
+    public void testConstruction()
+    {
+        LongTimestamp ts = new LongTimestamp(123456L, 789);
+        assertEquals(ts.getEpochMicros(), 123456L);
+        assertEquals(ts.getPicosOfMicro(), 789);
+    }
+
+    @Test
+    public void testConstructionWithZeroPicos()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 0);
+        assertEquals(ts.getEpochMicros(), 0L);
+        assertEquals(ts.getPicosOfMicro(), 0);
+    }
+
+    @Test
+    public void testConstructionWithMaxPicos()
+    {
+        LongTimestamp ts = new LongTimestamp(0L, 999999);
+        assertEquals(ts.getEpochMicros(), 0L);
+        assertEquals(ts.getPicosOfMicro(), 999999);
+    }
+
+    @Test
+    public void testConstructionWithNegativeEpochMicros()
+    {
+        LongTimestamp ts = new LongTimestamp(-1L, 0);
+        assertEquals(ts.getEpochMicros(), -1L);
+        assertEquals(ts.getPicosOfMicro(), 0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativePicosThrows()
+    {
+        new LongTimestamp(0L, -1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testPicosExceedingMaxThrows()
+    {
+        new LongTimestamp(0L, 1_000_000);
+    }
+
+    @Test
+    public void testEquals()
+    {
+        LongTimestamp ts1 = new LongTimestamp(100L, 42);
+        LongTimestamp ts2 = new LongTimestamp(100L, 42);
+        LongTimestamp ts3 = new LongTimestamp(100L, 43);
+        LongTimestamp ts4 = new LongTimestamp(101L, 42);
+
+        assertTrue(ts1.equals(ts2));
+        assertFalse(ts1.equals(ts3));
+        assertFalse(ts1.equals(ts4));
+        assertFalse(ts1.equals(null));
+        assertFalse(ts1.equals("not a timestamp"));
+    }
+
+    @Test
+    public void testHashCode()
+    {
+        LongTimestamp ts1 = new LongTimestamp(100L, 42);
+        LongTimestamp ts2 = new LongTimestamp(100L, 42);
+        assertEquals(ts1.hashCode(), ts2.hashCode());
+
+        // Different values should typically have different hash codes
+        LongTimestamp ts3 = new LongTimestamp(200L, 42);
+        assertNotEquals(ts1.hashCode(), ts3.hashCode());
+    }
+
+    @Test
+    public void testCompareTo()
+    {
+        LongTimestamp ts1 = new LongTimestamp(100L, 42);
+        LongTimestamp ts2 = new LongTimestamp(100L, 42);
+        LongTimestamp ts3 = new LongTimestamp(100L, 43);
+        LongTimestamp ts4 = new LongTimestamp(101L, 0);
+        LongTimestamp ts5 = new LongTimestamp(99L, 999999);
+
+        assertEquals(ts1.compareTo(ts2), 0);
+        assertTrue(ts1.compareTo(ts3) < 0);
+        assertTrue(ts3.compareTo(ts1) > 0);
+        assertTrue(ts1.compareTo(ts4) < 0);
+        assertTrue(ts4.compareTo(ts1) > 0);
+        assertTrue(ts5.compareTo(ts1) < 0);
+        assertTrue(ts1.compareTo(ts5) > 0);
+    }
+
+    @Test
+    public void testCompareToWithNegativeEpochMicros()
+    {
+        LongTimestamp ts1 = new LongTimestamp(-100L, 0);
+        LongTimestamp ts2 = new LongTimestamp(-100L, 500000);
+        LongTimestamp ts3 = new LongTimestamp(0L, 0);
+
+        assertTrue(ts1.compareTo(ts2) < 0);
+        assertTrue(ts2.compareTo(ts3) < 0);
+    }
+
+    @Test
+    public void testToString()
+    {
+        // LongTimestamp.toString() uses Timestamps.formatTimestamp(12, epochMicros, picosOfMicro)
+        LongTimestamp ts = new LongTimestamp(0L, 0);
+        String str = ts.toString();
+        // Should format as a timestamp string with 12 digits of fractional precision
+        assertTrue(str.contains("1970-01-01"), "Expected epoch date in toString: " + str);
+    }
+
+    @Test
+    public void testToStringWithPositiveTimestamp()
+    {
+        // 2020-01-01 00:00:00.000000 = 1577836800 seconds = 1577836800000000 micros
+        LongTimestamp ts = new LongTimestamp(1577836800000000L, 123456);
+        String str = ts.toString();
+        assertTrue(str.contains("2020-01-01"), "Expected 2020-01-01 in toString: " + str);
+        assertTrue(str.contains("00:00:00"), "Expected 00:00:00 in toString: " + str);
+    }
+
+    @Test
+    public void testSelfEquality()
+    {
+        LongTimestamp ts = new LongTimestamp(100L, 42);
+        assertTrue(ts.equals(ts));
+    }
+
+    @Test
+    public void testCompareToSelf()
+    {
+        LongTimestamp ts = new LongTimestamp(100L, 42);
+        assertEquals(ts.compareTo(ts), 0);
+    }
+
+    @Test
+    public void testBoundaryValues()
+    {
+        LongTimestamp minTs = new LongTimestamp(Long.MIN_VALUE, 0);
+        LongTimestamp maxTs = new LongTimestamp(Long.MAX_VALUE, 999999);
+
+        assertTrue(minTs.compareTo(maxTs) < 0);
+        assertTrue(maxTs.compareTo(minTs) > 0);
+        assertNotEquals(minTs, maxTs);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestamps.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestamps.java
@@ -63,7 +63,6 @@ public class TestTimestamps
         assertEquals(PICOSECONDS_PER_MILLISECOND, 1_000_000_000L);
 
         assertEquals(NANOSECONDS_PER_MICROSECOND, 1_000L);
-
         assertEquals(PICOSECONDS_PER_MICROSECOND, 1_000_000L);
 
         assertEquals(PICOSECONDS_PER_NANOSECOND, 1_000L);
@@ -115,9 +114,26 @@ public class TestTimestamps
     @Test
     public void testRescaleDownTruncation()
     {
-        // Truncation behavior (toward zero)
+        // FloorDiv behavior (rounds toward negative infinity)
         assertEquals(rescale(1999L, 6, 3), 1L);
-        assertEquals(rescale(-1999L, 6, 3), -1L);
+        assertEquals(rescale(-1999L, 6, 3), -2L);  // floorDiv(-1999, 1000) = -2
+    }
+
+    @Test
+    public void testRescaleNegativeValues()
+    {
+        // Negative values at various precision pairs
+        assertEquals(rescale(-1500L, 3, 0), -2L);  // floorDiv(-1500, 1000) = -2
+        assertEquals(rescale(-1000L, 3, 0), -1L);
+        assertEquals(rescale(-999L, 3, 0), -1L);   // floorDiv(-999, 1000) = -1
+        assertEquals(rescale(-1L, 6, 0), -1L);     // floorDiv(-1, 1000000) = -1
+        assertEquals(rescale(-1_000_000L, 6, 0), -1L);
+        // Scale up negative values
+        assertEquals(rescale(-5L, 0, 3), -5000L);
+        assertEquals(rescale(-1L, 3, 6), -1000L);
+        // Extreme precision pairs
+        assertEquals(rescale(-1L, 12, 0), -1L);    // floorDiv(-1, 10^12) = -1
+        assertEquals(rescale(-1L, 0, 12), -1_000_000_000_000L);
     }
 
     @Test
@@ -146,6 +162,26 @@ public class TestTimestamps
 
         // Round to precision 0
         assertEquals(round(123456789012L, 0), 0L);
+    }
+
+    @Test
+    public void testRoundNegative()
+    {
+        // At max precision, negative values are preserved as-is
+        assertEquals(round(-123456789012L, 12), -123456789012L);
+
+        // Truncate toward zero for negative values at precision 9
+        assertEquals(round(-123456789012L, 9), -123456789000L);
+
+        // Truncate toward zero for negative values at precision 6
+        assertEquals(round(-123456789012L, 6), -123456000000L);
+
+        // Truncate toward zero for negative values at precision 0
+        assertEquals(round(-123456789012L, 0), 0L);
+
+        // Small negative values
+        assertEquals(round(-1L, 12), -1L);
+        assertEquals(round(-1L, 9), 0L);
     }
 
     @Test

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestamps.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestamps.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.Timestamps.DEFAULT_PRECISION;
+import static com.facebook.presto.common.type.Timestamps.MAX_PRECISION;
+import static com.facebook.presto.common.type.Timestamps.MAX_SHORT_PRECISION;
+import static com.facebook.presto.common.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static com.facebook.presto.common.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static com.facebook.presto.common.type.Timestamps.MILLISECONDS_PER_DAY;
+import static com.facebook.presto.common.type.Timestamps.MILLISECONDS_PER_SECOND;
+import static com.facebook.presto.common.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static com.facebook.presto.common.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
+import static com.facebook.presto.common.type.Timestamps.NANOSECONDS_PER_SECOND;
+import static com.facebook.presto.common.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static com.facebook.presto.common.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static com.facebook.presto.common.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static com.facebook.presto.common.type.Timestamps.PICOSECONDS_PER_SECOND;
+import static com.facebook.presto.common.type.Timestamps.POWERS_OF_TEN;
+import static com.facebook.presto.common.type.Timestamps.formatTimestamp;
+import static com.facebook.presto.common.type.Timestamps.isShortTimestamp;
+import static com.facebook.presto.common.type.Timestamps.microsToMillis;
+import static com.facebook.presto.common.type.Timestamps.microsToNanos;
+import static com.facebook.presto.common.type.Timestamps.millisToMicros;
+import static com.facebook.presto.common.type.Timestamps.nanosToMicros;
+import static com.facebook.presto.common.type.Timestamps.rescale;
+import static com.facebook.presto.common.type.Timestamps.round;
+import static com.facebook.presto.common.type.Timestamps.roundDiv;
+import static com.facebook.presto.common.type.Timestamps.truncateToMicros;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestTimestamps
+{
+    @Test
+    public void testConstants()
+    {
+        assertEquals(MAX_PRECISION, 12);
+        assertEquals(MAX_SHORT_PRECISION, 6);
+        assertEquals(DEFAULT_PRECISION, 3);
+
+        assertEquals(MILLISECONDS_PER_SECOND, 1_000L);
+        assertEquals(MICROSECONDS_PER_SECOND, 1_000_000L);
+        assertEquals(NANOSECONDS_PER_SECOND, 1_000_000_000L);
+        assertEquals(PICOSECONDS_PER_SECOND, 1_000_000_000_000L);
+
+        assertEquals(MICROSECONDS_PER_MILLISECOND, 1_000L);
+        assertEquals(NANOSECONDS_PER_MILLISECOND, 1_000_000L);
+        assertEquals(PICOSECONDS_PER_MILLISECOND, 1_000_000_000L);
+
+        assertEquals(NANOSECONDS_PER_MICROSECOND, 1_000L);
+        assertEquals(PICOSECONDS_PER_MICROSECOND, 1_000_000L);
+
+        assertEquals(PICOSECONDS_PER_NANOSECOND, 1_000L);
+
+        assertEquals(MILLISECONDS_PER_DAY, 86_400_000L);
+    }
+
+    @Test
+    public void testPowersOfTen()
+    {
+        assertEquals(POWERS_OF_TEN.length, 13);
+        assertEquals(POWERS_OF_TEN[0], 1L);
+        assertEquals(POWERS_OF_TEN[1], 10L);
+        assertEquals(POWERS_OF_TEN[3], 1_000L);
+        assertEquals(POWERS_OF_TEN[6], 1_000_000L);
+        assertEquals(POWERS_OF_TEN[9], 1_000_000_000L);
+        assertEquals(POWERS_OF_TEN[12], 1_000_000_000_000L);
+    }
+
+    @Test
+    public void testRescaleSamePrecision()
+    {
+        assertEquals(rescale(123456L, 6, 6), 123456L);
+        assertEquals(rescale(0L, 3, 3), 0L);
+    }
+
+    @Test
+    public void testRescaleUp()
+    {
+        // From ms to µs: multiply by 1000
+        assertEquals(rescale(123L, 3, 6), 123000L);
+        // From seconds to ms: multiply by 1000
+        assertEquals(rescale(5L, 0, 3), 5000L);
+        // From ms to ns: multiply by 1_000_000
+        assertEquals(rescale(1L, 3, 9), 1_000_000L);
+    }
+
+    @Test
+    public void testRescaleDown()
+    {
+        // From µs to ms: divide by 1000
+        assertEquals(rescale(123456L, 6, 3), 123L);
+        // From ns to ms: divide by 1_000_000
+        assertEquals(rescale(1_234_567_890L, 9, 3), 1234L);
+        // From µs to seconds
+        assertEquals(rescale(5_000_000L, 6, 0), 5L);
+    }
+
+    @Test
+    public void testRescaleDownTruncation()
+    {
+        // Truncation behavior (toward zero)
+        assertEquals(rescale(1999L, 6, 3), 1L);
+        assertEquals(rescale(-1999L, 6, 3), -1L);
+    }
+
+    @Test
+    public void testRoundDiv()
+    {
+        assertEquals(roundDiv(10, 3), 3);
+        assertEquals(roundDiv(-10, 3), -3);
+        assertEquals(roundDiv(0, 3), 0);
+        assertEquals(roundDiv(9, 3), 3);
+    }
+
+    @Test
+    public void testRound()
+    {
+        // At max precision, no rounding
+        assertEquals(round(123456789012L, 12), 123456789012L);
+
+        // Round to precision 9 (truncate last 3 digits of picos)
+        assertEquals(round(123456789012L, 9), 123456789000L);
+
+        // Round to precision 6
+        assertEquals(round(123456789012L, 6), 123456000000L);
+
+        // Round to precision 3
+        assertEquals(round(123456789012L, 3), 123000000000L);
+
+        // Round to precision 0
+        assertEquals(round(123456789012L, 0), 0L);
+    }
+
+    @Test
+    public void testTruncateToMicros()
+    {
+        assertEquals(truncateToMicros(12345L, 678), 12345L);
+        assertEquals(truncateToMicros(-1L, 999999), -1L);
+    }
+
+    @Test
+    public void testIsShortTimestamp()
+    {
+        for (int p = 0; p <= 6; p++) {
+            assertTrue(isShortTimestamp(p), "Precision " + p + " should be short");
+        }
+        for (int p = 7; p <= 12; p++) {
+            assertFalse(isShortTimestamp(p), "Precision " + p + " should not be short");
+        }
+    }
+
+    @Test
+    public void testFormatTimestampEpoch()
+    {
+        // Epoch at precision 3
+        assertEquals(formatTimestamp(3, 0L, 0), "1970-01-01 00:00:00.000");
+    }
+
+    @Test
+    public void testFormatTimestampPrecision0()
+    {
+        assertEquals(formatTimestamp(0, 0L, 0), "1970-01-01 00:00:00");
+    }
+
+    @Test
+    public void testFormatTimestampPrecision6()
+    {
+        // 1 second in microseconds
+        assertEquals(formatTimestamp(6, 1_000_000L, 0), "1970-01-01 00:00:01.000000");
+    }
+
+    @Test
+    public void testFormatTimestampPrecision9()
+    {
+        // 1 second and 1 microsecond
+        assertEquals(formatTimestamp(9, 1_000_001L, 0), "1970-01-01 00:00:01.000001000");
+    }
+
+    @Test
+    public void testFormatTimestampPrecision12()
+    {
+        // 1 second, 1 microsecond, 123 picoseconds of micro
+        assertEquals(formatTimestamp(12, 1_000_001L, 123), "1970-01-01 00:00:01.000001000123");
+    }
+
+    @Test
+    public void testFormatTimestampNegative()
+    {
+        // -1 microsecond from epoch
+        String result = formatTimestamp(6, -1L, 0);
+        assertTrue(result.contains("1969-12-31"), "Expected 1969-12-31 for negative timestamp: " + result);
+    }
+
+    @Test
+    public void testMillisToMicros()
+    {
+        assertEquals(millisToMicros(0L), 0L);
+        assertEquals(millisToMicros(1L), 1_000L);
+        assertEquals(millisToMicros(-1L), -1_000L);
+        assertEquals(millisToMicros(1000L), 1_000_000L);
+    }
+
+    @Test
+    public void testMicrosToMillis()
+    {
+        assertEquals(microsToMillis(0L), 0L);
+        assertEquals(microsToMillis(1_000L), 1L);
+        assertEquals(microsToMillis(1_500L), 1L);
+        assertEquals(microsToMillis(-1L), -1L); // floorDiv behavior
+        assertEquals(microsToMillis(-1_000L), -1L);
+    }
+
+    @Test
+    public void testMicrosToNanos()
+    {
+        assertEquals(microsToNanos(0L), 0L);
+        assertEquals(microsToNanos(1L), 1_000L);
+        assertEquals(microsToNanos(-1L), -1_000L);
+    }
+
+    @Test
+    public void testNanosToMicros()
+    {
+        assertEquals(nanosToMicros(0L), 0L);
+        assertEquals(nanosToMicros(1_000L), 1L);
+        assertEquals(nanosToMicros(1_500L), 1L);
+        assertEquals(nanosToMicros(-1L), -1L); // floorDiv behavior
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestamps.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimestamps.java
@@ -63,6 +63,7 @@ public class TestTimestamps
         assertEquals(PICOSECONDS_PER_MILLISECOND, 1_000_000_000L);
 
         assertEquals(NANOSECONDS_PER_MICROSECOND, 1_000L);
+
         assertEquals(PICOSECONDS_PER_MICROSECOND, 1_000_000L);
 
         assertEquals(PICOSECONDS_PER_NANOSECOND, 1_000L);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1714,7 +1714,7 @@ public abstract class IcebergAbstractMetadata
             }
             else if (tableVersion.getVersionExpressionType() instanceof TimestampType) {
                 long timestampValue = (long) tableVersion.getTableVersion();
-                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).getPrecision().toMillis(timestampValue);
+                long millisUtc = ((TimestampType) tableVersion.getVersionExpressionType()).getStorageUnit().toMillis(timestampValue);
                 return getSnapshotIdTimeOperator(table, millisUtc, tableVersion.getVersionOperator());
             }
             else if (tableVersion.getVersionExpressionType() instanceof BigintType) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSink.java
@@ -442,7 +442,7 @@ public class IcebergPageSink
         }
         if (type instanceof TimestampType) {
             long timestamp = type.getLong(block, position);
-            return ((TimestampType) type).getPrecision() == MILLISECONDS ? MILLISECONDS.toMicros(timestamp) : timestamp;
+            return ((TimestampType) type).getStorageUnit() == MILLISECONDS ? MILLISECONDS.toMicros(timestamp) : timestamp;
         }
         if (type instanceof TimeType) {
             long time = type.getLong(block, position);
@@ -456,14 +456,14 @@ public class IcebergPageSink
         if (type instanceof TimestampType && functionProperties.isLegacyTimestamp()) {
             long timestampValue = (long) value;
             TimestampType timestampType = (TimestampType) type;
-            Instant instant = Instant.ofEpochSecond(timestampType.getPrecision().toSeconds(timestampValue),
-                    timestampType.getPrecision().toNanos(timestampValue % timestampType.getPrecision().convert(1, SECONDS)));
+            Instant instant = Instant.ofEpochSecond(timestampType.getStorageUnit().toSeconds(timestampValue),
+                    timestampType.getStorageUnit().toNanos(timestampValue % timestampType.getStorageUnit().convert(1, SECONDS)));
             LocalDateTime localDateTime = instant
                     .atZone(ZoneId.of(functionProperties.getTimeZoneKey().getId()))
                     .toLocalDateTime();
 
-            return timestampType.getPrecision().convert(localDateTime.toEpochSecond(ZoneOffset.UTC), SECONDS) +
-                    timestampType.getPrecision().convert(localDateTime.getNano(), NANOSECONDS);
+            return timestampType.getStorageUnit().convert(localDateTime.toEpochSecond(ZoneOffset.UTC), SECONDS) +
+                    timestampType.getStorageUnit().convert(localDateTime.getNano(), NANOSECONDS);
         }
         return value;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -299,7 +299,7 @@ public class PartitionTable
         }
         if (type instanceof Types.TimestampType) {
             com.facebook.presto.common.type.Type prestoType = toPrestoType(type, typeManager);
-            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == MILLISECONDS) {
+            if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getStorageUnit() == MILLISECONDS) {
                 return MICROSECONDS.toMillis((long) value);
             }
         }

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -268,7 +268,9 @@ import com.facebook.presto.type.SmallintOperators;
 import com.facebook.presto.type.TDigestOperators;
 import com.facebook.presto.type.TimeOperators;
 import com.facebook.presto.type.TimeWithTimeZoneOperators;
+import com.facebook.presto.type.TimestampMicrosecondsOperators;
 import com.facebook.presto.type.TimestampOperators;
+import com.facebook.presto.type.TimestampParametricType;
 import com.facebook.presto.type.TimestampWithTimeZoneOperators;
 import com.facebook.presto.type.TinyintOperators;
 import com.facebook.presto.type.UnknownOperators;
@@ -331,7 +333,7 @@ import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TDigestParametricType.TDIGEST;
 import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
-import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
@@ -644,7 +646,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
         addType(DATE);
         addType(TIME);
         addType(TIME_WITH_TIME_ZONE);
-        addType(TIMESTAMP);
+        addParametricType(TimestampParametricType.TIMESTAMP);
+        addType(TIMESTAMP_MICROSECONDS);
         addType(TIMESTAMP_WITH_TIME_ZONE);
         addType(INTERVAL_YEAR_MONTH);
         addType(INTERVAL_DAY_TIME);
@@ -835,6 +838,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(TimeOperators.TimeDistinctFromOperator.class)
                 .scalars(TimestampOperators.class)
                 .scalar(TimestampOperators.TimestampDistinctFromOperator.class)
+                .scalars(TimestampMicrosecondsOperators.class)
+                .scalar(TimestampMicrosecondsOperators.TimestampMicrosecondsDistinctFromOperator.class)
                 .scalars(IntervalDayTimeOperators.class)
                 .scalar(IntervalDayTimeOperators.IntervalDayTimeDistinctFromOperator.class)
                 .scalars(IntervalYearMonthOperators.class)

--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -333,6 +333,7 @@ import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TDigestParametricType.TDIGEST;
 import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
@@ -646,6 +647,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
         addType(DATE);
         addType(TIME);
         addType(TIME_WITH_TIME_ZONE);
+        addType(TIMESTAMP);
         addParametricType(TimestampParametricType.TIMESTAMP);
         addType(TIMESTAMP_MICROSECONDS);
         addType(TIMESTAMP_WITH_TIME_ZONE);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -573,7 +573,7 @@ public class IOPlanPrinter
             }
             if (type instanceof TimestampType) {
                 TimestampType timestampType = (TimestampType) type;
-                long timestampValue = timestampType.getPrecision().toMillis((Long) value);
+                long timestampValue = timestampType.getStorageUnit().toMillis((Long) value);
                 return printTimestampWithoutTimeZone(timestampValue);
             }
             if (type instanceof TimestampWithTimeZoneType) {

--- a/presto-main-base/src/main/java/com/facebook/presto/type/TimestampMicrosecondsOperators.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/type/TimestampMicrosecondsOperators.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.AbstractLongType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.BlockIndex;
+import com.facebook.presto.spi.function.BlockPosition;
+import com.facebook.presto.spi.function.IsNull;
+import com.facebook.presto.spi.function.ScalarOperator;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.XxHash64;
+
+import static com.facebook.presto.common.function.OperatorType.BETWEEN;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
+import static com.facebook.presto.common.function.OperatorType.INDETERMINATE;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+
+/**
+ * Operators for the TIMESTAMP_MICROSECONDS type (precision 6, stored as epoch microseconds).
+ * These operators are required by the type system's verifyComparableOrderableContract check.
+ */
+public final class TimestampMicrosecondsOperators
+{
+    private TimestampMicrosecondsOperators() {}
+
+    @ScalarOperator(EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean equal(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long left, @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long right)
+    {
+        return left == right;
+    }
+
+    @ScalarOperator(NOT_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean notEqual(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long left, @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long right)
+    {
+        return left != right;
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThan(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long left, @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long right)
+    {
+        return left < right;
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqual(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long left, @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long right)
+    {
+        return left <= right;
+    }
+
+    @ScalarOperator(GREATER_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThan(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long left, @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long right)
+    {
+        return left > right;
+    }
+
+    @ScalarOperator(GREATER_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean greaterThanOrEqual(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long left, @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long right)
+    {
+        return left >= right;
+    }
+
+    @ScalarOperator(BETWEEN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean between(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long value, @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long min, @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long max)
+    {
+        return min <= value && value <= max;
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    public static long hashCode(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long value)
+    {
+        return AbstractLongType.hash(value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    @SqlType(StandardTypes.BIGINT)
+    public static long xxHash64(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long value)
+    {
+        return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(IS_DISTINCT_FROM)
+    public static class TimestampMicrosecondsDistinctFromOperator
+    {
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long left,
+                @IsNull boolean leftNull,
+                @SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long right,
+                @IsNull boolean rightNull)
+        {
+            if (leftNull != rightNull) {
+                return true;
+            }
+            if (leftNull) {
+                return false;
+            }
+            return left != right;
+        }
+
+        @SqlType(StandardTypes.BOOLEAN)
+        public static boolean isDistinctFrom(
+                @BlockPosition @SqlType(value = StandardTypes.TIMESTAMP_MICROSECONDS, nativeContainerType = long.class) Block left,
+                @BlockIndex int leftPosition,
+                @BlockPosition @SqlType(value = StandardTypes.TIMESTAMP_MICROSECONDS, nativeContainerType = long.class) Block right,
+                @BlockIndex int rightPosition)
+        {
+            if (left.isNull(leftPosition) != right.isNull(rightPosition)) {
+                return true;
+            }
+            if (left.isNull(leftPosition)) {
+                return false;
+            }
+            return TIMESTAMP_MICROSECONDS.getLong(left, leftPosition) != TIMESTAMP_MICROSECONDS.getLong(right, rightPosition);
+        }
+    }
+
+    @ScalarOperator(INDETERMINATE)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean indeterminate(@SqlType(StandardTypes.TIMESTAMP_MICROSECONDS) long value, @IsNull boolean isNull)
+    {
+        return isNull;
+    }
+}

--- a/presto-main-base/src/main/java/com/facebook/presto/type/TimestampParametricType.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/type/TimestampParametricType.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.ParametricType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeParameter;
+
+import java.util.List;
+
+/**
+ * Parametric type handler for TIMESTAMP(p) where p is the precision (0..12).
+ * <p>
+ * When no parameter is specified, defaults to TIMESTAMP(3) for backward compatibility
+ * with existing millisecond-precision behavior.
+ * <p>
+ * Precision 0-6: Short timestamps, stored as a single long
+ * Precision 7-12: Long timestamps, stored as 12 bytes (epoch micros + picos of micro)
+ */
+public class TimestampParametricType
+        implements ParametricType
+{
+    public static final TimestampParametricType TIMESTAMP = new TimestampParametricType();
+
+    @Override
+    public String getName()
+    {
+        return StandardTypes.TIMESTAMP;
+    }
+
+    @Override
+    public Type createType(List<TypeParameter> parameters)
+    {
+        if (parameters.isEmpty()) {
+            return TimestampType.TIMESTAMP;
+        }
+        if (parameters.size() != 1) {
+            throw new IllegalArgumentException("Expected exactly one parameter for TIMESTAMP");
+        }
+
+        TypeParameter parameter = parameters.get(0);
+
+        if (!parameter.isLongLiteral()) {
+            throw new IllegalArgumentException("TIMESTAMP precision must be a number");
+        }
+
+        long precision = parameter.getLongLiteral();
+
+        if (precision < 0 || precision > 12) {
+            throw new IllegalArgumentException("Invalid TIMESTAMP precision " + precision);
+        }
+
+        return TimestampType.createTimestampType((int) precision);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/type/TestLongTimestampType.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/TestLongTimestampType.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.Fixed12Block;
+import com.facebook.presto.common.block.Fixed12BlockBuilder;
+import com.facebook.presto.common.type.LongTimestamp;
+import com.facebook.presto.common.type.LongTimestampType;
+import com.facebook.presto.common.type.TimestampType;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_NANOS;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_PICOS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestLongTimestampType
+{
+    @Test
+    public void testBasicProperties()
+    {
+        LongTimestampType type = (LongTimestampType) TimestampType.createTimestampType(9);
+        assertEquals(type.getPrecision(), 9);
+        assertTrue(type.isLong());
+        assertFalse(type.isShort());
+        assertEquals(type.getFixedSize(), 12);
+        assertTrue(type.isComparable());
+        assertTrue(type.isOrderable());
+    }
+
+    @Test
+    public void testWriteAndRead()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_NANOS;
+        BlockBuilder builder = type.createBlockBuilder(null, 5);
+        type.writeObject(builder, new LongTimestamp(100L, 42));
+        type.writeObject(builder, new LongTimestamp(200L, 84));
+        type.writeObject(builder, new LongTimestamp(300L, 999999));
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 3);
+
+        LongTimestamp ts0 = type.getObject(block, 0);
+        assertEquals(ts0.getEpochMicros(), 100L);
+        assertEquals(ts0.getPicosOfMicro(), 42);
+
+        LongTimestamp ts1 = type.getObject(block, 1);
+        assertEquals(ts1.getEpochMicros(), 200L);
+        assertEquals(ts1.getPicosOfMicro(), 84);
+
+        LongTimestamp ts2 = type.getObject(block, 2);
+        assertEquals(ts2.getEpochMicros(), 300L);
+        assertEquals(ts2.getPicosOfMicro(), 999999);
+    }
+
+    @Test
+    public void testEqualTo()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_PICOS;
+        BlockBuilder builder1 = type.createBlockBuilder(null, 2);
+        type.writeObject(builder1, new LongTimestamp(100L, 42));
+        Block block1 = builder1.build();
+
+        BlockBuilder builder2 = type.createBlockBuilder(null, 2);
+        type.writeObject(builder2, new LongTimestamp(100L, 42));
+        Block block2 = builder2.build();
+
+        BlockBuilder builder3 = type.createBlockBuilder(null, 2);
+        type.writeObject(builder3, new LongTimestamp(100L, 43));
+        Block block3 = builder3.build();
+
+        assertTrue(type.equalTo(block1, 0, block2, 0));
+        assertFalse(type.equalTo(block1, 0, block3, 0));
+    }
+
+    @Test
+    public void testCompareTo()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_PICOS;
+
+        BlockBuilder builder1 = type.createBlockBuilder(null, 1);
+        type.writeObject(builder1, new LongTimestamp(100L, 42));
+        Block block1 = builder1.build();
+
+        BlockBuilder builder2 = type.createBlockBuilder(null, 1);
+        type.writeObject(builder2, new LongTimestamp(100L, 42));
+        Block block2 = builder2.build();
+
+        BlockBuilder builder3 = type.createBlockBuilder(null, 1);
+        type.writeObject(builder3, new LongTimestamp(100L, 43));
+        Block block3 = builder3.build();
+
+        BlockBuilder builder4 = type.createBlockBuilder(null, 1);
+        type.writeObject(builder4, new LongTimestamp(200L, 0));
+        Block block4 = builder4.build();
+
+        assertEquals(type.compareTo(block1, 0, block2, 0), 0);
+        assertTrue(type.compareTo(block1, 0, block3, 0) < 0);
+        assertTrue(type.compareTo(block3, 0, block1, 0) > 0);
+        assertTrue(type.compareTo(block1, 0, block4, 0) < 0);
+        assertTrue(type.compareTo(block4, 0, block1, 0) > 0);
+    }
+
+    @Test
+    public void testHash()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_NANOS;
+
+        BlockBuilder builder1 = type.createBlockBuilder(null, 1);
+        type.writeObject(builder1, new LongTimestamp(100L, 42));
+        Block block1 = builder1.build();
+
+        BlockBuilder builder2 = type.createBlockBuilder(null, 1);
+        type.writeObject(builder2, new LongTimestamp(100L, 42));
+        Block block2 = builder2.build();
+
+        assertEquals(type.hash(block1, 0), type.hash(block2, 0));
+    }
+
+    @Test
+    public void testAppendTo()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_NANOS;
+
+        BlockBuilder sourceBuilder = type.createBlockBuilder(null, 2);
+        type.writeObject(sourceBuilder, new LongTimestamp(100L, 42));
+        sourceBuilder.appendNull();
+        Block source = sourceBuilder.build();
+
+        BlockBuilder targetBuilder = type.createBlockBuilder(null, 2);
+        type.appendTo(source, 0, targetBuilder);
+        type.appendTo(source, 1, targetBuilder);
+        Block target = targetBuilder.build();
+
+        assertEquals(target.getPositionCount(), 2);
+        assertFalse(target.isNull(0));
+        assertTrue(target.isNull(1));
+
+        LongTimestamp ts = type.getObject(target, 0);
+        assertEquals(ts.getEpochMicros(), 100L);
+        assertEquals(ts.getPicosOfMicro(), 42);
+    }
+
+    @Test
+    public void testCreateBlockBuilder()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_NANOS;
+        BlockBuilder builder = type.createBlockBuilder(null, 10);
+        assertNotNull(builder);
+        assertTrue(builder instanceof Fixed12BlockBuilder);
+    }
+
+    @Test
+    public void testCreateFixedSizeBlockBuilder()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_NANOS;
+        BlockBuilder builder = type.createFixedSizeBlockBuilder(10);
+        assertNotNull(builder);
+        assertTrue(builder instanceof Fixed12BlockBuilder);
+    }
+
+    @Test
+    public void testGetObjectValueNullPosition()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_NANOS;
+        BlockBuilder builder = type.createBlockBuilder(null, 1);
+        builder.appendNull();
+        Block block = builder.build();
+
+        Object value = type.getObjectValue(null, block, 0);
+        assertEquals(value, null);
+    }
+
+    @Test
+    public void testGetObjectValueWithFixed12Block()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_NANOS;
+        BlockBuilder builder = type.createBlockBuilder(null, 1);
+        type.writeObject(builder, new LongTimestamp(12345L, 678));
+        Block block = builder.build();
+        assertTrue(block instanceof Fixed12Block);
+
+        Object value = type.getObjectValue(null, block, 0);
+        assertTrue(value instanceof LongTimestamp);
+        LongTimestamp ts = (LongTimestamp) value;
+        assertEquals(ts.getEpochMicros(), 12345L);
+        assertEquals(ts.getPicosOfMicro(), 678);
+    }
+
+    @Test
+    public void testNullHandling()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_NANOS;
+        BlockBuilder builder = type.createBlockBuilder(null, 3);
+        type.writeObject(builder, new LongTimestamp(100L, 42));
+        builder.appendNull();
+        type.writeObject(builder, new LongTimestamp(300L, 84));
+
+        Block block = builder.build();
+        assertEquals(block.getPositionCount(), 3);
+        assertFalse(block.isNull(0));
+        assertTrue(block.isNull(1));
+        assertFalse(block.isNull(2));
+    }
+
+    @Test
+    public void testMultiplePrecisions()
+    {
+        for (int precision = 7; precision <= 12; precision++) {
+            LongTimestampType type = (LongTimestampType) TimestampType.createTimestampType(precision);
+            assertEquals(type.getPrecision(), precision);
+            assertTrue(type.isLong());
+            assertEquals(type.getFixedSize(), 12);
+
+            // Test write and read
+            BlockBuilder builder = type.createBlockBuilder(null, 1);
+            type.writeObject(builder, new LongTimestamp(42L, 123));
+            Block block = builder.build();
+
+            LongTimestamp ts = type.getObject(block, 0);
+            assertEquals(ts.getEpochMicros(), 42L);
+            assertEquals(ts.getPicosOfMicro(), 123);
+        }
+    }
+
+    @Test
+    public void testTypeEquality()
+    {
+        LongTimestampType type9a = (LongTimestampType) TimestampType.createTimestampType(9);
+        LongTimestampType type9b = (LongTimestampType) TimestampType.createTimestampType(9);
+        LongTimestampType type12 = (LongTimestampType) TimestampType.createTimestampType(12);
+
+        assertEquals(type9a, type9b);
+        assertEquals(type9a.hashCode(), type9b.hashCode());
+        assertFalse(type9a.equals(type12));
+    }
+
+    @Test
+    public void testLargeValues()
+    {
+        LongTimestampType type = (LongTimestampType) TIMESTAMP_PICOS;
+        BlockBuilder builder = type.createBlockBuilder(null, 2);
+        type.writeObject(builder, new LongTimestamp(Long.MAX_VALUE, 999999));
+        type.writeObject(builder, new LongTimestamp(Long.MIN_VALUE, 0));
+
+        Block block = builder.build();
+
+        LongTimestamp ts0 = type.getObject(block, 0);
+        assertEquals(ts0.getEpochMicros(), Long.MAX_VALUE);
+        assertEquals(ts0.getPicosOfMicro(), 999999);
+
+        LongTimestamp ts1 = type.getObject(block, 1);
+        assertEquals(ts1.getEpochMicros(), Long.MIN_VALUE);
+        assertEquals(ts1.getPicosOfMicro(), 0);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/type/TestTimestampParametricType.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/TestTimestampParametricType.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.LongTimestampType;
+import com.facebook.presto.common.type.ShortTimestampType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeParameter;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROS;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MILLIS;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_NANOS;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_PICOS;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestTimestampParametricType
+{
+    private final TimestampParametricType parametricType = new TimestampParametricType();
+
+    @Test
+    public void testGetName()
+    {
+        assertEquals(parametricType.getName(), "timestamp");
+    }
+
+    @Test
+    public void testDefaultPrecision()
+    {
+        Type type = parametricType.createType(Collections.emptyList());
+        assertTrue(type instanceof TimestampType);
+        assertEquals(((TimestampType) type).getPrecision(), 3);
+    }
+
+    @Test
+    public void testPrecision0()
+    {
+        Type type = parametricType.createType(List.of(TypeParameter.of(0L)));
+        assertTrue(type instanceof ShortTimestampType);
+        assertEquals(((TimestampType) type).getPrecision(), 0);
+    }
+
+    @Test
+    public void testPrecision3()
+    {
+        Type type = parametricType.createType(List.of(TypeParameter.of(3L)));
+        assertTrue(type instanceof ShortTimestampType);
+        assertEquals(((TimestampType) type).getPrecision(), 3);
+    }
+
+    @Test
+    public void testPrecision6()
+    {
+        Type type = parametricType.createType(List.of(TypeParameter.of(6L)));
+        assertTrue(type instanceof ShortTimestampType);
+        assertEquals(((TimestampType) type).getPrecision(), 6);
+    }
+
+    @Test
+    public void testPrecision7()
+    {
+        Type type = parametricType.createType(List.of(TypeParameter.of(7L)));
+        assertTrue(type instanceof LongTimestampType);
+        assertEquals(((TimestampType) type).getPrecision(), 7);
+    }
+
+    @Test
+    public void testPrecision9()
+    {
+        Type type = parametricType.createType(List.of(TypeParameter.of(9L)));
+        assertTrue(type instanceof LongTimestampType);
+        assertEquals(((TimestampType) type).getPrecision(), 9);
+    }
+
+    @Test
+    public void testPrecision12()
+    {
+        Type type = parametricType.createType(List.of(TypeParameter.of(12L)));
+        assertTrue(type instanceof LongTimestampType);
+        assertEquals(((TimestampType) type).getPrecision(), 12);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testPrecisionNegative()
+    {
+        parametricType.createType(List.of(TypeParameter.of(-1L)));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testPrecisionTooHigh()
+    {
+        parametricType.createType(List.of(TypeParameter.of(13L)));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooManyParameters()
+    {
+        parametricType.createType(List.of(TypeParameter.of(3L), TypeParameter.of(6L)));
+    }
+
+    @Test
+    public void testPreDefinedConstants()
+    {
+        assertEquals(TIMESTAMP_SECONDS.getPrecision(), 0);
+        assertEquals(TIMESTAMP_MILLIS.getPrecision(), 3);
+        assertEquals(TIMESTAMP_MICROS.getPrecision(), 6);
+        assertEquals(TIMESTAMP_NANOS.getPrecision(), 9);
+        assertEquals(TIMESTAMP_PICOS.getPrecision(), 12);
+
+        assertTrue(TIMESTAMP_SECONDS instanceof ShortTimestampType);
+        assertTrue(TIMESTAMP_MILLIS instanceof ShortTimestampType);
+        assertTrue(TIMESTAMP_MICROS instanceof ShortTimestampType);
+        assertTrue(TIMESTAMP_NANOS instanceof LongTimestampType);
+        assertTrue(TIMESTAMP_PICOS instanceof LongTimestampType);
+    }
+
+    @Test
+    public void testBackwardCompatibleAliases()
+    {
+        assertSame(TIMESTAMP, TIMESTAMP_MILLIS);
+        assertSame(TIMESTAMP_MICROSECONDS, TIMESTAMP_MICROS);
+    }
+
+    @Test
+    public void testTimestampTypeEquality()
+    {
+        TimestampType ts3a = TimestampType.createTimestampType(3);
+        TimestampType ts3b = TimestampType.createTimestampType(3);
+        assertEquals(ts3a, ts3b);
+        assertEquals(ts3a.hashCode(), ts3b.hashCode());
+
+        TimestampType ts6 = TimestampType.createTimestampType(6);
+        assertFalse(ts3a.equals(ts6));
+    }
+
+    @Test
+    public void testIsShortIsLong()
+    {
+        for (int p = 0; p <= 6; p++) {
+            TimestampType type = TimestampType.createTimestampType(p);
+            assertTrue(type.isShort(), "precision " + p + " should be short");
+            assertFalse(type.isLong(), "precision " + p + " should not be long");
+        }
+        for (int p = 7; p <= 12; p++) {
+            TimestampType type = TimestampType.createTimestampType(p);
+            assertFalse(type.isShort(), "precision " + p + " should not be short");
+            assertTrue(type.isLong(), "precision " + p + " should be long");
+        }
+    }
+
+    @Test
+    public void testIsComparableAndOrderable()
+    {
+        for (int p = 0; p <= 12; p++) {
+            TimestampType type = TimestampType.createTimestampType(p);
+            assertTrue(type.isComparable());
+            assertTrue(type.isOrderable());
+        }
+    }
+
+    @Test
+    public void testAllPrecisionsCreate()
+    {
+        for (int p = 0; p <= 12; p++) {
+            TimestampType type = TimestampType.createTimestampType(p);
+            assertEquals(type.getPrecision(), p);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testCreateTimestampTypeNegative()
+    {
+        TimestampType.createTimestampType(-1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testCreateTimestampTypeTooHigh()
+    {
+        TimestampType.createTimestampType(13);
+    }
+}

--- a/presto-main-base/src/test/java/com/facebook/presto/type/TestTimestampParametricType.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/type/TestTimestampParametricType.java
@@ -51,6 +51,17 @@ public class TestTimestampParametricType
         Type type = parametricType.createType(Collections.emptyList());
         assertTrue(type instanceof TimestampType);
         assertEquals(((TimestampType) type).getPrecision(), 3);
+
+        // Default parametric type should return the predefined constant instance
+        assertSame(type, TimestampType.TIMESTAMP);
+    }
+
+    @Test
+    public void testTypeSignatures()
+    {
+        // Lock in special-cased type signatures for backward compatibility
+        assertEquals(TimestampType.TIMESTAMP.getTypeSignature().toString(), "timestamp");
+        assertEquals(TimestampType.TIMESTAMP_MICROSECONDS.getTypeSignature().toString(), "timestamp microseconds");
     }
 
     @Test


### PR DESCRIPTION
Port the core type infrastructure for parametric `TIMESTAMP(p)` (precision 0–12) from Trino to PrestoDB. 

  **New classes in `presto-common`:**
  - `TimestampType` is refactored from a concrete `final` class to an abstract base. `ShortTimestampType` (p=0–6) stores values as a `long` in a `LongArrayBlock` (millis for p≤3, micros for p=4–6).
  `LongTimestampType` (p=7–12) stores values as 12 bytes in a `Fixed12Block` (epoch microseconds + picoseconds-of-microsecond).
  - `LongTimestamp` — immutable value class carrying `(long epochMicros, int picosOfMicro)` for high-precision timestamps.
  - `Timestamps` — utility class with all unit-conversion constants (`PICOSECONDS_PER_MICROSECOND`, etc.), a `POWERS_OF_TEN` table, and helpers for rescaling and rounding values between precisions.
  - `Fixed12Block` / `Fixed12BlockBuilder` / `Fixed12BlockEncoding` — new 12-byte fixed-width block type. Each position stores a `(long, int)` pair, the storage format used by `LongTimestampType`.
  **New classes in `presto-main-base`:** 
  - `TimestampParametricType` — `ParametricType` factory that produces `TimestampType` instances for `timestamp(p)` type signatures. Registered in `BuiltInTypeAndFunctionNamespaceManager`.
  - `TimestampMicrosecondsOperators` — operator set for `TIMESTAMP_MICROSECONDS` (p=6), satisfying the type system's `verifyComparableOrderableContract` requirement.
  **Backward compatibility:** `TIMESTAMP = createTimestampType(3)` and `TIMESTAMP_MICROSECONDS = createTimestampType(6)` are preserved as constants. `ShortTimestampType` replicates the `AbstractLongType` 
  block contract so all existing operators and ORC readers continue to work without modification.
  ## Motivation and Context   

  PrestoDB currently supports only two fixed timestamp precisions: milliseconds (`TIMESTAMP`) and microseconds (`TIMESTAMP_MICROSECONDS`). The SQL standard and Trino support `TIMESTAMP(p)` for p=0–12,    
  including picosecond precision. This port brings PrestoDB to parity. 
  This PR follows [Trino PR #3783](https://github.com/trinodb/trino/pull/3783) (parametric TIMESTAMP) as the primary reference. Follow-up PRs will port operators, scalar functions, the SQL analyzer, ORC  
  storage, and the client wire format. [Trino PR #3947](https://github.com/trinodb/trino/pull/3947) (parametric TIMESTAMP WITH TIME ZONE) will follow. 
  ## Impact
  - No change to existing query behavior. `TIMESTAMP` and `TIMESTAMP_MICROSECONDS` continue to resolve to p=3 and p=6 respectively. 
  - `TimestampType` is now abstract; any code that instantiated it directly (outside of the factory) will fail to compile — but no such call sites existed in the codebase.
  - `Fixed12Block` is a new public block type added to `BlockEncodingManager`. 
  ## Test Plan
  | Test class | What it covers |
  |---|---|
  | `TestFixed12Block` | Read/write correctness, null handling, serialization round-trip for `Fixed12Block` |
  | `TestLongTimestamp` | Value class equality, hash code, constructor bounds validation |
  | `TestTimestamps` | All unit-conversion constants, `POWERS_OF_TEN`, rescale and round helpers |
  | `TestLongTimestampType` | `LongTimestampType` block operations, `getObjectValue` round-trip via `Fixed12Block` |
  | `TestTimestampParametricType` | Factory precision range (0–12), singleton identity, out-of-range rejection, type signature format |

All existing timestamp tests (`TestTimestampOperators`, `TestDateTimeFunctions`, etc.) pass without modification, confirming backward compatibility.

## Contributor checklist

- [X] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [X] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [X] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [X] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [X] Adequate tests were added if applicable.
- [X] CI passed.
- [X] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== RELEASE NOTES ==
General Changes
* Add type infrastructure for parametric TIMESTAMP(p) with precision 0–12, introducing ShortTimestampType (p=0–6, stored as a single long) and LongTimestampType (p=7–12, stored as 12 bytes of epoch-microseconds plus picoseconds-of-microsecond). Existing TIMESTAMP (p=3) and TIMESTAMP_MICROSECONDS (p=6) behavior is unchanged.
```

## Summary by Sourcery

Introduce parametric TIMESTAMP(p) support with shared infrastructure for short and long timestamps, while preserving existing TIMESTAMP and TIMESTAMP_MICROSECONDS behavior.

New Features:
- Add abstract TimestampType with factory-based creation for precisions 0–12, including predefined constants for common precisions.
- Introduce ShortTimestampType and LongTimestampType to represent low- and high-precision timestamps with appropriate storage layouts.
- Add LongTimestamp value class and Timestamps utility for precision handling, rescaling, and formatting.
- Introduce Fixed12Block, its builder, and encoding as a new fixed-width 12-byte block type for high-precision values.
- Register TimestampParametricType and associated microsecond-precision operators in the type system for TIMESTAMP(p) handling.

Enhancements:
- Wire new timestamp storage semantics into Iceberg, IO plan printing, and type registration while keeping legacy aliases for TIMESTAMP and TIMESTAMP_MICROSECONDS.
- Extend block encoding manager and type metadata to recognize new TIMESTAMP-related encodings and signatures.

Tests:
- Add unit tests for Fixed12Block, LongTimestamp, Timestamps utilities, LongTimestampType behavior, and TimestampParametricType creation and validation.