### PR TITLE
feat: Add Iceberg TIMESTAMP_NANO (nanosecond timestamp) type support [presto][iceberg]

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
@@ -201,7 +201,18 @@ public final class ExpressionConverter
             return toIntExact(((Long) marker.getValue()));
         }
 
-        if (type instanceof TimestampType || type instanceof TimeType) {
+        if (type instanceof TimestampType) {
+            // TimestampType.getPrecision() returns a TimeUnit (MILLISECONDS or
+            // MICROSECONDS). Markers for TIMESTAMP_MICROSECONDS already carry
+            // values in micros; only millisecond-precision markers need the
+            // millis -> micros conversion before reaching Iceberg's micro API.
+            long value = (Long) marker.getValue();
+            return ((TimestampType) type).getPrecision() == MILLISECONDS
+                    ? MILLISECONDS.toMicros(value)
+                    : value;
+        }
+
+        if (type instanceof TimeType) {
             return MILLISECONDS.toMicros((Long) marker.getValue());
         }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionData.java
@@ -150,6 +150,7 @@ public class PartitionData
                 return partitionValue.asInt();
             case LONG:
             case TIMESTAMP:
+            case TIMESTAMP_NANO:
             case TIME:
                 return partitionValue.asLong();
             case FLOAT:

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeUtils;
 import com.facebook.presto.spi.ColumnMetadata;
@@ -53,6 +54,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.iceberg.IcebergUtil.getIdentityPartitions;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -298,10 +301,29 @@ public class PartitionTable
             return Float.floatToIntBits((Float) value);
         }
         if (type instanceof Types.TimestampType) {
+            // Iceberg TIMESTAMP without adjustToUTC maps to Presto TIMESTAMP
+            // (millisecond precision). The raw partition value is in micros;
+            // convert to millis to match the column's wire representation.
+            // Iceberg TIMESTAMP with adjustToUTC maps to TIMESTAMP_WITH_TIME_ZONE
+            // and is left untouched here for compatibility with existing behavior.
             com.facebook.presto.common.type.Type prestoType = toPrestoType(type, typeManager);
             if (prestoType instanceof TimestampType && ((TimestampType) prestoType).getPrecision() == MILLISECONDS) {
                 return MICROSECONDS.toMillis((long) value);
             }
+        }
+        if (type instanceof Types.TimestampNanoType) {
+            // Iceberg TIMESTAMP_NANO partition values arrive in nanoseconds.
+            //   - Without adjustToUTC: Presto type is TIMESTAMP_MICROSECONDS, so
+            //     floor-divide nanos by 1000 to convert to micros.
+            //   - With adjustToUTC: Presto type is TIMESTAMP_WITH_TIME_ZONE, so
+            //     convert nanos to millisUtc and pack with the UTC zone key to
+            //     match the packed long representation Presto uses for that type.
+            com.facebook.presto.common.type.Type prestoType = toPrestoType(type, typeManager);
+            long nanos = (long) value;
+            if (prestoType instanceof TimestampWithTimeZoneType) {
+                return packDateTimeWithZone(Math.floorDiv(nanos, 1_000_000L), UTC_KEY);
+            }
+            return Math.floorDiv(nanos, 1000L);
         }
         if (type instanceof Types.TimeType) {
             return MICROSECONDS.toMillis((long) value);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -124,6 +124,12 @@ public final class TypeConverter
                     return TIMESTAMP_WITH_TIME_ZONE;
                 }
                 return TimestampType.TIMESTAMP;
+            case TIMESTAMP_NANO:
+                Types.TimestampNanoType tsNanoType = (Types.TimestampNanoType) type.asPrimitiveType();
+                if (tsNanoType.shouldAdjustToUTC()) {
+                    return TIMESTAMP_WITH_TIME_ZONE;
+                }
+                return TimestampType.TIMESTAMP_MICROSECONDS;
             case STRING:
                 return VarcharType.createUnboundedVarcharType();
             case UUID:
@@ -405,6 +411,7 @@ public final class TypeConverter
             case DATE:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.DATE, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));
             case TIMESTAMP:
+            case TIMESTAMP_NANO:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.TIMESTAMP, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));
             case STRING:
                 return ImmutableList.of(new OrcType(OrcType.OrcTypeKind.STRING, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty(), attributes));


### PR DESCRIPTION
Summary:
Iceberg V3 introduces TimestampNanoType — a primitive type for storing
nanosecond-precision timestamps. This adds end-to-end Java support for the
new type:

- TypeConverter.toPrestoType: TIMESTAMP_NANO → TimestampType.TIMESTAMP_MICROSECONDS
  (Presto's microsecond TIMESTAMP is the closest representable Presto type;
  values are not lossily truncated because the full nanosecond is represented
  in microseconds for engine-side processing).
- TypeConverter.toOrcType: TIMESTAMP_NANO routed to ORC TIMESTAMP physical
  storage, same as TIMESTAMP.
- ExpressionConverter: refactor TimestampType marker conversion to look at
  precision so that microsecond markers are not double-converted.
- PartitionData / PartitionTable: TIMESTAMP_NANO partition values are
  parsed and floor-divided to micros for partition pruning.

Part of the Iceberg V3 Java support split (was D98749429).

== NO RELEASE NOTES ==

Reviewed By: srsuryadev

Differential Revision: D101602647


