### PR TITLE
fix: Remove duplicate checkQueryIntegrity call in CreateMaterializedViewTask

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
@@ -23,8 +23,11 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.analyzer.ViewDefinition;
 import com.facebook.presto.spi.analyzer.ViewDefinitionReferences;
 import com.facebook.presto.spi.security.AccessControl;
+import com.facebook.presto.spi.security.AccessControlContext;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.ViewSecurity;
 import com.facebook.presto.sql.analyzer.Analysis;
 import com.facebook.presto.sql.analyzer.Analyzer;
@@ -179,6 +182,9 @@ public class CreateMaterializedViewTask
 
         return immediateFuture(null);
     }
+
+    @Override
+    public void queryPermissionCheck(AccessControl accessControl, Identity identity, AccessControlContext context, String query, Map<String, String> preparedStatements, Map<QualifiedObjectName, ViewDefinition> viewDefinitions, Map<QualifiedObjectName, MaterializedViewDefinition> materializedViewDefinitions) {}
 
     @Override
     public String explain(CreateMaterializedView statement, List<Expression> parameters)


### PR DESCRIPTION
## Description
Override `queryPermissionCheck` with a no-op in `CreateMaterializedViewTask` to prevent `checkQueryIntegrity` from being called twice during `CREATE MATERIALIZED VIEW` execution.

## Motivation and Context
`DDLDefinitionExecution.executeTask()` calls `queryPermissionCheck` (which invokes `checkQueryIntegrity`) before calling `execute()`. However, `CreateMaterializedViewTask.execute()` also calls `checkAccessPermissions` internally after analyzing the statement, which in turn calls `checkQueryIntegrity` again. The first call from the DDL framework passes empty view/materialized-view definition maps since analysis hasn't happened yet, making it redundant. The meaningful check happens inside `execute()` with the actual view definitions from the analysis result.

## Impact
Eliminates one redundant permission check call per `CREATE MATERIALIZED VIEW` query. No functional behavior change — the actual permission check inside `execute()` still runs with the correct view definitions.

## Test Plan
No behavior change

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.

## Release Notes

```
== NO RELEASE NOTE ==
```

Differential Revision: D100486260

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate query integrity and permission checks during CREATE MATERIALIZED VIEW execution by bypassing the generic DDL queryPermissionCheck for this task.