### PR TITLE
chore(deps): Bump org.apache.logging.log4j:log4j-core from 2.25.3 to 2.25.4

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -17,7 +17,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.accumulo.version>1.10.1</dep.accumulo.version>
         <dep.curator.version>2.12.0</dep.curator.version>
-        <dep.log4j.version>2.25.3</dep.log4j.version>
+        <dep.log4j.version>2.25.4</dep.log4j.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
 

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.log4j.version>2.25.3</dep.log4j.version>
+        <dep.log4j.version>2.25.4</dep.log4j.version>
         <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
     </properties>
@@ -139,6 +139,10 @@
                     <artifactId>log4j-jul</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
@@ -228,6 +232,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jul</artifactId>
+            <version>${dep.log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${dep.log4j.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.elasticsearch.version>7.17.27</dep.elasticsearch.version>
-        <dep.log4j.version>2.25.3</dep.log4j.version>
+        <dep.log4j.version>2.25.4</dep.log4j.version>
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <dep.lucene.version>8.11.3</dep.lucene.version>
     </properties>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -20,7 +20,7 @@
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.fastutil.version>8.5.15</dep.fastutil.version>
         <dep.datasketches-memory.version>3.0.2</dep.datasketches-memory.version>
-        <dep.log4j.version>2.25.3</dep.log4j.version>
+        <dep.log4j.version>2.25.4</dep.log4j.version>
     </properties>
 
     <dependencyManagement>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -19,7 +19,7 @@
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.datasketches-java.version>6.1.1</dep.datasketches-java.version>
         <dep.datasketches-memory.version>3.0.2</dep.datasketches-memory.version>
-        <dep.log4j.version>2.25.3</dep.log4j.version>
+        <dep.log4j.version>2.25.4</dep.log4j.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Bumps org.apache.logging.log4j:log4j-core from 2.25.3 to 2.25.4.

Additionally, added log4j-slf4j2-impl as a runtime dependency in the Druid module to ensure consistent Log4j versions across Presto.


Reason:

The transitive dependency from druid-processing was pulling in
log4j-slf4j2-impl:2.22.1, which resulted in a version mismatch with the
updated Log4j APIs (2.25.4).

Dependency tree before:
<img width="792" height="413" alt="Screenshot 2026-04-14 at 12 19 13 PM" src="https://github.com/user-attachments/assets/8604ccd4-64b8-4f2b-afa6-2462642c59df" />

Dependency tree after:

<img width="792" height="413" alt="Screenshot 2026-04-14 at 12 18 30 PM" src="https://github.com/user-attachments/assets/b413f10a-e7e1-4899-b5fb-afbd41a13bd9" />


## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->
Druid connector is tested locally and the test result is attatched below:
<img width="1496" height="575" alt="Screenshot 2026-04-14 at 2 51 59 PM" src="https://github.com/user-attachments/assets/89623dfe-5c64-4923-a541-8a4ebca2f70f" />


## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

Security Changes
* Upgrade org.apache.logging.log4j:log4j-core from 2.25.3 to 2.25.4 inorder to address `CVE-2026-34480 <https://nvd.nist.gov/vuln/detail/CVE-2026-34480>`_. 

```