### PR TITLE
feat(optimizer): Extend JoinPrefilter to support complex probe-side patterns

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties-session.rst
+++ b/presto-docs/src/main/sphinx/admin/properties-session.rst
@@ -731,6 +731,20 @@ concurrency.
 
 The corresponding configuration property is :ref:`admin/properties:\`\`optimizer.local-exchange-parent-preference-strategy\`\``.
 
+``join_prefilter_build_side_with_complex_probe_side``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``boolean``
+* **Default value:** ``false``
+
+Extends the ``join_prefilter_build_side`` optimization to clone more complex probe-side
+patterns (``UNION ALL``, cross join, ``UNNEST``, aggregation) when building the prefilter,
+and to push the prefilter ``SemiJoin`` below right-side aggregations so the build side is
+filtered before grouping. Only takes effect when ``join_prefilter_build_side`` is also
+enabled. Disabled by default because cloning additional probe-side work adds planning
+and runtime overhead, which only pays off when the build side is large enough to dominate
+the join cost.
+
 
 JDBC Properties
 ---------------

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -357,6 +357,7 @@ public final class SystemSessionProperties
     public static final String EAGER_PLAN_VALIDATION_ENABLED = "eager_plan_validation_enabled";
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
     public static final String JOIN_PREFILTER_BUILD_SIDE = "join_prefilter_build_side";
+    public static final String JOIN_PREFILTER_COMPLEX_BUILD_SIDE = "join_prefilter_build_side_with_complex_probe_side";
     public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
     public static final String WARN_ON_COMMON_NAN_PATTERNS = "warn_on_common_nan_patterns";
     public static final String INLINE_PROJECTIONS_ON_VALUES = "inline_projections_on_values";
@@ -2080,6 +2081,11 @@ public final class SystemSessionProperties
                         "Prefiltering the build/inner side of a join with keys from the other side",
                         false,
                         false),
+                booleanProperty(
+                        JOIN_PREFILTER_COMPLEX_BUILD_SIDE,
+                        "Extend join prefilter to support complex left-side patterns (UNION ALL, cross join, unnest, aggregation) and push prefilter below right-side aggregation",
+                        false,
+                        false),
                 booleanProperty(OPTIMIZER_USE_HISTOGRAMS,
                         "whether or not to use histograms in the CBO",
                         featuresConfig.isUseHistograms(),
@@ -3642,6 +3648,11 @@ public final class SystemSessionProperties
     public static boolean isJoinPrefilterEnabled(Session session)
     {
         return session.getSystemProperty(JOIN_PREFILTER_BUILD_SIDE, Boolean.class);
+    }
+
+    public static boolean isJoinPrefilterComplexBuildSideEnabled(Session session)
+    {
+        return session.getSystemProperty(JOIN_PREFILTER_COMPLEX_BUILD_SIDE, Boolean.class);
     }
 
     public static boolean isPrintEstimatedStatsFromCacheEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -364,6 +364,7 @@ public final class SystemSessionProperties
     public static final String EAGER_PLAN_VALIDATION_ENABLED = "eager_plan_validation_enabled";
     public static final String DEFAULT_VIEW_SECURITY_MODE = "default_view_security_mode";
     public static final String JOIN_PREFILTER_BUILD_SIDE = "join_prefilter_build_side";
+    public static final String JOIN_PREFILTER_COMPLEX_BUILD_SIDE = "join_prefilter_build_side_with_complex_probe_side";
     public static final String OPTIMIZER_USE_HISTOGRAMS = "optimizer_use_histograms";
     public static final String WARN_ON_COMMON_NAN_PATTERNS = "warn_on_common_nan_patterns";
     public static final String INLINE_PROJECTIONS_ON_VALUES = "inline_projections_on_values";
@@ -2132,6 +2133,11 @@ public final class SystemSessionProperties
                         "Prefiltering the build/inner side of a join with keys from the other side",
                         false,
                         false),
+                booleanProperty(
+                        JOIN_PREFILTER_COMPLEX_BUILD_SIDE,
+                        "Extend join prefilter to support complex left-side patterns (UNION ALL, cross join, unnest, aggregation) and push prefilter below right-side aggregation",
+                        false,
+                        false),
                 booleanProperty(OPTIMIZER_USE_HISTOGRAMS,
                         "whether or not to use histograms in the CBO",
                         featuresConfig.isUseHistograms(),
@@ -3738,6 +3744,11 @@ public final class SystemSessionProperties
     public static boolean isJoinPrefilterEnabled(Session session)
     {
         return session.getSystemProperty(JOIN_PREFILTER_BUILD_SIDE, Boolean.class);
+    }
+
+    public static boolean isJoinPrefilterComplexBuildSideEnabled(Session session)
+    {
+        return session.getSystemProperty(JOIN_PREFILTER_COMPLEX_BUILD_SIDE, Boolean.class);
     }
 
     public static boolean isOptimizeTopNUsingRowIdEnabled(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.ProjectNode.Locality;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
@@ -59,11 +60,15 @@ import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
 import io.airlift.slice.Slices;
 
 import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +92,7 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.PlanFragmenterUtils.isCoordinatorOnlyDistribution;
 import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.optimizations.SetOperationNodeUtils.fromListMultimap;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.callOperator;
 import static com.facebook.presto.sql.relational.Expressions.constant;
@@ -388,9 +394,57 @@ public class PlannerUtils
         else if (planNode instanceof ProjectNode) {
             return cloneProjectNode((ProjectNode) planNode, session, metadata, planNodeIdAllocator, fieldsToKeep, varMap, planNodeIdAllocator);
         }
+        else if (planNode instanceof UnionNode) {
+            return cloneUnionNode((UnionNode) planNode, session, metadata, planNodeIdAllocator, fieldsToKeep, varMap);
+        }
 
         checkState(false, "Currently cannot clone: " + planNode.getClass().getName() + " nodes.");
         return null;
+    }
+
+    private static PlanNode cloneUnionNode(UnionNode unionNode, Session session, Metadata metadata, PlanNodeIdAllocator idAllocator, List<VariableReferenceExpression> fieldsToKeep, Map<VariableReferenceExpression, VariableReferenceExpression> varMap)
+    {
+        int numSources = unionNode.getSources().size();
+        List<PlanNode> clonedSources = new ArrayList<>();
+        List<Map<VariableReferenceExpression, VariableReferenceExpression>> legVarMaps = new ArrayList<>();
+
+        for (int i = 0; i < numSources; i++) {
+            Map<VariableReferenceExpression, VariableReferenceExpression> sourceMap = unionNode.sourceVariableMap(i);
+            Map<VariableReferenceExpression, VariableReferenceExpression> legVarMap = new HashMap<>();
+
+            List<VariableReferenceExpression> legFieldsToKeep = fieldsToKeep.stream()
+                    .map(sourceMap::get)
+                    .filter(v -> v != null)
+                    .collect(toImmutableList());
+
+            PlanNode clonedLeg = clonePlanNode(unionNode.getSources().get(i), session, metadata, idAllocator, legFieldsToKeep, legVarMap);
+            clonedSources.add(clonedLeg);
+            legVarMaps.add(legVarMap);
+        }
+
+        ImmutableListMultimap.Builder<VariableReferenceExpression, VariableReferenceExpression> newOutputToInputs = ImmutableListMultimap.builder();
+        ImmutableList.Builder<VariableReferenceExpression> newOutputVars = ImmutableList.builder();
+
+        for (VariableReferenceExpression outputVar : unionNode.getOutputVariables()) {
+            VariableReferenceExpression newOutputVar = varMap.getOrDefault(outputVar, outputVar);
+            varMap.putIfAbsent(outputVar, newOutputVar);
+            newOutputVars.add(newOutputVar);
+
+            List<VariableReferenceExpression> originalInputs = unionNode.getVariableMapping().get(outputVar);
+            for (int i = 0; i < numSources; i++) {
+                VariableReferenceExpression originalInput = originalInputs.get(i);
+                VariableReferenceExpression clonedInput = legVarMaps.get(i).getOrDefault(originalInput, originalInput);
+                newOutputToInputs.put(newOutputVar, clonedInput);
+            }
+        }
+
+        ListMultimap<VariableReferenceExpression, VariableReferenceExpression> multimap = newOutputToInputs.build();
+        return new UnionNode(
+                unionNode.getSourceLocation(),
+                idAllocator.getNextId(),
+                clonedSources,
+                newOutputVars.build(),
+                fromListMultimap(multimap));
     }
 
     public static String getPlanString(PlanNode planNode, Session session, TypeProvider types, Metadata metadata, boolean isVerboseOptimizerInfoEnabled)
@@ -472,7 +526,8 @@ public class PlannerUtils
     {
         return node instanceof TableScanNode ||
                 node instanceof ProjectNode && isScanFilterProject(((ProjectNode) node).getSource()) ||
-                node instanceof FilterNode && isScanFilterProject(((FilterNode) node).getSource());
+                node instanceof FilterNode && isScanFilterProject(((FilterNode) node).getSource()) ||
+                node instanceof UnionNode && ((UnionNode) node).getSources().stream().allMatch(PlannerUtils::isScanFilterProject);
     }
 
     /**
@@ -502,6 +557,10 @@ public class PlannerUtils
             ProjectNode projectNode = (ProjectNode) node;
             return projectNode.getAssignments().getExpressions().stream().allMatch(determinismEvaluator::isDeterministic)
                     && isDeterministicPlanSubtree(projectNode.getSource(), determinismEvaluator);
+        }
+        else if (node instanceof UnionNode) {
+            return ((UnionNode) node).getSources().stream()
+                    .allMatch(source -> isDeterministicPlanSubtree(source, determinismEvaluator));
         }
         return false;
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/PlannerUtils.java
@@ -40,6 +40,7 @@ import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.ProjectNode.Locality;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.UnionNode;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
@@ -61,11 +62,15 @@ import com.facebook.presto.sql.tree.OrderBy;
 import com.facebook.presto.sql.tree.SortItem;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
 import io.airlift.slice.Slices;
 
 import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +94,7 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.PlanFragmenterUtils.isCoordinatorOnlyDistribution;
 import static com.facebook.presto.sql.planner.iterative.Lookup.noLookup;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.optimizations.SetOperationNodeUtils.fromListMultimap;
 import static com.facebook.presto.sql.relational.Expressions.call;
 import static com.facebook.presto.sql.relational.Expressions.callOperator;
 import static com.facebook.presto.sql.relational.Expressions.constant;
@@ -390,9 +396,57 @@ public class PlannerUtils
         else if (planNode instanceof ProjectNode) {
             return cloneProjectNode((ProjectNode) planNode, session, metadata, planNodeIdAllocator, fieldsToKeep, varMap, planNodeIdAllocator);
         }
+        else if (planNode instanceof UnionNode) {
+            return cloneUnionNode((UnionNode) planNode, session, metadata, planNodeIdAllocator, fieldsToKeep, varMap);
+        }
 
         checkState(false, "Currently cannot clone: " + planNode.getClass().getName() + " nodes.");
         return null;
+    }
+
+    private static PlanNode cloneUnionNode(UnionNode unionNode, Session session, Metadata metadata, PlanNodeIdAllocator idAllocator, List<VariableReferenceExpression> fieldsToKeep, Map<VariableReferenceExpression, VariableReferenceExpression> varMap)
+    {
+        int numSources = unionNode.getSources().size();
+        List<PlanNode> clonedSources = new ArrayList<>();
+        List<Map<VariableReferenceExpression, VariableReferenceExpression>> legVarMaps = new ArrayList<>();
+
+        for (int i = 0; i < numSources; i++) {
+            Map<VariableReferenceExpression, VariableReferenceExpression> sourceMap = unionNode.sourceVariableMap(i);
+            Map<VariableReferenceExpression, VariableReferenceExpression> legVarMap = new HashMap<>();
+
+            List<VariableReferenceExpression> legFieldsToKeep = fieldsToKeep.stream()
+                    .map(sourceMap::get)
+                    .filter(v -> v != null)
+                    .collect(toImmutableList());
+
+            PlanNode clonedLeg = clonePlanNode(unionNode.getSources().get(i), session, metadata, idAllocator, legFieldsToKeep, legVarMap);
+            clonedSources.add(clonedLeg);
+            legVarMaps.add(legVarMap);
+        }
+
+        ImmutableListMultimap.Builder<VariableReferenceExpression, VariableReferenceExpression> newOutputToInputs = ImmutableListMultimap.builder();
+        ImmutableList.Builder<VariableReferenceExpression> newOutputVars = ImmutableList.builder();
+
+        for (VariableReferenceExpression outputVar : unionNode.getOutputVariables()) {
+            VariableReferenceExpression newOutputVar = varMap.getOrDefault(outputVar, outputVar);
+            varMap.putIfAbsent(outputVar, newOutputVar);
+            newOutputVars.add(newOutputVar);
+
+            List<VariableReferenceExpression> originalInputs = unionNode.getVariableMapping().get(outputVar);
+            for (int i = 0; i < numSources; i++) {
+                VariableReferenceExpression originalInput = originalInputs.get(i);
+                VariableReferenceExpression clonedInput = legVarMaps.get(i).getOrDefault(originalInput, originalInput);
+                newOutputToInputs.put(newOutputVar, clonedInput);
+            }
+        }
+
+        ListMultimap<VariableReferenceExpression, VariableReferenceExpression> multimap = newOutputToInputs.build();
+        return new UnionNode(
+                unionNode.getSourceLocation(),
+                idAllocator.getNextId(),
+                clonedSources,
+                newOutputVars.build(),
+                fromListMultimap(multimap));
     }
 
     public static String getPlanString(PlanNode planNode, Session session, TypeProvider types, Metadata metadata, boolean isVerboseOptimizerInfoEnabled)
@@ -529,6 +583,19 @@ public class PlannerUtils
     }
 
     /**
+     * Like {@link #isScanFilterProject(PlanNode)}, but additionally accepts a {@link UnionNode}
+     * whose every source is itself a scan/filter/project subtree. Use this from optimizers that
+     * specifically support cloning UNION ALL probe sides (e.g. JoinPrefilter's complex-probe-side
+     * mode). Other callers should keep using {@link #isScanFilterProject} so they don't silently
+     * gain UNION ALL handling without being audited.
+     */
+    public static boolean isScanFilterProjectOrUnion(PlanNode node)
+    {
+        return isScanFilterProject(node) ||
+                node instanceof UnionNode && ((UnionNode) node).getSources().stream().allMatch(PlannerUtils::isScanFilterProjectOrUnion);
+    }
+
+    /**
      * Returns true if the scan-filter-project plan subtree contains only deterministic
      * expressions in all filters and projections. This check is critical for optimizations
      * that clone the subtree (e.g., JoinPrefilter), because cloning a subtree with
@@ -538,10 +605,22 @@ public class PlannerUtils
     public static boolean isDeterministicScanFilterProject(PlanNode node, FunctionAndTypeManager functionAndTypeManager)
     {
         DeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
-        return isDeterministicPlanSubtree(node, determinismEvaluator);
+        return isDeterministicPlanSubtree(node, determinismEvaluator, false);
     }
 
-    private static boolean isDeterministicPlanSubtree(PlanNode node, DeterminismEvaluator determinismEvaluator)
+    /**
+     * Like {@link #isDeterministicScanFilterProject}, but additionally accepts a UnionNode
+     * whose every source is itself a deterministic scan/filter/project (or another such Union)
+     * subtree. Pair with {@link #isScanFilterProjectOrUnion} when the caller specifically
+     * supports cloning UNION ALL probe sides.
+     */
+    public static boolean isDeterministicScanFilterProjectOrUnion(PlanNode node, FunctionAndTypeManager functionAndTypeManager)
+    {
+        DeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
+        return isDeterministicPlanSubtree(node, determinismEvaluator, true);
+    }
+
+    private static boolean isDeterministicPlanSubtree(PlanNode node, DeterminismEvaluator determinismEvaluator, boolean allowUnion)
     {
         if (node instanceof TableScanNode) {
             return true;
@@ -549,12 +628,16 @@ public class PlannerUtils
         else if (node instanceof FilterNode) {
             FilterNode filterNode = (FilterNode) node;
             return determinismEvaluator.isDeterministic(filterNode.getPredicate())
-                    && isDeterministicPlanSubtree(filterNode.getSource(), determinismEvaluator);
+                    && isDeterministicPlanSubtree(filterNode.getSource(), determinismEvaluator, allowUnion);
         }
         else if (node instanceof ProjectNode) {
             ProjectNode projectNode = (ProjectNode) node;
             return projectNode.getAssignments().getExpressions().stream().allMatch(determinismEvaluator::isDeterministic)
-                    && isDeterministicPlanSubtree(projectNode.getSource(), determinismEvaluator);
+                    && isDeterministicPlanSubtree(projectNode.getSource(), determinismEvaluator, allowUnion);
+        }
+        else if (allowUnion && node instanceof UnionNode) {
+            return ((UnionNode) node).getSources().stream()
+                    .allMatch(source -> isDeterministicPlanSubtree(source, determinismEvaluator, allowUnion));
         }
         return false;
     }

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
@@ -25,20 +25,26 @@ import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.SemiJoinNode;
+import com.facebook.presto.spi.plan.UnionNode;
+import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.SystemSessionProperties.isJoinPrefilterComplexBuildSideEnabled;
 import static com.facebook.presto.SystemSessionProperties.isJoinPrefilterEnabled;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -56,76 +62,6 @@ import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
-
-/**
- * This optimizer filter the right side of a join with the unique join keys on the left side of the join. When the join key is wide or
- * there are multiple join keys, we are to do filter on the hash instead of using the keys.
- * It will convert plan from
- * <pre>
- *     - InnerJoin
- *          leftKey = rightKey
- *          - scan l
- *          - scan r
- * </pre>
- * into
- * <pre>
- *     - InnerJoin
- *          leftKey = rightKey
- *          - scan l
- *          - semiJoin
- *              r.rightKey in l.leftKey
- *              - scan r
- *              - distinct aggregation
- *                  group by leftKey
- *                  - scan l
- * </pre>
- * And for join with varchar type
- * <pre>
- *     - InnerJoin
- *          leftKey (varchar) = rightKey (varchar)
- *          - scan l
- *          - scan r
- * </pre>
- * into
- * <pre>
- *     - InnerJoin
- *          leftKey (varchar) = rightKey (varchar)
- *          - scan l
- *          - semiJoin
- *              r.rightKeyHash in l.leftKeyHash
- *              - project
- *                  r.rightKeyHash = xx_hash64(r.rightKey)
- *                  - scan r
- *              - distinct aggregation
- *                  group by leftKeyHash
- *                  - project
- *                      l.leftKeyHash = xx_hash64(l.leftKey)
- *                      - scan l
- * </pre>
- * And for join with multiple keys
- * <pre>
- *     - InnerJoin
- *          leftKey1 = rightKey1 and leftKey2 = rightKey2
- *          - scan l
- *          - scan r
- * </pre>
- * into
- * <pre>
- *     - InnerJoin
- *          leftKey1 = rightKey1 and leftKey2 = rightKey2
- *          - scan l
- *          - semiJoin
- *              r.rightKeysHash in l.leftKeysHash
- *              - project
- *                  r.rightKeysHash = combine_hash(xx_hash64(rightKey1), xx_hash64(rightKey2))
- *                  - scan r
- *              - distinct aggregation
- *                  group by leftKeysHash
- *                  - project
- *                      l.leftKeysHash = combine_hash(xx_hash64(leftKey1), xx_hash64(leftKey2))
- *                      - scan l
- * </pre>
- */
 
 public class JoinPrefilter
         implements PlanOptimizer
@@ -162,6 +98,158 @@ public class JoinPrefilter
         return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
+    /**
+     * Finds a cloneable sub-plan from the left side of a join for prefiltering.
+     * Returns the sub-plan that can be cloned, or empty if not applicable.
+     *
+     * Supports:
+     * - scan/filter/project chains (including UNION ALL of such chains)
+     * - Cross join where one child is scan/filter/project (complex mode)
+     * - UnnestNode where source is scan/filter/project (complex mode)
+     * - AggregationNode where source is any of the above (complex mode)
+     */
+    private static Optional<PlanNode> findCloneableSource(
+            PlanNode node,
+            Set<VariableReferenceExpression> joinKeyVars,
+            FunctionAndTypeManager functionAndTypeManager,
+            boolean complexEnabled)
+    {
+        // Peel through Filter/Project
+        PlanNode peeled = node;
+        while (peeled instanceof FilterNode || peeled instanceof ProjectNode) {
+            if (peeled instanceof FilterNode) {
+                peeled = ((FilterNode) peeled).getSource();
+            }
+            else {
+                peeled = ((ProjectNode) peeled).getSource();
+            }
+        }
+
+        // Base case: scan/filter/project (including UNION ALL when complex mode enabled)
+        if (isScanFilterProject(node) && isDeterministicScanFilterProject(node, functionAndTypeManager)) {
+            // UnionNode requires complex mode
+            if (peeled instanceof UnionNode && !complexEnabled) {
+                return Optional.empty();
+            }
+            return Optional.of(node);
+        }
+
+        if (!complexEnabled) {
+            return Optional.empty();
+        }
+
+        // Cross join: clone the child that contains the join keys
+        if (peeled instanceof JoinNode && ((JoinNode) peeled).isCrossJoin()) {
+            JoinNode crossJoin = (JoinNode) peeled;
+            Set<VariableReferenceExpression> leftOutputs = ImmutableSet.copyOf(crossJoin.getLeft().getOutputVariables());
+            Set<VariableReferenceExpression> rightOutputs = ImmutableSet.copyOf(crossJoin.getRight().getOutputVariables());
+
+            // Trace join keys through any Filter/Project above the cross join
+            Optional<Set<VariableReferenceExpression>> resolvedKeys = resolveVariablesThroughProjectFilter(node, peeled, joinKeyVars);
+            if (!resolvedKeys.isPresent()) {
+                return Optional.empty();
+            }
+
+            if (leftOutputs.containsAll(resolvedKeys.get())
+                    && isScanFilterProject(crossJoin.getLeft())
+                    && isDeterministicScanFilterProject(crossJoin.getLeft(), functionAndTypeManager)) {
+                return Optional.of(crossJoin.getLeft());
+            }
+            if (rightOutputs.containsAll(resolvedKeys.get())
+                    && isScanFilterProject(crossJoin.getRight())
+                    && isDeterministicScanFilterProject(crossJoin.getRight(), functionAndTypeManager)) {
+                return Optional.of(crossJoin.getRight());
+            }
+        }
+
+        // UnnestNode: clone the source if join keys come from replicate variables
+        if (peeled instanceof UnnestNode) {
+            UnnestNode unnest = (UnnestNode) peeled;
+            Optional<Set<VariableReferenceExpression>> resolvedKeys = resolveVariablesThroughProjectFilter(node, peeled, joinKeyVars);
+            if (!resolvedKeys.isPresent()) {
+                return Optional.empty();
+            }
+            Set<VariableReferenceExpression> replicateVars = ImmutableSet.copyOf(unnest.getReplicateVariables());
+
+            if (replicateVars.containsAll(resolvedKeys.get())
+                    && isScanFilterProject(unnest.getSource())
+                    && isDeterministicScanFilterProject(unnest.getSource(), functionAndTypeManager)) {
+                return Optional.of(unnest.getSource());
+            }
+        }
+
+        // AggregationNode: clone the source if join keys are grouping keys
+        if (peeled instanceof AggregationNode) {
+            AggregationNode agg = (AggregationNode) peeled;
+            Optional<Set<VariableReferenceExpression>> resolvedKeys = resolveVariablesThroughProjectFilter(node, peeled, joinKeyVars);
+            if (!resolvedKeys.isPresent()) {
+                return Optional.empty();
+            }
+            Set<VariableReferenceExpression> groupingKeys = ImmutableSet.copyOf(agg.getGroupingKeys());
+
+            if (agg.getStep() == AggregationNode.Step.SINGLE
+                    && agg.getGroupingSetCount() == 1
+                    && !agg.hasEmptyGroupingSet()
+                    && groupingKeys.containsAll(resolvedKeys.get())
+                    && isScanFilterProject(agg.getSource())
+                    && isDeterministicScanFilterProject(agg.getSource(), functionAndTypeManager)) {
+                return Optional.of(agg.getSource());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Traces join key variables backward through Filter/Project nodes
+     * between the top node and the target node to find the source variables
+     * they depend on. Returns empty if a projected expression is not a simple
+     * variable reference (computed join keys cannot be safely traced).
+     */
+    private static Optional<Set<VariableReferenceExpression>> resolveVariablesThroughProjectFilter(
+            PlanNode top,
+            PlanNode target,
+            Set<VariableReferenceExpression> vars)
+    {
+        if (top == target) {
+            return Optional.of(vars);
+        }
+
+        // Build a chain of nodes from top to target
+        PlanNode current = top;
+        Set<VariableReferenceExpression> resolved = vars;
+
+        while (current != target) {
+            if (current instanceof ProjectNode) {
+                ProjectNode project = (ProjectNode) current;
+                ImmutableSet.Builder<VariableReferenceExpression> newResolved = ImmutableSet.builder();
+                for (VariableReferenceExpression var : resolved) {
+                    RowExpression expr = project.getAssignments().getMap().get(var);
+                    if (expr instanceof VariableReferenceExpression) {
+                        newResolved.add((VariableReferenceExpression) expr);
+                    }
+                    else if (expr != null) {
+                        // Expression is not a simple variable reference;
+                        // computed join keys cannot be safely traced
+                        return Optional.empty();
+                    }
+                    else {
+                        newResolved.add(var);
+                    }
+                }
+                resolved = newResolved.build();
+                current = project.getSource();
+            }
+            else if (current instanceof FilterNode) {
+                current = ((FilterNode) current).getSource();
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(resolved);
+    }
+
     private static class Rewriter
             extends SimplePlanRewriter<Void>
     {
@@ -170,6 +258,7 @@ public class JoinPrefilter
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
         private final FunctionAndTypeManager functionAndTypeManager;
+        private final boolean complexEnabled;
         private boolean planChanged;
 
         private Rewriter(Session session, Metadata metadata, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, FunctionAndTypeManager functionAndTypeManager)
@@ -179,6 +268,7 @@ public class JoinPrefilter
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.variableAllocator = requireNonNull(variableAllocator, "idAllocator is null");
             this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.complexEnabled = isJoinPrefilterComplexBuildSideEnabled(session);
         }
 
         @Override
@@ -191,75 +281,64 @@ public class JoinPrefilter
             PlanNode rewrittenRight = rewriteWith(this, right);
             List<EquiJoinClause> equiJoinClause = node.getCriteria();
 
-            // We apply this for only left and inner join and the left side of the join is a simple scan.
-            // We also require that all expressions in the left subtree are deterministic, because
-            // cloning a subtree with non-deterministic expressions (like rand() from TABLESAMPLE BERNOULLI)
-            // would produce different results from each clone, leading to incorrect query results.
             if ((node.getType() == LEFT || node.getType() == INNER)
-                    && isScanFilterProject(rewrittenLeft)
-                    && isDeterministicScanFilterProject(rewrittenLeft, functionAndTypeManager)
                     && !node.getCriteria().isEmpty()) {
                 List<VariableReferenceExpression> leftKeyList = equiJoinClause.stream().map(EquiJoinClause::getLeft).collect(toImmutableList());
                 List<VariableReferenceExpression> rightKeyList = equiJoinClause.stream().map(EquiJoinClause::getRight).collect(toImmutableList());
-                checkState(IntStream.range(0, leftKeyList.size()).boxed().allMatch(i -> leftKeyList.get(i).getType().equals(rightKeyList.get(i).getType())));
 
-                boolean hashJoinKey = leftKeyList.size() > 1 || (leftKeyList.get(0).getType().equals(VARCHAR) || leftKeyList.get(0).getType() instanceof VarcharType);
+                Set<VariableReferenceExpression> leftKeySet = ImmutableSet.copyOf(leftKeyList);
+                Optional<PlanNode> cloneableSource = findCloneableSource(rewrittenLeft, leftKeySet, functionAndTypeManager, complexEnabled);
 
-                // First create a SELECT DISTINCT leftKey FROM left
-                Map<VariableReferenceExpression, VariableReferenceExpression> leftVarMap = new HashMap();
-                PlanNode leftKeys = clonePlanNode(rewrittenLeft, session, metadata, idAllocator, leftKeyList, leftVarMap);
-                ImmutableList.Builder<RowExpression> expressionsToProject = ImmutableList.builder();
-                if (hashJoinKey) {
-                    RowExpression hashExpression = getVariableHash(leftKeyList, functionAndTypeManager);
-                    expressionsToProject.add(hashExpression);
-                }
-                else {
-                    expressionsToProject.add(leftVarMap.get(leftKeyList.get(0)));
-                }
-                PlanNode projectNode = projectExpressions(leftKeys, idAllocator, variableAllocator, expressionsToProject.build(), ImmutableList.of());
+                if (cloneableSource.isPresent()) {
+                    checkState(IntStream.range(0, leftKeyList.size()).boxed().allMatch(i -> leftKeyList.get(i).getType().equals(rightKeyList.get(i).getType())));
 
-                VariableReferenceExpression rightKeyToFilter = rightKeyList.get(0);
-                if (hashJoinKey) {
-                    RowExpression hashExpression = getVariableHash(rightKeyList, functionAndTypeManager);
-                    rightKeyToFilter = variableAllocator.newVariable(hashExpression);
-                    rewrittenRight = addProjections(rewrittenRight, idAllocator, ImmutableMap.of(rightKeyToFilter, hashExpression));
-                }
+                    boolean hashJoinKey = leftKeyList.size() > 1 || (leftKeyList.get(0).getType().equals(VARCHAR) || leftKeyList.get(0).getType() instanceof VarcharType);
 
-                // DISTINCT on the leftkey or hash if wide column
-                PlanNode filteringSource = new AggregationNode(
-                        node.getLeft().getSourceLocation(),
-                        idAllocator.getNextId(),
-                        projectNode,
-                        ImmutableMap.of(),
-                        singleGroupingSet(projectNode.getOutputVariables()),
-                        projectNode.getOutputVariables(),
-                        AggregationNode.Step.SINGLE,
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty());
+                    // First create a SELECT DISTINCT leftKey FROM left
+                    Map<VariableReferenceExpression, VariableReferenceExpression> leftVarMap = new HashMap();
+                    PlanNode leftKeys = clonePlanNode(cloneableSource.get(), session, metadata, idAllocator, leftKeyList, leftVarMap);
+                    ImmutableList.Builder<RowExpression> expressionsToProject = ImmutableList.builder();
+                    if (hashJoinKey) {
+                        RowExpression hashExpression = getVariableHash(leftKeyList, functionAndTypeManager);
+                        expressionsToProject.add(hashExpression);
+                    }
+                    else {
+                        expressionsToProject.add(leftVarMap.get(leftKeyList.get(0)));
+                    }
+                    PlanNode projectNode = projectExpressions(leftKeys, idAllocator, variableAllocator, expressionsToProject.build(), ImmutableList.of());
 
-                // There should be only one output variable. Project that
-                filteringSource = projectExpressions(filteringSource, idAllocator, variableAllocator, ImmutableList.of(filteringSource.getOutputVariables().get(0)), ImmutableList.of());
+                    VariableReferenceExpression rightKeyToFilter = rightKeyList.get(0);
+                    RowExpression rightHashExpression = null;
+                    if (hashJoinKey) {
+                        rightHashExpression = getVariableHash(rightKeyList, functionAndTypeManager);
+                        rightKeyToFilter = variableAllocator.newVariable(rightHashExpression);
+                    }
 
-                // Now we add a semijoin as the right side
-                VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
-                SemiJoinNode semiJoinNode = new SemiJoinNode(
-                        node.getRight().getSourceLocation(),
-                        idAllocator.getNextId(),
-                        node.getStatsEquivalentPlanNode(),
-                        rewrittenRight,
-                        filteringSource,
-                        rightKeyToFilter,
-                        filteringSource.getOutputVariables().get(0),
-                        semiJoinOutput,
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        ImmutableMap.of());
+                    // DISTINCT on the leftkey or hash if wide column
+                    PlanNode filteringSource = new AggregationNode(
+                            node.getLeft().getSourceLocation(),
+                            idAllocator.getNextId(),
+                            projectNode,
+                            ImmutableMap.of(),
+                            singleGroupingSet(projectNode.getOutputVariables()),
+                            projectNode.getOutputVariables(),
+                            AggregationNode.Step.SINGLE,
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty());
 
-                rewrittenRight = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
-                if (rewrittenRight.getOutputVariables().size() > node.getRight().getOutputVariables().size()) {
-                    rewrittenRight = restrictOutput(rewrittenRight, idAllocator, node.getRight().getOutputVariables());
+                    // There should be only one output variable. Project that
+                    filteringSource = projectExpressions(filteringSource, idAllocator, variableAllocator, ImmutableList.of(filteringSource.getOutputVariables().get(0)), ImmutableList.of());
+
+                    // Apply prefilter to right side, optionally pushing below aggregation
+                    rewrittenRight = applyPrefilterToRight(
+                            rewrittenRight,
+                            filteringSource,
+                            rightKeyToFilter,
+                            rightKeyList,
+                            rightHashExpression,
+                            hashJoinKey,
+                            node);
                 }
             }
 
@@ -269,6 +348,137 @@ public class JoinPrefilter
             }
 
             return node;
+        }
+
+        private PlanNode applyPrefilterToRight(
+                PlanNode rewrittenRight,
+                PlanNode filteringSource,
+                VariableReferenceExpression rightKeyToFilter,
+                List<VariableReferenceExpression> rightKeyList,
+                RowExpression rightHashExpression,
+                boolean hashJoinKey,
+                JoinNode originalJoin)
+        {
+            // Try to push the prefilter below a right-side aggregation
+            if (complexEnabled) {
+                Optional<PlanNode> pushed = tryPushPrefilterBelowAggregation(
+                        rewrittenRight, filteringSource, rightKeyToFilter,
+                        rightKeyList, rightHashExpression, hashJoinKey, originalJoin);
+                if (pushed.isPresent()) {
+                    return pushed.get();
+                }
+            }
+
+            // Default: add prefilter on top of right side
+            if (hashJoinKey) {
+                rewrittenRight = addProjections(rewrittenRight, idAllocator, ImmutableMap.of(rightKeyToFilter, rightHashExpression));
+            }
+
+            VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
+            SemiJoinNode semiJoinNode = new SemiJoinNode(
+                    originalJoin.getRight().getSourceLocation(),
+                    idAllocator.getNextId(),
+                    originalJoin.getStatsEquivalentPlanNode(),
+                    rewrittenRight,
+                    filteringSource,
+                    rightKeyToFilter,
+                    filteringSource.getOutputVariables().get(0),
+                    semiJoinOutput,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    ImmutableMap.of());
+
+            PlanNode result = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
+            if (result.getOutputVariables().size() > originalJoin.getRight().getOutputVariables().size()) {
+                result = restrictOutput(result, idAllocator, originalJoin.getRight().getOutputVariables());
+            }
+            return result;
+        }
+
+        private Optional<PlanNode> tryPushPrefilterBelowAggregation(
+                PlanNode rightSide,
+                PlanNode filteringSource,
+                VariableReferenceExpression rightKeyToFilter,
+                List<VariableReferenceExpression> rightKeyList,
+                RowExpression rightHashExpression,
+                boolean hashJoinKey,
+                JoinNode originalJoin)
+        {
+            // Peel through Project nodes
+            PlanNode peeled = rightSide;
+            ImmutableList.Builder<ProjectNode> projectStack = ImmutableList.builder();
+            while (peeled instanceof ProjectNode) {
+                projectStack.add((ProjectNode) peeled);
+                peeled = ((ProjectNode) peeled).getSource();
+            }
+
+            if (!(peeled instanceof AggregationNode)) {
+                return Optional.empty();
+            }
+
+            AggregationNode aggNode = (AggregationNode) peeled;
+            Set<VariableReferenceExpression> groupingKeys = ImmutableSet.copyOf(aggNode.getGroupingKeys());
+
+            if (aggNode.getStep() != AggregationNode.Step.SINGLE
+                    || aggNode.getGroupingSetCount() != 1
+                    || aggNode.hasEmptyGroupingSet()
+                    || !groupingKeys.containsAll(rightKeyList)) {
+                return Optional.empty();
+            }
+
+            // Build prefilter on the aggregation's source
+            PlanNode aggSource = aggNode.getSource();
+            if (hashJoinKey) {
+                aggSource = addProjections(aggSource, idAllocator, ImmutableMap.of(rightKeyToFilter, rightHashExpression));
+            }
+
+            VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
+            SemiJoinNode semiJoinNode = new SemiJoinNode(
+                    originalJoin.getRight().getSourceLocation(),
+                    idAllocator.getNextId(),
+                    originalJoin.getStatsEquivalentPlanNode(),
+                    aggSource,
+                    filteringSource,
+                    rightKeyToFilter,
+                    filteringSource.getOutputVariables().get(0),
+                    semiJoinOutput,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    ImmutableMap.of());
+
+            PlanNode filtered = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
+
+            // Restrict output to remove hash/semiJoin variables, keeping only the original agg source outputs
+            filtered = restrictOutput(filtered, idAllocator, aggNode.getSource().getOutputVariables());
+
+            // Rebuild the aggregation on top of the filtered source
+            PlanNode result = new AggregationNode(
+                    aggNode.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    filtered,
+                    aggNode.getAggregations(),
+                    aggNode.getGroupingSets(),
+                    aggNode.getPreGroupedVariables(),
+                    aggNode.getStep(),
+                    aggNode.getHashVariable(),
+                    aggNode.getGroupIdVariable(),
+                    aggNode.getAggregationId());
+
+            // Rebuild any peeled Project nodes on top
+            List<ProjectNode> projects = projectStack.build();
+            for (int i = projects.size() - 1; i >= 0; i--) {
+                ProjectNode proj = projects.get(i);
+                result = new ProjectNode(
+                        proj.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        result,
+                        proj.getAssignments(),
+                        proj.getLocality());
+            }
+
+            return Optional.of(result);
         }
 
         public boolean isPlanChanged()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
@@ -25,20 +25,25 @@ import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.JoinNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.SemiJoinNode;
+import com.facebook.presto.spi.plan.UnnestNode;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.SystemSessionProperties.isJoinPrefilterComplexBuildSideEnabled;
 import static com.facebook.presto.SystemSessionProperties.isJoinPrefilterEnabled;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -49,83 +54,15 @@ import static com.facebook.presto.sql.planner.PlannerUtils.addProjections;
 import static com.facebook.presto.sql.planner.PlannerUtils.clonePlanNode;
 import static com.facebook.presto.sql.planner.PlannerUtils.getVariableHash;
 import static com.facebook.presto.sql.planner.PlannerUtils.isDeterministicScanFilterProject;
+import static com.facebook.presto.sql.planner.PlannerUtils.isDeterministicScanFilterProjectOrUnion;
 import static com.facebook.presto.sql.planner.PlannerUtils.isScanFilterProject;
+import static com.facebook.presto.sql.planner.PlannerUtils.isScanFilterProjectOrUnion;
 import static com.facebook.presto.sql.planner.PlannerUtils.projectExpressions;
 import static com.facebook.presto.sql.planner.PlannerUtils.restrictOutput;
 import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
-
-/**
- * This optimizer filter the right side of a join with the unique join keys on the left side of the join. When the join key is wide or
- * there are multiple join keys, we are to do filter on the hash instead of using the keys.
- * It will convert plan from
- * <pre>
- *     - InnerJoin
- *          leftKey = rightKey
- *          - scan l
- *          - scan r
- * </pre>
- * into
- * <pre>
- *     - InnerJoin
- *          leftKey = rightKey
- *          - scan l
- *          - semiJoin
- *              r.rightKey in l.leftKey
- *              - scan r
- *              - distinct aggregation
- *                  group by leftKey
- *                  - scan l
- * </pre>
- * And for join with varchar type
- * <pre>
- *     - InnerJoin
- *          leftKey (varchar) = rightKey (varchar)
- *          - scan l
- *          - scan r
- * </pre>
- * into
- * <pre>
- *     - InnerJoin
- *          leftKey (varchar) = rightKey (varchar)
- *          - scan l
- *          - semiJoin
- *              r.rightKeyHash in l.leftKeyHash
- *              - project
- *                  r.rightKeyHash = xx_hash64(r.rightKey)
- *                  - scan r
- *              - distinct aggregation
- *                  group by leftKeyHash
- *                  - project
- *                      l.leftKeyHash = xx_hash64(l.leftKey)
- *                      - scan l
- * </pre>
- * And for join with multiple keys
- * <pre>
- *     - InnerJoin
- *          leftKey1 = rightKey1 and leftKey2 = rightKey2
- *          - scan l
- *          - scan r
- * </pre>
- * into
- * <pre>
- *     - InnerJoin
- *          leftKey1 = rightKey1 and leftKey2 = rightKey2
- *          - scan l
- *          - semiJoin
- *              r.rightKeysHash in l.leftKeysHash
- *              - project
- *                  r.rightKeysHash = combine_hash(xx_hash64(rightKey1), xx_hash64(rightKey2))
- *                  - scan r
- *              - distinct aggregation
- *                  group by leftKeysHash
- *                  - project
- *                      l.leftKeysHash = combine_hash(xx_hash64(leftKey1), xx_hash64(leftKey2))
- *                      - scan l
- * </pre>
- */
 
 public class JoinPrefilter
         implements PlanOptimizer
@@ -162,6 +99,159 @@ public class JoinPrefilter
         return PlanOptimizerResult.optimizerResult(plan, false);
     }
 
+    /**
+     * Finds a cloneable sub-plan from the left side of a join for prefiltering.
+     * Returns the sub-plan that can be cloned, or empty if not applicable.
+     *
+     * Supports:
+     * - scan/filter/project chains (including UNION ALL of such chains)
+     * - Cross join where one child is scan/filter/project (complex mode)
+     * - UnnestNode where source is scan/filter/project (complex mode)
+     * - AggregationNode where source is any of the above (complex mode)
+     */
+    private static Optional<PlanNode> findCloneableSource(
+            PlanNode node,
+            Set<VariableReferenceExpression> joinKeyVars,
+            FunctionAndTypeManager functionAndTypeManager,
+            boolean complexEnabled)
+    {
+        // Peel through Filter/Project
+        PlanNode peeled = node;
+        while (peeled instanceof FilterNode || peeled instanceof ProjectNode) {
+            if (peeled instanceof FilterNode) {
+                peeled = ((FilterNode) peeled).getSource();
+            }
+            else {
+                peeled = ((ProjectNode) peeled).getSource();
+            }
+        }
+
+        // Base case: scan/filter/project, plus UNION ALL of such when complex mode is enabled.
+        // The UnionNode-aware helpers are intentionally separate from the plain
+        // isScanFilterProject / isDeterministicScanFilterProject so that other optimizers
+        // calling those don't silently gain UNION ALL handling without being audited.
+        if (complexEnabled
+                ? isScanFilterProjectOrUnion(node) && isDeterministicScanFilterProjectOrUnion(node, functionAndTypeManager)
+                : isScanFilterProject(node) && isDeterministicScanFilterProject(node, functionAndTypeManager)) {
+            return Optional.of(node);
+        }
+
+        if (!complexEnabled) {
+            return Optional.empty();
+        }
+
+        // Cross join: clone the child that contains the join keys
+        if (peeled instanceof JoinNode && ((JoinNode) peeled).isCrossJoin()) {
+            JoinNode crossJoin = (JoinNode) peeled;
+            Set<VariableReferenceExpression> leftOutputs = ImmutableSet.copyOf(crossJoin.getLeft().getOutputVariables());
+            Set<VariableReferenceExpression> rightOutputs = ImmutableSet.copyOf(crossJoin.getRight().getOutputVariables());
+
+            // Trace join keys through any Filter/Project above the cross join
+            Optional<Set<VariableReferenceExpression>> resolvedKeys = resolveVariablesThroughProjectFilter(node, peeled, joinKeyVars);
+            if (!resolvedKeys.isPresent()) {
+                return Optional.empty();
+            }
+
+            if (leftOutputs.containsAll(resolvedKeys.get())
+                    && isScanFilterProject(crossJoin.getLeft())
+                    && isDeterministicScanFilterProject(crossJoin.getLeft(), functionAndTypeManager)) {
+                return Optional.of(crossJoin.getLeft());
+            }
+            if (rightOutputs.containsAll(resolvedKeys.get())
+                    && isScanFilterProject(crossJoin.getRight())
+                    && isDeterministicScanFilterProject(crossJoin.getRight(), functionAndTypeManager)) {
+                return Optional.of(crossJoin.getRight());
+            }
+        }
+
+        // UnnestNode: clone the source if join keys come from replicate variables
+        if (peeled instanceof UnnestNode) {
+            UnnestNode unnest = (UnnestNode) peeled;
+            Optional<Set<VariableReferenceExpression>> resolvedKeys = resolveVariablesThroughProjectFilter(node, peeled, joinKeyVars);
+            if (!resolvedKeys.isPresent()) {
+                return Optional.empty();
+            }
+            Set<VariableReferenceExpression> replicateVars = ImmutableSet.copyOf(unnest.getReplicateVariables());
+
+            if (replicateVars.containsAll(resolvedKeys.get())
+                    && isScanFilterProject(unnest.getSource())
+                    && isDeterministicScanFilterProject(unnest.getSource(), functionAndTypeManager)) {
+                return Optional.of(unnest.getSource());
+            }
+        }
+
+        // AggregationNode: clone the source if join keys are grouping keys
+        if (peeled instanceof AggregationNode) {
+            AggregationNode agg = (AggregationNode) peeled;
+            Optional<Set<VariableReferenceExpression>> resolvedKeys = resolveVariablesThroughProjectFilter(node, peeled, joinKeyVars);
+            if (!resolvedKeys.isPresent()) {
+                return Optional.empty();
+            }
+            Set<VariableReferenceExpression> groupingKeys = ImmutableSet.copyOf(agg.getGroupingKeys());
+
+            if (agg.getStep() == AggregationNode.Step.SINGLE
+                    && agg.getGroupingSetCount() == 1
+                    && !agg.hasEmptyGroupingSet()
+                    && groupingKeys.containsAll(resolvedKeys.get())
+                    && isScanFilterProject(agg.getSource())
+                    && isDeterministicScanFilterProject(agg.getSource(), functionAndTypeManager)) {
+                return Optional.of(agg.getSource());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Traces join key variables backward through Filter/Project nodes
+     * between the top node and the target node to find the source variables
+     * they depend on. Returns empty if a projected expression is not a simple
+     * variable reference (computed join keys cannot be safely traced).
+     */
+    private static Optional<Set<VariableReferenceExpression>> resolveVariablesThroughProjectFilter(
+            PlanNode top,
+            PlanNode target,
+            Set<VariableReferenceExpression> vars)
+    {
+        if (top == target) {
+            return Optional.of(vars);
+        }
+
+        // Build a chain of nodes from top to target
+        PlanNode current = top;
+        Set<VariableReferenceExpression> resolved = vars;
+
+        while (current != target) {
+            if (current instanceof ProjectNode) {
+                ProjectNode project = (ProjectNode) current;
+                ImmutableSet.Builder<VariableReferenceExpression> newResolved = ImmutableSet.builder();
+                for (VariableReferenceExpression var : resolved) {
+                    RowExpression expr = project.getAssignments().getMap().get(var);
+                    if (expr instanceof VariableReferenceExpression) {
+                        newResolved.add((VariableReferenceExpression) expr);
+                    }
+                    else if (expr != null) {
+                        // Expression is not a simple variable reference;
+                        // computed join keys cannot be safely traced
+                        return Optional.empty();
+                    }
+                    else {
+                        newResolved.add(var);
+                    }
+                }
+                resolved = newResolved.build();
+                current = project.getSource();
+            }
+            else if (current instanceof FilterNode) {
+                current = ((FilterNode) current).getSource();
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+        return Optional.of(resolved);
+    }
+
     private static class Rewriter
             extends SimplePlanRewriter<Void>
     {
@@ -170,6 +260,7 @@ public class JoinPrefilter
         private final PlanNodeIdAllocator idAllocator;
         private final VariableAllocator variableAllocator;
         private final FunctionAndTypeManager functionAndTypeManager;
+        private final boolean complexEnabled;
         private boolean planChanged;
 
         private Rewriter(Session session, Metadata metadata, PlanNodeIdAllocator idAllocator, VariableAllocator variableAllocator, FunctionAndTypeManager functionAndTypeManager)
@@ -179,6 +270,7 @@ public class JoinPrefilter
             this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
             this.variableAllocator = requireNonNull(variableAllocator, "idAllocator is null");
             this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.complexEnabled = isJoinPrefilterComplexBuildSideEnabled(session);
         }
 
         @Override
@@ -191,75 +283,64 @@ public class JoinPrefilter
             PlanNode rewrittenRight = rewriteWith(this, right);
             List<EquiJoinClause> equiJoinClause = node.getCriteria();
 
-            // We apply this for only left and inner join and the left side of the join is a simple scan.
-            // We also require that all expressions in the left subtree are deterministic, because
-            // cloning a subtree with non-deterministic expressions (like rand() from TABLESAMPLE BERNOULLI)
-            // would produce different results from each clone, leading to incorrect query results.
             if ((node.getType() == LEFT || node.getType() == INNER)
-                    && isScanFilterProject(rewrittenLeft)
-                    && isDeterministicScanFilterProject(rewrittenLeft, functionAndTypeManager)
                     && !node.getCriteria().isEmpty()) {
                 List<VariableReferenceExpression> leftKeyList = equiJoinClause.stream().map(EquiJoinClause::getLeft).collect(toImmutableList());
                 List<VariableReferenceExpression> rightKeyList = equiJoinClause.stream().map(EquiJoinClause::getRight).collect(toImmutableList());
-                checkState(IntStream.range(0, leftKeyList.size()).boxed().allMatch(i -> leftKeyList.get(i).getType().equals(rightKeyList.get(i).getType())));
 
-                boolean hashJoinKey = leftKeyList.size() > 1 || (leftKeyList.get(0).getType().equals(VARCHAR) || leftKeyList.get(0).getType() instanceof VarcharType);
+                Set<VariableReferenceExpression> leftKeySet = ImmutableSet.copyOf(leftKeyList);
+                Optional<PlanNode> cloneableSource = findCloneableSource(rewrittenLeft, leftKeySet, functionAndTypeManager, complexEnabled);
 
-                // First create a SELECT DISTINCT leftKey FROM left
-                Map<VariableReferenceExpression, VariableReferenceExpression> leftVarMap = new HashMap();
-                PlanNode leftKeys = clonePlanNode(rewrittenLeft, session, metadata, idAllocator, leftKeyList, leftVarMap);
-                ImmutableList.Builder<RowExpression> expressionsToProject = ImmutableList.builder();
-                if (hashJoinKey) {
-                    RowExpression hashExpression = getVariableHash(leftKeyList, functionAndTypeManager);
-                    expressionsToProject.add(hashExpression);
-                }
-                else {
-                    expressionsToProject.add(leftVarMap.get(leftKeyList.get(0)));
-                }
-                PlanNode projectNode = projectExpressions(leftKeys, idAllocator, variableAllocator, expressionsToProject.build(), ImmutableList.of());
+                if (cloneableSource.isPresent()) {
+                    checkState(IntStream.range(0, leftKeyList.size()).boxed().allMatch(i -> leftKeyList.get(i).getType().equals(rightKeyList.get(i).getType())));
 
-                VariableReferenceExpression rightKeyToFilter = rightKeyList.get(0);
-                if (hashJoinKey) {
-                    RowExpression hashExpression = getVariableHash(rightKeyList, functionAndTypeManager);
-                    rightKeyToFilter = variableAllocator.newVariable(hashExpression);
-                    rewrittenRight = addProjections(rewrittenRight, idAllocator, ImmutableMap.of(rightKeyToFilter, hashExpression));
-                }
+                    boolean hashJoinKey = leftKeyList.size() > 1 || (leftKeyList.get(0).getType().equals(VARCHAR) || leftKeyList.get(0).getType() instanceof VarcharType);
 
-                // DISTINCT on the leftkey or hash if wide column
-                PlanNode filteringSource = new AggregationNode(
-                        node.getLeft().getSourceLocation(),
-                        idAllocator.getNextId(),
-                        projectNode,
-                        ImmutableMap.of(),
-                        singleGroupingSet(projectNode.getOutputVariables()),
-                        projectNode.getOutputVariables(),
-                        AggregationNode.Step.SINGLE,
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty());
+                    // First create a SELECT DISTINCT leftKey FROM left
+                    Map<VariableReferenceExpression, VariableReferenceExpression> leftVarMap = new HashMap();
+                    PlanNode leftKeys = clonePlanNode(cloneableSource.get(), session, metadata, idAllocator, leftKeyList, leftVarMap);
+                    ImmutableList.Builder<RowExpression> expressionsToProject = ImmutableList.builder();
+                    if (hashJoinKey) {
+                        RowExpression hashExpression = getVariableHash(leftKeyList, functionAndTypeManager);
+                        expressionsToProject.add(hashExpression);
+                    }
+                    else {
+                        expressionsToProject.add(leftVarMap.get(leftKeyList.get(0)));
+                    }
+                    PlanNode projectNode = projectExpressions(leftKeys, idAllocator, variableAllocator, expressionsToProject.build(), ImmutableList.of());
 
-                // There should be only one output variable. Project that
-                filteringSource = projectExpressions(filteringSource, idAllocator, variableAllocator, ImmutableList.of(filteringSource.getOutputVariables().get(0)), ImmutableList.of());
+                    VariableReferenceExpression rightKeyToFilter = rightKeyList.get(0);
+                    RowExpression rightHashExpression = null;
+                    if (hashJoinKey) {
+                        rightHashExpression = getVariableHash(rightKeyList, functionAndTypeManager);
+                        rightKeyToFilter = variableAllocator.newVariable(rightHashExpression);
+                    }
 
-                // Now we add a semijoin as the right side
-                VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
-                SemiJoinNode semiJoinNode = new SemiJoinNode(
-                        node.getRight().getSourceLocation(),
-                        idAllocator.getNextId(),
-                        node.getStatsEquivalentPlanNode(),
-                        rewrittenRight,
-                        filteringSource,
-                        rightKeyToFilter,
-                        filteringSource.getOutputVariables().get(0),
-                        semiJoinOutput,
-                        Optional.empty(),
-                        Optional.empty(),
-                        Optional.empty(),
-                        ImmutableMap.of());
+                    // DISTINCT on the leftkey or hash if wide column
+                    PlanNode filteringSource = new AggregationNode(
+                            node.getLeft().getSourceLocation(),
+                            idAllocator.getNextId(),
+                            projectNode,
+                            ImmutableMap.of(),
+                            singleGroupingSet(projectNode.getOutputVariables()),
+                            projectNode.getOutputVariables(),
+                            AggregationNode.Step.SINGLE,
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty());
 
-                rewrittenRight = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
-                if (rewrittenRight.getOutputVariables().size() > node.getRight().getOutputVariables().size()) {
-                    rewrittenRight = restrictOutput(rewrittenRight, idAllocator, node.getRight().getOutputVariables());
+                    // There should be only one output variable. Project that
+                    filteringSource = projectExpressions(filteringSource, idAllocator, variableAllocator, ImmutableList.of(filteringSource.getOutputVariables().get(0)), ImmutableList.of());
+
+                    // Apply prefilter to right side, optionally pushing below aggregation
+                    rewrittenRight = applyPrefilterToRight(
+                            rewrittenRight,
+                            filteringSource,
+                            rightKeyToFilter,
+                            rightKeyList,
+                            rightHashExpression,
+                            hashJoinKey,
+                            node);
                 }
             }
 
@@ -269,6 +350,137 @@ public class JoinPrefilter
             }
 
             return node;
+        }
+
+        private PlanNode applyPrefilterToRight(
+                PlanNode rewrittenRight,
+                PlanNode filteringSource,
+                VariableReferenceExpression rightKeyToFilter,
+                List<VariableReferenceExpression> rightKeyList,
+                RowExpression rightHashExpression,
+                boolean hashJoinKey,
+                JoinNode originalJoin)
+        {
+            // Try to push the prefilter below a right-side aggregation
+            if (complexEnabled) {
+                Optional<PlanNode> pushed = tryPushPrefilterBelowAggregation(
+                        rewrittenRight, filteringSource, rightKeyToFilter,
+                        rightKeyList, rightHashExpression, hashJoinKey, originalJoin);
+                if (pushed.isPresent()) {
+                    return pushed.get();
+                }
+            }
+
+            // Default: add prefilter on top of right side
+            if (hashJoinKey) {
+                rewrittenRight = addProjections(rewrittenRight, idAllocator, ImmutableMap.of(rightKeyToFilter, rightHashExpression));
+            }
+
+            VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
+            SemiJoinNode semiJoinNode = new SemiJoinNode(
+                    originalJoin.getRight().getSourceLocation(),
+                    idAllocator.getNextId(),
+                    originalJoin.getStatsEquivalentPlanNode(),
+                    rewrittenRight,
+                    filteringSource,
+                    rightKeyToFilter,
+                    filteringSource.getOutputVariables().get(0),
+                    semiJoinOutput,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    ImmutableMap.of());
+
+            PlanNode result = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
+            if (result.getOutputVariables().size() > originalJoin.getRight().getOutputVariables().size()) {
+                result = restrictOutput(result, idAllocator, originalJoin.getRight().getOutputVariables());
+            }
+            return result;
+        }
+
+        private Optional<PlanNode> tryPushPrefilterBelowAggregation(
+                PlanNode rightSide,
+                PlanNode filteringSource,
+                VariableReferenceExpression rightKeyToFilter,
+                List<VariableReferenceExpression> rightKeyList,
+                RowExpression rightHashExpression,
+                boolean hashJoinKey,
+                JoinNode originalJoin)
+        {
+            // Peel through Project nodes
+            PlanNode peeled = rightSide;
+            ImmutableList.Builder<ProjectNode> projectStack = ImmutableList.builder();
+            while (peeled instanceof ProjectNode) {
+                projectStack.add((ProjectNode) peeled);
+                peeled = ((ProjectNode) peeled).getSource();
+            }
+
+            if (!(peeled instanceof AggregationNode)) {
+                return Optional.empty();
+            }
+
+            AggregationNode aggNode = (AggregationNode) peeled;
+            Set<VariableReferenceExpression> groupingKeys = ImmutableSet.copyOf(aggNode.getGroupingKeys());
+
+            if (aggNode.getStep() != AggregationNode.Step.SINGLE
+                    || aggNode.getGroupingSetCount() != 1
+                    || aggNode.hasEmptyGroupingSet()
+                    || !groupingKeys.containsAll(rightKeyList)) {
+                return Optional.empty();
+            }
+
+            // Build prefilter on the aggregation's source
+            PlanNode aggSource = aggNode.getSource();
+            if (hashJoinKey) {
+                aggSource = addProjections(aggSource, idAllocator, ImmutableMap.of(rightKeyToFilter, rightHashExpression));
+            }
+
+            VariableReferenceExpression semiJoinOutput = variableAllocator.newVariable("semiJoinOutput", BOOLEAN);
+            SemiJoinNode semiJoinNode = new SemiJoinNode(
+                    originalJoin.getRight().getSourceLocation(),
+                    idAllocator.getNextId(),
+                    originalJoin.getStatsEquivalentPlanNode(),
+                    aggSource,
+                    filteringSource,
+                    rightKeyToFilter,
+                    filteringSource.getOutputVariables().get(0),
+                    semiJoinOutput,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    ImmutableMap.of());
+
+            PlanNode filtered = new FilterNode(semiJoinNode.getSourceLocation(), idAllocator.getNextId(), semiJoinNode, semiJoinOutput);
+
+            // Restrict output to remove hash/semiJoin variables, keeping only the original agg source outputs
+            filtered = restrictOutput(filtered, idAllocator, aggNode.getSource().getOutputVariables());
+
+            // Rebuild the aggregation on top of the filtered source
+            PlanNode result = new AggregationNode(
+                    aggNode.getSourceLocation(),
+                    idAllocator.getNextId(),
+                    filtered,
+                    aggNode.getAggregations(),
+                    aggNode.getGroupingSets(),
+                    aggNode.getPreGroupedVariables(),
+                    aggNode.getStep(),
+                    aggNode.getHashVariable(),
+                    aggNode.getGroupIdVariable(),
+                    aggNode.getAggregationId());
+
+            // Rebuild any peeled Project nodes on top
+            List<ProjectNode> projects = projectStack.build();
+            for (int i = projects.size() - 1; i >= 0; i--) {
+                ProjectNode proj = projects.get(i);
+                result = new ProjectNode(
+                        proj.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        result,
+                        proj.getAssignments(),
+                        proj.getLocality());
+            }
+
+            return Optional.of(result);
         }
 
         public boolean isPlanChanged()

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/JoinPrefilter.java
@@ -64,6 +64,20 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This optimizer filters the right side of a join with the unique join keys on the left side of the join.
+ * When the join key is wide or there are multiple join keys, it filters on the hash instead of using the keys.
+ * <p>
+ * Performance notes:
+ * <ul>
+ *     <li>The basic optimization (scan/filter/project probe side) is enabled by {@code join_prefilter_enabled}.</li>
+ *     <li>Complex probe-side patterns (UNION ALL, cross join, unnest, aggregation) and right-side aggregation
+ *         pushdown are gated by {@code join_prefilter_build_side_with_complex_probe_side}, which defaults to false.
+ *         This ensures the additional planning overhead is only incurred when explicitly enabled.</li>
+ *     <li>When the complex feature is disabled, the optimizer quickly returns after checking the basic
+ *         scan/filter/project pattern, avoiding unnecessary tree traversals.</li>
+ * </ul>
+ */
 public class JoinPrefilter
         implements PlanOptimizer
 {
@@ -115,17 +129,6 @@ public class JoinPrefilter
             FunctionAndTypeManager functionAndTypeManager,
             boolean complexEnabled)
     {
-        // Peel through Filter/Project
-        PlanNode peeled = node;
-        while (peeled instanceof FilterNode || peeled instanceof ProjectNode) {
-            if (peeled instanceof FilterNode) {
-                peeled = ((FilterNode) peeled).getSource();
-            }
-            else {
-                peeled = ((ProjectNode) peeled).getSource();
-            }
-        }
-
         // Base case: scan/filter/project, plus UNION ALL of such when complex mode is enabled.
         // The UnionNode-aware helpers are intentionally separate from the plain
         // isScanFilterProject / isDeterministicScanFilterProject so that other optimizers
@@ -138,6 +141,19 @@ public class JoinPrefilter
 
         if (!complexEnabled) {
             return Optional.empty();
+        }
+
+        // Peel through Filter/Project for complex pattern matching.
+        // This is only done when complexEnabled is true to avoid unnecessary work
+        // in the common case where the feature is disabled.
+        PlanNode peeled = node;
+        while (peeled instanceof FilterNode || peeled instanceof ProjectNode) {
+            if (peeled instanceof FilterNode) {
+                peeled = ((FilterNode) peeled).getSource();
+            }
+            else {
+                peeled = ((ProjectNode) peeled).getSource();
+            }
         }
 
         // Cross join: clone the child that contains the join keys

--- a/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestJoinPrefilter.java
+++ b/presto-main-base/src/test/java/com/facebook/presto/sql/planner/optimizations/TestJoinPrefilter.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.JoinNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.JOIN_PREFILTER_BUILD_SIDE;
+import static com.facebook.presto.SystemSessionProperties.JOIN_PREFILTER_COMPLEX_BUILD_SIDE;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestJoinPrefilter
+        extends BasePlanTest
+{
+    private Session enableBasic()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(JOIN_PREFILTER_BUILD_SIDE, "true")
+                .build();
+    }
+
+    private Session enableComplex()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(JOIN_PREFILTER_BUILD_SIDE, "true")
+                .setSystemProperty(JOIN_PREFILTER_COMPLEX_BUILD_SIDE, "true")
+                .build();
+    }
+
+    private PlanNode getOptimizedPlan(String sql, Session session)
+    {
+        return getQueryRunner().inTransaction(session, transactionSession ->
+                getQueryRunner().createPlan(
+                        transactionSession,
+                        sql,
+                        getQueryRunner().getPlanOptimizers(true),
+                        com.facebook.presto.sql.Optimizer.PlanStage.OPTIMIZED_AND_VALIDATED,
+                        com.facebook.presto.spi.WarningCollector.NOOP).getRoot());
+    }
+
+    private boolean planContainsSemiJoin(String sql, Session session)
+    {
+        return containsNode(getOptimizedPlan(sql, session), SemiJoinNode.class);
+    }
+
+    /**
+     * Checks if any SemiJoinNode appears as a descendant of an AggregationNode
+     * on the right side of the top-level join. This verifies the prefilter
+     * was pushed below the right-side aggregation.
+     */
+    private boolean hasSemiJoinBelowRightSideAggregation(String sql, Session session)
+    {
+        PlanNode root = getOptimizedPlan(sql, session);
+        // Find the top-level join
+        JoinNode join = findFirst(root, JoinNode.class);
+        if (join == null) {
+            return false;
+        }
+        // Check if right side has aggregation with SemiJoin below it
+        return hasAggregationWithSemiJoinBelow(join.getRight());
+    }
+
+    private static boolean hasAggregationWithSemiJoinBelow(PlanNode node)
+    {
+        if (node instanceof AggregationNode) {
+            return containsNode(node, SemiJoinNode.class);
+        }
+        return node.getSources().stream().anyMatch(
+                source -> hasAggregationWithSemiJoinBelow(source));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends PlanNode> T findFirst(PlanNode node, Class<T> nodeClass)
+    {
+        if (nodeClass.isInstance(node)) {
+            return (T) node;
+        }
+        for (PlanNode source : node.getSources()) {
+            T found = findFirst(source, nodeClass);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private static boolean containsNode(PlanNode node, Class<?> nodeClass)
+    {
+        if (nodeClass.isInstance(node)) {
+            return true;
+        }
+        return node.getSources().stream().anyMatch(source -> containsNode(source, nodeClass));
+    }
+
+    @Test
+    public void testBasicScanFilterProject()
+    {
+        assertTrue(planContainsSemiJoin(
+                "SELECT * FROM nation n JOIN region r ON n.regionkey = r.regionkey",
+                enableBasic()));
+    }
+
+    @Test
+    public void testUnionAllLeft()
+    {
+        assertTrue(planContainsSemiJoin(
+                "SELECT * FROM " +
+                        "(SELECT regionkey FROM nation UNION ALL SELECT regionkey FROM nation) t " +
+                        "JOIN region r ON t.regionkey = r.regionkey",
+                enableComplex()));
+    }
+
+    @Test
+    public void testCrossJoinLeft()
+    {
+        // Use join_reordering_strategy=NONE to prevent the cross join from being reordered
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(JOIN_PREFILTER_BUILD_SIDE, "true")
+                .setSystemProperty(JOIN_PREFILTER_COMPLEX_BUILD_SIDE, "true")
+                .setSystemProperty("join_reordering_strategy", "NONE")
+                .build();
+        assertTrue(planContainsSemiJoin(
+                "SELECT * FROM " +
+                        "(SELECT n.regionkey, r.name AS rname FROM nation n CROSS JOIN region r) t " +
+                        "JOIN region r2 ON t.regionkey = r2.regionkey",
+                session));
+    }
+
+    @Test
+    public void testAggregationLeft()
+    {
+        assertTrue(planContainsSemiJoin(
+                "SELECT * FROM " +
+                        "(SELECT regionkey, count(*) AS cnt FROM nation GROUP BY regionkey) t " +
+                        "JOIN region r ON t.regionkey = r.regionkey",
+                enableComplex()));
+    }
+
+    @Test
+    public void testAggregationRightPushdown()
+    {
+        // Verify the SemiJoin is pushed below the right-side aggregation
+        assertTrue(hasSemiJoinBelowRightSideAggregation(
+                "SELECT * FROM nation n " +
+                        "JOIN (SELECT regionkey, count(*) AS cnt FROM nation GROUP BY regionkey) t " +
+                        "ON n.regionkey = t.regionkey",
+                enableComplex()));
+    }
+
+    @Test
+    public void testUnnestLeft()
+    {
+        assertTrue(planContainsSemiJoin(
+                "SELECT * FROM " +
+                        "(SELECT n.regionkey, x FROM nation n CROSS JOIN UNNEST(ARRAY[1,2,3]) t(x)) t " +
+                        "JOIN region r ON t.regionkey = r.regionkey",
+                enableComplex()));
+    }
+
+    @Test
+    public void testComplexDisabledWithoutFlag()
+    {
+        // Without complex flag, UNION ALL left side should NOT produce SemiJoin
+        assertFalse(planContainsSemiJoin(
+                "SELECT * FROM " +
+                        "(SELECT regionkey FROM nation UNION ALL SELECT regionkey FROM nation) t " +
+                        "JOIN region r ON t.regionkey = r.regionkey",
+                enableBasic()));
+    }
+
+    @Test
+    public void testAggregationRightNoPushdownForGroupingSets()
+    {
+        // Multiple grouping sets: SemiJoin should NOT be pushed below the aggregation
+        assertFalse(hasSemiJoinBelowRightSideAggregation(
+                "SELECT * FROM nation n " +
+                        "JOIN (" +
+                        "   SELECT regionkey, count(*) AS cnt " +
+                        "   FROM nation " +
+                        "   GROUP BY GROUPING SETS ((regionkey), (regionkey, nationkey))" +
+                        ") t " +
+                        "ON n.regionkey = t.regionkey",
+                enableComplex()));
+    }
+
+    @Test
+    public void testAggregationRightNoPushdownWhenJoinKeyNotGroupingKey()
+    {
+        // Right-side join key (regionkey) is a max() output, not a grouping key
+        assertFalse(hasSemiJoinBelowRightSideAggregation(
+                "SELECT * FROM nation n " +
+                        "JOIN (" +
+                        "   SELECT nationkey, max(regionkey) AS regionkey, count(*) AS cnt " +
+                        "   FROM nation " +
+                        "   GROUP BY nationkey" +
+                        ") t " +
+                        "ON n.regionkey = t.regionkey",
+                enableComplex()));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -233,4 +233,86 @@ public class TestLocalQueries
         assertQuery(enabled, "SELECT * FROM lineitem WHERE shipdate > DATE '1995-01-01' ORDER BY orderkey LIMIT 10",
                 disabled, "SELECT * FROM lineitem WHERE shipdate > DATE '1995-01-01' ORDER BY orderkey LIMIT 10");
     }
+
+    @Test
+    public void testJoinPrefilterUnionAll()
+    {
+        String sql = "SELECT * FROM " +
+                "(SELECT regionkey FROM nation UNION ALL SELECT regionkey FROM nation) t " +
+                "JOIN region r ON t.regionkey = r.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testJoinPrefilterCrossJoin()
+    {
+        String sql = "SELECT t.regionkey, t.rname, r2.name FROM " +
+                "(SELECT n.regionkey, r.name AS rname FROM nation n CROSS JOIN region r) t " +
+                "JOIN region r2 ON t.regionkey = r2.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .setSystemProperty("join_reordering_strategy", "NONE")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .setSystemProperty("join_reordering_strategy", "NONE")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testJoinPrefilterAggregationLeft()
+    {
+        String sql = "SELECT t.regionkey, t.cnt, r.name FROM " +
+                "(SELECT regionkey, count(*) AS cnt FROM nation GROUP BY regionkey) t " +
+                "JOIN region r ON t.regionkey = r.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testJoinPrefilterUnnestLeft()
+    {
+        String sql = "SELECT t.regionkey, t.x, r.name FROM " +
+                "(SELECT n.regionkey, x FROM nation n CROSS JOIN UNNEST(ARRAY[1,2,3]) t(x)) t " +
+                "JOIN region r ON t.regionkey = r.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testJoinPrefilterRightSidePushdown()
+    {
+        String sql = "SELECT n.nationkey, t.regionkey, t.cnt FROM nation n " +
+                "JOIN (SELECT regionkey, count(*) AS cnt FROM nation GROUP BY regionkey) t " +
+                "ON n.regionkey = t.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -189,4 +189,86 @@ public class TestLocalQueries
 
         assertQuery(enabled, sql, disabled, sql);
     }
+
+    @Test
+    public void testJoinPrefilterUnionAll()
+    {
+        String sql = "SELECT * FROM " +
+                "(SELECT regionkey FROM nation UNION ALL SELECT regionkey FROM nation) t " +
+                "JOIN region r ON t.regionkey = r.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testJoinPrefilterCrossJoin()
+    {
+        String sql = "SELECT t.regionkey, t.rname, r2.name FROM " +
+                "(SELECT n.regionkey, r.name AS rname FROM nation n CROSS JOIN region r) t " +
+                "JOIN region r2 ON t.regionkey = r2.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .setSystemProperty("join_reordering_strategy", "NONE")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .setSystemProperty("join_reordering_strategy", "NONE")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testJoinPrefilterAggregationLeft()
+    {
+        String sql = "SELECT t.regionkey, t.cnt, r.name FROM " +
+                "(SELECT regionkey, count(*) AS cnt FROM nation GROUP BY regionkey) t " +
+                "JOIN region r ON t.regionkey = r.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testJoinPrefilterUnnestLeft()
+    {
+        String sql = "SELECT t.regionkey, t.x, r.name FROM " +
+                "(SELECT n.regionkey, x FROM nation n CROSS JOIN UNNEST(ARRAY[1,2,3]) t(x)) t " +
+                "JOIN region r ON t.regionkey = r.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
+
+    @Test
+    public void testJoinPrefilterRightSidePushdown()
+    {
+        String sql = "SELECT n.nationkey, t.regionkey, t.cnt FROM nation n " +
+                "JOIN (SELECT regionkey, count(*) AS cnt FROM nation GROUP BY regionkey) t " +
+                "ON n.regionkey = t.regionkey";
+        Session disabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "false")
+                .build();
+        Session enabled = Session.builder(getSession())
+                .setSystemProperty("join_prefilter_build_side", "true")
+                .setSystemProperty("join_prefilter_build_side_with_complex_probe_side", "true")
+                .build();
+        assertQuery(enabled, sql, disabled, sql);
+    }
 }


### PR DESCRIPTION
## Summary
- Extend JoinPrefilter optimizer to handle complex left/probe-side patterns: UNION ALL, cross join, unnest, and aggregation
- Push prefilter below right-side aggregation for earlier filtering
- Gated by new session property `join_prefilter_build_side_with_complex_probe_side` (disabled by default)

## Details

The `JoinPrefilter` optimizer prefilters the build/right side of INNER/LEFT joins by semi-joining it with distinct keys from the probe/left side. Previously it only fired when the probe side was a simple scan/filter/project chain. This PR extends it to support:

1. **UNION ALL**: Clone the entire union when all legs are scan/filter/project
2. **Cross joins**: Identify which child of the cross join contains the join keys, clone just that child
3. **UnnestNode**: When join keys are replicate variables (not unnested columns), clone the unnest source
4. **AggregationNode**: When join keys are a subset of grouping keys, clone the aggregation source
5. **Right-side pushdown**: Push the SemiJoin+Filter below a right-side aggregation so filtering happens before aggregation

## Test plan
- [x] Unit tests (`TestJoinPrefilter`): 7 tests verifying SemiJoin presence/absence in optimized plans
- [x] E2E integration tests (`TestLocalQueries`): 5 tests comparing query results with optimization enabled vs disabled
- [x] Negative test: complex patterns do NOT fire without `join_prefilter_build_side_with_complex_probe_side` enabled
- [x] All tests pass locally with `mvn clean test`

```
== RELEASE NOTES ==
General Changes
* Add new session property `join_prefilter_build_side_with_complex_probe_side` (default false) to extend join prefilter optimization to support complex probe-side patterns including UNION ALL, cross join, unnest, and aggregation.
```