### PR TITLE
misc(planner): Move RpcFunctionOptimizer after RewriteRowExpressions

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -388,9 +388,6 @@ public class PlanOptimizers
 
         builder.add(new LogicalCteOptimizer(metadata));
 
-        // Rewrite RPC function calls (e.g., fb_llm_inference) to use async RPC pattern
-        builder.add(new RpcFunctionOptimizer(rpcFunctionNames));
-
         builder.add(new IterativeOptimizer(
                 metadata,
                 ruleStats,
@@ -644,6 +641,7 @@ public class PlanOptimizers
 
         builder.add(new IterativeOptimizer(metadata, ruleStats, statsCalculator, estimatedExchangesCostCalculator,
                 new RewriteRowExpressions(expressionOptimizerManager).rules()));
+        builder.add(new RpcFunctionOptimizer(rpcFunctionNames));
 
         builder.add(new IterativeOptimizer(
                 metadata,


### PR DESCRIPTION
## Description
Move `RpcFunctionOptimizer` to run after `RewriteRowExpressions` in the optimizer pipeline in `PlanOptimizers.java`.

## Motivation and Context
`RewriteRowExpressions` can rewrite functions into RPC functions. If `RpcFunctionOptimizer` runs before `RewriteRowExpressions`, it will miss these rewritten RPC function calls.

## Impact
No public API or user-facing feature change. No performance impact.

## Test Plan
Existing tests pass.

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely. If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== NO RELEASE NOTE ==
```