### PR TITLE
test: Enable native e2e test for array_split_into_chunks null literal

### DIFF
--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
@@ -132,6 +132,15 @@ public class TestArraySqlFunctions
     }
 
     @Test
+    public void testArraySplitIntoChunksEmptyArray()
+    {
+        assertFunction("array_split_into_chunks(cast(array[] as array(bigint)), 2)", new ArrayType(new ArrayType(BIGINT)), emptyList());
+        assertFunction("array_split_into_chunks(cast(array[] as array(varchar)), 3)", new ArrayType(new ArrayType(VARCHAR)), emptyList());
+        assertFunction("array_split_into_chunks(cast(array[] as array(integer)), 1)", new ArrayType(new ArrayType(INTEGER)), emptyList());
+        assertFunction("array_split_into_chunks(cast(array[] as array(double)), 5)", new ArrayType(new ArrayType(DOUBLE)), emptyList());
+    }
+
+    @Test
     public void testArrayFrequencyBigint()
     {
         assertFunction("array_frequency(cast(null as array(bigint)))", createMapType(BIGINT, INTEGER), null);

--- a/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
@@ -120,6 +120,15 @@ public class TestArraySqlFunctions
     }
 
     @Test
+    public void testArraySplitIntoChunksEmptyArray()
+    {
+        assertInvalidFunction("array_split_into_chunks(cast(array[] as array(bigint)), 2)", StandardErrorCode.GENERIC_USER_ERROR, "Cannot split an empty array.");
+        assertInvalidFunction("array_split_into_chunks(cast(array[] as array(varchar)), 1)", StandardErrorCode.GENERIC_USER_ERROR, "Cannot split an empty array.");
+        assertInvalidFunction("array_split_into_chunks(cast(array[] as array(integer)), 5)", StandardErrorCode.GENERIC_USER_ERROR, "Cannot split an empty array.");
+        assertInvalidFunction("array_split_into_chunks(cast(array[] as array(double)), 100)", StandardErrorCode.GENERIC_USER_ERROR, "Cannot split an empty array.");
+    }
+
+    @Test
     public void testArraySplitIntoChunksNulls()
     {
         assertFunction("array_split_into_chunks(array[cast(null as bigint), bigint '1', cast(null as bigint), bigint '2'], 2)", new ArrayType(new ArrayType(BIGINT)), ImmutableList.of(asList(null, 1L), asList(null, 2L)));

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeArrayFunctionQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestPrestoNativeArrayFunctionQueries.java
@@ -111,4 +111,25 @@ public class TestPrestoNativeArrayFunctionQueries
         assertQueryFails("SELECT array_top_n(a, b) FROM (VALUES(ARRAY[1, 2, 3], -2)) as t(a,b)",
                 "n >= 0 \\(-2 vs\\. 0\\) Parameter n: -2 to ARRAY_TOP_N is negative Top-level Expression: (presto|native)\\.default\\.array_top_n\\(field, field_0\\)");
     }
+
+    @Test
+    public void testArraySplitIntoChunks()
+    {
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[1, 2, 3, 4, 5, 6], 2)) as t(a, b)");
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[1, 2, 3, 4, 5], 3)) as t(a, b)");
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[1, 2, 3], 5)) as t(a, b)");
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[1, 2, 3], 3)) as t(a, b)");
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[1, NULL, 3, NULL, 5], 2)) as t(a, b)");
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY['a', 'b', 'c', 'd'], 2)) as t(a, b)");
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[1.1, 2.2, 3.3, 4.4, 5.5], 2)) as t(a, b)");
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[true, false, true, false, true], 2)) as t(a, b)");
+        assertQuery("SELECT array_split_into_chunks(a, b) FROM (VALUES(CAST(NULL AS ARRAY(INTEGER)), 2)) as t(a, b)");
+        assertQuery("select array_split_into_chunks(null, 2)");
+        assertQueryFails("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[1, 2, 3], 0)) as t(a, b)",
+                ".*Invalid slice size: 0. Size must be greater than zero.*");
+        assertQueryFails("SELECT array_split_into_chunks(a, b) FROM (VALUES(ARRAY[1, 2, 3], -1)) as t(a, b)",
+                ".*Invalid slice size: -1. Size must be greater than zero.*");
+        assertQueryFails("SELECT array_split_into_chunks(a, b) FROM (VALUES(CAST(ARRAY[] AS ARRAY(INTEGER)), 2)) as t(a, b)",
+                ".*Cannot split an empty array.*");
+    }
 }

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestSqlInvokedFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestSqlInvokedFunctions.java
@@ -108,11 +108,4 @@ public class TestSqlInvokedFunctions
             assertQuery("SELECT TRY(ARRAY_MAX(ARRAY [ARRAY[1, NULL], ARRAY[1, 2]]))", "SELECT NULL");
         }
     }
-
-    @Override
-    @Test
-    public void testArraySplitIntoChunks()
-    {
-        // TODO: https://github.com/prestodb/presto/issues/27429
-    }
 }

--- a/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/ArraySqlFunctions.java
+++ b/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/ArraySqlFunctions.java
@@ -48,11 +48,13 @@ public class ArraySqlFunctions
     {
         return "RETURN IF(sz <= 0, " +
                 "fail('Invalid slice size: ' || cast(sz as varchar) || '. Size must be greater than zero.'), " +
+                "IF(cardinality(input) = 0, " +
+                "fail('Cannot split an empty array.'), " +
                 "IF(cardinality(input) / sz > 10000, " +
                 "fail('Cannot split array of size: ' || cast(cardinality(input) as varchar) || ' into more than 10000 parts.'), " +
                 "transform(" +
                 "sequence(1, cardinality(input), sz), " +
-                "x -> slice(input, x, sz))))";
+                "x -> slice(input, x, sz)))))";
     }
 
     @SqlInvokedScalarFunction(value = "array_frequency", deterministic = true, calledOnNullInput = false)

--- a/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/ArraySqlFunctions.java
+++ b/presto-sql-helpers/presto-sql-invoked-functions-plugin/src/main/java/com/facebook/presto/scalar/sql/ArraySqlFunctions.java
@@ -48,11 +48,13 @@ public class ArraySqlFunctions
     {
         return "RETURN IF(sz <= 0, " +
                 "fail('Invalid slice size: ' || cast(sz as varchar) || '. Size must be greater than zero.'), " +
+                "IF(cardinality(input) = 0, " +
+                "array[], " +
                 "IF(cardinality(input) / sz > 10000, " +
                 "fail('Cannot split array of size: ' || cast(cardinality(input) as varchar) || ' into more than 10000 parts.'), " +
                 "transform(" +
                 "sequence(1, cardinality(input), sz), " +
-                "x -> slice(input, x, sz))))";
+                "x -> slice(input, x, sz)))))";
     }
 
     @SqlInvokedScalarFunction(value = "array_frequency", deterministic = true, calledOnNullInput = false)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestSqlInvokedFunctions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestSqlInvokedFunctions.java
@@ -68,6 +68,21 @@ public abstract class AbstractTestSqlInvokedFunctions
 
         sql = "select array_split_into_chunks(array[], 0)";
         assertQueryFails(sql, ".*Invalid slice size: 0. Size must be greater than zero.*");
+
+        sql = "select array_split_into_chunks(cast(array[] as array(integer)), 2)";
+        assertQuery(sql, "values array[]");
+
+        sql = "select array_split_into_chunks(cast(array[] as array(bigint)), 5)";
+        assertQuery(sql, "values array[]");
+
+        sql = "select array_split_into_chunks(cast(array[] as array(varchar)), 1)";
+        assertQuery(sql, "values array[]");
+
+        sql = "select array_split_into_chunks(cast(array[] as array(double)), 3)";
+        assertQuery(sql, "values array[]");
+
+        sql = "select array_split_into_chunks(array[], -1)";
+        assertQueryFails(sql, ".*Invalid slice size: -1. Size must be greater than zero.*");
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestSqlInvokedFunctions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestSqlInvokedFunctions.java
@@ -68,6 +68,21 @@ public abstract class AbstractTestSqlInvokedFunctions
 
         sql = "select array_split_into_chunks(array[], 0)";
         assertQueryFails(sql, ".*Invalid slice size: 0. Size must be greater than zero.*");
+
+        // Empty arrays throw with the same message on Java and native engines.
+        sql = "select array_split_into_chunks(cast(array[] as array(integer)), 2)";
+        assertQueryFails(sql, ".*Cannot split an empty array.*");
+
+        sql = "select array_split_into_chunks(cast(array[] as array(varchar)), 1)";
+        assertQueryFails(sql, ".*Cannot split an empty array.*");
+
+        // Exact-fit boundary: chunk size equals array size.
+        sql = "select array_split_into_chunks(array[1, 2, 3], 3)";
+        assertQuery(sql, "values array[array[1, 2, 3]]");
+
+        // Boolean elements.
+        sql = "select array_split_into_chunks(array[true, false, true, false, true], 2)";
+        assertQuery(sql, "values array[array[true, false], array[true, false], array[true]]");
     }
 
     @Test


### PR DESCRIPTION
 ## Summary                                                                                                                                              
  Match Velox's behavior for `array_split_into_chunks(array[], n)` so the inherited
  native e2e test (`TestSqlInvokedFunctions#testArraySplitIntoChunks`) can run                                                                            
  unmodified:                                                                                                                                             
                                                                                                                                                          
  - Add an explicit empty-array check to the SQL definition that throws                                                                                   
    `"Cannot split an empty array."` — byte-identical to Velox's  
    `VELOX_USER_CHECK_GT(inputSize, 0, "Cannot split an empty array.")` in                                                                                
    `velox/functions/prestosql/ArrayFunctions.h`.                                                                                                         
  - Remove the `// TODO` override in `presto-native-tests/.../TestSqlInvokedFunctions.java`                                                               
    that was suppressing the entire native run of `testArraySplitIntoChunks`.                                                                             
  - Extend `AbstractTestSqlInvokedFunctions.testArraySplitIntoChunks` with empty-array,                                                                   
    exact-fit, and boolean-element cases. These run against H2 (Java) directly and                                                                        
    against the native engine via the inherited `TestSqlInvokedFunctions`.                                                                                
  - Add `TestArraySqlFunctions.testArraySplitIntoChunksEmptyArray` covering empty                                                                         
    arrays of bigint / varchar / integer / double. 

Tracks prestodb/presto#27429.

## Behavior change                                                                                                                                      
  `array_split_into_chunks(array[], n)` with `n > 0` failed with
  the `sequence` builtin's error: `"sequence stop value should be greater than`                                                                            `or equal to start value if step is greater than zero..."`. After this PR it                                                                             
  throws `"Cannot split an empty array."`, identical to what Velox throws,                                                                           
  so the same call fails the same way on both engines and the inherited native                                                                            
  e2e test can assert one regex against both. The original sequence failure throw is
 ambiguous and should be changed.  

 ## Test plan                                                                                                                                            
  - [ ] `TestArraySqlFunctions#testArraySplitIntoChunksEmptyArray` passes
  - [ ] `AbstractTestSqlInvokedFunctions#testArraySplitIntoChunks` passes (Java/H2)                                                                       
  - [ ] `TestSqlInvokedFunctions#testArraySplitIntoChunks` passes against the native engine                                                               
                                                                                                                                                          
  ## Merge order                                                                                                                                          
  This PR must wait for facebookincubator/velox#16923 to land **and** for the                                                                             
  Velox SHA pinned by Presto to advance past it. That PR fixes the null-literal                                                                           
  overload-resolution half of #27429; until it's in, the inherited test's                                                                                 
  `array_split_into_chunks(null, 2)` assertion will still fail on native.

```
== NO RELEASE NOTE ==
```