### PR TITLE
feat(plugin-native-sidecar): Add operational metrics to sidecar

### DIFF
--- a/presto-native-sidecar-plugin/pom.xml
+++ b/presto-native-sidecar-plugin/pom.xml
@@ -57,6 +57,16 @@
 
         <dependency>
             <groupId>com.facebook.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
             <artifactId>log-manager</artifactId>
         </dependency>
 

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/NativeSidecarCommunicationModule.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/NativeSidecarCommunicationModule.java
@@ -14,16 +14,28 @@
 package com.facebook.presto.sidecar;
 
 import com.facebook.presto.common.AuthClientConfigs;
+import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.guice.MBeanModule;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanServer;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static com.facebook.presto.server.CommonInternalCommunicationModule.bindInternalAuth;
+import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 import static java.util.Objects.requireNonNull;
 
 public class NativeSidecarCommunicationModule
         implements Module
 {
+    private static final MBeanExporter EXPORTER = new SidecarAwareMBeanExporter(getPlatformMBeanServer());
     private final AuthClientConfigs authClientConfigs;
 
     public NativeSidecarCommunicationModule(AuthClientConfigs authClientConfigs)
@@ -36,5 +48,69 @@ public class NativeSidecarCommunicationModule
     {
         bindInternalAuth(binder, authClientConfigs);
         httpClientBinder(binder).bindHttpClient("sidecar", ForSidecarInfo.class);
+    }
+
+    public static void installMBeanModule(Binder binder)
+    {
+        Module module = Modules.override(new MBeanModule())
+                .with(new AbstractModule()
+                {
+                    @Override
+                    protected void configure()
+                    {
+                        bind(MBeanExporter.class).toInstance(EXPORTER);
+                    }
+                });
+        binder.install(module);
+        binder.bind(MBeanServer.class).toInstance(getPlatformMBeanServer());
+    }
+
+    /**
+     * Custom MBeanExporter to avoid duplicate JMX registration for the sidecar HttpClient.
+     * Multiple modules bind the same HttpClient ("sidecar", @ForSidecarInfo) across different injectors,
+     * but JMX is JVM-global and requires unique ObjectNames. This exporter ensures the sidecar MBean is
+     * registered only once while preserving default behavior for all other MBeans.
+     **/
+    private static class SidecarAwareMBeanExporter
+            extends MBeanExporter
+    {
+        private static final String SIDECAR_BEAN_OBJECT_NAME =
+                "com.facebook.airlift.http.client:type=HttpClient,name=ForSidecarInfo";
+        private final Set<String> exportedBeanNames = ConcurrentHashMap.newKeySet();
+
+        public SidecarAwareMBeanExporter(MBeanServer server)
+        {
+            super(server);
+        }
+
+        @Override
+        public void export(String name, Object object)
+        {
+            if (SIDECAR_BEAN_OBJECT_NAME.equals(name) && !exportedBeanNames.add(name)) {
+                return;
+            }
+
+            try {
+                super.export(name, object);
+            }
+            catch (RuntimeException e) {
+                // Only suppress duplicate for @ForSidecarInfo
+                if (SIDECAR_BEAN_OBJECT_NAME.equals(name) && isInstanceAlreadyExists(e)) {
+                    return;
+                }
+                throw e;
+            }
+        }
+
+        private boolean isInstanceAlreadyExists(Throwable t)
+        {
+            while (t != null) {
+                if (t instanceof InstanceAlreadyExistsException) {
+                    return true;
+                }
+                t = t.getCause();
+            }
+            return false;
+        }
     }
 }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionsModule.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeExpressionsModule.java
@@ -26,7 +26,9 @@ import com.google.inject.Scopes;
 
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.sidecar.NativeSidecarCommunicationModule.installMBeanModule;
 import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class NativeExpressionsModule
         implements Module
@@ -64,6 +66,10 @@ public class NativeExpressionsModule
         jsonCodecBinder(binder).bindListJsonCodec(RowExpressionOptimizationResult.class);
 
         binder.bind(NativeSidecarExpressionInterpreter.class).in(Scopes.SINGLETON);
+
+        // jmx metrics
+        installMBeanModule(binder);
+        newExporter(binder).export(NativeSidecarExpressionInterpreter.class).withGeneratedName();
 
         // The main service provider
         binder.bind(NativeExpressionOptimizer.class).in(Scopes.SINGLETON);

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeSidecarExpressionInterpreter.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeSidecarExpressionInterpreter.java
@@ -17,6 +17,9 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.HttpUriBuilder;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.TimeStat;
+import com.facebook.airlift.units.Duration;
 import com.facebook.presto.sidecar.ForSidecarInfo;
 import com.facebook.presto.sidecar.NativeSidecarFailureInfo;
 import com.facebook.presto.spi.ConnectorSession;
@@ -28,12 +31,15 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 import java.net.URI;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
@@ -56,7 +62,8 @@ public class NativeSidecarExpressionInterpreter
     public static final String PRESTO_EXPRESSION_OPTIMIZER_LEVEL_HEADER = "X-Presto-Expression-Optimizer-Level";
     public static final String PRESTO_SESSION_START_TIME_HEADER = "X-Presto-Session-Start-Time";
     private static final String EXPRESSIONS_ENDPOINT = "/v1/expressions";
-
+    private static final TimeStat latency = new TimeStat();
+    private static final Logger log = Logger.get(NativeSidecarExpressionInterpreter.class);
     private final NodeManager nodeManager;
     private final HttpClient httpClient;
     private final JsonCodec<ExpressionOptimizationRequest> expressionOptimizationRequestCodec;
@@ -109,6 +116,7 @@ public class NativeSidecarExpressionInterpreter
     public List<RowExpressionOptimizationResult> optimize(ConnectorSession session, ExpressionOptimizer.Level level, List<RowExpression> resolvedExpressions)
     {
         List<RowExpressionOptimizationResult> optimizedExpressions;
+        long start = System.nanoTime();
         try {
             optimizedExpressions = httpClient.execute(
                     getSidecarRequest(session, level, resolvedExpressions),
@@ -117,7 +125,19 @@ public class NativeSidecarExpressionInterpreter
         catch (Exception e) {
             throw new PrestoException(INVALID_ARGUMENTS, "Failed to get optimized expressions from sidecar.", e);
         }
+        finally {
+            Duration duration = new Duration(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            latency.add(duration);
+            log.debug("queryId=%s, expression optimization latencyMs=%d", session.getQueryId(), duration.toMillis());
+        }
         return optimizedExpressions;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getLatency()
+    {
+        return latency;
     }
 
     private Request getSidecarRequest(ConnectorSession session, Level level, List<RowExpression> resolvedExpressions)

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeSidecarExpressionInterpreter.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/expressions/NativeSidecarExpressionInterpreter.java
@@ -17,6 +17,9 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.HttpUriBuilder;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.TimeStat;
+import com.facebook.airlift.units.Duration;
 import com.facebook.presto.sidecar.ForSidecarInfo;
 import com.facebook.presto.sidecar.NativeSidecarFailureInfo;
 import com.facebook.presto.spi.ConnectorSession;
@@ -28,12 +31,15 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 import java.net.URI;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
@@ -56,7 +62,8 @@ public class NativeSidecarExpressionInterpreter
     public static final String PRESTO_EXPRESSION_OPTIMIZER_LEVEL_HEADER = "X-Presto-Expression-Optimizer-Level";
     public static final String PRESTO_SESSION_START_TIME_HEADER = "X-Presto-Session-Start-Time";
     private static final String EXPRESSIONS_ENDPOINT = "/v1/expressions";
-
+    private static final TimeStat latency = new TimeStat();
+    private static final Logger log = Logger.get(NativeSidecarExpressionInterpreter.class);
     private final NodeManager nodeManager;
     private final HttpClient httpClient;
     private final JsonCodec<ExpressionOptimizationRequest> expressionOptimizationRequestCodec;
@@ -109,6 +116,7 @@ public class NativeSidecarExpressionInterpreter
     public List<RowExpressionOptimizationResult> optimize(ConnectorSession session, ExpressionOptimizer.Level level, List<RowExpression> resolvedExpressions)
     {
         List<RowExpressionOptimizationResult> optimizedExpressions;
+        long start = System.nanoTime();
         try {
             optimizedExpressions = httpClient.execute(
                     getSidecarRequest(session, level, resolvedExpressions),
@@ -117,7 +125,19 @@ public class NativeSidecarExpressionInterpreter
         catch (Exception e) {
             throw new PrestoException(INVALID_ARGUMENTS, "Failed to get optimized expressions from sidecar.", e);
         }
+        finally {
+            Duration duration = new Duration(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            latency.add(duration);
+            log.info("queryId=%s, expression optimization latencyMs=%d", session.getQueryId(), duration.toMillis());
+        }
         return optimizedExpressions;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getLatency()
+    {
+        return latency;
     }
 
     private Request getSidecarRequest(ConnectorSession session, Level level, List<RowExpression> resolvedExpressions)

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
@@ -19,6 +19,8 @@ import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.StringResponseHandler.StringResponse;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.TimeStat;
+import com.facebook.airlift.units.Duration;
 import com.facebook.presto.sidecar.ForSidecarInfo;
 import com.facebook.presto.sidecar.NativeSidecarFailureInfo;
 import com.facebook.presto.spi.ConnectorId;
@@ -41,10 +43,13 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.http.client.Request.Builder.preparePost;
 import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
@@ -71,6 +76,7 @@ public final class NativePlanChecker
     private static final Logger LOG = Logger.get(NativePlanChecker.class);
     private static final JsonCodec<PlanConversionResponse> PLAN_CONVERSION_RESPONSE_JSON_CODEC = JsonCodec.jsonCodec(PlanConversionResponse.class);
     public static final String PLAN_CONVERSION_ENDPOINT = "/v1/velox/plan";
+    private static final TimeStat latency = new TimeStat();
 
     private final NodeManager nodeManager;
     private final JsonCodec<SimplePlanFragment> planFragmentJsonCodec;
@@ -107,6 +113,13 @@ public final class NativePlanChecker
         return httpClient;
     }
 
+    @Managed
+    @Nested
+    public TimeStat getLatency()
+    {
+        return latency;
+    }
+
     /**
      * HACK: Replace TableWriterNode from the plan fragment with a ProjectNode because validating a TableWriterNode
      * is unsupported by the native sidecar.  They are unsupported because they contain information only determined
@@ -138,6 +151,7 @@ public final class NativePlanChecker
     {
         LOG.debug("Starting native plan validation [fragment: %s, root: %s]", planFragment.getId(), planFragment.getRoot().getId());
         String requestBodyJson = planFragmentJsonCodec.toJson(planFragment);
+        long start = System.nanoTime();
 
         try {
             StringResponse response = httpClient.execute(getSidecarRequest(requestBodyJson), createStringResponseHandler());
@@ -154,6 +168,9 @@ public final class NativePlanChecker
             throw new PrestoException(NATIVEPLANCHECKER_CONNECTION_ERROR, "Error getting native plan checker response", e);
         }
         finally {
+            Duration duration = new Duration(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            latency.add(duration);
+            LOG.debug("Fragment: %s, root: %s, native plan validation latencyMs=%d", planFragment.getId(), planFragment.getRoot().getId(), duration.toMillis());
             LOG.debug("Native plan validation complete [fragment: %s, root: %s]", planFragment.getId(), planFragment.getRoot().getId());
         }
     }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanChecker.java
@@ -19,6 +19,8 @@ import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.StringResponseHandler.StringResponse;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.TimeStat;
+import com.facebook.airlift.units.Duration;
 import com.facebook.presto.sidecar.ForSidecarInfo;
 import com.facebook.presto.sidecar.NativeSidecarFailureInfo;
 import com.facebook.presto.spi.ConnectorId;
@@ -41,10 +43,13 @@ import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.http.client.Request.Builder.preparePost;
 import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
@@ -71,6 +76,7 @@ public final class NativePlanChecker
     private static final Logger LOG = Logger.get(NativePlanChecker.class);
     private static final JsonCodec<PlanConversionResponse> PLAN_CONVERSION_RESPONSE_JSON_CODEC = JsonCodec.jsonCodec(PlanConversionResponse.class);
     public static final String PLAN_CONVERSION_ENDPOINT = "/v1/velox/plan";
+    private static final TimeStat latency1 = new TimeStat();
 
     private final NodeManager nodeManager;
     private final JsonCodec<SimplePlanFragment> planFragmentJsonCodec;
@@ -107,6 +113,13 @@ public final class NativePlanChecker
         return httpClient;
     }
 
+    @Managed
+    @Nested
+    public TimeStat getLatency1()
+    {
+        return latency1;
+    }
+
     /**
      * HACK: Replace TableWriterNode from the plan fragment with a ProjectNode because validating a TableWriterNode
      * is unsupported by the native sidecar.  They are unsupported because they contain information only determined
@@ -138,6 +151,7 @@ public final class NativePlanChecker
     {
         LOG.debug("Starting native plan validation [fragment: %s, root: %s]", planFragment.getId(), planFragment.getRoot().getId());
         String requestBodyJson = planFragmentJsonCodec.toJson(planFragment);
+        long start = System.nanoTime();
 
         try {
             StringResponse response = httpClient.execute(getSidecarRequest(requestBodyJson), createStringResponseHandler());
@@ -154,6 +168,9 @@ public final class NativePlanChecker
             throw new PrestoException(NATIVEPLANCHECKER_CONNECTION_ERROR, "Error getting native plan checker response", e);
         }
         finally {
+            Duration duration = new Duration(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            latency1.add(duration);
+            LOG.info("Fragment: %s, root: %s, native plan validation latencyMs=%d", planFragment.getId(), planFragment.getRoot().getId(), duration.toMillis());
             LOG.debug("Native plan validation complete [fragment: %s, root: %s]", planFragment.getId(), planFragment.getRoot().getId());
         }
     }

--- a/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanCheckerModule.java
+++ b/presto-native-sidecar-plugin/src/main/java/com/facebook/presto/sidecar/nativechecker/NativePlanCheckerModule.java
@@ -25,7 +25,9 @@ import com.google.inject.Scopes;
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.sidecar.NativeSidecarCommunicationModule.installMBeanModule;
 import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class NativePlanCheckerModule
         implements Module
@@ -50,5 +52,9 @@ public class NativePlanCheckerModule
         jsonCodecBinder(binder).bindJsonCodec(SimplePlanFragment.class);
         binder.bind(NativePlanChecker.class).in(Scopes.SINGLETON);
         binder.bind(PlanCheckerProvider.class).to(NativePlanCheckerProvider.class).in(Scopes.SINGLETON);
+
+        // jmx metrics
+        installMBeanModule(binder);
+        newExporter(binder).export(NativePlanChecker.class).withGeneratedName();
     }
 }


### PR DESCRIPTION
## Description
Add operational JMX metrics to the sidecar plugin.

## Motivation and Context
Operational metrics are important to understand how the system is behaving and to troubleshoot issues.

## Impact
JMX metrics exposed. 

## Test Plan
CI

## Contributor checklist

- [x] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [x] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [x] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [x] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [x] Adequate tests were added if applicable.
- [x] CI passed.
- [x] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Add JMX-exposed operational latency metrics and logging for native sidecar interactions in the Presto native sidecar plugin.

New Features:
- Expose latency metrics for native expression optimization calls via JMX.
- Expose latency metrics for native plan checker validation calls via JMX.

Enhancements:
- Log per-request latency for expression optimization and native plan validation to aid observability and troubleshooting.
- Introduce a custom MBean exporter to prevent duplicate JMX registration for the sidecar HTTP client while wiring JMX modules into sidecar-related Guice modules.

Build:
- Add stats and JMX utilities dependencies to the native sidecar plugin module.