### PR TITLE
fix: Integer overflow in range filter boundary conversion (#27600)

### DIFF
--- a/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.cpp
@@ -87,7 +87,7 @@ bool toBoolean(
   return variant.value<bool>();
 }
 
-std::unique_ptr<common::BigintRange> bigintRangeToFilter(
+std::unique_ptr<common::Filter> bigintRangeToFilter(
     const protocol::Range& range,
     bool nullAllowed,
     const VeloxExprConverter& exprConverter,
@@ -96,6 +96,12 @@ std::unique_ptr<common::BigintRange> bigintRangeToFilter(
   auto low = lowUnbounded ? std::numeric_limits<int64_t>::min()
                           : toInt64(range.low.valueBlock, exprConverter, type);
   if (!lowUnbounded && range.low.bound == protocol::Bound::ABOVE) {
+    if (low == std::numeric_limits<int64_t>::max()) {
+      return nullAllowed
+          ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+          : std::unique_ptr<common::Filter>(
+                std::make_unique<common::AlwaysFalse>());
+    }
     low++;
   }
 
@@ -104,12 +110,18 @@ std::unique_ptr<common::BigintRange> bigintRangeToFilter(
       ? std::numeric_limits<int64_t>::max()
       : toInt64(range.high.valueBlock, exprConverter, type);
   if (!highUnbounded && range.high.bound == protocol::Bound::BELOW) {
+    if (high == std::numeric_limits<int64_t>::min()) {
+      return nullAllowed
+          ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+          : std::unique_ptr<common::Filter>(
+                std::make_unique<common::AlwaysFalse>());
+    }
     high--;
   }
   return std::make_unique<common::BigintRange>(low, high, nullAllowed);
 }
 
-std::unique_ptr<common::HugeintRange> hugeintRangeToFilter(
+std::unique_ptr<common::Filter> hugeintRangeToFilter(
     const protocol::Range& range,
     bool nullAllowed,
     const VeloxExprConverter& exprConverter,
@@ -118,6 +130,12 @@ std::unique_ptr<common::HugeintRange> hugeintRangeToFilter(
   auto low = lowUnbounded ? std::numeric_limits<int128_t>::min()
                           : toInt128(range.low.valueBlock, exprConverter, type);
   if (!lowUnbounded && range.low.bound == protocol::Bound::ABOVE) {
+    if (low == std::numeric_limits<int128_t>::max()) {
+      return nullAllowed
+          ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+          : std::unique_ptr<common::Filter>(
+                std::make_unique<common::AlwaysFalse>());
+    }
     low++;
   }
 
@@ -126,12 +144,18 @@ std::unique_ptr<common::HugeintRange> hugeintRangeToFilter(
       ? std::numeric_limits<int128_t>::max()
       : toInt128(range.high.valueBlock, exprConverter, type);
   if (!highUnbounded && range.high.bound == protocol::Bound::BELOW) {
+    if (high == std::numeric_limits<int128_t>::min()) {
+      return nullAllowed
+          ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+          : std::unique_ptr<common::Filter>(
+                std::make_unique<common::AlwaysFalse>());
+    }
     high--;
   }
   return std::make_unique<common::HugeintRange>(low, high, nullAllowed);
 }
 
-std::unique_ptr<common::TimestampRange> timestampRangeToFilter(
+std::unique_ptr<common::Filter> timestampRangeToFilter(
     const protocol::Range& range,
     bool nullAllowed,
     const VeloxExprConverter& exprConverter,
@@ -141,6 +165,12 @@ std::unique_ptr<common::TimestampRange> timestampRangeToFilter(
       ? std::numeric_limits<Timestamp>::min()
       : toTimestamp(range.low.valueBlock, exprConverter, type);
   if (!lowUnbounded && range.low.bound == protocol::Bound::ABOVE) {
+    if (low == std::numeric_limits<Timestamp>::max()) {
+      return nullAllowed
+          ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+          : std::unique_ptr<common::Filter>(
+                std::make_unique<common::AlwaysFalse>());
+    }
     ++low;
   }
 
@@ -149,6 +179,12 @@ std::unique_ptr<common::TimestampRange> timestampRangeToFilter(
       ? std::numeric_limits<Timestamp>::max()
       : toTimestamp(range.high.valueBlock, exprConverter, type);
   if (!highUnbounded && range.high.bound == protocol::Bound::BELOW) {
+    if (high == std::numeric_limits<Timestamp>::min()) {
+      return nullAllowed
+          ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+          : std::unique_ptr<common::Filter>(
+                std::make_unique<common::AlwaysFalse>());
+    }
     --high;
   }
   return std::make_unique<common::TimestampRange>(low, high, nullAllowed);
@@ -312,7 +348,7 @@ std::unique_ptr<common::BytesRange> varcharRangeToFilter(
       nullAllowed);
 }
 
-std::unique_ptr<common::BigintRange> dateRangeToFilter(
+std::unique_ptr<common::Filter> dateRangeToFilter(
     const protocol::Range& range,
     bool nullAllowed,
     const VeloxExprConverter& exprConverter,
@@ -322,6 +358,12 @@ std::unique_ptr<common::BigintRange> dateRangeToFilter(
       ? std::numeric_limits<int32_t>::min()
       : dateToInt64(range.low.valueBlock, exprConverter, type);
   if (!lowUnbounded && range.low.bound == protocol::Bound::ABOVE) {
+    if (low == std::numeric_limits<int32_t>::max()) {
+      return nullAllowed
+          ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+          : std::unique_ptr<common::Filter>(
+                std::make_unique<common::AlwaysFalse>());
+    }
     low++;
   }
 
@@ -330,6 +372,12 @@ std::unique_ptr<common::BigintRange> dateRangeToFilter(
       ? std::numeric_limits<int32_t>::max()
       : dateToInt64(range.high.valueBlock, exprConverter, type);
   if (!highUnbounded && range.high.bound == protocol::Bound::BELOW) {
+    if (high == std::numeric_limits<int32_t>::min()) {
+      return nullAllowed
+          ? std::unique_ptr<common::Filter>(std::make_unique<common::IsNull>())
+          : std::unique_ptr<common::Filter>(
+                std::make_unique<common::AlwaysFalse>());
+    }
     high--;
   }
 
@@ -622,8 +670,27 @@ std::unique_ptr<common::Filter> toFilter(
       std::vector<std::unique_ptr<common::BigintRange>> dateFilters;
       dateFilters.reserve(ranges.size());
       for (const auto& range : ranges) {
+        std::unique_ptr<common::Filter> filter =
+            dateRangeToFilter(range, nullAllowed, exprConverter, type);
+        VELOX_CHECK_NOT_NULL(filter);
+        if (filter->kind() == common::FilterKind::kAlwaysFalse ||
+            filter->kind() == common::FilterKind::kIsNull) {
+          continue;
+        }
+        auto* bigintRange = dynamic_cast<common::BigintRange*>(filter.get());
+        VELOX_CHECK_NOT_NULL(bigintRange, "Expected BigintRange filter");
         dateFilters.emplace_back(
-            dateRangeToFilter(range, nullAllowed, exprConverter, type));
+            std::unique_ptr<common::BigintRange>(
+                static_cast<common::BigintRange*>(filter.release())));
+      }
+      if (dateFilters.empty()) {
+        return nullAllowed ? std::unique_ptr<common::Filter>(
+                                 std::make_unique<common::IsNull>())
+                           : std::unique_ptr<common::Filter>(
+                                 std::make_unique<common::AlwaysFalse>());
+      }
+      if (dateFilters.size() == 1) {
+        return std::move(dateFilters[0]);
       }
       return std::make_unique<common::BigintMultiRange>(
           std::move(dateFilters), nullAllowed);
@@ -635,8 +702,27 @@ std::unique_ptr<common::Filter> toFilter(
       std::vector<std::unique_ptr<common::BigintRange>> bigintFilters;
       bigintFilters.reserve(ranges.size());
       for (const auto& range : ranges) {
+        std::unique_ptr<common::Filter> filter =
+            bigintRangeToFilter(range, nullAllowed, exprConverter, type);
+        VELOX_CHECK_NOT_NULL(filter);
+        if (filter->kind() == common::FilterKind::kAlwaysFalse ||
+            filter->kind() == common::FilterKind::kIsNull) {
+          continue;
+        }
+        auto* bigintRange = dynamic_cast<common::BigintRange*>(filter.get());
+        VELOX_CHECK_NOT_NULL(bigintRange, "Expected BigintRange filter");
         bigintFilters.emplace_back(
-            bigintRangeToFilter(range, nullAllowed, exprConverter, type));
+            std::unique_ptr<common::BigintRange>(
+                static_cast<common::BigintRange*>(filter.release())));
+      }
+      if (bigintFilters.empty()) {
+        return nullAllowed ? std::unique_ptr<common::Filter>(
+                                 std::make_unique<common::IsNull>())
+                           : std::unique_ptr<common::Filter>(
+                                 std::make_unique<common::AlwaysFalse>());
+      }
+      if (bigintFilters.size() == 1) {
+        return std::move(bigintFilters[0]);
       }
       return combineIntegerRanges(bigintFilters, nullAllowed);
     }

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -15,14 +15,18 @@
 #include <gtest/gtest.h>
 #include "presto_cpp/main/connectors/HivePrestoToVeloxConnector.h"
 #include "presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h"
+#include "presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h"
 #include "presto_cpp/main/types/PrestoToVeloxExpr.h"
 #include "presto_cpp/presto_protocol/connector/hive/HiveConnectorProtocol.h"
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/type/Filter.h"
 
 using namespace facebook::presto;
 using namespace facebook::velox;
@@ -205,6 +209,49 @@ protocol::iceberg::IcebergColumnHandle createIcebergColumnHandle(
   column.type = type;
   column.columnType = protocol::hive::ColumnType::REGULAR;
   return column;
+}
+
+std::shared_ptr<protocol::Block> serializeToBlock(
+    const VectorPtr& vector,
+    memory::MemoryPool* pool) {
+  serializer::presto::PrestoVectorSerde serde;
+  std::ostringstream output;
+  serde.serializeSingleColumn(vector, nullptr, pool, &output);
+  const auto serialized = output.str();
+  auto block = std::make_shared<protocol::Block>();
+  block->data = encoding::Base64::encode(serialized.c_str(), serialized.size());
+  return block;
+}
+
+protocol::Domain createSingleRangeDomain(
+    const std::string& typeStr,
+    std::shared_ptr<protocol::Block> lowBlock,
+    protocol::Bound lowBound,
+    std::shared_ptr<protocol::Block> highBlock,
+    protocol::Bound highBound,
+    bool nullAllowed) {
+  protocol::Marker lowMarker;
+  lowMarker.type = typeStr;
+  lowMarker.valueBlock = std::move(lowBlock);
+  lowMarker.bound = lowBound;
+
+  protocol::Marker highMarker;
+  highMarker.type = typeStr;
+  highMarker.valueBlock = std::move(highBlock);
+  highMarker.bound = highBound;
+
+  protocol::Range range;
+  range.low = lowMarker;
+  range.high = highMarker;
+
+  auto rangeSet = std::make_shared<protocol::SortedRangeSet>();
+  rangeSet->type = typeStr;
+  rangeSet->ranges = {range};
+
+  protocol::Domain domain;
+  domain.values = rangeSet;
+  domain.nullAllowed = nullAllowed;
+  return domain;
 }
 
 } // namespace
@@ -474,4 +521,113 @@ TEST_F(PrestoToVeloxConnectorTest, hiveInsertTableHandleTableParameters) {
   EXPECT_EQ(storageParams.size(), 2);
   EXPECT_EQ(storageParams.at("param1"), "value1");
   EXPECT_EQ(storageParams.at("param2"), "value2");
+}
+
+TEST_F(PrestoToVeloxConnectorTest, bigintOverflowLowAboveMax) {
+  auto lowBlock = serializeToBlock(
+      BaseVector::createConstant(
+          BIGINT(),
+          variant(std::numeric_limits<int64_t>::max()),
+          1,
+          pool_.get()),
+      pool_.get());
+  auto domain = createSingleRangeDomain(
+      "bigint",
+      lowBlock,
+      protocol::Bound::ABOVE,
+      nullptr,
+      protocol::Bound::BELOW,
+      false);
+
+  auto filter = toFilter(domain, *exprConverter_, *typeParser_);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::max()));
+  EXPECT_FALSE(filter->testNull());
+}
+
+TEST_F(PrestoToVeloxConnectorTest, bigintOverflowHighBelowMin) {
+  auto highBlock = serializeToBlock(
+      BaseVector::createConstant(
+          BIGINT(),
+          variant(std::numeric_limits<int64_t>::min()),
+          1,
+          pool_.get()),
+      pool_.get());
+  auto domain = createSingleRangeDomain(
+      "bigint",
+      nullptr,
+      protocol::Bound::ABOVE,
+      highBlock,
+      protocol::Bound::BELOW,
+      false);
+
+  auto filter = toFilter(domain, *exprConverter_, *typeParser_);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::min()));
+  EXPECT_FALSE(filter->testNull());
+}
+
+TEST_F(PrestoToVeloxConnectorTest, bigintOverflowWithNullAllowed) {
+  auto lowBlock = serializeToBlock(
+      BaseVector::createConstant(
+          BIGINT(),
+          variant(std::numeric_limits<int64_t>::max()),
+          1,
+          pool_.get()),
+      pool_.get());
+  auto domain = createSingleRangeDomain(
+      "bigint",
+      lowBlock,
+      protocol::Bound::ABOVE,
+      nullptr,
+      protocol::Bound::BELOW,
+      true);
+
+  auto filter = toFilter(domain, *exprConverter_, *typeParser_);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kIsNull);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::max()));
+  EXPECT_TRUE(filter->testNull());
+}
+
+TEST_F(PrestoToVeloxConnectorTest, dateOverflowLowAboveMax) {
+  auto lowBlock = serializeToBlock(
+      BaseVector::createConstant(
+          DATE(), variant(std::numeric_limits<int32_t>::max()), 1, pool_.get()),
+      pool_.get());
+  auto domain = createSingleRangeDomain(
+      "date",
+      lowBlock,
+      protocol::Bound::ABOVE,
+      nullptr,
+      protocol::Bound::BELOW,
+      false);
+
+  auto filter = toFilter(domain, *exprConverter_, *typeParser_);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int32_t>::max()));
+  EXPECT_FALSE(filter->testNull());
+}
+
+TEST_F(PrestoToVeloxConnectorTest, dateOverflowHighBelowMin) {
+  auto highBlock = serializeToBlock(
+      BaseVector::createConstant(
+          DATE(), variant(std::numeric_limits<int32_t>::min()), 1, pool_.get()),
+      pool_.get());
+  auto domain = createSingleRangeDomain(
+      "date",
+      nullptr,
+      protocol::Bound::ABOVE,
+      highBlock,
+      protocol::Bound::BELOW,
+      false);
+
+  auto filter = toFilter(domain, *exprConverter_, *typeParser_);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int32_t>::min()));
+  EXPECT_FALSE(filter->testNull());
 }


### PR DESCRIPTION
Summary:

Guard against integer overflow when converting exclusive bounds to inclusive bounds for BigintRange, HugeintRange, and TimestampRange filters in the OSS Hive connector. When the boundary value is at the type limit, return AlwaysFalse or IsNull instead of overflowing. This mirrors the fix applied to the Prism connector and Velox expression filters.
```
NO RELEASE NOTE
```

Reviewed By: natashasehgal

Differential Revision: D101072577


