### PR TITLE
test: Add end to end test for jaccard_index

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -36,6 +36,7 @@ public final class StandardTypes
     public static final String KLL_SKETCH = "kllsketch";
     public static final String K_HYPER_LOG_LOG = "KHyperLogLog";
     public static final String P4_HYPER_LOG_LOG = "P4HyperLogLog";
+    public static final String SETDIGEST = "SetDigest";
     public static final String INTERVAL_DAY_TO_SECOND = "interval day to second";
     public static final String INTERVAL_YEAR_TO_MONTH = "interval year to month";
     public static final String TIMESTAMP = "timestamp";

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/typemanager/NativeTypeManager.java
@@ -60,6 +60,7 @@ import static com.facebook.presto.common.type.StandardTypes.P4_HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.StandardTypes.QDIGEST;
 import static com.facebook.presto.common.type.StandardTypes.REAL;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
+import static com.facebook.presto.common.type.StandardTypes.SETDIGEST;
 import static com.facebook.presto.common.type.StandardTypes.SMALLINT;
 import static com.facebook.presto.common.type.StandardTypes.TDIGEST;
 import static com.facebook.presto.common.type.StandardTypes.TIME;
@@ -97,6 +98,7 @@ public class NativeTypeManager
                     HYPER_LOG_LOG,
                     K_HYPER_LOG_LOG,
                     P4_HYPER_LOG_LOG,
+                    SETDIGEST,
                     JSON,
                     TIME_WITH_TIME_ZONE,
                     TIMESTAMP_WITH_TIME_ZONE,

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/SetDigestTestUtils.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/SetDigestTestUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.testing.QueryRunner;
+
+public class SetDigestTestUtils
+{
+    private SetDigestTestUtils() {};
+    public static void createJaccardIndexValues(QueryRunner queryRunner) {
+        queryRunner.execute("DROP TABLE IF EXISTS jaccardIndexTable");
+        queryRunner.execute("CREATE TABLE jaccardIndexTable (v1 integer, v2 integer, u1 integer, u2 integer)");
+        queryRunner.execute("INSERT INTO jaccardIndexTable VALUES " +
+                "(1, 1, NULL, NULL)," +
+                "(NULL, 2, NULL, NULL)," +
+                "(2, 3, NULL, NULL)," +
+                "(NULL, 4, NULL, NULL)," +
+                "(1, 10, NULL, NULL)," +
+                "(2, 11, NULL, NULL)," +
+                "(3, 12, NULL, NULL)," +
+                "(4, 13, NULL, NULL)," +
+                "(5, 14, NULL, NULL)," +
+                "(1, 101, NULL, NULL)," +
+                "(2, 102, NULL, NULL)," +
+                "(3, 103, NULL, NULL)," +
+                "(4, 104, NULL, NULL)," +
+                "(5, 105, NULL, NULL)," +
+                "(1, 50, NULL, NULL)," +
+                "(25, 75, NULL, NULL)," +
+                "(50, 100, NULL, NULL)," +
+                "(75, 125, NULL, NULL)," +
+                "(100, 150, NULL, NULL)," +
+                "(1, 25, NULL, NULL)," +
+                "(25, 50, NULL, NULL)," +
+                "(50, 75, NULL, NULL)," +
+                "(75, 100, NULL, NULL)," +
+                "(100, 25, NULL, NULL)," +
+                "(1, 95, NULL, NULL)," +
+                "(50, 100, NULL, NULL)," +
+                "(100, 150, NULL, NULL)," +
+                "(95, 200, NULL, NULL)," +
+                "(1, 3, NULL, NULL)," +
+                "(2, 4, NULL, NULL)," +
+                "(3, 5, NULL, NULL)," +
+                "(4, 6, NULL, NULL)," +
+                "(5, 7, NULL, NULL)," +
+                "(1, 2, NULL, NULL)," +
+                "(2, 3, NULL, NULL)," +
+                "(3, 4, NULL, NULL)," +
+                "(4, 2, NULL, NULL)," +
+                "(5, 3, NULL, NULL)," +
+                "(6, 4, NULL, NULL)," +
+                "(7, 2, NULL, NULL)," +
+                "(8, 3, NULL, NULL)," +
+                "(9, 4, NULL, NULL)," +
+                "(10, 2, NULL, NULL)," +
+                "(NULL, 1, NULL, NULL)," +
+                "(NULL, 2, NULL, NULL)," +
+                "(NULL, 3, NULL, NULL)," +
+                "(1, NULL, NULL, NULL)," +
+                "(2, NULL, NULL, NULL)," +
+                "(3, NULL, NULL, NULL)," +
+                "(NULL, NULL, NULL, NULL)," +
+                "(1, 1, 101, 101)," +
+                "(2, 2, 102, 102)," +
+                "(3, 30, 103, 130)," +
+                "(4, 40, 104, 140)," +
+                "(1, 10, 101, 201)," +
+                "(2, 20, 102, 202)," +
+                "(3, 30, 103, 203)," +
+                "(4, 40, 104, 204)," +
+                "(NULL, 1, 101, 201)," +
+                "(1, NULL, 101, 201)," +
+                "(NULL, NULL, NULL, NULL)");
+    }
+}

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/SetDigestTestUtils.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/SetDigestTestUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.testing.QueryRunner;
+
+public class SetDigestTestUtils
+{
+    private SetDigestTestUtils() {};
+    public static void createJaccardIndexValues(QueryRunner queryRunner)
+    {
+        queryRunner.execute("DROP TABLE IF EXISTS jaccardIndexTable");
+        queryRunner.execute("CREATE TABLE jaccardIndexTable (v1 integer, v2 integer, u1 integer, u2 integer)");
+        queryRunner.execute("INSERT INTO jaccardIndexTable VALUES " +
+                "(1, 1, NULL, NULL)," +
+                "(NULL, 2, NULL, NULL)," +
+                "(2, 3, NULL, NULL)," +
+                "(NULL, 4, NULL, NULL)," +
+                "(1, 10, NULL, NULL)," +
+                "(2, 11, NULL, NULL)," +
+                "(3, 12, NULL, NULL)," +
+                "(4, 13, NULL, NULL)," +
+                "(5, 14, NULL, NULL)," +
+                "(1, 101, NULL, NULL)," +
+                "(2, 102, NULL, NULL)," +
+                "(3, 103, NULL, NULL)," +
+                "(4, 104, NULL, NULL)," +
+                "(5, 105, NULL, NULL)," +
+                "(1, 50, NULL, NULL)," +
+                "(25, 75, NULL, NULL)," +
+                "(50, 100, NULL, NULL)," +
+                "(75, 125, NULL, NULL)," +
+                "(100, 150, NULL, NULL)," +
+                "(1, 25, NULL, NULL)," +
+                "(25, 50, NULL, NULL)," +
+                "(50, 75, NULL, NULL)," +
+                "(75, 100, NULL, NULL)," +
+                "(100, 25, NULL, NULL)," +
+                "(1, 95, NULL, NULL)," +
+                "(50, 100, NULL, NULL)," +
+                "(100, 150, NULL, NULL)," +
+                "(95, 200, NULL, NULL)," +
+                "(1, 3, NULL, NULL)," +
+                "(2, 4, NULL, NULL)," +
+                "(3, 5, NULL, NULL)," +
+                "(4, 6, NULL, NULL)," +
+                "(5, 7, NULL, NULL)," +
+                "(1, 2, NULL, NULL)," +
+                "(2, 3, NULL, NULL)," +
+                "(3, 4, NULL, NULL)," +
+                "(4, 2, NULL, NULL)," +
+                "(5, 3, NULL, NULL)," +
+                "(6, 4, NULL, NULL)," +
+                "(7, 2, NULL, NULL)," +
+                "(8, 3, NULL, NULL)," +
+                "(9, 4, NULL, NULL)," +
+                "(10, 2, NULL, NULL)," +
+                "(NULL, 1, NULL, NULL)," +
+                "(NULL, 2, NULL, NULL)," +
+                "(NULL, 3, NULL, NULL)," +
+                "(1, NULL, NULL, NULL)," +
+                "(2, NULL, NULL, NULL)," +
+                "(3, NULL, NULL, NULL)," +
+                "(NULL, NULL, NULL, NULL)," +
+                "(1, 1, 101, 101)," +
+                "(2, 2, 102, 102)," +
+                "(3, 30, 103, 130)," +
+                "(4, 40, 104, 140)," +
+                "(1, 10, 101, 201)," +
+                "(2, 20, 102, 202)," +
+                "(3, 30, 103, 203)," +
+                "(4, 40, 104, 204)," +
+                "(NULL, 1, 101, 201)," +
+                "(1, NULL, 101, 201)," +
+                "(NULL, NULL, NULL, NULL)");
+    }
+}

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestSetDigestFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestSetDigestFunctions.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativetests.SetDigestTestUtils.createJaccardIndexValues;
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static java.lang.Boolean.parseBoolean;
+
+public class TestSetDigestFunctions
+        extends AbstractTestQueryFramework
+{
+    private String storageFormat;
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        storageFormat = System.getProperty("storageFormat", "PARQUET");
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "false"));
+        super.init();
+    }
+
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createJaccardIndexValues(queryRunner);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+    {
+        QueryRunner expectedQueryRunner = (QueryRunner) getExpectedQueryRunner();
+        expectedQueryRunner.execute("DROP TABLE IF EXISTS jaccardIndexTable");
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setCoordinatorSidecarEnabled(sidecarEnabled)
+                .build();
+        if (sidecarEnabled) {
+            setupNativeSidecarPlugin(queryRunner);
+        }
+        return queryRunner;
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Test
+    public void testJaccardIndex()
+    {
+        assertQuery("SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) FROM jaccardIndexTable");
+        assertQuery("SELECT jaccard_index(khyperloglog_agg(v1, u1), khyperloglog_agg(v2, u2)) FROM jaccardIndexTable");
+        assertQuery("WITH t AS ( SELECT v1, v2, make_set_digest(v1) OVER () AS sd1_all, make_set_digest(v2) OVER () AS sd2_all FROM jaccardIndexTable ) SELECT v1, v2, jaccard_index( IF(v1 IS NULL, CAST(NULL AS setdigest), sd1_all), IF(v2 IS NULL, CAST(NULL AS setdigest), sd2_all)) AS j FROM t")
+        assertQueryFails("SELECT jaccard_index(v1, v2) FROM (VALUES ('invalid', 'invalid')) T(v1,v2)", "(?i)line 1:8: Unexpected parameters \\(varchar\\(7\\), varchar\\(7\\)\\) for function (native\\.default\\.)?jaccard_index\\. Expected: .*jaccard_index\\((setdigest|khyperloglog), (setdigest|khyperloglog)\\).*");
+    }
+}

--- a/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestSetDigestFunctions.java
+++ b/presto-native-tests/src/test/java/com/facebook/presto/nativetests/TestSetDigestFunctions.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nativetests;
+
+import com.facebook.presto.nativeworker.PrestoNativeQueryRunnerUtils;
+import com.facebook.presto.testing.ExpectedQueryRunner;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.nativetests.SetDigestTestUtils.createJaccardIndexValues;
+import static com.facebook.presto.sidecar.NativeSidecarPluginQueryRunnerUtils.setupNativeSidecarPlugin;
+import static java.lang.Boolean.parseBoolean;
+
+public class TestSetDigestFunctions
+        extends AbstractTestQueryFramework
+{
+    private String storageFormat;
+    private boolean sidecarEnabled;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        storageFormat = System.getProperty("storageFormat", "PARQUET");
+        sidecarEnabled = parseBoolean(System.getProperty("sidecarEnabled", "false"));
+        super.init();
+    }
+
+    @Override
+    protected void createTables()
+    {
+        QueryRunner queryRunner = (QueryRunner) getExpectedQueryRunner();
+        createJaccardIndexValues(queryRunner);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+    {
+        QueryRunner expectedQueryRunner = (QueryRunner) getExpectedQueryRunner();
+        expectedQueryRunner.execute("DROP TABLE IF EXISTS jaccardIndexTable");
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = PrestoNativeQueryRunnerUtils.nativeHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .setUseThrift(true)
+                .setCoordinatorSidecarEnabled(sidecarEnabled)
+                .build();
+        if (sidecarEnabled) {
+            setupNativeSidecarPlugin(queryRunner);
+        }
+        return queryRunner;
+    }
+
+    @Override
+    protected ExpectedQueryRunner createExpectedQueryRunner()
+            throws Exception
+    {
+        return PrestoNativeQueryRunnerUtils.javaHiveQueryRunnerBuilder()
+                .setStorageFormat(storageFormat)
+                .setAddStorageFormatToPath(true)
+                .build();
+    }
+
+    @Test
+    public void testJaccardIndex()
+    {
+        assertQuery("SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) FROM jaccardIndexTable");
+        assertQuery("SELECT jaccard_index(khyperloglog_agg(v1, u1), khyperloglog_agg(v2, u2)) FROM jaccardIndexTable");
+        assertQuery("WITH t AS ( SELECT v1, v2, make_set_digest(v1) OVER () AS sd1_all, make_set_digest(v2) OVER () AS sd2_all FROM jaccardIndexTable ) SELECT v1, v2, jaccard_index( IF(v1 IS NULL, CAST(NULL AS setdigest), sd1_all), IF(v2 IS NULL, CAST(NULL AS setdigest), sd2_all)) AS j FROM t");
+        assertQueryFails("SELECT jaccard_index(v1, v2) FROM (VALUES ('invalid', 'invalid')) T(v1,v2)", "(?i)line 1:8: Unexpected parameters \\(varchar\\(7\\), varchar\\(7\\)\\) for function (native\\.default\\.)?jaccard_index\\. Expected: .*jaccard_index\\((setdigest|khyperloglog), (setdigest|khyperloglog)\\).*");
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Adding in end to end test for `jaccard_index` function

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
closes https://github.com/prestodb/presto/issues/27590

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.


```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add native end-to-end coverage for set digest–based jaccard_index and register the SetDigest type with the native sidecar type system.

Enhancements:
- Register the SetDigest type constant and include it in the native sidecar type manager so native execution can recognize set digest values.

Tests:
- Introduce TestSetDigestFunctions native end-to-end test class validating jaccard_index over make_set_digest inputs, null handling, and invalid argument errors across storage formats and optional sidecar.