### PR TITLE
feat: Add PUFFIN file format enum to FileFormat wrapper [presto][iceberg] (#27616)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
@@ -26,7 +26,8 @@ public enum FileFormat
     ORC("orc", true),
     PARQUET("parquet", true),
     AVRO("avro", true),
-    METADATA("metadata.json", false);
+    METADATA("metadata.json", false),
+    PUFFIN("puffin", false);
 
     private final String ext;
     private final boolean splittable;
@@ -61,6 +62,9 @@ public enum FileFormat
             case METADATA:
                 prestoFileFormat = METADATA;
                 break;
+            case PUFFIN:
+                prestoFileFormat = PUFFIN;
+                break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + format);
         }
@@ -80,6 +84,12 @@ public enum FileFormat
                 break;
             case AVRO:
                 fileFormat = org.apache.iceberg.FileFormat.AVRO;
+                break;
+            case METADATA:
+                fileFormat = org.apache.iceberg.FileFormat.METADATA;
+                break;
+            case PUFFIN:
+                fileFormat = org.apache.iceberg.FileFormat.PUFFIN;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + this);

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -320,7 +320,8 @@ static const std::pair<FileFormat, json> FileFormat_enum_table[] =
         {FileFormat::ORC, "ORC"},
         {FileFormat::PARQUET, "PARQUET"},
         {FileFormat::AVRO, "AVRO"},
-        {FileFormat::METADATA, "METADATA"}};
+        {FileFormat::METADATA, "METADATA"},
+        {FileFormat::PUFFIN, "PUFFIN"}};
 void to_json(json& j, const FileFormat& e) {
   static_assert(std::is_enum<FileFormat>::value, "FileFormat must be an enum!");
   const auto* it = std::find_if(

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -84,7 +84,7 @@ extern void to_json(json& j, const FileContent& e);
 extern void from_json(const json& j, FileContent& e);
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-enum class FileFormat { ORC, PARQUET, AVRO, METADATA };
+enum class FileFormat { ORC, PARQUET, AVRO, METADATA, PUFFIN };
 extern void to_json(json& j, const FileFormat& e);
 extern void from_json(const json& j, FileFormat& e);
 } // namespace facebook::presto::protocol::iceberg


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/presto-facebook/pull/3643


Adds a PUFFIN entry to the Presto-side FileFormat wrapper enum and wires it
through the bidirectional conversion methods (fromIcebergFileFormat /
toIceberg). PUFFIN is the standard Iceberg sidecar file format used to store
deletion vector indexes and table-level statistics blobs; without an enum
entry, any reference to a PUFFIN file from manifest tracking surfaces as
'Unsupported file format'. The METADATA case is also wired through toIceberg
for completeness so that round-tripping the enum no longer throws.

This is a strictly-additive change with no behavior change for existing
callers — every prior code path keeps the same dispatch.

Part of the Iceberg V3 Java support split (was D98749429).

== NO RELEASE NOTES ==



