### PR TITLE
feat(planner): Support CUBE/ROLLUP/GROUPING SETS column rewriting in MV optimizer (#27538)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/ExpressionUtils.java
@@ -15,16 +15,19 @@ package com.facebook.presto.sql;
 
 import com.facebook.presto.sql.planner.ExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
 import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupingElement;
+import com.facebook.presto.sql.tree.GroupingSets;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.NotExpression;
+import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.SimpleGroupBy;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.SortItem;
@@ -296,21 +299,33 @@ public final class ExpressionUtils
         if (!removablePrefix.isPresent()) {
             return groupingElement;
         }
+        if (groupingElement instanceof GroupingSets) {
+            ImmutableList.Builder<List<Expression>> rewrittenSets = ImmutableList.builder();
+            for (List<Expression> set : ((GroupingSets) groupingElement).getSets()) {
+                rewrittenSets.add(removePrefixFromExpressions(set, removablePrefix));
+            }
+            return new GroupingSets(rewrittenSets.build());
+        }
+        List<Expression> rewritten = removePrefixFromExpressions(groupingElement.getExpressions(), removablePrefix);
         if (groupingElement instanceof SimpleGroupBy) {
-            boolean prefixRemoved = false;
-            ImmutableList.Builder<Expression> rewrittenColumns = ImmutableList.builder();
-            for (Expression column : groupingElement.getExpressions()) {
-                Expression processedColumn = removeExpressionPrefix(column, removablePrefix);
-                if (processedColumn != column) {
-                    prefixRemoved = true;
-                }
-                rewrittenColumns.add(processedColumn);
-            }
-            if (prefixRemoved) {
-                return new SimpleGroupBy(rewrittenColumns.build());
-            }
+            return new SimpleGroupBy(rewritten);
+        }
+        if (groupingElement instanceof Cube) {
+            return new Cube(rewritten);
+        }
+        if (groupingElement instanceof Rollup) {
+            return new Rollup(rewritten);
         }
         return groupingElement;
+    }
+
+    private static List<Expression> removePrefixFromExpressions(List<Expression> expressions, Optional<Identifier> removablePrefix)
+    {
+        ImmutableList.Builder<Expression> rewritten = ImmutableList.builder();
+        for (Expression column : expressions) {
+            rewritten.add(removeExpressionPrefix(column, removablePrefix));
+        }
+        return rewritten.build();
     }
 
     public static SortItem removeSortItemPrefix(SortItem sortItem, Optional<Identifier> removablePrefix)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -44,6 +44,7 @@ import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.Except;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.ExpressionRewriter;
@@ -51,6 +52,7 @@ import com.facebook.presto.sql.tree.ExpressionTreeRewriter;
 import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.GroupingElement;
+import com.facebook.presto.sql.tree.GroupingSets;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.Intersect;
 import com.facebook.presto.sql.tree.Join;
@@ -65,6 +67,7 @@ import com.facebook.presto.sql.tree.QueryBody;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.QueryWithMVRewriteCandidates;
 import com.facebook.presto.sql.tree.Relation;
+import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.SampledRelation;
 import com.facebook.presto.sql.tree.Select;
 import com.facebook.presto.sql.tree.SelectItem;
@@ -757,11 +760,38 @@ public class MaterializedViewQueryOptimizer
         @Override
         protected Node visitSimpleGroupBy(SimpleGroupBy node, Void context)
         {
-            ImmutableList.Builder<Expression> rewrittenSimpleGroupBy = ImmutableList.builder();
-            for (Expression column : node.getExpressions()) {
-                rewrittenSimpleGroupBy.add((Expression) process(removeExpressionPrefix(column, removablePrefix), context));
+            return new SimpleGroupBy(rewriteGroupByExpressions(node.getExpressions(), context));
+        }
+
+        @Override
+        protected Node visitCube(Cube node, Void context)
+        {
+            return new Cube(rewriteGroupByExpressions(node.getExpressions(), context));
+        }
+
+        @Override
+        protected Node visitRollup(Rollup node, Void context)
+        {
+            return new Rollup(rewriteGroupByExpressions(node.getExpressions(), context));
+        }
+
+        @Override
+        protected Node visitGroupingSets(GroupingSets node, Void context)
+        {
+            ImmutableList.Builder<List<Expression>> rewrittenSets = ImmutableList.builder();
+            for (List<Expression> set : node.getSets()) {
+                rewrittenSets.add(rewriteGroupByExpressions(set, context));
             }
-            return new SimpleGroupBy(rewrittenSimpleGroupBy.build());
+            return new GroupingSets(rewrittenSets.build());
+        }
+
+        private List<Expression> rewriteGroupByExpressions(List<Expression> expressions, Void context)
+        {
+            ImmutableList.Builder<Expression> rewritten = ImmutableList.builder();
+            for (Expression column : expressions) {
+                rewritten.add((Expression) process(removeExpressionPrefix(column, removablePrefix), context));
+            }
+            return rewritten.build();
         }
 
         private boolean validateExpressionForGroupBy(Set<Expression> groupByOfMaterializedView, Expression expression)

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -316,6 +316,116 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testWithGroupByCubeColumnName()
+    {
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), b FROM %s GROUP BY CUBE(b) ORDER BY 1 DESC", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT MAX(mv_max_a), mv_b as b FROM %s GROUP BY CUBE(mv_b) ORDER BY 1 DESC", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByCubeMultiColumn()
+    {
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b, c as mv_c FROM %s GROUP BY b, c", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), b, c FROM %s GROUP BY CUBE(b, c)", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT MAX(mv_max_a), mv_b as b, mv_c as c FROM %s GROUP BY CUBE(mv_b, mv_c)", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByRollupColumnName()
+    {
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), b FROM %s GROUP BY ROLLUP(b) ORDER BY 1 DESC", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT MAX(mv_max_a), mv_b as b FROM %s GROUP BY ROLLUP(mv_b) ORDER BY 1 DESC", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByRollupMultiColumn()
+    {
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b, c as mv_c FROM %s GROUP BY b, c", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), b, c FROM %s GROUP BY ROLLUP(b, c)", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT MAX(mv_max_a), mv_b as b, mv_c as c FROM %s GROUP BY ROLLUP(mv_b, mv_c)", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByGroupingSetsColumnName()
+    {
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), b FROM %s GROUP BY GROUPING SETS((b)) ORDER BY 1 DESC", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT MAX(mv_max_a), mv_b as b FROM %s GROUP BY GROUPING SETS((mv_b)) ORDER BY 1 DESC", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByGroupingSetsMultiColumn()
+    {
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b, c as mv_c FROM %s GROUP BY b, c", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), b, c FROM %s GROUP BY GROUPING SETS((b, c), (b))", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT MAX(mv_max_a), mv_b as b, mv_c as c FROM %s GROUP BY GROUPING SETS((mv_b, mv_c), (mv_b))", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByCubeColumnNotInMv()
+    {
+        // MV only has column b, but query uses CUBE on column that is not in MV — no rewrite
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), x FROM %s GROUP BY CUBE(x)", BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByRollupColumnNotInMv()
+    {
+        // MV only has column b, but query uses ROLLUP on column not in MV — no rewrite
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), x FROM %s GROUP BY ROLLUP(x)", BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByGroupingSetsColumnNotInMv()
+    {
+        // MV only has column b, but query uses GROUPING SETS on column not in MV — no rewrite
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), x FROM %s GROUP BY GROUPING SETS((x))", BASE_TABLE_1);
+
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByAndOrderByColumnName()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b, c as mv_c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT SUM(a * b), c FROM %s GROUP BY c ORDER BY c ASC", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(mv_a * b), mv_c as c FROM %s GROUP BY mv_c ORDER BY mv_c ASC", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithCubeAndOrderByColumnName()
+    {
+        String originalViewSql = format("SELECT MAX(a) as mv_max_a, b as mv_b FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT MAX(a), b FROM %s GROUP BY CUBE(b) ORDER BY b ASC", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT MAX(mv_max_a), mv_b as b FROM %s GROUP BY CUBE(mv_b) ORDER BY mv_b ASC", VIEW_1);
+
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testWithNoMatchingBaseTable()
     {
         String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_2);
@@ -426,6 +536,48 @@ public class TestMaterializedViewQueryOptimizer
         originalViewSql = format("SELECT SUM(a) AS a, c FROM %s WHERE b > 0 GROUP BY c", BASE_TABLE_1);
         baseQuerySql = format("SELECT SUM(a) FROM %s GROUP BY c", BASE_TABLE_1);
         assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByCube()
+    {
+        String originalViewSql = format("SELECT SUM(a) AS a, SUM(b*c) AS bc, d, e FROM %s GROUP BY d, e", BASE_TABLE_1);
+
+        String baseQuerySql = format("SELECT SUM(a), d, e FROM %s GROUP BY CUBE(d, e)", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(a), d, e FROM %s GROUP BY CUBE(d, e)", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        baseQuerySql = format("SELECT SUM(a), d FROM %s GROUP BY CUBE(d)", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(a), d FROM %s GROUP BY CUBE(d)", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByRollup()
+    {
+        String originalViewSql = format("SELECT SUM(a) AS a, SUM(b*c) AS bc, d, e FROM %s GROUP BY d, e", BASE_TABLE_1);
+
+        String baseQuerySql = format("SELECT SUM(a), d, e FROM %s GROUP BY ROLLUP(d, e)", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(a), d, e FROM %s GROUP BY ROLLUP(d, e)", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        baseQuerySql = format("SELECT SUM(a), d FROM %s GROUP BY ROLLUP(d)", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(a), d FROM %s GROUP BY ROLLUP(d)", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWithGroupByGroupingSets()
+    {
+        String originalViewSql = format("SELECT SUM(a) AS a, SUM(b*c) AS bc, d, e FROM %s GROUP BY d, e", BASE_TABLE_1);
+
+        String baseQuerySql = format("SELECT SUM(a), d, e FROM %s GROUP BY GROUPING SETS((d, e), (d))", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(a), d, e FROM %s GROUP BY GROUPING SETS((d, e), (d))", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+
+        baseQuerySql = format("SELECT SUM(a), d FROM %s GROUP BY GROUPING SETS((d))", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(a), d FROM %s GROUP BY GROUPING SETS((d))", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
     }
 
     @Test


### PR DESCRIPTION
Summary:

The MV query rewriter only overrode visitSimpleGroupBy, so column
references inside CUBE, ROLLUP, and GROUPING SETS were never rewritten
from base table columns to MV columns. Fix by adding visitCube,
visitRollup, and visitGroupingSets overrides, and extending
removeGroupingElementPrefix to handle all GroupingElement types.

Differential Revision: D99539143

```
== RELEASE NOTES ==

General Changes
* Fix materialized view query rewriting for ``CUBE``, ``ROLLUP``, and
  ``GROUPING SETS`` clauses. Column references inside these grouping
  elements are now correctly rewritten to materialized view columns.
```

