### PR TITLE
fix(plugin-native-sidecar): Add additional CAST for mismatching array constructor args

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/expressions/ExpressionOptimizerManager.java
@@ -117,7 +117,7 @@ public class ExpressionOptimizerManager
         log.info("-- Loading expression optimizer [%s] --", optimizerName);
         ExpressionOptimizer optimizer = expressionOptimizerFactories.get(factoryName).createOptimizer(
                 properties,
-                new ExpressionOptimizerContext(nodeManager, rowExpressionSerde, functionAndTypeManager, functionResolution, authClientConfigs));
+                new ExpressionOptimizerContext(nodeManager, rowExpressionSerde, functionAndTypeManager, functionResolution, authClientConfigs, functionAndTypeManager));
         expressionOptimizers.put(optimizerName, optimizer);
         log.info("-- Added expression optimizer [%s] --", optimizerName);
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -159,6 +159,7 @@ public final class FunctionResolution
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(JAVA_BUILTIN_NAMESPACE, "TRY_CAST"));
     }
 
+    @Override
     public boolean isArrayConstructor(FunctionHandle functionHandle)
     {
         return functionAndTypeResolver.getFunctionMetadata(functionHandle).getName().equals(functionAndTypeResolver.qualifyObjectName(QualifiedName.of(ARRAY_CONSTRUCTOR)));

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizer.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.sidecar.expressions;
 
+import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.function.FunctionKind;
@@ -43,10 +45,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static com.facebook.presto.common.Utils.checkArgument;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.EVALUATED;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.COALESCE;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.newSetFromMap;
 import static java.util.Objects.requireNonNull;
@@ -57,16 +61,19 @@ public class NativeExpressionOptimizer
     private final FunctionMetadataManager functionMetadataManager;
     private final StandardFunctionResolution resolution;
     private final NativeSidecarExpressionInterpreter rowExpressionInterpreterService;
+    private final CastInsertionVisitor castInsertionVisitor;
 
     @Inject
     public NativeExpressionOptimizer(
             NativeSidecarExpressionInterpreter rowExpressionInterpreterService,
             FunctionMetadataManager functionMetadataManager,
-            StandardFunctionResolution resolution)
+            StandardFunctionResolution resolution,
+            TypeManager typeManager)
     {
         this.rowExpressionInterpreterService = requireNonNull(rowExpressionInterpreterService, "rowExpressionInterpreterService is null");
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.resolution = requireNonNull(resolution, "resolution is null");
+        this.castInsertionVisitor = new CastInsertionVisitor(resolution, requireNonNull(typeManager, "typeManager is null"));
     }
 
     @Override
@@ -74,6 +81,7 @@ public class NativeExpressionOptimizer
     {
         // Collect expressions to optimize
         CollectingVisitor collectingVisitor = new CollectingVisitor(functionMetadataManager, level, resolution);
+        expression = expression.accept(castInsertionVisitor, null);
         expression.accept(collectingVisitor, variableResolver);
         List<RowExpression> expressionsToOptimize = collectingVisitor.getExpressionsToOptimize();
 
@@ -405,6 +413,93 @@ public class NativeExpressionOptimizer
                     .map(argument -> toRowExpression(argument.getSourceLocation(), argument.accept(this, context), argument.getType()))
                     .collect(toImmutableList());
             return new SpecialFormExpression(specialForm.getSourceLocation(), specialForm.getForm(), specialForm.getType(), updatedArguments);
+        }
+    }
+
+    /**
+     * This visitor preprocesses the expression tree to insert casts for array constructor arguments
+     * that don't match the array element type. This must happen before sending expressions to the
+     * native sidecar for optimization.
+     */
+    private static class CastInsertionVisitor
+            implements RowExpressionVisitor<RowExpression, Void>
+    {
+        private final StandardFunctionResolution resolution;
+        private final TypeManager typeManager;
+
+        public CastInsertionVisitor(StandardFunctionResolution resolution, TypeManager typeManager)
+        {
+            this.resolution = requireNonNull(resolution, "resolution is null");
+            this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        }
+
+        @Override
+        public RowExpression visitCall(CallExpression call, Void context)
+        {
+            // First, recursively process all arguments
+            List<RowExpression> processedArguments = call.getArguments().stream()
+                    .map(arg -> arg.accept(this, context))
+                    .collect(toImmutableList());
+
+            // For array constructor functions, check arguments and add casts if needed
+            if (resolution.isArrayConstructor(call.getFunctionHandle())) {
+                checkArgument(call.getType() instanceof ArrayType, format("%s is not an instance of ArrayType", call.getType()));
+                ArrayType arrayReturnType = (ArrayType) call.getType();
+                Type elementType = arrayReturnType.getElementType();
+
+                processedArguments = processedArguments.stream()
+                        .map(arg -> insertCastIfNeeded(arg, elementType))
+                        .collect(toImmutableList());
+            }
+            return new CallExpression(call.getSourceLocation(), call.getDisplayName(), call.getFunctionHandle(), call.getType(), processedArguments);
+        }
+
+        @Override
+        public RowExpression visitSpecialForm(SpecialFormExpression specialForm, Void context)
+        {
+            List<RowExpression> processedArguments = specialForm.getArguments().stream()
+                    .map(arg -> arg.accept(this, context))
+                    .collect(toImmutableList());
+            return new SpecialFormExpression(specialForm.getSourceLocation(), specialForm.getForm(), specialForm.getType(), processedArguments);
+        }
+
+        @Override
+        public RowExpression visitLambda(LambdaDefinitionExpression lambda, Void context)
+        {
+            RowExpression processedBody = lambda.getBody().accept(this, context);
+            return new LambdaDefinitionExpression(lambda.getSourceLocation(), lambda.getArgumentTypes(), lambda.getArguments(), processedBody);
+        }
+
+        @Override
+        public RowExpression visitVariableReference(VariableReferenceExpression variable, Void context)
+        {
+            return variable;
+        }
+
+        @Override
+        public RowExpression visitConstant(ConstantExpression constant, Void context)
+        {
+            return constant;
+        }
+
+        @Override
+        public RowExpression visitExpression(RowExpression expression, Void context)
+        {
+            return expression;
+        }
+
+        private RowExpression insertCastIfNeeded(RowExpression arg, Type returnType)
+        {
+            // If argument type doesn't match the return type and can be coerced, add cast
+            if (!arg.getType().equals(returnType) && typeManager.canCoerce(arg.getType(), returnType)) {
+                return new CallExpression(
+                        arg.getSourceLocation(),
+                        "CAST",
+                        resolution.lookupCast("CAST", arg.getType(), returnType),
+                        returnType,
+                        ImmutableList.of(arg));
+            }
+            return arg;
         }
     }
 

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizerFactory.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionOptimizerFactory.java
@@ -51,7 +51,12 @@ public class NativeExpressionOptimizerFactory
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
                     new NativeSidecarCommunicationModule(context.getAuthClientConfigs()),
-                    new NativeExpressionsModule(context.getNodeManager(), context.getRowExpressionSerde(), context.getFunctionMetadataManager(), context.getFunctionResolution()));
+                    new NativeExpressionsModule(
+                            context.getNodeManager(),
+                            context.getRowExpressionSerde(),
+                            context.getFunctionMetadataManager(),
+                            context.getFunctionResolution(),
+                            context.getTypeManager()));
 
             Injector injector = app
                     .doNotInitializeLogging()

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionsModule.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionsModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sidecar.expressions;
 
 import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.RowExpressionSerde;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
@@ -34,13 +35,15 @@ public class NativeExpressionsModule
     private final RowExpressionSerde rowExpressionSerde;
     private final FunctionMetadataManager functionMetadataManager;
     private final StandardFunctionResolution functionResolution;
+    private final TypeManager typeManager;
 
-    public NativeExpressionsModule(NodeManager nodeManager, RowExpressionSerde rowExpressionSerde, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution functionResolution)
+    public NativeExpressionsModule(NodeManager nodeManager, RowExpressionSerde rowExpressionSerde, FunctionMetadataManager functionMetadataManager, StandardFunctionResolution functionResolution, TypeManager typeManager)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.rowExpressionSerde = requireNonNull(rowExpressionSerde, "rowExpressionSerde is null");
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     @Override
@@ -51,6 +54,7 @@ public class NativeExpressionsModule
         binder.bind(RowExpressionSerde.class).toInstance(rowExpressionSerde);
         binder.bind(FunctionMetadataManager.class).toInstance(functionMetadataManager);
         binder.bind(StandardFunctionResolution.class).toInstance(functionResolution);
+        binder.bind(TypeManager.class).toInstance(typeManager);
 
         // JSON dependencies and setup
         binder.install(new JsonModule());

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -797,6 +797,35 @@ public class TestNativeSidecarPlugin
         assertQuerySucceeds(session, "SELECT TRY_CAST(orderkey AS TINYINT) FROM orders");
         assertQuerySucceeds(session, "SELECT TRY_CAST(comment AS BIGINT) FROM orders");
         assertQuerySucceeds(session, "SELECT TRY_CAST(orderkey AS DOUBLE) FROM orders");
+
+        // Ensure args passed down to the native expression optimizer are of the same type.
+        Session preparedStatementSession = Session.builder(session)
+                .addPreparedStatement("my_query", "SELECT c1[10] FROM (SELECT ? as c1)")
+                .build();
+        assertQueryWithSameQueryRunner(preparedStatementSession,
+                "EXECUTE my_query USING MAP(ARRAY[BIGINT '10', 200], ARRAY [100, 300])", "VALUES (100)");
+
+        // This test ensures we correctly pick the bigint implementation version of the grouping
+        // function which supports up to 62 columns. Semantically it is exactly the same as
+        // TestGroupingOperationFunction#testMoreThanThirtyTwoArguments. That test is a little easier to
+        // understand and verify.
+        String fortyLetterSequence = "aa, ab, ac, ad, ae, af, ag, ah, ai, aj, ak, al, am, an, ao, ap, aq, ar, asa, at, au, av, aw, ax, ay, az, " +
+                "ba, bb, bc, bd, be, bf, bg, bh, bi, bj, bk, bl, bm, bn";
+        String fortyIntegers = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, " +
+                "31, 32, 33, 34, 35, 36, 37, 38, 39, 40";
+        // 20, 2, 13, 33, 40, 9 , 14 (corresponding indices from Left to right in the above fortyLetterSequence)
+        String groupingSet1 = "at, ab, am, bg, bn, ai, an";
+        // 28, 4, 5, 29, 31, 10 (corresponding indices from left to right in the above fortyLetterSequence)
+        String groupingSet2 = "bb, ad, ae, bc, be, aj";
+        String query = String.format(
+                "SELECT grouping(%s) FROM (VALUES (%s)) AS t(%s) GROUP BY GROUPING SETS ((%s), (%s), (%s))",
+                fortyLetterSequence,
+                fortyIntegers,
+                fortyLetterSequence,
+                fortyLetterSequence,
+                groupingSet1,
+                groupingSet2);
+        assertQueryWithSameQueryRunner(session, query, "VALUES (0), (822283861886), (995358664191)");
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -99,4 +99,6 @@ public interface StandardFunctionResolution
     FunctionHandle lookupBuiltInFunction(String functionName, List<Type> inputTypes);
 
     FunctionHandle lookupFunction(String catalog, String schema, String functionName, List<Type> inputTypes);
+
+    boolean isArrayConstructor(FunctionHandle functionHandle);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/sql/planner/ExpressionOptimizerContext.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.sql.planner;
 
 import com.facebook.presto.common.AuthClientConfigs;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.RowExpressionSerde;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
@@ -28,19 +29,22 @@ public class ExpressionOptimizerContext
     private final FunctionMetadataManager functionMetadataManager;
     private final StandardFunctionResolution functionResolution;
     private final AuthClientConfigs authClientConfigs;
+    private final TypeManager typeManager;
 
     public ExpressionOptimizerContext(
             NodeManager nodeManager,
             RowExpressionSerde rowExpressionSerde,
             FunctionMetadataManager functionMetadataManager,
             StandardFunctionResolution functionResolution,
-            AuthClientConfigs authClientConfigs)
+            AuthClientConfigs authClientConfigs,
+            TypeManager typeManager)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.rowExpressionSerde = requireNonNull(rowExpressionSerde, "rowExpressionSerde is null");
         this.functionMetadataManager = requireNonNull(functionMetadataManager, "functionMetadataManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.authClientConfigs = requireNonNull(authClientConfigs, "authClientConfigs is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     public NodeManager getNodeManager()
@@ -66,5 +70,10 @@ public class ExpressionOptimizerContext
     public AuthClientConfigs getAuthClientConfigs()
     {
         return authClientConfigs;
+    }
+
+    public TypeManager getTypeManager()
+    {
+        return typeManager;
     }
 }


### PR DESCRIPTION
## Description
Adds an additional cast to the array constructor arg types if their type does not match the array return type.

## Motivation and Context
Fixes: https://github.com/prestodb/presto/issues/27575

## Impact
No impact

## Test Plan
e2e tests, CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure native sidecar expression optimization correctly handles array constructor arguments by inserting necessary casts based on type coercion capabilities.

Bug Fixes:
- Prevent type mismatches in native sidecar-optimized expressions by inserting casts for array constructor arguments whose types differ from the array element type but can be coerced.
- Correctly identify array constructor functions via the standard function resolution interface to support array-related optimizations in the sidecar.

Enhancements:
- Propagate TypeManager into the expression optimizer context and native sidecar modules to support type-aware preprocessing of expressions before optimization.

## Summary by Sourcery

Ensure native sidecar expression optimization correctly handles array constructors by inserting necessary casts and wiring type metadata through the optimization pipeline.

Bug Fixes:
- Prevent type mismatches in native sidecar-optimized expressions by casting array constructor arguments whose types differ from the array element type but can be coerced.
- Correctly identify array constructor functions via the standard function resolution interface to support array-related optimizations in the sidecar.

Enhancements:
- Propagate TypeManager into the expression optimizer context, native sidecar optimizer, and module wiring to enable type-aware preprocessing of expressions.

Tests:
- Extend native sidecar plugin tests to cover prepared statements using array and map literals and complex grouping scenarios under the native optimizer.