### PR TITLE
fix(testing): Fix TPC-H native-execution tests to use the right storage format and standard queries

### DIFF
--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeHiveExternalTableTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeHiveExternalTableTpchQueries.java
@@ -57,6 +57,12 @@ public abstract class AbstractTestNativeHiveExternalTableTpchQueries
             "customer", "part", "partsupp", "region", "supplier");
 
     @Override
+    protected String getStorageFormat()
+    {
+        return "DWRF";
+    }
+
+    @Override
     public Session getSession()
     {
         return Session.builder(super.getSession()).setCatalog(HIVE).setSchema(TPCH_EXTERNAL_SCHEMA).build();

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeIcebergTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeIcebergTpchQueries.java
@@ -16,7 +16,7 @@ package com.facebook.presto.nativeworker;
 import com.facebook.presto.testing.QueryRunner;
 
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createCustomer;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitemStandard;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitemWithNativeDate;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNationWithFormat;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
 import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPart;
@@ -27,14 +27,22 @@ import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createSupp
 public abstract class AbstractTestNativeIcebergTpchQueries
         extends AbstractTestNativeTpchQueries
 {
-    String storageFormat = "PARQUET";
+    @Override
+    protected String getStorageFormat()
+    {
+        return "PARQUET";
+    }
+
     @Override
     protected void createTables()
     {
         QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
-        createLineitemStandard(queryRunner);
-        createOrders(queryRunner);
-        createNationWithFormat(queryRunner, storageFormat);
+        // createLineitemWithNativeDate uses standard TPC-H columns with native
+        // DATE, omitting the SMALLINT/TINYINT derived columns from createLineitem()
+        // that Iceberg cannot write (ShortArrayBlock/ByteArrayBlock crash).
+        createLineitemWithNativeDate(queryRunner);
+        createOrders(queryRunner, getStorageFormat());
+        createNationWithFormat(queryRunner, getStorageFormat());
         createCustomer(queryRunner);
         createPart(queryRunner);
         createPartSupp(queryRunner);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/AbstractTestNativeTpchQueries.java
@@ -21,46 +21,36 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createBucketedCustomer;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createBucketedLineitemAndOrders;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createCustomer;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createLineitem;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createNation;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrders;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersEx;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createOrdersHll;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPart;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createPartSupp;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createRegion;
-import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createSupplier;
+import static com.facebook.presto.nativeworker.NativeQueryRunnerUtils.createAllTables;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class AbstractTestNativeTpchQueries
         extends AbstractTestQueryFramework
 {
+    /// Returns the storage format used by this test class (e.g. "DWRF", "ORC", "PARQUET").
+    protected abstract String getStorageFormat();
+
     @Override
     protected void createTables()
     {
-        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
-        createLineitem(queryRunner);
-        createBucketedLineitemAndOrders(queryRunner);
-        createOrders(queryRunner);
-        createOrdersEx(queryRunner);
-        createOrdersHll(queryRunner);
-        createNation(queryRunner);
-        createCustomer(queryRunner);
-        createBucketedCustomer(queryRunner);
-        createPart(queryRunner);
-        createPartSupp(queryRunner);
-        createRegion(queryRunner);
-        createSupplier(queryRunner);
+        createAllTables((QueryRunner) getExpectedQueryRunner(), getStorageFormat());
     }
 
-    private static String getTpchQuery(int q)
+    protected String getTpchQuery(int q)
             throws IOException
     {
         String sql = Resources.toString(Resources.getResource("tpch/queries/q" + q + ".sql"), UTF_8);
         sql = sql.replaceFirst("(?m);$", "");
+        // Resolve ${col} placeholders: DWRF and ORC store date columns as VARCHAR,
+        // so they need cast(col as date) for date comparisons; PARQUET stores them
+        // as native DATE, so the column reference is used directly.
+        String format = getStorageFormat();
+        if (format.equals("DWRF") || format.equals("ORC")) {
+            sql = sql.replaceAll("\\$\\{([^}]+)}", "cast($1 as date)");
+        }
+        else {
+            sql = sql.replaceAll("\\$\\{([^}]+)}", "$1");
+        }
         return sql;
     }
 

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/NativeQueryRunnerUtils.java
@@ -140,6 +140,21 @@ public class NativeQueryRunnerUtils
                 "FROM tpch.tiny.lineitem");
     }
 
+    /// Creates a lineitem table with only the standard TPC-H columns and
+    /// native DATE types.  Unlike {@link #createLineitem}, this omits the extra
+    /// derived columns (is_open, is_returned, tax_as_real, discount_as_real,
+    /// linenumber_as_smallint, linenumber_as_tinyint) that are incompatible
+    /// with Iceberg (which has no SMALLINT/TINYINT types).
+    public static void createLineitemWithNativeDate(QueryRunner queryRunner)
+    {
+        queryRunner.execute("DROP TABLE IF EXISTS lineitem");
+        queryRunner.execute("CREATE TABLE lineitem AS " +
+                "SELECT orderkey, partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, " +
+                "   returnflag, linestatus, shipdate, commitdate, receiptdate, " +
+                "   shipinstruct, shipmode, comment " +
+                "FROM tpch.tiny.lineitem");
+    }
+
     public static void createLineitemStandard(QueryRunner queryRunner)
     {
         createLineitemStandard(queryRunner.getDefaultSession(), queryRunner);

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpchQueriesOrcUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpchQueriesOrcUsingThrift.java
@@ -22,6 +22,12 @@ public class TestPrestoNativeIcebergTpchQueriesOrcUsingThrift
     private final String storageFormat = "ORC";
 
     @Override
+    protected String getStorageFormat()
+    {
+        return storageFormat;
+    }
+
+    @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpchQueriesParquetUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeIcebergTpchQueriesParquetUsingThrift.java
@@ -19,13 +19,11 @@ import com.facebook.presto.testing.QueryRunner;
 public class TestPrestoNativeIcebergTpchQueriesParquetUsingThrift
         extends AbstractTestNativeIcebergTpchQueries
 {
-    private final String storageFormat = "PARQUET";
-
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.nativeIcebergQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setUseThrift(true)
                 .build();
     }
@@ -34,7 +32,7 @@ public class TestPrestoNativeIcebergTpchQueriesParquetUsingThrift
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.javaIcebergQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .build();
     }
 }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesDwrfUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesDwrfUsingThrift.java
@@ -19,13 +19,17 @@ import com.facebook.presto.testing.QueryRunner;
 public class TestPrestoNativeTpchQueriesDwrfUsingThrift
         extends AbstractTestNativeTpchQueries
 {
-    private final String storageFormat = "DWRF";
+    @Override
+    protected String getStorageFormat()
+    {
+        return "DWRF";
+    }
 
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .setUseThrift(true)
                 .build();
@@ -35,7 +39,7 @@ public class TestPrestoNativeTpchQueriesDwrfUsingThrift
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesOrcUsingJSON.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesOrcUsingJSON.java
@@ -21,13 +21,17 @@ import org.testng.annotations.Test;
 public class TestPrestoNativeTpchQueriesOrcUsingJSON
         extends AbstractTestNativeTpchQueries
 {
-    private final String storageFormat = "ORC";
+    @Override
+    protected String getStorageFormat()
+    {
+        return "ORC";
+    }
 
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }
@@ -36,7 +40,7 @@ public class TestPrestoNativeTpchQueriesOrcUsingJSON
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesOrcUsingThrift.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesOrcUsingThrift.java
@@ -19,13 +19,17 @@ import com.facebook.presto.testing.QueryRunner;
 public class TestPrestoNativeTpchQueriesOrcUsingThrift
         extends AbstractTestNativeTpchQueries
 {
-    private final String storageFormat = "ORC";
+    @Override
+    protected String getStorageFormat()
+    {
+        return "ORC";
+    }
 
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .setUseThrift(true)
                 .build();
@@ -35,7 +39,7 @@ public class TestPrestoNativeTpchQueriesOrcUsingThrift
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesParquetUsingJSON.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/nativeworker/TestPrestoNativeTpchQueriesParquetUsingJSON.java
@@ -21,13 +21,17 @@ import org.testng.annotations.Test;
 public class TestPrestoNativeTpchQueriesParquetUsingJSON
         extends AbstractTestNativeTpchQueries
 {
-    private final String storageFormat = "PARQUET";
+    @Override
+    protected String getStorageFormat()
+    {
+        return "PARQUET";
+    }
 
     @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }
@@ -36,7 +40,7 @@ public class TestPrestoNativeTpchQueriesParquetUsingJSON
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }

--- a/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
+++ b/presto-native-execution/src/test/java/com/facebook/presto/spark/TestPrestoSparkNativeTpchQueries.java
@@ -21,6 +21,12 @@ public class TestPrestoSparkNativeTpchQueries
         extends AbstractTestNativeTpchQueries
 {
     @Override
+    protected String getStorageFormat()
+    {
+        return "DWRF";
+    }
+
+    @Override
     protected QueryRunner createQueryRunner()
     {
         return PrestoSparkNativeQueryRunnerUtils.createHiveRunner();

--- a/presto-native-execution/src/test/resources/tpch/queries/q1.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q1.sql
@@ -1,7 +1,6 @@
 -- TPC-H/TPC-R Pricing Summary Report Query (Q1)
 -- Functional Query Definition
 -- Approved February 1998
--- Fixed shipdate predicate as DWRF doesn't support DATE types
 select
 	returnflag,
 	linestatus,
@@ -16,8 +15,8 @@ select
 from
 	lineitem
 where
-    cast(shipdate as date) >= date '1998-12-01' - interval '90' day
-    and shipdate <= '1998-12-01'
+	${shipdate} >= date '1998-12-01' - interval '90' day
+	and ${shipdate} <= date '1998-12-01'
 group by
 	returnflag,
 	linestatus

--- a/presto-native-execution/src/test/resources/tpch/queries/q10.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q10.sql
@@ -18,8 +18,8 @@ from
 where
 	c.custkey = o.custkey
 	and l.orderkey = o.orderkey
-	and o.orderdate >= '1993-10-01'
-	and cast(o.orderdate as date) < date '1993-10-01' + interval '3' month
+	and ${o.orderdate} >= date '1993-10-01'
+	and ${o.orderdate} < date '1993-10-01' + interval '3' month
 	and l.returnflag = 'R'
 	and c.nationkey = n.nationkey
 group by

--- a/presto-native-execution/src/test/resources/tpch/queries/q12.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q12.sql
@@ -23,8 +23,8 @@ where
 	and l.shipmode in ('MAIL', 'SHIP')
 	and l.commitdate < l.receiptdate
 	and l.shipdate < l.commitdate
-	and l.receiptdate >= '1994-01-01'
-	and cast(l.receiptdate as date) < date '1994-01-01' + interval '1' year
+	and ${l.receiptdate} >= date '1994-01-01'
+	and ${l.receiptdate} < date '1994-01-01' + interval '1' year
 group by
 	l.shipmode
 order by

--- a/presto-native-execution/src/test/resources/tpch/queries/q14.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q14.sql
@@ -12,5 +12,5 @@ from
 	part as p
 where
 	l.partkey = p.partkey
-	and l.shipdate >= '1995-09-01'
-	and cast(l.shipdate as date) < date '1995-09-01' + interval '1' month;
+	and ${l.shipdate} >= date '1995-09-01'
+	and ${l.shipdate} < date '1995-09-01' + interval '1' month;

--- a/presto-native-execution/src/test/resources/tpch/queries/q15.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q15.sql
@@ -4,13 +4,13 @@
 
 with revenue as (
 select
-    suppkey as supplier_no,
-    sum(extendedprice * (1 - discount)) as total_revenue
+	suppkey as supplier_no,
+	sum(extendedprice * (1 - discount)) as total_revenue
 from
-    lineitem
+	lineitem
 where
-    shipdate >= '1996-01-01'
-    and cast(shipdate as date) < date '1996-01-01' + interval '3' month
+	${shipdate} >= date '1996-01-01'
+	and ${shipdate} < date '1996-01-01' + interval '3' month
 group by suppkey
 )
 

--- a/presto-native-execution/src/test/resources/tpch/queries/q20.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q20.sql
@@ -10,7 +10,7 @@ from
 where
 	s.suppkey in (
 		select
-            ps.suppkey
+			ps.suppkey
 		from
 			partsupp as ps
 		where
@@ -30,8 +30,8 @@ where
 				where
 					l.partkey = ps.partkey
 					and l.suppkey = ps.suppkey
-					and l.shipdate >= '1994-01-01'
-					and cast(l.shipdate as date) < date('1994-01-01') + interval '1' year
+					and ${l.shipdate} >= date '1994-01-01'
+					and ${l.shipdate} < date '1994-01-01' + interval '1' year
 			)
 	)
 	and s.nationkey = n.nationkey

--- a/presto-native-execution/src/test/resources/tpch/queries/q3.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q3.sql
@@ -14,8 +14,8 @@ where
 	c.mktsegment = 'BUILDING'
 	and c.custkey = o.custkey
 	and l.orderkey = o.orderkey
-	and o.orderdate < '1995-03-15'
-	and l.shipdate > '1995-03-15'
+	and ${o.orderdate} < date '1995-03-15'
+	and ${l.shipdate} > date '1995-03-15'
 group by
 	l.orderkey,
 	o.orderdate,

--- a/presto-native-execution/src/test/resources/tpch/queries/q4.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q4.sql
@@ -7,8 +7,8 @@ select
 from
 	orders as o
 where
-	o.orderdate >= '1993-07-01'
-	and cast(o.orderdate as date) < date '1993-07-01' + interval '3' month
+	${o.orderdate} >= date '1993-07-01'
+	and ${o.orderdate} < date '1993-07-01' + interval '3' month
 	and exists (
 		select
 			*

--- a/presto-native-execution/src/test/resources/tpch/queries/q5.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q5.sql
@@ -19,8 +19,8 @@ where
 	and s.nationkey = n.nationkey
 	and n.regionkey = r.regionkey
 	and r.name = 'ASIA'
-        and o.orderdate >= '1994-01-01'
-        and cast(o.orderdate as date) < date '1994-01-01' + interval '1' year
+	and ${o.orderdate} >= date '1994-01-01'
+	and ${o.orderdate} < date '1994-01-01' + interval '1' year
 group by
 	n.name
 order by

--- a/presto-native-execution/src/test/resources/tpch/queries/q6.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q6.sql
@@ -6,7 +6,7 @@ select
 from
 	lineitem
 where
-	shipdate >= '1994-01-01'
-        and cast(shipdate as date) < date '1994-01-01' + interval '1' year
-        and discount between decimal '0.06' - decimal '0.01' and decimal '0.06' + decimal '0.01'
+	${shipdate} >= date '1994-01-01'
+	and ${shipdate} < date '1994-01-01' + interval '1' year
+	and discount between decimal '0.06' - decimal '0.01' and decimal '0.06' + decimal '0.01'
 	and quantity < 24;

--- a/presto-native-execution/src/test/resources/tpch/queries/q7.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q7.sql
@@ -30,7 +30,7 @@ from
 				(n1.name = 'FRANCE' and n2.name = 'GERMANY')
 				or (n1.name = 'GERMANY' and n2.name = 'FRANCE')
 			)
-			and l.shipdate between '1995-01-01' and '1996-12-31'
+			and ${l.shipdate} between date '1995-01-01' and date '1996-12-31'
 	) as shipping
 group by
 	supp_nation,

--- a/presto-native-execution/src/test/resources/tpch/queries/q8.sql
+++ b/presto-native-execution/src/test/resources/tpch/queries/q8.sql
@@ -31,7 +31,7 @@ from
 			and n1.regionkey = r.regionkey
 			and r.name = 'AMERICA'
 			and s.nationkey = n2.nationkey
-			and o.orderdate between '1995-01-01' and '1996-12-31'
+			and ${o.orderdate} between date '1995-01-01' and date '1996-12-31'
 			and p.type = 'ECONOMY ANODIZED STEEL'
 	) as all_nations
 group by

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestTextReaderWithTpchQueriesUsingJSON.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestTextReaderWithTpchQueriesUsingJSON.java
@@ -24,10 +24,22 @@ public class TestTextReaderWithTpchQueriesUsingJSON
     private static final String TEXTFILE = "TEXTFILE";
 
     @Override
+    protected String getStorageFormat()
+    {
+        return TEXTFILE;
+    }
+
+    @Override
+    protected void createTables()
+    {
+        NativeTestsUtils.createTables(getStorageFormat());
+    }
+
+    @Override
     protected QueryRunner createQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
-                .setStorageFormat(TEXTFILE)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }
@@ -36,7 +48,7 @@ public class TestTextReaderWithTpchQueriesUsingJSON
     protected ExpectedQueryRunner createExpectedQueryRunner() throws Exception
     {
         return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
-                .setStorageFormat(TEXTFILE)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/cudf/TestCudfTpchQueries.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/cudf/TestCudfTpchQueries.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.nativetests.cudf;
 
+import com.facebook.presto.nativetests.NativeTestsUtils;
 import com.facebook.presto.nativeworker.AbstractTestNativeTpchQueries;
 import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
 import com.facebook.presto.testing.ExpectedQueryRunner;
@@ -24,12 +25,23 @@ public class TestCudfTpchQueries
     private static final String DEFAULT_STORAGE_FORMAT = "PARQUET";
 
     @Override
+    protected String getStorageFormat()
+    {
+        return System.getProperty("storageFormat", DEFAULT_STORAGE_FORMAT);
+    }
+
+    @Override
+    protected void createTables()
+    {
+        NativeTestsUtils.createTables(getStorageFormat());
+    }
+
+    @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        String storageFormat = System.getProperty("storageFormat", DEFAULT_STORAGE_FORMAT);
         return PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .setCoordinatorSidecarEnabled(false)
                 .setEnableCudf(true)
@@ -40,9 +52,8 @@ public class TestCudfTpchQueries
     protected ExpectedQueryRunner createExpectedQueryRunner()
             throws Exception
     {
-        String storageFormat = System.getProperty("storageFormat", DEFAULT_STORAGE_FORMAT);
         return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
-                .setStorageFormat(storageFormat)
+                .setStorageFormat(getStorageFormat())
                 .setAddStorageFormatToPath(true)
                 .build();
     }


### PR DESCRIPTION
## Description
This PR refactors the TPC-H query test infrastructure for Presto Native execution to correctly support different storage formats. 

Previously, some tests such as `TestPrestoNativeTpchQueriesParquetUsingJSON` and `TestCudfTpchQueries` were inadvertently testing `DWRF` files due to hardcoded table creation logic inherited from the base class. This change ensures that the table creation lifecycle respects the targeted storage format, so Parquet tests correctly instantiate and query Parquet files.

Additionally, the TPC-H SQL query files have been updated to align cleanly with the standard TPC-H benchmark. The query templates are now format-aware; workarounds for specific format limitations (such as casting string literals to dates for formats that store dates as `VARCHAR`) are applied dynamically at runtime only when necessary. This allows formats with native date types, like Parquet, to be queried directly using standard TPC-H SQL syntax.

## Motivation and Context
Testing Parquet logic against DWRF data undermined the purpose of the format-specific test suites. This fix restores the correct behavior and ensures test coverage metrics for Native execution readers (like Parquet) are valid. Furthermore, maintaining standard TPC-H queries ensures our benchmarks and integration tests remain accurate and comparable to the specification.

## Impact
- **Bug Fix:** TPC-H tests for Parquet now correctly generate, load, and query Parquet data.
- **Test Integrity:** TPC-H query files are restored to their standard representation.
- **Maintainability:** The native test infrastructure natively supports multiple storage formats in a truly format-aware manner.

## Test Plan
- Verified that `TestPrestoNativeTpchQueriesParquetUsingJSON` and `TestCudfTpchQueries` correctly execute and pass on Parquet data.
- Verified all 22 TPC-H queries run successfully across various DWRF, ORC, and Parquet native test suites without regressions.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [x] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Refactor native TPC-H test infrastructure to be storage-format aware and to use standard TPC-H SQL while dynamically handling date column differences across formats.

Bug Fixes:
- Ensure Parquet-native TPC-H tests generate and query data in the correct Parquet storage format instead of inadvertently using DWRF.

Enhancements:
- Centralize TPC-H table creation for native tests so that all suites derive their schema from a single format-aware helper based on the declared storage format.
- Make TPC-H query loading in native tests apply format-specific substitutions for date columns, allowing a single canonical SQL definition to work across DWRF, ORC, Parquet, and text formats.
- Define explicit storage formats for native TPC-H test subclasses (including Hive external, Iceberg, Spark, CUDF, and text reader tests) via an overridable accessor to keep configuration consistent.

Tests:
- Update TPC-H SQL resource files to use placeholders for date predicates, restoring them to spec-like syntax while supporting dynamic resolution per storage format.

## Summary by Sourcery

Refactor native TPC-H test infrastructure to be storage-format aware so that each suite creates and queries data using its declared format while keeping queries close to the TPC-H spec.

Bug Fixes:
- Ensure Parquet-native and other format-specific TPC-H tests generate and read data in the correct storage format instead of defaulting to DWRF.

Enhancements:
- Centralize native TPC-H table creation behind a format-aware helper and expose a storage-format accessor on abstract test classes used by Hive, Iceberg, Spark, CUDF, and text reader tests.
- Make TPC-H query loading perform format-dependent substitution for date columns, allowing canonical SQL files with placeholders to work across formats that store dates as VARCHAR or native DATE types.
- Adjust Iceberg lineitem table creation to use only standard TPC-H columns with native DATE types, avoiding unsupported smallint/tinyint-derived columns.

Tests:
- Update TPC-H SQL resource files to use date column placeholders instead of hard-coded casts, preserving standard query semantics while enabling dynamic resolution per storage format.