### PR TITLE
docs: Add missing authentication and advanced configs for Druid connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/druid.rst
+++ b/presto-docs/src/main/sphinx/connector/druid.rst
@@ -32,31 +32,36 @@ Configuration Properties
 
 The following configuration properties are available:
 
-================================== ============================================================
-Property Name                       Description
-================================== ============================================================
-``druid.coordinator-url``           Druid coordinator url.
-``druid.broker-url``                Druid broker url.
-``druid.schema-name``               Druid schema name.
-``druid.compute-pushdown-enabled``  Whether to pushdown all query processing to Druid.
-``case-sensitive-name-matching``    Enable case-sensitive identifier support for schema,
-                                    table, and column names for the connector. When disabled,
-                                    names are matched case-insensitively using lowercase
-                                    normalization. Default is ``false``.
-``druid.tls.enabled``               Enable TLS when connecting to Druid.
-``druid.tls.truststore-path``       Path to the trust certificate file.
-``druid.tls.truststore-password``   Password for the trust certificate file.
-================================== ============================================================
+======================================== =========================================================
+Property Name                            Description
+======================================== =========================================================
+``druid.coordinator-url``                Druid coordinator URL.
+``druid.broker-url``                     Druid broker URL.
+``druid.schema-name``                    Druid schema name.
+``druid.compute-pushdown-enabled``       Whether to pushdown all query processing to Druid.
+``case-sensitive-name-matching``         Enable case-sensitive identifier support for schema,
+                                         table, and column names for the connector. When disabled,
+                                         names are matched case-insensitively using lowercase
+                                         normalization. Default is ``false``.
+``druid.tls.enabled``                    Enable TLS when connecting to Druid.
+``druid.tls.truststore-path``            Path to the trust certificate file.
+``druid.tls.truststore-password``        Password for the trust certificate file.
+``druid.authentication.type``            Authentication type for Druid.
+``druid.basic.authentication.username``  Username for basic authentication.
+``druid.basic.authentication.password``  Password for basic authentication.
+``druid.hadoop.config.resources``        Hadoop configuration resources.
+``druid.ingestion.storage.path``         Local storage path for ingestion.
+======================================== =========================================================
 
 ``druid.coordinator-url``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Druid coordinator url, e.g. localhost:8081.
+Druid coordinator URL. For example, ``localhost:8081``.
 
 ``druid.broker-url``
 ^^^^^^^^^^^^^^^^^^^^
 
-Druid broker url, e.g. localhost:8082.
+Druid broker URL. For example, ``localhost:8082``.
 
 ``druid.schema-name``
 ^^^^^^^^^^^^^^^^^^^^^
@@ -70,7 +75,7 @@ This property is optional; the default is ``druid``.
 
 Whether to pushdown all query processing to Druid.
 
-the default is ``false``.
+The default is ``false``.
 
 ``druid.tls.enabled``
 ^^^^^^^^^^^^^^^^^^^^^
@@ -88,6 +93,36 @@ Path to the trust certificate file.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Password for the trust certificate file.
+
+``druid.authentication.type``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Authentication type for Druid.
+
+Supported values are: ``NONE`` (default), ``BASIC`` and ``KERBEROS``.
+
+``druid.basic.authentication.username``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Username for basic authentication. Required when ``druid.authentication.type`` is set to ``BASIC``.
+
+``druid.basic.authentication.password``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Password for basic authentication. Required when ``druid.authentication.type`` is set to ``BASIC``.
+
+``druid.hadoop.config.resources``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Comma-separated list of Hadoop configuration resource paths (for example, ``core-site.xml``, ``hdfs-site.xml``).
+Required if Druid uses HDFS for deep storage or requires Kerberos configuration.
+
+``druid.ingestion.storage.path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Local storage path on Presto nodes used for temporary files during data ingestion.
+
+The default is the system temporary directory (``java.io.tmpdir``).
 
 Data Types
 ----------


### PR DESCRIPTION
## Description
This PR resolves issue #17683 by documenting 5 missing configuration properties for the Druid connector:

**druid.authentication.type
druid.basic.authentication.username
druid.basic.authentication.password
druid.hadoop.config.resources
druid.ingestion.storage.path**

## Motivation and Context
Added Missing documentation

## Impact
No Performance Impact

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.
- [ ] If adding new dependencies, verified they have an [OpenSSF Scorecard](https://securityscorecards.dev/#the-checks) score of 5.0 or higher (or obtained explicit TSC approval for lower scores).

## Release Notes
```
== NO RELEASE NOTE ==
```

## Summary by Sourcery

Document additional authentication and advanced configuration options for the Druid connector.

Documentation:
- Add documentation for Druid connector authentication properties, including authentication type and basic auth credentials.
- Describe advanced Druid connector settings such as Hadoop configuration resources and ingestion storage path.