### PR TITLE
docs: Add undocumented Druid connector auth configs (#17683)

### DIFF
--- a/presto-docs/src/main/sphinx/connector/druid.rst
+++ b/presto-docs/src/main/sphinx/connector/druid.rst
@@ -32,21 +32,26 @@ Configuration Properties
 
 The following configuration properties are available:
 
-================================== ============================================================
-Property Name                       Description
-================================== ============================================================
-``druid.coordinator-url``           Druid coordinator url.
-``druid.broker-url``                Druid broker url.
-``druid.schema-name``               Druid schema name.
-``druid.compute-pushdown-enabled``  Whether to pushdown all query processing to Druid.
-``case-sensitive-name-matching``    Enable case-sensitive identifier support for schema,
-                                    table, and column names for the connector. When disabled,
-                                    names are matched case-insensitively using lowercase
-                                    normalization. Default is ``false``.
-``druid.tls.enabled``               Enable TLS when connecting to Druid.
-``druid.tls.truststore-path``       Path to the trust certificate file.
-``druid.tls.truststore-password``   Password for the trust certificate file.
-================================== ============================================================
+======================================== ============================================================
+Property Name                            Description
+======================================== ============================================================
+``druid.coordinator-url``                Druid coordinator url.
+``druid.broker-url``                     Druid broker url.
+``druid.schema-name``                    Druid schema name.
+``druid.compute-pushdown-enabled``       Whether to pushdown all query processing to Druid.
+``case-sensitive-name-matching``         Enable case-sensitive identifier support for schema,
+                                         table, and column names for the connector. When disabled,
+                                         names are matched case-insensitively using lowercase
+                                         normalization. Default is ``false``.
+``druid.tls.enabled``                    Enable TLS when connecting to Druid.
+``druid.tls.truststore-path``            Path to the trust certificate file.
+``druid.tls.truststore-password``        Password for the trust certificate file.
+``druid.authentication.type``            Authentication type for Druid.
+``druid.basic.authentication.username``  Username for basic authentication.
+``druid.basic.authentication.password``  Password for basic authentication.
+``druid.hadoop.config.resources``        Hadoop configuration resources.
+``druid.ingestion.storage.path``         Local storage path for ingestion.
+======================================== ============================================================
 
 ``druid.coordinator-url``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,6 +93,36 @@ Path to the trust certificate file.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Password for the trust certificate file.
+
+``druid.authentication.type``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Authentication type for Druid.
+
+Supported values are: ``NONE`` (default), ``BASIC`` and ``KERBEROS``
+
+``druid.basic.authentication.username``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Username for basic authentication. Required when ``druid.authentication.type`` is set to ``BASIC``.
+
+``druid.basic.authentication.password``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Password for basic authentication. Required when ``druid.authentication.type`` is set to ``BASIC``.
+
+``druid.hadoop.config.resources``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Comma-separated list of Hadoop configuration resource paths (e.g., ``core-site.xml``, ``hdfs-site.xml``).
+Required if Druid uses HDFS for deep storage or requires Kerberos configuration.
+
+``druid.ingestion.storage.path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Local storage path on Presto nodes used for temporary files during data ingestion.
+
+The default is the system temporary directory (``java.io.tmpdir``).
 
 Data Types
 ----------

--- a/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
+++ b/presto-docs/src/main/sphinx/presto_cpp/properties-session.rst
@@ -45,6 +45,27 @@ that a final aggregation operation can utilize before it starts spilling to disk
 If set to ``0``, there is no limit, allowing the aggregation to consume unlimited memory resources,
 which may impact system performance.
 
+``native_max_partial_aggregation_memory``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``16777216``
+
+Native Execution only. Defines the maximum memory used by partial aggregation when data reduction is not optimal.
+Default is 16MB.
+
+``native_max_extended_partial_aggregation_memory``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``67108864``
+
+Native Execution only. The maximum partial aggregation memory when data reduction is optimal.
+When good data reduction is achieved through partial aggregation, more memory would be given even
+when we reach the limit of ``native_max_partial_aggregation_memory``.
+Default is 64MB.
+
+
 ``native_debug_validate_output_from_operators``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -155,6 +176,15 @@ A value of ``0`` indicates no limit, permitting the join operation to use unlimi
 Native Execution only. Specifies the number of bits (N)
 used to calculate the spilling partition number for hash join and RowNumber operations.
 The partition number is determined as ``2`` raised to the power of N, defining how data is partitioned during the spill process.
+
+``native_max_spill_bytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``bigint``
+* **Default value:** ``107374182400``
+
+Native Execution only. The maximum allowed spill bytes.
+Default is 100GB.
 
 ``native_max_spill_file_size``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR resolves issue #17683  by documenting 5 missing configuration properties for the Druid connector:

**druid.authentication.type
druid.basic.authentication.username
druid.basic.authentication.password
druid.hadoop.config.resources
druid.ingestion.storage.path**

## Motivation and Context
Added Missing documentation

## Impact
No Performance Impact

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes

```
== RELEASE NOTES ==

## Summary by Sourcery

Document missing authentication and related configuration properties for the Druid connector.

Documentation:
- Add documentation for Druid connector authentication properties, including username and password configuration.
- Document additional Druid connector settings such as Hadoop configuration resources and ingestion storage path.
- Update Presto C++ session properties documentation to reflect the new or clarified Druid-related configuration options.