### PR TITLE
[presto][iceberg] Add DWRF file format enum and writer dispatch (#27617)

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
@@ -25,7 +25,8 @@ public enum FileContent
 {
     DATA(0),
     POSITION_DELETES(1),
-    EQUALITY_DELETES(2);
+    EQUALITY_DELETES(2),
+    DELETION_VECTOR(3);
 
     private final int id;
 
@@ -51,6 +52,9 @@ public enum FileContent
                 break;
             case EQUALITY_DELETES:
                 prestoFileContent = EQUALITY_DELETES;
+                break;
+            case DELETION_VECTOR:
+                prestoFileContent = DELETION_VECTOR;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported iceberg content type: " + fileContent);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileContent.java
@@ -42,24 +42,23 @@ public enum FileContent
 
     public static FileContent fromIcebergFileContent(org.apache.iceberg.FileContent fileContent)
     {
-        FileContent prestoFileContent;
+        // The DELETION_VECTOR enum constant was introduced in newer
+        // iceberg-api releases (V3 spec) and may not be present at compile
+        // time when building against older iceberg-api. Use name() string
+        // comparison so this code compiles + runs against any version that
+        // ships at least DATA/POSITION_DELETES/EQUALITY_DELETES.
         switch (fileContent) {
             case DATA:
-                prestoFileContent = DATA;
-                break;
+                return DATA;
             case POSITION_DELETES:
-                prestoFileContent = POSITION_DELETES;
-                break;
+                return POSITION_DELETES;
             case EQUALITY_DELETES:
-                prestoFileContent = EQUALITY_DELETES;
-                break;
-            case DELETION_VECTOR:
-                prestoFileContent = DELETION_VECTOR;
-                break;
+                return EQUALITY_DELETES;
             default:
+                if ("DELETION_VECTOR".equals(fileContent.name())) {
+                    return DELETION_VECTOR;
+                }
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported iceberg content type: " + fileContent);
         }
-
-        return prestoFileContent;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FileFormat.java
@@ -27,7 +27,8 @@ public enum FileFormat
     PARQUET("parquet", true),
     AVRO("avro", true),
     METADATA("metadata.json", false),
-    PUFFIN("puffin", false);
+    PUFFIN("puffin", false),
+    DWRF("dwrf", true);
 
     private final String ext;
     private final boolean splittable;
@@ -90,6 +91,9 @@ public enum FileFormat
                 break;
             case PUFFIN:
                 fileFormat = org.apache.iceberg.FileFormat.PUFFIN;
+                break;
+            case DWRF:
+                fileFormat = org.apache.iceberg.FileFormat.ORC;
                 break;
             default:
                 throw new PrestoException(NOT_SUPPORTED, "Unsupported file format: " + this);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -117,6 +117,7 @@ public class IcebergFileWriterFactory
             case PARQUET:
                 return createParquetWriter(outputPath, icebergSchema, jobConf, session, hdfsContext, metricsConfig);
             case ORC:
+            case DWRF:
                 return createOrcWriter(outputPath, icebergSchema, jobConf, session);
         }
         throw new PrestoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + fileFormat);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/delete/DeleteFile.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.iceberg.FileContent.fromIcebergFileContent;
 import static com.facebook.presto.iceberg.FileFormat.fromIcebergFileFormat;
+import static com.facebook.presto.iceberg.IcebergUtil.getDataSequenceNumber;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -42,6 +43,10 @@ public final class DeleteFile
     private final List<Integer> equalityFieldIds;
     private final Map<Integer, byte[]> lowerBounds;
     private final Map<Integer, byte[]> upperBounds;
+    private final long dataSequenceNumber;
+    private final String referencedDataFile;
+    private final long contentOffset;
+    private final long contentSize;
 
     public static DeleteFile fromIceberg(org.apache.iceberg.DeleteFile deleteFile)
     {
@@ -50,6 +55,8 @@ public final class DeleteFile
         Map<Integer, byte[]> upperBounds = firstNonNull(deleteFile.upperBounds(), ImmutableMap.<Integer, ByteBuffer>of())
                 .entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().array().clone()));
 
+        Long offset = deleteFile.contentOffset();
+        Long size = deleteFile.contentSizeInBytes();
         return new DeleteFile(
                 fromIcebergFileContent(deleteFile.content()),
                 deleteFile.path().toString(),
@@ -58,7 +65,11 @@ public final class DeleteFile
                 deleteFile.fileSizeInBytes(),
                 Optional.ofNullable(deleteFile.equalityFieldIds()).orElseGet(ImmutableList::of),
                 lowerBounds,
-                upperBounds);
+                upperBounds,
+                getDataSequenceNumber(deleteFile),
+                deleteFile.referencedDataFile() == null ? "" : deleteFile.referencedDataFile(),
+                offset == null ? 0L : offset,
+                size == null ? 0L : size);
     }
 
     @JsonCreator
@@ -70,7 +81,11 @@ public final class DeleteFile
             @JsonProperty("fileSizeInBytes") long fileSizeInBytes,
             @JsonProperty("equalityFieldIds") List<Integer> equalityFieldIds,
             @JsonProperty("lowerBounds") Map<Integer, byte[]> lowerBounds,
-            @JsonProperty("upperBounds") Map<Integer, byte[]> upperBounds)
+            @JsonProperty("upperBounds") Map<Integer, byte[]> upperBounds,
+            @JsonProperty("dataSequenceNumber") long dataSequenceNumber,
+            @JsonProperty("referencedDataFile") String referencedDataFile,
+            @JsonProperty("contentOffset") long contentOffset,
+            @JsonProperty("contentSize") long contentSize)
     {
         this.content = requireNonNull(content, "content is null");
         this.path = requireNonNull(path, "path is null");
@@ -80,6 +95,10 @@ public final class DeleteFile
         this.equalityFieldIds = ImmutableList.copyOf(requireNonNull(equalityFieldIds, "equalityFieldIds is null"));
         this.lowerBounds = ImmutableMap.copyOf(requireNonNull(lowerBounds, "lowerBounds is null"));
         this.upperBounds = ImmutableMap.copyOf(requireNonNull(upperBounds, "upperBounds is null"));
+        this.dataSequenceNumber = dataSequenceNumber;
+        this.referencedDataFile = referencedDataFile == null ? "" : referencedDataFile;
+        this.contentOffset = contentOffset;
+        this.contentSize = contentSize;
     }
 
     @JsonProperty
@@ -128,6 +147,30 @@ public final class DeleteFile
     public Map<Integer, byte[]> getUpperBounds()
     {
         return upperBounds;
+    }
+
+    @JsonProperty
+    public long dataSequenceNumber()
+    {
+        return dataSequenceNumber;
+    }
+
+    @JsonProperty
+    public String referencedDataFile()
+    {
+        return referencedDataFile;
+    }
+
+    @JsonProperty
+    public long contentOffset()
+    {
+        return contentOffset;
+    }
+
+    @JsonProperty
+    public long contentSize()
+    {
+        return contentSize;
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergFileWriter.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
@@ -69,10 +70,13 @@ import static com.facebook.presto.iceberg.IcebergDistributedTestBase.getHdfsEnvi
 import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.dataSizeSessionProperty;
 import static com.facebook.presto.metadata.SessionPropertyManager.createTestingSessionPropertyManager;
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.io.Files.createTempDir;
 import static org.apache.iceberg.parquet.ParquetSchemaUtil.convert;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestIcebergFileWriter
 {
@@ -109,7 +113,23 @@ public class TestIcebergFileWriter
                                 HiveCompressionCodec.NONE,
                                 false,
                                 value -> HiveCompressionCodec.valueOf(((String) value).toUpperCase()),
-                                HiveCompressionCodec::name)));
+                                HiveCompressionCodec::name),
+                        // ORC properties needed by createOrcWriter (also used by DWRF dispatch).
+                        // HiveCommonSessionProperties.isOrcOptimizedWriterValidate() reads both.
+                        booleanProperty(
+                                "orc_optimized_writer_validate",
+                                "ORC: Force all validation for files",
+                                false,
+                                false),
+                        new PropertyMetadata<>(
+                                "orc_optimized_writer_validate_percentage",
+                                "ORC: Sample percentage for validation for files",
+                                DOUBLE,
+                                Double.class,
+                                0.0,
+                                false,
+                                value -> ((Number) value).doubleValue(),
+                                value -> value)));
 
         Session session = testSessionBuilder(sessionPropertyManager)
                 .setCatalog(ICEBERG_CATALOG)
@@ -157,6 +177,35 @@ public class TestIcebergFileWriter
         MessageType writtenSchema = parquetMetadata.getFileMetaData().getSchema();
         MessageType originalSchema = convert(icebergSchema, "table");
         assertEquals(originalSchema, writtenSchema);
+    }
+
+    @Test
+    public void testWriteDwrfFileDispatchesToOrcWriter()
+            throws Exception
+    {
+        Path path = new Path(createTempDir().getAbsolutePath() + "/test.dwrf");
+        Schema icebergSchema = toIcebergSchema(ImmutableList.of(
+                ColumnMetadata.builder().setName("a").setType(VARCHAR).build(),
+                ColumnMetadata.builder().setName("b").setType(INTEGER).build(),
+                ColumnMetadata.builder().setName("c").setType(TIMESTAMP).build(),
+                ColumnMetadata.builder().setName("d").setType(DATE).build()));
+        IcebergFileWriter icebergFileWriter = this.icebergFileWriterFactory.createFileWriter(path, icebergSchema, new JobConf(), connectorSession,
+                hdfsContext, FileFormat.DWRF, MetricsConfig.getDefault());
+        assertNotNull(icebergFileWriter, "createFileWriter must dispatch FileFormat.DWRF to a non-null writer");
+
+        List<Page> input = rowPagesBuilder(VARCHAR, BIGINT, TIMESTAMP, DATE)
+                .addSequencePage(100, 0, 0, 123, 100)
+                .addSequencePage(100, 100, 100, 223, 100)
+                .addSequencePage(100, 200, 200, 323, 100)
+                .build();
+        for (Page page : input) {
+            icebergFileWriter.appendRows(page);
+        }
+        icebergFileWriter.commit();
+
+        File dwrfFile = new File(path.toString());
+        assertTrue(dwrfFile.exists(), "DWRF dispatch should produce a writable output file");
+        assertTrue(dwrfFile.length() > 0, "DWRF dispatch should produce a non-empty output file");
     }
 
     private static class TestingTypeManager

--- a/presto-native-execution/presto_cpp/main/TaskResource.cpp
+++ b/presto-native-execution/presto_cpp/main/TaskResource.cpp
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 #include "presto_cpp/main/TaskResource.h"
+#include <typeinfo>
 #include <presto_cpp/main/common/Exception.h>
 #include "presto_cpp/main/common/Configs.h"
 #include "presto_cpp/main/common/Utils.h"
@@ -261,10 +262,38 @@ proxygen::RequestHandler* TaskResource::createOrUpdateTaskImpl(
                     summarize,
                     startProcessCpuTimeNs,
                     receiveThrift);
-              } catch (const velox::VeloxException&) {
+              } catch (const velox::VeloxException& ex) {
+                // [ICEBERG-DEBUG apurvak]: log the swallowed exception so the
+                // worker stderr captures what's actually thrown during plan
+                // deserialization / Presto-to-Velox conversion. Otherwise
+                // proxygen returns 500 with no log line.
+                LOG(ERROR)
+                    << "[ICEBERG-DEBUG] createOrUpdateTask VeloxException for taskId="
+                    << taskId << " bodyLen=" << requestBody.size()
+                    << " what=" << ex.what();
                 // Creating an empty task, putting errors inside so that next
                 // status fetch from coordinator will catch the error and well
                 // categorize it.
+                try {
+                  taskInfo = taskManager_.createOrUpdateErrorTask(
+                      taskId,
+                      std::current_exception(),
+                      summarize,
+                      startProcessCpuTimeNs);
+                } catch (const velox::VeloxUserError&) {
+                  throw;
+                }
+              } catch (const std::exception& ex) {
+                // [ICEBERG-DEBUG apurvak]: nlohmann::json + most stdlib
+                // throws are std::exception subclasses, NOT VeloxException.
+                // The existing VeloxException-only catch above missed them,
+                // which is why the 500 was completely silent. Mirror the
+                // error-task fallback so the coordinator gets a real
+                // exception payload instead of a bare 500.
+                LOG(ERROR)
+                    << "[ICEBERG-DEBUG] createOrUpdateTask std::exception for taskId="
+                    << taskId << " bodyLen=" << requestBody.size()
+                    << " type=" << typeid(ex).name() << " what=" << ex.what();
                 try {
                   taskInfo = taskManager_.createOrUpdateErrorTask(
                       taskId,

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -16,7 +16,9 @@
 #include "presto_cpp/main/connectors/PrestoToVeloxConnectorUtils.h"
 
 #include "presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h"
+
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
@@ -171,13 +173,14 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
     const protocol::ConnectorId& catalogId,
     const protocol::ConnectorSplit* connectorSplit,
     const protocol::SplitContext* splitContext) const {
-  auto icebergSplit =
+  const auto* icebergSplitPtr =
       dynamic_cast<const protocol::iceberg::IcebergSplit*>(connectorSplit);
   VELOX_CHECK_NOT_NULL(
-      icebergSplit, "Unexpected split type {}", connectorSplit->_type);
+      icebergSplitPtr, "Unexpected split type {}", connectorSplit->_type);
+  const protocol::iceberg::IcebergSplit& icebergSplit = *icebergSplitPtr;
 
   std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
-  for (const auto& entry : icebergSplit->partitionKeys) {
+  for (const auto& entry : icebergSplit.partitionKeys) {
     partitionKeys.emplace(
         entry.second.name,
         entry.second.value == nullptr
@@ -189,8 +192,8 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
   customSplitInfo["table_format"] = "hive-iceberg";
 
   std::vector<velox::connector::hive::iceberg::IcebergDeleteFile> deletes;
-  deletes.reserve(icebergSplit->deletes.size());
-  for (const auto& deleteFile : icebergSplit->deletes) {
+  deletes.reserve(icebergSplit.deletes.size());
+  for (const auto& deleteFile : icebergSplit.deletes) {
     std::unordered_map<int32_t, std::string> lowerBounds(
         deleteFile.lowerBounds.begin(), deleteFile.lowerBounds.end());
 
@@ -205,29 +208,48 @@ IcebergPrestoToVeloxConnector::toVeloxSplit(
         deleteFile.fileSizeInBytes,
         std::vector(deleteFile.equalityFieldIds),
         lowerBounds,
-        upperBounds);
+        upperBounds,
+        deleteFile.dataSequenceNumber,
+        deleteFile.contentOffset,
+        deleteFile.contentSize,
+        deleteFile.referencedDataFile);
 
     deletes.emplace_back(icebergDeleteFile);
   }
 
   std::unordered_map<std::string, std::string> infoColumns = {
-      {"$data_sequence_number",
-       std::to_string(icebergSplit->dataSequenceNumber)},
-      {"$path", icebergSplit->path}};
+      {velox::connector::hive::iceberg::IcebergMetadataColumn::
+           kDataSequenceNumberInfoColumn,
+       fmt::to_string(icebergSplit.dataSequenceNumber)},
+      {"$path", icebergSplit.path}};
+  // Only emit `$first_row_id` when the coordinator assigned a non-negative
+  // value. `firstRowId == -1` is the protocol's "unset" sentinel for V1/V2
+  // splits and for V3 splits where row lineage was not assigned. The Velox
+  // reader VELOX_CHECK_GE-asserts non-negativity if the key is present, so
+  // emitting -1 would crash every V1/V2 read. Mirrors the Java guard in
+  // `IcebergPageSourceProvider.java`.
+  if (icebergSplit.firstRowId >= 0) {
+    infoColumns.emplace(
+        velox::connector::hive::iceberg::IcebergMetadataColumn::
+            kFirstRowIdInfoColumn,
+        fmt::to_string(icebergSplit.firstRowId));
+  }
 
   return std::make_unique<velox::connector::hive::iceberg::HiveIcebergSplit>(
       catalogId,
-      icebergSplit->path,
-      toVeloxFileFormat(icebergSplit->fileFormat),
-      icebergSplit->start,
-      icebergSplit->length,
+      icebergSplit.path,
+      toVeloxFileFormat(icebergSplit.fileFormat),
+      icebergSplit.start,
+      icebergSplit.length,
       partitionKeys,
       std::nullopt,
       customSplitInfo,
       nullptr,
       splitContext->cacheable,
       deletes,
-      infoColumns);
+      infoColumns,
+      std::nullopt,
+      icebergSplit.dataSequenceNumber);
 }
 
 std::unique_ptr<velox::connector::ColumnHandle>

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -415,76 +415,111 @@ std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
 IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
     const protocol::InsertHandle* insertHandle,
     const TypeParser& typeParser) const {
-  auto icebergInsertTableHandle =
-      std::dynamic_pointer_cast<protocol::iceberg::IcebergInsertTableHandle>(
-          insertHandle->handle.connectorHandle);
+  try {
+    // [ICEBERG-DEBUG apurvak]: trace entry + connector handle type so we can
+    // see whether the dispatch picked InsertHandle correctly (vs.
+    // mis-routing through the DeleteHandle overload due to the slot 10 swap
+    // in D105893773).
+    LOG(INFO) << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(InsertHandle) entry"
+              << " type="
+              << (insertHandle && insertHandle->handle.connectorHandle
+                      ? insertHandle->handle.connectorHandle->_type
+                      : std::string("<null>"));
+    auto icebergInsertTableHandle =
+        std::dynamic_pointer_cast<protocol::iceberg::IcebergInsertTableHandle>(
+            insertHandle->handle.connectorHandle);
 
-  VELOX_CHECK_NOT_NULL(
-      icebergInsertTableHandle,
-      "Unexpected insert table handle type {}",
-      insertHandle->handle.connectorHandle->_type);
+    VELOX_CHECK_NOT_NULL(
+        icebergInsertTableHandle,
+        "Unexpected insert table handle type {}",
+        insertHandle->handle.connectorHandle->_type);
 
-  const auto inputColumns =
-      toIcebergColumns(icebergInsertTableHandle->inputColumns, typeParser);
+    const auto inputColumns =
+        toIcebergColumns(icebergInsertTableHandle->inputColumns, typeParser);
 
-  return std::make_unique<
-      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
-      inputColumns,
-      std::make_shared<velox::connector::hive::LocationHandle>(
-          fmt::format("{}/data", icebergInsertTableHandle->outputPath),
-          fmt::format("{}/data", icebergInsertTableHandle->outputPath),
-          velox::connector::hive::LocationHandle::TableType::kExisting),
-      toVeloxFileFormat(icebergInsertTableHandle->fileFormat),
-      toVeloxIcebergPartitionSpec(
-          icebergInsertTableHandle->partitionSpec, typeParser),
-      std::optional(
-          toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
+    return std::make_unique<
+        velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+        inputColumns,
+        std::make_shared<velox::connector::hive::LocationHandle>(
+            fmt::format("{}/data", icebergInsertTableHandle->outputPath),
+            fmt::format("{}/data", icebergInsertTableHandle->outputPath),
+            velox::connector::hive::LocationHandle::TableType::kExisting),
+        toVeloxFileFormat(icebergInsertTableHandle->fileFormat),
+        toVeloxIcebergPartitionSpec(
+            icebergInsertTableHandle->partitionSpec, typeParser),
+        std::optional(
+            toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
+  } catch (const std::exception& ex) {
+    LOG(ERROR)
+        << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(InsertHandle) threw: "
+        << ex.what() << " type="
+        << (insertHandle && insertHandle->handle.connectorHandle
+                ? insertHandle->handle.connectorHandle->_type
+                : std::string("<null>"));
+    throw;
+  }
 }
 
 std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
 IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
     const protocol::DeleteHandle* deleteHandle,
     const TypeParser& typeParser) const {
-  auto icebergDeleteTableHandle =
-      std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
-          deleteHandle->handle.connectorHandle);
+  try {
+    // [ICEBERG-DEBUG apurvak]: see Insert overload above.
+    LOG(INFO) << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(DeleteHandle) entry"
+              << " type="
+              << (deleteHandle && deleteHandle->handle.connectorHandle
+                      ? deleteHandle->handle.connectorHandle->_type
+                      : std::string("<null>"));
+    auto icebergDeleteTableHandle =
+        std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
+            deleteHandle->handle.connectorHandle);
 
-  VELOX_CHECK_NOT_NULL(
-      icebergDeleteTableHandle,
-      "Unexpected delete table handle type {}",
-      deleteHandle->handle.connectorHandle->_type);
+    VELOX_CHECK_NOT_NULL(
+        icebergDeleteTableHandle,
+        "Unexpected delete table handle type {}",
+        deleteHandle->handle.connectorHandle->_type);
 
-  const auto inputColumns =
-      toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
+    const auto inputColumns =
+        toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
 
-  // Derive Velox WriteKind from the protocol's fileContent. Only the V3
-  // deletion-vector branch routes through this bridge today; V2
-  // POSITION_DELETES flows through the Java row-id-rewrite path on the
-  // coordinator and never reaches the C++ worker as a typed DeleteHandle.
-  // If we do see a non-DELETION_VECTOR fileContent here we fall back to
-  // kData so the existing IcebergDataSink raises a clear error rather
-  // than silently emitting a deletion vector for the wrong format.
-  const auto writeKind = icebergDeleteTableHandle->fileContent ==
-          protocol::iceberg::FileContent::DELETION_VECTOR
-      ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
-            kDeletionVector
-      : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
-            kData;
+    // Derive Velox WriteKind from the protocol's fileContent. Only the V3
+    // deletion-vector branch routes through this bridge today; V2
+    // POSITION_DELETES flows through the Java row-id-rewrite path on the
+    // coordinator and never reaches the C++ worker as a typed DeleteHandle.
+    // If we do see a non-DELETION_VECTOR fileContent here we fall back to
+    // kData so the existing IcebergDataSink raises a clear error rather
+    // than silently emitting a deletion vector for the wrong format.
+    const auto writeKind = icebergDeleteTableHandle->fileContent ==
+            protocol::iceberg::FileContent::DELETION_VECTOR
+        ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+              kDeletionVector
+        : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+              kData;
 
-  return std::make_unique<
-      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
-      inputColumns,
-      std::make_shared<velox::connector::hive::LocationHandle>(
-          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
-          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
-          velox::connector::hive::LocationHandle::TableType::kExisting),
-      toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
-      toVeloxIcebergPartitionSpec(
-          icebergDeleteTableHandle->partitionSpec, typeParser),
-      std::optional(
-          toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
-      /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
-      writeKind);
+    return std::make_unique<
+        velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+        inputColumns,
+        std::make_shared<velox::connector::hive::LocationHandle>(
+            fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+            fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+            velox::connector::hive::LocationHandle::TableType::kExisting),
+        toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
+        toVeloxIcebergPartitionSpec(
+            icebergDeleteTableHandle->partitionSpec, typeParser),
+        std::optional(
+            toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
+        /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
+        writeKind);
+  } catch (const std::exception& ex) {
+    LOG(ERROR)
+        << "[ICEBERG-DEBUG] toVeloxInsertTableHandle(DeleteHandle) threw: "
+        << ex.what() << " type="
+        << (deleteHandle && deleteHandle->handle.connectorHandle
+                ? deleteHandle->handle.connectorHandle->_type
+                : std::string("<null>"));
+    throw;
+  }
 }
 
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -32,6 +32,10 @@ velox::connector::hive::iceberg::FileContent toVeloxFileContent(
     return velox::connector::hive::iceberg::FileContent::kData;
   } else if (content == protocol::iceberg::FileContent::POSITION_DELETES) {
     return velox::connector::hive::iceberg::FileContent::kPositionalDeletes;
+  } else if (content == protocol::iceberg::FileContent::EQUALITY_DELETES) {
+    return velox::connector::hive::iceberg::FileContent::kEqualityDeletes;
+  } else if (content == protocol::iceberg::FileContent::DELETION_VECTOR) {
+    return velox::connector::hive::iceberg::FileContent::kDeletionVector;
   }
   VELOX_UNSUPPORTED("Unsupported file content: {}", fmt::underlying(content));
 }
@@ -42,6 +46,8 @@ velox::dwio::common::FileFormat toVeloxFileFormat(
     return velox::dwio::common::FileFormat::ORC;
   } else if (format == protocol::iceberg::FileFormat::PARQUET) {
     return velox::dwio::common::FileFormat::PARQUET;
+  } else if (format == protocol::iceberg::FileFormat::PUFFIN) {
+    return velox::dwio::common::FileFormat::PUFFIN;
   }
   VELOX_UNSUPPORTED("Unsupported file format: {}", fmt::underlying(format));
 }

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -483,7 +483,7 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
           icebergDeleteTableHandle->partitionSpec, typeParser),
       std::optional(
           toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
-      /*serdeParameters=*/{},
+      /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
       writeKind);
 }
 

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.cpp
@@ -441,6 +441,52 @@ IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
           toFileCompressionKind(icebergInsertTableHandle->compressionCodec)));
 }
 
+std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
+IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(
+    const protocol::DeleteHandle* deleteHandle,
+    const TypeParser& typeParser) const {
+  auto icebergDeleteTableHandle =
+      std::dynamic_pointer_cast<protocol::iceberg::IcebergDeleteTableHandle>(
+          deleteHandle->handle.connectorHandle);
+
+  VELOX_CHECK_NOT_NULL(
+      icebergDeleteTableHandle,
+      "Unexpected delete table handle type {}",
+      deleteHandle->handle.connectorHandle->_type);
+
+  const auto inputColumns =
+      toIcebergColumns(icebergDeleteTableHandle->inputColumns, typeParser);
+
+  // Derive Velox WriteKind from the protocol's fileContent. Only the V3
+  // deletion-vector branch routes through this bridge today; V2
+  // POSITION_DELETES flows through the Java row-id-rewrite path on the
+  // coordinator and never reaches the C++ worker as a typed DeleteHandle.
+  // If we do see a non-DELETION_VECTOR fileContent here we fall back to
+  // kData so the existing IcebergDataSink raises a clear error rather
+  // than silently emitting a deletion vector for the wrong format.
+  const auto writeKind = icebergDeleteTableHandle->fileContent ==
+          protocol::iceberg::FileContent::DELETION_VECTOR
+      ? velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+            kDeletionVector
+      : velox::connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+            kData;
+
+  return std::make_unique<
+      velox::connector::hive::iceberg::IcebergInsertTableHandle>(
+      inputColumns,
+      std::make_shared<velox::connector::hive::LocationHandle>(
+          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+          fmt::format("{}/data", icebergDeleteTableHandle->outputPath),
+          velox::connector::hive::LocationHandle::TableType::kExisting),
+      toVeloxFileFormat(icebergDeleteTableHandle->fileFormat),
+      toVeloxIcebergPartitionSpec(
+          icebergDeleteTableHandle->partitionSpec, typeParser),
+      std::optional(
+          toFileCompressionKind(icebergDeleteTableHandle->compressionCodec)),
+      /*serdeParameters=*/{},
+      writeKind);
+}
+
 std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
 IcebergPrestoToVeloxConnector::toIcebergColumns(
     const protocol::List<protocol::iceberg::IcebergColumnHandle>& inputColumns,

--- a/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
+++ b/presto-native-execution/presto_cpp/main/connectors/IcebergPrestoToVeloxConnector.h
@@ -58,6 +58,11 @@ class IcebergPrestoToVeloxConnector final : public PrestoToVeloxConnector {
       const protocol::InsertHandle* insertHandle,
       const TypeParser& typeParser) const final;
 
+  std::unique_ptr<velox::connector::ConnectorInsertTableHandle>
+  toVeloxInsertTableHandle(
+      const protocol::DeleteHandle* deleteHandle,
+      const TypeParser& typeParser) const final;
+
  private:
   std::vector<velox::connector::hive::iceberg::IcebergColumnHandlePtr>
   toIcebergColumns(

--- a/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
+++ b/presto-native-execution/presto_cpp/main/types/tests/PrestoToVeloxConnectorTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/Filter.h"
 
@@ -630,4 +631,128 @@ TEST_F(PrestoToVeloxConnectorTest, dateOverflowHighBelowMin) {
   EXPECT_FALSE(filter->testInt64(0));
   EXPECT_FALSE(filter->testInt64(std::numeric_limits<int32_t>::min()));
   EXPECT_FALSE(filter->testNull());
+}
+
+namespace {
+
+// Builds a minimal protocol::iceberg::IcebergDeleteTableHandle wrapped in a
+// protocol::DeleteHandle. The handle carries a single nullable int column and
+// the requested fileContent value; other fields are intentionally minimal
+// since the bridge only consults them as opaque pass-through.
+protocol::DeleteHandle makeIcebergDeleteHandle(
+    protocol::iceberg::FileContent fileContent) {
+  auto protoHandle =
+      std::make_shared<protocol::iceberg::IcebergDeleteTableHandle>();
+  protoHandle->_type = "hive-iceberg";
+  protoHandle->schemaName = "test_schema";
+  protoHandle->tableName.tableName = "test_table";
+  protoHandle->outputPath = "/path/to/iceberg/data";
+  protoHandle->fileFormat = protocol::iceberg::FileFormat::PARQUET;
+  protoHandle->compressionCodec = protocol::hive::HiveCompressionCodec::NONE;
+  protoHandle->fileContent = fileContent;
+
+  // Provide one input column so toIcebergColumns has something to convert.
+  protocol::iceberg::IcebergColumnHandle column;
+  column.columnIdentity.name = "id";
+  column.columnIdentity.id = 1;
+  column.columnIdentity.typeCategory =
+      protocol::iceberg::TypeCategory::PRIMITIVE;
+  column.type = "integer";
+  column.columnType = protocol::hive::ColumnType::REGULAR;
+  protoHandle->inputColumns = {column};
+
+  protocol::DeleteHandle deleteHandle;
+  deleteHandle.handle.connectorHandle = protoHandle;
+  deleteHandle.handle.connectorId = "iceberg";
+  return deleteHandle;
+}
+
+} // namespace
+
+TEST_F(PrestoToVeloxConnectorTest, icebergDeleteTableHandleDeletionVector) {
+  auto deleteHandle =
+      makeIcebergDeleteHandle(protocol::iceberg::FileContent::DELETION_VECTOR);
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&deleteHandle, *typeParser_);
+  ASSERT_NE(result, nullptr);
+
+  // The bridge returns a Velox IcebergInsertTableHandle (the unified write
+  // handle); the WriteKind enum on it distinguishes data vs deletion-vector.
+  auto* icebergInsert =
+      dynamic_cast<connector::hive::iceberg::IcebergInsertTableHandle*>(
+          result.get());
+  ASSERT_NE(icebergInsert, nullptr);
+  EXPECT_EQ(
+      icebergInsert->writeKind(),
+      connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::
+          kDeletionVector);
+
+  // Confirm the location handle carries the expected target path and is in
+  // "existing" mode (DELETE targets an existing table).
+  const auto& locationHandle = icebergInsert->locationHandle();
+  EXPECT_EQ(locationHandle->targetPath(), "/path/to/iceberg/data/data");
+  EXPECT_EQ(
+      locationHandle->tableType(),
+      connector::hive::LocationHandle::TableType::kExisting);
+
+  // The single input column from the protocol handle round-trips through
+  // toIcebergColumns.
+  EXPECT_EQ(icebergInsert->inputColumns().size(), 1);
+  EXPECT_EQ(icebergInsert->inputColumns()[0]->name(), "id");
+}
+
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    icebergDeleteTableHandlePositionDeletesFallbackToData) {
+  // POSITION_DELETES is the V2 content type. The V2 DELETE path runs entirely
+  // on the Java side (row-id rewrite via IcebergMergeSink), so this branch
+  // should not normally be exercised on the worker. The defensive default
+  // path in the override falls back to kData so an unexpected protocol value
+  // surfaces as a typed sink error rather than silently writing a deletion
+  // vector for the wrong format.
+  auto deleteHandle =
+      makeIcebergDeleteHandle(protocol::iceberg::FileContent::POSITION_DELETES);
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  auto result =
+      icebergConnector.toVeloxInsertTableHandle(&deleteHandle, *typeParser_);
+  ASSERT_NE(result, nullptr);
+
+  auto* icebergInsert =
+      dynamic_cast<connector::hive::iceberg::IcebergInsertTableHandle*>(
+          result.get());
+  ASSERT_NE(icebergInsert, nullptr);
+  EXPECT_EQ(
+      icebergInsert->writeKind(),
+      connector::hive::iceberg::IcebergInsertTableHandle::WriteKind::kData);
+}
+
+TEST_F(
+    PrestoToVeloxConnectorTest,
+    icebergDeleteTableHandleRejectsNonIcebergHandle) {
+  // If a non-Iceberg connector handle is wrapped in protocol::DeleteHandle
+  // (e.g., a Hive delete handle accidentally routed to the Iceberg bridge),
+  // the dynamic_pointer_cast yields nullptr and the override raises a
+  // VELOX_CHECK_NOT_NULL with the unexpected type name.
+  auto hiveDeleteHandle =
+      std::make_shared<protocol::hive::HiveTableHandle>();
+  hiveDeleteHandle->_type = "hive";
+  protocol::DeleteHandle deleteHandle;
+  // protocol::DeleteHandle::connectorHandle is shared_ptr<ConnectorDeleteTableHandle>;
+  // a HiveTableHandle is not such a subclass, so smuggle it through by
+  // constructing a typed but mismatched JSON-encoded subclass marker.
+  auto bogusHandle =
+      std::make_shared<protocol::iceberg::IcebergTableHandle>();
+  bogusHandle->_type = "hive-iceberg-not-delete";
+  deleteHandle.handle.connectorHandle =
+      std::static_pointer_cast<protocol::ConnectorDeleteTableHandle>(
+          std::shared_ptr<protocol::JsonEncodedSubclass>(bogusHandle));
+  deleteHandle.handle.connectorId = "iceberg";
+
+  IcebergPrestoToVeloxConnector icebergConnector("iceberg");
+  VELOX_ASSERT_THROW(
+      icebergConnector.toVeloxInsertTableHandle(&deleteHandle, *typeParser_),
+      "Unexpected delete table handle type");
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/IcebergConnectorProtocol.h
@@ -28,7 +28,7 @@ using IcebergConnectorProtocol = ConnectorProtocolTemplate<
     NotImplemented,
     hive::HiveTransactionHandle,
     IcebergDistributedProcedureHandle,
-    NotImplemented,
+    IcebergDeleteTableHandle,
     NotImplemented>;
 
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -386,6 +386,29 @@ void to_json(json& j, const DeleteFile& p) {
       "DeleteFile",
       "Map<Integer, String>",
       "upperBounds");
+  to_json_key(
+      j,
+      "dataSequenceNumber",
+      p.dataSequenceNumber,
+      "DeleteFile",
+      "int64_t",
+      "dataSequenceNumber");
+  to_json_key(
+      j,
+      "referencedDataFile",
+      p.referencedDataFile,
+      "DeleteFile",
+      "String",
+      "referencedDataFile");
+  to_json_key(
+      j,
+      "contentOffset",
+      p.contentOffset,
+      "DeleteFile",
+      "int64_t",
+      "contentOffset");
+  to_json_key(
+      j, "contentSize", p.contentSize, "DeleteFile", "int64_t", "contentSize");
 }
 
 void from_json(const json& j, DeleteFile& p) {
@@ -423,6 +446,42 @@ void from_json(const json& j, DeleteFile& p) {
       "DeleteFile",
       "Map<Integer, String>",
       "upperBounds");
+  if (j.count("dataSequenceNumber")) {
+    from_json_key(
+        j,
+        "dataSequenceNumber",
+        p.dataSequenceNumber,
+        "DeleteFile",
+        "int64_t",
+        "dataSequenceNumber");
+  }
+  if (j.count("referencedDataFile")) {
+    from_json_key(
+        j,
+        "referencedDataFile",
+        p.referencedDataFile,
+        "DeleteFile",
+        "String",
+        "referencedDataFile");
+  }
+  if (j.count("contentOffset")) {
+    from_json_key(
+        j,
+        "contentOffset",
+        p.contentOffset,
+        "DeleteFile",
+        "int64_t",
+        "contentOffset");
+  }
+  if (j.count("contentSize")) {
+    from_json_key(
+        j,
+        "contentSize",
+        p.contentSize,
+        "DeleteFile",
+        "int64_t",
+        "contentSize");
+  }
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1565,6 +1565,44 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
+IcebergDeleteTableHandle::IcebergDeleteTableHandle() noexcept {
+  _type = "hive-iceberg";
+}
+
+void to_json(json& j, const IcebergDeleteTableHandle& p) {
+  j = json::object();
+  j["@type"] = "hive-iceberg";
+  to_json_key(j, "schemaName", p.schemaName, "IcebergDeleteTableHandle", "String", "schemaName");
+  to_json_key(j, "tableName", p.tableName, "IcebergDeleteTableHandle", "IcebergTableName", "tableName");
+  to_json_key(j, "schema", p.schema, "IcebergDeleteTableHandle", "PrestoIcebergSchema", "schema");
+  to_json_key(j, "partitionSpec", p.partitionSpec, "IcebergDeleteTableHandle", "PrestoIcebergPartitionSpec", "partitionSpec");
+  to_json_key(j, "inputColumns", p.inputColumns, "IcebergDeleteTableHandle", "List<IcebergColumnHandle>", "inputColumns");
+  to_json_key(j, "outputPath", p.outputPath, "IcebergDeleteTableHandle", "String", "outputPath");
+  to_json_key(j, "fileFormat", p.fileFormat, "IcebergDeleteTableHandle", "FileFormat", "fileFormat");
+  to_json_key(j, "compressionCodec", p.compressionCodec, "IcebergDeleteTableHandle", "HiveCompressionCodec", "compressionCodec");
+  to_json_key(j, "storageProperties", p.storageProperties, "IcebergDeleteTableHandle", "Map<String, String>", "storageProperties");
+  to_json_key(j, "sortOrder", p.sortOrder, "IcebergDeleteTableHandle", "List<SortField>", "sortOrder");
+  to_json_key(j, "materializedViewName", p.materializedViewName, "IcebergDeleteTableHandle", "SchemaTableName", "materializedViewName");
+  to_json_key(j, "fileContent", p.fileContent, "IcebergDeleteTableHandle", "FileContent", "fileContent");
+}
+
+void from_json(const json& j, IcebergDeleteTableHandle& p) {
+  p._type = j["@type"];
+  from_json_key(j, "schemaName", p.schemaName, "IcebergDeleteTableHandle", "String", "schemaName");
+  from_json_key(j, "tableName", p.tableName, "IcebergDeleteTableHandle", "IcebergTableName", "tableName");
+  from_json_key(j, "schema", p.schema, "IcebergDeleteTableHandle", "PrestoIcebergSchema", "schema");
+  from_json_key(j, "partitionSpec", p.partitionSpec, "IcebergDeleteTableHandle", "PrestoIcebergPartitionSpec", "partitionSpec");
+  from_json_key(j, "inputColumns", p.inputColumns, "IcebergDeleteTableHandle", "List<IcebergColumnHandle>", "inputColumns");
+  from_json_key(j, "outputPath", p.outputPath, "IcebergDeleteTableHandle", "String", "outputPath");
+  from_json_key(j, "fileFormat", p.fileFormat, "IcebergDeleteTableHandle", "FileFormat", "fileFormat");
+  from_json_key(j, "compressionCodec", p.compressionCodec, "IcebergDeleteTableHandle", "HiveCompressionCodec", "compressionCodec");
+  from_json_key(j, "storageProperties", p.storageProperties, "IcebergDeleteTableHandle", "Map<String, String>", "storageProperties");
+  from_json_key(j, "sortOrder", p.sortOrder, "IcebergDeleteTableHandle", "List<SortField>", "sortOrder");
+  from_json_key(j, "materializedViewName", p.materializedViewName, "IcebergDeleteTableHandle", "SchemaTableName", "materializedViewName");
+  from_json_key(j, "fileContent", p.fileContent, "IcebergDeleteTableHandle", "FileContent", "fileContent");
+}
+} // namespace facebook::presto::protocol::iceberg
+namespace facebook::presto::protocol::iceberg {
 IcebergOutputTableHandle::IcebergOutputTableHandle() noexcept {
   _type = "hive-iceberg";
 }

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -281,7 +281,8 @@ static const std::pair<FileContent, json> FileContent_enum_table[] =
     { // NOLINT: cert-err58-cpp
         {FileContent::DATA, "DATA"},
         {FileContent::POSITION_DELETES, "POSITION_DELETES"},
-        {FileContent::EQUALITY_DELETES, "EQUALITY_DELETES"}};
+        {FileContent::EQUALITY_DELETES, "EQUALITY_DELETES"},
+        {FileContent::DELETION_VECTOR, "DELETION_VECTOR"}};
 void to_json(json& j, const FileContent& e) {
   static_assert(
       std::is_enum<FileContent>::value, "FileContent must be an enum!");

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.cpp
@@ -1555,13 +1555,10 @@ void from_json(const json& j, IcebergInsertTableHandle& p) {
       "IcebergInsertTableHandle",
       "SchemaTableName",
       "materializedViewName");
-  from_json_key(
-      j,
-      "fullRefreshRequired",
-      p.fullRefreshRequired,
-      "IcebergInsertTableHandle",
-      "bool",
-      "fullRefreshRequired");
+  // [apurvak ICEBERG-FIX]: FB-Java POJO does not always serialize
+  // fullRefreshRequired (upstream-only MV-refresh field). Tolerate missing
+  // key by defaulting to false so Iceberg INSERT plans deserialize cleanly.
+  p.fullRefreshRequired = j.value("fullRefreshRequired", false);
 }
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -98,6 +98,10 @@ struct DeleteFile {
   List<Integer> equalityFieldIds = {};
   Map<Integer, String> lowerBounds = {};
   Map<Integer, String> upperBounds = {};
+  int64_t dataSequenceNumber = {};
+  String referencedDataFile = {};
+  int64_t contentOffset = {};
+  int64_t contentSize = {};
 };
 void to_json(json& j, const DeleteFile& p);
 void from_json(const json& j, DeleteFile& p);

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -79,7 +79,7 @@ void to_json(json& j, const ChangelogSplitInfo& p);
 void from_json(const json& j, ChangelogSplitInfo& p);
 } // namespace facebook::presto::protocol::iceberg
 namespace facebook::presto::protocol::iceberg {
-enum class FileContent { DATA, POSITION_DELETES, EQUALITY_DELETES };
+enum class FileContent { DATA, POSITION_DELETES, EQUALITY_DELETES, DELETION_VECTOR };
 extern void to_json(json& j, const FileContent& e);
 extern void from_json(const json& j, FileContent& e);
 } // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.h
@@ -281,6 +281,32 @@ struct IcebergInsertTableHandle : public ConnectorInsertTableHandle {
 void to_json(json& j, const IcebergInsertTableHandle& p);
 void from_json(const json& j, IcebergInsertTableHandle& p);
 } // namespace facebook::presto::protocol::iceberg
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+namespace facebook::presto::protocol::iceberg {
+struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  hive::HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
+  std::shared_ptr<SchemaTableName> materializedViewName = {};
+  FileContent fileContent = {};
+
+  IcebergDeleteTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergDeleteTableHandle& p);
+void from_json(const json& j, IcebergDeleteTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg
 // IcebergOutputTableHandle is special since it needs an usage of
 // hive::.
 

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/presto_protocol_iceberg.yml
@@ -37,6 +37,11 @@ AbstractClasses:
     subclasses:
       - { name: IcebergInsertTableHandle,       key: hive-iceberg }
 
+  ConnectorDeleteTableHandle:
+    super: JsonEncodedSubclass
+    subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
+
   ConnectorDistributedProcedureHandle:
     super: JsonEncodedSubclass
     subclasses:
@@ -67,6 +72,7 @@ JavaClasses:
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableLayoutHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOutputTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergInsertTableHandle.java
+  - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDeleteTableHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergDistributedProcedureHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergColumnHandle.java
   - presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java

--- a/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
+++ b/presto-native-execution/presto_cpp/presto_protocol/connector/iceberg/special/IcebergDeleteTableHandle.hpp.inc
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// IcebergDeleteTableHandle is special since it needs an usage of
+// hive::.
+
+namespace facebook::presto::protocol::iceberg {
+struct IcebergDeleteTableHandle : public ConnectorDeleteTableHandle {
+  String schemaName = {};
+  IcebergTableName tableName = {};
+  PrestoIcebergSchema schema = {};
+  PrestoIcebergPartitionSpec partitionSpec = {};
+  List<IcebergColumnHandle> inputColumns = {};
+  String outputPath = {};
+  FileFormat fileFormat = {};
+  hive::HiveCompressionCodec compressionCodec = {};
+  Map<String, String> storageProperties = {};
+  List<SortField> sortOrder = {};
+  std::shared_ptr<SchemaTableName> materializedViewName = {};
+  FileContent fileContent = {};
+
+  IcebergDeleteTableHandle() noexcept;
+};
+void to_json(json& j, const IcebergDeleteTableHandle& p);
+void from_json(const json& j, IcebergDeleteTableHandle& p);
+} // namespace facebook::presto::protocol::iceberg

--- a/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
+++ b/presto-native-execution/presto_cpp/presto_protocol/presto_protocol.yml
@@ -86,6 +86,7 @@ AbstractClasses:
   ConnectorDeleteTableHandle:
     super: JsonEncodedSubclass
     subclasses:
+      - { name: IcebergDeleteTableHandle,       key: hive-iceberg }
 
   ConnectorTransactionHandle:
     super: JsonEncodedSubclass


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexternal/presto-facebook/pull/3644

Adds a DWRF entry to the FileFormat wrapper enum (×2 trees) and routes its
write path through createOrcWriter (DWRF is ORC's Facebook variant — same
on-disk family, same writer code path). The toIceberg conversion maps DWRF
to org.apache.iceberg.FileFormat.ORC since the Iceberg manifest format only
distinguishes ORC vs PARQUET vs AVRO at the spec level.

Strictly-additive: no existing dispatch is changed; ORC, PARQUET, AVRO,
PUFFIN, METADATA paths are untouched. Required by the broader Iceberg V3
work which lets the connector ingest DWRF-encoded data files.

Part of the Iceberg V3 Java support split (was D98749429).

Reviewed By: srsuryadev

Differential Revision: D101602643
