### PR TITLE
feat: Validate embedding column type in CREATE VECTOR INDEX

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1180,6 +1180,14 @@ class StatementAnalyzer
             Table sourceTable = new Table(node.getTableName());
             Scope tableScope = analyzer.analyze(sourceTable, scope);
 
+            // Check for duplicate columns
+            Set<String> seenColumns = new HashSet<>();
+            for (Identifier column : node.getColumns()) {
+                if (!seenColumns.add(column.getValue())) {
+                    throw new SemanticException(DUPLICATE_COLUMN_NAME, column, "Column name '%s' specified more than once", column.getValue());
+                }
+            }
+
             // Validate that specified columns exist in the source table
             TableHandle sourceTableHandle = session.getRuntimeStats().recordWallTime(
                     RuntimeMetricName.GET_TABLE_HANDLE_TIME_NANOS,

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1201,6 +1201,23 @@ class StatementAnalyzer
                 }
             }
 
+            // Validate that the last column (embedding column) is array(real) or array(double)
+            Identifier embeddingColumn = node.getColumns().get(node.getColumns().size() - 1);
+            String embeddingColumnName = embeddingColumn.getValue();
+            Type embeddingType = metadataResolver.getColumns(sourceTableHandle).stream()
+                    .filter(col -> col.getName().equals(embeddingColumnName))
+                    .findFirst()
+                    .orElseThrow(() -> new SemanticException(MISSING_COLUMN, embeddingColumn,
+                            "Column '%s' does not exist in source table '%s'", embeddingColumnName, sourceTableName))
+                    .getType();
+            if (!(embeddingType instanceof ArrayType)
+                    || (!(((ArrayType) embeddingType).getElementType() instanceof RealType)
+                    && !(((ArrayType) embeddingType).getElementType() instanceof DoubleType))) {
+                throw new SemanticException(TYPE_MISMATCH, embeddingColumn,
+                        "Embedding column '%s' must be of type array(real) or array(double), but was %s",
+                        embeddingColumnName, embeddingType);
+            }
+
             // Analyze UPDATING FOR predicate (validates column references, types, etc.)
             node.getUpdatingFor().ifPresent(where -> analyzeWhere(node, tableScope, where));
 

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -362,6 +362,16 @@ public class AbstractAnalyzerTest
                         ColumnMetadata.builder().setName("z").setType(BIGINT).build())),
                 false));
 
+        // table with id and embedding columns for vector index tests
+        SchemaTableName table14 = new SchemaTableName("s1", "t14");
+        inSetupTransaction(session -> metadata.createTable(session, TPCH_CATALOG,
+                new ConnectorTableMetadata(table14, ImmutableList.of(
+                        ColumnMetadata.builder().setName("id").setType(BIGINT).build(),
+                        ColumnMetadata.builder().setName("embedding_real").setType(new ArrayType(RealType.REAL)).build(),
+                        ColumnMetadata.builder().setName("embedding_double").setType(new ArrayType(DOUBLE)).build(),
+                        ColumnMetadata.builder().setName("name").setType(VARCHAR).build())),
+                false));
+
         // materialized view referencing table in same schema
         List<SchemaTableName> baseTables = new ArrayList<>(Collections.singletonList(table2));
         MaterializedViewDefinition.TableColumn baseTableColumns = new MaterializedViewDefinition.TableColumn(table2, "a", true);

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -2378,47 +2378,55 @@ public class TestAnalyzer
     @Test
     public void testCreateVectorIndex()
     {
-        // basic success cases
-        analyze("CREATE VECTOR INDEX test_index ON t1(a, b)");
-        analyze("CREATE VECTOR INDEX test_index ON t1(a, b) WITH (p1 = 'val1')");
-        analyze("CREATE VECTOR INDEX test_index ON t1(a, b) WITH (p1 = 'val1', p2 = 'val2')");
+        // basic success cases — t14 has id:BIGINT, embedding_real:array(real), embedding_double:array(double), name:VARCHAR
+        analyze("CREATE VECTOR INDEX test_index ON t14(id, embedding_real)");
+        analyze("CREATE VECTOR INDEX test_index ON t14(id, embedding_double)");
+        analyze("CREATE VECTOR INDEX test_index ON t14(id, embedding_real) WITH (p1 = 'val1')");
+        analyze("CREATE VECTOR INDEX test_index ON t14(id, embedding_real) WITH (p1 = 'val1', p2 = 'val2')");
 
         // with UPDATING FOR clause
-        analyze("CREATE VECTOR INDEX test_index ON t1(a, b) UPDATING FOR a > 10");
-        analyze("CREATE VECTOR INDEX test_index ON t1(a, b) WITH (p1 = 'val1') UPDATING FOR a BETWEEN 1 AND 100");
+        analyze("CREATE VECTOR INDEX test_index ON t14(id, embedding_real) UPDATING FOR id > 10");
+        analyze("CREATE VECTOR INDEX test_index ON t14(id, embedding_real) WITH (p1 = 'val1') UPDATING FOR id BETWEEN 1 AND 100");
 
-        // single column
-        analyze("CREATE VECTOR INDEX test_index ON t1(a)");
+        // single column (embedding only)
+        analyze("CREATE VECTOR INDEX test_index ON t14(embedding_real)");
+        analyze("CREATE VECTOR INDEX test_index ON t14(embedding_double)");
 
         // source table does not exist
         assertFails(MISSING_TABLE, ".*Source table '.*' does not exist",
                 "CREATE VECTOR INDEX test_index ON nonexistent_table(a, b)");
 
         // destination table already exists — allowed (connector decides how to handle)
-        analyze("CREATE VECTOR INDEX t1 ON t2(a, b)");
+        analyze("CREATE VECTOR INDEX t1 ON t14(id, embedding_real)");
 
         // column does not exist in source table
         assertFails(MISSING_COLUMN, ".*Column 'unknown' does not exist in source table '.*'",
-                "CREATE VECTOR INDEX test_index ON t1(a, unknown)");
+                "CREATE VECTOR INDEX test_index ON t14(id, unknown)");
         assertFails(MISSING_COLUMN, ".*Column 'nonexistent' does not exist in source table '.*'",
-                "CREATE VECTOR INDEX test_index ON t1(nonexistent)");
+                "CREATE VECTOR INDEX test_index ON t14(nonexistent)");
 
         // duplicate columns
-        assertFails(DUPLICATE_COLUMN_NAME, ".*Column name 'a' specified more than once",
-                "CREATE VECTOR INDEX test_index ON t1(a, a)");
+        assertFails(DUPLICATE_COLUMN_NAME, ".*Column name 'id' specified more than once",
+                "CREATE VECTOR INDEX test_index ON t14(id, id)");
+
+        // embedding column type validation — last column must be array(real) or array(double)
+        assertFails(TYPE_MISMATCH, ".*Embedding column 'id' must be of type array\\(real\\) or array\\(double\\).*",
+                "CREATE VECTOR INDEX test_index ON t14(id)");
+        assertFails(TYPE_MISMATCH, ".*Embedding column 'name' must be of type array\\(real\\) or array\\(double\\).*",
+                "CREATE VECTOR INDEX test_index ON t14(id, name)");
 
         // duplicate properties
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1",
-                "CREATE VECTOR INDEX test_index ON t1(a, b) WITH (p1 = 'v1', p2 = 'v2', p1 = 'v3')");
+                "CREATE VECTOR INDEX test_index ON t14(id, embedding_real) WITH (p1 = 'v1', p2 = 'v2', p1 = 'v3')");
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1",
-                "CREATE VECTOR INDEX test_index ON t1(a, b) WITH (p1 = 'v1', \"p1\" = 'v2')");
+                "CREATE VECTOR INDEX test_index ON t14(id, embedding_real) WITH (p1 = 'v1', \"p1\" = 'v2')");
 
         // unresolved property value
         assertFails(MISSING_ATTRIBUTE, ".*'y' cannot be resolved",
-                "CREATE VECTOR INDEX test_index ON t1(a, b) WITH (p1 = y)");
+                "CREATE VECTOR INDEX test_index ON t14(id, embedding_real) WITH (p1 = y)");
 
         // UPDATING FOR with invalid column reference
         assertFails(MISSING_ATTRIBUTE, ".*",
-                "CREATE VECTOR INDEX test_index ON t1(a, b) UPDATING FOR nonexistent_col > 10");
+                "CREATE VECTOR INDEX test_index ON t14(id, embedding_real) UPDATING FOR nonexistent_col > 10");
     }
 }

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -2403,6 +2403,10 @@ public class TestAnalyzer
         assertFails(MISSING_COLUMN, ".*Column 'nonexistent' does not exist in source table '.*'",
                 "CREATE VECTOR INDEX test_index ON t1(nonexistent)");
 
+        // duplicate columns
+        assertFails(DUPLICATE_COLUMN_NAME, ".*Column name 'a' specified more than once",
+                "CREATE VECTOR INDEX test_index ON t1(a, a)");
+
         // duplicate properties
         assertFails(DUPLICATE_PROPERTY, ".* Duplicate property: p1",
                 "CREATE VECTOR INDEX test_index ON t1(a, b) WITH (p1 = 'v1', p2 = 'v2', p1 = 'v3')");


### PR DESCRIPTION
Summary:
The last column in `CREATE VECTOR INDEX idx ON table(id, embedding)` must
be `array(real)` or `array(double)` to match the `CreateVectorIndexAggregation`
overloads. Previously, wrong types (e.g., bigint, varchar) caused a confusing
`FUNCTION_NOT_FOUND` error from `lookupFunction("create_vector_index", ...)`.

Add type validation in StatementAnalyzer that checks the embedding column
type and throws a clear `TYPE_MISMATCH` error with a helpful message.

Also adds test table `t14` with proper embedding columns and updates all
CREATE VECTOR INDEX test cases to use typed columns.

## Release Notes
```
== NO RELEASE NOTE ==
```

Differential Revision: D99786962

## Summary by Sourcery

Validate embedding column types for CREATE VECTOR INDEX and extend analyzer tests with a dedicated table schema for vector index scenarios.

Bug Fixes:
- Detect invalid embedding column types in CREATE VECTOR INDEX and return a clear TYPE_MISMATCH error instead of a generic FUNCTION_NOT_FOUND failure.

Enhancements:
- Reject duplicate column specifications in CREATE VECTOR INDEX statements during semantic analysis.
- Add a test table with explicit embedding columns and update CREATE VECTOR INDEX analyzer tests to cover valid and invalid embeddings.