### PR TITLE
feat(optimizer): Add distributed execution for RPCNode via rpc_function_parallelism session property

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -381,6 +381,7 @@ public final class SystemSessionProperties
     public static final String SKIP_PUSHDOWN_THROUGH_EXCHANGE_FOR_REMOTE_PROJECTION = "skip_pushdown_through_exchange_for_remote_projection";
     public static final String REMOTE_FUNCTION_NAMES_FOR_FIXED_PARALLELISM = "remote_function_names_for_fixed_parallelism";
     public static final String REMOTE_FUNCTION_FIXED_PARALLELISM_TASK_COUNT = "remote_function_fixed_parallelism_task_count";
+    public static final String RPC_FUNCTION_PARALLELISM = "rpc_function_parallelism";
 
     // TODO: Native execution related session properties that are temporarily put here. They will be relocated in the future.
     public static final String NATIVE_AGGREGATION_SPILL_ALL = "native_aggregation_spill_all";
@@ -2197,6 +2198,15 @@ public final class SystemSessionProperties
                         featuresConfig.getRemoteFunctionFixedParallelismTaskCount(),
                         false),
                 new PropertyMetadata<>(
+                        RPC_FUNCTION_PARALLELISM,
+                        "Number of tasks for distributed RPC execution. 0 means use default planning (no forced parallelism, task count determined by query structure). Values > 1 distribute across N tasks via ROUND_ROBIN exchange.",
+                        INTEGER,
+                        Integer.class,
+                        0,
+                        false,
+                        value -> validateIntegerValue(value, RPC_FUNCTION_PARALLELISM, 0, false),
+                        object -> object),
+                new PropertyMetadata<>(
                         QUERY_CLIENT_TIMEOUT,
                         "Configures how long the query runs without contact from the client application, such as the CLI, before it's abandoned",
                         VARCHAR,
@@ -3797,6 +3807,11 @@ public final class SystemSessionProperties
     public static int getRemoteFunctionFixedParallelismTaskCount(Session session)
     {
         return session.getSystemProperty(REMOTE_FUNCTION_FIXED_PARALLELISM_TASK_COUNT, Integer.class);
+    }
+
+    public static int getRpcFunctionParallelism(Session session)
+    {
+        return session.getSystemProperty(RPC_FUNCTION_PARALLELISM, Integer.class);
     }
 
     public static String getTryFunctionCatchableErrors(Session session)

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -122,6 +122,7 @@ import static com.facebook.presto.SystemSessionProperties.getPartialMergePushdow
 import static com.facebook.presto.SystemSessionProperties.getPartitioningProviderCatalog;
 import static com.facebook.presto.SystemSessionProperties.getRemoteFunctionFixedParallelismTaskCount;
 import static com.facebook.presto.SystemSessionProperties.getRemoteFunctionNamesForFixedParallelism;
+import static com.facebook.presto.SystemSessionProperties.getRpcFunctionParallelism;
 import static com.facebook.presto.SystemSessionProperties.getTableScanShuffleParallelismThreshold;
 import static com.facebook.presto.SystemSessionProperties.getTableScanShuffleStrategy;
 import static com.facebook.presto.SystemSessionProperties.getTaskPartitionedWriterCount;
@@ -869,6 +870,14 @@ public class AddExchanges
         public PlanWithProperties visitRPC(RPCNode node, PreferredProperties preferredProperties)
         {
             PlanWithProperties source = accept(node.getSource(), preferredProperties);
+
+            int taskCount = getRpcFunctionParallelism(session);
+            if (taskCount > 1) {
+                PlanNode newNode = roundRobinExchange(idAllocator.getNextId(), REMOTE_STREAMING, source.getNode(), taskCount);
+                newNode = ChildReplacer.replaceChildren(node, ImmutableList.of(newNode));
+                return new PlanWithProperties(newNode, derivePropertiesRecursively(newNode));
+            }
+
             return rebaseAndDeriveProperties(node, source);
         }
 


### PR DESCRIPTION
Summary:
When RPCNode is in the output stage of a query (e.g., SELECT fb_llm_inference(...)), force_single_node_output places it in a SINGLE fragment with 1 task. For queries where RPCNode is not in the output stage (e.g., inside INSERT or before a JOIN/aggregation), RPCNode may already run distributed.

This diff adds a session property to explicitly control RPCNode parallelism using a ROUND_ROBIN exchange, following the same pattern as remote_function_fixed_parallelism_task_count for Python/Thrift UDFs.

Changes:
- AddExchanges.java: visitRPC() inserts a ROUND_ROBIN exchange below RPCNode when rpc_function_parallelism > 1
- SystemSessionProperties.java: Add rpc_function_parallelism integer session property (default 0 = default planning, task count determined by query structure)

Usage:
  SET SESSION rpc_function_parallelism = 4;
  SELECT fb_llm_inference(...) FROM big_table;

Plan with rpc_function_parallelism=4:
  Fragment 0 [SINGLE]: Output -> GATHER
  Fragment 1 [ROUND_ROBIN 4 tasks]: Project -> RPCNode -> ROUND_ROBIN exchange
  Fragment 2 [SOURCE]: TableScan (distributed reads)

Default (0): No exchange inserted — RPCNode uses default planning. For output-stage queries this means single task; for other query shapes it may be distributed.

Differential Revision: D101288404


