### PR TITLE
fix(build): Wire up ENABLE_ALL_WARNINGS CMake flag

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -42,6 +42,10 @@ endif()
 # Important warnings that must be explicitly enabled.
 set(ENABLE_WARNINGS "-Wreorder")
 
+if("${ENABLE_ALL_WARNINGS}")
+  string(APPEND ENABLE_WARNINGS " -Wall")
+endif()
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DISABLED_WARNINGS} ${ENABLE_WARNINGS}")
 
 # Add all Presto options below.


### PR DESCRIPTION
Summary:
The Makefile passes -DENABLE_ALL_WARNINGS=${ENABLE_WALL} to CMake, but CMakeLists.txt never checks this variable, so -Wall is never added to the compiler flags. This means the ENABLE_WALL Makefile variable (defaulting to 1) has no effect.

Add the missing check in CMakeLists.txt so that when ENABLE_ALL_WARNINGS is set, -Wall is appended to the enabled warnings.

## Summary by Sourcery

Build:
- Connect the ENABLE_ALL_WARNINGS CMake flag to append -Wall to the compiler warning flags when enabled.