### PR TITLE
fix: Add logic for including buffered bytes in parquet file size recording

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
@@ -86,7 +86,7 @@ public class ParquetFileWriter
     @Override
     public long getWrittenBytes()
     {
-        return parquetWriter.getWrittenBytes() + parquetWriter.getBufferedBytes();
+        return parquetWriter.getWrittenBytes();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetFileWriter.java
@@ -86,7 +86,11 @@ public class ParquetFileWriter
     @Override
     public long getWrittenBytes()
     {
-        return parquetWriter.getWrittenBytes() + parquetWriter.getBufferedBytes();
+        if (parquetWriter.isClosed()) {
+            return parquetWriter.getWrittenBytes();
+        }
+        return parquetWriter.getWrittenBytes()
+                + parquetWriter.getBufferedBytes();
     }
 
     @Override

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -341,4 +341,9 @@ public class ParquetWriter
         }
         throw new IllegalArgumentException("Invalid compressionCodec: " + compressionCodecClass);
     }
+
+    public boolean isClosed()
+    {
+        return closed;
+    }
 }


### PR DESCRIPTION
## Description
Adding buffered bytes in `getWrittenBytes` for parquet files results in presto giving an inaccurate file size as file_size_in_bytes that's stored in iceberg. For example...

```
presto> CREATE TABLE iceberg.default.size_test ( id BIGINT, name VARCHAR ) WITH (format = 'PARQUET');
CREATE TABLE

Query 20260413_205844_00002_ca7bv, FINISHED, 0 nodes
Splits: 0 total, 0 done (0.00%)
[Latency: client-side: 316ms, server-side: 310ms] [0 rows, 0B] [0 rows/s, 0B/s]

presto> INSERT INTO iceberg.default.size_test VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
INSERT: 3 rows

Query 20260413_205849_00003_ca7bv, FINISHED, 1 node
Splits: 35 total, 35 done (100.00%)
[Latency: client-side: 0:07, server-side: 0:07] [0 rows, 0B] [0 rows/s, 0B/s]

presto> SELECT file_path, file_size_in_bytes FROM iceberg.default."size_test$files";
                                            file_path                                            | file_size_in_bytes
-------------------------------------------------------------------------------------------------+--------------------
 file:/tmp/iceberg-warehouse/default/size_test/data/a187d767-9992-4833-b37b-d935e326f597.parquet |                409
(1 row)

Query 20260413_205903_00004_ca7bv, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 231ms, server-side: 197ms] [1 rows, 420B] [5 rows/s, 2.08KB/s]
```

And then...

```
stat /tmp/iceberg-warehouse/default/size_test/data/a187d767-9992-4833-b37b-d935e326f597.parquet
16777231 282572804 -rw-r--r-- 1 awoolfson wheel 0 296 "Apr 13 13:58:55 2026" "Apr 13 13:58:55 2026" "Apr 13 13:58:55 2026" "Apr 13 13:58:50 2026" 4096 8 0 /tmp/iceberg-warehouse/default/size_test/data/a187d767-9992-4833-b37b-d935e326f597.parquet
```

Where the actual file size is shown to be 296, the 113 byte difference comes from the buffered bytes. 

By removing that part of the code, this is fixed. The query above shows 296 bytes


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Enhancements:
- Change ParquetFileWriter#getWrittenBytes to return only the bytes actually written by the underlying parquetWriter, no longer including buffered bytes.

## Summary by Sourcery

Enhancements:
- Update Parquet file writer metrics to report only bytes flushed to storage, no longer counting buffered bytes in getWrittenBytes().