### PR TITLE
refactor(plugin-iceberg): Defer the start of transaction for procedure

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -1479,7 +1479,7 @@ public abstract class IcebergAbstractMetadata
                         procedureName.getSchemaName(),
                         procedureName.getObjectName()));
         verify(procedure instanceof DistributedProcedure, "procedure must be DistributedProcedure");
-        verify(procedureContext.compareAndSet(null, (IcebergCommonProcedureContext) ((DistributedProcedure) procedure).createContext(icebergTable, icebergTable.newTransaction(), arguments)),
+        verify(procedureContext.compareAndSet(null, (IcebergCommonProcedureContext) ((DistributedProcedure) procedure).createContext(icebergTable, this, arguments)),
                 "procedure context must not be present");
         return ((DistributedProcedure) procedure).begin(session, procedureContext.get(), tableLayoutHandle, arguments);
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/RewriteDataFilesProcedure.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.iceberg.CommitTaskData;
+import com.facebook.presto.iceberg.IcebergAbstractMetadata;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.iceberg.IcebergDistributedProcedureHandle;
 import com.facebook.presto.iceberg.IcebergTableHandle;
@@ -47,7 +48,6 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
-import org.apache.iceberg.Transaction;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Type;
 
@@ -118,12 +118,12 @@ public class RewriteDataFilesProcedure
                 arguments -> {
                     // Context provider receives [Table, Transaction, procedureArguments]
                     checkArgument(arguments.length >= 2, format("invalid number of arguments: %s (should have at least %s)", arguments.length, 2));
-                    checkArgument(arguments[0] instanceof Table && arguments[1] instanceof Transaction, "Invalid arguments, required: [Table, Transaction]");
+                    checkArgument(arguments[0] instanceof Table && arguments[1] instanceof IcebergAbstractMetadata, "Invalid arguments, required: [Table, IcebergAbstractMetadata]");
 
                     // Extract and validate options from procedure arguments if present
                     Map<String, String> options = extractAndValidateOptions(arguments);
 
-                    return new IcebergRewriteDataFilesProcedureContext((Table) arguments[0], (Transaction) arguments[1], options);
+                    return new IcebergRewriteDataFilesProcedureContext((Table) arguments[0], (IcebergAbstractMetadata) arguments[1], options);
                 });
     }
 
@@ -199,7 +199,7 @@ public class RewriteDataFilesProcedure
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
             IcebergDistributedProcedureHandle handle = (IcebergDistributedProcedureHandle) procedureHandle;
-            Table icebergTable = procedureContext.getTransaction().table();
+            Table icebergTable = procedureContext.getTable();
 
             List<CommitTaskData> commitTasks = fragments.stream()
                     .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
@@ -269,7 +269,7 @@ public class RewriteDataFilesProcedure
                 return;
             }
 
-            RewriteFiles rewriteFiles = procedureContext.getTransaction().newRewrite()
+            RewriteFiles rewriteFiles = icebergTable.newRewrite()
                     .rewriteFiles(scannedDataFiles, fullyAppliedDeleteFiles, newFiles, ImmutableSet.of());
 
             // Table.snapshot method returns null if there is no matching snapshot

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/context/IcebergRewriteDataFilesProcedureContext.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/procedure/context/IcebergRewriteDataFilesProcedureContext.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.iceberg.procedure.context;
 
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.iceberg.IcebergAbstractMetadata;
 import com.facebook.presto.iceberg.IcebergColumnHandle;
 import com.facebook.presto.iceberg.IcebergSplitSource;
 import com.facebook.presto.iceberg.procedure.splits.RewriteDataFilesIcebergSplitSource;
@@ -21,7 +22,6 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
-import org.apache.iceberg.Transaction;
 
 import java.util.Map;
 import java.util.Optional;
@@ -32,18 +32,18 @@ public class IcebergRewriteDataFilesProcedureContext
         implements IcebergCommonProcedureContext
 {
     final Table table;
-    final Transaction transaction;
+    final IcebergAbstractMetadata metadata;
     final Map<String, String> options;
 
-    public IcebergRewriteDataFilesProcedureContext(Table table, Transaction transaction)
+    public IcebergRewriteDataFilesProcedureContext(Table table, IcebergAbstractMetadata metadata)
     {
-        this(table, transaction, ImmutableMap.of());
+        this(table, metadata, ImmutableMap.of());
     }
 
-    public IcebergRewriteDataFilesProcedureContext(Table table, Transaction transaction, Map<String, String> options)
+    public IcebergRewriteDataFilesProcedureContext(Table table, IcebergAbstractMetadata metadata, Map<String, String> options)
     {
         this.table = requireNonNull(table, "table is null");
-        this.transaction = requireNonNull(transaction, "transaction is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
         this.options = ImmutableMap.copyOf(requireNonNull(options, "options is null"));
     }
 
@@ -52,9 +52,9 @@ public class IcebergRewriteDataFilesProcedureContext
         return table;
     }
 
-    public Transaction getTransaction()
+    public IcebergAbstractMetadata getMetadata()
     {
-        return transaction;
+        return metadata;
     }
 
     public Map<String, String> getOptions()


### PR DESCRIPTION
## Description

This PR defers the start of transaction for distributed procedure in Iceberg connector.

This way, the distributed procedure can decide for itself which table's transaction to start. In some scenarios, the specific procedure may want to start and write to a target table that is not necessarily the one specified by the first two parameters (which might only serve as a source table, or a materialized view).

## Motivation and Context

Make the distributed procedure more generic in Iceberg.

## Impact

N/A

## Test Plan

Make sure the change do not affect any existing tests.

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Defer starting Iceberg table transactions for distributed procedures by passing connector metadata instead of an already-started transaction into the rewrite-data-files procedure context.

Enhancements:
- Refactor the Iceberg rewrite-data-files procedure context to carry IcebergAbstractMetadata instead of a pre-created Transaction.
- Update the distributed procedure initiation flow to let procedures decide when and how to create table transactions rather than starting them in beginCallDistributedProcedure.