### PR TITLE
feat(planner): Support scalar functions in MV query rewriting (#27549)

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewLogicalPlanner.java
@@ -2121,7 +2121,7 @@ public class TestHiveMaterializedViewLogicalPlanner
     }
 
     @Test
-    public void testMaterializedViewOptimizationWithUnsupportedFunctionSubquery()
+    public void testMaterializedViewOptimizationWithScalarFunctionSubquery()
     {
         Session queryOptimizationWithMaterializedView = Session.builder(getSession())
                 .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
@@ -2165,27 +2165,10 @@ public class TestHiveMaterializedViewLogicalPlanner
                     "ON s1.orderkey = s2.orderkey " +
                     "ORDER BY s1.orderkey, longest_comment", table, table2);
 
+            // Both subqueries should be rewritten to use MVs (length() is now supported as a scalar function)
             MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
             MaterializedResult baseQueryResult = computeActual(baseQuery);
             assertEquals(baseQueryResult, optimizedQueryResult);
-
-            assertPlan(queryOptimizationWithMaterializedView, baseQuery, anyTree(
-                    node(JoinNode.class,
-                            exchange(
-                                    anyTree(
-                                            constrainedTableScan(table,
-                                                    ImmutableMap.of(),
-                                                    ImmutableMap.of()))),
-                            anyTree(
-                                    exchange(
-                                            anyTree(
-                                                    constrainedTableScan(table2,
-                                                            ImmutableMap.of(),
-                                                            ImmutableMap.of("orderkey_13", "orderkey"))),
-                                            anyTree(
-                                                    constrainedTableScan(view2,
-                                                            ImmutableMap.of(),
-                                                            ImmutableMap.of("ds_42", "ds", "orderkey_41", "orderkey"))))))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view2);

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -29,6 +29,7 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.analyzer.MetadataResolver;
 import com.facebook.presto.spi.analyzer.ViewDefinitionReferences;
+import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.security.AccessControl;
@@ -43,6 +44,7 @@ import com.facebook.presto.sql.tree.AllColumns;
 import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
 import com.facebook.presto.sql.tree.AstVisitor;
 import com.facebook.presto.sql.tree.Cast;
+import com.facebook.presto.sql.tree.CoalesceExpression;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.Cube;
 import com.facebook.presto.sql.tree.Except;
@@ -54,12 +56,18 @@ import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.GroupingSets;
 import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.IfExpression;
+import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.Intersect;
+import com.facebook.presto.sql.tree.IsNotNullPredicate;
+import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.Join;
 import com.facebook.presto.sql.tree.Lateral;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.NotExpression;
+import com.facebook.presto.sql.tree.NullIfExpression;
 import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
@@ -69,14 +77,17 @@ import com.facebook.presto.sql.tree.QueryWithMVRewriteCandidates;
 import com.facebook.presto.sql.tree.Relation;
 import com.facebook.presto.sql.tree.Rollup;
 import com.facebook.presto.sql.tree.SampledRelation;
+import com.facebook.presto.sql.tree.SearchedCaseExpression;
 import com.facebook.presto.sql.tree.Select;
 import com.facebook.presto.sql.tree.SelectItem;
+import com.facebook.presto.sql.tree.SimpleCaseExpression;
 import com.facebook.presto.sql.tree.SimpleGroupBy;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
 import com.facebook.presto.sql.tree.Union;
+import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.sql.tree.With;
 import com.facebook.presto.sql.tree.WithQuery;
 import com.google.common.collect.ImmutableList;
@@ -85,6 +96,7 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -136,6 +148,7 @@ public class MaterializedViewQueryOptimizer
     private final RowExpressionDomainTranslator domainTranslator;
     private final LogicalRowExpressions logicalRowExpressions;
     private final MetadataResolver metadataResolver;
+    private final Set<String> builtInScalarFunctionNames;
 
     public MaterializedViewQueryOptimizer(
             Metadata metadata,
@@ -151,6 +164,10 @@ public class MaterializedViewQueryOptimizer
         this.domainTranslator = requireNonNull(domainTranslator, "row expression domain translator is null");
         this.metadataResolver = requireNonNull(metadata.getMetadataResolver(session), "metadataResolver is null");
         FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
+        this.builtInScalarFunctionNames = functionAndTypeManager.listBuiltInFunctions().stream()
+                .filter(fn -> fn.getSignature().getKind() == FunctionKind.SCALAR)
+                .map(fn -> fn.getSignature().getNameSuffix().toLowerCase(Locale.ENGLISH))
+                .collect(ImmutableSet.toImmutableSet());
         logicalRowExpressions = new LogicalRowExpressions(
                 new RowExpressionDeterminismEvaluator(functionAndTypeManager),
                 new FunctionResolution(functionAndTypeManager.getFunctionAndTypeResolver()),
@@ -647,7 +664,11 @@ public class MaterializedViewQueryOptimizer
         @Override
         protected Node visitExpression(Expression node, Void context)
         {
-            return super.visitExpression(removeExpressionPrefix(node, removablePrefix), context);
+            Expression stripped = removeExpressionPrefix(node, removablePrefix);
+            if (stripped != node) {
+                return process(stripped, context);
+            }
+            return super.visitExpression(node, context);
         }
 
         @Override
@@ -662,7 +683,21 @@ public class MaterializedViewQueryOptimizer
             }
 
             if (!ASSOCIATIVE_REWRITE_FUNCTIONS.contains(node.getName())) {
-                throw new SemanticException(NOT_SUPPORTED, node, "Was unable to rewrite non-associative function call with materialized view");
+                if (!isScalarFunction(node)) {
+                    throw new SemanticException(NOT_SUPPORTED, node, "Unsupported function for materialized view rewrite: " + node.getName());
+                }
+                // Scalar function (CONCAT, JSON_EXTRACT, ABS, etc.) — rewrite arguments recursively
+                for (Expression argument : node.getArguments()) {
+                    rewrittenArguments.add((Expression) process(argument, context));
+                }
+                return new FunctionCall(
+                        node.getName(),
+                        node.getWindow(),
+                        node.getFilter(),
+                        node.getOrderBy(),
+                        node.isDistinct(),
+                        node.isIgnoreNulls(),
+                        rewrittenArguments.build());
             }
 
             if (baseToViewColumnMap.containsKey(node)) {
@@ -675,6 +710,9 @@ public class MaterializedViewQueryOptimizer
                 rewrittenArguments.add(derivedColumn);
             }
             else {
+                if (materializedViewInfo.getGroupBy().isPresent()) {
+                    throw new SemanticException(NOT_SUPPORTED, node, "Materialized view does not pre-compute aggregate: " + node.getName());
+                }
                 for (Expression argument : node.getArguments()) {
                     rewrittenArguments.add((Expression) process(argument, context));
                 }
@@ -722,6 +760,102 @@ public class MaterializedViewQueryOptimizer
                     node.getOperator(),
                     (Expression) process(node.getLeft(), context),
                     (Expression) process(node.getRight(), context));
+        }
+
+        @Override
+        protected Node visitIfExpression(IfExpression node, Void context)
+        {
+            return new IfExpression(
+                    (Expression) process(node.getCondition(), context),
+                    (Expression) process(node.getTrueValue(), context),
+                    node.getFalseValue().map(v -> (Expression) process(v, context)).orElse(null));
+        }
+
+        @Override
+        protected Node visitCoalesceExpression(CoalesceExpression node, Void context)
+        {
+            ImmutableList.Builder<Expression> operands = ImmutableList.builder();
+            for (Expression operand : node.getOperands()) {
+                operands.add((Expression) process(operand, context));
+            }
+            return new CoalesceExpression(operands.build());
+        }
+
+        @Override
+        protected Node visitSearchedCaseExpression(SearchedCaseExpression node, Void context)
+        {
+            ImmutableList.Builder<WhenClause> whenClauses = ImmutableList.builder();
+            for (WhenClause whenClause : node.getWhenClauses()) {
+                whenClauses.add((WhenClause) process(whenClause, context));
+            }
+            return new SearchedCaseExpression(
+                    whenClauses.build(),
+                    node.getDefaultValue().map(v -> (Expression) process(v, context)));
+        }
+
+        @Override
+        protected Node visitSimpleCaseExpression(SimpleCaseExpression node, Void context)
+        {
+            ImmutableList.Builder<WhenClause> whenClauses = ImmutableList.builder();
+            for (WhenClause whenClause : node.getWhenClauses()) {
+                whenClauses.add((WhenClause) process(whenClause, context));
+            }
+            return new SimpleCaseExpression(
+                    (Expression) process(node.getOperand(), context),
+                    whenClauses.build(),
+                    node.getDefaultValue().map(v -> (Expression) process(v, context)));
+        }
+
+        @Override
+        protected Node visitWhenClause(WhenClause node, Void context)
+        {
+            return new WhenClause(
+                    (Expression) process(node.getOperand(), context),
+                    (Expression) process(node.getResult(), context));
+        }
+
+        @Override
+        protected Node visitNullIfExpression(NullIfExpression node, Void context)
+        {
+            return new NullIfExpression(
+                    (Expression) process(node.getFirst(), context),
+                    (Expression) process(node.getSecond(), context));
+        }
+
+        @Override
+        protected Node visitCast(Cast node, Void context)
+        {
+            return new Cast(
+                    (Expression) process(node.getExpression(), context),
+                    node.getType(),
+                    node.isSafe(),
+                    node.isTypeOnly());
+        }
+
+        @Override
+        protected Node visitInPredicate(InPredicate node, Void context)
+        {
+            return new InPredicate(
+                    (Expression) process(node.getValue(), context),
+                    (Expression) process(node.getValueList(), context));
+        }
+
+        @Override
+        protected Node visitNotExpression(NotExpression node, Void context)
+        {
+            return new NotExpression((Expression) process(node.getValue(), context));
+        }
+
+        @Override
+        protected Node visitIsNullPredicate(IsNullPredicate node, Void context)
+        {
+            return new IsNullPredicate((Expression) process(node.getValue(), context));
+        }
+
+        @Override
+        protected Node visitIsNotNullPredicate(IsNotNullPredicate node, Void context)
+        {
+            return new IsNotNullPredicate((Expression) process(node.getValue(), context));
         }
 
         @Override
@@ -800,9 +934,21 @@ public class MaterializedViewQueryOptimizer
                     && (ASSOCIATIVE_REWRITE_FUNCTIONS.contains(((FunctionCall) expression).getName())
                     || MaterializedViewUtils.validateNonAssociativeFunctionRewrite((FunctionCall) expression, materializedViewInfo.getBaseToViewColumnMap()));
 
+            // Scalar expressions (IF, CASE, COALESCE, scalar functions like CONCAT/ABS/JSON_EXTRACT)
+            // are valid in SELECT — the rewriter handles them by rewriting leaf identifiers.
+            // Only known built-in scalar functions qualify; unknown/plugin functions are not assumed scalar.
+            boolean isScalar = !(expression instanceof Identifier)
+                    && (!(expression instanceof FunctionCall) || isScalarFunction((FunctionCall) expression));
+
             // If a selected column is not present in GROUP BY node of the query.
             // It must be 1) be selected in the materialized view and 2) not present in GROUP BY node of the materialized view
-            return groupByOfMaterializedView.contains(expression) || !(materializedViewInfo.getBaseToViewColumnMap().containsKey(expression) || canRewrite);
+            return groupByOfMaterializedView.contains(expression) || !(materializedViewInfo.getBaseToViewColumnMap().containsKey(expression) || canRewrite || isScalar);
+        }
+
+        private boolean isScalarFunction(FunctionCall functionCall)
+        {
+            return !functionCall.getWindow().isPresent()
+                    && builtInScalarFunctionNames.contains(functionCall.getName().getSuffix().toLowerCase(Locale.ENGLISH));
         }
 
         /**

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewRewriteQueryShapeValidator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewRewriteQueryShapeValidator.java
@@ -14,15 +14,9 @@
 package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
-import com.facebook.presto.sql.tree.FunctionCall;
-import com.facebook.presto.sql.tree.GroupBy;
-import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.QuerySpecification;
 
 import java.util.Optional;
-
-import static com.facebook.presto.sql.MaterializedViewUtils.SUPPORTED_FUNCTION_CALLS;
-import static java.lang.String.format;
 
 /**
  * Validates that the {@link QuerySpecification} provided to
@@ -44,7 +38,6 @@ public final class MaterializedViewRewriteQueryShapeValidator
             extends DefaultTraversalVisitor<Void, Void>
     {
         private Optional<String> errorMessage = Optional.empty();
-        boolean hasGroupBy;
 
         public Optional<String> validateMaterializedViewOptimizationQueryShape(QuerySpecification querySpecification)
         {
@@ -60,23 +53,6 @@ public final class MaterializedViewRewriteQueryShapeValidator
 
             // TODO: add a check requiring GROUP BY or WHERE to be present
             return errorMessage;
-        }
-
-        @Override
-        protected Void visitGroupBy(GroupBy node, Void context)
-        {
-            hasGroupBy = true;
-            return super.visitGroupBy(node, context);
-        }
-
-        @Override
-        protected Void visitFunctionCall(FunctionCall node, Void context)
-        {
-            QualifiedName name = node.getName();
-            if (!SUPPORTED_FUNCTION_CALLS.contains(name)) {
-                errorMessage = Optional.of(format("Query shape invalid: %s function is not supported for materialized view optimizations", name));
-            }
-            return super.visitFunctionCall(node, context);
         }
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -426,6 +426,238 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testScalarFunctionInSelect()
+    {
+        String originalViewSql = format("SELECT a, b, SUM(c) AS sum_c FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ABS(a), SUM(c) FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT ABS(a), SUM(sum_c) FROM %s GROUP BY a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testJsonExtractInSelect()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT JSON_EXTRACT_SCALAR(a, '$.key'), b FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT JSON_EXTRACT_SCALAR(mv_a, '$.key'), b FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testIfExpressionInSelect()
+    {
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT IF(a > 0, a, 0), SUM(b) FROM %s GROUP BY a", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT IF(a > 0, a, 0), SUM(sum_b) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testCoalesceInSelect()
+    {
+        String originalViewSql = format("SELECT a, b, SUM(c) AS sum_c FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT COALESCE(a, b), SUM(c) FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT COALESCE(a, b), SUM(sum_c) FROM %s GROUP BY a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testCaseExpressionInSelect()
+    {
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT CASE WHEN a > 0 THEN a ELSE 0 END, SUM(b) FROM %s GROUP BY a", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT CASE WHEN a > 0 THEN a ELSE 0 END, SUM(sum_b) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testCastInSelect()
+    {
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT CAST(a AS VARCHAR), SUM(b) FROM %s GROUP BY a", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT CAST(a AS VARCHAR), SUM(sum_b) FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testNestedScalarFunctionsInSelect()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b, SUM(c) AS sum_c FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ABS(a + b), SUM(c) FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT ABS(mv_a + b), SUM(sum_c) FROM %s GROUP BY mv_a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testScalarFunctionUnmappedColumn()
+    {
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ABS(d), SUM(b) FROM %s GROUP BY a", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testScalarFunctionMixedMappedAndUnmappedColumns()
+    {
+        String originalViewSql = format("SELECT a, SUM(b) AS sum_b FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ABS(a + d), SUM(b) FROM %s GROUP BY a", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testScalarWrappingAggregate()
+    {
+        String originalViewSql = format("SELECT a, SUM(c) AS sum_c FROM %s GROUP BY a", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ABS(SUM(c)), a FROM %s GROUP BY a", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT ABS(SUM(sum_c)), a FROM %s GROUP BY a", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testNotExpressionInSelect()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT NOT (a > 0), b FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT NOT (a > 0), b FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testIsNullPredicateInSelect()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a IS NULL, b FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a IS NULL, b FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testIsNotNullPredicateInSelect()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a IS NOT NULL, b FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a IS NOT NULL, b FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testNullIfInSelect()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT NULLIF(a, 0), b FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT NULLIF(a, 0), b FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testInPredicateInSelect()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a IN (1, 2, 3), b FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a IN (1, 2, 3), b FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testNestedCaseWithScalarFunctions()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b, SUM(c) AS sum_c FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT CASE WHEN ABS(a) > 0 THEN CONCAT(CAST(a AS VARCHAR), CAST(b AS VARCHAR)) ELSE 'none' END, SUM(c) FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT CASE WHEN ABS(mv_a) > 0 THEN CONCAT(CAST(mv_a AS VARCHAR), CAST(b AS VARCHAR)) ELSE 'none' END, SUM(sum_c) FROM %s GROUP BY mv_a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testMultipleScalarFunctionsInSelect()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ABS(a), LOWER(CAST(b AS VARCHAR)), COALESCE(a, b) FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT ABS(mv_a), LOWER(CAST(b AS VARCHAR)), COALESCE(mv_a, b) FROM %s", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testWindowFunctionNotRewrittenAsScalar()
+    {
+        // Window functions should NOT be rewritten — they must fall back to base query
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ROW_NUMBER() OVER (ORDER BY a), b FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testUnsupportedAggregateFunctionApproxSet()
+    {
+        // APPROX_SET is an aggregate — should NOT be rewritten as scalar
+        String originalViewSql = format("SELECT a FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT APPROX_SET(a) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testUnsupportedAggregateFunctionArrayAgg()
+    {
+        // ARRAY_AGG is an aggregate — should NOT be rewritten as scalar
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ARRAY_AGG(a), b FROM %s GROUP BY b", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testScalarWrappingUnsupportedAggregate()
+    {
+        // ABS(APPROX_SET(a)) — inner aggregate should cause fallback
+        String originalViewSql = format("SELECT a FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ABS(APPROX_SET(a)) FROM %s", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testScalarFunctionWithTablePrefix()
+    {
+        String originalViewSql = format("SELECT a, b, SUM(c) AS sum_c FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT ABS(%s.a), SUM(%s.c) FROM %s GROUP BY %s.a, %s.b", BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT ABS(a), SUM(sum_c) FROM %s GROUP BY a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testScalarFunctionWithTableAlias()
+    {
+        String originalViewSql = format("SELECT a, b, SUM(c) AS sum_c FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT COALESCE(t.a, t.b), SUM(c) FROM %s t GROUP BY t.a, t.b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT COALESCE(a, b), SUM(sum_c) FROM %s GROUP BY a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testNestedScalarFunctionWithTablePrefix()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b, SUM(c) AS sum_c FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT CASE WHEN ABS(%s.a) > 0 THEN CONCAT(CAST(%s.a AS VARCHAR), CAST(%s.b AS VARCHAR)) ELSE 'none' END, SUM(%s.c) FROM %s GROUP BY %s.a, %s.b",
+                BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1, BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT CASE WHEN ABS(mv_a) > 0 THEN CONCAT(CAST(mv_a AS VARCHAR), CAST(b AS VARCHAR)) ELSE 'none' END, SUM(sum_c) FROM %s GROUP BY mv_a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testNestedScalarFunctionWithTableAlias()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b, SUM(c) AS sum_c FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT IF(t.a > 0, COALESCE(t.a, t.b), 0), SUM(t.c) FROM %s t GROUP BY t.a, t.b", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT IF(mv_a > 0, COALESCE(mv_a, b), 0), SUM(sum_c) FROM %s GROUP BY mv_a, b", VIEW_1);
+        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
+    public void testNonPreComputedCountRejected()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s GROUP BY a, b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT count(a), a, b FROM %s GROUP BY a, b", BASE_TABLE_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
+    }
+
+    @Test
     public void testWithNoMatchingBaseTable()
     {
         String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_2);
@@ -508,8 +740,7 @@ public class TestMaterializedViewQueryOptimizer
         assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
 
         baseQuerySql = format("SELECT SUM(d) FROM %s GROUP BY e", BASE_TABLE_1);
-        expectedRewrittenSql = format("SELECT SUM(d) FROM %s GROUP BY e", VIEW_1);
-        assertOptimizedQuery(baseQuerySql, expectedRewrittenSql, originalViewSql, BASE_TABLE_1, VIEW_1);
+        assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
 
         baseQuerySql = format("SELECT d, e FROM %s", BASE_TABLE_1);
         assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
@@ -599,16 +830,16 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
-    public void testWithUnsupportedFunction()
+    public void testWithUnsupportedAggregateFunction()
     {
+        // GEOMETRIC_MEAN is an aggregate — cannot be rewritten, falls back to base query
         String originalViewSql = format("SELECT GEOMETRIC_MEAN(a) FROM %s", BASE_TABLE_1);
         String baseQuerySql = format("SELECT GEOMETRIC_MEAN(a) FROM %s", BASE_TABLE_1);
-
         assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
 
+        // GEOMETRIC_MEAN with MV that has the column — still an aggregate, cannot rewrite
         originalViewSql = format("SELECT a FROM %s", BASE_TABLE_1);
         baseQuerySql = format("SELECT GEOMETRIC_MEAN(a) FROM %s", BASE_TABLE_1);
-
         assertOptimizedQuery(baseQuerySql, baseQuerySql, originalViewSql, BASE_TABLE_1, VIEW_1);
     }
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewRewriteQueryShapeValidator.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewRewriteQueryShapeValidator.java
@@ -34,11 +34,21 @@ public class TestMaterializedViewRewriteQueryShapeValidator
         assertSucceeds("SELECT SUM(x) AS sum_x, y FROM tbl GROUP BY y ORDER BY z");
     }
     @Test
-    public void unsupportedFunction()
+    public void scalarFunction()
     {
-        assertFails(
-                "SELECT GEOMETRIC_MEAN(x) AS geomean_x, y FROM tbl GROUP BY y",
-                "Query shape invalid: geometric_mean function is not supported for materialized view optimizations");
+        assertSucceeds("SELECT CONCAT(x, y) AS concat_xy, z FROM tbl GROUP BY z");
+    }
+
+    @Test
+    public void scalarFunctionWithAggregate()
+    {
+        assertSucceeds("SELECT IF(y > 0, SUM(x), 0) AS conditional_sum, y FROM tbl GROUP BY y");
+    }
+
+    @Test
+    public void jsonFunction()
+    {
+        assertSucceeds("SELECT JSON_EXTRACT_SCALAR(x, '$.key'), y FROM tbl GROUP BY y");
     }
 
     @Test


### PR DESCRIPTION
Summary:

The MV query rewriter previously rejected all non-aggregate
function calls. This change treats any function not in
ASSOCIATIVE_REWRITE_FUNCTIONS or NON_ASSOCIATIVE_REWRITE_FUNCTIONS as a
scalar function and recursively rewrites its arguments. This supports all
scalar functions (CONCAT, ABS, JSON_EXTRACT, JSON_EXTRACT_SCALAR, LOWER,
CAST, IF, COALESCE, CASE, etc.) without maintaining an allowlist.

Changes:
- visitFunctionCall: rewrite arguments recursively for non-aggregate functions
- visitExpression: re-dispatch after prefix stripping so DereferenceExpression
  nodes get mapped correctly
- Add visitor overrides for IfExpression, CoalesceExpression,
  SearchedCaseExpression, SimpleCaseExpression, WhenClause,
  NullIfExpression, Cast, InPredicate, NotExpression, IsNullPredicate,
  IsNotNullPredicate
- validateExpressionForGroupBy: allow scalar expressions over GROUP BY columns
- Remove SUPPORTED_FUNCTION_CALLS gate from validator

```
== RELEASE NOTES ==

General Changes
* Add support for scalar functions in materialized view query rewriting.
  Queries using functions like ``CONCAT``, ``ABS``, ``JSON_EXTRACT``,
  ``CAST``, ``IF``, ``COALESCE``, and ``CASE`` expressions now correctly
  rewrite to scan the materialized view.
```

Differential Revision: D99652975


