### PR TITLE
misc: Fix code style issues, copy-paste bug, and UB in presto-native-execution (#27572)

### DIFF
--- a/presto-native-execution/presto_cpp/main/common/Exception.h
+++ b/presto-native-execution/presto_cpp/main/common/Exception.h
@@ -13,14 +13,13 @@
  */
 #pragma once
 
-#include <folly/Singleton.h>
+#include <exception>
 #include <unordered_map>
+
+#include <folly/Singleton.h>
+
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 #include "velox/common/base/VeloxException.h"
-
-namespace std {
-class exception;
-}
 
 namespace facebook::presto {
 namespace protocol {

--- a/presto-native-execution/presto_cpp/main/common/Utils.cpp
+++ b/presto-native-execution/presto_cpp/main/common/Utils.cpp
@@ -141,7 +141,7 @@ std::string decompressMessageBody(
   }
 }
 
-const std::vector<std::string> getFunctionNameParts(
+std::vector<std::string> getFunctionNameParts(
     const std::string& registeredFunction) {
   std::vector<std::string> parts;
   folly::split('.', registeredFunction, parts, true);

--- a/presto-native-execution/presto_cpp/main/common/Utils.h
+++ b/presto-native-execution/presto_cpp/main/common/Utils.h
@@ -67,6 +67,6 @@ inline std::string addDefaultNamespacePrefix(
 /// The keys in velox function maps are of the format
 /// `catalog.schema.function_name`. This utility function extracts the
 /// three parts, {catalog, schema, function_name}, from the registered function.
-const std::vector<std::string> getFunctionNameParts(
+std::vector<std::string> getFunctionNameParts(
     const std::string& registeredFunction);
 } // namespace facebook::presto::util

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionProperties.cpp
@@ -558,9 +558,8 @@ SessionProperties::SessionProperties() {
 
   addSessionProperty(
       kUnnestSplitOutput,
-      "In streaming aggregation, wait until we have enough number of output"
-      "rows to produce a batch of size specified by this. If set to 0, then"
-      "Operator::outputBatchRows will be used as the min output batch rows.",
+      "If true, the unnest operator might split output for each input batch "
+      "based on the output batch size control.",
       BOOLEAN(),
       false,
       QueryConfig::kUnnestSplitOutput,

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionPropertiesProvider.cpp
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionPropertiesProvider.cpp
@@ -19,6 +19,8 @@
 
 namespace facebook::presto {
 
+using json = nlohmann::json;
+
 void SessionPropertiesProvider::addSessionProperty(
     const std::string& name,
     const std::string& description,

--- a/presto-native-execution/presto_cpp/main/properties/session/SessionPropertiesProvider.h
+++ b/presto-native-execution/presto_cpp/main/properties/session/SessionPropertiesProvider.h
@@ -20,8 +20,6 @@
 #include "presto_cpp/presto_protocol/core/presto_protocol_core.h"
 #include "velox/type/Type.h"
 
-using json = nlohmann::json;
-
 namespace facebook::presto {
 
 /// This is the interface of the session property.
@@ -39,15 +37,15 @@ class SessionProperty {
         veloxConfig_(veloxConfig),
         value_(defaultValue) {}
 
-  const protocol::SessionPropertyMetadata getMetadata() {
+  const protocol::SessionPropertyMetadata& getMetadata() const {
     return metadata_;
   }
 
-  const std::optional<std::string> getVeloxConfig() {
+  const std::optional<std::string>& getVeloxConfig() const {
     return veloxConfig_;
   }
 
-  const std::string getValue() {
+  const std::string& getValue() const {
     return value_;
   }
 
@@ -83,7 +81,7 @@ class SessionPropertiesProvider {
   const std::string toVeloxConfig(const std::string& name) const;
 
   /// Serialize all properties to JSON.
-  json serialize() const;
+  nlohmann::json serialize() const;
 
   /// Check if a property has a corresponding Velox config.
   inline bool hasVeloxConfig(const std::string& key) {

--- a/presto-native-execution/presto_cpp/presto_protocol/core/DataSize.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/core/DataSize.cpp
@@ -13,7 +13,7 @@
  */
 #include "presto_cpp/presto_protocol/core/DataSize.h"
 #include <fmt/format.h>
-#include <math.h>
+#include <cmath>
 
 namespace facebook::presto::protocol {
 


### PR DESCRIPTION
Summary:

Fix low-severity issues found during code review:

1. **Remove UB forward declaration of std::exception** (Exception.h): Forward-declaring types in namespace std is undefined behavior per the C++ standard. Replaced with proper #include <exception> and fixed include ordering.

2. **Fix const return values preventing move semantics** (Utils.h/cpp): getFunctionNameParts() returned const std::vector by value, preventing move semantics. Removed the const qualifier.

3. **Fix <math.h> -> <cmath>** (DataSize.cpp): C++ code should use <cmath> instead of <math.h> to keep names in the std namespace.

4. **Fix copy-paste bug in session property description** (SessionProperties.cpp): kUnnestSplitOutput had the description from kStreamingAggregationMinOutputBatchRows. Updated to correct description.

5. **Add const qualifiers to SessionProperty getters** (SessionPropertiesProvider.h): getMetadata(), getVeloxConfig(), and getValue() were non-const methods that don't modify the object. Changed to const methods returning by const reference.

6. **Remove using-declaration from header** (SessionPropertiesProvider.h): Removed using json = nlohmann::json from header to avoid namespace pollution. Used nlohmann::json directly in the header and moved the alias into the .cpp file.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Address minor correctness and style issues across native execution, including session property handling, exception declarations, and utility functions.

Bug Fixes:
- Correct the description text for the kUnnestSplitOutput session property.
- Remove undefined-behavior-inducing forward declaration of std::exception in the exception helper header.
- Allow move semantics for getFunctionNameParts() by returning a non-const std::vector by value.

Enhancements:
- Make SessionProperty accessors const and return values by const reference to better reflect immutability and avoid unnecessary copies.
- Replace <math.h> with <cmath> in DataSize to use the C++-standard math header.
- Eliminate a JSON using-alias from a public header and use fully qualified nlohmann::json there, moving the alias into the implementation file.