### PR TITLE
fix(ui): Fix version, environment, and uptime visibility in navbar

### DIFF
--- a/presto-ui/src/components/PageTitle.tsx
+++ b/presto-ui/src/components/PageTitle.tsx
@@ -181,15 +181,11 @@ export const PageTitle = (props: Props): React.ReactElement => {
                         <span className="navbar-toggler-icon"></span>
                     </button>
                     <div id="navbar" className="navbar-collapse collapse min-width-0">
-                        <ul className="nav navbar-nav navbar-right gap-3 flex-nowrap justify-content-end align-items-center min-width-0 flex-grow-1">
-                            <li className="flex-basis-40 min-width-0 flex-grow-1">
+                        <ul className="nav navbar-nav navbar-right gap-3 justify-content-end align-items-center min-width-0 flex-grow-1">
+                            <li className="flex-basis-100 min-width-0">
                                 <div className="navbar-cluster-info">
                                     <div className="uppercase">Version</div>
-                                    <div
-                                        title={info?.nodeVersion?.version}
-                                        className="text text-truncate"
-                                        id="version-number"
-                                    >
+                                    <div title={info?.nodeVersion?.version} className="text" id="version-number">
                                         {isOffline() ? "N/A" : info?.nodeVersion?.version}
                                     </div>
                                 </div>

--- a/presto-ui/src/static/assets/presto.css
+++ b/presto-ui/src/static/assets/presto.css
@@ -277,6 +277,7 @@ pre {
 
 .flex-basis-100 {
     flex-basis: 100%;
+    min-width: 0;
 }
 
 .flex-basis-40 {

--- a/presto-ui/src/static/assets/presto.css
+++ b/presto-ui/src/static/assets/presto.css
@@ -275,6 +275,10 @@ pre {
     min-width: 0;
 }
 
+.flex-basis-100 {
+    flex-basis: 100%;
+}
+
 .flex-basis-40 {
     flex-basis: 40%;
     min-width: 0;


### PR DESCRIPTION
## Description

#26485 introduced `flex-nowrap` on the navbar, which causes
version, environment, and uptime to truncate or overlap when
the values are long (e.g. `0.297-uber-native-SNAPSHOT-99dfabf`).

Removed `flex-nowrap` so items can wrap naturally, and gave the
version field `flex-basis: 100%` so it sits on its own row. Also
dropped `text-truncate` from the version div. This brings back
the pre-#26485 layout while keeping cluster tag support.

Resolves: #26895

## Test plan
- ESLint passes with no new errors
- All 199 existing UI tests pass (6 suites)

## Release Notes
```
== RELEASE NOTES ==
General Changes
* Fix version, environment, and uptime values being truncated in the Web UI navbar.
```