### PR TITLE
fix(plugin-druid): Add version for at.yawk.lz4:lz4-java to fix maven publishing

### DIFF
--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -44,6 +44,7 @@
             <dependency>
                 <groupId>at.yawk.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
+                <version>1.10.2</version>
             </dependency>
             <dependency>
                 <groupId>org.mozilla</groupId>


### PR DESCRIPTION
## Description

Got error when validating maven artifacts
```
[INFO] Waiting until Deployment 187b74fc-1b32-40a7-b88a-7ff972813e55 is validated
Error:  

Deployment 187b74fc-1b32-40a7-b88a-7ff972813e55 failed
pkg:maven/com.facebook.presto/presto-druid@0.297:
 - Dependency management dependency version information is missing for dependency: at.yawk.lz4:lz4-java
```

## Motivation and Context


## Impact
Release 0.297

## Test Plan
Re-publish

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

