### PR TITLE
fix(optimizer): Fix cascading projection pass-through in PushProjectionThroughCrossJoin

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughCrossJoin.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushProjectionThroughCrossJoin.java
@@ -292,6 +292,20 @@ public class PushProjectionThroughCrossJoin
                 continue;
             }
 
+            // For non-top-level residuals, add pass-throughs for source variables
+            // not already in the residual so that upper levels can reference them
+            // (e.g. variables pushed at higher levels that flow through the cross join)
+            if (!isTopLevel) {
+                Assignments.Builder augmented = Assignments.builder();
+                augmented.putAll(res);
+                for (VariableReferenceExpression v : result.getOutputVariables()) {
+                    if (!res.getMap().containsKey(v)) {
+                        augmented.put(v, v);
+                    }
+                }
+                res = augmented.build();
+            }
+
             result = new ProjectNode(
                     project.getSourceLocation(),
                     context.getIdAllocator().getNextId(),

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughCrossJoin.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughCrossJoin.java
@@ -478,6 +478,55 @@ public class TestPushProjectionThroughCrossJoin
     }
 
     @Test
+    public void testCascadingWithMixedResidualAndHigherLevelPush()
+    {
+        // Reproduces: "Expression dependencies ([pushed_right]) not in source plan output ([left_var, mixed])"
+        // Intermediate project has a mixed (both-sides) expression creating a non-identity residual.
+        // Top project pushes an expression to the right side.
+        // Without the fix, the intermediate residual project doesn't pass through
+        // the pushed variable, causing a validation error.
+        tester().assertThat(new PushProjectionThroughCrossJoin(getFunctionManager()))
+                .setSystemProperty(PUSH_PROJECTION_THROUGH_CROSS_JOIN, "true")
+                .on(p -> {
+                    VariableReferenceExpression a = p.variable("a", BIGINT);
+                    VariableReferenceExpression b = p.variable("b", BIGINT);
+                    VariableReferenceExpression mixed = p.variable("mixed", BIGINT);
+
+                    return p.project(
+                            Assignments.builder()
+                                    .put(p.variable("pushed_right", BIGINT), p.rowExpression("b + BIGINT '1'"))
+                                    .put(p.variable("out2", BIGINT), p.rowExpression("a + mixed"))
+                                    .build(),
+                            p.project(
+                                    Assignments.builder()
+                                            .put(a, a)
+                                            .put(b, b)
+                                            .put(mixed, p.rowExpression("a + b"))
+                                            .build(),
+                                    p.join(
+                                            JoinType.INNER,
+                                            p.values(a),
+                                            p.values(b))));
+                })
+                .matches(
+                        project(
+                                ImmutableMap.of(
+                                        "pushed_right", expression("pushed_right"),
+                                        "out2", expression("a + mixed")),
+                                project(
+                                        ImmutableMap.of(
+                                                "a", expression("a"),
+                                                "b", expression("b"),
+                                                "mixed", expression("a + b"),
+                                                "pushed_right", expression("pushed_right")),
+                                        join(
+                                                values("a"),
+                                                project(
+                                                        ImmutableMap.of("pushed_right", expression("b + BIGINT '1'")),
+                                                        values("b"))))));
+    }
+
+    @Test
     public void testCascadingDoesNotFireOnAllIdentity()
     {
         // All cascading projects are identity — nothing to push

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -158,4 +158,35 @@ public class TestLocalQueries
     public void testSetSessionNativeWorkerSessionProperty()
     {
     }
+
+    @Test
+    public void testPushProjectionThroughCrossJoinWithCascadingProjects()
+    {
+        // Verifies that push_projection_through_cross_join handles cascading projects
+        // where the intermediate level has a both-sides expression (non-identity residual)
+        // and a higher level pushes an expression to one side.
+        // Without the fix, the intermediate residual drops the pushed variable,
+        // causing: "Expression dependencies ([r_scaled]) not in source plan output"
+        String sql = "SELECT " +
+                "    sub.nationkey + sub.regionkey AS mixed, " +
+                "    sub.r_scaled " +
+                "FROM ( " +
+                "    SELECT " +
+                "        n.nationkey, " +
+                "        r.regionkey, " +
+                "        n.nationkey + r.regionkey AS nr_sum, " +
+                "        r.regionkey * 100 AS r_scaled " +
+                "    FROM nation n " +
+                "    CROSS JOIN region r " +
+                ") sub";
+
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("push_projection_through_cross_join", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("push_projection_through_cross_join", "true")
+                .build();
+
+        assertQuery(enabled, sql, disabled, sql);
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes a bug in PushProjectionThroughCrossJoin where intermediate residual projects drop variables that were pushed from higher levels to one side of the cross join, causing "Expression dependencies not in source plan output" validation errors.
- When cascading projections exist above a cross join (e.g., Project -> Project -> CrossJoin), the intermediate residual now adds pass-through identity assignments for all source variables not already in its assignments, ensuring pushed variables flow through correctly to upper levels.
- Reproduces with patterns like A JOIN B CROSS JOIN (C CROSS JOIN D) where higher-level expressions push to one side while intermediate levels have mixed (both-sides) expressions.

## Test plan
- [x] Added unit test `testCascadingWithMixedResidualAndHigherLevelPush` in `TestPushProjectionThroughCrossJoin` that verifies the fix (fails without fix, passes with fix)
- [x] Added e2e integration test `testPushProjectionThroughCrossJoinWithCascadingProjects` in `TestLocalQueries` that compares query results with optimization enabled vs disabled
- [x] All 17 unit tests pass (`TestPushProjectionThroughCrossJoin`)
- [x] E2e test passes (`TestLocalQueries#testPushProjectionThroughCrossJoinWithCascadingProjects`)
- [x] Compile passes

```
== RELEASE NOTES ==
General Changes
* Fix a bug in PushProjectionThroughCrossJoin optimizer rule where cascading projections above a cross join could cause validation errors by dropping pushed variables from intermediate residual projects.
```