### PR TITLE
fix(native): Fix BIND expression loss for captured lambdas in NativeExpressionOptimizer

### DIFF
--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -140,6 +140,8 @@ std::shared_ptr<protocol::FunctionHandle> getFunctionHandle(
 // Collects free FieldAccessTypedExpr leaf nodes from a Velox expression tree
 // that are not bound by any enclosing lambda's signature. The 'boundNames'
 // parameter contains names that are in scope from enclosing lambda signatures.
+// For x -> x + y, 'x' is a bound name from the lambda signature and 'y' is a
+// free field captured from the input.
 // Captured fields are recorded in first DFS encounter order. The exact order is
 // not semantically important to Presto, but BIND arguments and the prepended
 // lambda parameters must use the same order. 'visitedFreeFieldNames' ensures
@@ -154,7 +156,9 @@ void collectFreeFieldAccesses(
               expr)) {
     if (fieldAccess->isInputColumn() &&
         !boundNames.count(fieldAccess->name())) {
-      if (visitedFreeFieldNames.insert(fieldAccess->name()).second) {
+      const auto& name = fieldAccess->name();
+      if (visitedFreeFieldNames.find(name) == visitedFreeFieldNames.end()) {
+        visitedFreeFieldNames.insert(name);
         freeFields.push_back(fieldAccess);
       }
     }
@@ -182,6 +186,14 @@ void collectFreeFieldAccesses(
     collectFreeFieldAccesses(
         input, boundNames, freeFields, visitedFreeFieldNames);
   }
+}
+
+void collectFreeFieldAccesses(
+    const velox::core::TypedExprPtr& expr,
+    const std::unordered_set<std::string>& boundNames,
+    std::vector<FieldAccessTypedExprPtr>& freeFields) {
+  std::unordered_set<std::string> visitedFreeFieldNames;
+  collectFreeFieldAccesses(expr, boundNames, freeFields, visitedFreeFieldNames);
 }
 } // namespace
 
@@ -444,9 +456,7 @@ RowExpressionPtr VeloxToPrestoExprConverter::getLambdaExpression(
   std::unordered_set<std::string> boundNames(
       signature->names().begin(), signature->names().end());
   std::vector<FieldAccessTypedExprPtr> freeFields;
-  std::unordered_set<std::string> visitedFreeFieldNames;
-  collectFreeFieldAccesses(
-      lambdaExpr->body(), boundNames, freeFields, visitedFreeFieldNames);
+  collectFreeFieldAccesses(lambdaExpr->body(), boundNames, freeFields);
 
   return resolveLambdaExpression(lambdaExpr, freeFields);
 }

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -136,6 +136,49 @@ std::shared_ptr<protocol::FunctionHandle> getFunctionHandle(
   handle->signature = signature;
   return handle;
 }
+
+// Collects free FieldAccessTypedExpr leaf nodes from a Velox expression tree
+// that are not bound by any enclosing lambda's signature. The 'boundNames'
+// parameter contains names that are in scope from enclosing lambda signatures.
+// Results are appended to 'freeFields' in DFS order with deduplication.
+void collectFreeFieldAccesses(
+    const velox::core::TypedExprPtr& expr,
+    const std::unordered_set<std::string>& boundNames,
+    std::vector<FieldAccessExprPtr>& freeFields,
+    std::unordered_set<std::string>& visitedNames) {
+  if (auto fieldAccess =
+          std::dynamic_pointer_cast<const velox::core::FieldAccessTypedExpr>(
+              expr)) {
+    if (fieldAccess->isInputColumn() &&
+        !boundNames.count(fieldAccess->name())) {
+      // Free variable: not bound by any enclosing lambda and not yet seen.
+      if (visitedNames.insert(fieldAccess->name()).second) {
+        freeFields.push_back(fieldAccess);
+      }
+    }
+    // Recurse into inputs for dereference-like field accesses.
+    for (const auto& input : fieldAccess->inputs()) {
+      collectFreeFieldAccesses(input, boundNames, freeFields, visitedNames);
+    }
+    return;
+  }
+
+  if (auto lambda =
+          std::dynamic_pointer_cast<const velox::core::LambdaTypedExpr>(expr)) {
+    // For nested lambdas, extend the bound set with the lambda's parameters.
+    auto innerBound = boundNames;
+    const auto& names = lambda->signature()->names();
+    innerBound.insert(names.begin(), names.end());
+    collectFreeFieldAccesses(
+        lambda->body(), innerBound, freeFields, visitedNames);
+    return;
+  }
+
+  // Recurse into all inputs for other expression types.
+  for (const auto& input : expr->inputs()) {
+    collectFreeFieldAccesses(input, boundNames, freeFields, visitedNames);
+  }
+}
 } // namespace
 
 std::string VeloxToPrestoExprConverter::getValueBlock(
@@ -390,27 +433,76 @@ SpecialFormExpressionPtr VeloxToPrestoExprConverter::getDereferenceExpression(
   return result;
 }
 
-LambdaDefinitionExpressionPtr VeloxToPrestoExprConverter::getLambdaExpression(
+// Lambda expression will be wrapped with a BIND expression if the lambda
+// references variables that are not bound by its signature.
+RowExpressionPtr VeloxToPrestoExprConverter::resolveLambdaExpression(
     const velox::core::LambdaTypedExpr* lambdaExpr) const {
-  static constexpr char const* kLambda = "lambda";
+  const auto& signature = lambdaExpr->signature();
 
+  std::unordered_set<std::string> boundNames(
+      signature->names().begin(), signature->names().end());
+  std::vector<FieldAccessExprPtr> freeFields;
+  std::unordered_set<std::string> visitedNames;
+  collectFreeFieldAccesses(
+      lambdaExpr->body(), boundNames, freeFields, visitedNames);
+
+  const LambdaDefinitionExpressionPtr lambdaDefinitionExpression =
+      getLambdaExpression(lambdaExpr, freeFields);
+  if (freeFields.empty()) {
+    // Return a LambdaDefinitionExpression if there are no captured variables.
+    return lambdaDefinitionExpression;
+  }
+  // Return a BIND expression with captured variables.
+  return getBindExpression(
+      lambdaDefinitionExpression, freeFields, lambdaExpr->type());
+}
+
+LambdaDefinitionExpressionPtr VeloxToPrestoExprConverter::getLambdaExpression(
+    const velox::core::LambdaTypedExpr* lambdaExpr,
+    const std::vector<FieldAccessExprPtr>& freeFields) const {
+  static constexpr char const* kLambda = "lambda";
   json result;
   result["@type"] = kLambda;
-  const auto& signature = lambdaExpr->signature();
   std::vector<protocol::TypeSignature> argumentTypes;
-  argumentTypes.reserve(signature->children().size());
+  std::vector<std::string> arguments;
+  const auto& signature = lambdaExpr->signature();
+
+  // Prepend captured variable names/types to the lambda signature.
+  for (const auto& field : freeFields) {
+    arguments.emplace_back(field->name());
+    argumentTypes.emplace_back(getTypeSignature(field->type()));
+  }
+  // Then add the original lambda arguments.
   for (const auto& type : signature->children()) {
     argumentTypes.emplace_back(getTypeSignature(type));
   }
-  result["argumentTypes"] = argumentTypes;
-
-  std::vector<std::string> arguments;
-  arguments.reserve(signature->names().size());
   for (const auto& name : signature->names()) {
     arguments.emplace_back(name);
   }
+
+  result["argumentTypes"] = argumentTypes;
   result["arguments"] = arguments;
   result["body"] = getRowExpression(lambdaExpr->body());
+  return result;
+}
+
+// BIND(capturedVar1, ..., expandedLambda) provides captured outer variables
+// to the lambda at evaluation time.
+SpecialFormExpressionPtr VeloxToPrestoExprConverter::getBindExpression(
+    const LambdaDefinitionExpressionPtr& lambdaDefinitionExpression,
+    const std::vector<FieldAccessExprPtr>& freeFields,
+    const velox::TypePtr& returnType) const {
+  static constexpr char const* kBind = "BIND";
+  json result;
+  result["@type"] = kSpecial;
+  result["form"] = kBind;
+  result["returnType"] = getTypeSignature(returnType);
+
+  result["arguments"] = json::array();
+  for (const auto& field : freeFields) {
+    result["arguments"].push_back(getVariableReferenceExpression(field.get()));
+  }
+  result["arguments"].push_back(lambdaDefinitionExpression);
   return result;
 }
 
@@ -465,7 +557,7 @@ CallExpressionPtr VeloxToPrestoExprConverter::getCallExpression(
     const auto lambdaExpr = std::make_shared<velox::core::LambdaTypedExpr>(
         velox::ROW({}), exprInputs.at(0));
     argumentTypes.emplace_back(getTypeSignature(lambdaExpr->type()));
-    result["arguments"].push_back(getLambdaExpression(lambdaExpr.get()));
+    result["arguments"].push_back(resolveLambdaExpression(lambdaExpr.get()));
   } else {
     for (const auto& input : exprInputs) {
       argumentTypes.emplace_back(getTypeSignature(input->type()));
@@ -529,7 +621,7 @@ RowExpressionPtr VeloxToPrestoExprConverter::getRowExpression(
     case velox::core::ExprKind::kLambda: {
       const auto* lambdaExpr =
           expr->asUnchecked<velox::core::LambdaTypedExpr>();
-      return getLambdaExpression(lambdaExpr);
+      return resolveLambdaExpression(lambdaExpr);
     }
     // Presto does not have a RowExpression type for kConcat and kInput Velox
     // expressions. Presto to Velox expression conversion should not generate

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -136,6 +136,52 @@ std::shared_ptr<protocol::FunctionHandle> getFunctionHandle(
   handle->signature = signature;
   return handle;
 }
+
+// Collects free FieldAccessTypedExpr leaf nodes from a Velox expression tree
+// that are not bound by any enclosing lambda's signature. The 'boundNames'
+// parameter contains names that are in scope from enclosing lambda signatures.
+// Results are appended to 'freeFields' in DFS order with deduplication.
+// 'visitedNames' tracks field names already added to 'freeFields' so that each
+// captured variable appears exactly once, even if referenced multiple times in
+// the expression tree.
+void collectFreeFieldAccesses(
+    const velox::core::TypedExprPtr& expr,
+    const std::unordered_set<std::string>& boundNames,
+    std::vector<FieldAccessTypedExprPtr>& freeFields,
+    std::unordered_set<std::string>& visitedNames) {
+  if (auto fieldAccess =
+          std::dynamic_pointer_cast<const velox::core::FieldAccessTypedExpr>(
+              expr)) {
+    if (fieldAccess->isInputColumn() &&
+        !boundNames.count(fieldAccess->name())) {
+      // Free variable: not bound by any enclosing lambda and not yet seen.
+      if (visitedNames.insert(fieldAccess->name()).second) {
+        freeFields.push_back(fieldAccess);
+      }
+    }
+    // Recurse into inputs for dereference-like field accesses.
+    for (const auto& input : fieldAccess->inputs()) {
+      collectFreeFieldAccesses(input, boundNames, freeFields, visitedNames);
+    }
+    return;
+  }
+
+  if (auto lambda =
+          std::dynamic_pointer_cast<const velox::core::LambdaTypedExpr>(expr)) {
+    // For nested lambdas, extend the bound set with the lambda's parameters.
+    auto innerBound = boundNames;
+    const auto& names = lambda->signature()->names();
+    innerBound.insert(names.begin(), names.end());
+    collectFreeFieldAccesses(
+        lambda->body(), innerBound, freeFields, visitedNames);
+    return;
+  }
+
+  // Recurse into all inputs for other expression types.
+  for (const auto& input : expr->inputs()) {
+    collectFreeFieldAccesses(input, boundNames, freeFields, visitedNames);
+  }
+}
 } // namespace
 
 std::string VeloxToPrestoExprConverter::getValueBlock(
@@ -390,27 +436,78 @@ SpecialFormExpressionPtr VeloxToPrestoExprConverter::getDereferenceExpression(
   return result;
 }
 
-LambdaDefinitionExpressionPtr VeloxToPrestoExprConverter::getLambdaExpression(
+RowExpressionPtr VeloxToPrestoExprConverter::getLambdaExpression(
     const velox::core::LambdaTypedExpr* lambdaExpr) const {
-  static constexpr char const* kLambda = "lambda";
+  const auto& signature = lambdaExpr->signature();
 
+  std::unordered_set<std::string> boundNames(
+      signature->names().begin(), signature->names().end());
+  std::vector<FieldAccessTypedExprPtr> freeFields;
+  std::unordered_set<std::string> visitedNames;
+  collectFreeFieldAccesses(
+      lambdaExpr->body(), boundNames, freeFields, visitedNames);
+
+  return resolveLambdaExpression(lambdaExpr, freeFields);
+}
+
+RowExpressionPtr VeloxToPrestoExprConverter::resolveLambdaExpression(
+    const velox::core::LambdaTypedExpr* lambdaExpr,
+    const std::vector<FieldAccessTypedExprPtr>& freeFields) const {
+  static constexpr char const* kLambda = "lambda";
   json result;
   result["@type"] = kLambda;
   const auto& signature = lambdaExpr->signature();
+
   std::vector<protocol::TypeSignature> argumentTypes;
-  argumentTypes.reserve(signature->children().size());
+  std::vector<std::string> arguments;
+  argumentTypes.reserve(freeFields.size() + signature->children().size());
+  arguments.reserve(freeFields.size() + signature->names().size());
+
+  // Prepend captured variable names/types to the lambda signature.
+  for (const auto& field : freeFields) {
+    arguments.emplace_back(field->name());
+    argumentTypes.emplace_back(getTypeSignature(field->type()));
+  }
+  // Then add the original lambda arguments.
   for (const auto& type : signature->children()) {
     argumentTypes.emplace_back(getTypeSignature(type));
   }
-  result["argumentTypes"] = argumentTypes;
-
-  std::vector<std::string> arguments;
-  arguments.reserve(signature->names().size());
   for (const auto& name : signature->names()) {
     arguments.emplace_back(name);
   }
+
+  result["argumentTypes"] = argumentTypes;
   result["arguments"] = arguments;
   result["body"] = getRowExpression(lambdaExpr->body());
+
+  if (freeFields.empty()) {
+    // Return a plain LambdaDefinitionExpression when there are no captured
+    // variables.
+    return result;
+  }
+  // Wrap in a BIND expression with captured variables.
+  LambdaDefinitionExpressionPtr lambdaDefinitionExpression = result;
+  return getBindExpression(
+      lambdaDefinitionExpression, freeFields, lambdaExpr->type());
+}
+
+// BIND(capturedVar1, ..., expandedLambda) provides captured outer variables
+// to the lambda at evaluation time.
+SpecialFormExpressionPtr VeloxToPrestoExprConverter::getBindExpression(
+    const LambdaDefinitionExpressionPtr& lambdaDefinitionExpression,
+    const std::vector<FieldAccessTypedExprPtr>& freeFields,
+    const velox::TypePtr& returnType) const {
+  static constexpr char const* kBind = "BIND";
+  json result;
+  result["@type"] = kSpecial;
+  result["form"] = kBind;
+  result["returnType"] = getTypeSignature(returnType);
+
+  result["arguments"] = json::array();
+  for (const auto& field : freeFields) {
+    result["arguments"].push_back(getVariableReferenceExpression(field.get()));
+  }
+  result["arguments"].push_back(lambdaDefinitionExpression);
   return result;
 }
 

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -140,28 +140,28 @@ std::shared_ptr<protocol::FunctionHandle> getFunctionHandle(
 // Collects free FieldAccessTypedExpr leaf nodes from a Velox expression tree
 // that are not bound by any enclosing lambda's signature. The 'boundNames'
 // parameter contains names that are in scope from enclosing lambda signatures.
-// Results are appended to 'freeFields' in DFS order with deduplication.
-// 'visitedNames' tracks field names already added to 'freeFields' so that each
-// captured variable appears exactly once, even if referenced multiple times in
-// the expression tree.
+// Captured fields are recorded in first DFS encounter order. The exact order is
+// not semantically important to Presto, but BIND arguments and the prepended
+// lambda parameters must use the same order. 'visitedFreeFieldNames' ensures
+// each captured variable is bound once even if referenced multiple times.
 void collectFreeFieldAccesses(
     const velox::core::TypedExprPtr& expr,
     const std::unordered_set<std::string>& boundNames,
     std::vector<FieldAccessTypedExprPtr>& freeFields,
-    std::unordered_set<std::string>& visitedNames) {
+    std::unordered_set<std::string>& visitedFreeFieldNames) {
   if (auto fieldAccess =
           std::dynamic_pointer_cast<const velox::core::FieldAccessTypedExpr>(
               expr)) {
     if (fieldAccess->isInputColumn() &&
         !boundNames.count(fieldAccess->name())) {
-      // Free variable: not bound by any enclosing lambda and not yet seen.
-      if (visitedNames.insert(fieldAccess->name()).second) {
+      if (visitedFreeFieldNames.insert(fieldAccess->name()).second) {
         freeFields.push_back(fieldAccess);
       }
     }
     // Recurse into inputs for dereference-like field accesses.
     for (const auto& input : fieldAccess->inputs()) {
-      collectFreeFieldAccesses(input, boundNames, freeFields, visitedNames);
+      collectFreeFieldAccesses(
+          input, boundNames, freeFields, visitedFreeFieldNames);
     }
     return;
   }
@@ -173,13 +173,14 @@ void collectFreeFieldAccesses(
     const auto& names = lambda->signature()->names();
     innerBound.insert(names.begin(), names.end());
     collectFreeFieldAccesses(
-        lambda->body(), innerBound, freeFields, visitedNames);
+        lambda->body(), innerBound, freeFields, visitedFreeFieldNames);
     return;
   }
 
   // Recurse into all inputs for other expression types.
   for (const auto& input : expr->inputs()) {
-    collectFreeFieldAccesses(input, boundNames, freeFields, visitedNames);
+    collectFreeFieldAccesses(
+        input, boundNames, freeFields, visitedFreeFieldNames);
   }
 }
 } // namespace
@@ -443,9 +444,9 @@ RowExpressionPtr VeloxToPrestoExprConverter::getLambdaExpression(
   std::unordered_set<std::string> boundNames(
       signature->names().begin(), signature->names().end());
   std::vector<FieldAccessTypedExprPtr> freeFields;
-  std::unordered_set<std::string> visitedNames;
+  std::unordered_set<std::string> visitedFreeFieldNames;
   collectFreeFieldAccesses(
-      lambdaExpr->body(), boundNames, freeFields, visitedNames);
+      lambdaExpr->body(), boundNames, freeFields, visitedFreeFieldNames);
 
   return resolveLambdaExpression(lambdaExpr, freeFields);
 }
@@ -485,30 +486,24 @@ RowExpressionPtr VeloxToPrestoExprConverter::resolveLambdaExpression(
     // variables.
     return result;
   }
-  // Wrap in a BIND expression with captured variables.
-  LambdaDefinitionExpressionPtr lambdaDefinitionExpression = result;
-  return getBindExpression(
-      lambdaDefinitionExpression, freeFields, lambdaExpr->type());
-}
 
-// BIND(capturedVar1, ..., expandedLambda) provides captured outer variables
-// to the lambda at evaluation time.
-SpecialFormExpressionPtr VeloxToPrestoExprConverter::getBindExpression(
-    const LambdaDefinitionExpressionPtr& lambdaDefinitionExpression,
-    const std::vector<FieldAccessTypedExprPtr>& freeFields,
-    const velox::TypePtr& returnType) const {
+  VELOX_CHECK(!freeFields.empty(), "BIND expression requires captured fields.");
   static constexpr char const* kBind = "BIND";
-  json result;
-  result["@type"] = kSpecial;
-  result["form"] = kBind;
-  result["returnType"] = getTypeSignature(returnType);
+  LambdaDefinitionExpressionPtr lambdaDefinitionExpression = result;
 
-  result["arguments"] = json::array();
+  // BIND(capturedVar1, ..., expandedLambda) provides captured outer variables
+  // to the lambda at evaluation time.
+  json bind;
+  bind["@type"] = kSpecial;
+  bind["form"] = kBind;
+  bind["returnType"] = getTypeSignature(lambdaExpr->type());
+
+  bind["arguments"] = json::array();
   for (const auto& field : freeFields) {
-    result["arguments"].push_back(getVariableReferenceExpression(field.get()));
+    bind["arguments"].push_back(getVariableReferenceExpression(field.get()));
   }
-  result["arguments"].push_back(lambdaDefinitionExpression);
-  return result;
+  bind["arguments"].push_back(lambdaDefinitionExpression);
+  return bind;
 }
 
 CallExpressionPtr VeloxToPrestoExprConverter::getCallExpression(

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
@@ -28,6 +28,8 @@ using LambdaDefinitionExpressionPtr =
     std::shared_ptr<facebook::presto::protocol::LambdaDefinitionExpression>;
 using SpecialFormExpressionPtr =
     std::shared_ptr<facebook::presto::protocol::SpecialFormExpression>;
+using FieldAccessTypedExprPtr =
+    std::shared_ptr<const facebook::velox::core::FieldAccessTypedExpr>;
 
 namespace facebook::presto::expression {
 
@@ -117,10 +119,28 @@ class VeloxToPrestoExprConverter {
   SpecialFormExpressionPtr getDereferenceExpression(
       const velox::core::DereferenceTypedExpr* dereferenceExpr) const;
 
-  /// Helper function to construct a Presto
-  /// `protocol::LambdaDefinitionExpression` from a Velox lambda expression.
-  LambdaDefinitionExpressionPtr getLambdaExpression(
+  /// Converts a Velox lambda expression to a Presto RowExpression. Collects
+  /// free (captured) variables from the lambda body and delegates to
+  /// resolveLambdaExpression to produce either a plain
+  /// LambdaDefinitionExpression or a BIND-wrapped one.
+  RowExpressionPtr getLambdaExpression(
       const velox::core::LambdaTypedExpr* lambdaExpr) const;
+
+  /// Builds a Presto LambdaDefinitionExpression (prepending any captured
+  /// variable names/types) and, when freeFields is non-empty, wraps it in a
+  /// BIND SpecialFormExpression so the captured variables are explicit
+  /// planner-visible inputs. Returns a plain LambdaDefinitionExpression when
+  /// freeFields is empty.
+  RowExpressionPtr resolveLambdaExpression(
+      const velox::core::LambdaTypedExpr* lambdaExpr,
+      const std::vector<FieldAccessTypedExprPtr>& freeFields) const;
+
+  /// Helper function to construct a Presto SpecialFormExpression of type BIND
+  /// that wraps an expanded lambda with the given free variables.
+  SpecialFormExpressionPtr getBindExpression(
+      const LambdaDefinitionExpressionPtr& lambdaDefinitionExpression,
+      const std::vector<FieldAccessTypedExprPtr>& freeFields,
+      const velox::TypePtr& returnType) const;
 
   /// Helper function to construct a Presto `protocol::CallExpression` from a
   /// Velox call expression.

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
@@ -28,6 +28,8 @@ using LambdaDefinitionExpressionPtr =
     std::shared_ptr<facebook::presto::protocol::LambdaDefinitionExpression>;
 using SpecialFormExpressionPtr =
     std::shared_ptr<facebook::presto::protocol::SpecialFormExpression>;
+using FieldAccessExprPtr =
+    std::shared_ptr<const facebook::velox::core::FieldAccessTypedExpr>;
 
 namespace facebook::presto::expression {
 
@@ -117,10 +119,26 @@ class VeloxToPrestoExprConverter {
   SpecialFormExpressionPtr getDereferenceExpression(
       const velox::core::DereferenceTypedExpr* dereferenceExpr) const;
 
-  /// Helper function to construct a Presto
-  /// `protocol::LambdaDefinitionExpression` from a Velox lambda expression.
-  LambdaDefinitionExpressionPtr getLambdaExpression(
+  /// Helper function to construct a Presto RowExpression from a Velox lambda
+  /// expression. If the lambda body contains free variables (captured from an
+  /// outer scope), the result is a SpecialFormExpression of type BIND wrapping
+  /// an expanded LambdaDefinitionExpression. Otherwise, returns a plain
+  /// LambdaDefinitionExpression.
+  RowExpressionPtr resolveLambdaExpression(
       const velox::core::LambdaTypedExpr* lambdaExpr) const;
+
+  /// Helper function to construct a Presto LambdaDefinitionExpression from a
+  /// Velox lambda expression.
+  LambdaDefinitionExpressionPtr getLambdaExpression(
+      const velox::core::LambdaTypedExpr* lambdaExpr,
+      const std::vector<FieldAccessExprPtr>& freeFields) const;
+
+  /// Helper function to construct a Presto SpecialFormExpression of type BIND
+  /// that wraps an expanded lambda with the given free variables.
+  SpecialFormExpressionPtr getBindExpression(
+      const LambdaDefinitionExpressionPtr& lambdaDefinitionExpression,
+      const std::vector<FieldAccessExprPtr>& freeFields,
+      const velox::TypePtr& returnType) const;
 
   /// Helper function to construct a Presto `protocol::CallExpression` from a
   /// Velox call expression.

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.h
@@ -119,10 +119,9 @@ class VeloxToPrestoExprConverter {
   SpecialFormExpressionPtr getDereferenceExpression(
       const velox::core::DereferenceTypedExpr* dereferenceExpr) const;
 
-  /// Converts a Velox lambda expression to a Presto RowExpression. Collects
-  /// free (captured) variables from the lambda body and delegates to
-  /// resolveLambdaExpression to produce either a plain
-  /// LambdaDefinitionExpression or a BIND-wrapped one.
+  /// Converts a Velox lambda expression to a Presto RowExpression. Lambdas
+  /// without captures become LambdaDefinitionExpression; lambdas with captures
+  /// become BIND SpecialFormExpression wrapping an expanded lambda.
   RowExpressionPtr getLambdaExpression(
       const velox::core::LambdaTypedExpr* lambdaExpr) const;
 
@@ -134,13 +133,6 @@ class VeloxToPrestoExprConverter {
   RowExpressionPtr resolveLambdaExpression(
       const velox::core::LambdaTypedExpr* lambdaExpr,
       const std::vector<FieldAccessTypedExprPtr>& freeFields) const;
-
-  /// Helper function to construct a Presto SpecialFormExpression of type BIND
-  /// that wraps an expanded lambda with the given free variables.
-  SpecialFormExpressionPtr getBindExpression(
-      const LambdaDefinitionExpressionPtr& lambdaDefinitionExpression,
-      const std::vector<FieldAccessTypedExprPtr>& freeFields,
-      const velox::TypePtr& returnType) const;
 
   /// Helper function to construct a Presto `protocol::CallExpression` from a
   /// Velox call expression.

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -797,6 +797,16 @@ public class TestNativeSidecarPlugin
         assertQuerySucceeds(session, "SELECT TRY_CAST(orderkey AS TINYINT) FROM orders");
         assertQuerySucceeds(session, "SELECT TRY_CAST(comment AS BIGINT) FROM orders");
         assertQuerySucceeds(session, "SELECT TRY_CAST(orderkey AS DOUBLE) FROM orders");
+
+        // Test BIND expression is preserved when lambda captures outer variable.
+        assertQuerySucceeds(session,
+                "SELECT IF(TRY(CAST(a AS INT)) IN (1, 5), TRY(CAST(b AS DOUBLE)), 0.0) FROM (VALUES (varchar'1', varchar'2.1'), (varchar'5', varchar'3.4')) t(a, b)");
+        assertQuerySucceeds(session,
+                "select transform(col1, x -> if(x, col2[2], 0)) from (values (array[false], array[0])) t(col1, col2)");
+        assertQuerySucceeds(session,
+                "SELECT FILTER( MAP_VALUES(map1), x -> x >= ELEMENT_AT( MAP(ARRAY['low','medium','high'], ARRAY[40000,40000,40000]), COALESCE( ELEMENT_AT( other_map, name ), 'low' ) ) ) AS v1, FILTER( MAP_VALUES(map1), x -> x >= ELEMENT_AT( MAP(ARRAY['low','medium','high'], ARRAY[40000,40000,40000]), COALESCE( ELEMENT_AT( other_map, name ), 'low' ) ) ) AS v2 FROM (select MAP(ARRAY['low'], ARRAY[100000]) map1, '' name) CROSS JOIN ( SELECT MAP() AS other_map ) risk_map");
+        assertQuerySucceeds(session,
+                "SELECT COALESCE( TRY( TRANSFORM_VALUES( id, (k, v) -> k / v ) ) , MAP() ) FROM ( VALUES (MAP(ARRAY[1, 2], ARRAY[0, 0])),  (MAP(ARRAY[1, 2], ARRAY[1, 2])),  (MAP(ARRAY[28, 56], ARRAY[2, 4])), (MAP(ARRAY[4, 5], ARRAY[0, 0])), (MAP(ARRAY[12, 72], ARRAY[3, 6]))) AS t (id)");
     }
 
     @Test

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -832,12 +832,18 @@ public class TestNativeSidecarPlugin
         // Test BIND expression is preserved when lambda captures outer variable.
         assertQueryWithSameQueryRunner(session,
                 "SELECT IF(TRY(CAST(a AS INT)) IN (1, 5), TRY(CAST(b AS DOUBLE)), 0.0) " +
-                        "FROM (VALUES (varchar'1', varchar'2.1'), (varchar'5', varchar'3.4')) t(a, b)",
-                "VALUES CAST(2.1 AS DOUBLE), CAST(3.4 AS DOUBLE)");
+                        "FROM (VALUES " +
+                        "(varchar'1', varchar'2.1'), " +
+                        "(varchar'5', varchar'3.4'), " +
+                        "(varchar'2', varchar'9.8')) t(a, b)",
+                "VALUES CAST(2.1 AS DOUBLE), CAST(3.4 AS DOUBLE), CAST(0.0 AS DOUBLE)");
         assertQueryWithSameQueryRunner(session,
                 "SELECT TRANSFORM(col1, x -> IF(x, col2[2], 0)) " +
-                        "FROM (VALUES (ARRAY[false], ARRAY[0])) t(col1, col2)",
-                "VALUES ARRAY[0]");
+                        "FROM (VALUES " +
+                        "(ARRAY[false], ARRAY[0, 7]), " +
+                        "(ARRAY[true], ARRAY[0, 7]), " +
+                        "(ARRAY[false], ARRAY[0, 9])) t(col1, col2)",
+                "VALUES ARRAY[0], ARRAY[7], ARRAY[0]");
         assertQueryWithSameQueryRunner(session,
                 "SELECT FILTER(MAP_VALUES(map1), x -> x >= ELEMENT_AT(MAP(ARRAY['low','medium','high'], ARRAY[40000,40000,40000]), " +
                         "COALESCE(ELEMENT_AT(other_map, name), 'low'))) AS v1, " +
@@ -851,9 +857,16 @@ public class TestNativeSidecarPlugin
                         "(MAP(ARRAY[1, 2], ARRAY[0, 0])), " +
                         "(MAP(ARRAY[1, 2], ARRAY[1, 2])), " +
                         "(MAP(ARRAY[28, 56], ARRAY[2, 4])), " +
+                        "(MAP(ARRAY[5, 7], ARRAY[2, 3])), " +
                         "(MAP(ARRAY[4, 5], ARRAY[0, 0])), " +
                         "(MAP(ARRAY[12, 72], ARRAY[3, 6]))) AS t (id)",
-                "VALUES MAP(), MAP(ARRAY[1, 2], ARRAY[1, 1]), MAP(ARRAY[28, 56], ARRAY[14, 14]), MAP(), MAP(ARRAY[12, 72], ARRAY[4, 12])");
+                "VALUES " +
+                        "MAP(), " +
+                        "MAP(ARRAY[1, 2], ARRAY[1, 1]), " +
+                        "MAP(ARRAY[28, 56], ARRAY[14, 14]), " +
+                        "MAP(ARRAY[5, 7], ARRAY[2, 2]), " +
+                        "MAP(), " +
+                        "MAP(ARRAY[12, 72], ARRAY[4, 12])");
     }
 
     @Test

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/TestNativeSidecarPlugin.java
@@ -828,6 +828,32 @@ public class TestNativeSidecarPlugin
         Instant current = getNowInstant(session);
         Instant future = getNowInstant(session);
         assertTrue(future.isAfter(current));
+
+        // Test BIND expression is preserved when lambda captures outer variable.
+        assertQueryWithSameQueryRunner(session,
+                "SELECT IF(TRY(CAST(a AS INT)) IN (1, 5), TRY(CAST(b AS DOUBLE)), 0.0) " +
+                        "FROM (VALUES (varchar'1', varchar'2.1'), (varchar'5', varchar'3.4')) t(a, b)",
+                "VALUES CAST(2.1 AS DOUBLE), CAST(3.4 AS DOUBLE)");
+        assertQueryWithSameQueryRunner(session,
+                "SELECT TRANSFORM(col1, x -> IF(x, col2[2], 0)) " +
+                        "FROM (VALUES (ARRAY[false], ARRAY[0])) t(col1, col2)",
+                "VALUES ARRAY[0]");
+        assertQueryWithSameQueryRunner(session,
+                "SELECT FILTER(MAP_VALUES(map1), x -> x >= ELEMENT_AT(MAP(ARRAY['low','medium','high'], ARRAY[40000,40000,40000]), " +
+                        "COALESCE(ELEMENT_AT(other_map, name), 'low'))) AS v1, " +
+                        "FILTER(MAP_VALUES(map1), x -> x >= ELEMENT_AT(MAP(ARRAY['low','medium','high'], ARRAY[40000,40000,40000]), " +
+                        "COALESCE(ELEMENT_AT(other_map, name), 'low'))) AS v2 " +
+                        "FROM (SELECT MAP(ARRAY['low'], ARRAY[100000]) map1, '' name) CROSS JOIN (SELECT MAP() AS other_map) risk_map",
+                "VALUES (ARRAY[100000], ARRAY[100000])");
+        assertQueryWithSameQueryRunner(session,
+                "SELECT COALESCE(TRY(TRANSFORM_VALUES(id, (k, v) -> k / v)), MAP()) " +
+                        "FROM (VALUES " +
+                        "(MAP(ARRAY[1, 2], ARRAY[0, 0])), " +
+                        "(MAP(ARRAY[1, 2], ARRAY[1, 2])), " +
+                        "(MAP(ARRAY[28, 56], ARRAY[2, 4])), " +
+                        "(MAP(ARRAY[4, 5], ARRAY[0, 0])), " +
+                        "(MAP(ARRAY[12, 72], ARRAY[3, 6]))) AS t (id)",
+                "VALUES MAP(), MAP(ARRAY[1, 2], ARRAY[1, 1]), MAP(ARRAY[28, 56], ARRAY[14, 14]), MAP(), MAP(ARRAY[12, 72], ARRAY[4, 12])");
     }
 
     @Test


### PR DESCRIPTION
## Description
Fixes `Field not found` errors when the native expression optimizer processes lambda expressions that capture outer-scope variables i.e., lambdas inside `BIND` expressions. 

## Motivation and Context
Resolves https://github.com/prestodb/presto/issues/27449.

When a query contains a higher-order function (e.g., `transform`, `filter`) whose lambda body references a column from an outer scope, Presto's planner desugars this into a `BIND` special-form expression, eg: `BIND(capturedVar, Lambda(extraArg, x, body))` indicates `capturedVar` is supplied as the first argument of the lambda at call time.

The native sidecar optimizer receives this `BIND` expression and in the process of converting it to a Velox expression, discards the `BIND` wrapper, inlines the captured variable references directly into the lambda body, and returns a plain `LambdaTypedExpr`. After optimization, `VeloxToPrestoExpr::getLambdaExpression` converts the result back to Presto `RowExpression`, but it previously returned a plain `LambdaDefinitionExpression` with no `BIND` around it.

The resulting expression had dangling free variable references (e.g., `field_0`) with nothing to supply them. These were no longer visible to the Presto planner as explicit `BIND` arguments, so the planner could prune the column from the input row. At native execution time, Velox then failed with `VeloxUserError: Field not found: field_0. Available fields are: expr, field.`

## Impact
Queries that use higher-order functions with lambda expressions capturing outer-scope columns (e.g., `SELECT transform(some_array, x -> x + outer_col) FROM t`) would fail at runtime when the native expression optimizer was enabled. This is a correctness fix with no performance impact.

## Test Plan
Added e2e tests.

## Release Notes

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Ensure native expression conversion preserves captured variables in lambdas by wrapping them in BIND expressions when needed.

Bug Fixes:
- Fix loss of captured outer variables in lambda expressions during Velox-to-Presto RowExpression conversion by introducing BIND wrappers for lambdas with free variables.

Tests:
- Extend native expression optimizer tests to cover queries where lambdas capture outer columns, verifying BIND expressions are preserved.

## Summary by Sourcery

Preserve captured outer-scope variables when converting Velox lambdas to Presto RowExpressions by wrapping lambdas with BIND expressions when free variables are present.

Bug Fixes:
- Fix loss of captured variables in lambda expressions during Velox-to-Presto conversion that caused `Field not found` errors at runtime.

Tests:
- Extend native expression optimizer end-to-end tests to cover queries where lambdas capture outer columns and verify successful execution.