### PR TITLE
feat: Use Velox NULLIF special form (#27615)

### DIFF
--- a/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -829,7 +829,7 @@ public class FunctionAndTypeManager
 
     public boolean nullIfSpecialFormEnabled()
     {
-        return !nativeExecution;
+        return true;
     }
 
     /**

--- a/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main-base/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -926,6 +926,19 @@ public final class SqlToRowExpressionTranslator
                 // if (equal(cast(first as <common type>), cast(second as <common type>)), cast(null as firstType), first)
                 return specialForm(IF, returnType, equal, constantNull(returnType), firstArgWithoutCast);
             }
+            if (!second.getType().equals(first.getType())) {
+                Optional<Type> commonType = functionAndTypeResolver.getCommonSuperType(first.getType(), second.getType());
+                if (!commonType.isPresent()) {
+                    throw new SemanticException(TYPE_MISMATCH, node, "Types are not comparable with NULLIF: %s vs %s", first.getType(), second.getType());
+                }
+                if (!second.getType().equals(commonType.get())) {
+                    second = call(
+                            getSourceLocation(node),
+                            CAST.name(),
+                            functionAndTypeResolver.lookupCast(CAST.name(), second.getType(), commonType.get()),
+                            commonType.get(), second);
+                }
+            }
             return specialForm(getSourceLocation(node), NULL_IF, returnType, first, second);
         }
 

--- a/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp
@@ -20,6 +20,7 @@
 #include "presto_cpp/presto_protocol/Base64Util.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/ExprUtils.h"
+#include "velox/expression/NullIfExpr.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/ConstantVector.h"
@@ -858,7 +859,10 @@ TypedExprPtr VeloxExprConverter::toVeloxExpr(
   }
 
   if (pexpr->form == protocol::Form::NULL_IF) {
-    VELOX_UNREACHABLE("NULL_IF not supported in specialForm");
+    VELOX_USER_CHECK_EQ(args.size(), 2, "NULL_IF requires exactly 2 arguments");
+    auto commonType = args[1]->type();
+    return std::make_shared<NullIfTypedExpr>(
+        std::move(args[0]), std::move(args[1]), std::move(commonType));
   }
 
   auto form = std::string(json(pexpr->form));

--- a/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
+++ b/presto-native-execution/presto_cpp/main/types/VeloxToPrestoExpr.cpp
@@ -633,6 +633,11 @@ RowExpressionPtr VeloxToPrestoExprConverter::getRowExpression(
           expr->asUnchecked<velox::core::LambdaTypedExpr>();
       return getLambdaExpression(lambdaExpr);
     }
+    case velox::core::ExprKind::kNullIf: {
+      auto callExpr = std::make_shared<velox::core::CallTypedExpr>(
+          expr->type(), expr->inputs(), "null_if");
+      return getSpecialFormExpression(callExpr.get());
+    }
     // Presto does not have a RowExpression type for kConcat and kInput Velox
     // expressions. Presto to Velox expression conversion should not generate
     // Velox expressions of these types.

--- a/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/expressions/TestNativeExpressionInterpreter.java
+++ b/presto-native-sidecar-plugin/src/test/java/com/facebook/presto/sidecar/expressions/TestNativeExpressionInterpreter.java
@@ -296,8 +296,6 @@ public class TestNativeExpressionInterpreter
     @Test(enabled = false)
     public void testInvalidLike() {}
 
-    /// TODO: NULL_IF special form is unsupported in Presto C++.
-    @Override
     @Test(enabled = false)
     public void testNullIf() {}
 


### PR DESCRIPTION
Summary:

Updates Prestissimo to use NULLIF special form rather than expression rewrite, following added support in D101170683. Previously, Presto rewrote NULLIF(a, b) to IF(equal(a, b), null, a) before execution in Velox, duplicating the first argument and producing wrong results for non-deterministic expressions (see: https://velox-lib.io/blog/nullif-special-form/). We want to update this usage with a NULLIF special form to avoid duplicating non-deterministic expressions, resulting in correctness issues.

```
NO RELEASE NOTE
```

Differential Revision: D101267194


