### PR TITLE
feat: Reject duplicate columns in CREATE VECTOR INDEX

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1180,6 +1180,14 @@ class StatementAnalyzer
             Table sourceTable = new Table(node.getTableName());
             Scope tableScope = analyzer.analyze(sourceTable, scope);
 
+            // Check for duplicate columns
+            Set<String> seenColumns = new HashSet<>();
+            for (Identifier column : node.getColumns()) {
+                if (!seenColumns.add(column.getValue())) {
+                    throw new SemanticException(DUPLICATE_COLUMN_NAME, column, "Column name '%s' specified more than once", column.getValue());
+                }
+            }
+
             // Validate that specified columns exist in the source table
             TableHandle sourceTableHandle = session.getRuntimeStats().recordWallTime(
                     RuntimeMetricName.GET_TABLE_HANDLE_TIME_NANOS,

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -2403,6 +2403,10 @@ public class TestAnalyzer
         assertFails(MISSING_COLUMN, ".*Column 'nonexistent' does not exist in source table '.*'",
                 "CREATE VECTOR INDEX test_index ON t1(nonexistent)");
 
+        // duplicate columns
+        assertFails(DUPLICATE_COLUMN_NAME, ".*Column name 'a' specified more than once",
+                "CREATE VECTOR INDEX test_index ON t1(a, a)");
+
         // duplicate properties
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1",
                 "CREATE VECTOR INDEX test_index ON t1(a, b) WITH (p1 = 'v1', p2 = 'v2', p1 = 'v3')");


### PR DESCRIPTION
Summary:
`CREATE VECTOR INDEX idx ON table(id, id)` was silently accepted but
caused a confusing `FUNCTION_NOT_FOUND` error. The `LinkedHashSet` in
LogicalPlanner deduplicated to one scan variable, but `indexColumnNames`
retained both entries, causing `lookupFunction("create_vector_index",
bigint, bigint)` which has no matching overload.

Add duplicate column check in StatementAnalyzer.visitCreateVectorIndex()
that rejects duplicates with a clear `DUPLICATE_COLUMN_NAME` error,
consistent with 7 other duplicate column checks in the same file.

Differential Revision: D99786965

## Summary by Sourcery

Reject CREATE VECTOR INDEX statements that specify the same column multiple times and add coverage for this behavior.

Bug Fixes:
- Return a DUPLICATE_COLUMN_NAME semantic error when CREATE VECTOR INDEX is defined with duplicate columns instead of allowing it and failing later with a generic function error.

Tests:
- Add analyzer tests asserting that CREATE VECTOR INDEX with duplicate columns fails with DUPLICATE_COLUMN_NAME.

## Release Notes
```
== NO RELEASE NOTE ==
```